### PR TITLE
Polish playground graph runtime context

### DIFF
--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -52,6 +52,7 @@ import {
   type ProjectUpdate,
   type TestInfo,
   type Run,
+  type RunTarget,
   type BoundaryId,
   type RunStatus,
   type SourceNavigationTarget,
@@ -123,6 +124,43 @@ const RUN_SHORTCUT_HINT = IS_MAC ? '⌘↵' : 'Ctrl+↵';
 
 // ---------------------------------------------------------------------------
 // Helpers
+
+function runTargetLabel(target: RunTarget): string {
+  switch (target.kind) {
+    case 'function':
+    case 'companion':
+      return `${target.functionName}()`;
+    case 'preview':
+      return `${target.parentFunctionName}() prompt preview`;
+    case 'test':
+      return `test ${target.testName}`;
+    case 'internal':
+      return target.name;
+    default:
+      target satisfies never;
+      return 'run';
+  }
+}
+
+function runTargetFunctionName(target: RunTarget): string | null {
+  switch (target.kind) {
+    case 'function':
+    case 'companion':
+      return target.functionName;
+    case 'preview':
+      return target.parentFunctionName;
+    case 'test':
+    case 'internal':
+      return null;
+    default:
+      target satisfies never;
+      return null;
+  }
+}
+
+function runStatusLabel(status: RunStatus): string {
+  return status.replace(/([A-Z])/g, ' $1').toLowerCase();
+}
 // ---------------------------------------------------------------------------
 
 function tryFormatJson(str: string): string {
@@ -2261,7 +2299,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
   const llmFunctionNames = new Set(
     functions.filter((f) => f.kind === 'llm').map((f) => f.name),
   );
-  const latestGraphRunSnapshot = useMemo(
+  const latestGraphRunSelection = useMemo(
     () =>
       findLatestGraphRunSnapshot(
         executionSnapshot.runs,
@@ -2270,6 +2308,14 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
       ),
     [executionSnapshot.runs, selectedFn, selectedProject],
   );
+  const latestGraphRunSnapshot = latestGraphRunSelection?.run;
+  // A run that merely contains this function has an overlay keyed to the
+  // target function's CFG today. Keep the trace/profile context available,
+  // but do not paint that overlay onto a different graph.
+  const graphRuntimeRunSnapshot =
+    latestGraphRunSelection?.match === 'target'
+      ? latestGraphRunSelection.run
+      : undefined;
   // The run-history/logs strip is lifted out of the sidebar+content row so it
   // spans the panel's full width; the row gets bottom padding to make room.
   const runLogsVisible =
@@ -2536,6 +2582,42 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
       ))}
     </div>
   );
+
+  const containingRunTarget =
+    latestGraphRunSelection?.match === 'viaCalls'
+      ? runTargetFunctionName(latestGraphRunSelection.run.target)
+      : null;
+  const graphRunContextBanner =
+    latestGraphRunSelection?.match === 'viaCalls' && selectedFn ? (
+      <div className="flex items-center gap-2 px-2.5 py-1.5 text-[10px] bg-vsc-accent/5 border-b border-vsc-border shrink-0">
+        <span className="min-w-0 truncate text-vsc-text-muted">
+          <span className="font-vsc-mono font-semibold text-vsc-text">
+            {selectedFn}()
+          </span>{' '}
+          last ran inside{' '}
+          <span className="font-vsc-mono font-semibold text-vsc-text">
+            {runTargetLabel(latestGraphRunSelection.run.target)}
+          </span>{' '}
+          <span className="text-vsc-text-faint">
+            · {runStatusLabel(latestGraphRunSelection.run.status)}
+          </span>
+        </span>
+        {containingRunTarget && functionNames.includes(containingRunTarget) ? (
+          <button
+            type="button"
+            className="ml-auto shrink-0 text-vsc-accent hover:underline font-medium"
+            onClick={() => {
+              setWorkflowContext(null);
+              setSelectedPreviewTestKey(null);
+              setSelectedFn(containingRunTarget);
+              setHighlightedNodeId(null);
+            }}
+          >
+            View that run →
+          </button>
+        ) : null}
+      </div>
+    ) : null;
 
   // ── Render ─────────────────────────────────────────────────────────────
 
@@ -3153,19 +3235,20 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                   style={{ minHeight: 300 }}
                 >
                   {workflowSwitcherBar}
