### PR TITLE
fix(playground): teach baml_project::Position to handle emojis (utf8->utf16 translation)

### DIFF
--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -1877,6 +1877,39 @@ function Workflow(input: string) -> string {
     }
 
     #[test]
+    fn graph_source_spans_use_vscode_utf16_columns() {
+        use baml_compiler2_visualization::control_flow::NodeType;
+
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(std::path::Path::new("/tmp"));
+        let src = r#"function Workflow() -> string { let rocket = "🚀"; Summarize(rocket) }"#;
+        db.add_or_update_file(std::path::Path::new("/tmp/workflow.baml"), src);
+
+        let graph = db.ast_control_flow_graph("Workflow").unwrap();
+        let call_span = graph
+            .nodes
+            .values()
+            .find(|node| {
+                matches!(node.node_type, NodeType::OtherScope) && node.label == "Summarize(rocket)"
+            })
+            .and_then(|node| node.source_span.as_ref())
+            .expect("call graph node should have a source span");
+
+        let byte_start = src.find("Summarize(rocket)").unwrap();
+        let byte_end = byte_start + "Summarize(rocket)".len();
+        assert_eq!(call_span.start_offset, u32::try_from(byte_start).unwrap());
+        assert_eq!(call_span.end_offset, u32::try_from(byte_end).unwrap());
+        assert_eq!(
+            call_span.column,
+            u32::try_from(src[..byte_start].encode_utf16().count()).unwrap()
+        );
+        assert_eq!(
+            call_span.end_column,
+            u32::try_from(src[..byte_end].encode_utf16().count()).unwrap()
+        );
+    }
+
+    #[test]
     #[allow(clippy::cast_possible_truncation)] // tiny test fixtures fit in u32
     fn cursor_in_header_region_selects_governing_header() {
         use baml_compiler2_visualization::control_flow::{NodeType, STMT_SOURCE_EXPR_TAG};

--- a/baml_language/crates/baml_project/src/position.rs
+++ b/baml_language/crates/baml_project/src/position.rs
@@ -8,9 +8,10 @@ use lsp_types::{Position, Range};
 
 /// A line index for efficient offset-to-position conversion.
 ///
-/// This is a simple implementation that stores line start offsets.
-/// For a file with N lines, we store N+1 offsets (including the end).
-pub struct LineIndex {
+/// This stores each line's UTF-8 byte start and converts columns to and from
+/// the UTF-16 code units used by VS Code and the playground protocol.
+pub struct LineIndex<'a> {
+    text: &'a str,
     /// Byte offsets of line starts. `line_starts[0]` is always 0.
     /// `line_starts[i]` is the byte offset of the start of line `i`.
     line_starts: Vec<u32>,
@@ -18,29 +19,44 @@ pub struct LineIndex {
     len: u32,
 }
 
-impl LineIndex {
+impl<'a> LineIndex<'a> {
     /// Create a new line index from source text.
-    pub fn new(text: &str) -> Self {
+    pub fn new(text: &'a str) -> Self {
         let mut line_starts = vec![0];
-
-        for (offset, c) in text.char_indices() {
-            if c == '\n' {
-                // The next line starts after the newline character
-                line_starts.push(to_u32_saturating(offset + 1));
+        let bytes = text.as_bytes();
+        let mut offset = 0;
+        while offset < bytes.len() {
+            match bytes[offset] {
+                b'\n' => {
+                    offset += 1;
+                    line_starts.push(to_u32_saturating(offset));
+                }
+                b'\r' => {
+                    offset += if bytes.get(offset + 1) == Some(&b'\n') {
+                        2
+                    } else {
+                        1
+                    };
+                    line_starts.push(to_u32_saturating(offset));
+                }
+                _ => offset += 1,
             }
         }
 
         Self {
+            text,
             line_starts,
             len: to_u32_saturating(text.len()),
         }
     }
 
-    /// Convert a byte offset to an LSP position (0-indexed line and column).
+    /// Convert a UTF-8 byte offset to an LSP position with a UTF-16 column.
     ///
-    /// Returns `None` if the offset is out of bounds.
+    /// VS Code and the playground wire use UTF-16 code units for columns.
+    /// Returns `None` if the offset is out of bounds or inside a UTF-8 code point.
     pub fn offset_to_position(&self, offset: u32) -> Option<Position> {
-        if offset > self.len {
+        let offset_usize = offset as usize;
+        if offset > self.len || !self.text.is_char_boundary(offset_usize) {
             return None;
         }
 
@@ -50,8 +66,11 @@ impl LineIndex {
             Err(line) => line.saturating_sub(1), // Between lines - use previous line
         };
 
-        let line_start = self.line_starts[line];
-        let column = offset - line_start;
+        let line_start = self.line_starts[line] as usize;
+        let content_end = self.line_content_end(line);
+        let clamped_offset = offset_usize.min(content_end);
+        let column =
+            to_u32_saturating(self.text[line_start..clamped_offset].encode_utf16().count());
 
         Some(Position {
             line: to_u32_saturating(line),
@@ -59,9 +78,10 @@ impl LineIndex {
         })
     }
 
-    /// Convert an LSP position to a byte offset.
+    /// Convert an LSP position with a UTF-16 column to a UTF-8 byte offset.
     ///
-    /// Returns `None` if the position is out of bounds.
+    /// Returns `None` if the line is out of bounds or the column falls inside
+    /// a surrogate pair. Columns beyond the line clamp to its content end.
     pub fn position_to_offset(&self, pos: &Position) -> Option<u32> {
         let line = pos.line as usize;
 
@@ -69,20 +89,39 @@ impl LineIndex {
             return None;
         }
 
-        let line_start = self.line_starts[line];
-        let offset = line_start + pos.character;
-
-        if offset > self.len {
-            // Clamp to end of file
-            Some(self.len)
-        } else {
-            Some(offset)
+        let line_start = self.line_starts[line] as usize;
+        let content_end = self.line_content_end(line);
+        let line_text = &self.text[line_start..content_end];
+        let mut utf16_column = 0;
+        for (byte_column, ch) in line_text.char_indices() {
+            if utf16_column == pos.character {
+                return Some(to_u32_saturating(line_start + byte_column));
+            }
+            let next_column = utf16_column
+                + u32::try_from(ch.len_utf16()).expect("a char uses at most two UTF-16 code units");
+            if next_column > pos.character {
+                return None;
+            }
+            utf16_column = next_column;
         }
+        Some(to_u32_saturating(content_end))
     }
 
     /// Get the number of lines in the file.
     pub fn line_count(&self) -> usize {
         self.line_starts.len()
+    }
+
+    fn line_content_end(&self, line: usize) -> usize {
+        let start = self.line_starts[line] as usize;
+        let mut end = self.line_starts.get(line + 1).copied().unwrap_or(self.len) as usize;
+        if end > start && self.text.as_bytes()[end - 1] == b'\n' {
+            end -= 1;
+        }
+        if end > start && self.text.as_bytes()[end - 1] == b'\r' {
+            end -= 1;
+        }
+        end
     }
 }
 
@@ -254,6 +293,49 @@ mod tests {
                 character: 5
             }),
             Some(11)
+        );
+    }
+
+    #[test]
+    fn test_line_index_uses_utf16_columns() {
+        let text = "a🚀é\r\nnext";
+        let index = LineIndex::new(text);
+
+        assert_eq!(
+            index.offset_to_position(5),
+            Some(Position {
+                line: 0,
+                character: 3
+            })
+        );
+        assert_eq!(
+            index.offset_to_position(7),
+            Some(Position {
+                line: 0,
+                character: 4
+            })
+        );
+        assert_eq!(
+            index.position_to_offset(&Position {
+                line: 0,
+                character: 3,
+            }),
+            Some(5)
+        );
+        assert_eq!(
+            index.position_to_offset(&Position {
+                line: 0,
+                character: 2,
+            }),
+            None,
+            "a UTF-16 column inside the emoji surrogate pair is invalid"
+        );
+        assert_eq!(
+            index.offset_to_position(9),
+            Some(Position {
+                line: 1,
+                character: 0
+            })
         );
     }
 


### PR DESCRIPTION
## Summary

- emit graph source span columns in the UTF-16 code units expected by VS Code and the playground protocol
- retain UTF-8 byte offsets for compiler-side cursor and span matching
- handle LF, CRLF, bare CR, non-ASCII code points, and invalid surrogate-pair positions
- add graph-level and line-index regression coverage

## Root cause

The compiler stores graph spans as UTF-8 byte offsets, and the outgoing span conversion reused those byte deltas as line columns. VS Code interprets columns as UTF-16 code units, so non-ASCII source text shifted graph node selections by the difference between its UTF-8 and UTF-16 widths.

## Validation

- `cargo test -p baml_project --lib` (79 passed, 2 ignored)
- `cargo fmt --all -- --check`
- `cargo clippy -p baml_project --all-targets -- -D warnings`

Linear: B-807

## Before / after

**Before — base `d0dbf79`:** Clicking the `Summarize(rocket)` graph node starts the editor selection two UTF-16 columns late, selecting `mmarize(rocket) }`.

![Before: graph node selection is shifted after an emoji](https://gist.githubusercontent.com/sxlijin/550d60d318b79423271403a3da5b6ee2/raw/0a2169ca81cd2d0ae541cc20ec9ced3f69b695fe/B-807-before.png)

**After — PR head `a9d5f2b`:** The same graph-node click selects exactly `Summarize(rocket)`.

![After: graph node selection exactly matches the call](https://gist.githubusercontent.com/sxlijin/550d60d318b79423271403a3da5b6ee2/raw/aa3c0f363a3ad697147775703f124b5df7a485a1/B-807-after.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor position handling for emoji and other multi-byte characters.
  * Corrected UTF-16 column calculations for language-server features.
  * Improved support for Windows-style line endings.
  * Added validation for invalid or out-of-range text positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
