### PR TITLE
Fix graph display for message-only errors

### DIFF
--- a/typescript2/pkg-playground/src/run-store-projections.test.ts
+++ b/typescript2/pkg-playground/src/run-store-projections.test.ts
@@ -861,6 +861,49 @@ describe('run-store-projections', () => {
     ]);
   });
 
+  it('projects root errors without captured values onto the root graph node', () => {
+    const run = runFixture({
+      status: 'failed',
+      completedAtMs: 150,
+      rootCallNodeId: 'root-main',
+      error: {
+        class: 'Runtime',
+        message: 'plain runtime failure',
+        details: null,
+        valueRef: null,
+      },
+      calls: [
+        callFixture({
+          id: 'root-main',
+          functionName: 'throws.main',
+          payloadIds: [],
+          status: 'errored',
+        }),
+      ],
+    });
+
+    const valuesByNodeId = runToGraphNodeValues(
+      run,
+      {
+        ...graphOverlayFixture(12, []),
+        unattachedCallNodeIds: ['root-main'],
+      },
+      undefined,
+      { rootGraphNodeId: '1' },
+    );
+
+    expect(valuesByNodeId.get('1')).toEqual([
+      expect.objectContaining({
+        id: 'root-error',
+        role: 'callError',
+        label: 'error',
+        value: null,
+        state: 'error',
+        diagnostic: 'plain runtime failure',
+      }),
+    ]);
+  });
+
   it('projects explicit log body availability states', () => {
     const run = runFixture({
       calls: [

--- a/typescript2/pkg-playground/src/run-store-projections.ts
+++ b/typescript2/pkg-playground/src/run-store-projections.ts
@@ -964,12 +964,14 @@ function rootResultToGraphValue(
   run: Run,
   valueBodyCache?: ValueBodyCache,
 ): GraphNodeValuePreview | null {
-  if (run.error?.valueRef) {
-    const projected = projectValueRef(
-      run.boundaryId,
-      run.error.valueRef,
-      valueBodyCache,
-    );
+  if (run.error) {
+    const projected = run.error.valueRef
+      ? projectValueRef(run.boundaryId, run.error.valueRef, valueBodyCache)
+      : {
+          state: 'error' as const,
+          value: null,
+          diagnostic: run.error.message,
+        };
     return {
       id: 'root-error',
       timestampMs: run.completedAtMs ?? run.startedAtMs ?? run.createdAtMs,


### PR DESCRIPTION
## Summary

- Preserve root failures in graph projections even when the runtime error has no captured value.
- Render a diagnostic-only error preview on the workflow root instead of silently dropping the failure.
- Add regression coverage for an unattached root call with a message-only runtime error.

## Root cause

The graph projection only created a root error value when `RunError.valueRef` existed. Ordinary runtime failures can carry only a message, and root calls are often unattached to CFG overlay entries, so neither the value projection nor runtime decoration surfaced the failure.

## Validation

- `pnpm --filter @b/pkg-playground exec vitest run src/run-store-projections.test.ts`
- `pnpm --filter @b/pkg-playground test` (126 tests)
- `pnpm --filter @b/pkg-playground typecheck`

Fixes B-813.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Root-level failed runs without a value reference now display correctly on the graph root.
  * Error previews show an error state, a null value, and the associated runtime diagnostic message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Before / after

### Before

Message-only root failures were omitted from the playground graph.

<img width="800" height="500" alt="Before: message-only root failure is omitted from the playground graph" src="https://github.com/user-attachments/assets/004bf8e5-bfb4-4caf-8cba-6ef4d45f5e49" />

### After

The playground graph renders a diagnostic error card on the failed root.

<img width="800" height="500" alt="After: playground root renders a diagnostic error card for the plain runtime failure" src="https://github.com/user-attachments/assets/1040172b-e45a-481a-8690-b9c07a5254a6" />