+                  {graphRunContextBanner}
                   {controlFlowGraph ? (
                     <GraphView
                       graph={controlFlowGraph}
                       functionName={selectedFn}
                       graphRuntimeOverlay={
-                        latestGraphRunSnapshot?.graphRuntimeOverlay
+                        graphRuntimeRunSnapshot?.graphRuntimeOverlay
                       }
-                      calls={latestGraphRunSnapshot?.calls}
-                      run={latestGraphRunSnapshot ?? null}
+                      calls={graphRuntimeRunSnapshot?.calls}
+                      run={graphRuntimeRunSnapshot ?? null}
                       valueBodyCache={valueBodyCache}
                       valueBodyCacheVersion={valueBodyCacheVersion}
-                      runStatus={latestGraphRunSnapshot?.status}
-                      runError={latestGraphRunSnapshot?.error?.message ?? null}
+                      runStatus={graphRuntimeRunSnapshot?.status}
+                      runError={graphRuntimeRunSnapshot?.error?.message ?? null}
                       customRenderers={resultRenderers}
                       selectedNodeId={highlightedNodeId}
                       onNodeClick={handleGraphNodeClick}
@@ -3353,20 +3436,21 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                     style={{ minHeight: 180 }}
                   >
                     {workflowSwitcherBar}
+                    {graphRunContextBanner}
                     {controlFlowGraph ? (
                       <GraphView
                         graph={controlFlowGraph}
                         functionName={selectedFn}
                         graphRuntimeOverlay={
-                          latestGraphRunSnapshot?.graphRuntimeOverlay
+                          graphRuntimeRunSnapshot?.graphRuntimeOverlay
                         }
-                        calls={latestGraphRunSnapshot?.calls}
-                        run={latestGraphRunSnapshot ?? null}
+                        calls={graphRuntimeRunSnapshot?.calls}
+                        run={graphRuntimeRunSnapshot ?? null}
                         valueBodyCache={valueBodyCache}
                         valueBodyCacheVersion={valueBodyCacheVersion}
-                        runStatus={latestGraphRunSnapshot?.status}
+                        runStatus={graphRuntimeRunSnapshot?.status}
                         runError={
-                          latestGraphRunSnapshot?.error?.message ?? null
+                          graphRuntimeRunSnapshot?.error?.message ?? null
                         }
                         customRenderers={resultRenderers}
                         selectedNodeId={highlightedNodeId}

--- a/typescript2/pkg-playground/src/graph-run-selection.test.ts
+++ b/typescript2/pkg-playground/src/graph-run-selection.test.ts
@@ -25,9 +25,11 @@ describe('findLatestGraphRunSnapshot', () => {
     });
 
     expect(
-      findLatestGraphRunSnapshot([newest, oldest], 'throws.main', 'project')
-        ?.boundaryId,
-    ).toBe('newest');
+      findLatestGraphRunSnapshot([newest, oldest], 'throws.main', 'project'),
+    ).toMatchObject({
+      run: { boundaryId: 'newest' },
+      match: 'target',
+    });
   });
 
   it('does not depend on run array ordering', () => {
@@ -48,8 +50,11 @@ describe('findLatestGraphRunSnapshot', () => {
         [older, middleOtherProject, newer],
         'throws.main',
         'project',
-      )?.boundaryId,
-    ).toBe('newer');
+      ),
+    ).toMatchObject({
+      run: { boundaryId: 'newer' },
+      match: 'target',
+    });
   });
 
   it('can select a workflow run that contains the displayed function', () => {
@@ -62,8 +67,26 @@ describe('findLatestGraphRunSnapshot', () => {
     });
 
     expect(
-      findLatestGraphRunSnapshot([run], 'throws.main', 'project')?.boundaryId,
-    ).toBe('workflow');
+      findLatestGraphRunSnapshot([run], 'throws.main', 'project'),
+    ).toMatchObject({
+      run: { boundaryId: 'workflow' },
+      match: 'viaCalls',
+    });
+  });
+
+  it('prefers a newer containing workflow over an older direct run', () => {
+    const direct = runFixture('direct', 100);
+    const workflow = runFixture('workflow', 200, {
+      target: { kind: 'function', functionName: 'throws.workflow' },
+      calls: [callFixture('child', 'throws.main')],
+    });
+
+    expect(
+      findLatestGraphRunSnapshot([direct, workflow], 'throws.main', 'project'),
+    ).toMatchObject({
+      run: { boundaryId: 'workflow' },
+      match: 'viaCalls',
+    });
   });
 });
 

--- a/typescript2/pkg-playground/src/graph-run-selection.ts
+++ b/typescript2/pkg-playground/src/graph-run-selection.ts
@@ -1,44 +1,52 @@
 import type { Run } from './worker-protocol';
 
