### PR TITLE
feat(playground): open history runs in graph

### DIFF
--- a/baml_language/crates/bex_project/src/bex_lsp/mod.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/mod.rs
@@ -239,6 +239,8 @@ pub struct ProjectDiagnostic {
 #[serde(rename_all = "camelCase")]
 pub struct ProjectUpdate {
     pub is_bex_current: bool,
+    /// Generation of the installed engine that backs this project update.
+    pub generation: u64,
     pub functions: Vec<FunctionInfo>,
     /// Statically declared legacy test cases that can seed function previews.
     pub tests: Vec<TestInfo>,

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/mod.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/mod.rs
@@ -1173,6 +1173,7 @@ impl BexMulitProject {
     /// keeps the last announced state rather than sending a wiped payload.
     fn build_project_update(&self, project: &LiveProject) -> Option<crate::bex_lsp::ProjectUpdate> {
         let is_bex_current = project.project.is_bex_current();
+        let generation = project.project.current_generation();
 
         let guard = project.project.read_source_for_request().ok()?;
         let candidate = crate::project::collect_diagnostic_candidate(&guard);
@@ -1217,6 +1218,7 @@ impl BexMulitProject {
 
         Some(crate::bex_lsp::ProjectUpdate {
             is_bex_current,
+            generation,
             functions,
             tests,
             types: Some(listing.types),

--- a/baml_language/crates/bridge_wasm/src/wasm_playground.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_playground.rs
@@ -213,6 +213,7 @@ pub struct TestInfo {
 #[serde(rename_all = "camelCase")]
 pub struct ProjectUpdate {
     pub is_bex_current: bool,
+    pub generation: u64,
     pub functions: Vec<FunctionInfo>,
     pub tests: Vec<TestInfo>,
     /// Shared type table for `FunctionInfo.params` refs; `None` = binary
@@ -338,6 +339,7 @@ impl From<bex_project::PlaygroundNotification> for PlaygroundNotification {
                     project,
                     update: ProjectUpdate {
                         is_bex_current: update.is_bex_current,
+                        generation: update.generation,
                         functions: update
                             .functions
                             .into_iter()

--- a/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
+++ b/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
@@ -177,6 +177,95 @@ describe('ExecutionPanel StrictMode lifecycle', () => {
   });
 });
 
+describe('ExecutionPanel run history', () => {
+  it('opens the selected historical run in the graph tab', async () => {
+    const port = new FakeRuntimePort();
+
+    render(<ExecutionPanel port={port} />);
+
+    act(() => {
+      port.emit({
+        type: 'playgroundNotification',
+        notification: { type: 'listProjects', projects: ['project'] },
+      });
+      port.emit({
+        type: 'playgroundNotification',
+        notification: {
+          type: 'updateProject',
+          project: 'project',
+          update: {
+            isBexCurrent: true,
+            functions: [
+              { name: 'ReadNote', kind: 'expr', origin: 'userDefined' },
+            ],
+            diagnostics: [],
+          },
+        },
+      });
+    });
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Functions (1)' }),
+    );
+    fireEvent.click(await screen.findByRole('button', { name: 'ReadNote' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
+
+    const startRun = await waitFor(() => {
+      const message = port.sent.find(
+        (candidate): candidate is Extract<
+          WorkerInMessage,
+          { type: 'startRun' }
+        > => candidate.type === 'startRun',
+      );
+      expect(message).toBeDefined();
+      return message!;
+    });
+    const run = runFixture(startRun.project, startRun.functionName);
+    act(() => {
+      port.emit({
+        type: 'runStarted',
+        requestId: startRun.requestId,
+        run,
+      });
+    });
+    const snapshot = await waitFor(() => {
+      const message = port.sent.find(
+        (candidate): candidate is Extract<
+          WorkerInMessage,
+          { type: 'snapshot' }
+        > => candidate.type === 'snapshot',
+      );
+      expect(message).toBeDefined();
+      return message!;
+    });
+    act(() => {
+      port.emit({
+        type: 'runSnapshot',
+        requestId: snapshot.requestId,
+        boundaryId: run.boundaryId,
+        snapshot: { ...run, status: 'succeeded', cursor: 1 },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {
+          name: 'View ReadNote run in graph',
+        }),
+      ).toBeInTheDocument();
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'View ReadNote run in graph' }),
+    );
+
+    expect(screen.getByRole('tab', { name: 'Graph' })).toHaveAttribute(
+      'data-state',
+      'active',
+    );
+    expect(screen.getByText('Loading graph...')).toBeInTheDocument();
+  });
+});
+
 describe('ExecutionPanel test previews', () => {
   it('hydrates legacy test args without running and releases selection on navigation', async () => {
     const port = new FakeRuntimePort();

--- a/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
+++ b/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
@@ -1,15 +1,16 @@
-import { StrictMode, act } from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+/** biome-ignore-all lint/style/useFilenamingConvention: preserve the established test filename */
 import {
-  ExecutionPanel,
   type ControlFlowGraph,
+  ExecutionPanel,
   type ProjectUpdate,
-  type RuntimePort,
   type Run,
+  type RuntimePort,
   type WorkerInMessage,
   type WorkerOutMessage,
 } from '@b/pkg-playground';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, StrictMode } from 'react';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 
 beforeAll(() => {
   HTMLElement.prototype.scrollTo ??= vi.fn();
@@ -27,26 +28,26 @@ describe('ExecutionPanel StrictMode lifecycle', () => {
 
     act(() => {
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'listProjects',
           projects: ['project'],
+          type: 'listProjects',
         },
+        type: 'playgroundNotification',
       });
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
-            isBexCurrent: true,
-            generation: 1,
-            functions: [
-              { name: 'ReadNote', kind: 'expr', origin: 'userDefined' },
-            ],
             diagnostics: [],
+            functions: [
+              { kind: 'expr', name: 'ReadNote', origin: 'userDefined' },
+            ],
+            generation: 1,
+            isBexCurrent: true,
           },
         },
+        type: 'playgroundNotification',
       });
     });
 
@@ -69,9 +70,9 @@ describe('ExecutionPanel StrictMode lifecycle', () => {
     const run = runFixture(startRun!.project, startRun!.functionName);
     act(() => {
       port.emit({
-        type: 'runStarted',
         requestId: startRun!.requestId,
         run,
+        type: 'runStarted',
       });
     });
 
@@ -87,10 +88,10 @@ describe('ExecutionPanel StrictMode lifecycle', () => {
 
     act(() => {
       port.emit({
-        type: 'runSnapshot',
-        requestId: snapshot!.requestId,
         boundaryId: run.boundaryId,
-        snapshot: { ...run, status: 'running', cursor: 1 },
+        requestId: snapshot!.requestId,
+        snapshot: { ...run, cursor: 1, status: 'running' },
+        type: 'runSnapshot',
       });
     });
 
@@ -107,30 +108,30 @@ describe('ExecutionPanel StrictMode lifecycle', () => {
 
     act(() => {
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'listProjects',
           projects: ['project'],
+          type: 'listProjects',
         },
+        type: 'playgroundNotification',
       });
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
-            isBexCurrent: true,
+            diagnostics: [],
             functions: [
-              { name: 'paulo.Hi', kind: 'expr', origin: 'userDefined' },
+              { kind: 'expr', name: 'paulo.Hi', origin: 'userDefined' },
               {
-                name: 'paulo.childFunc1',
                 kind: 'expr',
+                name: 'paulo.childFunc1',
                 origin: 'userDefined',
               },
             ],
-            diagnostics: [],
+            isBexCurrent: true,
           },
         },
+        type: 'playgroundNotification',
       });
     });
 
@@ -142,20 +143,20 @@ describe('ExecutionPanel StrictMode lifecycle', () => {
 
     act(() => {
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'controlFlowGraphResult',
           functionName: 'paulo.Hi',
           graph: graphFixture('paulo.Hi', ['childFunc1']),
+          type: 'controlFlowGraphResult',
         },
+        type: 'playgroundNotification',
       });
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'controlFlowGraphResult',
           functionName: 'paulo.childFunc1',
           graph: graphFixture('paulo.childFunc1'),
+          type: 'controlFlowGraphResult',
         },
+        type: 'playgroundNotification',
       });
     });
 
@@ -170,8 +171,7 @@ describe('ExecutionPanel StrictMode lifecycle', () => {
       expect(
         port.sent.some(
           (msg) =>
-            msg.type === 'startRun' &&
-            msg.functionName === 'paulo.childFunc1',
+            msg.type === 'startRun' && msg.functionName === 'paulo.childFunc1',
         ),
       ).toBe(true);
     });
@@ -186,23 +186,23 @@ describe('ExecutionPanel run history', () => {
 
     act(() => {
       port.emit({
+        notification: { projects: ['project'], type: 'listProjects' },
         type: 'playgroundNotification',
-        notification: { type: 'listProjects', projects: ['project'] },
       });
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
-            isBexCurrent: true,
-            generation: 1,
-            functions: [
-              { name: 'ReadNote', kind: 'expr', origin: 'userDefined' },
-            ],
             diagnostics: [],
+            functions: [
+              { kind: 'expr', name: 'ReadNote', origin: 'userDefined' },
+            ],
+            generation: 1,
+            isBexCurrent: true,
           },
         },
+        type: 'playgroundNotification',
       });
     });
 
@@ -214,10 +214,10 @@ describe('ExecutionPanel run history', () => {
 
     const startRun = await waitFor(() => {
       const message = port.sent.find(
-        (candidate): candidate is Extract<
-          WorkerInMessage,
-          { type: 'startRun' }
-        > => candidate.type === 'startRun',
+        (
+          candidate,
+        ): candidate is Extract<WorkerInMessage, { type: 'startRun' }> =>
+          candidate.type === 'startRun',
       );
       expect(message).toBeDefined();
       return message!;
@@ -225,27 +225,27 @@ describe('ExecutionPanel run history', () => {
     const run = runFixture(startRun.project, startRun.functionName);
     act(() => {
       port.emit({
-        type: 'runStarted',
         requestId: startRun.requestId,
         run,
+        type: 'runStarted',
       });
     });
     const snapshot = await waitFor(() => {
       const message = port.sent.find(
-        (candidate): candidate is Extract<
-          WorkerInMessage,
-          { type: 'snapshot' }
-        > => candidate.type === 'snapshot',
+        (
+          candidate,
+        ): candidate is Extract<WorkerInMessage, { type: 'snapshot' }> =>
+          candidate.type === 'snapshot',
       );
       expect(message).toBeDefined();
       return message!;
     });
     act(() => {
       port.emit({
-        type: 'runSnapshot',
-        requestId: snapshot.requestId,
         boundaryId: run.boundaryId,
-        snapshot: { ...run, status: 'succeeded', cursor: 1 },
+        requestId: snapshot.requestId,
+        snapshot: { ...run, cursor: 1, status: 'succeeded' },
+        type: 'runSnapshot',
       });
     });
 
@@ -258,19 +258,19 @@ describe('ExecutionPanel run history', () => {
     });
     act(() => {
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
-            isBexCurrent: true,
-            generation: 2,
-            functions: [
-              { name: 'ReadNote', kind: 'expr', origin: 'userDefined' },
-            ],
             diagnostics: [],
+            functions: [
+              { kind: 'expr', name: 'ReadNote', origin: 'userDefined' },
+            ],
+            generation: 2,
+            isBexCurrent: true,
           },
         },
+        type: 'playgroundNotification',
       });
     });
     expect(
@@ -279,19 +279,19 @@ describe('ExecutionPanel run history', () => {
 
     act(() => {
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
-            isBexCurrent: true,
-            generation: 1,
-            functions: [
-              { name: 'ReadNote', kind: 'expr', origin: 'userDefined' },
-            ],
             diagnostics: [],
+            functions: [
+              { kind: 'expr', name: 'ReadNote', origin: 'userDefined' },
+            ],
+            generation: 1,
+            isBexCurrent: true,
           },
         },
+        type: 'playgroundNotification',
       });
     });
     fireEvent.click(
@@ -310,58 +310,56 @@ describe('ExecutionPanel test previews', () => {
   it('hydrates legacy test args without running and releases selection on navigation', async () => {
     const port = new FakeRuntimePort();
     const projectUpdate: ProjectUpdate = {
-      isBexCurrent: true,
+      diagnostics: [],
       functions: [
         {
-          name: 'ClassifySentiment',
-          kind: 'llm',
-          origin: 'userDefined',
           capabilities: {
-            renderPrompt: true,
             buildRequest: true,
             clientName: 'Gpt5',
+            renderPrompt: true,
           },
+          kind: 'llm',
+          name: 'ClassifySentiment',
+          origin: 'userDefined',
           params: [
             {
-              name: 'text',
               hasDefault: false,
+              name: 'text',
               schema: { type: 'string' },
             },
           ],
         },
-        { name: 'OtherFunction', kind: 'expr', origin: 'userDefined' },
+        { kind: 'expr', name: 'OtherFunction', origin: 'userDefined' },
       ],
+      isBexCurrent: true,
       tests: [
         {
-          name: 'HappySentiment',
-          functionName: 'ClassifySentiment',
           argsJson: '{"text":"I absolutely love this feature"}',
+          functionName: 'ClassifySentiment',
+          name: 'HappySentiment',
         },
       ],
-      diagnostics: [],
     };
 
     render(<ExecutionPanel port={port} />);
 
     act(() => {
       port.emit({
+        notification: { projects: ['project'], type: 'listProjects' },
         type: 'playgroundNotification',
-        notification: { type: 'listProjects', projects: ['project'] },
       });
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: projectUpdate,
         },
+        type: 'playgroundNotification',
       });
     });
 
     fireEvent.click(
-      await screen.findByTitle(
-        'Use HappySentiment args for ClassifySentiment',
-      ),
+      await screen.findByTitle('Use HappySentiment args for ClassifySentiment'),
     );
     fireEvent.click(await screen.findByRole('button', { name: 'raw' }));
 
@@ -369,32 +367,33 @@ describe('ExecutionPanel test previews', () => {
     expect(JSON.parse((rawInput as HTMLInputElement).value)).toEqual({
       text: 'I absolutely love this feature',
     });
-    expect(
-      screen.getByText('ClassifySentiment()'),
-    ).toBeInTheDocument();
-    expect(port.sent.some((message) => message.type === 'startRun')).toBe(false);
-    expect(port.sent.some((message) => message.type === 'startTestRun')).toBe(false);
+    expect(screen.getByText('ClassifySentiment()')).toBeInTheDocument();
+    expect(port.sent.some((message) => message.type === 'startRun')).toBe(
+      false,
+    );
+    expect(port.sent.some((message) => message.type === 'startTestRun')).toBe(
+      false,
+    );
 
     act(() => {
       port.emit({
-        type: 'cursorContext',
         context: {
           functionName: 'OtherFunction',
           isWorkflow: false,
-          workflowMemberships: [],
           sourceExprId: null,
           testName: null,
+          workflowMemberships: [],
         },
+        type: 'cursorContext',
       });
     });
     expect(await screen.findByText('OtherFunction()')).toBeInTheDocument();
 
     act(() => {
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
             ...projectUpdate,
             tests: projectUpdate.tests?.map((test) => ({
@@ -403,6 +402,7 @@ describe('ExecutionPanel test previews', () => {
             })),
           },
         },
+        type: 'playgroundNotification',
       });
     });
     expect(await screen.findByText('OtherFunction()')).toBeInTheDocument();
@@ -417,40 +417,44 @@ describe('ExecutionPanel args form', () => {
 
     act(() => {
       port.emit({
+        notification: { projects: ['project'], type: 'listProjects' },
         type: 'playgroundNotification',
-        notification: { type: 'listProjects', projects: ['project'] },
       });
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
-            isBexCurrent: true,
+            diagnostics: [],
             functions: [
               {
-                name: 'Greet',
                 kind: 'expr',
+                name: 'Greet',
                 origin: 'userDefined',
                 params: [
-                  { name: 'name', hasDefault: false, schema: { type: 'string' } },
                   {
-                    name: 'color',
                     hasDefault: false,
-                    schema: { type: 'ref', name: 'user.Color' },
+                    name: 'name',
+                    schema: { type: 'string' },
+                  },
+                  {
+                    hasDefault: false,
+                    name: 'color',
+                    schema: { name: 'user.Color', type: 'ref' },
                   },
                 ],
               },
             ],
+            isBexCurrent: true,
             types: {
               'user.Color': {
                 kind: 'enum',
                 values: ['Red', 'Green', 'Blue'],
               },
             },
-            diagnostics: [],
           },
         },
+        type: 'playgroundNotification',
       });
     });
 
@@ -470,8 +474,8 @@ describe('ExecutionPanel args form', () => {
     const rawInput = await screen.findByPlaceholderText('{"key": "value"}');
     const parsed = JSON.parse((rawInput as HTMLInputElement).value);
     expect(parsed).toEqual({
-      name: 'Ada',
       color: { $baml: { enum: 'user.Color', value: 'Green' } },
+      name: 'Ada',
     });
 
     fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
@@ -501,40 +505,40 @@ describe('ExecutionPanel args form', () => {
 
     act(() => {
       port.emit({
+        notification: { projects: ['project'], type: 'listProjects' },
         type: 'playgroundNotification',
-        notification: { type: 'listProjects', projects: ['project'] },
       });
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
-            isBexCurrent: true,
+            diagnostics: [],
             functions: [
               {
-                name: 'Greet',
                 kind: 'expr',
+                name: 'Greet',
                 origin: 'userDefined',
                 params: [
                   {
-                    name: 'color',
                     hasDefault: false,
-                    schema: { type: 'ref', name: 'user.Color' },
+                    name: 'color',
+                    schema: { name: 'user.Color', type: 'ref' },
                   },
                 ],
               },
-              { name: 'Zero', kind: 'expr', origin: 'userDefined', params: [] },
+              { kind: 'expr', name: 'Zero', origin: 'userDefined', params: [] },
             ],
+            isBexCurrent: true,
             types: {
               'user.Color': {
                 kind: 'enum',
                 values: ['Red', 'Green', 'Blue'],
               },
             },
-            diagnostics: [],
           },
         },
+        type: 'playgroundNotification',
       });
     });
 
@@ -568,42 +572,42 @@ describe('ExecutionPanel args form', () => {
 
     act(() => {
       port.emit({
+        notification: { projects: ['project'], type: 'listProjects' },
         type: 'playgroundNotification',
-        notification: { type: 'listProjects', projects: ['project'] },
       });
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
-            isBexCurrent: true,
+            diagnostics: [],
             functions: [
               {
-                name: 'EchoPerson',
                 kind: 'expr',
+                name: 'EchoPerson',
                 origin: 'userDefined',
                 params: [
                   {
-                    name: 'person',
                     hasDefault: false,
-                    schema: { type: 'ref', name: 'user.Person' },
+                    name: 'person',
+                    schema: { name: 'user.Person', type: 'ref' },
                   },
                 ],
               },
             ],
+            isBexCurrent: true,
             types: {
               'user.Person': {
-                kind: 'class',
                 fields: [
                   { name: 'name', schema: { type: 'string' } },
                   { name: 'active', schema: { type: 'bool' } },
                 ],
+                kind: 'class',
               },
             },
-            diagnostics: [],
           },
         },
+        type: 'playgroundNotification',
       });
     });
 
@@ -618,39 +622,39 @@ describe('ExecutionPanel args form', () => {
     // Hot-reload the same function name with a new required class field.
     act(() => {
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
-            isBexCurrent: true,
+            diagnostics: [],
             functions: [
               {
-                name: 'EchoPerson',
                 kind: 'expr',
+                name: 'EchoPerson',
                 origin: 'userDefined',
                 params: [
                   {
-                    name: 'person',
                     hasDefault: false,
-                    schema: { type: 'ref', name: 'user.Person' },
+                    name: 'person',
+                    schema: { name: 'user.Person', type: 'ref' },
                   },
                 ],
               },
             ],
+            isBexCurrent: true,
             types: {
               'user.Person': {
-                kind: 'class',
                 fields: [
                   { name: 'name', schema: { type: 'string' } },
                   { name: 'active', schema: { type: 'bool' } },
                   { name: 'age', schema: { type: 'int' } },
                 ],
+                kind: 'class',
               },
             },
-            diagnostics: [],
           },
         },
+        type: 'playgroundNotification',
       });
     });
 
