### PR TITLE
Add editable inputs to graph reruns

### DIFF
--- a/typescript2/app-vscode-webview/src/ExecutionPanel.graph-rerun.test.tsx
+++ b/typescript2/app-vscode-webview/src/ExecutionPanel.graph-rerun.test.tsx
@@ -111,6 +111,39 @@ describe('ExecutionPanel graph reruns', () => {
       false,
     );
   });
+
+  it('clears argument validation errors when switching tabs', async () => {
+    const port = new FakeRuntimePort();
+    render(
+      <ExecutionPanel port={port} initialTab="run" initialArgsJson="{}" />,
+    );
+
+    announceProject(port);
+    await selectPlanTrip();
+
+    const runArgsEditor = await screen.findByTestId('run-args-editor');
+    fireEvent.change(
+      within(runArgsEditor).getByRole('textbox', { name: 'Arguments JSON' }),
+      { target: { value: '{"destination":' } },
+    );
+    fireEvent.click(
+      within(runArgsEditor).getByRole('button', { name: 'Run' }),
+    );
+    expect(
+      await screen.findByText(/Unexpected end of JSON input/),
+    ).toBeVisible();
+
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Graph' }), {
+      button: 0,
+      ctrlKey: false,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/Unexpected end of JSON input/),
+      ).not.toBeInTheDocument();
+    });
+  });
 });
 
 class FakeRuntimePort implements RuntimePort {

--- a/typescript2/app-vscode-webview/src/ExecutionPanel.graph-rerun.test.tsx
+++ b/typescript2/app-vscode-webview/src/ExecutionPanel.graph-rerun.test.tsx
@@ -1,0 +1,138 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import { encodeRunArgs } from '@b/pkg-proto';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  ExecutionPanel,
+  type ProjectUpdate,
+  type RuntimePort,
+  type WorkerInMessage,
+  type WorkerOutMessage,
+} from '@b/pkg-playground';
+
+beforeAll(() => {
+  HTMLElement.prototype.scrollTo ??= vi.fn();
+});
+
+function announceProject(port: FakeRuntimePort): void {
+  const update: ProjectUpdate = {
+    isBexCurrent: true,
+    functions: [{ name: 'PlanTrip', kind: 'expr', origin: 'userDefined' }],
+    diagnostics: [],
+  };
+  act(() => {
+    port.emit({
+      type: 'playgroundNotification',
+      notification: { type: 'listProjects', projects: ['project'] },
+    });
+    port.emit({
+      type: 'playgroundNotification',
+      notification: { type: 'updateProject', project: 'project', update },
+    });
+  });
+}
+
+async function selectPlanTrip(): Promise<void> {
+  fireEvent.click(await screen.findByRole('button', { name: 'Functions (1)' }));
+  fireEvent.click(await screen.findByRole('button', { name: 'PlanTrip' }));
+}
+
+describe('ExecutionPanel graph reruns', () => {
+  it('edits arguments and starts a rerun without leaving the graph', async () => {
+    const port = new FakeRuntimePort();
+    render(
+      <ExecutionPanel
+        port={port}
+        initialTab="graph"
+        initialArgsJson='{"destination":"Paris"}'
+      />,
+    );
+
+    announceProject(port);
+    await selectPlanTrip();
+
+    const graphArgsEditor = await screen.findByTestId('graph-args-editor');
+    const argsInput = within(graphArgsEditor).getByRole('textbox', {
+      name: 'Arguments JSON',
+    });
+    expect(argsInput).toHaveValue('{"destination":"Paris"}');
+
+    fireEvent.change(argsInput, {
+      target: { value: '{"destination":"Kyoto"}' },
+    });
+    fireEvent.click(
+      within(graphArgsEditor).getByRole('button', { name: 'Run' }),
+    );
+
+    await waitFor(() => {
+      const startRun = port.sent.find(
+        (message): message is Extract<WorkerInMessage, { type: 'startRun' }> =>
+          message.type === 'startRun',
+      );
+      expect(startRun?.functionName).toBe('PlanTrip');
+      expect(startRun?.argsBytes).toEqual(
+        encodeRunArgs({ destination: 'Kyoto' }),
+      );
+    });
+    expect(screen.getByRole('tab', { name: 'Graph' })).toHaveAttribute(
+      'data-state',
+      'active',
+    );
+  });
+
+  it('shows argument validation errors in the graph and does not start a run', async () => {
+    const port = new FakeRuntimePort();
+    render(
+      <ExecutionPanel port={port} initialTab="graph" initialArgsJson="{}" />,
+    );
+
+    announceProject(port);
+    await selectPlanTrip();
+
+    const graphArgsEditor = await screen.findByTestId('graph-args-editor');
+    fireEvent.change(
+      within(graphArgsEditor).getByRole('textbox', { name: 'Arguments JSON' }),
+      { target: { value: '{"destination":' } },
+    );
+    fireEvent.click(
+      within(graphArgsEditor).getByRole('button', { name: 'Run' }),
+    );
+
+    expect(
+      await screen.findByText(/Unexpected end of JSON input/),
+    ).toBeVisible();
+    expect(port.sent.some((message) => message.type === 'startRun')).toBe(
+      false,
+    );
+  });
+});
+
+class FakeRuntimePort implements RuntimePort {
+  sent: WorkerInMessage[] = [];
+  private handlers = new Set<(message: WorkerOutMessage) => void>();
+
+  postMessage(message: WorkerInMessage): void {
+    this.sent.push(message);
+  }
+
+  onMessage(handler: (message: WorkerOutMessage) => void): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  emit(message: WorkerOutMessage): void {
+    for (const handler of this.handlers) handler(message);
+  }
+
+  dispose(): void {
+    this.handlers.clear();
+  }
+}

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -2537,6 +2537,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     </div>
   );
 
