### PR TITLE
Order explorer functions by call breadth

### DIFF
--- a/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
+++ b/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
@@ -175,6 +175,94 @@ describe('ExecutionPanel StrictMode lifecycle', () => {
       ).toBe(true);
     });
   });
+
+  it('orders explorer functions by call breadth after all graphs arrive', async () => {
+    const port = new FakeRuntimePort();
+
+    render(<ExecutionPanel port={port} />);
+
+    act(() => {
+      port.emit({
+        type: 'playgroundNotification',
+        notification: {
+          type: 'listProjects',
+          projects: ['project'],
+        },
+      });
+      port.emit({
+        type: 'playgroundNotification',
+        notification: {
+          type: 'updateProject',
+          project: 'project',
+          update: {
+            isBexCurrent: true,
+            functions: [
+              { name: 'Leaf', kind: 'expr', origin: 'userDefined' },
+              { name: 'Root', kind: 'expr', origin: 'userDefined' },
+              { name: 'Branch', kind: 'expr', origin: 'userDefined' },
+            ],
+            diagnostics: [],
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        port.sent.filter((msg) => msg.type === 'requestControlFlowGraph'),
+      ).toHaveLength(3);
+    });
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Functions (3)' }),
+    );
+    expect(visibleFunctionOrder(['Leaf', 'Root', 'Branch'])).toEqual([
+      'Leaf',
+      'Root',
+      'Branch',
+    ]);
+
+    act(() => {
+      port.emit({
+        type: 'playgroundNotification',
+        notification: {
+          type: 'controlFlowGraphResult',
+          functionName: 'Root',
+          graph: graphFixture('Root', ['Branch']),
+        },
+      });
+      port.emit({
+        type: 'playgroundNotification',
+        notification: {
+          type: 'controlFlowGraphResult',
+          functionName: 'Branch',
+          graph: graphFixture('Branch', ['Leaf']),
+        },
+      });
+    });
+    expect(visibleFunctionOrder(['Leaf', 'Root', 'Branch'])).toEqual([
+      'Leaf',
+      'Root',
+      'Branch',
+    ]);
+
+    act(() => {
+      port.emit({
+        type: 'playgroundNotification',
+        notification: {
+          type: 'controlFlowGraphResult',
+          functionName: 'Leaf',
+          graph: graphFixture('Leaf'),
+        },
+      });
+    });
+    await waitFor(() => {
+      expect(visibleFunctionOrder(['Leaf', 'Root', 'Branch'])).toEqual([
+        'Root',
+        'Branch',
+        'Leaf',
+      ]);
+    });
+  });
 });
 
 describe('ExecutionPanel test previews', () => {
@@ -1029,4 +1117,12 @@ function graphFixture(
     },
     edgesBySrc: {},
   };
+}
+
+function visibleFunctionOrder(names: string[]): string[] {
+  const expected = new Set(names);
+  return screen
+    .getAllByRole('button')
+    .map((button) => button.textContent ?? '')
+    .filter((name) => expected.has(name));
 }

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -74,6 +74,7 @@ import {
 } from './renderers/HttpRequestCurl';
 import { GraphView } from './graph/GraphView';
 import { FunctionSidebar } from './FunctionSidebar';