@@ -669,9 +673,9 @@ describe('ExecutionPanel args form', () => {
       expect(JSON.parse((rawInput as HTMLInputElement).value)).toEqual({
         person: {
           $baml: { type: 'user.Person' },
-          name: 'Ada Lovelace',
           active: false,
           age: 0,
+          name: 'Ada Lovelace',
         },
       });
     });
@@ -684,48 +688,48 @@ describe('ExecutionPanel args form', () => {
 
     act(() => {
       port.emit({
+        notification: { projects: ['project'], type: 'listProjects' },
         type: 'playgroundNotification',
-        notification: { type: 'listProjects', projects: ['project'] },
       });
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
-            isBexCurrent: true,
+            diagnostics: [],
             functions: [
               {
-                name: 'EchoEnvelope',
                 kind: 'expr',
+                name: 'EchoEnvelope',
                 origin: 'userDefined',
                 params: [
                   {
-                    name: 'envelope',
                     hasDefault: false,
-                    schema: { type: 'ref', name: 'user.Envelope' },
+                    name: 'envelope',
+                    schema: { name: 'user.Envelope', type: 'ref' },
                   },
                 ],
               },
             ],
+            isBexCurrent: true,
             types: {
-              'user.Flag': {
-                kind: 'class',
-                fields: [{ name: 'active', schema: { type: 'bool' } }],
-              },
               'user.Envelope': {
-                kind: 'class',
                 fields: [
                   {
                     name: 'flag',
-                    schema: { type: 'ref', name: 'user.Flag' },
+                    schema: { name: 'user.Flag', type: 'ref' },
                   },
                 ],
+                kind: 'class',
+              },
+              'user.Flag': {
+                fields: [{ name: 'active', schema: { type: 'bool' } }],
+                kind: 'class',
               },
             },
-            diagnostics: [],
           },
         },
+        type: 'playgroundNotification',
       });
     });
 
@@ -761,25 +765,24 @@ describe('ExecutionPanel args form', () => {
 
     act(() => {
       port.emit({
+        notification: { projects: ['project'], type: 'listProjects' },
         type: 'playgroundNotification',
-        notification: { type: 'listProjects', projects: ['project'] },
       });
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
-            isBexCurrent: true,
+            diagnostics: [],
             functions: [
               {
-                name: 'Mix',
                 kind: 'expr',
+                name: 'Mix',
                 origin: 'userDefined',
                 params: [
                   {
-                    name: 'x',
                     hasDefault: false,
+                    name: 'x',
                     schema: {
                       type: 'union',
                       variants: [{ type: 'int' }, { type: 'float' }],
@@ -788,10 +791,11 @@ describe('ExecutionPanel args form', () => {
                 ],
               },
             ],
+            isBexCurrent: true,
             types: {},
-            diagnostics: [],
           },
         },
+        type: 'playgroundNotification',
       });
     });
 
@@ -825,48 +829,48 @@ describe('ExecutionPanel args form', () => {
 
     act(() => {
       port.emit({
+        notification: { projects: ['project'], type: 'listProjects' },
         type: 'playgroundNotification',
-        notification: { type: 'listProjects', projects: ['project'] },
       });
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
-            isBexCurrent: true,
+            diagnostics: [],
             functions: [
               {
-                name: 'Walk',
                 kind: 'expr',
+                name: 'Walk',
                 origin: 'userDefined',
                 params: [
                   {
-                    name: 't',
                     hasDefault: false,
-                    schema: { type: 'ref', name: 'user.Tree' },
+                    name: 't',
+                    schema: { name: 'user.Tree', type: 'ref' },
                   },
                 ],
               },
             ],
+            isBexCurrent: true,
             types: {
               'user.Tree': {
-                kind: 'class',
                 fields: [
                   { name: 'value', schema: { type: 'int' } },
                   {
                     name: 'children',
                     schema: {
+                      item: { name: 'user.Tree', type: 'ref' },
                       type: 'list',
-                      item: { type: 'ref', name: 'user.Tree' },
                     },
                   },
                 ],
+                kind: 'class',
               },
             },
-            diagnostics: [],
           },
         },
+        type: 'playgroundNotification',
       });
     });
 
@@ -900,10 +904,8 @@ describe('ExecutionPanel args form', () => {
     expect(JSON.parse((rawInput as HTMLInputElement).value)).toEqual({
       t: {
         $baml: { type: 'user.Tree' },
+        children: [{ $baml: { type: 'user.Tree' }, children: [], value: 7 }],
         value: 0,
-        children: [
-          { $baml: { type: 'user.Tree' }, value: 7, children: [] },
-        ],
       },
     });
   });
@@ -919,45 +921,42 @@ describe('ExecutionPanel args form', () => {
 
     act(() => {
       port.emit({
+        notification: { projects: ['project'], type: 'listProjects' },
         type: 'playgroundNotification',
-        notification: { type: 'listProjects', projects: ['project'] },
       });
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
-            isBexCurrent: true,
+            diagnostics: [],
             functions: [
               {
-                name: 'Loop',
                 kind: 'expr',
+                name: 'Loop',
                 origin: 'userDefined',
                 params: [
                   {
-                    name: 'a',
                     hasDefault: false,
-                    schema: { type: 'ref', name: 'user.A' },
+                    name: 'a',
+                    schema: { name: 'user.A', type: 'ref' },
                   },
                 ],
               },
             ],
+            isBexCurrent: true,
             types: {
               'user.A': {
                 kind: 'alias',
                 schema: {
                   type: 'union',
-                  variants: [
-                    { type: 'ref', name: 'user.A' },
-                    { type: 'int' },
-                  ],
+                  variants: [{ name: 'user.A', type: 'ref' }, { type: 'int' }],
                 },
               },
             },
-            diagnostics: [],
           },
         },
+        type: 'playgroundNotification',
       });
     });
 
@@ -969,51 +968,49 @@ describe('ExecutionPanel args form', () => {
     // Union chips render; the self-referential variant is reachable but its
     // widget degrades to the raw-JSON textarea.
     fireEvent.click(await screen.findByRole('button', { name: 'A' }));
-    expect(
-      await screen.findByPlaceholderText('JSON (A)'),
-    ).toBeInTheDocument();
+    expect(await screen.findByPlaceholderText('JSON (A)')).toBeInTheDocument();
   });
 
   it('normalizes a bare-enum host seed into the wire marker', async () => {
     const port = new FakeRuntimePort();
 
-    render(<ExecutionPanel port={port} initialArgsJson='{"c":"Red"}' />);
+    render(<ExecutionPanel initialArgsJson='{"c":"Red"}' port={port} />);
 
     act(() => {
       port.emit({
+        notification: { projects: ['project'], type: 'listProjects' },
         type: 'playgroundNotification',
-        notification: { type: 'listProjects', projects: ['project'] },
       });
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
-            isBexCurrent: true,
+            diagnostics: [],
             functions: [
               {
-                name: 'IsRed',
                 kind: 'expr',
+                name: 'IsRed',
                 origin: 'userDefined',
                 params: [
                   {
-                    name: 'c',
                     hasDefault: false,
-                    schema: { type: 'ref', name: 'user.Color' },
+                    name: 'c',
+                    schema: { name: 'user.Color', type: 'ref' },
                   },
                 ],
               },
             ],
+            isBexCurrent: true,
             types: {
               'user.Color': {
                 kind: 'enum',
                 values: ['Red', 'Green', 'Blue'],
               },
             },
-            diagnostics: [],
           },
         },
+        type: 'playgroundNotification',
       });
     });
 