+  useEffect(() => {
+    setRunValidationError(null);
+  }, [activeTab, selectedFn]);
+
   const renderArgsEditor = (surface: 'graph' | 'run') => (
     <div
       className="nokey flex flex-col border-b border-vsc-border shrink-0"

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -2537,6 +2537,87 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     </div>
   );
 
+  const renderArgsEditor = (surface: 'graph' | 'run') => (
+    <div
+      className="nokey flex flex-col border-b border-vsc-border shrink-0"
+      data-testid={`${surface}-args-editor`}
+    >
+      <div className="flex items-center min-h-7">
+        <span className="px-2 py-1 text-[10px] text-vsc-text-faint font-vsc-mono bg-vsc-surface border-r border-vsc-border self-stretch flex items-center">
+          args
+        </span>
+        {showArgsForm ? (
+          <div className="flex-1" />
+        ) : (
+          <div className="flex-1 flex items-center min-w-0">
+            <Input
+              aria-label="Arguments JSON"
+              spellCheck={false}
+              value={argsJson}
+              onChange={onArgsJsonChange}
+              className="flex-1 h-7 rounded-none border-none font-vsc-mono text-xs"
+              placeholder='{"key": "value"}'
+            />
+            {argsFormUnavailable && (
+              <span className="px-2 text-[10px] text-vsc-text-faint whitespace-nowrap">
+                not a JSON object — form off
+              </span>
+            )}
+          </div>
+        )}
+        {paramSchemas !== undefined && (
+          <ToggleGroup
+            size="sm"
+            className="px-1.5 shrink-0"
+            value={argsMode}
+            options={[
+              { value: 'form', label: 'form' },
+              { value: 'raw', label: 'raw' },
+            ]}
+            onValueChange={setArgsMode}
+          />
+        )}
+        <Button
+          variant="success"
+          size="xs"
+          className="mx-1 my-0.5 shrink-0 text-[11px] font-semibold"
+          aria-label={isRunning ? 'Running' : 'Run'}
+          disabled={runtimeControlsDisabled || isRunning || !selectedProject}
+          onClick={onRunFunction}
+        >
+          {isRunning ? (
+            'Running...'
+          ) : (
+            <>
+              Run
+              <span className="font-normal opacity-70">
+                {RUN_SHORTCUT_HINT}
+              </span>
+            </>
+          )}
+        </Button>
+      </div>
+      {showArgsForm && paramSchemas && reconciledFormArgs && (
+        <div className="max-h-56 overflow-y-auto px-2 py-1.5 border-t border-vsc-border">
+          {/* Remount on function, schema, or surface changes so local widget
+              drafts cannot outlive the editor that owns them. */}
+          <ArgsForm
+            key={`${surface}:${selectedProject ?? ''}:${selectedFn ?? ''}:${argsSchemaKey}`}
+            params={paramSchemas}
+            types={projectTypes}
+            value={reconciledFormArgs}
+            onChange={onArgsFormChange}
+          />
+        </div>
+      )}
+      {surface === 'graph' && runValidationError && (
+        <div className="px-2 py-1.5 border-t border-vsc-border bg-vsc-error/10">
+          <ErrorDisplay error={runValidationError} />
+        </div>
+      )}
+    </div>
+  );
+
   // ── Render ─────────────────────────────────────────────────────────────
 
   return (
@@ -2651,7 +2732,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
           {selectedFn &&
             !viewingCollection &&
             !viewingTestRun &&
-            activeTab !== 'run' && (
+            activeTab !== 'run' &&
+            activeTab !== 'graph' && (
               <TooltipProvider>
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -3152,6 +3234,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                   className="flex-1 min-h-0 mt-0 flex flex-col"
                   style={{ minHeight: 300 }}
                 >
+                  {renderArgsEditor('graph')}
                   {workflowSwitcherBar}
                   {controlFlowGraph ? (
                     <GraphView
@@ -3270,82 +3353,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                   value="run"
                   className="flex-1 flex flex-col min-h-0 mt-0"
                 >
-                  {/* Args */}
-                  {/* `nokey`: keep React Flow's global key capture (Space,
-                      Backspace, ...) out of the args inputs */}
-                  <div className="nokey flex flex-col border-b border-vsc-border shrink-0">
-                    <div className="flex items-center min-h-7">
-                      <span className="px-2 py-1 text-[10px] text-vsc-text-faint font-vsc-mono bg-vsc-surface border-r border-vsc-border self-stretch flex items-center">
-                        args
-                      </span>
-                      {showArgsForm ? (
-                        <div className="flex-1" />
-                      ) : (
-                        <div className="flex-1 flex items-center min-w-0">
-                          <Input
-                            spellCheck={false}
-                            value={argsJson}
-                            onChange={onArgsJsonChange}
-                            className="flex-1 h-7 rounded-none border-none font-vsc-mono text-xs"
-                            placeholder='{"key": "value"}'
-                          />
-                          {argsFormUnavailable && (
-                            <span className="px-2 text-[10px] text-vsc-text-faint whitespace-nowrap">
-                              not a JSON object — form off
-                            </span>
-                          )}
-                        </div>
-                      )}
-                      {paramSchemas !== undefined && (
-                        <ToggleGroup
-                          size="sm"
-                          className="px-1.5 shrink-0"
-                          value={argsMode}
-                          options={[
-                            { value: 'form', label: 'form' },
-                            { value: 'raw', label: 'raw' },
-                          ]}
-                          onValueChange={setArgsMode}
-                        />
-                      )}
-                      <Button
-                        variant="success"
-                        size="xs"
-                        className="mx-1 my-0.5 shrink-0 text-[11px] font-semibold"
-                        aria-label={isRunning ? 'Running' : 'Run'}
-                        disabled={
-                          runtimeControlsDisabled ||
-                          isRunning ||
-                          !selectedProject
-                        }
-                        onClick={onRunFunction}
-                      >
-                        {isRunning ? (
-                          'Running...'
-                        ) : (
-                          <>
-                            Run
-                            <span className="font-normal opacity-70">
-                              {RUN_SHORTCUT_HINT}
-                            </span>
-                          </>
-                        )}
-                      </Button>
-                    </div>
-                    {showArgsForm && paramSchemas && reconciledFormArgs && (
-                      <div className="max-h-56 overflow-y-auto px-2 py-1.5 border-t border-vsc-border">
-                        {/* Remount on function or schema changes so local widget
-                            drafts cannot outlive the schema they represent. */}
-                        <ArgsForm
-                          key={`${selectedProject ?? ''}:${selectedFn ?? ''}:${argsSchemaKey}`}
-                          params={paramSchemas}
-                          types={projectTypes}
-                          value={reconciledFormArgs}
-                          onChange={onArgsFormChange}
-                        />
-                      </div>
-                    )}
-                  </div>
+                  {/* Keep React Flow's global key capture (Space, Backspace,
+                      ...) out of the shared args editor. */}
+                  {renderArgsEditor('run')}
 
                   {/* Live graph */}
                   <div


### PR DESCRIPTION
## Summary

- expose the existing schema-aware form/raw arguments editor directly above the Graph view
- rerun with edited inputs without leaving Graph, while preserving graph state and the shared execution path
- show argument validation feedback in Graph and remove the now-redundant header run icon
- add interaction coverage for edited encoded arguments and invalid JSON

## User impact

Users can inspect a workflow graph, adjust its function inputs, and rerun it in place instead of switching back to the Run tab.

## Before / after

Before — the Graph view only exposed a compact header Run icon, with no in-place argument editor.

![Before: Graph view without editable inputs](https://github.com/user-attachments/assets/fd73e1ff-4d47-4b77-9301-7edaa97c507b)

After — Graph exposes the shared raw/form argument editor and in-place Run control; invalid JSON is rejected with visible feedback without leaving the graph.

![After: Graph view with editable raw input, Run control, and invalid JSON feedback](https://github.com/user-attachments/assets/47e83fee-31eb-414b-92c6-6ed0e7f57805)

## Validation

- `pnpm test` (`typescript2/pkg-playground`): 125 tests passed
- `pnpm test:unit:run` (`typescript2/app-vscode-webview`): 23 tests passed
- `pnpm typecheck` in both packages
- `pnpm build` in both packages
- browser QA of form and raw input modes over the live graph

Linear: [B-811](https://linear.app/boundaryml2/issue/B-811/input-box-in-graph-with-run-button-or-re-eddit-them-therein)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added argument editing and run controls to the Graph tab.
  * Added validation feedback for invalid JSON arguments.
  * Preserved the selected Graph tab after starting a run.
  * Hid the redundant top-level Run button while viewing Graph or Run tabs.

* **Bug Fixes**
  * Prevented runs from starting when graph arguments contain invalid JSON.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
