### PR TITLE
fix(python): order type aliases after definitions

### DIFF
--- a/baml_language/sdk_tests/crates/python_pydantic2/type_shapes/customizable/roundtrip_tests/test_alias_order.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/type_shapes/customizable/roundtrip_tests/test_alias_order.py
@@ -1,0 +1,8 @@
+import importlib
+
+
+def test_type_alias_declared_before_classes_is_importable():
+    alias_order = importlib.import_module("baml_sdk.alias_order")
+    importlib.import_module("baml_sdk.stream_types.alias_order")
+    result = alias_order.UsesResult(value=alias_order.Success())
+    assert isinstance(result.value, alias_order.Success)

--- a/baml_language/sdk_tests/crates/python_pydantic2/type_shapes/customizable/roundtrip_tests/test_alias_order.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/type_shapes/customizable/roundtrip_tests/test_alias_order.py
@@ -1,6 +1,7 @@
 import importlib
 
 
+# SDK_PARITY_LINT(skip): validates Python-specific generated type alias ordering
 def test_type_alias_declared_before_classes_is_importable():
     alias_order = importlib.import_module("baml_sdk.alias_order")
     importlib.import_module("baml_sdk.stream_types.alias_order")

--- a/baml_language/sdk_tests/fixtures/type_shapes/baml_src/ns_alias_order/types.baml
+++ b/baml_language/sdk_tests/fixtures/type_shapes/baml_src/ns_alias_order/types.baml
@@ -1,0 +1,26 @@
+type AliasChainHead = AliasChainTail[]
+type AliasChainTail = Result
+type Result = Success | Failure
+type AliasMap = map<string, AliasChainTail>
+type EnumResult = Status | Failure
+type GenericResult = Box<AliasChainHead>
+type RecursiveContainer = RecursiveResult[]
+type RecursiveResult = int | Success | RecursiveResult[]
+type MutualA = int | MutualB[]
+type MutualB = string | MutualA[]
+
+class Success {}
+
+class Failure {}
+
+enum Status {
+  Ready,
+}
+
+class Box<T> {
+  value T
+}
+
+class UsesResult {
+  value Result
+}

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
@@ -688,46 +688,160 @@ pub(crate) fn group_and_sort(
     // Stable sort preserves intra-parent function fan-out order (base
     // sync, base async, companions each sync/async).
     //
-    // Tertiary tie-breaker: when sort keys collide (PPIR assigns
-    // synthetic `$stream` symbols `TextRange::default()` so they share
-    // span 0), emit type aliases last — the alias's RHS may reference
-    // stream classes in the same leaf, and the class must be defined
-    // before the alias's RHS evaluates.
-    //
-    // Then, with a second stable pass, hoist recursive aliases to the
-    // very front of the leaf. Pyright recognizes a
-    // `Name = typing_extensions.TypeAliasType("Name", …)` assignment
-    // as a type alias only after the assignment line; consuming
+    // Recursive aliases are hoisted to the front of the leaf. Pyright
+    // recognizes a
+    // `Name = typing_extensions.TypeAliasType("Name", ...)` assignment as a
+    // type alias only after the assignment line; consuming
     // classes whose field annotations name the alias must come *after*
     // the assignment or pyright reports
     // `reportInvalidTypeForm` on the alias's own self-reference (18c).
+    //
+    // Non-recursive aliases are emitted after every other symbol because
+    // their right-hand sides evaluate eagerly. Same-leaf dependencies are
+    // topologically ordered within both alias phases so forward chains
+    // evaluate safely; recursive strongly connected components stay stable.
     let mut out: BTreeMap<LeafPath, LeafBody> = BTreeMap::new();
     for (leaf, mut pairs) in buckets {
-        pairs.sort_by(|a, b| {
-            a.1.cmp(&b.1)
-                .then_with(|| symbol_kind_ord(&a.0).cmp(&symbol_kind_ord(&b.0)))
-        });
-        // Stable hoist: recursive aliases first, everything else in
-        // the order produced by the previous sort.
-        pairs.sort_by_key(|(sym, _)| match sym {
-            EmittedSymbol::TypeAlias(a) if a.recursive => 0u8,
-            _ => 1,
-        });
-        out.insert(
-            leaf.clone(),
-            LeafBody {
-                leaf,
-                symbols: pairs,
-            },
+        pairs.sort_by(|a, b| a.1.cmp(&b.1));
+
+        let mut recursive_aliases = Vec::new();
+        let mut other_symbols = Vec::new();
+        let mut non_recursive_aliases = Vec::new();
+        for pair in pairs {
+            match &pair.0 {
+                EmittedSymbol::TypeAlias(a) if a.recursive => recursive_aliases.push(pair),
+                EmittedSymbol::TypeAlias(_) => non_recursive_aliases.push(pair),
+                _ => other_symbols.push(pair),
+            }
+        }
+
+        let mut symbols = Vec::with_capacity(
+            recursive_aliases.len() + other_symbols.len() + non_recursive_aliases.len(),
         );
+        symbols.extend(sort_aliases(recursive_aliases));
+        symbols.extend(other_symbols);
+        symbols.extend(sort_aliases(non_recursive_aliases));
+        out.insert(leaf.clone(), LeafBody { leaf, symbols });
     }
     out
 }
 
-fn symbol_kind_ord(sym: &EmittedSymbol) -> u8 {
-    match sym {
-        EmittedSymbol::TypeAlias(_) => 1,
-        _ => 0,
+fn sort_aliases(aliases: Vec<(EmittedSymbol, SortKey)>) -> Vec<(EmittedSymbol, SortKey)> {
+    let alias_indices: BTreeMap<baml_codegen_types::Name, usize> = aliases
+        .iter()
+        .enumerate()
+        .map(|(index, (symbol, _))| match symbol {
+            EmittedSymbol::TypeAlias(alias) => (alias.source.clone(), index),
+            _ => unreachable!("only type aliases are passed here"),
+        })
+        .collect();
+
+    let mut dependencies = vec![BTreeSet::new(); aliases.len()];
+    for (index, (symbol, _)) in aliases.iter().enumerate() {
+        let EmittedSymbol::TypeAlias(alias) = symbol else {
+            unreachable!("only type aliases are passed here");
+        };
+        collect_alias_dependencies(&alias.resolves_to, &alias_indices, &mut dependencies[index]);
+        dependencies[index].remove(&index);
+    }
+
+    let mut in_degree: Vec<usize> = dependencies.iter().map(BTreeSet::len).collect();
+    let mut dependents = vec![Vec::new(); aliases.len()];
+    for (dependent, required) in dependencies.iter().enumerate() {
+        for dependency in required {
+            dependents[*dependency].push(dependent);
+        }
+    }
+
+    let mut ready: BTreeSet<usize> = in_degree
+        .iter()
+        .enumerate()
+        .filter_map(|(index, degree)| (*degree == 0).then_some(index))
+        .collect();
+    let mut order = Vec::with_capacity(aliases.len());
+    while let Some(index) = ready.iter().next().copied() {
+        ready.remove(&index);
+        order.push(index);
+        for dependent in &dependents[index] {
+            in_degree[*dependent] -= 1;
+            if in_degree[*dependent] == 0 {
+                ready.insert(*dependent);
+            }
+        }
+    }
+
+    // Preserve deterministic source order for strongly connected components,
+    // which cannot be topologically separated.
+    if order.len() != aliases.len() {
+        order.extend(
+            in_degree
+                .iter()
+                .enumerate()
+                .filter_map(|(index, degree)| (*degree != 0).then_some(index)),
+        );
+    }
+
+    let mut aliases: Vec<Option<(EmittedSymbol, SortKey)>> =
+        aliases.into_iter().map(Some).collect();
+    order
+        .into_iter()
+        .map(|index| aliases[index].take().expect("alias index is unique"))
+        .collect()
+}
+
+fn collect_alias_dependencies(
+    ty: &Ty,
+    alias_indices: &BTreeMap<baml_codegen_types::Name, usize>,
+    out: &mut BTreeSet<usize>,
+) {
+    match ty {
+        Ty::TypeAlias(name, _) => {
+            if let Some(index) = alias_indices.get(name) {
+                out.insert(*index);
+            }
+        }
+        Ty::Class(_, arguments, _) => {
+            for argument in arguments {
+                collect_alias_dependencies(argument, alias_indices, out);
+            }
+        }
+        Ty::List(inner, _) => collect_alias_dependencies(inner, alias_indices, out),
+        Ty::Map { key, value, .. } => {
+            collect_alias_dependencies(key, alias_indices, out);
+            collect_alias_dependencies(value, alias_indices, out);
+        }
+        Ty::Union(members, _) => {
+            for member in members {
+                collect_alias_dependencies(member, alias_indices, out);
+            }
+        }
+        Ty::Function { params, ret, .. } => {
+            for param in params {
+                collect_alias_dependencies(&param.ty, alias_indices, out);
+            }
+            collect_alias_dependencies(ret, alias_indices, out);
+        }
+        Ty::Int { .. }
+        | Ty::Bigint { .. }
+        | Ty::Float { .. }
+        | Ty::String { .. }
+        | Ty::Bool { .. }
+        | Ty::Null { .. }
+        | Ty::Literal(..)
+        | Ty::Uint8Array { .. }
+        | Ty::Media(..)
+        | Ty::Enum(..)
+        | Ty::EnumVariant(..)
+        | Ty::TypeVar(..)
+        | Ty::RustType { .. }
+        | Ty::Type { .. }
+        | Ty::Resource { .. }
+        | Ty::PromptAst { .. }
+        | Ty::BuiltinUnknown { .. }
+        | Ty::Never { .. }
+        | Ty::Void { .. }
+        | Ty::Interface(..)
+        | Ty::Future(..) => {}
     }
 }
 


### PR DESCRIPTION
## Summary

- emit recursive aliases before concrete definitions and non-recursive aliases after them
- topologically order same-leaf alias dependencies while preserving recursive cycles
- add Python runtime, stream, Pyright, and Ruff coverage for B-996

## Tests

- cargo test -p sdkgen_python_pydantic2
- cargo clippy -p sdkgen_python_pydantic2 --all-targets -- -D warnings
- cargo nextest run -p sdk_test_python_pydantic2 type_shapes --no-fail-fast

Linear: B-996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Python SDK generation to emit type aliases in a deterministic, dependency-aware order.
  - Ensured recursive and mutually dependent aliases are generated without importability issues, even when aliases appear before referenced types.
- **Tests**
  - Added a new round-trip/importability test to validate alias ordering behavior.
  - Introduced a new fixture covering chained, recursive, generic, and mutually recursive alias/type scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->