### PR TITLE
Fix Go release smoke dependency setup

### DIFF
--- a/scripts/smoke-go-release.py
+++ b/scripts/smoke-go-release.py
@@ -298,7 +298,9 @@ def main() -> None:
     if "replace " in (consumer / "go.mod").read_text(encoding="utf-8"):
         fail("external consumer unexpectedly contains a Go replace directive")
     run(
-        ["go", "mod", "download", f"{GO_MODULE}@{module_version}"],
+        # Reconcile the generated imports into the consumer's go.mod and go.sum.
+        # A named download does not add transitive requirements to the main module.
+        ["go", "mod", "tidy"],
         cwd=consumer,
         env=env,
         attempts=6,

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -997,7 +997,7 @@ class WorkflowGraphTests(unittest.TestCase):
 
         self.assertIn('["go", "mod", "tidy"]', smoke)
         self.assertNotIn(
-            '["go", "mod", "download", f"{GO_MODULE}@{module_version}"]',
+            '["go", "mod", "download",',
             smoke,
         )
 

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -13,6 +13,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 CONTRACT_TOOL = ROOT / "scripts" / "baml-csharp-release-contract"
 VERSION_TOOL = ROOT / "scripts" / "baml-language-version"
+GO_RELEASE_SMOKE = ROOT / "scripts" / "smoke-go-release.py"
 PLATFORMS = ROOT / "release" / "platforms.json"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-baml-language.yml"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yaml"
@@ -990,6 +991,15 @@ class WorkflowGraphTests(unittest.TestCase):
             self.assertIn("!cancelled()", block)
             for result in required_results:
                 self.assertIn(result, block)
+
+    def test_go_release_smoke_reconciles_complete_dependency_graph(self) -> None:
+        smoke = GO_RELEASE_SMOKE.read_text(encoding="utf-8")
+
+        self.assertIn('["go", "mod", "tidy"]', smoke)
+        self.assertNotIn(
+            '["go", "mod", "download", f"{GO_MODULE}@{module_version}"]',
+            smoke,
+        )
 
     def test_nuget_repair_and_nightly_pack_contracts_are_fail_closed(self) -> None:
         publisher = NUGET_PUBLISHER.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- reconcile the generated external Go consumer with `go mod tidy` before testing it
- prevent the release smoke from using a single-module download that omits transitive requirements from the main module
- add a release-contract regression assertion for the dependency setup

## Root cause

The smoke test hand-writes an exact `baml-go` requirement, then previously ran `go mod download github.com/boundaryml/baml-go@<version>`. That command downloaded and authenticated only the named module. With Go's pruned module graph, the clean consumer still lacked the indirect protobuf requirement and checksums, so `go test` failed on every OS even though the published `baml-go` module was valid.

`go mod tidy` is the canonical minimal operation after client generation: it preserves the exact BAML version already pinned in `go.mod`, reconciles transitive requirements, and populates the consumer's `go.sum`.

## Validation

- `python3 -m unittest scripts.tests.test_release_pipeline_contract` — 22 tests passed
- Python compilation and `git diff --check` passed
- ran the corrected `scripts/smoke-go-release.py` end to end against public release `0.15.1-nightly.20260727.f`; it resolved the exact proxy module, compiled the generated client, downloaded the manifest-selected native runtime, verified its checksum, and completed the runtime call successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Go release smoke testing by reconciling the complete dependency graph before validation.
  * Reduced issues caused by incomplete or outdated module dependency metadata.

* **Tests**
  * Added coverage to verify the Go release smoke script performs module tidying (and avoids module downloading) to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->