### PR TITLE
fix(cli): report exact describe budget

### DIFF
--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -525,6 +525,8 @@ fn render_keyword_json(name: &str) -> serde_json::Value {
     }
 }
 
+// The full-output hint is computed before sections are rendered, so fixed
+// layout groups have explicit costs shared by the planner and renderer.
 const ITEM_HEADER_COST: usize = 1;
 const SECTION_HEADER_COST: usize = 2;
 const CONTAINER_SECTION_COST: usize = 3;
@@ -936,7 +938,7 @@ fn write_elision_marker(
     if elided > 0 {
         writeln!(
             w,
-            "  \u{2026} {elided} more lines (re-run with `--budget {full_output_budget}`)"
+            "  \u{2026} {elided} more lines (re-run with a higher `--budget` to see more; use `--budget {full_output_budget}` for full output)"
         )?;
     }
     Ok(())

--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -525,6 +525,11 @@ fn render_keyword_json(name: &str) -> serde_json::Value {
     }
 }
 
+const ITEM_HEADER_COST: usize = 1;
+const SECTION_HEADER_COST: usize = 2;
+const CONTAINER_SECTION_COST: usize = 3;
+const LIST_ENTRY_COST: usize = 1;
+
 /// Render a SymbolDescription to stdout with budget-based output.
 pub fn render_description(
     db: &ProjectDatabase,
@@ -578,7 +583,7 @@ pub fn write_description(
         painter.keyword(kind_str)
     )?;
 
-    let mut lines_used = 1;
+    let mut lines_used = ITEM_HEADER_COST;
 
     // ── Body ─────────────────────────────────────────────────────────────────
     // The body slice already includes any leading `///` doc-comments
@@ -592,6 +597,12 @@ pub fn write_description(
         baml_lsp2_actions::DefinitionKind::Parameter | baml_lsp2_actions::DefinitionKind::Binding
     );
     let body_lines: Vec<&str> = desc.full_body.lines().collect();
+    let highlighted_body = colors.then(|| hl.range(desc.file, desc.item_range));
+    let highlighted_body_lines = highlighted_body.as_deref().map(trim_blank_edge_lines);
+    let body_line_count = highlighted_body_lines
+        .as_ref()
+        .map_or(body_lines.len(), Vec::len);
+    let full_output_budget = minimum_full_output_budget(desc, body_line_count, is_local);
 
     if !is_local {
         // The separator blank line is deliberately not counted against the
@@ -602,10 +613,10 @@ pub fn write_description(
         let available_for_body = budget.saturating_sub(lines_used);
 
         // Colored TTY output renders the verbatim definition slice through the
-        // compiler's semantic tokens. Plain output (pipes, JSON, tests) keeps
-        // the existing cleaned/truncated behavior byte-for-byte.
-        if colors {
-            lines_used += write_highlighted_body(w, &hl, desc, available_for_body)?;
+        // compiler's semantic tokens. Plain output (pipes, JSON, tests) uses
+        // the cleaned body representation.
+        if let Some(lines) = highlighted_body_lines.as_deref() {
+            lines_used += write_highlighted_body(w, lines, available_for_body, full_output_budget)?;
         } else {
             let was_truncated = body_lines.len() > available_for_body;
             let shown_body_lines;
@@ -638,7 +649,7 @@ pub fn write_description(
                     "[INFO] showing {shown} of {total} lines; use `--budget {needed}` for full output",
                     shown = shown_body_lines,
                     total = body_lines.len(),
-                    needed = body_lines.len() + 1,
+                    needed = full_output_budget,
                 )?;
                 lines_used += 2;
             }
@@ -650,28 +661,29 @@ pub fn write_description(
     // budget is soft: section headers are always emitted (so the symbol's
     // surface stays discoverable), entries are never split mid-unit, and
     // anything elided is replaced by an explicit "… <n> more lines" marker.
-    let mut remaining = budget.saturating_sub(lines_used);
+    let mut render_budget =
+        RenderBudget::new(budget.saturating_sub(lines_used), full_output_budget);
 
     // ── Methods (instance) ───────────────────────────────────────────────────
-    remaining = write_method_section(
+    write_method_section(
         w,
         db,
         &painter,
         project_root,
         "methods",
         &desc.instance_methods,
-        remaining,
+        &mut render_budget,
     )?;
 
     // ── Static methods ───────────────────────────────────────────────────────
-    remaining = write_method_section(
+    write_method_section(
         w,
         db,
         &painter,
         project_root,
         "static_methods",
         &desc.static_methods,
-        remaining,
+        &mut render_budget,
     )?;
 
     // ── Container ────────────────────────────────────────────────────────────
@@ -692,17 +704,17 @@ pub fn write_description(
             &c_path.display().to_string(),
             c_line,
         )?;
-        remaining = remaining.saturating_sub(3);
+        render_budget.consume(CONTAINER_SECTION_COST);
     }
 
     // ── Dependencies ─────────────────────────────────────────────────────────
     if !desc.dependencies.is_empty() {
         writeln!(w)?;
         writeln!(w, "dependencies:")?;
-        remaining = remaining.saturating_sub(2);
+        render_budget.consume(SECTION_HEADER_COST);
         let mut elided = 0usize;
         for dep in &desc.dependencies {
-            if remaining == 0 {
+            if !render_budget.can_start_atomic() {
                 elided += 1;
                 continue;
             }
@@ -718,9 +730,9 @@ pub fn write_description(
                 &dep_path.display().to_string(),
                 dep_line,
             )?;
-            remaining -= 1;
+            render_budget.consume(LIST_ENTRY_COST);
         }
-        write_elision_marker(w, elided)?;
+        write_elision_marker(w, elided, render_budget.full_output)?;
     }
 
     // ── References ───────────────────────────────────────────────────────────
@@ -728,10 +740,10 @@ pub fn write_description(
     // tight budget. The header always shows the total count.
     writeln!(w)?;
     writeln!(w, "references ({}):", desc.references.len())?;
-    remaining = remaining.saturating_sub(2);
+    render_budget.consume(SECTION_HEADER_COST);
     let mut elided = 0usize;
     for r in &desc.references {
-        if remaining == 0 {
+        if !render_budget.can_start_atomic() {
             elided += 1;
             continue;
         }
@@ -753,9 +765,9 @@ pub fn write_description(
             &r.line_number.to_string(),
         );
         writeln!(w, "  {loc}  {preview}")?;
-        remaining -= 1;
+        render_budget.consume(LIST_ENTRY_COST);
     }
-    write_elision_marker(w, elided)?;
+    write_elision_marker(w, elided, render_budget.full_output)?;
 
     Ok(())
 }
@@ -767,21 +779,10 @@ pub fn write_description(
 /// run is never split). Returns the number of output lines consumed.
 fn write_highlighted_body(
     w: &mut impl std::io::Write,
-    hl: &crate::paint::Highlighter,
-    desc: &SymbolDescription,
+    lines: &[&str],
     available_for_body: usize,
+    full_output_budget: usize,
 ) -> std::io::Result<usize> {
-    let colored = hl.range(desc.file, desc.item_range);
-    let all: Vec<&str> = colored.lines().collect();
-    // `item_range` can swallow leading doc-comments/blank lines and trailing
-    // whitespace; trim blank edges so the block starts at the declaration.
-    let first = all.iter().position(|l| !l.trim().is_empty()).unwrap_or(0);
-    let last = all
-        .iter()
-        .rposition(|l| !l.trim().is_empty())
-        .map_or(first, |e| e + 1);
-    let lines = &all[first..last];
-
     if lines.len() <= available_for_body {
         for line in lines {
             writeln!(w, "{line}")?;
@@ -809,16 +810,134 @@ fn write_highlighted_body(
         "[INFO] showing {} of {} lines; use `--budget {}` for full output",
         head + tail + 1,
         lines.len(),
-        lines.len() + 1,
+        full_output_budget,
     )?;
     Ok(head + tail + 3)
 }
 
+fn trim_blank_edge_lines(text: &str) -> Vec<&str> {
+    let all: Vec<&str> = text.lines().collect();
+    let first = all
+        .iter()
+        .position(|line| !line.trim().is_empty())
+        .unwrap_or(0);
+    let last = all
+        .iter()
+        .rposition(|line| !line.trim().is_empty())
+        .map_or(first, |end| end + 1);
+    all[first..last].to_vec()
+}
+
+/// Tracks the minimum starting budget needed to render every guarded unit.
+///
+/// Soft overhead is always printed, even after the budget is exhausted, so it
+/// only advances `consumed`. A required block must fit in full. An atomic unit
+/// may start whenever one line remains, even when its full cost is larger.
+#[derive(Default)]
+struct BudgetRequirement {
+    consumed: usize,
+    minimum: usize,
+}
+
+struct RenderBudget {
+    remaining: usize,
+    full_output: usize,
+}
+
+impl RenderBudget {
+    fn new(remaining: usize, full_output: usize) -> Self {
+        Self {
+            remaining,
+            full_output,
+        }
+    }
+
+    fn consume(&mut self, cost: usize) {
+        self.remaining = self.remaining.saturating_sub(cost);
+    }
+
+    fn can_start_atomic(&self) -> bool {
+        self.remaining > 0
+    }
+}
+
+impl BudgetRequirement {
+    fn add_soft_overhead(&mut self, cost: usize) {
+        self.consumed = self.consumed.saturating_add(cost);
+    }
+
+    fn add_required(&mut self, cost: usize) {
+        self.add_soft_overhead(cost);
+        self.minimum = self.minimum.max(self.consumed);
+    }
+
+    fn add_atomic(&mut self, cost: usize) {
+        debug_assert!(cost > 0);
+        self.minimum = self.minimum.max(self.consumed.saturating_add(1));
+        self.add_soft_overhead(cost);
+    }
+}
+
+fn minimum_full_output_budget(
+    desc: &SymbolDescription,
+    body_line_count: usize,
+    is_local: bool,
+) -> usize {
+    let mut required = BudgetRequirement::default();
+
+    if is_local {
+        required.add_soft_overhead(ITEM_HEADER_COST);
+    } else {
+        required.add_required(ITEM_HEADER_COST.saturating_add(body_line_count));
+    }
+
+    add_method_budget(&mut required, &desc.instance_methods);
+    add_method_budget(&mut required, &desc.static_methods);
+
+    if desc.container.is_some() {
+        required.add_soft_overhead(CONTAINER_SECTION_COST);
+    }
+
+    if !desc.dependencies.is_empty() {
+        required.add_soft_overhead(SECTION_HEADER_COST);
+        for _ in &desc.dependencies {
+            required.add_atomic(LIST_ENTRY_COST);
+        }
+    }
+
+    required.add_soft_overhead(SECTION_HEADER_COST);
+    for _ in &desc.references {
+        required.add_atomic(LIST_ENTRY_COST);
+    }
+
+    required.minimum
+}
+
+fn add_method_budget(required: &mut BudgetRequirement, methods: &[describe::MethodRef]) {
+    if !methods.is_empty() {
+        required.add_soft_overhead(SECTION_HEADER_COST);
+        for method in methods {
+            required.add_atomic(method_line_cost(method));
+        }
+    }
+}
+
+fn method_line_cost(method: &describe::MethodRef) -> usize {
+    1 + usize::from(method.docstring.is_some())
+}
+
 /// Write the soft-budget elision marker for `elided` hidden lines (no-op when
 /// nothing was elided).
-fn write_elision_marker(w: &mut impl std::io::Write, elided: usize) -> std::io::Result<()> {
+fn write_elision_marker(
+    w: &mut impl std::io::Write,
+    elided: usize,
+    full_output_budget: usize,
+) -> std::io::Result<()> {
     if elided > 0 {
-        writeln!(w, "  … {elided} more lines (re-run with a higher --budget)")?;
+        writeln!(
+            w,
+            "  \u{2026} {elided} more lines (re-run with `--budget {full_output_budget}`)"
+        )?;
     }
     Ok(())
 }
@@ -873,10 +992,10 @@ pub(crate) fn definition_line_range(
 ///
 /// Each method shows its first-line docstring (when present) followed by its
 /// canonical signature and full definition line range. The section consumes
-/// from the soft line `budget` and returns what's left: the header is always
-/// emitted, each method is an atomic unit (docstring + signature are never
-/// split, even if the last one runs slightly over), and methods that don't
-/// fit are summarized by an elision marker.
+/// from the shared soft line `budget`: the header is always emitted, each
+/// method is an atomic unit (docstring + signature are never split, even if
+/// the last one runs slightly over), and methods that don't fit are summarized
+/// by an elision marker.
 fn write_method_section(
     w: &mut impl std::io::Write,
     db: &ProjectDatabase,
@@ -884,18 +1003,18 @@ fn write_method_section(
     project_root: &std::path::Path,
     label: &str,
     methods: &[describe::MethodRef],
-    budget: usize,
-) -> std::io::Result<usize> {
+    budget: &mut RenderBudget,
+) -> std::io::Result<()> {
     if methods.is_empty() {
-        return Ok(budget);
+        return Ok(());
     }
     writeln!(w)?;
     writeln!(w, "{label}:")?;
-    let mut remaining = budget.saturating_sub(2);
+    budget.consume(SECTION_HEADER_COST);
     let mut elided_lines = 0usize;
     for m in methods {
-        let unit_cost = 1 + usize::from(m.docstring.is_some());
-        if remaining == 0 {
+        let unit_cost = method_line_cost(m);
+        if !budget.can_start_atomic() {
             elided_lines += unit_cost;
             continue;
         }
@@ -916,10 +1035,10 @@ fn write_method_section(
         );
         let sig = painter.fragment(&m.signature);
         writeln!(w, "  {sig}  {loc}")?;
-        remaining = remaining.saturating_sub(unit_cost);
+        budget.consume(unit_cost);
     }
-    write_elision_marker(w, elided_lines)?;
-    Ok(remaining)
+    write_elision_marker(w, elided_lines, budget.full_output)?;
+    Ok(())
 }
 
 /// Render a flat listing of entries to stdout.

--- a/baml_language/crates/baml_cli/src/describe_command_tests.rs
+++ b/baml_language/crates/baml_cli/src/describe_command_tests.rs
@@ -988,7 +988,7 @@ fn render_describe_methods_respect_budget() {
     for needle in [
         "methods:",
         "static_methods:",
-        "more lines (re-run with `--budget ",
+        "more lines (re-run with a higher `--budget` to see more; use `--budget ",
     ] {
         assert!(
             tight.contains(needle),
@@ -1018,7 +1018,7 @@ fn render_describe_methods_respect_budget() {
         );
     }
     assert!(
-        !full.contains("re-run with `--budget "),
+        !full.contains("re-run with a higher `--budget`"),
         "no elision marker expected at budget 1000:\n{full}"
     );
     assert!(
@@ -1069,7 +1069,7 @@ fn render_describe_fields_only_body_fits_tight_budget() {
     let body_part = |s: &str| s[..s.find("\nmethods:").expect("methods section")].to_string();
     assert_eq!(body_part(&tight), body_part(&full));
     assert!(
-        tight.contains("more lines (re-run with `--budget "),
+        tight.contains("more lines (re-run with a higher `--budget` to see more; use `--budget "),
         "methods exceeding the tight budget must be elided with a marker:\n{tight}"
     );
     for needle in ["class User {", "    name: string,", "    age: int,", "}"] {

--- a/baml_language/crates/baml_cli/src/describe_command_tests.rs
+++ b/baml_language/crates/baml_cli/src/describe_command_tests.rs
@@ -42,6 +42,57 @@ fn capture_description(
     String::from_utf8(buf).unwrap()
 }
 
+fn truncation_budgets(output: &str) -> Vec<usize> {
+    output
+        .split("`--budget ")
+        .skip(1)
+        .map(|suffix| {
+            suffix
+                .split('`')
+                .next()
+                .expect("budget hint must have a closing backtick")
+                .parse()
+                .expect("budget hint must contain an integer")
+        })
+        .collect()
+}
+
+fn assert_reported_budget_is_minimum(
+    db: &ProjectDatabase,
+    desc: &baml_lsp2_actions::SymbolDescription,
+    probe_budget: usize,
+) -> usize {
+    let truncated = capture_description(db, desc, probe_budget);
+    let hinted_budgets = truncation_budgets(&truncated);
+    assert!(
+        !hinted_budgets.is_empty(),
+        "expected a budget hint:\n{truncated}"
+    );
+
+    let required = hinted_budgets[0];
+    assert!(
+        hinted_budgets.iter().all(|budget| *budget == required),
+        "all truncation markers must report the same full-output budget: {hinted_budgets:?}\n{truncated}"
+    );
+
+    let previous = required
+        .checked_sub(1)
+        .expect("a truncated description must require a positive budget");
+    let almost_full = capture_description(db, desc, previous);
+    assert!(
+        !truncation_budgets(&almost_full).is_empty(),
+        "the reported budget must be minimal; budget {previous} unexpectedly rendered everything:\n{almost_full}"
+    );
+
+    let exactly_full = capture_description(db, desc, required);
+    assert!(
+        truncation_budgets(&exactly_full).is_empty(),
+        "the reported budget must render the complete description:\n{exactly_full}"
+    );
+
+    required
+}
+
 /// Capture `write_keyword` output as a String.
 fn capture_keyword(name: &str) -> String {
     let mut buf = Vec::new();
@@ -937,7 +988,7 @@ fn render_describe_methods_respect_budget() {
     for needle in [
         "methods:",
         "static_methods:",
-        "more lines (re-run with a higher --budget)",
+        "more lines (re-run with `--budget ",
     ] {
         assert!(
             tight.contains(needle),
@@ -967,7 +1018,7 @@ fn render_describe_methods_respect_budget() {
         );
     }
     assert!(
-        !full.contains("re-run with a higher --budget"),
+        !full.contains("re-run with `--budget "),
         "no elision marker expected at budget 1000:\n{full}"
     );
     assert!(
@@ -979,6 +1030,23 @@ fn render_describe_methods_respect_budget() {
             && full.contains("function from_code_points(unicode: int[]) -> string"),
         "generous budgets should still show full method details:\n{full}"
     );
+
+    assert_eq!(assert_reported_budget_is_minimum(&db, &descs[0], 5), 97);
+}
+
+#[test]
+fn render_describe_budget_hint_covers_dependencies_and_references() {
+    let db = simple_project();
+    let files = baml_compiler2_hir::compiler2_all_files(&db);
+    let point = baml_lsp2_actions::describe(&db, &files, "Point");
+    assert_eq!(point.len(), 1);
+    assert_reported_budget_is_minimum(&db, &point[0], 0);
+
+    let db = methods_project();
+    let files = baml_compiler2_hir::compiler2_all_files(&db);
+    let wrapper = baml_lsp2_actions::describe(&db, &files, "Wrapper");
+    assert_eq!(wrapper.len(), 1);
+    assert_reported_budget_is_minimum(&db, &wrapper[0], 0);
 }
 
 /// A class with a fields-only body (no docstring) still fits that body under a
@@ -1001,7 +1069,7 @@ fn render_describe_fields_only_body_fits_tight_budget() {
     let body_part = |s: &str| s[..s.find("\nmethods:").expect("methods section")].to_string();
     assert_eq!(body_part(&tight), body_part(&full));
     assert!(
-        tight.contains("more lines (re-run with a higher --budget)"),
+        tight.contains("more lines (re-run with `--budget "),
         "methods exceeding the tight budget must be elided with a marker:\n{tight}"
     );
     for needle in ["class User {", "    name: string,", "    age: int,", "}"] {

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_alias_string.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_alias_string.snap
@@ -33,9 +33,9 @@ methods:
   function starts_with(self, prefix: string) -> bool  <builtin>/baml/string.baml:135-137
   /// Returns true if the string ends with `suffix`.
   function ends_with(self, suffix: string) -> bool  <builtin>/baml/string.baml:140-142
-  … 60 more lines (re-run with a higher --budget)
+  … 60 more lines (re-run with `--budget 97`)
 
 static_methods:
-  … 6 more lines (re-run with a higher --budget)
+  … 6 more lines (re-run with `--budget 97`)
 
 references (0):

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_alias_string.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_alias_string.snap
@@ -33,9 +33,9 @@ methods:
   function starts_with(self, prefix: string) -> bool  <builtin>/baml/string.baml:135-137
   /// Returns true if the string ends with `suffix`.
   function ends_with(self, suffix: string) -> bool  <builtin>/baml/string.baml:140-142
-  … 60 more lines (re-run with `--budget 97`)
+  … 60 more lines (re-run with a higher `--budget` to see more; use `--budget 97` for full output)
 
 static_methods:
-  … 6 more lines (re-run with `--budget 97`)
+  … 6 more lines (re-run with a higher `--budget` to see more; use `--budget 97` for full output)
 
 references (0):

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_item_by_definition.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_item_by_definition.snap
@@ -33,9 +33,9 @@ methods:
   function starts_with(self, prefix: string) -> bool  <builtin>/baml/string.baml:135-137
   /// Returns true if the string ends with `suffix`.
   function ends_with(self, suffix: string) -> bool  <builtin>/baml/string.baml:140-142
-  … 60 more lines (re-run with a higher --budget)
+  … 60 more lines (re-run with `--budget 97`)
 
 static_methods:
-  … 6 more lines (re-run with a higher --budget)
+  … 6 more lines (re-run with `--budget 97`)
 
 references (0):

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_item_by_definition.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_item_by_definition.snap
@@ -33,9 +33,9 @@ methods:
   function starts_with(self, prefix: string) -> bool  <builtin>/baml/string.baml:135-137
   /// Returns true if the string ends with `suffix`.
   function ends_with(self, suffix: string) -> bool  <builtin>/baml/string.baml:140-142
-  … 60 more lines (re-run with `--budget 97`)
+  … 60 more lines (re-run with a higher `--budget` to see more; use `--budget 97` for full output)
 
 static_methods:
-  … 6 more lines (re-run with `--budget 97`)
+  … 6 more lines (re-run with a higher `--budget` to see more; use `--budget 97` for full output)
 
 references (0):

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_string.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_string.snap
@@ -33,9 +33,9 @@ methods:
   function starts_with(self, prefix: string) -> bool  <builtin>/baml/string.baml:135-137
   /// Returns true if the string ends with `suffix`.
   function ends_with(self, suffix: string) -> bool  <builtin>/baml/string.baml:140-142
-  … 60 more lines (re-run with a higher --budget)
+  … 60 more lines (re-run with `--budget 97`)
 
 static_methods:
-  … 6 more lines (re-run with a higher --budget)
+  … 6 more lines (re-run with `--budget 97`)
 
 references (0):

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_string.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_describe_builtin_string.snap
@@ -33,9 +33,9 @@ methods:
   function starts_with(self, prefix: string) -> bool  <builtin>/baml/string.baml:135-137
   /// Returns true if the string ends with `suffix`.
   function ends_with(self, suffix: string) -> bool  <builtin>/baml/string.baml:140-142
-  … 60 more lines (re-run with `--budget 97`)
+  … 60 more lines (re-run with a higher `--budget` to see more; use `--budget 97` for full output)
 
 static_methods:
-  … 6 more lines (re-run with `--budget 97`)
+  … 6 more lines (re-run with a higher `--budget` to see more; use `--budget 97` for full output)
 
 references (0):


### PR DESCRIPTION
## Summary

- compute the minimum budget that renders a complete describe result
- report the same exact budget from body and section truncation hints
- share budget costs between planning and rendering to keep accounting consistent

## Testing

- cargo test -p baml_cli --lib
- cargo clippy -p baml_cli --all-targets -- -D warnings
- cargo fmt --all --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `baml describe` symbol-description truncation by enforcing a more accurate cost-based rendering budget.
  * Updated truncation/ellipsis messaging to report the minimum required budget to show complete output.
  * Refined budget handling across methods, dependencies, and references for more consistent results.

* **Tests**
  * Added/expanded tests validating budget-hint parsing and minimum-required budget calculations.
  * Updated expected outputs to match the new budget-hint format and values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->