### PR TITLE
Keep playground form args marker-free

### DIFF
--- a/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
+++ b/typescript2/app-vscode-webview/src/ExecutionPanel.strict-mode.test.tsx
@@ -335,14 +335,14 @@ describe('ExecutionPanel args form', () => {
     fireEvent.change(nameInput, { target: { value: 'Ada' } });
     fireEvent.click(await screen.findByRole('button', { name: 'Green' }));
 
-    // Raw view shows the same argsJson the form writes — including the enum
-    // wire marker — proving the form and raw input share one state.
+    // Raw view shows the same marker-free JSON the form writes. Type
+    // annotations are added only to the transient execution payload.
     fireEvent.click(await screen.findByRole('button', { name: 'raw' }));
     const rawInput = await screen.findByPlaceholderText('{"key": "value"}');
     const parsed = JSON.parse((rawInput as HTMLInputElement).value);
     expect(parsed).toEqual({
       name: 'Ada',
-      color: { $baml: { enum: 'user.Color', value: 'Green' } },
+      color: 'Green',
     });
 
     fireEvent.click(await screen.findByRole('button', { name: 'Run' }));
@@ -414,9 +414,7 @@ describe('ExecutionPanel args form', () => {
     );
     fireEvent.click(await screen.findByRole('button', { name: 'Greet' }));
     // Wait for the seed effect, then bounce to Zero and back.
-    const seeded = {
-      color: { $baml: { enum: 'user.Color', value: 'Red' } },
-    };
+    const seeded = { color: 'Red' };
     fireEvent.click(await screen.findByRole('button', { name: 'raw' }));
     const rawInput = await screen.findByPlaceholderText('{"key": "value"}');
     await waitFor(() => {
@@ -539,7 +537,6 @@ describe('ExecutionPanel args form', () => {
     await waitFor(() => {
       expect(JSON.parse((rawInput as HTMLInputElement).value)).toEqual({
         person: {
-          $baml: { type: 'user.Person' },
           name: 'Ada Lovelace',
           active: false,
           age: 0,
@@ -615,9 +612,7 @@ describe('ExecutionPanel args form', () => {
     await waitFor(() => {
       expect(JSON.parse((rawInput as HTMLInputElement).value)).toEqual({
         envelope: {
-          $baml: { type: 'user.Envelope' },
           flag: {
-            $baml: { type: 'user.Flag' },
             active: false,
           },
         },
@@ -770,10 +765,9 @@ describe('ExecutionPanel args form', () => {
     const rawInput = await screen.findByPlaceholderText('{"key": "value"}');
     expect(JSON.parse((rawInput as HTMLInputElement).value)).toEqual({
       t: {
-        $baml: { type: 'user.Tree' },
         value: 0,
         children: [
-          { $baml: { type: 'user.Tree' }, value: 7, children: [] },
+          { value: 7, children: [] },
         ],
       },
     });
@@ -845,7 +839,7 @@ describe('ExecutionPanel args form', () => {
     ).toBeInTheDocument();
   });
 
-  it('normalizes a bare-enum host seed into the wire marker', async () => {
+  it('keeps a bare-enum host seed marker-free in raw state', async () => {
     const port = new FakeRuntimePort();
 
     render(<ExecutionPanel port={port} initialArgsJson='{"c":"Red"}' />);
@@ -893,14 +887,13 @@ describe('ExecutionPanel args form', () => {
     );
     fireEvent.click(await screen.findByRole('button', { name: 'IsRed' }));
 
-    // The bare string would encode untyped (no String→Enum coercion exists);
-    // hydration must rewrite it to the marker even though the host seed is
-    // non-empty (so the seeding effect correctly stays away).
+    // Hydration keeps the user's JSON clean. The execution-boundary cast uses
+    // the known parameter schema without rewriting editor state.
     fireEvent.click(await screen.findByRole('button', { name: 'raw' }));
     const rawInput = await screen.findByPlaceholderText('{"key": "value"}');
     await waitFor(() => {
       expect(JSON.parse((rawInput as HTMLInputElement).value)).toEqual({
-        c: { $baml: { enum: 'user.Color', value: 'Red' } },
+        c: 'Red',
       });
     });
   });

--- a/typescript2/pkg-playground/src/ArgsForm.tsx
+++ b/typescript2/pkg-playground/src/ArgsForm.tsx
@@ -9,7 +9,8 @@
  * `CollapsibleContent`), which is what makes recursive types fully typed at
  * every depth the user opens. Fully controlled: the single source of truth is
  * the `value` record, which the host serializes into the existing `argsJson`
- * pipeline on every edit. Value/marker semantics live in args-form-model.ts.
+ * pipeline on every edit. Schema-directed execution casting lives in
+ * args-form-model.ts and does not leak wire annotations into this state.
  *
  * Nodes the form can't render typed (unsupported types, media, dangling refs)
  * degrade to a per-field raw-JSON textarea.
@@ -28,7 +29,6 @@ import { ChevronRight, Plus, Trash2 } from 'lucide-react';
 import {
   activeUnionVariant,
   defaultValueForSchema,
-  enumValue,
   enumVariantOf,
   isPlainObject,
   isRawJsonSchema,
@@ -335,7 +335,7 @@ const EnumField: FC<
         size="sm"
         value={current ?? ''}
         options={values.map((v) => ({ value: v, label: v }))}
-        onValueChange={(v) => onChange(enumValue(enumName, v))}
+        onValueChange={onChange}
       />
     );
   }
@@ -346,7 +346,7 @@ const EnumField: FC<
         onChange={(e) => {
           // The empty value is the "select…" placeholder, not a variant.
           if (e.target.value === '') return;
-          onChange(enumValue(enumName, e.target.value));
+          onChange(e.target.value);
         }}
       >
         {current === undefined && <option value="">select…</option>}
@@ -362,11 +362,11 @@ const EnumField: FC<
 
 const ClassSection: FC<
   FieldInputProps & { typeName: string; fields: FieldSchemaField[] }
-> = ({ typeName, fields, schema, value, onChange, depth }) => {
+> = ({ fields, schema, value, onChange, depth }) => {
   const [open, setOpen] = useState(depth < AUTO_COLLAPSE_DEPTH);
   const obj = isPlainObject(value) ? value : {};
   const setField = (name: string, v: unknown) =>
-    onChange({ ...obj, $baml: { type: typeName }, [name]: v });
+    onChange({ ...obj, [name]: v });
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
       <CollapsibleTrigger className="flex items-center gap-1 cursor-pointer text-xs text-vsc-description hover:text-foreground">

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -2225,8 +2225,9 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
         );
       }
       // Effects normally keep form state canonical, but Run must also close
-      // the same-commit race after a project/schema update. Raw mode remains
-      // an exact escape hatch and is intentionally not reconciled here.
+      // the same-commit race after a project/schema update. Raw mode skips
+      // reconciliation, but known values are still cast transiently below
+      // before wire encoding.
       const runArgs =
         argsMode === 'form' && paramSchemas !== undefined
           ? reconcileArgs(parsed, paramSchemas, typeLookup)

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -60,6 +60,7 @@ import {
 import type { ResultRendererProps } from './result-renderers';
 import { ArgsForm } from './ArgsForm';
 import {
+  castArgsToKnownTypes,
   isPlainObject,
   reconcileArgs,
   typeLookupFrom,
@@ -1682,7 +1683,19 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
 
       try {
         const previewFunctionName = companionFunctionName(selectedFn, subFn);
-        const argsBytes = encodeRunArgs(parsed as Record<string, unknown>);
+        const update = projectUpdates[selectedProject];
+        const params = update?.functions.find(
+          (fn) => fn.name === selectedFn,
+        )?.params;
+        const previewArgs =
+          params === undefined
+            ? (parsed as Record<string, unknown>)
+            : castArgsToKnownTypes(
+                parsed as Record<string, unknown>,
+                params,
+                typeLookupFrom(update.types),
+              );
+        const argsBytes = encodeRunArgs(previewArgs);
         const boundaryId = await executionStore.startPreviewRun({
           project: selectedProject,
           parentFunctionName: selectedFn,
@@ -2221,7 +2234,11 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
       const runArgsJson =
         runArgs === parsed ? argsJson : JSON.stringify(runArgs);
       if (runArgs !== parsed) updateArgsJson(runArgsJson);
-      const argsBytes = encodeRunArgs(runArgs);
+      const encodedArgs =
+        paramSchemas === undefined
+          ? runArgs
+          : castArgsToKnownTypes(runArgs, paramSchemas, typeLookup);
+      const argsBytes = encodeRunArgs(encodedArgs);
 
       const boundaryId = await executionStore.startRun({
         project: selectedProject,

--- a/typescript2/pkg-playground/src/args-form-model.test.ts
+++ b/typescript2/pkg-playground/src/args-form-model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   activeUnionVariant,
+  castArgsToKnownTypes,
   defaultValueForSchema,
   enumValue,
   enumVariantOf,
@@ -17,6 +18,7 @@ import type { FieldSchema, ParamSchema, TypeSchema } from './worker-protocol';
 
 const types: Record<string, TypeSchema> = {
   'user.Color': { kind: 'enum', values: ['Red', 'Green', 'Blue'] },
+  'user.OtherColor': { kind: 'enum', values: ['Red', 'Amber'] },
   'user.Nested': {
     kind: 'class',
     fields: [{ name: 'x', schema: { type: 'int' } }],
@@ -133,18 +135,15 @@ describe('defaultValueForSchema', () => {
 
   it('seeds required nested classes with every displayed field default', () => {
     expect(defaultValueForSchema(personRef, lookup)).toEqual({
-      $baml: { type: 'user.Person' },
       name: '',
       age: null,
-      color: { $baml: { enum: 'user.Color', value: 'Red' } },
-      nested: { $baml: { type: 'user.Nested' }, x: 0 },
+      color: 'Red',
+      nested: { x: 0 },
     });
   });
 
-  it('seeds enums with their first variant as a marker', () => {
-    expect(defaultValueForSchema(colorRef, lookup)).toEqual(
-      enumValue('user.Color', 'Red'),
-    );
+  it('seeds enums with their first variant as plain JSON', () => {
+    expect(defaultValueForSchema(colorRef, lookup)).toBe('Red');
   });
 
   it('seeds enum-variant params with their fixed variant', () => {
@@ -153,13 +152,12 @@ describe('defaultValueForSchema', () => {
         { type: 'enumVariant', name: 'user.Status', value: 'Active' },
         lookup,
       ),
-    ).toEqual(enumValue('user.Status', 'Active'));
+    ).toBe('Active');
   });
 
   it('seeds recursive types without blowing up', () => {
     expect(defaultValueForSchema({ type: 'ref', name: 'user.Tree' }, lookup))
       .toEqual({
-        $baml: { type: 'user.Tree' },
         value: 0,
         children: [],
       });
@@ -318,6 +316,123 @@ describe('isRawJsonSchema', () => {
   });
 });
 
+describe('castArgsToKnownTypes', () => {
+  it('casts uniquely known classes and enums only for wire encoding', () => {
+    const args = {
+      p: {
+        name: 'Ada',
+        age: null,
+        color: 'Green',
+        nested: { x: 7 },
+      },
+    };
+    expect(
+      castArgsToKnownTypes(
+        args,
+        [{ name: 'p', hasDefault: false, schema: personRef }],
+        lookup,
+      ),
+    ).toEqual({
+      p: {
+        $baml: { type: 'user.Person' },
+        name: 'Ada',
+        age: null,
+        color: { $baml: { enum: 'user.Color', value: 'Green' } },
+        nested: {
+          $baml: { type: 'user.Nested' },
+          x: 7,
+        },
+      },
+    });
+    expect(args).toEqual({
+      p: {
+        name: 'Ada',
+        age: null,
+        color: 'Green',
+        nested: { x: 7 },
+      },
+    });
+  });
+
+  it('casts the sole matching union member', () => {
+    expect(
+      castArgsToKnownTypes(
+        { value: 'Blue' },
+        [
+          {
+            name: 'value',
+            hasDefault: false,
+            schema: {
+              type: 'union',
+              variants: [colorRef, { type: 'int' }],
+            },
+          },
+        ],
+        lookup,
+      ),
+    ).toEqual({
+      value: { $baml: { enum: 'user.Color', value: 'Blue' } },
+    });
+  });
+
+  it('leaves ambiguous, invalid, and unsupported JSON unannotated', () => {
+    const ambiguous: ParamSchema = {
+      name: 'value',
+      hasDefault: false,
+      schema: {
+        type: 'union',
+        variants: [
+          colorRef,
+          { type: 'ref', name: 'user.OtherColor' },
+        ],
+      },
+    };
+    expect(
+      castArgsToKnownTypes({ value: 'Red' }, [ambiguous], lookup),
+    ).toEqual({ value: 'Red' });
+    expect(
+      castArgsToKnownTypes(
+        { value: 'Magenta' },
+        [{ name: 'value', hasDefault: false, schema: colorRef }],
+        lookup,
+      ),
+    ).toEqual({ value: 'Magenta' });
+    expect(
+      castArgsToKnownTypes(
+        { value: { arbitrary: true } },
+        [
+          {
+            name: 'value',
+            hasDefault: false,
+            schema: { type: 'unsupported', display: 'callback' },
+          },
+        ],
+        lookup,
+      ),
+    ).toEqual({ value: { arbitrary: true } });
+  });
+
+  it('accepts legacy markers but does not trust a mismatched type name', () => {
+    expect(
+      castArgsToKnownTypes(
+        { value: enumValue('user.Color', 'Red') },
+        [{ name: 'value', hasDefault: false, schema: colorRef }],
+        lookup,
+      ),
+    ).toEqual({
+      value: enumValue('user.Color', 'Red'),
+    });
+    const mismatched = enumValue('user.OtherColor', 'Red');
+    expect(
+      castArgsToKnownTypes(
+        { value: mismatched },
+        [{ name: 'value', hasDefault: false, schema: colorRef }],
+        lookup,
+      ),
+    ).toEqual({ value: mismatched });
+  });
+});
+
 describe('reconcileArgs', () => {
   const params: ParamSchema[] = [
     { name: 'c', hasDefault: false, schema: colorRef },
@@ -329,22 +444,19 @@ describe('reconcileArgs', () => {
     },
   ];
 
-  it('rewrites bare enum strings that name a valid variant', () => {
-    expect(reconcileArgs({ c: 'Red' }, [params[0]], lookup)).toEqual({
-      c: enumValue('user.Color', 'Red'),
-    });
+  it('keeps valid enum selections as plain JSON strings', () => {
+    const direct = { c: 'Red' };
+    expect(reconcileArgs(direct, [params[0]], lookup)).toBe(direct);
     // Inside containers too.
-    expect(reconcileArgs({ list: ['Red', 'Blue'] }, [params[2]], lookup))
-      .toEqual({
-        list: [enumValue('user.Color', 'Red'), enumValue('user.Color', 'Blue')],
-      });
+    const nested = { list: ['Red', 'Blue'] };
+    expect(reconcileArgs(nested, [params[2]], lookup)).toBe(nested);
     // An incompatible stale value resets to the schema default.
     expect(reconcileArgs({ c: 'Magenta' }, [params[0]], lookup)).toEqual({
-      c: enumValue('user.Color', 'Red'),
+      c: 'Red',
     });
   });
 
-  it('injects marker and missing-field defaults into markerless class objects', () => {
+  it('fills missing class fields without adding wire markers', () => {
     expect(
       reconcileArgs(
         { p: { name: 'Ada', color: 'Green' } },
@@ -353,57 +465,56 @@ describe('reconcileArgs', () => {
       ),
     ).toEqual({
       p: {
-        $baml: { type: 'user.Person' },
         name: 'Ada',
-        color: enumValue('user.Color', 'Green'),
+        color: 'Green',
         age: null,
-        nested: { $baml: { type: 'user.Nested' }, x: 0 },
+        nested: { x: 0 },
       },
     });
   });
 
-  it('overwrites a junk non-marker $baml key with the injected marker', () => {
-    // Raw editing can leave `$baml: 5` behind; spreading it over the marker
-    // would silently keep the value untyped while widgets render it typed.
+  it('removes a junk non-marker $baml key', () => {
     expect(
       reconcileArgs(
         { p: { $baml: 5, name: 'x' } },
         [params[1]],
         lookup,
       ),
-    ).toMatchObject({
-      p: { $baml: { type: 'user.Person' }, name: 'x' },
+    ).toEqual({
+      p: {
+        name: 'x',
+        age: null,
+        color: 'Red',
+        nested: { x: 0 },
+      },
     });
   });
 
-  it('fills marker-carrying objects and is idempotent once complete', () => {
+  it('migrates legacy markers to plain JSON and is then idempotent', () => {
     const args = {
       p: { $baml: { type: 'user.Person' }, color: 'Blue' },
     };
     expect(reconcileArgs(args, [params[1]], lookup)).toEqual({
       p: {
-        $baml: { type: 'user.Person' },
         name: '',
         age: null,
-        color: enumValue('user.Color', 'Blue'),
-        nested: { $baml: { type: 'user.Nested' }, x: 0 },
+        color: 'Blue',
+        nested: { x: 0 },
       },
     });
-    // Idempotent: already-typed input comes back by reference.
-    const typed = {
+    const plain = {
       p: {
-        $baml: { type: 'user.Person' },
         name: 'Ada',
         age: null,
-        color: enumValue('user.Color', 'Red'),
-        nested: { $baml: { type: 'user.Nested' }, x: 0 },
+        color: 'Red',
+        nested: { x: 0 },
       },
     };
-    expect(reconcileArgs(typed, [params[1]], lookup)).toBe(typed);
+    expect(reconcileArgs(plain, [params[1]], lookup)).toBe(plain);
   });
 
   it('preserves surplus keys and values without schemas', () => {
-    const args = { c: enumValue('user.Color', 'Red'), extra: { a: 1 } };
+    const args = { c: 'Red', extra: { a: 1 } };
     expect(reconcileArgs(args, [params[0]], lookup)).toBe(args);
   });
 
@@ -442,7 +553,6 @@ describe('reconcileArgs', () => {
       ),
     ).toEqual({
       p: {
-        $baml: { type: 'user.Person' },
         name: 'Ada',
         active: false,
         age: 0,

--- a/typescript2/pkg-playground/src/args-form-model.test.ts
+++ b/typescript2/pkg-playground/src/args-form-model.test.ts
@@ -32,6 +32,15 @@ const types: Record<string, TypeSchema> = {
       { name: 'nested', schema: { type: 'ref', name: 'user.Nested' } },
     ],
   },
+  'user.RawHolder': {
+    kind: 'class',
+    fields: [
+      {
+        name: 'payload',
+        schema: { type: 'unsupported', display: 'unknown callback' },
+      },
+    ],
+  },
   'user.Tree': {
     kind: 'class',
     fields: [
@@ -373,6 +382,51 @@ describe('castArgsToKnownTypes', () => {
     ).toEqual({
       value: { $baml: { enum: 'user.Color', value: 'Blue' } },
     });
+  });
+
+  it('keeps a known parent class cast when a raw child cannot be cast', () => {
+    expect(
+      castArgsToKnownTypes(
+        { value: { payload: { arbitrary: true } } },
+        [
+          {
+            name: 'value',
+            hasDefault: false,
+            schema: { type: 'ref', name: 'user.RawHolder' },
+          },
+        ],
+        lookup,
+      ),
+    ).toEqual({
+      value: {
+        $baml: { type: 'user.RawHolder' },
+        payload: { arbitrary: true },
+      },
+    });
+  });
+
+  it('preserves own __proto__ map entries while casting their values', () => {
+    const value = JSON.parse('{"__proto__":"Red"}') as Record<string, unknown>;
+    const result = castArgsToKnownTypes(
+      { value },
+      [
+        {
+          name: 'value',
+          hasDefault: false,
+          schema: {
+            type: 'map',
+            key: { type: 'string' },
+            value: colorRef,
+          },
+        },
+      ],
+      lookup,
+    );
+    const castMap = result.value as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(castMap, '__proto__')).toBe(
+      true,
+    );
+    expect(castMap['__proto__']).toEqual(enumValue('user.Color', 'Red'));
   });
 
   it('leaves ambiguous, invalid, and unsupported JSON unannotated', () => {

--- a/typescript2/pkg-playground/src/args-form-model.test.ts
+++ b/typescript2/pkg-playground/src/args-form-model.test.ts
@@ -384,6 +384,42 @@ describe('castArgsToKnownTypes', () => {
     });
   });
 
+  it('leaves surplus-key unions and classes missing required fields unannotated', () => {
+    const surplus = { x: 7, extra: true };
+    expect(
+      castArgsToKnownTypes(
+        { value: surplus },
+        [
+          {
+            name: 'value',
+            hasDefault: false,
+            schema: {
+              type: 'union',
+              variants: [
+                { type: 'ref', name: 'user.Nested' },
+                { type: 'int' },
+              ],
+            },
+          },
+        ],
+        lookup,
+      ),
+    ).toEqual({ value: surplus });
+
+    const missingRequired = {
+      age: null,
+      color: 'Red',
+      nested: { x: 7 },
+    };
+    expect(
+      castArgsToKnownTypes(
+        { value: missingRequired },
+        [{ name: 'value', hasDefault: false, schema: personRef }],
+        lookup,
+      ),
+    ).toEqual({ value: missingRequired });
+  });
+
   it('keeps a known parent class cast when a raw child cannot be cast', () => {
     expect(
       castArgsToKnownTypes(

--- a/typescript2/pkg-playground/src/args-form-model.ts
+++ b/typescript2/pkg-playground/src/args-form-model.ts
@@ -1,19 +1,11 @@
 /**
  * Pure logic for the dynamic args form (see ArgsForm.tsx for the widgets).
  *
- * The form's output is a plain JS object that round-trips through
- * `JSON.stringify` → the `argsJson` string → `JSON.parse` → `encodeRunArgs`.
- * Two `$baml` markers make typed values survive that pipeline:
- *
- * - class:  `{ $baml: { type: 'user.Person' }, ...fields }` — required for
- *   class values in *nested* positions (list/map elements, class fields),
- *   where the runtime does not promote bare maps to instances.
- * - enum:   `{ $baml: { enum: 'user.Color', value: 'Red' } }` — required for
- *   expr functions; plain strings are never coerced to enum variants on the
- *   args path.
- *
- * Names are the canonical dotted FQN the engine registers (`user.shapes.Foo`),
- * passed verbatim by the encoder.
+ * The form's output is ordinary JSON that round-trips through
+ * `JSON.stringify` → the `argsJson` string. Immediately before execution,
+ * [`castArgsToKnownTypes`] uses the parameter schema to add transient wire
+ * annotations for uniquely identified class and enum values. Ambiguous,
+ * unsupported, and invalid JSON stays unannotated for runtime validation.
  *
  * Named types arrive as `{ type: 'ref' }` nodes into the per-project table
  * (`ProjectUpdate.types`); every function here resolves refs through a
@@ -83,8 +75,7 @@ function classMarkerOf(value: unknown): string | undefined {
   return undefined;
 }
 
-/** Marker-only class instance — used as the finite cut point for a required
- *  recursive class path that cannot be populated to arbitrary depth. */
+/** Transient class annotation consumed by the protobuf encoder. */
 export function classMarkerValue(name: string): Record<string, unknown> {
   return { $baml: { type: name } };
 }
@@ -132,7 +123,7 @@ export function resolveRef(name: string, lookup: TypeLookup): ResolvedRef {
  *
  *  Required acyclic class refs are populated recursively so every default a
  *  typed widget displays is also present in the serialized value. A class ref
- *  already active on the current path becomes marker-only, which is the
+ *  already active on the current path becomes an empty object, which is the
  *  finite cut point for an irreducibly required recursive type. Optional and
  *  container branches terminate naturally at null/empty values. */
 export function defaultValueForSchema(
@@ -164,15 +155,13 @@ function defaultValue(
     case 'literal':
       return schema.value;
     case 'enumVariant':
-      return enumValue(schema.name, schema.value);
+      return schema.value;
     case 'ref': {
       if (aliasPath.has(schema.name)) return null;
       const resolved = resolveRef(schema.name, lookup);
       if (resolved === undefined) return null;
       if (resolved.kind === 'enum') {
-        return resolved.values.length > 0
-          ? enumValue(resolved.name, resolved.values[0])
-          : null;
+        return resolved.values[0] ?? null;
       }
       if (resolved.kind === 'schema') {
         const next = new Set(aliasPath);
@@ -180,11 +169,11 @@ function defaultValue(
         return defaultValue(resolved.schema, lookup, classPath, next);
       }
       if (classPath.has(resolved.name)) {
-        return classMarkerValue(resolved.name);
+        return {};
       }
       const nextClassPath = new Set(classPath);
       nextClassPath.add(resolved.name);
-      const obj = classMarkerValue(resolved.name);
+      const obj: Record<string, unknown> = {};
       for (const field of resolved.fields) {
         obj[field.name] = defaultValue(
           field.schema,
@@ -366,13 +355,221 @@ export function isRawJsonSchema(
   }
 }
 
+const CAST_FAILED = Symbol('cast-failed');
+type CastResult = unknown | typeof CAST_FAILED;
+
+/**
+ * Add transient type annotations to JSON arguments when the parameter schema
+ * identifies exactly one type. The returned value is only for `encodeRunArgs`;
+ * callers keep the original marker-free JSON as editor and history state.
+ *
+ * A union is cast only when exactly one member accepts the value. Invalid
+ * values, unsupported schemas, dangling refs, and ambiguous unions stay as
+ * ordinary JSON so the runtime's existing validation remains authoritative.
+ */
+export function castArgsToKnownTypes(
+  args: Record<string, unknown>,
+  params: ParamSchema[],
+  lookup: TypeLookup,
+): Record<string, unknown> {
+  const schemas = new Map(params.map((param) => [param.name, param.schema]));
+  return mapObject(args, (key, value) => {
+    const schema = schemas.get(key);
+    if (schema === undefined) return value;
+    const cast = tryCastValue(value, schema, lookup, new Set(), false);
+    return cast === CAST_FAILED ? value : cast;
+  });
+}
+
+function tryCastValue(
+  value: unknown,
+  schema: FieldSchema,
+  lookup: TypeLookup,
+  aliasPath: Set<string>,
+  strictObject: boolean,
+): CastResult {
+  switch (schema.type) {
+    case 'string':
+      return typeof value === 'string' ? value : CAST_FAILED;
+    case 'int':
+      return typeof value === 'number' &&
+        Number.isFinite(value) &&
+        Number.isInteger(value)
+        ? value
+        : CAST_FAILED;
+    case 'float':
+      return typeof value === 'number' && Number.isFinite(value)
+        ? value
+        : CAST_FAILED;
+    case 'bigint':
+      return (typeof value === 'number' &&
+        Number.isFinite(value) &&
+        Number.isInteger(value)) ||
+        typeof value === 'bigint'
+        ? value
+        : CAST_FAILED;
+    case 'bool':
+      return typeof value === 'boolean' ? value : CAST_FAILED;
+    case 'null':
+      return value === null ? null : CAST_FAILED;
+    case 'literal':
+      return Object.is(value, schema.value) ? value : CAST_FAILED;
+    case 'enumVariant': {
+      const variant = enumVariantOf(value);
+      if (
+        variant !== schema.value ||
+        (isEnumMarkerValue(value) && value.$baml.enum !== schema.name)
+      ) {
+        return CAST_FAILED;
+      }
+      return enumValue(schema.name, variant);
+    }
+    case 'ref': {
+      if (aliasPath.has(schema.name)) return CAST_FAILED;
+      const resolved = resolveRef(schema.name, lookup);
+      if (resolved === undefined) return CAST_FAILED;
+      if (resolved.kind === 'enum') {
+        const variant = enumVariantOf(value);
+        if (
+          variant === undefined ||
+          !resolved.values.includes(variant) ||
+          (isEnumMarkerValue(value) && value.$baml.enum !== resolved.name)
+        ) {
+          return CAST_FAILED;
+        }
+        return enumValue(resolved.name, variant);
+      }
+      if (resolved.kind === 'schema') {
+        const next = new Set(aliasPath);
+        next.add(schema.name);
+        return tryCastValue(
+          value,
+          resolved.schema,
+          lookup,
+          next,
+          strictObject,
+        );
+      }
+      if (!isPlainObject(value) || isEnumMarkerValue(value)) {
+        return CAST_FAILED;
+      }
+      const marker = classMarkerOf(value);
+      if (marker !== undefined && marker !== resolved.name) {
+        return CAST_FAILED;
+      }
+      const fields = new Map(
+        resolved.fields.map((field) => [field.name, field.schema]),
+      );
+      const entries = Object.entries(value).filter(([key]) => key !== '$baml');
+      if (strictObject && entries.some(([key]) => !fields.has(key))) {
+        return CAST_FAILED;
+      }
+      const cast: Record<string, unknown> = classMarkerValue(resolved.name);
+      for (const [key, fieldValue] of entries) {
+        const fieldSchema = fields.get(key);
+        if (fieldSchema === undefined) {
+          cast[key] = fieldValue;
+          continue;
+        }
+        const fieldCast = tryCastValue(
+          fieldValue,
+          fieldSchema,
+          lookup,
+          new Set(),
+          strictObject,
+        );
+        if (fieldCast === CAST_FAILED) return CAST_FAILED;
+        cast[key] = fieldCast;
+      }
+      for (const field of resolved.fields) {
+        if (!(field.name in cast)) {
+          if (!schemaAllowsOmission(field.schema, lookup, new Set())) {
+            return CAST_FAILED;
+          }
+          cast[field.name] = null;
+        }
+      }
+      return cast;
+    }
+    case 'list': {
+      if (!Array.isArray(value)) return CAST_FAILED;
+      const cast = value.map((item) =>
+        tryCastValue(item, schema.item, lookup, new Set(), strictObject),
+      );
+      return cast.some((item) => item === CAST_FAILED) ? CAST_FAILED : cast;
+    }
+    case 'map': {
+      if (
+        !isPlainObject(value) ||
+        classMarkerOf(value) !== undefined ||
+        isEnumMarkerValue(value)
+      ) {
+        return CAST_FAILED;
+      }
+      const cast: Record<string, unknown> = {};
+      for (const [key, entry] of Object.entries(value)) {
+        const entryCast = tryCastValue(
+          entry,
+          schema.value,
+          lookup,
+          new Set(),
+          strictObject,
+        );
+        if (entryCast === CAST_FAILED) return CAST_FAILED;
+        cast[key] = entryCast;
+      }
+      return cast;
+    }
+    case 'optional':
+      return value === null
+        ? null
+        : tryCastValue(
+            value,
+            schema.inner,
+            lookup,
+            aliasPath,
+            strictObject,
+          );
+    case 'union': {
+      const matches = schema.variants
+        .map((variant) => tryCastValue(value, variant, lookup, aliasPath, true))
+        .filter((candidate) => candidate !== CAST_FAILED);
+      return matches.length === 1 ? matches[0] : CAST_FAILED;
+    }
+    case 'media':
+    case 'unsupported':
+      return CAST_FAILED;
+    default:
+      return CAST_FAILED;
+  }
+}
+
+function schemaAllowsOmission(
+  schema: FieldSchema,
+  lookup: TypeLookup,
+  seen: Set<string>,
+): boolean {
+  if (schema.type === 'optional') return true;
+  if (schema.type === 'union') {
+    return schema.variants.some((variant) =>
+      schemaAllowsOmission(variant, lookup, seen),
+    );
+  }
+  if (schema.type !== 'ref' || seen.has(schema.name)) return false;
+  const resolved = resolveRef(schema.name, lookup);
+  if (resolved?.kind !== 'schema') return false;
+  const next = new Set(seen);
+  next.add(schema.name);
+  return schemaAllowsOmission(resolved.schema, lookup, next);
+}
+
 /**
  * Reconcile serialized args with the current function schema so the values
- * rendered by typed widgets are exactly the values that will be encoded.
+ * rendered by typed widgets are semantically the values that will be encoded.
  *
  * Compatible user values and surplus raw-JSON keys are preserved. Missing
  * required parameters/fields receive schema defaults, incompatible values are
- * replaced with defaults, and typed class/enum markers are normalized.
+ * replaced with defaults, and legacy class/enum markers are removed.
  * Defaulted function parameters remain absent so the runtime evaluates their
  * declared BAML defaults. Returns the input reference when no change is
  * required, allowing callers to avoid redundant state writes.
@@ -415,17 +612,13 @@ function reconcileValue(
 
   switch (schema.type) {
     case 'enumVariant':
-      return typeof value === 'string' && value === schema.value
-        ? enumValue(schema.name, value)
-        : value;
+      return enumVariantOf(value) ?? value;
     case 'ref': {
       if (aliasPath.has(schema.name)) return value;
       const resolved = resolveRef(schema.name, lookup);
       if (resolved === undefined) return value;
       if (resolved.kind === 'enum') {
-        return typeof value === 'string' && resolved.values.includes(value)
-          ? enumValue(resolved.name, value)
-          : value;
+        return enumVariantOf(value) ?? value;
       }
       if (resolved.kind === 'schema') {
         const next = new Set(aliasPath);
@@ -440,13 +633,19 @@ function reconcileValue(
       }
       if (!isPlainObject(value) || isEnumMarkerValue(value)) return value;
       const marker = classMarkerOf(value);
+      const classValue =
+        marker !== undefined || '$baml' in value
+          ? Object.fromEntries(
+              Object.entries(value).filter(([key]) => key !== '$baml'),
+            )
+          : value;
       const recursiveClass = classPath.has(resolved.name);
       const nextClassPath = new Set(classPath);
       nextClassPath.add(resolved.name);
       const fieldSchemas = new Map(
         resolved.fields.map((f) => [f.name, f.schema]),
       );
-      let reconciled = mapObject(value, (key, fieldValue) => {
+      let reconciled = mapObject(classValue, (key, fieldValue) => {
         const fieldSchema = fieldSchemas.get(key);
         return fieldSchema === undefined
           ? fieldValue
@@ -458,18 +657,10 @@ function reconcileValue(
               nextClassPath,
             );
       });
-      if (marker !== resolved.name) {
-        // Marker spread last: a junk non-marker `$baml` key from raw editing
-        // must be overwritten, not preserved over the injected marker.
-        reconciled = {
-          ...reconciled,
-          ...classMarkerValue(resolved.name),
-        };
-      }
       if (!recursiveClass) {
         for (const field of resolved.fields) {
           if (!(field.name in reconciled)) {
-            if (reconciled === value) reconciled = { ...value };
+            if (reconciled === classValue) reconciled = { ...classValue };
             reconciled[field.name] = defaultValue(
               field.schema,
               lookup,
@@ -479,7 +670,7 @@ function reconcileValue(
           }
         }
       }
-      return reconciled;
+      return reconciled === value && marker === undefined ? value : reconciled;
     }
     case 'list': {
       if (!Array.isArray(value)) return value;

--- a/typescript2/pkg-playground/src/args-form-model.ts
+++ b/typescript2/pkg-playground/src/args-form-model.ts
@@ -464,11 +464,15 @@ function tryCastValue(
       if (strictObject && entries.some(([key]) => !fields.has(key))) {
         return CAST_FAILED;
       }
-      const cast: Record<string, unknown> = classMarkerValue(resolved.name);
+      const castEntries: [string, unknown][] = [
+        ['$baml', { type: resolved.name }],
+      ];
+      const presentFields = new Set<string>();
       for (const [key, fieldValue] of entries) {
+        presentFields.add(key);
         const fieldSchema = fields.get(key);
         if (fieldSchema === undefined) {
-          cast[key] = fieldValue;
+          castEntries.push([key, fieldValue]);
           continue;
         }
         const fieldCast = tryCastValue(
@@ -478,18 +482,22 @@ function tryCastValue(
           new Set(),
           strictObject,
         );
-        if (fieldCast === CAST_FAILED) return CAST_FAILED;
-        cast[key] = fieldCast;
+        if (fieldCast === CAST_FAILED) {
+          if (strictObject) return CAST_FAILED;
+          castEntries.push([key, fieldValue]);
+          continue;
+        }
+        castEntries.push([key, fieldCast]);
       }
       for (const field of resolved.fields) {
-        if (!(field.name in cast)) {
+        if (!presentFields.has(field.name)) {
           if (!schemaAllowsOmission(field.schema, lookup, new Set())) {
             return CAST_FAILED;
           }
-          cast[field.name] = null;
+          castEntries.push([field.name, null]);
         }
       }
-      return cast;
+      return Object.fromEntries(castEntries);
     }
     case 'list': {
       if (!Array.isArray(value)) return CAST_FAILED;
@@ -506,7 +514,7 @@ function tryCastValue(
       ) {
         return CAST_FAILED;
       }
-      const cast: Record<string, unknown> = {};
+      const castEntries: [string, unknown][] = [];
       for (const [key, entry] of Object.entries(value)) {
         const entryCast = tryCastValue(
           entry,
@@ -516,9 +524,9 @@ function tryCastValue(
           strictObject,
         );
         if (entryCast === CAST_FAILED) return CAST_FAILED;
-        cast[key] = entryCast;
+        castEntries.push([key, entryCast]);
       }
-      return cast;
+      return Object.fromEntries(castEntries);
     }
     case 'optional':
       return value === null
@@ -721,11 +729,11 @@ function mapObject(
   map: (key: string, value: unknown) => unknown,
 ): Record<string, unknown> {
   let changed = false;
-  const out: Record<string, unknown> = {};
+  const entries: [string, unknown][] = [];
   for (const [key, value] of Object.entries(obj)) {
     const next = map(key, value);
     if (next !== value) changed = true;
-    out[key] = next;
+    entries.push([key, next]);
   }
-  return changed ? out : obj;
+  return changed ? Object.fromEntries(entries) : obj;
 }

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -82,7 +82,7 @@ export interface FieldSchemaField {
 /** Recursive type schema for the args form (mirrors
  *  `baml_project::FieldSchema`). Named types are `ref`s into
  *  `ProjectUpdate.types`; `name`s are the canonical dotted FQN the engine
- *  registers (`user.shapes.Foo`), usable verbatim in `$baml` markers. */
+ *  registers (`user.shapes.Foo`), used for schema-directed argument casts. */
 export type FieldSchema =
   | { type: 'string' }
   | { type: 'int' }
@@ -96,7 +96,7 @@ export type FieldSchema =
    *  (mid-edit inconsistency) degrades to the raw-JSON fallback. */
   | { type: 'ref'; name: string }
   /** A specific-variant param type (`s: Status.Active`) — self-contained so
-   *  the form can emit the enum wire marker without a table entry. */
+   *  the execution-boundary cast does not need a table entry. */
   | { type: 'enumVariant'; name: string; value: string }
   | { type: 'list'; item: FieldSchema }
   | { type: 'map'; key: FieldSchema; value: FieldSchema }


### PR DESCRIPTION
## Summary

- Keep schema-driven form and raw editor state as ordinary JSON.
- Cast uniquely matched class and enum values only in transient execution payloads.
- Preserve unannotated runtime fallback for ambiguous, invalid, and unsupported values.

## Why

The dynamic args form currently writes `$baml` transport markers into user-visible JSON. The parameter and type schemas already identify most values, so marker generation belongs at the execution boundary rather than editor state.

## Validation

- `pnpm --filter @b/pkg-playground test` (132 tests)
- `pnpm --filter @b/pkg-playground typecheck`
- `pnpm --filter app-vscode-webview typecheck`
- `pnpm --filter app-vscode-webview test:unit:run` (21 tests)
- `pnpm run build:wasm`
- `pnpm --filter app-vscode-webview build`

Linear: B-814

## Before / after

### Before — `$baml` markers in editor state

At the exact PR base (`2960e7a`), the TypeScript2 playground's raw editor persists class and enum transport markers.

![Before: raw playground arguments include class and enum $baml markers](https://github.com/user-attachments/assets/6d551cf5-0d96-4289-9481-aff01ce3c289)

### After — marker-free editor with execution-boundary casting

At the exact PR head (`c4ec9b2`), the same fixture and viewport keep ordinary JSON in the raw editor; the successful graph input renders `user.Person`, demonstrating that the known type is applied only at the execution boundary.

![After: raw playground arguments are plain JSON while the successful graph input is typed as user.Person](https://github.com/user-attachments/assets/df49198e-7520-4bf2-8260-de81891dea8d)
