### PR TITLE
fix(ci): skip unused bridge protoc setup

### DIFF
--- a/.github/workflows/build2-bridge-cffi.reusable.yaml
+++ b/.github/workflows/build2-bridge-cffi.reusable.yaml
@@ -158,6 +158,7 @@ jobs:
         with:
           targets: ${{ matrix._.target }}
           enable-cache: false
+          skip-protoc: true
 
       - name: Exclude optional AWS-LC jitter exports on Windows
         if: contains(matrix._.target, 'windows-msvc')


### PR DESCRIPTION
## Summary

- skip protoc installation in the `bridge_cffi` build matrix
- retain the existing Rust toolchain, target, cache, and cross-compilation setup

## Root cause

`bridge_cffi` vendors protoc and does not need a protoc installation, but its call to the shared `setup-rust` action inherited `skip-protoc: false`. That caused every bridge matrix leg to run `arduino/setup-protoc@v3`, whose dynamic GitHub release lookup intermittently failed with `unable to get latest version`. A Windows ARM64 lookup failure then blocked the required bridge build and the release fan-out.

## Impact

The bridge build no longer performs the unnecessary external protobuf release lookup. Builds that genuinely require protoc continue using the shared action's existing default behavior.

## Validation

- `actionlint .github/workflows/build2-bridge-cffi.reusable.yaml`
- `git diff --check`
- `python3 -m unittest scripts.tests.test_release_pipeline_contract` (22 tests)
- repository pre-commit hooks: branch guard, merge-conflict check, and YAML validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bridge CFFI build workflow to skip unnecessary Protocol Buffers setup, streamlining the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->