### PR TITLE
chore: refresh size-gate baselines

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -44,13 +44,13 @@ policy.max_delta_pct = 3.0
 # unformatted generated SDK output).
 # macOS arm64: baseline 21.00 MB file (21_002_656), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = 21_820_377
+max_file_bytes = 21_854_475
 # Linux x86_64: baseline 27.08 MB file (27_075_600), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 28_083_783
+max_file_bytes = 28_120_698
 # Windows x86_64: baseline 22.67 MB file (22_671_360), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 23_518_674
+max_file_bytes = 23_559_808
 
 [artifacts.packed-program]
 kind = "pack"
@@ -58,13 +58,13 @@ policy.max_delta_pct = 3.0
 
 # macOS arm64: baseline 13.77 MB file.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = 14_234_586
+max_file_bytes = 14_268_683
 # Linux x86_64: baseline 17.64 MB file.
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 18_210_565
+max_file_bytes = 18_251_048
 # Windows x86_64: baseline 14.70 MB file.
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 15_172_856
+max_file_bytes = 15_220_725
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"
@@ -88,4 +88,4 @@ policy.max_delta_pct = 3.0
 
 # Single platform; baseline 4.40 MB gzip.
 [artifacts.bridge_wasm.platform.wasm32-unknown-unknown]
-max_gzip_bytes = 4_646_802
+max_gzip_bytes = 4_667_528

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-27T10:30:56Z"
-git_sha = "01f9b1a749d69ecdcd8da456a8dbeddeaba65d43"
+recorded_at = "2026-07-28T10:11:38Z"
+git_sha = "6b237531a5b664a250c5823c4d6a6957b5f2d7f2"
 
 [artifacts.baml-cli]
-file_bytes = 21184832
-stripped_bytes = 21184880
-gzip_bytes = 10121944
+file_bytes = 21217936
+stripped_bytes = 21217984
+gzip_bytes = 10143229
 
 [artifacts.packed-program]
-file_bytes = 13819986
-gzip_bytes = 6400400
+file_bytes = 13853090
+gzip_bytes = 6415513

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -1,7 +1,7 @@
 version = 1
-recorded_at = "2026-07-27T10:30:56Z"
-git_sha = "01f9b1a749d69ecdcd8da456a8dbeddeaba65d43"
+recorded_at = "2026-07-28T10:11:38Z"
+git_sha = "6b237531a5b664a250c5823c4d6a6957b5f2d7f2"
 
 [artifacts.bridge_wasm]
-file_bytes = 16540770
-gzip_bytes = 4511458
+file_bytes = 16595890
+gzip_bytes = 4531580

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-27T10:30:56Z"
-git_sha = "01f9b1a749d69ecdcd8da456a8dbeddeaba65d43"
+recorded_at = "2026-07-28T10:11:38Z"
+git_sha = "6b237531a5b664a250c5823c4d6a6957b5f2d7f2"
 
 [artifacts.baml-cli]
-file_bytes = 22833664
-stripped_bytes = 22833664
-gzip_bytes = 10333294
+file_bytes = 22873600
+stripped_bytes = 22873600
+gzip_bytes = 10349862
 
 [artifacts.packed-program]
-file_bytes = 14730928
-gzip_bytes = 6494635
+file_bytes = 14777402
+gzip_bytes = 6511861

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-27T10:30:56Z"
-git_sha = "01f9b1a749d69ecdcd8da456a8dbeddeaba65d43"
+recorded_at = "2026-07-28T10:11:38Z"
+git_sha = "6b237531a5b664a250c5823c4d6a6957b5f2d7f2"
 
 [artifacts.baml-cli]
-file_bytes = 27265808
-stripped_bytes = 27265800
-gzip_bytes = 11594361
+file_bytes = 27301648
+stripped_bytes = 27301640
+gzip_bytes = 11610256
 
 [artifacts.packed-program]
-file_bytes = 17680160
-gzip_bytes = 7291779
+file_bytes = 17719464
+gzip_bytes = 7313803


### PR DESCRIPTION
Adopted from CI run [`6b237531a5b664a250c5823c4d6a6957b5f2d7f2`](https://github.com/BoundaryML/baml/actions/runs/30316680966).

# Binary size checks passed

✅ **7** passed

| | Artifact | Platform | File | Gzip | Gated on | Baseline | Delta | Status |
|---|----------|----------|------|------|----------|----------|-------|--------|
| :white_check_mark: | `baml-cli` | Linux | 🔒 27.3 MB | 11.6 MB | **file** | 27.3 MB | +35.8 KB (+0.1%) | OK |
| :white_check_mark: | `packed-program` | Linux | 🔒 17.7 MB | 7.3 MB | **file** | 17.7 MB | +39.3 KB (+0.2%) | OK |
| :white_check_mark: | `baml-cli` | macOS | 🔒 21.2 MB | 10.1 MB | **file** | 21.2 MB | +33.1 KB (+0.2%) | OK |
| :white_check_mark: | `packed-program` | macOS | 🔒 13.9 MB | 6.4 MB | **file** | 13.8 MB | +33.1 KB (+0.2%) | OK |
| :white_check_mark: | `bridge_wasm` | WASM | 16.6 MB | 🔒 4.5 MB | **gzip** | 4.5 MB | +20.1 KB (+0.4%) | OK |
| :white_check_mark: | `baml-cli` | Windows | 🔒 22.9 MB | 10.3 MB | **file** | 22.8 MB | +39.9 KB (+0.2%) | OK |
| :white_check_mark: | `packed-program` | Windows | 🔒 14.8 MB | 6.5 MB | **file** | 14.7 MB | +46.5 KB (+0.3%) | OK |

> 🔒 = the size this artifact is GATED on (ceiling + delta). Binaries gate on **file** size (installed binary); WASM gates on **gzip** (download size). The other size is shown for information only.

---
*Generated by `cargo size-gate`*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release artifact size limits across supported platforms.
  * Refreshed recorded build metadata and measured artifact sizes for command-line, packaged program, and WebAssembly artifacts.
  * Ensured automated size checks reflect the latest build outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->