### PR TITLE
fix(playground): stabilize graph layout during value hydration

### DIFF
--- a/typescript2/pkg-playground/src/CapturedValueCard.tsx
+++ b/typescript2/pkg-playground/src/CapturedValueCard.tsx
@@ -13,6 +13,7 @@ export const CAPTURED_VALUE_CARD_TILE_IMAGE_HEIGHT = 126;
 export const CAPTURED_VALUE_CARD_TEXT_HEIGHT = 96;
 export const CAPTURED_VALUE_CARD_HEADER_HEIGHT = 21;
 export const CAPTURED_VALUE_CARD_PADDING_Y = 16;
+export const CAPTURED_VALUE_CARD_DIAGNOSTIC_HEIGHT = 20;
 export const CAPTURED_VALUE_CARD_FIXED_HEIGHT =
   CAPTURED_VALUE_CARD_HEADER_HEIGHT +
   CAPTURED_VALUE_CARD_PADDING_Y +
@@ -57,10 +58,13 @@ export function CapturedValueCard({
   const images = valueToImagePreviews(value.value);
   const visibleImages = images.slice(0, CAPTURED_VALUE_CARD_MAX_IMAGES);
   const remainingImages = images.length - visibleImages.length;
+  const fixedContentHeight =
+    CAPTURED_VALUE_CARD_TEXT_HEIGHT -
+    (value.diagnostic ? CAPTURED_VALUE_CARD_DIAGNOSTIC_HEIGHT : 0);
   const fixedImageHeight =
     visibleImages.length <= 2
-      ? CAPTURED_VALUE_CARD_TEXT_HEIGHT
-      : (CAPTURED_VALUE_CARD_TEXT_HEIGHT - CAPTURED_VALUE_CARD_IMAGE_GAP) / 2;
+      ? fixedContentHeight
+      : (fixedContentHeight - CAPTURED_VALUE_CARD_IMAGE_GAP) / 2;
   const stateLabel =
     value.state === 'available' ? null : STATE_LABELS[value.state];
   const roleColor = ROLE_COLORS[value.role];
@@ -222,7 +226,11 @@ export function CapturedValueCard({
         <div
           style={{
             marginTop: 6,
-            maxHeight: compact ? CAPTURED_VALUE_CARD_TEXT_HEIGHT : 180,
+            maxHeight: fixedHeight
+              ? fixedContentHeight
+              : compact
+                ? CAPTURED_VALUE_CARD_TEXT_HEIGHT
+                : 180,
             overflow: 'auto',
             color: isError ? '#fecdd3' : '#e5e7eb',
             fontSize: 10,
@@ -242,6 +250,14 @@ export function CapturedValueCard({
             color: '#a1a1aa',
             fontSize: 10,
             lineHeight: 1.35,
+            ...(fixedHeight
+              ? {
+                  height: CAPTURED_VALUE_CARD_DIAGNOSTIC_HEIGHT,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }
+              : {}),
           }}
         >
           {value.diagnostic}

--- a/typescript2/pkg-playground/src/CapturedValueCard.tsx
+++ b/typescript2/pkg-playground/src/CapturedValueCard.tsx
@@ -14,6 +14,7 @@ export const CAPTURED_VALUE_CARD_TEXT_HEIGHT = 96;
 export const CAPTURED_VALUE_CARD_HEADER_HEIGHT = 21;
 export const CAPTURED_VALUE_CARD_PADDING_Y = 16;
 export const CAPTURED_VALUE_CARD_DIAGNOSTIC_HEIGHT = 20;
+export const CAPTURED_VALUE_CARD_DIAGNOSTIC_GAP = 5;
 export const CAPTURED_VALUE_CARD_FIXED_HEIGHT =
   CAPTURED_VALUE_CARD_HEADER_HEIGHT +
   CAPTURED_VALUE_CARD_PADDING_Y +
@@ -60,7 +61,10 @@ export function CapturedValueCard({
   const remainingImages = images.length - visibleImages.length;
   const fixedContentHeight =
     CAPTURED_VALUE_CARD_TEXT_HEIGHT -
-    (value.diagnostic ? CAPTURED_VALUE_CARD_DIAGNOSTIC_HEIGHT : 0);
+    (value.diagnostic
+      ? CAPTURED_VALUE_CARD_DIAGNOSTIC_HEIGHT +
+        CAPTURED_VALUE_CARD_DIAGNOSTIC_GAP
+      : 0);
   const fixedImageHeight =
     visibleImages.length <= 2
       ? fixedContentHeight
@@ -246,7 +250,7 @@ export function CapturedValueCard({
       {value.diagnostic ? (
         <div
           style={{
-            marginTop: 5,
+            marginTop: CAPTURED_VALUE_CARD_DIAGNOSTIC_GAP,
             color: '#a1a1aa',
             fontSize: 10,
             lineHeight: 1.35,

--- a/typescript2/pkg-playground/src/CapturedValueCard.tsx
+++ b/typescript2/pkg-playground/src/CapturedValueCard.tsx
@@ -13,6 +13,10 @@ export const CAPTURED_VALUE_CARD_TILE_IMAGE_HEIGHT = 126;
 export const CAPTURED_VALUE_CARD_TEXT_HEIGHT = 96;
 export const CAPTURED_VALUE_CARD_HEADER_HEIGHT = 21;
 export const CAPTURED_VALUE_CARD_PADDING_Y = 16;
+export const CAPTURED_VALUE_CARD_FIXED_HEIGHT =
+  CAPTURED_VALUE_CARD_HEADER_HEIGHT +
+  CAPTURED_VALUE_CARD_PADDING_Y +
+  CAPTURED_VALUE_CARD_TEXT_HEIGHT;
 
 const ROLE_LABELS: Record<RunTraceCallValue['role'], string> = {
   callInput: 'Input',
@@ -40,33 +44,25 @@ const STATE_LABELS: Partial<Record<RunTraceCallValue['state'], string>> = {
 interface CapturedValueCardProps {
   value: RunTraceCallValue;
   compact?: boolean;
+  fixedHeight?: boolean;
   customRenderers?: Record<string, FC<ResultRendererProps>>;
-}
-
-export function capturedValueCardContentHeight(value: RunTraceCallValue): number {
-  const images = valueToImagePreviews(value.value);
-  if (images.length > 0) {
-    const visibleCount = Math.min(images.length, CAPTURED_VALUE_CARD_MAX_IMAGES);
-    if (visibleCount === 1) return CAPTURED_VALUE_CARD_SINGLE_IMAGE_HEIGHT;
-    const rows = Math.ceil(visibleCount / 2);
-    return (
-      rows * CAPTURED_VALUE_CARD_TILE_IMAGE_HEIGHT +
-      (rows - 1) * CAPTURED_VALUE_CARD_IMAGE_GAP
-    );
-  }
-  if (value.value !== null) return CAPTURED_VALUE_CARD_TEXT_HEIGHT;
-  return 0;
 }
 
 export function CapturedValueCard({
   value,
   compact = false,
+  fixedHeight = false,
   customRenderers,
 }: CapturedValueCardProps) {
   const images = valueToImagePreviews(value.value);
   const visibleImages = images.slice(0, CAPTURED_VALUE_CARD_MAX_IMAGES);
   const remainingImages = images.length - visibleImages.length;
-  const stateLabel = value.state === 'available' ? null : STATE_LABELS[value.state];
+  const fixedImageHeight =
+    visibleImages.length <= 2
+      ? CAPTURED_VALUE_CARD_TEXT_HEIGHT
+      : (CAPTURED_VALUE_CARD_TEXT_HEIGHT - CAPTURED_VALUE_CARD_IMAGE_GAP) / 2;
+  const stateLabel =
+    value.state === 'available' ? null : STATE_LABELS[value.state];
   const roleColor = ROLE_COLORS[value.role];
   const isError = value.role === 'callError' || value.state === 'error';
 
@@ -80,6 +76,8 @@ export function CapturedValueCard({
         }`,
         background: isError ? 'rgba(64,21,30,0.72)' : 'rgba(15,23,42,0.72)',
         padding: compact ? 7 : 8,
+        boxSizing: 'border-box',
+        height: fixedHeight ? CAPTURED_VALUE_CARD_FIXED_HEIGHT : undefined,
         overflow: 'hidden',
       }}
       title={value.diagnostic ?? undefined}
@@ -146,9 +144,7 @@ export function CapturedValueCard({
           style={{
             display: 'grid',
             gridTemplateColumns:
-              visibleImages.length === 1
-                ? '1fr'
-                : 'repeat(2, minmax(0, 1fr))',
+              visibleImages.length === 1 ? '1fr' : 'repeat(2, minmax(0, 1fr))',
             gap: CAPTURED_VALUE_CARD_IMAGE_GAP,
             marginTop: 6,
           }}
@@ -163,8 +159,9 @@ export function CapturedValueCard({
                 style={{
                   position: 'relative',
                   width: '100%',
-                  height:
-                    visibleImages.length === 1
+                  height: fixedHeight
+                    ? fixedImageHeight
+                    : visibleImages.length === 1
                       ? CAPTURED_VALUE_CARD_SINGLE_IMAGE_HEIGHT
                       : CAPTURED_VALUE_CARD_TILE_IMAGE_HEIGHT,
                   borderRadius: 6,

--- a/typescript2/pkg-playground/src/graph/layout.test.ts
+++ b/typescript2/pkg-playground/src/graph/layout.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import type { GraphNodeValuePreview } from '../run-store-projections';
+import { layoutGraph } from './layout';
+import type { WorkflowNode } from './types';
+
+describe('graph value preview layout', () => {
+  it.each([
+    ['text', 'hydrated output'],
+    [
+      'image',
+      {
+        $baml: { type: '$media' },
+        media_type: 'image',
+        content_type: 'url',
+        url: 'https://example.com/output.png',
+      },
+    ],
+  ])(
+    'keeps node geometry stable while a captured %s body hydrates',
+    async (_kind, hydratedValue) => {
+      const pending = await layoutGraph(
+        [nodeWithPreview(valuePreview(null, 'loading'))],
+        [],
+      );
+      const hydrated = await layoutGraph(
+        [nodeWithPreview(valuePreview(hydratedValue, 'available'))],
+        [],
+      );
+
+      expect(hydrated.nodes[0]?.style?.width).toBe(
+        pending.nodes[0]?.style?.width,
+      );
+      expect(hydrated.nodes[0]?.style?.height).toBe(
+        pending.nodes[0]?.style?.height,
+      );
+    },
+  );
+});
+
+function nodeWithPreview(value: GraphNodeValuePreview): WorkflowNode {
+  return {
+    id: 'node',
+    type: 'base',
+    position: { x: 0, y: 0 },
+    data: {
+      label: 'node',
+      graphNodeType: 'function',
+      executionState: 'running',
+      selected: false,
+      logFilterKey: 'node',
+      valuePreviews: [value],
+    },
+  };
+}
+
+function valuePreview(
+  value: GraphNodeValuePreview['value'],
+  state: GraphNodeValuePreview['state'],
+): GraphNodeValuePreview {
+  return {
+    id: 'value',
+    timestampMs: 0,
+    role: 'callOutput',
+    label: 'output',
+    valueRef: null,
+    value,
+    state,
+    diagnostic: null,
+  };
+}

--- a/typescript2/pkg-playground/src/graph/layout.ts
+++ b/typescript2/pkg-playground/src/graph/layout.ts
@@ -1,11 +1,6 @@
 import ELK from 'elkjs/lib/elk.bundled.js';
 import type { ElkNode, ElkExtendedEdge } from 'elkjs/lib/elk-api';
-import {
-  capturedValueCardContentHeight,
-  CAPTURED_VALUE_CARD_HEADER_HEIGHT,
-  CAPTURED_VALUE_CARD_PADDING_Y,
-  CAPTURED_VALUE_CARD_TEXT_HEIGHT,
-} from '../CapturedValueCard';
+import { CAPTURED_VALUE_CARD_FIXED_HEIGHT } from '../CapturedValueCard';
 import { depthScale } from './lod';
 import type { WorkflowNode, WorkflowEdge } from './types';
 import {
@@ -85,10 +80,7 @@ function nodeSize(node: WorkflowNode): { w: number; h: number } {
         NODE_VALUE_PREVIEW_MAX,
       );
       const previewHeight =
-        visibleValues.reduce(
-          (height, value) => height + capturedValueCardHeight(value),
-          0,
-        ) +
+        visibleValues.length * CAPTURED_VALUE_CARD_FIXED_HEIGHT +
         Math.max(0, visibleValues.length - 1) * NODE_VALUE_PREVIEW_GAP;
       return {
         w: Math.max(base.w, NODE_VALUE_PREVIEW_WIDTH),
@@ -99,17 +91,14 @@ function nodeSize(node: WorkflowNode): { w: number; h: number } {
     if (node.data.errorMessage) {
       return {
         w: Math.max(base.w, NODE_VALUE_PREVIEW_WIDTH),
-        h: base.h + capturedValueCardHeightForContent(0, true) + 14,
+        h: base.h + CAPTURED_VALUE_CARD_FIXED_HEIGHT + 14,
       };
     }
 
     if (node.data.hasResult) {
       return {
         w: Math.max(base.w, NODE_VALUE_PREVIEW_WIDTH),
-        h:
-          base.h +
-          capturedValueCardHeightForContent(CAPTURED_VALUE_CARD_TEXT_HEIGHT, false) +
-          14,
+        h: base.h + CAPTURED_VALUE_CARD_FIXED_HEIGHT + 14,
       };
     }
 
@@ -128,28 +117,6 @@ function nodeSize(node: WorkflowNode): { w: number; h: number } {
     w: visualSize.w * s + 2 * NODE_BUFFER,
     h: visualSize.h * s + 2 * NODE_BUFFER,
   };
-}
-
-function capturedValueCardHeight(
-  value: NonNullable<WorkflowNode['data']['valuePreviews']>[number],
-): number {
-  return capturedValueCardHeightForContent(
-    capturedValueCardContentHeight(value),
-    value.diagnostic != null,
-  );
-}
-
-function capturedValueCardHeightForContent(
-  contentHeight: number,
-  hasDiagnostic: boolean,
-): number {
-  return (
-    CAPTURED_VALUE_CARD_HEADER_HEIGHT +
-    CAPTURED_VALUE_CARD_PADDING_Y +
-    contentHeight +
-    (contentHeight > 0 ? 6 : 0) +
-    (hasDiagnostic ? 18 : 0)
-  );
 }
 
 function buildElkNodes(
@@ -240,10 +207,13 @@ function buildElkNodes(
 }
 
 function graphValuePreviewHeight(node: WorkflowNode): number {
-  const values = (node.data.valuePreviews ?? []).slice(0, NODE_VALUE_PREVIEW_MAX);
+  const values = (node.data.valuePreviews ?? []).slice(
+    0,
+    NODE_VALUE_PREVIEW_MAX,
+  );
   if (values.length === 0) return 0;
   return (
-    values.reduce((height, value) => height + capturedValueCardHeight(value), 0) +
+    values.length * CAPTURED_VALUE_CARD_FIXED_HEIGHT +
     Math.max(0, values.length - 1) * NODE_VALUE_PREVIEW_GAP
   );
 }

--- a/typescript2/pkg-playground/src/graph/nodes/NodeOutputPreview.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/NodeOutputPreview.tsx
@@ -26,7 +26,12 @@ export function NodeOutputPreview({
   errorMessage,
   customRenderers,
 }: NodeOutputPreviewProps) {
-  const values = graphPreviewValues(valuePreviews, result, hasResult, errorMessage);
+  const values = graphPreviewValues(
+    valuePreviews,
+    result,
+    hasResult,
+    errorMessage,
+  );
   if (values.length === 0) return null;
 
   const visible = values.slice(0, NODE_VALUE_PREVIEW_MAX);
@@ -49,6 +54,7 @@ export function NodeOutputPreview({
           key={value.id}
           value={value}
           compact
+          fixedHeight
           customRenderers={customRenderers}
         />
       ))}


### PR DESCRIPTION
## Summary

- reserve fixed-height slots for captured values rendered inside playground graph nodes
- clamp hydrated image previews into the reserved card body while leaving non-graph cards unchanged
- add regression coverage proving pending, text, and image payloads produce identical ELK node geometry

## Root cause

Graph node sizing depended on the captured value body. A pending value had no content height, while hydrated text added 96px and an image could add 240px or more. Every value-body cache update retriggered ELK, so lazy hydration moved nodes even though the set of value slots had not changed.

## Verification

- Before the fix, the regression measured one node growing from 113px pending to 215px for text and 359px for an image.
- `pnpm --filter @b/pkg-playground test` — 127 tests passed
- `pnpm --filter @b/pkg-playground typecheck`
- `pnpm --filter app-vscode-webview test:unit:run` — 21 tests passed
- `pnpm --filter app-vscode-webview typecheck`
- `pnpm --filter app-vscode-webview build`
- `pnpm build:wasm`

Linear: [B-750](https://linear.app/boundaryml2/issue/B-750/react-state-bugs-and-hydration)

## Before / after

**Before — exact PR base `02b7355a`:** the same playground graph node grows from 113px while its captured image is loading to 359px once hydration completes, forcing the graph to relayout.

<img width="1180" height="720" alt="Before: playground graph node grows from 113px to 359px when its captured image hydrates" src="https://github.com/user-attachments/assets/3c397679-c479-4e86-8bd3-6c7aa5103df6" />

**After — exact PR head `43cef971`:** the loading and hydrated states both reserve 209px of graph geometry, with the hydrated image clamped inside the fixed card body.

<img width="1180" height="720" alt="After: playground graph node remains 209px before and after captured image hydration" src="https://github.com/user-attachments/assets/89931b3f-e3fc-4454-ac5d-b33dfb759c37" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for fixed-height captured value cards, with consistent text/image sizing.
  - Fixed-height cards now apply consistent diagnostic spacing and truncation behavior.

- **Bug Fixes**
  - Improved graph value preview layout so node dimensions remain stable when preview data transitions from loading to hydrated.

- **Tests**
  - Added coverage to verify graph layout stability for loading vs. hydrated value previews.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
