### PR TITLE
feat(cli): feedback payload preview and day-long decline cooldown

### DIFF
--- a/baml_language/crates/baml_cli/src/auth.rs
+++ b/baml_language/crates/baml_cli/src/auth.rs
@@ -223,6 +223,7 @@ pub(crate) fn device_login(no_open: bool, existing: Credentials) -> Result<Crede
             .clone()
             .or_else(|| Some(uuid::Uuid::new_v4().to_string())),
         feedback_anonymous: false,
+        feedback_declined_at: None,
         user_id: user.and_then(|u| u.id.clone()),
         user_email: user.and_then(|u| u.email.clone()),
         access_token: Some(tokens.access_token),
@@ -486,6 +487,11 @@ pub(crate) struct Credentials {
     /// login replaces these credentials.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub feedback_anonymous: bool,
+    /// Unix seconds of the last "Don't send" choice at the prompt. For a
+    /// day afterwards, `baml feedback` declines quietly instead of
+    /// re-asking; explicit `--anonymous`/`--email` still send.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub feedback_declined_at: Option<u64>,
     /// Cached WorkOS access token (absent while anonymous).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     access_token: Option<String>,
@@ -500,7 +506,7 @@ fn creds_path() -> Result<PathBuf> {
     Ok(baml_release::baml_home().join("creds.json"))
 }
 
-fn now_unix() -> u64 {
+pub(crate) fn now_unix() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|d| d.as_secs())

--- a/baml_language/crates/baml_cli/src/feedback_command.rs
+++ b/baml_language/crates/baml_cli/src/feedback_command.rs
@@ -24,6 +24,9 @@ const MAX_PAYLOAD_BYTES: usize = 256 * 1024;
 
 const FEEDBACK_EVENT: &str = "baml_feedback";
 
+/// How long a "Don't send" choice suppresses the prompt.
+const DECLINE_COOLDOWN_SECS: u64 = 24 * 60 * 60;
+
 /// PostHog ingestion host, overridable for tests and self-hosted setups.
 fn posthog_host() -> String {
     std::env::var("BAML_POSTHOG_HOST")
@@ -105,7 +108,22 @@ impl FeedbackArgs {
             // A prior report was sent anonymously; honor that choice without
             // re-prompting until a login replaces it.
             false
+        } else if creds
+            .feedback_declined_at
+            .is_some_and(|at| auth::now_unix() < at.saturating_add(DECLINE_COOLDOWN_SECS))
+        {
+            // "Don't send" was chosen within the last day: decline quietly
+            // instead of re-asking. Explicit --anonymous/--email (handled
+            // above) still send.
+            println!(
+                "Nothing sent (you declined recently). Pass --anonymous or \
+                 --email to send anyway."
+            );
+            return Ok(crate::ExitCode::Success);
         } else {
+            println!("I found an issue with BAML. I can report it to Boundary.");
+            println!();
+            self.print_preview(&payload);
             match self.prompt_for_mode()? {
                 ReportMode::Anonymous => false,
                 ReportMode::Email => {
@@ -113,6 +131,8 @@ impl FeedbackArgs {
                     true
                 }
                 ReportMode::DontSend => {
+                    creds.feedback_declined_at = Some(auth::now_unix());
+                    creds.write()?;
                     println!("Nothing sent.");
                     return Ok(crate::ExitCode::Success);
                 }
@@ -138,6 +158,8 @@ impl FeedbackArgs {
                 // (until a login resets it).
                 creds.feedback_anonymous = true;
             }
+            // A sent report supersedes any earlier "Don't send" cooldown.
+            creds.feedback_declined_at = None;
             creds.write()?;
             creds.posthog_distinct_id.clone().expect("set above")
         };
@@ -234,10 +256,33 @@ impl FeedbackArgs {
         Ok(from_json)
     }
 
+    /// Shows exactly what a report will contain before the user decides.
+    #[allow(clippy::print_stdout)]
+    fn print_preview(&self, payload: &Value) {
+        println!("Here's what will be sent:");
+        println!();
+        for (label, key) in [
+            ("Issue", "issue"),
+            ("Repro", "repro"),
+            ("Context", "context"),
+        ] {
+            if let Some(text) = payload.get(key).and_then(Value::as_str) {
+                println!("  {label}: {text}");
+            }
+        }
+        println!(
+            "  (plus: cli version {}, {}/{})",
+            baml_version::CANONICAL_VERSION,
+            std::env::consts::OS,
+            std::env::consts::ARCH
+        );
+        println!();
+    }
+
     /// The interactive choice.
     #[allow(clippy::print_stdout)]
     fn prompt_for_mode(&self) -> Result<ReportMode> {
-        println!("I found a way to improve the BAML language. Report it to Boundary?");
+        println!("How should I report it?");
         println!("  1) Anonymously");
         println!(
             "  2) Via your email (requires `baml login`; you'll be notified when a fix ships)"

--- a/baml_language/crates/baml_cli/tests/feedback_auth_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/feedback_auth_e2e.rs
@@ -274,7 +274,7 @@ fn interactive_prompt_anonymous_choice() {
         Some("1\n"),
     );
     assert!(ok, "{out}");
-    assert!(out.contains("Report it to Boundary?"), "{out}");
+    assert!(out.contains("How should I report it?"), "{out}");
     assert!(out.contains("Feedback sent anonymously"), "{out}");
     assert_eq!(feedback_events(&state).len(), 1);
 
@@ -287,7 +287,7 @@ fn interactive_prompt_anonymous_choice() {
         None,
     );
     assert!(ok, "{out}");
-    assert!(!out.contains("Report it to Boundary?"), "{out}");
+    assert!(!out.contains("How should I report it?"), "{out}");
     assert!(out.contains("Feedback sent anonymously"), "{out}");
     assert_eq!(feedback_events(&state).len(), 2);
 }
@@ -298,34 +298,65 @@ fn interactive_prompt_decline_sends_nothing() {
     let base = spawn_mock(state.clone());
     let home = tempfile::tempdir().unwrap();
 
-    // Choosing 3 declines: nothing sent, nothing persisted, and the next
-    // run prompts again (declining is not sticky).
+    // The prompt is preceded by a preview of exactly what would be sent.
+    // Choosing 3 declines: nothing sent, and the decline is remembered.
     let (ok, out) = run_baml(
         home.path(),
         &base,
-        &["feedback", "--issue", "never mind"],
+        &["feedback", "--issue", "never mind", "--repro", "class A {}"],
         Some("3\n"),
     );
     assert!(ok, "{out}");
+    assert!(out.contains("Here's what will be sent:"), "{out}");
+    assert!(out.contains("Issue: never mind"), "{out}");
+    assert!(out.contains("Repro: class A {}"), "{out}");
     assert!(out.contains("Nothing sent"), "{out}");
     assert_eq!(feedback_events(&state).len(), 0);
-    assert!(
-        !home.path().join("creds.json").exists(),
-        "nothing persisted"
-    );
+    let creds = std::fs::read_to_string(home.path().join("creds.json")).unwrap();
+    assert!(creds.contains("feedback_declined_at"), "{creds}");
 
+    // Within the day-long cooldown: no prompt, nothing sent, still exit 0.
     let (ok, out) = run_baml(
         home.path(),
         &base,
-        &["feedback", "--issue", "ok fine"],
-        Some("1\n"),
+        &["feedback", "--issue", "still nothing"],
+        None,
+    );
+    assert!(ok, "{out}");
+    assert!(!out.contains("How should I report it?"), "{out}");
+    assert!(out.contains("declined recently"), "{out}");
+    assert_eq!(feedback_events(&state).len(), 0);
+
+    // Explicit --anonymous overrides the cooldown and clears it.
+    let (ok, out) = run_baml(
+        home.path(),
+        &base,
+        &["feedback", "--anonymous", "--issue", "ok fine"],
+        None,
+    );
+    assert!(ok, "{out}");
+    assert_eq!(feedback_events(&state).len(), 1);
+    let creds = std::fs::read_to_string(home.path().join("creds.json")).unwrap();
+    assert!(!creds.contains("feedback_declined_at"), "{creds}");
+
+    // An expired cooldown prompts again: write stale state directly (a
+    // 1970 decline, no sticky-anonymous flag) and expect the prompt.
+    std::fs::write(
+        home.path().join("creds.json"),
+        r#"{"feedback_declined_at":1}"#,
+    )
+    .unwrap();
+    let (ok, out) = run_baml(
+        home.path(),
+        &base,
+        &["feedback", "--issue", "after cooldown"],
+        Some("3\n"),
     );
     assert!(ok, "{out}");
     assert!(
-        out.contains("Report it to Boundary?"),
-        "prompts again: {out}"
+        out.contains("How should I report it?"),
+        "prompts again after expiry: {out}"
     );
-    assert_eq!(feedback_events(&state).len(), 1);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Follow-up to #4231. Two UX changes to the `baml feedback` interactive flow:

- **Payload preview**: before asking how to report, the CLI now shows exactly what will be sent:

  ```
  I found an issue with BAML. I can report it to Boundary.

  Here's what will be sent:

    Issue: parser panics on nested unions
    Repro: class A { ... }
    (plus: cli version 0.15.0, macos/aarch64)

  How should I report it?
    1) Anonymously
    2) Via your email (requires `baml login`; you'll be notified when a fix ships)
    3) Don't send
  ```

- **Day-long decline cooldown**: choosing "Don't send" persists `feedback_declined_at` (unix seconds) in `creds.json`. For 24 hours afterwards, `baml feedback` declines quietly ("Nothing sent (you declined recently)...", exit 0) instead of re-asking. Explicit `--anonymous`/`--email` still send, any sent report clears the cooldown, and login resets it.

## Test plan

- Extended the decline e2e test to cover: preview contents, decline persisting the timestamp, the quiet within-cooldown run (no prompt, no event), `--anonymous` overriding and clearing the cooldown, and an expired cooldown prompting again.
- Full `baml_cli` suite: 501 passed, 0 failed; rustfmt clean.
- Exercised interactively via a local dev build.
- Security review of the branch: no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a preview showing the information that will be included before feedback is submitted.
  - Added a one-day cooldown after choosing not to send feedback, reducing repeated prompts.
  - Added an option to override the cooldown and submit feedback anonymously.

- **Bug Fixes**
  - Improved persistence of feedback preferences across CLI sessions.
  - Updated feedback prompts and behavior to accurately reflect reporting choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->