+export type GraphRunMatch = {
+  run: Run;
+  match: 'target' | 'viaCalls';
+};
+
 export function findLatestGraphRunSnapshot(
   runs: Run[],
   selectedFn: string | null,
   selectedProject: string | null,
-): Run | undefined {
+): GraphRunMatch | undefined {
   if (!selectedFn) return undefined;
 
-  let latest: Run | undefined;
+  let latest: GraphRunMatch | undefined;
   for (const run of runs) {
-    if (!isGraphRunCandidate(run, selectedFn, selectedProject)) continue;
-    if (!latest || compareRunRecency(run, latest) > 0) {
-      latest = run;
+    const match = graphRunMatch(run, selectedFn, selectedProject);
+    if (!match) continue;
+    if (!latest || compareRunRecency(run, latest.run) > 0) {
+      latest = { run, match };
     }
   }
 
   return latest;
 }
 
-function isGraphRunCandidate(
+function graphRunMatch(
   run: Run,
   selectedFn: string,
   selectedProject: string | null,
-): boolean {
-  if (selectedProject && run.request.projectId !== selectedProject) return false;
+): GraphRunMatch['match'] | null {
+  if (selectedProject && run.request.projectId !== selectedProject) return null;
 
   if (
     (run.target.kind === 'function' || run.target.kind === 'companion') &&
     run.target.functionName === selectedFn
   ) {
-    return true;
+    return 'target';
   }
   if (
     run.target.kind === 'preview' &&
     run.target.parentFunctionName === selectedFn
   ) {
-    return true;
+    return 'target';
   }
 
-  return run.calls.some((call) => call.functionName === selectedFn);
+  return run.calls.some((call) => call.functionName === selectedFn)
+    ? 'viaCalls'
+    : null;
 }
 
 function compareRunRecency(left: Run, right: Run): number {

--- a/typescript2/pkg-playground/src/graph/GraphView.tsx
+++ b/typescript2/pkg-playground/src/graph/GraphView.tsx
@@ -902,7 +902,9 @@ function GraphViewInner({
             }}
           >
             <div style={{ fontWeight: 700, marginBottom: 5 }}>
-              Some runtime calls could not be placed on this graph.
+              {graphRuntimeNotices.unattachedCount > 0
+                ? 'Some runtime calls could not be placed on this graph.'
+                : 'Graph runtime diagnostics.'}
             </div>
             {graphRuntimeNotices.diagnostics.length > 0 ? (
               <ul

--- a/typescript2/pkg-playground/src/graph/GraphView.tsx
+++ b/typescript2/pkg-playground/src/graph/GraphView.tsx
@@ -361,6 +361,26 @@ function GraphViewInner({
 
   const effectiveRunStatus = runStatus ?? run?.status;
   const effectiveRunError = runError ?? run?.error?.message ?? null;
+  const graphRuntimeNotices = useMemo(() => {
+    if (
+      !graphRuntimeOverlay ||
+      (run && graphRuntimeOverlay.boundaryId !== run.boundaryId)
+    ) {
+      return null;
+    }
+    const diagnostics = [
+      ...new Map(
+        graphRuntimeOverlay.diagnostics.map((diagnostic) => [
+          `${diagnostic.code ?? ''}:${diagnostic.message}`,
+          diagnostic,
+        ]),
+      ).values(),
+    ];
+    const unattachedCount = graphRuntimeOverlay.unattachedCallNodeIds.length;
+    return unattachedCount > 0 || diagnostics.length > 0
+      ? { diagnostics, unattachedCount }
+      : null;
+  }, [graphRuntimeOverlay, run]);
   const rootGraphNodeId =
     graphModel.graphNodes.find((node) => node.type === 'function')?.id ?? null;
   const graphNodeValues = useMemo(
@@ -739,6 +759,12 @@ function GraphViewInner({
           to { transform: rotate(360deg); }
         }
         .react-flow__attribution { display: none !important; }
+        .baml-graph-notices > summary {
+          list-style: none;
+        }
+        .baml-graph-notices > summary::-webkit-details-marker {
+          display: none;
+        }
         /* Level-of-detail transitions: when expand/collapse re-layouts, nodes
            glide to their new spot and containers grow/shrink, and freshly
            revealed nodes fade in. Armed only after the first layout so the
@@ -798,6 +824,110 @@ function GraphViewInner({
         />
         <ColorfulMarkerDefinitions />
       </ReactFlow>
+      {graphRuntimeNotices ? (
+        <details
+          className="baml-graph-notices"
+          style={{
+            position: 'absolute',
+            top: 10,
+            left: 10,
+            zIndex: 11,
+            fontFamily:
+              'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
+          }}
+        >
+          <summary
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 5,
+              width: 'fit-content',
+              padding: '5px 9px',
+              borderRadius: 999,
+              border: `1px solid ${chrome.button.border}`,
+              background: chrome.button.bg,
+              backdropFilter: 'blur(8px)',
+              WebkitBackdropFilter: 'blur(8px)',
+              boxShadow: chrome.button.shadow,
+              color: chrome.button.text,
+              cursor: 'pointer',
+              fontSize: 11,
+              fontWeight: 600,
+            }}
+          >
+            <span
+              aria-hidden="true"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                width: 14,
+                height: 14,
+                borderRadius: '50%',
+                border: `1px solid ${chrome.button.borderHover}`,
+                fontSize: 9,
+                fontWeight: 800,
+              }}
+            >
+              i
+            </span>
+            {graphRuntimeNotices.unattachedCount > 0
+              ? `${graphRuntimeNotices.unattachedCount} ${
+                  graphRuntimeNotices.unattachedCount === 1 ? 'call' : 'calls'
+                } unattached`
+              : `${graphRuntimeNotices.diagnostics.length} graph ${
+                  graphRuntimeNotices.diagnostics.length === 1
+                    ? 'notice'
+                    : 'notices'
+                }`}
+          </summary>
+          <div
+            role="status"
+            style={{
+              width: 340,
+              maxWidth: 'calc(100vw - 32px)',
+              maxHeight: 220,
+              overflow: 'auto',
+              marginTop: 6,
+              padding: 10,
+              borderRadius: 10,
+              border: `1px solid ${chrome.button.border}`,
+              background: chrome.button.bg,
+              backdropFilter: 'blur(12px)',
+              WebkitBackdropFilter: 'blur(12px)',
+              boxShadow: chrome.button.shadow,
+              color: chrome.button.text,
+              fontSize: 11,
+              lineHeight: 1.45,
+            }}
+          >
+            <div style={{ fontWeight: 700, marginBottom: 5 }}>
+              Some runtime calls could not be placed on this graph.
+            </div>
+            {graphRuntimeNotices.diagnostics.length > 0 ? (
+              <ul
+                style={{
+                  margin: 0,
+                  paddingLeft: 16,
+                  display: 'grid',
+                  gap: 5,
+                  opacity: 0.82,
+                }}
+              >
+                {graphRuntimeNotices.diagnostics.map((diagnostic) => (
+                  <li key={`${diagnostic.code ?? ''}:${diagnostic.message}`}>
+                    {diagnostic.message}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div style={{ opacity: 0.72 }}>
+                Runtime data remains available in the trace view.
+              </div>
+            )}
+          </div>
+        </details>
+      ) : null}
       <button
         onClick={() => {
           refitAfterLayoutRef.current = true;


### PR DESCRIPTION
## Summary

- distinguish direct graph runs from newer runs that merely contain the displayed function
- keep trace/profile context for containing workflow runs while refusing to paint their target-function overlay onto a different CFG
- show a compact “last ran inside” banner with navigation back to the containing run target
- surface unattached-call counts and server diagnostics in an expandable graph-canvas notice

## Why

The playground previously selected workflow runs for child-function graphs without preserving how they matched. Because CFG node IDs are function-local, that could paint runtime state and values onto unrelated child nodes. Overlay diagnostics were also invisible, leaving unexplained gaps in graph decoration.

## Validation

- `pnpm --dir typescript2/pkg-playground typecheck`
- `pnpm --dir typescript2/pkg-playground test` (126 tests)
- visual verification in `app-promptfiddle` for the compact and expanded diagnostics notice

Linear: B-822


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contextual messaging when the latest graph run was reached “via calls”, including an option to jump to that run.
  * Added an in-graph “notices” panel that surfaces runtime diagnostics and unattached calls, with more details available in the trace view.

* **Bug Fixes**
  * Improved graph run selection so the overlay, calls, status, and errors shown match the correct run context and relationship.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Before / after

Before — with the same unmatched runtime-call overlay, the exact PR base gives no visible indication that runtime context could not be placed on the graph.

<img width="1440" height="1000" alt="Before: graph with no runtime diagnostics notice" src="https://github.com/user-attachments/assets/0596bbb0-c0ec-44b8-bb3e-fe9ee93f7895" />


After — the exact PR head surfaces the unmatched call as a compact graph notice and expands it to show the server diagnostic.

<img width="1440" height="1000" alt="After: expanded graph runtime diagnostics notice" src="https://github.com/user-attachments/assets/fd0a68ac-5703-4bf3-bfe6-679c6ce35f41" />