+import { orderFunctionsForExplorer } from './function-call-breadth';
 import { companionFunctionName } from './shared/companion-functions';
 import { createExecutionStore, type ExecutionStore } from './execution-store';
 import {
@@ -855,6 +856,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
   const workflowCfgResponsesRef = useRef<Map<string, ControlFlowGraph | null>>(
     new Map(),
   );
+  const prefetchedCfgRef = useRef<{ version: unknown; names: Set<string> }>({
+    version: undefined,
+    names: new Set(),
+  });
   const [workflowCacheVersion, setWorkflowCacheVersion] = useState(0);
   const [activeTab, setActiveTab] = useState<
     'run' | 'graph' | 'trace' | 'flame' | 'prompt' | 'curl'
@@ -2080,6 +2085,20 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
   const visibleFunctions = showInternalFunctions
     ? functions
     : functions.filter((fn) => !isInternalFunction(fn));
+  // Wait for every visible function's CFG response before applying the
+  // explorer ranking so asynchronous responses do not make rows jump around.
+  // Missing graphs are valid responses and contribute zero reachable callees.
+  const explorerFunctions = useMemo(() => {
+    void workflowCacheVersion;
+    if (prefetchedCfgRef.current.version !== projectUpdateVersion) {
+      return visibleFunctions;
+    }
+    return orderFunctionsForExplorer(
+      visibleFunctions,
+      workflowCfgResponsesRef.current,
+      workflowCfgCacheRef.current,
+    );
+  }, [visibleFunctions, workflowCacheVersion, projectUpdateVersion]);
   const functionNames = visibleFunctions.map((f) => f.name);
   const diags = currentUpdate?.diagnostics ?? [];
 
@@ -2287,10 +2306,6 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
   // Prefetch every visible function's CFG once per project build so the
   // workflow-root heuristic can see the whole call graph. The responses
   // land in workflowCfgCacheRef (display is guarded by selectedFn).
-  const prefetchedCfgRef = useRef<{ version: unknown; names: Set<string> }>({
-    version: undefined,
-    names: new Set(),
-  });
   useEffect(() => {
     if (!selectedProject) return;
     const slot = prefetchedCfgRef.current;
@@ -2878,7 +2893,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                 style={{ width: sidebarWidth }}
               >
                 <FunctionSidebar
-                  functions={visibleFunctions}
+                  functions={explorerFunctions}
                   showInternalFunctions={showInternalFunctions}
                   internalFunctionCount={internalFunctionCount}
                   isLoadingProject={isLoadingProject}

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -2079,12 +2079,19 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     ? projectUpdates[selectedProject]
     : undefined;
   const isLoadingProject = selectedProject != null && currentUpdate == null;
-  const functions: FunctionInfo[] = currentUpdate?.functions ?? [];
+  const functions: FunctionInfo[] = useMemo(
+    () => currentUpdate?.functions ?? [],
+    [currentUpdate],
+  );
   const previewTests = currentUpdate?.tests ?? [];
   const internalFunctionCount = functions.filter(isInternalFunction).length;
-  const visibleFunctions = showInternalFunctions
-    ? functions
-    : functions.filter((fn) => !isInternalFunction(fn));
+  const visibleFunctions = useMemo(
+    () =>
+      showInternalFunctions
+        ? functions
+        : functions.filter((fn) => !isInternalFunction(fn)),
+    [functions, showInternalFunctions],
+  );
   // Wait for every visible function's CFG response before applying the
   // explorer ranking so asynchronous responses do not make rows jump around.
   // Missing graphs are valid responses and contribute zero reachable callees.

--- a/typescript2/pkg-playground/src/function-call-breadth.test.ts
+++ b/typescript2/pkg-playground/src/function-call-breadth.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  functionCallBreadths,
+  orderFunctionsByCallBreadth,
+  orderFunctionsForExplorer,
+} from './function-call-breadth';
+import type {
+  ControlFlowGraph,
+  FunctionInfo,
+} from './worker-protocol';
+
+describe('function call breadth', () => {
+  it('orders broader transitive callers before their callees', () => {
+    const functions = [
+      functionInfo('Leaf'),
+      functionInfo('Branch'),
+      functionInfo('Root'),
+      functionInfo('Standalone'),
+    ];
+    const graphs = new Map<string, ControlFlowGraph>([
+      ['Leaf', graph()],
+      ['Branch', graph(['Leaf'])],
+      ['Root', graph(['Branch'])],
+      ['Standalone', graph()],
+    ]);
+
+    expect(functionCallBreadths(functions.map((fn) => fn.name), graphs)).toEqual(
+      new Map([
+        ['Leaf', 0],
+        ['Branch', 1],
+        ['Root', 2],
+        ['Standalone', 0],
+      ]),
+    );
+    expect(
+      orderFunctionsByCallBreadth(functions, graphs).map((fn) => fn.name),
+    ).toEqual(['Root', 'Branch', 'Leaf', 'Standalone']);
+  });
+
+  it('counts shared callees once and breaks equal-breadth ties by name', () => {
+    const functions = [
+      functionInfo('Zulu'),
+      functionInfo('Alpha'),
+      functionInfo('Shared'),
+      functionInfo('Root'),
+    ];
+    const graphs = new Map<string, ControlFlowGraph>([
+      ['Zulu', graph(['Shared'])],
+      ['Alpha', graph(['Shared'])],
+      ['Shared', graph()],
+      ['Root', graph(['Zulu', 'Alpha', 'Shared'])],
+    ]);
+
+    expect(
+      orderFunctionsByCallBreadth(functions, graphs).map((fn) => fn.name),
+    ).toEqual(['Root', 'Alpha', 'Zulu', 'Shared']);
+  });
+
+  it('resolves bare calls in the caller namespace and handles cycles', () => {
+    const functions = [
+      functionInfo('other.Helper'),
+      functionInfo('demo.Second'),
+      functionInfo('demo.Helper'),
+      functionInfo('demo.First'),
+    ];
+    const graphs = new Map<string, ControlFlowGraph>([
+      ['other.Helper', graph()],
+      ['demo.First', graph(['Second'])],
+      ['demo.Second', graph(['Helper', 'First'])],
+      ['demo.Helper', graph()],
+    ]);
+
+    expect(
+      functionCallBreadths(
+        functions.map((fn) => fn.name),
+        graphs,
+      ),
+    ).toEqual(
+      new Map([
+        ['other.Helper', 0],
+        ['demo.Second', 2],
+        ['demo.Helper', 0],
+        ['demo.First', 2],
+      ]),
+    );
+    expect(
+      orderFunctionsByCallBreadth(functions, graphs).map((fn) => fn.name),
+    ).toEqual([
+      'demo.First',
+      'demo.Second',
+      'demo.Helper',
+      'other.Helper',
+    ]);
+  });
+
+  it('keeps source order until every graph response has arrived', () => {
+    const functions = [functionInfo('Leaf'), functionInfo('Root')];
+    const graphs = new Map<string, ControlFlowGraph>([
+      ['Leaf', graph()],
+      ['Root', graph(['Leaf'])],
+    ]);
+
+    expect(
+      orderFunctionsForExplorer(
+        functions,
+        new Map([['Root', graphs.get('Root')!]]),
+        graphs,
+      ).map((fn) => fn.name),
+    ).toEqual(['Leaf', 'Root']);
+    expect(
+      orderFunctionsForExplorer(
+        functions,
+        new Map([
+          ['Root', graphs.get('Root')!],
+          ['Leaf', graphs.get('Leaf')!],
+        ]),
+        graphs,
+      ).map((fn) => fn.name),
+    ).toEqual(['Root', 'Leaf']);
+  });
+});
+
+function functionInfo(name: string): FunctionInfo {
+  return {
+    name,
+    kind: 'expr',
+    origin: 'userDefined',
+  };
+}
+
+function graph(callees: string[] = []): ControlFlowGraph {
+  return {
+    nodes: {
+      0: {
+        id: 0,
+        parentNodeId: null,
+        logFilterKey: 'root',
+        label: 'root',
+        sourceExpr: null,
+        nodeType: 'functionRoot',
+        isContainer: false,
+        ...(callees.length > 0 ? { calleeNames: callees } : {}),
+      },
+    },
+    edgesBySrc: {},
+  };
+}

--- a/typescript2/pkg-playground/src/function-call-breadth.test.ts
+++ b/typescript2/pkg-playground/src/function-call-breadth.test.ts
@@ -98,6 +98,35 @@ describe('function call breadth', () => {
     ]);
   });
 