@@ -1041,22 +1038,22 @@ describe('ExecutionPanel args form', () => {
 
     act(() => {
       port.emit({
+        notification: { projects: ['project'], type: 'listProjects' },
         type: 'playgroundNotification',
-        notification: { type: 'listProjects', projects: ['project'] },
       });
       port.emit({
-        type: 'playgroundNotification',
         notification: {
-          type: 'updateProject',
           project: 'project',
+          type: 'updateProject',
           update: {
-            isBexCurrent: true,
-            functions: [
-              { name: 'Zero', kind: 'expr', origin: 'userDefined', params: [] },
-            ],
             diagnostics: [],
+            functions: [
+              { kind: 'expr', name: 'Zero', origin: 'userDefined', params: [] },
+            ],
+            isBexCurrent: true,
           },
         },
+        type: 'playgroundNotification',
       });
     });
 
@@ -1109,33 +1106,33 @@ class FakeRuntimePort implements RuntimePort {
 function runFixture(projectId: string, functionName: string): Run {
   return {
     boundaryId: 'baml_id_1_AAAAAAAAAAAAAAAAAAAAAQ',
-    target: { kind: 'function', functionName },
-    visibility: { kind: 'history' },
-    status: 'pending',
-    createdAtMs: 100,
-    startedAtMs: null,
+    calls: [],
+    cancellation: null,
     completedAtMs: null,
+    createdAtMs: 100,
+    cursor: 0,
+    diagnostics: [],
+    error: null,
+    graphRuntimeOverlay: null,
+    payloads: [],
+    request: {
+      argsSummary: '{}',
+      optionsSummary: null,
+      projectGeneration: 1,
+      projectId,
+      target: { functionName, kind: 'function' },
+    },
+    result: null,
+    rootCallNodeId: null,
+    startedAtMs: null,
+    status: 'pending',
+    target: { functionName, kind: 'function' },
+    threads: [],
     timeAnchor: {
       epochCreatedAtMs: 100,
       traceZeroNs: '0',
     },
-    request: {
-      projectId,
-      projectGeneration: 1,
-      target: { kind: 'function', functionName },
-      argsSummary: '{}',
-      optionsSummary: null,
-    },
-    result: null,
-    error: null,
-    cancellation: null,
-    rootCallNodeId: null,
-    graphRuntimeOverlay: null,
-    calls: [],
-    threads: [],
-    payloads: [],
-    diagnostics: [],
-    cursor: 0,
+    visibility: { kind: 'history' },
   };
 }
 
@@ -1144,18 +1141,18 @@ function graphFixture(
   calleeNames: string[] = [],
 ): ControlFlowGraph {
   return {
+    edgesBySrc: {},
     nodes: {
       '1': {
-        id: 1,
-        parentNodeId: null,
-        logFilterKey: functionName,
-        label: functionName,
-        sourceExpr: null,
-        nodeType: 'functionRoot',
         calleeNames,
+        id: 1,
         isContainer: true,
+        label: functionName,
+        logFilterKey: functionName,
+        nodeType: 'functionRoot',
+        parentNodeId: null,
+        sourceExpr: null,
       },
     },
-    edgesBySrc: {},
   };
 }

--- a/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
+++ b/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
@@ -40,6 +40,7 @@ describe('ExecutionPanel StrictMode lifecycle', () => {
           project: 'project',
           update: {
             isBexCurrent: true,
+            generation: 1,
             functions: [
               { name: 'ReadNote', kind: 'expr', origin: 'userDefined' },
             ],
@@ -195,6 +196,7 @@ describe('ExecutionPanel run history', () => {
           project: 'project',
           update: {
             isBexCurrent: true,
+            generation: 1,
             functions: [
               { name: 'ReadNote', kind: 'expr', origin: 'userDefined' },
             ],
@@ -253,6 +255,44 @@ describe('ExecutionPanel run history', () => {
           name: 'View ReadNote run in graph',
         }),
       ).toBeInTheDocument();
+    });
+    act(() => {
+      port.emit({
+        type: 'playgroundNotification',
+        notification: {
+          type: 'updateProject',
+          project: 'project',
+          update: {
+            isBexCurrent: true,
+            generation: 2,
+            functions: [
+              { name: 'ReadNote', kind: 'expr', origin: 'userDefined' },
+            ],
+            diagnostics: [],
+          },
+        },
+      });
+    });
+    expect(
+      screen.getByRole('button', { name: 'View ReadNote run in graph' }),
+    ).toBeDisabled();
+
+    act(() => {
+      port.emit({
+        type: 'playgroundNotification',
+        notification: {
+          type: 'updateProject',
+          project: 'project',
+          update: {
+            isBexCurrent: true,
+            generation: 1,
+            functions: [
+              { name: 'ReadNote', kind: 'expr', origin: 'userDefined' },
+            ],
+            diagnostics: [],
+          },
+        },
+      });
     });
     fireEvent.click(
       screen.getByRole('button', { name: 'View ReadNote run in graph' }),

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -2249,7 +2249,6 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
 
     // Don't force the 'run' tab — running keeps the user on whatever tab
     // they're viewing (graph, trace, prompt, etc.).
-    setSelectedGraphRunId(null);
     setExpandedLogId(null);
     setRunValidationError(null);
 
@@ -2281,6 +2280,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
         functionName: selectedFn,
         argsBytes: new Uint8Array(argsBytes),
       });
+      setSelectedGraphRunId(null);
       setArgsJsonByBoundaryId((prev) => ({
         ...prev,
         [boundaryId]: runArgsJson,
@@ -2320,28 +2320,37 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
         executionSnapshot.runs,
         selectedFn,
         selectedProject,
+        currentUpdate?.generation ?? null,
         selectedGraphRunId,
       ),
     [
       executionSnapshot.runs,
       selectedFn,
       selectedProject,
+      currentUpdate?.generation,
       selectedGraphRunId,
     ],
   );
   const handleSelectHistoryRun = useCallback(
     (run: RunStoreDisplayRun) => {
-      if (!functionNames.includes(run.functionName)) return;
+      if (
+        !functionNames.includes(run.functionName) ||
+        currentUpdate?.generation == null ||
+        run.projectGeneration !== currentUpdate.generation
+      ) {
+        return;
+      }
       setWorkflowContext(null);
       setSelectedPreviewTestKey(null);
       setViewingCollection(false);
       setViewingTestRun(false);
+      setSelectedTestName(null);
       setSelectedFn(run.functionName);
       setSelectedGraphRunId(run.id);
       setHighlightedNodeId(null);
       setActiveTab('graph');
     },
-    [functionNames],
+    [currentUpdate?.generation, functionNames],
   );
   // The run-history/logs strip is lifted out of the sidebar+content row so it
   // spans the panel's full width; the row gets bottom padding to make room.
@@ -3510,6 +3519,12 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
 
                     {functionRuns.map((run, boundaryIdx) => {
                       const isLatest = boundaryIdx === 0;
+                      const isCurrentGeneration =
+                        currentUpdate?.generation != null &&
+                        run.projectGeneration === currentUpdate.generation;
+                      const canViewRunInGraph =
+                        functionNames.includes(run.functionName) &&
+                        isCurrentGeneration;
                       const isLlmFunctionRun = llmFunctionNames.has(
                         run.functionName,
                       );
@@ -3535,11 +3550,13 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                               type="button"
                               aria-label={`View ${run.functionName} run in graph`}
                               title={
-                                functionNames.includes(run.functionName)
+                                !functionNames.includes(run.functionName)
+                                  ? 'This function is not available in the current build'
+                                  : isCurrentGeneration
                                   ? 'View this run in the graph'
-                                  : 'This function is not available in the current build'
+                                  : 'This run belongs to an older build'
                               }
-                              disabled={!functionNames.includes(run.functionName)}
+                              disabled={!canViewRunInGraph}
                               onClick={() => handleSelectHistoryRun(run)}
                               className="flex flex-1 min-w-0 items-center gap-1.5 px-2.5 py-1.5 text-left hover:bg-vsc-accent/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-vsc-accent disabled:cursor-default disabled:hover:bg-transparent"
                             >

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -9,10 +9,9 @@
  * VS Code webview without an embedded Monaco editor).
  */
 
-import type { ChangeEvent, FC, RefObject } from 'react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { encodeRunArgs } from '@b/pkg-proto';
+/** biome-ignore-all lint/style/useFilenamingConvention: preserve the public component filename */
 import type { BamlJsValue } from '@b/pkg-proto';
+import { encodeRunArgs } from '@b/pkg-proto';
 import {
   KeyRound,
   Loader2,
@@ -21,95 +20,92 @@ import {
   Settings,
   Square,
 } from 'lucide-react';
-import { Button } from './components/ui/button';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
-import { Input } from './components/ui/input';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from './components/ui/tooltip';
-import { CodeBlock } from './components/ui/code-block';
-import { ToggleGroup } from './components/ui/toggle-group';
-import { cn } from './lib/utils';
-import { ApiKeysDialog } from './components/ApiKeysDialog';
-import { BOUNDARY_PROXY_URL_KEY, getProxyEnvVarConfig } from './proxy-config';
-import { setGatewayEnabled } from './gateway';
-import { useEnvVars } from './envAtoms';
-import { CopyButton } from './components/CopyButton';
-import { ErrorDisplay } from './components/ErrorDisplay';
-import { MetadataBadges } from './components/MetadataBadges';
-import { PromptStats } from './components/PromptStats';
-import type { RuntimePort } from './runtime-port';
-import {
-  previewTestKey,
-  type ControlFlowGraph,
-  type CursorContext,
-  type DiagnosticEntry,
-  type FetchLogEntry,
-  type FunctionInfo,
-  type ProjectUpdate,
-  type TestInfo,
-  type Run,
-  type BoundaryId,
-  type RunStatus,
-  type SourceNavigationTarget,
-  type WorkerOutMessage,
-} from './worker-protocol';
-import type { ResultRendererProps } from './result-renderers';
+import type { ChangeEvent, FC } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ArgsForm } from './ArgsForm';
 import {
   isPlainObject,
   reconcileArgs,
   typeLookupFrom,
 } from './args-form-model';
-import { ResultDisplay } from './ResultDisplay';
-import { ValueRenderer } from './ValueRenderer';
 import { CapturedValueCard } from './CapturedValueCard';
-import { registerBuiltinResultRenderers } from './renderers/registerBuiltins';
+import { ApiKeysDialog } from './components/ApiKeysDialog';
+import { CopyButton } from './components/CopyButton';
+import { ErrorDisplay } from './components/ErrorDisplay';
+import { MetadataBadges } from './components/MetadataBadges';
+import { PromptStats } from './components/PromptStats';
+import { Button } from './components/ui/button';
+import { CodeBlock } from './components/ui/code-block';
+import { Input } from './components/ui/input';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
+import { ToggleGroup } from './components/ui/toggle-group';
 import {
-  HttpRequestCurlRenderer,
-  isHttpRequest,
-} from './renderers/HttpRequestCurl';
-import { GraphView } from './graph/GraphView';
-import { FunctionSidebar } from './FunctionSidebar';
-import { companionFunctionName } from './shared/companion-functions';
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './components/ui/tooltip';
+import {
+  selectDefaultFunctionName,
+  selectMainFunctionName,
+} from './default-function-selection';
+import { ExecutionProfileView } from './ExecutionProfileView';
+import { useEnvVars } from './envAtoms';
+import type { ExecutionStoreSnapshot } from './execution-store';
 import { createExecutionStore, type ExecutionStore } from './execution-store';
+import { FunctionSidebar } from './FunctionSidebar';
+import { setGatewayEnabled } from './gateway';
+import { GraphView } from './graph/GraphView';
+import { findLatestGraphRunSnapshot } from './graph-run-selection';
+import { cn } from './lib/utils';
+import { BOUNDARY_PROXY_URL_KEY, getProxyEnvVarConfig } from './proxy-config';
+import { ResultDisplay } from './ResultDisplay';
+import { RunOutputTerminal } from './RunOutputTerminal';
+import { registerBuiltinResultRenderers } from './renderers/registerBuiltins';
+import type { ResultRendererProps } from './result-renderers';
+import {
+  applyProjectUpdateToGating,
+  isRunGated,
+  markProjectNotReady,
+  NO_NOT_READY_PROJECTS,
+  type NotReadyProjects,
+} from './run-gating';
 import {
   createRunStoreClient,
   isProjectNotReadyError,
 } from './run-store-client';
 import {
-  NO_NOT_READY_PROJECTS,
-  applyProjectUpdateToGating,
-  isRunGated,
-  markProjectNotReady,
-  type NotReadyProjects,
-} from './run-gating';
-import { createValueBodyCache } from './value-body-cache';
-import type { ValueBodyCache } from './value-body-cache';
-import type { ExecutionStoreSnapshot } from './execution-store';
-import {
   decodeRunResultValue,
-  runToTraceRows,
-  runToDisplayRun,
-  type RunTraceLog,
   type RunStoreDisplayRun,
+  type RunTraceLog,
+  runToDisplayRun,
+  runToTraceRows,
 } from './run-store-projections';
-import { RunOutputTerminal } from './RunOutputTerminal';
-import {
-  selectDefaultFunctionName,
-  selectMainFunctionName,
-} from './default-function-selection';
-import { findLatestGraphRunSnapshot } from './graph-run-selection';
-import { ExecutionProfileView } from './ExecutionProfileView';
+import type { RuntimePort } from './runtime-port';
 import {
   parseSerializedTestTreeJson,
   type SerializedTestDef,
   type SerializedTestSet,
 } from './serialized-test-tree';
+import { companionFunctionName } from './shared/companion-functions';
 import { collectLatestTestRunResults } from './test-run-results';
+import { ValueRenderer } from './ValueRenderer';
+import type { ValueBodyCache } from './value-body-cache';
+import { createValueBodyCache } from './value-body-cache';
+import {
+  type BoundaryId,
+  type ControlFlowGraph,
+  type CursorContext,
+  type FetchLogEntry,
+  type FunctionInfo,
+  type ProjectUpdate,
+  previewTestKey,
+  type Run,
+  type RunStatus,
+  type SourceNavigationTarget,
+  type TestInfo,
+  type WorkerOutMessage,
+} from './worker-protocol';
 
 registerBuiltinResultRenderers();
 
@@ -257,9 +253,9 @@ function formatBuildTime(epochSecs: number): {
   const d = new Date(epochSecs * 1000);
   const absolute = d.toLocaleTimeString([], {
     hour: '2-digit',
+    hour12: false,
     minute: '2-digit',
     second: '2-digit',
-    hour12: false,
   });
   const delta = Math.floor(Date.now() / 1000) - epochSecs;
   let relative: string;
@@ -431,9 +427,10 @@ const CollectionDebugView: FC<CollectionDebugViewProps> = ({
                   : 'text-vsc-yellow';
           return (
             <div key={`cl-${log.id}`}>
-              <div
+              <button
+                className="flex w-full items-center gap-1.5 border-0 border-b border-vsc-border-subtle bg-transparent py-0.5 pr-2.5 pl-[22px] text-left cursor-pointer"
                 onClick={() => setExpandedLogId(isExp ? null : log.id)}
-                className="flex items-center gap-1.5 py-0.5 pr-2.5 pl-[22px] cursor-pointer border-b border-vsc-border-subtle"
+                type="button"
               >
                 <span className={`${statusColorCls} font-semibold text-[11px]`}>
                   {log.status ?? '...'}
@@ -442,8 +439,8 @@ const CollectionDebugView: FC<CollectionDebugViewProps> = ({
                   {log.method}
                 </span>
                 <RequestUrlLabel
-                  url={log.url}
                   requestHeaders={log.requestHeaders}
+                  url={log.url}
                 />
                 {log.durationMs != null && (
                   <span className="text-vsc-text-faint text-[10px]">
@@ -453,7 +450,7 @@ const CollectionDebugView: FC<CollectionDebugViewProps> = ({
                 <span className="text-vsc-text-faint text-[9px]">
                   {isExp ? '\u25B4' : '\u25BE'}
                 </span>
-              </div>
+              </button>
               {isExp && (
                 <div className="py-2 pr-2.5 pl-[22px] flex flex-col gap-2 border-b border-vsc-border">
                   {log.error && (
@@ -533,7 +530,9 @@ function traceLogLevelClass(level: string | null): string {
   }
 }
 
-function traceValueStateLabel(value: { state: RunTraceLog['state'] }): string | null {
+function traceValueStateLabel(value: {
+  state: RunTraceLog['state'];
+}): string | null {
   switch (value.state) {
     case 'available':
       return null;
@@ -588,7 +587,7 @@ const TraceLogView: FC<{ log: RunTraceLog }> = ({ log }) => {
       </div>
       {log.value !== null && (
         <div className="mt-1 overflow-x-auto">
-          <ValueRenderer value={log.value} displayMode="inline" />
+          <ValueRenderer displayMode="inline" value={log.value} />
         </div>
       )}
       {log.diagnostic && (
@@ -618,8 +617,8 @@ const TraceTimelineView: FC<{
       <div className="min-w-[560px] p-2">
         {rows.map((row) => (
           <div
-            key={row.id}
             className="grid grid-cols-[72px_minmax(200px,1fr)_80px] gap-2 items-center border-b border-vsc-border-subtle py-1"
+            key={row.id}
           >
             <div className="text-[10px] text-vsc-text-faint text-right">
               {formatTraceMs(row.offsetMs)}
@@ -669,7 +668,7 @@ const TraceTimelineView: FC<{
                   style={{ paddingLeft: Math.min(row.depth, 12) * 12 + 10 }}
                 >
                   {row.callValues.map((value) => (
-                    <CapturedValueCard key={value.id} value={value} compact />
+                    <CapturedValueCard compact key={value.id} value={value} />
                   ))}
                 </div>
               )}
@@ -803,12 +802,16 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
   const displayRuns = useMemo(
     () =>
       executionSnapshot.runs
-        .map((run) => runToDisplayRun(run, argsJsonByBoundaryId, valueBodyCache))
-        .filter(
-          (run): run is RunStoreDisplayRun =>
-            run != null,
-        ),
-    [executionSnapshot.runs, argsJsonByBoundaryId, valueBodyCache, valueBodyCacheVersion],
+        .map((run) =>
+          runToDisplayRun(run, argsJsonByBoundaryId, valueBodyCache),
+        )
+        .filter((run): run is RunStoreDisplayRun => run != null),
+    [
+      executionSnapshot.runs,
+      argsJsonByBoundaryId,
+      valueBodyCache,
+      valueBodyCacheVersion,
+    ],
   );
   const functionRuns = useMemo(
     () =>
@@ -941,7 +944,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
   // the cursor handler only runs on messages, after the mirror is set.
   const workflowRouteForRef = useRef<
     (fn: string) => { roots: string[]; firstHop: Map<string, string> }
-  >(() => ({ roots: [], firstHop: new Map() }));
+  >(() => ({ firstHop: new Map(), roots: [] }));
   // Highlight to apply once the promoted workflow's graph arrives (the
   // selection-change effect clears highlights, so apply after, not before).
   const pendingHighlightRef = useRef<{ fn: string; nodeId: number } | null>(
@@ -1009,7 +1012,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
   ): { owner: Map<number, number>; any: Map<number, number> } {
     const owner = new Map<number, number>();
     const any = new Map<number, number>();
-    if (!graph) return { owner, any };
+    if (!graph) return { any, owner };
     const preferred = new Set([
       'otherScope',
       'loop',
@@ -1035,7 +1038,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
         );
       }
     }
-    return { owner, any };
+    return { any, owner };
   }
 
   /** Try each candidate expression ID (most-specific first) against the
@@ -1123,10 +1126,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     if (source && onNavigateToSource) {
       if (source.startOffset != null && source.endOffset != null) {
         graphNavigationRef.current = {
-          nodeId,
-          startOffset: source.startOffset,
           endOffset: source.endOffset,
           expiresAt: performance.now() + 1000,
+          nodeId,
+          startOffset: source.startOffset,
         };
       }
       onNavigateToSource(source);
@@ -1327,9 +1330,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                 pendingLogsRef.current.delete(n.callId);
                 const hasError = !!n.expandError;
                 const collectionState: CollectionDebugState = {
-                  id: n.callId,
-                  fetchLogs: buffered,
                   error: hasError ? n.expandError!.message : null,
+                  fetchLogs: buffered,
+                  id: n.callId,
                   status: hasError ? 'error' : 'success',
                 };
                 setCollectionDebug(collectionState);
@@ -1357,13 +1360,13 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                 setCollectionDebug(null);
                 setTestStartErrors(new Map());
                 setPendingTestTarget({
-                  project: n.project,
                   kind: n.testName ? 'test' : 'testset',
                   name: n.testName ?? n.testsetName!,
+                  project: n.project,
                 });
                 port.postMessage({
-                  type: 'requestCollectTests',
                   project: n.project,
+                  type: 'requestCollectTests',
                 });
               }
               break;
@@ -1449,14 +1452,18 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
           if (cached !== undefined) {
             if (runScoped) {
               void executionStore
-                .respondToEnv(runScoped.boundaryId, runScoped.envRequestId, cached)
+                .respondToEnv(
+                  runScoped.boundaryId,
+                  runScoped.envRequestId,
+                  cached,
+                )
                 .catch((error) => {
                   console.warn('[ExecutionPanel] respondToEnv failed:', error);
                 });
             } else {
               port.postMessage({
-                type: 'envVarResponse',
                 id: data.id,
+                type: 'envVarResponse',
                 value: cached,
                 variable: data.variable,
               });
@@ -1464,8 +1471,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
           } else {
             // Park the request — it will be resolved when the dialog closes
             pendingEnvRequestsRef.current.set(data.id, {
-              variable: data.variable,
               runScoped,
+              variable: data.variable,
             });
             if (!showApiKeysDialogRef.current) {
               setShowApiKeysDialog(true);
@@ -1552,9 +1559,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
       testGraphRequestsRef.current.add(selectedTestName);
     }
     port.postMessage({
-      type: 'requestControlFlowGraph',
-      project: selectedProject,
       functionName: graphTargetName,
+      project: selectedProject,
+      type: 'requestControlFlowGraph',
     });
   }, [
     port,
@@ -1687,7 +1694,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
           };
 
           unsubscribe = executionStore.subscribe((snapshot) => {
-            const run = snapshot.runs.find((entry) => entry.boundaryId === boundaryId);
+            const run = snapshot.runs.find(
+              (entry) => entry.boundaryId === boundaryId,
+            );
             if (run && isTerminalRunStatus(run.status)) {
               finish(run);
             }
@@ -1702,11 +1711,11 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
         const previewFunctionName = companionFunctionName(selectedFn, subFn);
         const argsBytes = encodeRunArgs(parsed as Record<string, unknown>);
         const boundaryId = await executionStore.startPreviewRun({
-          project: selectedProject,
-          parentFunctionName: selectedFn,
-          helper: subFn,
-          functionName: previewFunctionName,
           argsBytes: new Uint8Array(argsBytes),
+          functionName: previewFunctionName,
+          helper: subFn,
+          parentFunctionName: selectedFn,
+          project: selectedProject,
         });
         const run = await waitForPreviewRun(boundaryId);
         if (run.error) {
@@ -1812,7 +1821,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
   const toggleResultMode = useCallback((boundaryId: string) => {
     setResultModes((prev) => ({
       ...prev,
-      [boundaryId]: (prev[boundaryId] ?? 'parsed') === 'parsed' ? 'raw' : 'parsed',
+      [boundaryId]:
+        (prev[boundaryId] ?? 'parsed') === 'parsed' ? 'raw' : 'parsed',
     }));
   }, []);
 
@@ -1869,7 +1879,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
 
   const handleRefreshTests = useCallback(() => {
     if (!selectedProject) return;
-    port.postMessage({ type: 'requestCollectTests', project: selectedProject });
+    port.postMessage({ project: selectedProject, type: 'requestCollectTests' });
   }, [selectedProject, port]);
 
   const appliedInitialTestTargetRef = useRef(false);
@@ -1892,11 +1902,11 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     setCollectionDebug(null);
     setTestStartErrors(new Map());
     setPendingTestTarget({
-      project: selectedProject,
       kind: initialTestName ? 'test' : 'testset',
       name: initialTestName ?? initialTestsetName!,
+      project: selectedProject,
     });
-    port.postMessage({ type: 'requestCollectTests', project: selectedProject });
+    port.postMessage({ project: selectedProject, type: 'requestCollectTests' });
   }, [initialTestName, initialTestsetName, selectedProject, port]);
 
   const waitForTerminalRun = useCallback(
@@ -1920,7 +1930,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
         };
 
         unsubscribe = executionStore.subscribe((snapshot) => {
-          const run = snapshot.runs.find((entry) => entry.boundaryId === boundaryId);
+          const run = snapshot.runs.find(
+            (entry) => entry.boundaryId === boundaryId,
+          );
           if (run && isTerminalRunStatus(run.status)) {
             finish();
           }
@@ -1945,8 +1957,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
       });
       try {
         const boundaryId = await executionStore.startTestRun({
-          project: selectedProject,
           generation,
+          project: selectedProject,
           testName: name,
         });
         await waitForTerminalRun(boundaryId);
@@ -1958,12 +1970,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
           markSelectedProjectNotReady(selectedProject);
           return;
         }
-        setTestStartErrors(
-          (prev) =>
-            new Map(prev).set(
-              name,
-              e instanceof Error ? e.message : String(e),
-            ),
+        setTestStartErrors((prev) =>
+          new Map(prev).set(name, e instanceof Error ? e.message : String(e)),
         );
       }
     },
@@ -2023,7 +2031,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     project: string | null;
     generation: number;
     names: Set<string>;
-  }>({ project: null, generation: -1, names: new Set() });
+  }>({ generation: -1, names: new Set(), project: null });
 
   // Auto-expand lazy testsets after receiving a new testTree
   useEffect(() => {
@@ -2036,22 +2044,26 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
       pendingExpandsRef.current.project !== selectedProject
     ) {
       pendingExpandsRef.current = {
-        project: selectedProject,
         generation,
         names: new Set(),
+        project: selectedProject,
       };
       setFailedExpands(new Set());
     }
     const pending = pendingExpandsRef.current.names;
     const expandLazy = (items: SerializedTestDef[]) => {
       for (const item of items) {
-        if ('type' in item && item.type === 'lazyTestSet' && !pending.has(item.name)) {
+        if (
+          'type' in item &&
+          item.type === 'lazyTestSet' &&
+          !pending.has(item.name)
+        ) {
           pending.add(item.name);
           port.postMessage({
-            type: 'expandTestSet',
-            project: selectedProject,
             generation,
+            project: selectedProject,
             testsetName: item.name,
+            type: 'expandTestSet',
           });
         } else if (isExpandedTestSet(item)) {
           // Recurse into expanded testsets to find nested lazy items
@@ -2077,10 +2089,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
       // Re-send expansion request
       pendingExpandsRef.current.names.add(testsetName);
       port.postMessage({
-        type: 'expandTestSet',
-        project: selectedProject,
         generation,
+        project: selectedProject,
         testsetName,
+        type: 'expandTestSet',
       });
     },
     [selectedProject, generation, port],
@@ -2209,8 +2221,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     ? JSON.stringify([selectedProject ?? null, selectedFn, argsSchemaKey])
     : null;
   const reconcileStateRef = useRef<{ scope: string | null; done: boolean }>({
-    scope: null,
     done: false,
+    scope: null,
   });
   useEffect(() => {
     const state = reconcileStateRef.current;
@@ -2222,7 +2234,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
       return;
     }
     if (state.scope === argsSchemaScope && state.done) return;
-    reconcileStateRef.current = { scope: argsSchemaScope, done: true };
+    reconcileStateRef.current = { done: true, scope: argsSchemaScope };
     let args: unknown;
     try {
       args = JSON.parse(baseArgsFor(selectedFn));
@@ -2253,7 +2265,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     setRunValidationError(null);
 
     requestAnimationFrame(() => {
-      outputRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+      outputRef.current?.scrollTo({ behavior: 'smooth', top: 0 });
     });
 
     try {
@@ -2276,9 +2288,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
       const argsBytes = encodeRunArgs(runArgs);
 
       const boundaryId = await executionStore.startRun({
-        project: selectedProject,
-        functionName: selectedFn,
         argsBytes: new Uint8Array(argsBytes),
+        functionName: selectedFn,
+        project: selectedProject,
       });
       setSelectedGraphRunId(null);
       setArgsJsonByBoundaryId((prev) => ({
@@ -2370,8 +2382,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
   // workflow-root heuristic can see the whole call graph. The responses
   // land in workflowCfgCacheRef (display is guarded by selectedFn).
   const prefetchedCfgRef = useRef<{ version: unknown; names: Set<string> }>({
-    version: undefined,
     names: new Set(),
+    version: undefined,
   });
   useEffect(() => {
     if (!selectedProject) return;
@@ -2386,9 +2398,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
       if (slot.names.has(name)) continue;
       slot.names.add(name);
       port.postMessage({
-        type: 'requestControlFlowGraph',
-        project: selectedProject,
         functionName: name,
+        project: selectedProject,
+        type: 'requestControlFlowGraph',
       });
     }
   }, [functionNames, selectedProject, projectUpdateVersion, port]);
@@ -2461,7 +2473,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
           stack.push(...[...ups].map((u) => ({ node: u, via: entry.node })));
         }
       }
-      return { roots: [...roots], firstHop };
+      return { firstHop, roots: [...roots] };
     },
     [workflowCallers, functionNames],
   );
@@ -2513,14 +2525,17 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     project: string | null;
     update: ProjectUpdate | undefined;
     applied: boolean;
-  }>({ project: null, update: undefined, applied: false });
+  }>({ applied: false, project: null, update: undefined });
   useEffect(() => {
     const scope = defaultSelectionScopeRef.current;
-    if (scope.project !== selectedProject || scope.update !== projectUpdateVersion) {
+    if (
+      scope.project !== selectedProject ||
+      scope.update !== projectUpdateVersion
+    ) {
       defaultSelectionScopeRef.current = {
+        applied: false,
         project: selectedProject,
         update: projectUpdateVersion,
-        applied: false,
       };
     }
 
@@ -2538,7 +2553,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
 
     if (initialFunctionName && !appliedInitialFnRef.current) {
       const initialMatch = functionNames.find(
-        (n) => n === initialFunctionName || n.endsWith(`.${initialFunctionName}`),
+        (n) =>
+          n === initialFunctionName || n.endsWith(`.${initialFunctionName}`),
       );
       if (initialMatch) return;
     }
@@ -2550,7 +2566,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
         graphResponses.has(name),
       );
       if (!hasAllGraphResponses) return;
-      next = selectDefaultFunctionName(functionNames, workflowCfgCacheRef.current);
+      next = selectDefaultFunctionName(
+        functionNames,
+        workflowCfgCacheRef.current,
+      );
     }
     if (!next) return;
 
@@ -2595,10 +2614,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
       <span className="text-vsc-text-faint">Workflow:</span>
       {workflowContext.workflows.map((wf) => (
         <Button
-          key={wf}
-          variant={wf === selectedFn ? 'secondary' : 'outline'}
-          size="sm"
           className="h-auto px-1.5 py-0.5 text-[10px]"
+          key={wf}
           onClick={() => {
             if (wf === selectedFn) return;
             const route = workflowRouteFor(workflowContext.functionName);
@@ -2612,6 +2629,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
             setSelectedFn(wf);
             setHighlightedNodeId(null);
           }}
+          size="sm"
+          variant={wf === selectedFn ? 'secondary' : 'outline'}
         >
           {wf}
         </Button>
@@ -2629,12 +2648,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
         </span>
       )}
       <Tabs
-        value={activeTab}
-        onValueChange={(v) => setActiveTab(v as typeof activeTab)}
         className="relative flex h-full min-h-0 w-full flex-1 flex-col gap-0 overflow-hidden"
-        // Panel-scoped run shortcut: fires for focus anywhere inside the
-        // playground (form fields, raw input, graph) without stealing
-        // Cmd/Ctrl+Enter from the host's code editor.
         onKeyDown={(e) => {
           if (!((e.metaKey || e.ctrlKey) && e.key === 'Enter')) return;
           // Same gates as the Run buttons: no runs from the collection or
@@ -2647,6 +2661,11 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
           e.preventDefault();
           if (!runtimeControlsDisabled) void onRunFunction();
         }}
+        onValueChange={(v) => setActiveTab(v as typeof activeTab)}
+        // Panel-scoped run shortcut: fires for focus anywhere inside the
+        // playground (form fields, raw input, graph) without stealing
+        // Cmd/Ctrl+Enter from the host's code editor.
+        value={activeTab}
       >
         {/* ──── Combined top bar ──── */}
         <div className="flex items-center gap-1.5 px-2 py-1 shrink-0 border-b border-vsc-border bg-vsc-surface">
@@ -2654,10 +2673,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
-                  variant="ghost"
-                  size="icon"
                   className="h-6 w-6 shrink-0"
                   onClick={() => setSidebarOpen((prev) => !prev)}
+                  size="icon"
+                  variant="ghost"
                 >
                   <PanelLeft className="h-3.5 w-3.5 text-vsc-text-muted" />
                 </Button>
@@ -2674,7 +2693,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                 {selectedTestName}
               </span>
               <TabsList className="bg-transparent border-b-0 ml-1 h-7">
-                <TabsTrigger value="graph" className="py-1 h-7">
+                <TabsTrigger className="py-1 h-7" value="graph">
                   Graph
                 </TabsTrigger>
               </TabsList>
@@ -2687,20 +2706,20 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                 {selectedFn}()
               </span>
               <TabsList className="bg-transparent border-b-0 ml-1 h-7">
-                <TabsTrigger value="run" className="py-1 h-7">
+                <TabsTrigger className="py-1 h-7" value="run">
                   Run
                 </TabsTrigger>
-                <TabsTrigger value="graph" className="py-1 h-7">
+                <TabsTrigger className="py-1 h-7" value="graph">
                   Graph
                 </TabsTrigger>
-                <TabsTrigger value="trace" className="py-1 h-7">
+                <TabsTrigger className="py-1 h-7" value="trace">
                   Trace
                 </TabsTrigger>
-                <TabsTrigger value="flame" className="py-1 h-7">
+                <TabsTrigger className="py-1 h-7" value="flame">
                   Flame
                 </TabsTrigger>
                 {canPreviewPrompt && (
-                  <TabsTrigger value="prompt" className="py-1 h-7">
+                  <TabsTrigger className="py-1 h-7" value="prompt">
                     Prompt
                     {selectedFnInfo?.capabilities?.clientName && (
                       <span className="ml-1 px-1 py-0 text-[9px] rounded bg-vsc-bg-secondary text-vsc-text-faint">
@@ -2710,7 +2729,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                   </TabsTrigger>
                 )}
                 {canPreviewCurl && (
-                  <TabsTrigger value="curl" className="py-1 h-7">
+                  <TabsTrigger className="py-1 h-7" value="curl">
                     cURL
                   </TabsTrigger>
                 )}
@@ -2722,10 +2741,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
 
           {projectRoots.length > 1 && (
             <ToggleGroup
-              value={selectedProject ?? projectRoots[0]}
               onValueChange={(v) => setSelectedProject(v)}
               options={projectRoots.map((root) => ({
-                value: root,
                 label: (
                   <>
                     {root}
@@ -2735,8 +2752,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                       )}
                   </>
                 ),
+                value: root,
               }))}
               size="sm"
+              value={selectedProject ?? projectRoots[0]}
             />
           )}
 
@@ -2751,14 +2770,14 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
-                      variant="success"
-                      size="icon-xs"
-                      className="h-7 w-7"
                       aria-label="Run"
+                      className="h-7 w-7"
                       disabled={
                         runtimeControlsDisabled || isRunning || !selectedProject
                       }
                       onClick={onRunFunction}
+                      size="icon-xs"
+                      variant="success"
                     >
                       <Play />
                     </Button>
@@ -2774,10 +2793,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
-                  variant="ghost"
-                  size="icon"
                   className="relative h-7 w-7 shrink-0"
                   onClick={() => setShowApiKeysDialog(true)}
+                  size="icon"
+                  variant="ghost"
                 >
                   <KeyRound size={14} />
                   {hasMissingKeys && (
@@ -2818,10 +2837,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button
-                    variant="ghost"
-                    size="icon"
                     className="h-7 w-7 shrink-0"
                     onClick={() => setShowSettingsMenu((v) => !v)}
+                    size="icon"
+                    variant="ghost"
                   >
                     <Settings size={14} />
                   </Button>
@@ -2832,20 +2851,20 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
             {showSettingsMenu && (
               <>
                 <button
-                  type="button"
                   aria-label="Close settings"
                   className="fixed inset-0 z-40 cursor-default bg-transparent border-none"
                   onClick={() => setShowSettingsMenu(false)}
+                  type="button"
                 />
                 <div className="absolute right-0 top-full mt-1 z-50 w-60 rounded border border-vsc-border bg-vsc-surface shadow-lg p-2.5">
                   <label className="flex items-center gap-1.5 text-[11px] text-vsc-text-muted cursor-pointer select-none">
                     <input
-                      type="checkbox"
                       checked={showInternalFunctions}
+                      className="h-3 w-3 accent-vsc-accent"
                       onChange={(e) =>
                         setShowInternalFunctions(e.currentTarget.checked)
                       }
-                      className="h-3 w-3 accent-vsc-accent"
+                      type="checkbox"
                     />
                     <span>Show internal functions</span>
                     <span className="ml-auto font-vsc-mono text-vsc-text-faint">
@@ -2861,7 +2880,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
         {/* WASM Panic banner */}
         {wasmPanic && (
           <button
-            type="button"
+            className="w-full flex items-center gap-2 px-2.5 py-2 border-none border-b border-vsc-border shrink-0 bg-[#5c1a1a] hover:bg-[#6e1f1f] transition-colors cursor-pointer text-left"
             onClick={() => {
               setWasmPanic(null);
               if (onReload) {
@@ -2870,7 +2889,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                 window.location.reload();
               }
             }}
-            className="w-full flex items-center gap-2 px-2.5 py-2 border-none border-b border-vsc-border shrink-0 bg-[#5c1a1a] hover:bg-[#6e1f1f] transition-colors cursor-pointer text-left"
+            type="button"
           >
             <span className="text-[12px]">⚠️</span>
             <div className="flex-1 min-w-0">
@@ -2888,15 +2907,12 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
             function/test catalog, but runtime-derived controls stay disabled
             until the fail-closed server reports a current build. */}
         {selectedProject && runtimePreparing && !hasErrors && (
-          <div
-            role="status"
-            className="flex shrink-0 items-center gap-2 border-b border-vsc-border bg-vsc-surface px-2.5 py-1.5"
-          >
+          <output className="flex shrink-0 items-center gap-2 border-b border-vsc-border bg-vsc-surface px-2.5 py-1.5">
             <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-vsc-accent" />
             <span className="font-vsc-mono text-[11px] text-vsc-text">
               Preparing current build…
             </span>
-          </div>
+          </output>
         )}
 
         {/* Diagnostics banner */}
@@ -2905,9 +2921,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
             {diags.length > 0 ? (
               <>
                 <button
-                  type="button"
-                  onClick={() => setDiagsExpanded((v) => !v)}
                   className="w-full flex items-center gap-1 px-2.5 py-1 bg-transparent border-none cursor-pointer text-left"
+                  onClick={() => setDiagsExpanded((v) => !v)}
+                  type="button"
                 >
                   <span
                     className="text-[10px] text-[#f48771] select-none transition-transform duration-150"
@@ -2933,18 +2949,18 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                 </button>
                 {diagsExpanded && (
                   <div className="px-2.5 pb-1.5 flex flex-col gap-0.5 max-h-[200px] overflow-y-auto">
-                    {errors.map((e, i) => (
+                    {errors.map((e) => (
                       <div
-                        key={`e${i}`}
                         className="font-vsc-mono text-[10px] text-[#f48771]/80 pl-3.5 break-words whitespace-pre-wrap"
+                        key={`error-${e.message}`}
                       >
                         {e.message}
                       </div>
                     ))}
-                    {warnings.map((w, i) => (
+                    {warnings.map((w) => (
                       <div
-                        key={`w${i}`}
                         className="font-vsc-mono text-[10px] text-[#cca700]/80 pl-3.5 break-words whitespace-pre-wrap"
+                        key={`warning-${w.message}`}
                       >
                         {w.message}
                       </div>
@@ -2973,18 +2989,20 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                 style={{ width: sidebarWidth }}
               >
                 <FunctionSidebar
+                  collectionLogCount={collectionDebug?.fetchLogs.length ?? 0}
+                  failedExpands={failedExpands}
                   functions={visibleFunctions}
-                  showInternalFunctions={showInternalFunctions}
                   internalFunctionCount={internalFunctionCount}
                   isLoadingProject={isLoadingProject}
-                  runtimeControlsDisabled={runtimeControlsDisabled}
-                  testTree={testTree}
-                  previewTests={previewTests}
-                  selectedPreviewTestKey={selectedPreviewTestKey}
-                  onSelectPreviewTest={handleSelectPreviewTest}
-                  selectedTestName={selectedTestName}
-                  onSelectTest={handleSelectTest}
-                  selectedFn={selectedFn}
+                  onRefreshTests={handleRefreshTests}
+                  onRetryExpand={handleRetryExpand}
+                  onRunTest={handleRunTest}
+                  onSelectCollectionView={() => {
+                    setViewingCollection(true);
+                    setViewingTestRun(false);
+                    setSelectedTestName(null);
+                    setSelectedFn(null);
+                  }}
                   onSelectFn={(fn) => {
                     setSelectedTestName(null);
                     setSelectedPreviewTestKey(null);
@@ -2994,24 +3012,22 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                     setWorkflowContext(null);
                     setSelectedFn(fn);
                   }}
-                  onRefreshTests={handleRefreshTests}
-                  onRunTest={handleRunTest}
+                  onSelectPreviewTest={handleSelectPreviewTest}
+                  onSelectTest={handleSelectTest}
+                  previewTests={previewTests}
+                  runtimeControlsDisabled={runtimeControlsDisabled}
+                  selectedFn={selectedFn}
+                  selectedPreviewTestKey={selectedPreviewTestKey}
+                  selectedTestName={selectedTestName}
+                  showInternalFunctions={showInternalFunctions}
                   testRunResults={testRunResults}
-                  failedExpands={failedExpands}
-                  onRetryExpand={handleRetryExpand}
-                  collectionLogCount={collectionDebug?.fetchLogs.length ?? 0}
+                  testTree={testTree}
                   viewingCollection={viewingCollection}
-                  onSelectCollectionView={() => {
-                    setViewingCollection(true);
-                    setViewingTestRun(false);
-                    setSelectedTestName(null);
-                    setSelectedFn(null);
-                  }}
                 />
               </div>
               <div
-                onMouseDown={onResizeStart}
                 className="w-1 shrink-0 cursor-col-resize hover:bg-vsc-accent/30 transition-colors border-r border-vsc-border"
+                onMouseDown={onResizeStart}
               />
             </>
           )}
@@ -3020,14 +3036,14 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
           <div className="flex-1 flex flex-col min-h-0 min-w-0">
             {viewingCollection && collectionDebug ? (
               <CollectionDebugView
-                state={collectionDebug}
                 expandedLogId={expandedLogId}
                 setExpandedLogId={setExpandedLogId}
+                state={collectionDebug}
               />
             ) : viewingTestRun ? (
               <div
-                ref={outputRef}
                 className="flex-1 overflow-auto font-vsc-mono text-xs bg-vsc-bg"
+                ref={outputRef}
               >
                 {testRuns.length === 0 && (
                   <div className="p-5 text-center text-vsc-text-faint text-[11px]">
@@ -3046,10 +3062,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                           : 'bg-vsc-text-muted';
                   return (
                     <div
-                      key={run.id}
                       className={
                         !isLatest ? 'border-b-2 border-vsc-border' : ''
                       }
+                      key={run.id}
                     >
                       <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-vsc-surface border-b border-vsc-border-subtle">
                         <span
@@ -3067,10 +3083,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                               <Tooltip>
                                 <TooltipTrigger asChild>
                                   <Button
-                                    variant="ghost"
-                                    size="icon"
                                     className="h-5 w-5 text-vsc-text-muted hover:text-vsc-error"
                                     onClick={() => onCancelFunctionRun(run.id)}
+                                    size="icon"
+                                    variant="ghost"
                                   >
                                     <Square size={12} />
                                   </Button>
@@ -3094,8 +3110,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                             Input
                           </div>
                           <ResultDisplay
-                            result={run.rootInput}
                             customRenderers={resultRenderers}
+                            result={run.rootInput}
                           />
                         </div>
                       )}
@@ -3111,11 +3127,12 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                                 : 'text-vsc-yellow';
                         return (
                           <div key={`t-${log.id}`}>
-                            <div
+                            <button
+                              className="flex w-full items-center gap-1.5 border-0 border-b border-vsc-border-subtle bg-transparent py-0.5 pr-2.5 pl-[22px] text-left cursor-pointer"
                               onClick={() =>
                                 setExpandedLogId(isExp ? null : log.id)
                               }
-                              className="flex items-center gap-1.5 py-0.5 pr-2.5 pl-[22px] cursor-pointer border-b border-vsc-border-subtle"
+                              type="button"
                             >
                               <span
                                 className={`${statusColorCls} font-semibold text-[11px]`}
@@ -3126,8 +3143,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                                 {log.method}
                               </span>
                               <RequestUrlLabel
-                                url={log.url}
                                 requestHeaders={log.requestHeaders}
+                                url={log.url}
                               />
                               {log.durationMs != null && (
                                 <span className="text-vsc-text-faint text-[10px]">
@@ -3137,7 +3154,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                               <span className="text-vsc-text-faint text-[9px]">
                                 {isExp ? '\u25B4' : '\u25BE'}
                               </span>
-                            </div>
+                            </button>
                             {isExp && (
                               <div className="py-2 pr-2.5 pl-[22px] flex flex-col gap-2 border-b border-vsc-border">
                                 {log.error && (
@@ -3184,15 +3201,16 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                       })}
                       {run.inputRequests.map((req) => (
                         <div
-                          key={req.id}
                           className="flex items-center gap-2 px-[22px] py-1.5 border-b border-vsc-border bg-vsc-surface"
+                          key={req.id}
                         >
                           <span className="text-vsc-text-faint text-xs shrink-0">
                             {req.prompt ?? 'Input:'}
                           </span>
                           <input
-                            className="flex-1 bg-vsc-bg border border-vsc-border rounded px-2 py-1 text-xs text-vsc-text font-vsc-mono focus:outline-none focus:border-vsc-accent"
+                            // biome-ignore lint/a11y/noAutofocus: focus the newly requested inline input
                             autoFocus
+                            className="flex-1 bg-vsc-bg border border-vsc-border rounded px-2 py-1 text-xs text-vsc-text font-vsc-mono focus:outline-none focus:border-vsc-accent"
                             onKeyDown={(e) => {
                               if (e.key === 'Enter') {
                                 submitRunInput(
@@ -3232,8 +3250,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                           {run.errorValue != null && (
                             <div className="mt-1">
                               <ResultDisplay
-                                result={run.errorValue}
                                 customRenderers={resultRenderers}
+                                result={run.errorValue}
                               />
                             </div>
                           )}
@@ -3245,8 +3263,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                             Result
                           </div>
                           <ResultDisplay
-                            result={run.result}
                             customRenderers={resultRenderers}
+                            result={run.result}
                           />
                         </div>
                       )}
@@ -3258,27 +3276,27 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
               <>
                 {/* Graph view */}
                 <TabsContent
-                  value="graph"
                   className="flex-1 min-h-0 mt-0 flex flex-col"
                   style={{ minHeight: 300 }}
+                  value="graph"
                 >
                   {workflowSwitcherBar}
                   {controlFlowGraph ? (
                     <GraphView
-                      graph={controlFlowGraph}
+                      calls={latestGraphRunSnapshot?.calls}
+                      customRenderers={resultRenderers}
                       functionName={graphTargetName}
+                      graph={controlFlowGraph}
                       graphRuntimeOverlay={
                         latestGraphRunSnapshot?.graphRuntimeOverlay
                       }
-                      calls={latestGraphRunSnapshot?.calls}
+                      onNodeClick={handleGraphNodeClick}
                       run={latestGraphRunSnapshot ?? null}
+                      runError={latestGraphRunSnapshot?.error?.message ?? null}
+                      runStatus={latestGraphRunSnapshot?.status}
+                      selectedNodeId={highlightedNodeId}
                       valueBodyCache={valueBodyCache}
                       valueBodyCacheVersion={valueBodyCacheVersion}
-                      runStatus={latestGraphRunSnapshot?.status}
-                      runError={latestGraphRunSnapshot?.error?.message ?? null}
-                      customRenderers={resultRenderers}
-                      selectedNodeId={highlightedNodeId}
-                      onNodeClick={handleGraphNodeClick}
                     />
                   ) : (
                     <div className="flex-1 flex items-center justify-center text-vsc-text-faint text-xs bg-vsc-bg h-full">
@@ -3289,9 +3307,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
 
                 {/* Trace timeline */}
                 <TabsContent
-                  value="trace"
                   className="flex-1 min-h-0 mt-0 flex flex-col"
                   style={{ minHeight: 300 }}
+                  value="trace"
                 >
                   <TraceTimelineView
                     run={latestGraphRunSnapshot}
@@ -3301,9 +3319,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
 
                 {/* Profile flamegraph */}
                 <TabsContent
-                  value="flame"
                   className="flex-1 min-h-0 mt-0 flex flex-col"
                   style={{ minHeight: 300 }}
+                  value="flame"
                 >
                   {activeTab === 'flame' && (
                     <ExecutionProfileView run={latestGraphRunSnapshot} />
@@ -3313,8 +3331,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                 {/* Prompt preview */}
                 {canPreviewPrompt && (
                   <TabsContent
-                    value="prompt"
                     className="flex-1 flex flex-col overflow-hidden mt-0"
+                    value="prompt"
                   >
                     {promptPreviewError && (
                       <div className="px-2.5 py-1.5 text-[10px] text-vsc-error bg-vsc-error/10 border-b border-vsc-error/20 shrink-0">
@@ -3330,8 +3348,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                       <div ref={promptContentRef}>
                         {promptPreviewResult != null ? (
                           <ResultDisplay
-                            result={promptPreviewResult}
                             customRenderers={resultRenderers}
+                            result={promptPreviewResult}
                           />
                         ) : (
                           <div className="flex items-center justify-center text-vsc-text-faint text-xs h-full">
@@ -3353,13 +3371,13 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                 {/* cURL preview */}
                 {canPreviewCurl && (
                   <TabsContent
-                    value="curl"
                     className="flex-1 overflow-auto font-vsc-mono text-xs bg-vsc-bg p-2.5 mt-0"
+                    value="curl"
                   >
                     {curlPreviewResult != null ? (
                       <ResultDisplay
-                        result={curlPreviewResult}
                         customRenderers={resultRenderers}
+                        result={curlPreviewResult}
                       />
                     ) : curlPreviewError ? (
                       <div className="flex items-center justify-center text-vsc-error text-xs h-full">
@@ -3377,8 +3395,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
 
                 {/* Execution area */}
                 <TabsContent
-                  value="run"
                   className="flex-1 flex flex-col min-h-0 mt-0"
+                  value="run"
                 >
                   {/* Args */}
                   {/* `nokey`: keep React Flow's global key capture (Space,
@@ -3393,11 +3411,11 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                       ) : (
                         <div className="flex-1 flex items-center min-w-0">
                           <Input
+                            className="flex-1 h-7 rounded-none border-none font-vsc-mono text-xs"
+                            onChange={onArgsJsonChange}
+                            placeholder='{"key": "value"}'
                             spellCheck={false}
                             value={argsJson}
-                            onChange={onArgsJsonChange}
-                            className="flex-1 h-7 rounded-none border-none font-vsc-mono text-xs"
-                            placeholder='{"key": "value"}'
                           />
                           {argsFormUnavailable && (
                             <span className="px-2 text-[10px] text-vsc-text-faint whitespace-nowrap">
@@ -3408,27 +3426,27 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                       )}
                       {paramSchemas !== undefined && (
                         <ToggleGroup
-                          size="sm"
                           className="px-1.5 shrink-0"
-                          value={argsMode}
-                          options={[
-                            { value: 'form', label: 'form' },
-                            { value: 'raw', label: 'raw' },
-                          ]}
                           onValueChange={setArgsMode}
+                          options={[
+                            { label: 'form', value: 'form' },
+                            { label: 'raw', value: 'raw' },
+                          ]}
+                          size="sm"
+                          value={argsMode}
                         />
                       )}
                       <Button
-                        variant="success"
-                        size="xs"
-                        className="mx-1 my-0.5 shrink-0 text-[11px] font-semibold"
                         aria-label={isRunning ? 'Running' : 'Run'}
+                        className="mx-1 my-0.5 shrink-0 text-[11px] font-semibold"
                         disabled={
                           runtimeControlsDisabled ||
                           isRunning ||
                           !selectedProject
                         }
                         onClick={onRunFunction}
+                        size="xs"
+                        variant="success"
                       >
                         {isRunning ? (
                           'Running...'
@@ -3448,10 +3466,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                             drafts cannot outlive the schema they represent. */}
                         <ArgsForm
                           key={`${selectedProject ?? ''}:${selectedFn ?? ''}:${argsSchemaKey}`}
+                          onChange={onArgsFormChange}
                           params={paramSchemas}
                           types={projectTypes}
                           value={reconciledFormArgs}
-                          onChange={onArgsFormChange}
                         />
                       </div>
                     )}
@@ -3465,22 +3483,22 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                     {workflowSwitcherBar}
                     {controlFlowGraph ? (
                       <GraphView
-                        graph={controlFlowGraph}
+                        calls={latestGraphRunSnapshot?.calls}
+                        customRenderers={resultRenderers}
                         functionName={graphTargetName}
+                        graph={controlFlowGraph}
                         graphRuntimeOverlay={
                           latestGraphRunSnapshot?.graphRuntimeOverlay
                         }
-                        calls={latestGraphRunSnapshot?.calls}
+                        onNodeClick={handleGraphNodeClick}
                         run={latestGraphRunSnapshot ?? null}
-                        valueBodyCache={valueBodyCache}
-                        valueBodyCacheVersion={valueBodyCacheVersion}
-                        runStatus={latestGraphRunSnapshot?.status}
                         runError={
                           latestGraphRunSnapshot?.error?.message ?? null
                         }
-                        customRenderers={resultRenderers}
+                        runStatus={latestGraphRunSnapshot?.status}
                         selectedNodeId={highlightedNodeId}
-                        onNodeClick={handleGraphNodeClick}
+                        valueBodyCache={valueBodyCache}
+                        valueBodyCacheVersion={valueBodyCacheVersion}
                       />
                     ) : (
                       <div className="flex-1 flex items-center justify-center text-vsc-text-faint text-xs bg-vsc-bg h-full">
@@ -3492,8 +3510,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                   {/* Logs resize handle — spans the full panel width, pinned
                       just above the run-history strip. */}
                   <div
-                    onMouseDown={onLogsResizeStart}
                     className="absolute left-0 right-0 z-10 h-1.5 cursor-row-resize bg-vsc-surface hover:bg-vsc-accent/30 transition-colors border-y border-vsc-border"
+                    onMouseDown={onLogsResizeStart}
                     style={{ bottom: logsPanelHeight }}
                     title="Resize logs"
                   />
@@ -3501,8 +3519,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                   {/* Run history (scrollable) — full panel width, below the
                       sidebar+content row. */}
                   <div
-                    ref={outputRef}
                     className="absolute left-0 right-0 bottom-0 z-10 overflow-auto font-vsc-mono text-xs bg-vsc-bg"
+                    ref={outputRef}
                     style={{ height: logsPanelHeight }}
                   >
                     {runValidationError && (
@@ -3539,26 +3557,26 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
 
                       return (
                         <div
-                          key={run.id}
                           className={
                             !isLatest ? 'border-b-2 border-vsc-border' : ''
                           }
+                          key={run.id}
                         >
                           {/* Run header */}
                           <div className="flex items-center bg-vsc-surface border-b border-vsc-border-subtle">
                             <button
-                              type="button"
                               aria-label={`View ${run.functionName} run in graph`}
+                              className="flex flex-1 min-w-0 items-center gap-1.5 px-2.5 py-1.5 text-left hover:bg-vsc-accent/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-vsc-accent disabled:cursor-default disabled:hover:bg-transparent"
+                              disabled={!canViewRunInGraph}
+                              onClick={() => handleSelectHistoryRun(run)}
                               title={
                                 !functionNames.includes(run.functionName)
                                   ? 'This function is not available in the current build'
                                   : isCurrentGeneration
-                                  ? 'View this run in the graph'
-                                  : 'This run belongs to an older build'
+                                    ? 'View this run in the graph'
+                                    : 'This run belongs to an older build'
                               }
-                              disabled={!canViewRunInGraph}
-                              onClick={() => handleSelectHistoryRun(run)}
-                              className="flex flex-1 min-w-0 items-center gap-1.5 px-2.5 py-1.5 text-left hover:bg-vsc-accent/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-vsc-accent disabled:cursor-default disabled:hover:bg-transparent"
+                              type="button"
                             >
                               <span
                                 className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusCls}`}
@@ -3579,12 +3597,12 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                                   <Tooltip>
                                     <TooltipTrigger asChild>
                                       <Button
-                                        variant="ghost"
-                                        size="icon"
                                         className="mr-1 h-5 w-5 text-vsc-text-muted hover:text-vsc-error"
                                         onClick={() =>
                                           onCancelFunctionRun(run.id)
                                         }
+                                        size="icon"
+                                        variant="ghost"
                                       >
                                         <Square size={12} />
                                       </Button>
@@ -3609,8 +3627,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                                 Input
                               </div>
                               <ResultDisplay
-                                result={run.rootInput}
                                 customRenderers={resultRenderers}
+                                result={run.rootInput}
                               />
                             </div>
                           )}
@@ -3628,11 +3646,12 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                                     : 'text-vsc-yellow';
                             return (
                               <div key={`n-${log.id}`}>
-                                <div
+                                <button
+                                  className="flex w-full items-center gap-1.5 border-0 border-b border-vsc-border-subtle bg-transparent py-0.5 pr-2.5 pl-[22px] text-left cursor-pointer"
                                   onClick={() =>
                                     setExpandedLogId(isExp ? null : log.id)
                                   }
-                                  className="flex items-center gap-1.5 py-0.5 pr-2.5 pl-[22px] cursor-pointer border-b border-vsc-border-subtle"
+                                  type="button"
                                 >
                                   <span
                                     className={`${statusColorCls} font-semibold text-[11px]`}
@@ -3643,8 +3662,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                                     {log.method}
                                   </span>
                                   <RequestUrlLabel
-                                    url={log.url}
                                     requestHeaders={log.requestHeaders}
+                                    url={log.url}
                                   />
                                   {log.durationMs != null && (
                                     <span className="text-vsc-text-faint text-[10px]">
@@ -3654,7 +3673,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                                   <span className="text-vsc-text-faint text-[9px]">
                                     {isExp ? '\u25B4' : '\u25BE'}
                                   </span>
-                                </div>
+                                </button>
                                 {isExp && (
                                   <div className="py-2 pr-2.5 pl-[22px] flex flex-col gap-2 border-b border-vsc-border">
                                     {log.error && (
@@ -3703,15 +3722,16 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                           {/* Inline io.input() prompts for this run */}
                           {run.inputRequests.map((req) => (
                             <div
-                              key={req.id}
                               className="flex items-center gap-2 px-[22px] py-1.5 border-b border-vsc-border bg-vsc-surface"
+                              key={req.id}
                             >
                               <span className="text-vsc-text-faint text-xs shrink-0">
                                 {req.prompt ?? 'Input:'}
                               </span>
                               <input
-                                className="flex-1 bg-vsc-bg border border-vsc-border rounded px-2 py-1 text-xs text-vsc-text font-vsc-mono focus:outline-none focus:border-vsc-accent"
+                                // biome-ignore lint/a11y/noAutofocus: focus the newly requested inline input
                                 autoFocus
+                                className="flex-1 bg-vsc-bg border border-vsc-border rounded px-2 py-1 text-xs text-vsc-text font-vsc-mono focus:outline-none focus:border-vsc-accent"
                                 onKeyDown={(e) => {
                                   if (e.key === 'Enter') {
                                     submitRunInput(
@@ -3760,8 +3780,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                               {run.errorValue != null && (
                                 <div className="mt-1">
                                   <ResultDisplay
-                                    result={run.errorValue}
                                     customRenderers={resultRenderers}
+                                    result={run.errorValue}
                                   />
                                 </div>
                               )}
@@ -3773,8 +3793,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                                 run.fetchLogs.length > 0 && (
                                   <div className="mb-1">
                                     <MetadataBadges
-                                      fetchLogs={run.fetchLogs}
                                       durationMs={run.durationMs}
+                                      fetchLogs={run.fetchLogs}
                                     />
                                   </div>
                                 )}
@@ -3788,7 +3808,6 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                                       expr functions return a structured value. */}
                                   {isLlmFunctionRun && (
                                     <ToggleGroup
-                                      value={resultModes[run.id] ?? 'parsed'}
                                       onValueChange={(v) =>
                                         setResultModes((prev) => ({
                                           ...prev,
@@ -3796,15 +3815,16 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                                         }))
                                       }
                                       options={[
-                                        { value: 'parsed', label: 'Parsed' },
-                                        { value: 'raw', label: 'Raw' },
+                                        { label: 'Parsed', value: 'parsed' },
+                                        { label: 'Raw', value: 'raw' },
                                       ]}
                                       size="sm"
+                                      value={resultModes[run.id] ?? 'parsed'}
                                     />
                                   )}
                                   <CopyButton
-                                    text={stringifyResult(run.result)}
                                     iconSize={11}
+                                    text={stringifyResult(run.result)}
                                   />
                                 </div>
                                 {isLlmFunctionRun &&
@@ -3814,8 +3834,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                                   </pre>
                                 ) : (
                                   <ResultDisplay
-                                    result={run.result}
                                     customRenderers={resultRenderers}
+                                    result={run.result}
                                   />
                                 )}
                               </div>
@@ -3832,8 +3852,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                 {isLoadingProject
                   ? 'Loading project...'
                   : viewingCollection
-                  ? 'Collection not yet available — click Refresh'
-                  : 'Select a function to run'}
+                    ? 'Collection not yet available — click Refresh'
+                    : 'Select a function to run'}
               </div>
             )}
           </div>
@@ -3841,15 +3861,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
       </Tabs>
 
       <ApiKeysDialog
-        open={showApiKeysDialog}
         envVars={envVars}
-        requiredKeys={knownRequiredKeys}
-        shellEnvVars={shellEnvVars}
-        shellOverriddenKeys={shellOverriddenKeys}
-        shellDeletedKeys={shellDeletedKeys}
-        showProxyEnvVar={getProxyEnvVarConfig().visible}
-        proxyEnabled={BOUNDARY_PROXY_URL_KEY in envVars}
-        onToggleProxy={setGatewayEnabled}
+        onDeleteEnvVar={removeEnvVar}
+        onImportEnvVars={importEnvVars}
         onOpenChange={(open) => {
           setShowApiKeysDialog(open);
           showApiKeysDialogRef.current = open;
@@ -3873,8 +3887,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                   });
               } else {
                 port.postMessage({
-                  type: 'envVarResponse',
                   id,
+                  type: 'envVarResponse',
                   value,
                   variable: pending.variable,
                 });
@@ -3883,10 +3897,16 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
             pendingEnvRequestsRef.current.clear();
           }
         }}
-        onSetEnvVar={addEnvVar}
-        onDeleteEnvVar={removeEnvVar}
-        onImportEnvVars={importEnvVars}
         onRevertToShell={revertToShell}
+        onSetEnvVar={addEnvVar}
+        onToggleProxy={setGatewayEnabled}
+        open={showApiKeysDialog}
+        proxyEnabled={BOUNDARY_PROXY_URL_KEY in envVars}
+        requiredKeys={knownRequiredKeys}
+        shellDeletedKeys={shellDeletedKeys}
+        shellEnvVars={shellEnvVars}
+        shellOverriddenKeys={shellOverriddenKeys}
+        showProxyEnvVar={getProxyEnvVarConfig().visible}
       />
     </>
   );

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -785,6 +785,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
   const [selectedFn, setSelectedFn] = useState<string | null>(null);
   const [selectedTestName, setSelectedTestName] = useState<string | null>(null);
   const graphTargetName = selectedTestName ?? selectedFn;
+  const [selectedGraphRunId, setSelectedGraphRunId] =
+    useState<BoundaryId | null>(null);
   const [selectedPreviewTestKey, setSelectedPreviewTestKey] = useState<
     string | null
   >(null);
@@ -2247,6 +2249,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
 
     // Don't force the 'run' tab — running keeps the user on whatever tab
     // they're viewing (graph, trace, prompt, etc.).
+    setSelectedGraphRunId(null);
     setExpandedLogId(null);
     setRunValidationError(null);
 
@@ -2317,8 +2320,28 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
         executionSnapshot.runs,
         selectedFn,
         selectedProject,
+        selectedGraphRunId,
       ),
-    [executionSnapshot.runs, selectedFn, selectedProject],
+    [
+      executionSnapshot.runs,
+      selectedFn,
+      selectedProject,
+      selectedGraphRunId,
+    ],
+  );
+  const handleSelectHistoryRun = useCallback(
+    (run: RunStoreDisplayRun) => {
+      if (!functionNames.includes(run.functionName)) return;
+      setWorkflowContext(null);
+      setSelectedPreviewTestKey(null);
+      setViewingCollection(false);
+      setViewingTestRun(false);
+      setSelectedFn(run.functionName);
+      setSelectedGraphRunId(run.id);
+      setHighlightedNodeId(null);
+      setActiveTab('graph');
+    },
+    [functionNames],
   );
   // The run-history/logs strip is lifted out of the sidebar+content row so it
   // spans the panel's full width; the row gets bottom padding to make room.
@@ -3507,16 +3530,29 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                           }
                         >
                           {/* Run header */}
-                          <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-vsc-surface border-b border-vsc-border-subtle">
-                            <span
-                              className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusCls}`}
-                            />
-                            <span className="text-vsc-accent font-semibold text-[11px]">
-                              {run.functionName}()
-                            </span>
-                            <span className="text-vsc-text-faint text-[10px] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
-                              {run.argsJson}
-                            </span>
+                          <div className="flex items-center bg-vsc-surface border-b border-vsc-border-subtle">
+                            <button
+                              type="button"
+                              aria-label={`View ${run.functionName} run in graph`}
+                              title={
+                                functionNames.includes(run.functionName)
+                                  ? 'View this run in the graph'
+                                  : 'This function is not available in the current build'
+                              }
+                              disabled={!functionNames.includes(run.functionName)}
+                              onClick={() => handleSelectHistoryRun(run)}
+                              className="flex flex-1 min-w-0 items-center gap-1.5 px-2.5 py-1.5 text-left hover:bg-vsc-accent/10 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-vsc-accent disabled:cursor-default disabled:hover:bg-transparent"
+                            >
+                              <span
+                                className={`w-1.5 h-1.5 rounded-full shrink-0 ${statusCls}`}
+                              />
+                              <span className="text-vsc-accent font-semibold text-[11px]">
+                                {run.functionName}()
+                              </span>
+                              <span className="text-vsc-text-faint text-[10px] flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
+                                {run.argsJson}
+                              </span>
+                            </button>
                             {run.status === 'running' && (
                               <>
                                 <span className="text-vsc-text-muted text-[10px]">
@@ -3528,7 +3564,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                                       <Button
                                         variant="ghost"
                                         size="icon"
-                                        className="h-5 w-5 text-vsc-text-muted hover:text-vsc-error"
+                                        className="mr-1 h-5 w-5 text-vsc-text-muted hover:text-vsc-error"
                                         onClick={() =>
                                           onCancelFunctionRun(run.id)
                                         }
@@ -3544,7 +3580,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                               </>
                             )}
                             {run.durationMs != null && (
-                              <span className="text-vsc-text-faint text-[10px] shrink-0">
+                              <span className="px-2.5 text-vsc-text-faint text-[10px] shrink-0">
                                 {run.durationMs}ms
                               </span>
                             )}

--- a/typescript2/pkg-playground/src/graph-run-selection.test.ts
+++ b/typescript2/pkg-playground/src/graph-run-selection.test.ts
@@ -52,6 +52,34 @@ describe('findLatestGraphRunSnapshot', () => {
     ).toBe('newer');
   });
 
+  it('selects a requested historical run instead of the newest snapshot', () => {
+    const older = runFixture('older', 100);
+    const newer = runFixture('newer', 300);
+
+    expect(
+      findLatestGraphRunSnapshot(
+        [newer, older],
+        'throws.main',
+        'project',
+        'older',
+      )?.boundaryId,
+    ).toBe('older');
+  });
+
+  it('falls back to the newest matching snapshot when a requested run is unavailable', () => {
+    const older = runFixture('older', 100);
+    const newer = runFixture('newer', 300);
+
+    expect(
+      findLatestGraphRunSnapshot(
+        [older, newer],
+        'throws.main',
+        'project',
+        'missing',
+      )?.boundaryId,
+    ).toBe('newer');
+  });
+
   it('can select a workflow run that contains the displayed function', () => {
     const run = runFixture('workflow', 100, {
       target: { kind: 'function', functionName: 'throws.workflow' },

--- a/typescript2/pkg-playground/src/graph-run-selection.test.ts
+++ b/typescript2/pkg-playground/src/graph-run-selection.test.ts
@@ -25,7 +25,12 @@ describe('findLatestGraphRunSnapshot', () => {
     });
 
     expect(
-      findLatestGraphRunSnapshot([newest, oldest], 'throws.main', 'project')
+      findLatestGraphRunSnapshot(
+        [newest, oldest],
+        'throws.main',
+        'project',
+        1,
+      )
         ?.boundaryId,
     ).toBe('newest');
   });
@@ -48,6 +53,7 @@ describe('findLatestGraphRunSnapshot', () => {
         [older, middleOtherProject, newer],
         'throws.main',
         'project',
+        1,
       )?.boundaryId,
     ).toBe('newer');
   });
@@ -61,6 +67,7 @@ describe('findLatestGraphRunSnapshot', () => {
         [newer, older],
         'throws.main',
         'project',
+        1,
         'older',
       )?.boundaryId,
     ).toBe('older');
@@ -75,6 +82,7 @@ describe('findLatestGraphRunSnapshot', () => {
         [older, newer],
         'throws.main',
         'project',
+        1,
         'missing',
       )?.boundaryId,
     ).toBe('newer');
@@ -90,8 +98,16 @@ describe('findLatestGraphRunSnapshot', () => {
     });
 
     expect(
-      findLatestGraphRunSnapshot([run], 'throws.main', 'project')?.boundaryId,
+      findLatestGraphRunSnapshot([run], 'throws.main', 'project', 1)?.boundaryId,
     ).toBe('workflow');
+  });
+
+  it('does not pair an obsolete run generation with the current graph', () => {
+    const obsolete = runFixture('obsolete', 100);
+
+    expect(
+      findLatestGraphRunSnapshot([obsolete], 'throws.main', 'project', 2),
+    ).toBeUndefined();
   });
 });
 

--- a/typescript2/pkg-playground/src/graph-run-selection.test.ts
+++ b/typescript2/pkg-playground/src/graph-run-selection.test.ts
@@ -6,31 +6,26 @@ import type { Run } from './worker-protocol';
 describe('findLatestGraphRunSnapshot', () => {
   it('selects the newest direct run when snapshots are newest-first', () => {
     const newest = runFixture('newest', 200, {
-      status: 'succeeded',
       result: {
-        valueRef: null,
-        value: 'new-output',
         rendererHint: null,
         supportingPayloadIds: [],
-      },
-    });
-    const oldest = runFixture('oldest', 100, {
-      status: 'failed',
-      error: {
-        class: 'Runtime',
-        message: 'old failure',
-        details: null,
+        value: 'new-output',
         valueRef: null,
       },
+      status: 'succeeded',
+    });
+    const oldest = runFixture('oldest', 100, {
+      error: {
+        class: 'Runtime',
+        details: null,
+        message: 'old failure',
+        valueRef: null,
+      },
+      status: 'failed',
     });
 
     expect(
-      findLatestGraphRunSnapshot(
-        [newest, oldest],
-        'throws.main',
-        'project',
-        1,
-      )
+      findLatestGraphRunSnapshot([newest, oldest], 'throws.main', 'project', 1)
         ?.boundaryId,
     ).toBe('newest');
   });
@@ -40,11 +35,11 @@ describe('findLatestGraphRunSnapshot', () => {
     const newer = runFixture('newer', 300);
     const middleOtherProject = runFixture('middle-other-project', 200, {
       request: {
-        projectId: 'other-project',
-        projectGeneration: 1,
-        target: { kind: 'function', functionName: 'throws.main' },
         argsSummary: null,
         optionsSummary: null,
+        projectGeneration: 1,
+        projectId: 'other-project',
+        target: { functionName: 'throws.main', kind: 'function' },
       },
     });
 
@@ -90,15 +85,16 @@ describe('findLatestGraphRunSnapshot', () => {
 
   it('can select a workflow run that contains the displayed function', () => {
     const run = runFixture('workflow', 100, {
-      target: { kind: 'function', functionName: 'throws.workflow' },
       calls: [
         callFixture('root', 'throws.workflow'),
         callFixture('child', 'throws.main'),
       ],
+      target: { functionName: 'throws.workflow', kind: 'function' },
     });
 
     expect(
-      findLatestGraphRunSnapshot([run], 'throws.main', 'project', 1)?.boundaryId,
+      findLatestGraphRunSnapshot([run], 'throws.main', 'project', 1)
+        ?.boundaryId,
     ).toBe('workflow');
   });
 
@@ -118,50 +114,50 @@ function runFixture(
 ): Run {
   return {
     boundaryId,
-    target: { kind: 'function', functionName: 'throws.main' },
-    visibility: { kind: 'history' },
-    status: 'running',
-    createdAtMs,
-    startedAtMs: createdAtMs,
+    calls: [],
+    cancellation: null,
     completedAtMs: null,
+    createdAtMs,
+    cursor: 0,
+    diagnostics: [],
+    error: null,
+    graphRuntimeOverlay: null,
+    payloads: [],
+    request: {
+      argsSummary: null,
+      optionsSummary: null,
+      projectGeneration: 1,
+      projectId: 'project',
+      target: { functionName: 'throws.main', kind: 'function' },
+    },
+    result: null,
+    rootCallNodeId: null,
+    startedAtMs: createdAtMs,
+    status: 'running',
+    target: { functionName: 'throws.main', kind: 'function' },
+    threads: [],
     timeAnchor: {
       epochCreatedAtMs: createdAtMs,
       traceZeroNs: '0',
     },
-    request: {
-      projectId: 'project',
-      projectGeneration: 1,
-      target: { kind: 'function', functionName: 'throws.main' },
-      argsSummary: null,
-      optionsSummary: null,
-    },
-    result: null,
-    error: null,
-    cancellation: null,
-    rootCallNodeId: null,
-    graphRuntimeOverlay: null,
-    calls: [],
-    threads: [],
-    payloads: [],
-    diagnostics: [],
-    cursor: 0,
+    visibility: { kind: 'history' },
     ...overrides,
   };
 }
 
 function callFixture(id: string, functionName: string): Run['calls'][number] {
   return {
-    id,
-    threadId: 'thread',
-    parentId: id === 'root' ? null : 'root',
+    calleeSource: null,
+    callSiteSource: null,
+    endedAtNs: null,
     functionId: id === 'root' ? 1 : 2,
     functionName,
     functionOrigin: null,
-    calleeSource: null,
-    callSiteSource: null,
-    startedAtNs: null,
-    endedAtNs: null,
-    status: 'ok',
+    id,
+    parentId: id === 'root' ? null : 'root',
     payloadIds: [],
+    startedAtNs: null,
+    status: 'ok',
+    threadId: 'thread',
   };
 }

--- a/typescript2/pkg-playground/src/graph-run-selection.ts
+++ b/typescript2/pkg-playground/src/graph-run-selection.ts
@@ -4,13 +4,23 @@ export function findLatestGraphRunSnapshot(
   runs: Run[],
   selectedFn: string | null,
   selectedProject: string | null,
+  selectedProjectGeneration: number | null,
   preferredBoundaryId?: string | null,
 ): Run | undefined {
-  if (!selectedFn) return undefined;
+  if (!selectedFn || selectedProjectGeneration == null) return undefined;
 
   let latest: Run | undefined;
   for (const run of runs) {
-    if (!isGraphRunCandidate(run, selectedFn, selectedProject)) continue;
+    if (
+      !isGraphRunCandidate(
+        run,
+        selectedFn,
+        selectedProject,
+        selectedProjectGeneration,
+      )
+    ) {
+      continue;
+    }
     if (preferredBoundaryId && run.boundaryId === preferredBoundaryId) {
       return run;
     }
@@ -26,8 +36,10 @@ function isGraphRunCandidate(
   run: Run,
   selectedFn: string,
   selectedProject: string | null,
+  selectedProjectGeneration: number,
 ): boolean {
   if (selectedProject && run.request.projectId !== selectedProject) return false;
+  if (run.request.projectGeneration !== selectedProjectGeneration) return false;
 
   if (
     (run.target.kind === 'function' || run.target.kind === 'companion') &&

--- a/typescript2/pkg-playground/src/graph-run-selection.ts
+++ b/typescript2/pkg-playground/src/graph-run-selection.ts
@@ -4,12 +4,16 @@ export function findLatestGraphRunSnapshot(
   runs: Run[],
   selectedFn: string | null,
   selectedProject: string | null,
+  preferredBoundaryId?: string | null,
 ): Run | undefined {
   if (!selectedFn) return undefined;
 
   let latest: Run | undefined;
   for (const run of runs) {
     if (!isGraphRunCandidate(run, selectedFn, selectedProject)) continue;
+    if (preferredBoundaryId && run.boundaryId === preferredBoundaryId) {
+      return run;
+    }
     if (!latest || compareRunRecency(run, latest) > 0) {
       latest = run;
     }

--- a/typescript2/pkg-playground/src/graph-run-selection.ts
+++ b/typescript2/pkg-playground/src/graph-run-selection.ts
@@ -38,7 +38,8 @@ function isGraphRunCandidate(
   selectedProject: string | null,
   selectedProjectGeneration: number,
 ): boolean {
-  if (selectedProject && run.request.projectId !== selectedProject) return false;
+  if (selectedProject && run.request.projectId !== selectedProject)
+    return false;
   if (run.request.projectGeneration !== selectedProjectGeneration) return false;
 
   if (

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -146,6 +146,8 @@ export function previewTestKey(
 
 export interface ProjectUpdate {
   isBexCurrent: boolean;
+  /** Generation of the installed engine backing this update. Omitted by older runtimes. */
+  generation?: number;
   functions: FunctionInfo[];
   /** Omitted by older runtimes; the UI treats that as no previewable tests. */
   tests?: TestInfo[];


### PR DESCRIPTION
## Summary

- make completed function-run history entries open the Graph tab
- pin the selected historical snapshot instead of silently showing the newest matching run
- preserve latest-run fallback behavior when a requested snapshot is no longer available
- add selection helper coverage and an end-to-end execution-panel regression test

## Why

The run-history strip at the bottom of the playground displayed prior executions, but its rows were inert. Users had no direct way to inspect a historical run in the graph, and the graph selection helper always chose the newest matching run.

## Validation

- `pnpm --filter @b/pkg-playground test` (127 tests)
- `pnpm --filter @b/pkg-playground typecheck`
- `pnpm --filter app-vscode-webview typecheck`
- `pnpm --filter app-vscode-webview test:unit` (22 tests)
- targeted strict-mode regression test after rebasing (13 tests)
- live browser QA: ran a minimal function, clicked its history entry, and verified the Graph tab showed that run's input/output overlay
- `git diff --check`

Linear: https://linear.app/boundary/issue/B-812/can-we-navigate-to-graph-if-we-click-the-history-at-the-bottom

## Before / after

**Before — base `384a6ff8`:** After running `InspectHistory` with values `1` and `2`, clicking the older `{ "value": 1 }` history row leaves the playground on Run and the graph pinned to the latest value `2`.

![Before: clicking the older history row leaves Run selected and the latest value 2 displayed](https://gist.githubusercontent.com/sxlijin/c69b0630b4c12ac9b781aafab77c9372/raw/47f6b42fb8c055d52a9213e1af79817dc2168d89/B-812-before.png)

**After — head `c683b42f`:** Clicking the same older history row opens Graph and pins its exact input/output snapshot, value `1`.

![After: clicking the older history row opens Graph with the pinned value 1 snapshot](https://gist.githubusercontent.com/sxlijin/c69b0630b4c12ac9b781aafab77c9372/raw/47f6b42fb8c055d52a9213e1af79817dc2168d89/B-812-after.png)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Run-history entries are now selectable, opening the chosen run in the Graph tab.
  - Graph views can stay pinned to the selected historical run, and clear back to the latest view when starting a new run.
- **Bug Fixes**
  - Generation-aware graph snapshot selection now correctly disables incompatible runs and falls back when a requested run isn’t available.
- **Tests**
  - Expanded coverage for run-history selection, Graph tab loading, and generation-aware snapshot selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
