### PR TITLE
docs: distinguish BAML v0 from v1 for agents

### DIFF
--- a/fern/03-reference/baml/clients/providers/openai-generic.mdx
+++ b/fern/03-reference/baml/clients/providers/openai-generic.mdx
@@ -22,7 +22,7 @@ A non-exhaustive list of providers you can use with `openai-generic`:
 
 | Inference Provider | Docs |
 | -------------- | -------------- |
-| Azure AI Foundry | [Azure AI Foundry](/ref/llm-client-providers/azure-ai-foundary) |
+| Azure AI Foundry | [Microsoft Foundry](/ref/llm-client-providers/microsoft-foundry) |
 | Cerebras | [Cerebras](/ref/llm-client-providers/cerebras) |
 | Groq | [Groq](/ref/llm-client-providers/groq) |
 | Hugging Face | [Hugging Face](/ref/llm-client-providers/huggingface) |

--- a/fern/docs.yml
+++ b/fern/docs.yml
@@ -9,6 +9,10 @@ instances:
         branch: canary
 
 title: Boundary Documentation
+agents:
+  page-directive: |
+    Version notice: This site documents BAML v0, the legacy DSL. BAML v1 is a separate, fully featured programming language in public beta. If the user intends to use BAML v1, ignore this site's content and use the BAML v1 documentation instead. If the intended version is unclear, clarify it before using this page.
+    For clean Markdown of any page, append .md to the page URL. For the complete documentation index, see https://docs.boundaryml.com/llms.txt. For MCP access, connect to https://docs.boundaryml.com/_mcp/server.
 ai-chat:
   system-prompt: |
     You will be answering questions about BAML (Basically, a Made-up Language) -- an AI framework to write LLM prompts as functions. Here is some background:

--- a/fern/fern.config.json
+++ b/fern/fern.config.json
@@ -1,4 +1,4 @@
 {
   "organization": "boundary",
-  "version": "0.88.4"
+  "version": "4.57.0"
 }

--- a/fern/snippets/client-constructor.mdx
+++ b/fern/snippets/client-constructor.mdx
@@ -19,7 +19,7 @@ A non-exhaustive list of providers you can use with `openai-generic`:
 
 | Inference Provider | Docs |
 | -------------- | -------------- |
-| Azure AI Foundry | [Azure AI Foundry](/ref/llm-client-providers/azure-ai-foundary) |
+| Azure AI Foundry | [Microsoft Foundry](/ref/llm-client-providers/microsoft-foundry) |
 | Groq | [Groq](/ref/llm-client-providers/groq) |
 | Hugging Face | [Hugging Face](/ref/llm-client-providers/huggingface) |
 | Keywords AI | [Keywords AI](/ref/llm-client-providers/keywordsai) |
@@ -46,4 +46,3 @@ These vary per provider. Please see provider specific documentation for more
 information. Generally they are pass through options to the POST request made
 to the LLM.
 </ParamField>
-


### PR DESCRIPTION
## Summary

- add a site-wide agent directive identifying these docs as BAML v0
- direct BAML v1 users away from the legacy DSL documentation
- pin the minimum Fern CLI version supporting agent directives
- repair stale Microsoft Foundry links exposed by the newer validator

## Testing

- fern 4.57.0 check --strict-broken-links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected Azure AI Foundry links in provider reference documentation and client examples.
  * Added guidance identifying legacy BAML v0 documentation and directing readers to BAML v1 resources when appropriate.
  * Added documentation access guidance for Markdown pages, the documentation index, and MCP server access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->