+  it('ignores unresolved and ambiguous bare callees', () => {
+    const functions = [
+      functionInfo('Caller'),
+      functionInfo('MissingCaller'),
+      functionInfo('first.Helper'),
+      functionInfo('second.Helper'),
+    ];
+    const graphs = new Map<string, ControlFlowGraph>([
+      ['Caller', graph(['Helper'])],
+      ['MissingCaller', graph(['DoesNotExist'])],
+      ['first.Helper', graph()],
+      ['second.Helper', graph()],
+    ]);
+
+    expect(
+      functionCallBreadths(
+        functions.map((fn) => fn.name),
+        graphs,
+      ),
+    ).toEqual(
+      new Map([
+        ['Caller', 0],
+        ['MissingCaller', 0],
+        ['first.Helper', 0],
+        ['second.Helper', 0],
+      ]),
+    );
+  });
+
   it('keeps source order until every graph response has arrived', () => {
     const functions = [functionInfo('Leaf'), functionInfo('Root')];
     const graphs = new Map<string, ControlFlowGraph>([

--- a/typescript2/pkg-playground/src/function-call-breadth.test.ts
+++ b/typescript2/pkg-playground/src/function-call-breadth.test.ts
@@ -59,6 +59,7 @@ describe('function call breadth', () => {
 
   it('resolves bare calls in the caller namespace and handles cycles', () => {
     const functions = [
+      functionInfo('Helper'),
       functionInfo('other.Helper'),
       functionInfo('demo.Second'),
       functionInfo('demo.Helper'),
@@ -66,6 +67,7 @@ describe('function call breadth', () => {
     ];
     const graphs = new Map<string, ControlFlowGraph>([
       ['other.Helper', graph()],
+      ['Helper', graph(['other.Helper'])],
       ['demo.First', graph(['Second'])],
       ['demo.Second', graph(['Helper', 'First'])],
       ['demo.Helper', graph()],
@@ -78,6 +80,7 @@ describe('function call breadth', () => {
       ),
     ).toEqual(
       new Map([
+        ['Helper', 1],
         ['other.Helper', 0],
         ['demo.Second', 2],
         ['demo.Helper', 0],
@@ -89,6 +92,7 @@ describe('function call breadth', () => {
     ).toEqual([
       'demo.First',
       'demo.Second',
+      'Helper',
       'demo.Helper',
       'other.Helper',
     ]);

--- a/typescript2/pkg-playground/src/function-call-breadth.ts
+++ b/typescript2/pkg-playground/src/function-call-breadth.ts
@@ -17,13 +17,13 @@ function resolveFunctionName(
   callerName: string,
   rawName: string,
 ): string | null {
-  if (functionNames.includes(rawName)) return rawName;
-
   const namespaceEnd = callerName.lastIndexOf('.');
   if (namespaceEnd >= 0) {
     const sameNamespaceName = `${callerName.slice(0, namespaceEnd)}.${rawName}`;
     if (functionNames.includes(sameNamespaceName)) return sameNamespaceName;
   }
+
+  if (functionNames.includes(rawName)) return rawName;
 
   const matches = functionNames.filter(
     (name) => name.endsWith(`.${rawName}`) || rawName.endsWith(`.${name}`),

--- a/typescript2/pkg-playground/src/function-call-breadth.ts
+++ b/typescript2/pkg-playground/src/function-call-breadth.ts
@@ -14,16 +14,17 @@ function calleeNames(graph: ControlFlowGraph): string[] {
 
 function resolveFunctionName(
   functionNames: readonly string[],
+  functionNameSet: ReadonlySet<string>,
   callerName: string,
   rawName: string,
 ): string | null {
   const namespaceEnd = callerName.lastIndexOf('.');
   if (namespaceEnd >= 0) {
     const sameNamespaceName = `${callerName.slice(0, namespaceEnd)}.${rawName}`;
-    if (functionNames.includes(sameNamespaceName)) return sameNamespaceName;
+    if (functionNameSet.has(sameNamespaceName)) return sameNamespaceName;
   }
 
-  if (functionNames.includes(rawName)) return rawName;
+  if (functionNameSet.has(rawName)) return rawName;
 
   const matches = functionNames.filter(
     (name) => name.endsWith(`.${rawName}`) || rawName.endsWith(`.${name}`),
@@ -36,6 +37,7 @@ export function functionCallBreadths(
   graphsByFunction: ReadonlyMap<string, ControlFlowGraph>,
 ): ReadonlyMap<string, number> {
   const calleesByFunction = new Map<string, Set<string>>();
+  const functionNameSet = new Set(functionNames);
   for (const functionName of functionNames) {
     const graph = graphsByFunction.get(functionName);
     const callees = new Set<string>();
@@ -43,6 +45,7 @@ export function functionCallBreadths(
       for (const rawName of calleeNames(graph)) {
         const callee = resolveFunctionName(
           functionNames,
+          functionNameSet,
           functionName,
           rawName,
         );

--- a/typescript2/pkg-playground/src/function-call-breadth.ts
+++ b/typescript2/pkg-playground/src/function-call-breadth.ts
@@ -1,0 +1,98 @@
+import type { ControlFlowGraph, FunctionInfo } from './worker-protocol';
+
+function calleeNames(graph: ControlFlowGraph): string[] {
+  const names: string[] = [];
+  for (const node of Object.values(graph.nodes)) {
+    if (node.calleeNames && node.calleeNames.length > 0) {
+      names.push(...node.calleeNames);
+    } else if (node.calleeName) {
+      names.push(node.calleeName);
+    }
+  }
+  return names;
+}
+
+function resolveFunctionName(
+  functionNames: readonly string[],
+  callerName: string,
+  rawName: string,
+): string | null {
+  if (functionNames.includes(rawName)) return rawName;
+
+  const namespaceEnd = callerName.lastIndexOf('.');
+  if (namespaceEnd >= 0) {
+    const sameNamespaceName = `${callerName.slice(0, namespaceEnd)}.${rawName}`;
+    if (functionNames.includes(sameNamespaceName)) return sameNamespaceName;
+  }
+
+  const matches = functionNames.filter(
+    (name) => name.endsWith(`.${rawName}`) || rawName.endsWith(`.${name}`),
+  );
+  return matches.length === 1 ? matches[0]! : null;
+}
+
+export function functionCallBreadths(
+  functionNames: readonly string[],
+  graphsByFunction: ReadonlyMap<string, ControlFlowGraph>,
+): ReadonlyMap<string, number> {
+  const calleesByFunction = new Map<string, Set<string>>();
+  for (const functionName of functionNames) {
+    const graph = graphsByFunction.get(functionName);
+    const callees = new Set<string>();
+    if (graph) {
+      for (const rawName of calleeNames(graph)) {
+        const callee = resolveFunctionName(
+          functionNames,
+          functionName,
+          rawName,
+        );
+        if (callee && callee !== functionName) callees.add(callee);
+      }
+    }
+    calleesByFunction.set(functionName, callees);
+  }
+
+  const breadths = new Map<string, number>();
+  for (const functionName of functionNames) {
+    const reachable = new Set<string>();
+    const pending = [...(calleesByFunction.get(functionName) ?? [])];
+    while (pending.length > 0) {
+      const callee = pending.pop()!;
+      if (reachable.has(callee)) continue;
+      reachable.add(callee);
+      pending.push(...(calleesByFunction.get(callee) ?? []));
+    }
+    reachable.delete(functionName);
+    breadths.set(functionName, reachable.size);
+  }
+  return breadths;
+}
+
+export function orderFunctionsByCallBreadth(
+  functions: readonly FunctionInfo[],
+  graphsByFunction: ReadonlyMap<string, ControlFlowGraph>,
+): FunctionInfo[] {
+  const breadths = functionCallBreadths(
+    functions.map((fn) => fn.name),
+    graphsByFunction,
+  );
+  return [...functions].sort((left, right) => {
+    const breadthDifference =
+      (breadths.get(right.name) ?? 0) - (breadths.get(left.name) ?? 0);
+    if (breadthDifference !== 0) return breadthDifference;
+    return left.name < right.name ? -1 : left.name > right.name ? 1 : 0;
+  });
+}
+
+export function orderFunctionsForExplorer(
+  functions: readonly FunctionInfo[],
+  graphResponses: ReadonlyMap<string, ControlFlowGraph | null>,
+  graphsByFunction: ReadonlyMap<string, ControlFlowGraph>,
+): FunctionInfo[] {
+  const hasAllGraphResponses = functions.every((fn) =>
+    graphResponses.has(fn.name),
+  );
+  return hasAllGraphResponses
+    ? orderFunctionsByCallBreadth(functions, graphsByFunction)
+    : [...functions];
+}


### PR DESCRIPTION
## Summary

- rank playground explorer functions by the number of distinct functions reachable through their static call graph
- resolve namespace-local calls, deduplicate shared callees, handle cycles, and use function names as a deterministic tie-breaker
- wait for every visible CFG response before applying the order so rows do not reshuffle incrementally

## Why

B-810 asks for functions that call a broader set of other functions to appear first in the explorer, making workflow entry points easier to find.

## Validation

- `pnpm --filter @b/pkg-playground test` (129 tests)
- `pnpm --filter @b/pkg-playground typecheck`
- `pnpm --filter @b/pkg-playground build`
- `pnpm --filter app-vscode-webview typecheck`
- `pnpm --filter app-vscode-webview test:run` (23 tests, including Chromium)
- `pnpm --filter app-vscode-webview test:unit:run` (22 tests after adding the explorer-order integration regression)
- `pnpm --filter app-vscode-webview build`
- `pnpm build:wasm`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved function ordering in the explorer based on call relationships and breadth.
  * Preserved the existing order while graph data loads, preventing visible row-jumping.
  * Applied the optimized ordering once all relevant graph information is available.

* **Tests**
  * Added coverage for ordering, shared callees, namespace resolution, cycles, and asynchronous graph loading.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->