### PR TITLE
Fix detached tests in the playground

### DIFF
--- a/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
+++ b/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
@@ -229,6 +229,9 @@ describe('ExecutionPanel test previews', () => {
       });
     });
 
+    expect(
+      await screen.findByRole('button', { name: 'ClassifySentiment (1)' }),
+    ).toBeInTheDocument();
     fireEvent.click(
       await screen.findByTitle(
         'Use HappySentiment args for ClassifySentiment',

--- a/typescript2/pkg-playground/src/FunctionSidebar.test.ts
+++ b/typescript2/pkg-playground/src/FunctionSidebar.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   buildFunctionSidebarTree,
+  buildPreviewTestGroups,
   type FunctionSidebarFolderNode,
   type FunctionSidebarTreeNode,
 } from './function-sidebar-tree';
@@ -66,12 +67,42 @@ describe('function sidebar tree', () => {
   });
 });
 
+describe('preview test groups', () => {
+  it('keeps each detached legacy test attached to its target function', () => {
+    const groups = buildPreviewTestGroups([
+      testInfo('HappyPath', 'ClassifySentiment'),
+      testInfo('SharedCase', 'ClassifySentiment'),
+      testInfo('SharedCase', 'ExtractResume'),
+    ]);
+
+    expect(
+      groups.map((group) => ({
+        functionName: group.functionName,
+        tests: group.tests.map((test) => test.name),
+      })),
+    ).toEqual([
+      {
+        functionName: 'ClassifySentiment',
+        tests: ['HappyPath', 'SharedCase'],
+      },
+      {
+        functionName: 'ExtractResume',
+        tests: ['SharedCase'],
+      },
+    ]);
+  });
+});
+
 function functionInfo(name: string): FunctionInfo {
   return {
     name,
     kind: 'expr',
     origin: 'userDefined',
   };
+}
+
+function testInfo(name: string, functionName: string) {
+  return { name, functionName, argsJson: '{}' };
 }
 
 function folder(

--- a/typescript2/pkg-playground/src/FunctionSidebar.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.tsx
@@ -21,7 +21,9 @@ import {
 } from 'lucide-react';
 import {
   buildFunctionSidebarTree,
+  buildPreviewTestGroups,
   type FunctionSidebarTreeNode,
+  type PreviewTestGroup,
 } from './function-sidebar-tree';
 import type {
   SerializedTestDef,
@@ -46,6 +48,72 @@ interface TestTreeNodeProps {
   testRunResults?: Map<string, unknown>;
   failedExpands?: Set<string>;
   onRetryExpand?: (name: string) => void;
+}
+
+interface PreviewTestGroupNodeProps {
+  group: PreviewTestGroup;
+  selectedPreviewTestKey?: string | null;
+  onSelectPreviewTest?: (test: TestInfo) => void;
+}
+
+function PreviewTestGroupNode({
+  group,
+  selectedPreviewTestKey,
+  onSelectPreviewTest,
+}: PreviewTestGroupNodeProps) {
+  const [expanded, setExpanded] = useState(true);
+  return (
+    <Collapsible open={expanded} onOpenChange={setExpanded}>
+      <CollapsibleTrigger
+        className="flex items-center gap-1 w-full pr-2 py-0.5 cursor-pointer text-[10px] font-vsc-mono text-vsc-text-muted hover:bg-vsc-hover"
+        style={{ paddingLeft: 8 }}
+        title={group.functionName}
+      >
+        <ChevronRight
+          className={cn(
+            'h-3 w-3 text-vsc-text-faint transition-transform',
+            expanded && 'rotate-90',
+          )}
+        />
+        <FunctionSquare className="h-3.5 w-3.5 shrink-0 text-vsc-text-faint" />
+        <span className="truncate text-[11px] font-medium">
+          {group.functionName}
+        </span>
+        <span className="text-vsc-text-faint ml-1">
+          ({group.tests.length})
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        {group.tests.map((test) => {
+          const key = previewTestKey(test);
+          return (
+            <button
+              type="button"
+              key={key}
+              className={cn(
+                'flex items-center gap-1.5 w-full pr-2 py-0.5 text-[10px] font-vsc-mono text-left',
+                selectedPreviewTestKey === key
+                  ? 'bg-vsc-accent/15 text-vsc-text font-semibold'
+                  : 'text-vsc-text-muted hover:bg-vsc-hover',
+              )}
+              style={{ paddingLeft: 32 }}
+              onClick={() => onSelectPreviewTest?.(test)}
+              title={`Use ${test.name} args for ${test.functionName}`}
+            >
+              <FlaskConical
+                size={12}
+                className="text-vsc-text-faint shrink-0"
+              />
+              <span className="truncate text-[11px]">{test.name}</span>
+              <span className="ml-auto text-[9px] text-vsc-text-faint shrink-0">
+                preview
+              </span>
+            </button>
+          );
+        })}
+      </CollapsibleContent>
+    </Collapsible>
+  );
 }
 
 function TestTreeNode({
@@ -384,13 +452,10 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
   };
 
   const treeItems = testTree ?? [];
-  const previewNameCounts = useMemo(() => {
-    const counts = new Map<string, number>();
-    for (const test of previewTests) {
-      counts.set(test.name, (counts.get(test.name) ?? 0) + 1);
-    }
-    return counts;
-  }, [previewTests]);
+  const previewTestGroups = useMemo(
+    () => buildPreviewTestGroups(previewTests),
+    [previewTests],
+  );
   let emptyFunctionMessage = 'No matches';
   if (isLoadingProject) {
     emptyFunctionMessage = 'Loading project...';
@@ -515,34 +580,14 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
                 </div>
               )}
 
-              {previewTests.map((test) => {
-                const key = previewTestKey(test);
-                const duplicateName = (previewNameCounts.get(test.name) ?? 0) > 1;
-                return (
-                  <button
-                    type="button"
-                    key={key}
-                    className={cn(
-                      'flex items-center gap-1.5 w-full pr-2 py-0.5 text-[10px] font-vsc-mono text-left',
-                      selectedPreviewTestKey === key
-                        ? 'bg-vsc-accent/15 text-vsc-text font-semibold'
-                        : 'text-vsc-text-muted hover:bg-vsc-hover',
-                    )}
-                    style={{ paddingLeft: 8 }}
-                    onClick={() => onSelectPreviewTest?.(test)}
-                    title={`Use ${test.name} args for ${test.functionName}`}
-                  >
-                    <FlaskConical size={12} className="text-vsc-text-faint shrink-0" />
-                    <span className="truncate text-[11px]">
-                      {test.name}
-                      {duplicateName ? ` → ${test.functionName}` : ''}
-                    </span>
-                    <span className="ml-auto text-[9px] text-vsc-text-faint shrink-0">
-                      preview
-                    </span>
-                  </button>
-                );
-              })}
+              {previewTestGroups.map((group) => (
+                <PreviewTestGroupNode
+                  key={group.functionName}
+                  group={group}
+                  selectedPreviewTestKey={selectedPreviewTestKey}
+                  onSelectPreviewTest={onSelectPreviewTest}
+                />
+              ))}
 
               {treeItems.map((def, i) => (
                 <TestTreeNode

--- a/typescript2/pkg-playground/src/function-sidebar-tree.ts
+++ b/typescript2/pkg-playground/src/function-sidebar-tree.ts
@@ -1,4 +1,4 @@
-import type { FunctionInfo } from './worker-protocol';
+import type { FunctionInfo, TestInfo } from './worker-protocol';
 
 export type FunctionSidebarFunctionNode = {
   type: 'function';
@@ -25,6 +25,11 @@ export type FunctionSidebarTree = {
   nodes: FunctionSidebarTreeNode[];
   functionCount: number;
   forcedOpenFolderKeys: Set<string>;
+};
+
+export type PreviewTestGroup = {
+  functionName: string;
+  tests: TestInfo[];
 };
 
 type MutableFolderNode = Omit<FunctionSidebarFolderNode, 'children'> & {
@@ -95,6 +100,25 @@ export function buildFunctionSidebarTree(
     functionCount,
     forcedOpenFolderKeys,
   };
+}
+
+export function buildPreviewTestGroups(
+  tests: readonly TestInfo[],
+): PreviewTestGroup[] {
+  const groups: PreviewTestGroup[] = [];
+  const groupsByFunction = new Map<string, PreviewTestGroup>();
+
+  for (const test of tests) {
+    let group = groupsByFunction.get(test.functionName);
+    if (!group) {
+      group = { functionName: test.functionName, tests: [] };
+      groupsByFunction.set(test.functionName, group);
+      groups.push(group);
+    }
+    group.tests.push(test);
+  }
+
+  return groups;
 }
 
 function createFolder(name: string, path: string[]): MutableFolderNode {


### PR DESCRIPTION
## Summary

- group legacy playground preview tests under their target functions instead of rendering a detached flat list
- keep shared legacy tests visible under every function they target
- preserve preview selection and argument hydration behavior

## Root cause

Legacy test metadata included the target function, but `FunctionSidebar` only used that relationship to disambiguate duplicate test names. A normal uniquely named test rendered as a top-level row with no visible connection to its function.

## User impact

The Tests section now shows an expanded, collapsible function group for each set of legacy preview tests, making the target relationship visible and keeping the test cases easy to select.

## Validation

- `pnpm test` in `typescript2/pkg-playground` (126 tests)
- `pnpm test:unit:run` in `typescript2/app-vscode-webview` (21 tests)
- `pnpm typecheck` in `typescript2/pkg-playground`
- `pnpm typecheck` in `typescript2/app-vscode-webview`
- `pnpm build:wasm` in `typescript2`

Linear: [B-809](https://linear.app/boundaryml2/issue/B-809/detached-tests-in-playground)


## Before / after

Before — preview tests were rendered as detached, flat rows, so their target function was unclear.

<img width="720" height="520" alt="Before: preview tests displayed as detached flat rows in the playground sidebar" src="https://github.com/user-attachments/assets/53a4cb4a-0a4f-487a-be98-99c386244255" />

After — preview tests are grouped beneath expanded function rows, making each target relationship explicit.

<img width="720" height="520" alt="After: preview tests grouped beneath their target functions in the playground sidebar" src="https://github.com/user-attachments/assets/b0791ef9-888f-4758-958e-5cd52e5a2c01" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Preview tests are now organized into collapsible groups by function.
  * Easily expand a function to view its associated preview tests.
  * The currently selected preview test is clearly highlighted.

* **Bug Fixes**
  * Improved preview test association when multiple tests belong to the same function.

* **Tests**
  * Added coverage for preview test grouping and function selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
