### PR TITLE
fix(playground): keep "run test" button in stable position, show test status to the left of "run"

### DIFF
--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -108,6 +108,7 @@ import {
   type SerializedTestDef,
   type SerializedTestSet,
 } from './serialized-test-tree';
+import { collectLatestTestRunResults } from './test-run-results';
 
 registerBuiltinResultRenderers();
 
@@ -823,26 +824,10 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
       ),
     [displayRuns, generation, selectedProject],
   );
-  const testRunResults = useMemo(() => {
-    const results = new Map<string, unknown>();
-    for (const [testName, error] of testStartErrors) {
-      results.set(testName, { outcome: 'error', error });
-    }
-    for (const run of testRuns) {
-      if (!run.testName) continue;
-      if (run.result != null) {
-        results.set(run.testName, run.result);
-      } else if (run.error) {
-        results.set(run.testName, { outcome: 'error', error: run.error });
-      } else if (run.status === 'cancelled') {
-        results.set(run.testName, {
-          outcome: 'error',
-          error: 'Cancelled',
-        });
-      }
-    }
-    return results;
-  }, [testRuns, testStartErrors]);
+  const testRunResults = useMemo(
+    () => collectLatestTestRunResults(testRuns, testStartErrors),
+    [testRuns, testStartErrors],
+  );
   const [expandedLogId, setExpandedLogId] = useState<number | null>(null);
   const outputRef = useRef<HTMLDivElement>(null);
   const promptContentRef = useRef<HTMLDivElement>(null);

--- a/typescript2/pkg-playground/src/FunctionSidebar.render.test.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.render.test.tsx
@@ -34,7 +34,7 @@ describe('FunctionSidebar test rows', () => {
       expect(statusIndex).toBeGreaterThan(-1);
       expect(runIndex).toBeGreaterThan(statusIndex);
       expect(markup).toContain(
-        `aria-label="Latest test run status: ${outcome}" title="Latest test run status: ${outcome}">${outcome}</span><button`,
+        `role="status" aria-label="Latest test run status: ${outcome}" title="Latest test run status: ${outcome}">${outcome}</span><button`,
       );
     },
   );

--- a/typescript2/pkg-playground/src/FunctionSidebar.render.test.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.render.test.tsx
@@ -1,0 +1,41 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { FunctionSidebar } from './FunctionSidebar';
+import type { SerializedTestDef } from './serialized-test-tree';
+
+describe('FunctionSidebar test rows', () => {
+  it.each(['pass', 'fail'])(
+    'renders the latest %s status immediately before the run action',
+    (outcome) => {
+      const testTree: SerializedTestDef[] = [
+        {
+          type: 'test',
+          name: 'resume/basic',
+        },
+      ];
+      const markup = renderToStaticMarkup(
+        <FunctionSidebar
+          functions={[]}
+          showInternalFunctions={false}
+          internalFunctionCount={0}
+          testTree={testTree}
+          selectedFn={null}
+          onSelectFn={() => {}}
+          onRefreshTests={() => {}}
+          onRunTest={() => {}}
+          testRunResults={new Map([['resume/basic', { outcome }]])}
+        />,
+      );
+
+      const statusIndex = markup.indexOf(`>${outcome}</span>`);
+      const runIndex = markup.indexOf('>run</button>');
+
+      expect(statusIndex).toBeGreaterThan(-1);
+      expect(runIndex).toBeGreaterThan(statusIndex);
+      expect(markup).toContain(
+        `aria-label="Latest test run status: ${outcome}" title="Latest test run status: ${outcome}">${outcome}</span><button`,
+      );
+    },
+  );
+});

--- a/typescript2/pkg-playground/src/FunctionSidebar.render.test.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.render.test.tsx
@@ -38,4 +38,24 @@ describe('FunctionSidebar test rows', () => {
       );
     },
   );
+
+  it('keeps the run action right-aligned when the test has no result', () => {
+    const markup = renderToStaticMarkup(
+      <FunctionSidebar
+        functions={[]}
+        showInternalFunctions={false}
+        internalFunctionCount={0}
+        testTree={[{ type: 'test', name: 'resume/basic' }]}
+        selectedFn={null}
+        onSelectFn={() => {}}
+        onRefreshTests={() => {}}
+        onRunTest={() => {}}
+      />,
+    );
+
+    expect(markup).not.toContain('Latest test run status:');
+    expect(markup).toMatch(
+      /<button class="[^"]*\bml-auto\b[^"]*" title="Run test: resume\/basic">run<\/button>/,
+    );
+  });
 });

--- a/typescript2/pkg-playground/src/FunctionSidebar.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.tsx
@@ -121,9 +121,24 @@ function TestTreeNode({
       >
         <FlaskConical className={SIDEBAR_LEAF_ICON_CLASS} />
         <span className="truncate">{def.name.split('/').pop()}</span>
+        {outcome && (
+          <span
+            className={cn(
+              'ml-auto text-[9px] shrink-0',
+              outcome === 'pass' ? 'text-green-500' : 'text-red-500',
+            )}
+            aria-label={`Latest test run status: ${outcome}`}
+            title={`Latest test run status: ${outcome}`}
+          >
+            {outcome}
+          </span>
+        )}
         {onRunTest && (
           <button
-            className="ml-auto text-[9px] text-vsc-text-faint hover:text-vsc-text px-1 shrink-0 disabled:cursor-not-allowed disabled:opacity-50"
+            className={cn(
+              'text-[9px] text-vsc-text-faint hover:text-vsc-text px-1 shrink-0 disabled:cursor-not-allowed disabled:opacity-50',
+              !outcome && 'ml-auto',
+            )}
             disabled={disabled}
             onClick={(e) => {
               e.stopPropagation();
@@ -133,16 +148,6 @@ function TestTreeNode({
           >
             run
           </button>
-        )}
-        {outcome && (
-          <span
-            className={cn(
-              'text-[9px] shrink-0',
-              outcome === 'pass' ? 'text-green-500' : 'text-red-500',
-            )}
-          >
-            {outcome}
-          </span>
         )}
       </div>
     );

--- a/typescript2/pkg-playground/src/FunctionSidebar.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.tsx
@@ -127,6 +127,7 @@ function TestTreeNode({
               'ml-auto text-[9px] shrink-0',
               outcome === 'pass' ? 'text-green-500' : 'text-red-500',
             )}
+            role="status"
             aria-label={`Latest test run status: ${outcome}`}
             title={`Latest test run status: ${outcome}`}
           >

--- a/typescript2/pkg-playground/src/test-run-results.test.ts
+++ b/typescript2/pkg-playground/src/test-run-results.test.ts
@@ -37,16 +37,49 @@ describe('collectLatestTestRunResults', () => {
       error: 'Could not start',
     });
   });
+
+  it('uses the newest run error instead of an older completed result', () => {
+    const runs: TestRunResultSource[] = [
+      testRun('my/test', null, {
+        error: 'Runtime failed',
+        status: 'error',
+      }),
+      testRun('my/test', { outcome: 'pass' }),
+    ];
+
+    expect(collectLatestTestRunResults(runs, new Map()).get('my/test')).toEqual(
+      {
+        outcome: 'error',
+        error: 'Runtime failed',
+      },
+    );
+  });
+
+  it('uses the newest cancellation instead of an older completed result', () => {
+    const runs: TestRunResultSource[] = [
+      testRun('my/test', null, { status: 'cancelled' }),
+      testRun('my/test', { outcome: 'pass' }),
+    ];
+
+    expect(collectLatestTestRunResults(runs, new Map()).get('my/test')).toEqual(
+      {
+        outcome: 'error',
+        error: 'Cancelled',
+      },
+    );
+  });
 });
 
 function testRun(
   testName: string,
   result: RunStoreDisplayRun['result'],
+  overrides: Partial<Pick<TestRunResultSource, 'error' | 'status'>> = {},
 ): TestRunResultSource {
   return {
     testName,
     result,
     error: null,
     status: 'success',
+    ...overrides,
   };
 }

--- a/typescript2/pkg-playground/src/test-run-results.test.ts
+++ b/typescript2/pkg-playground/src/test-run-results.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RunStoreDisplayRun } from './run-store-projections';
+import { collectLatestTestRunResults } from './test-run-results';
+
+type TestRunResultSource = Pick<
+  RunStoreDisplayRun,
+  'testName' | 'result' | 'error' | 'status'
+>;
+
+describe('collectLatestTestRunResults', () => {
+  it('keeps the newest result for each test when runs are newest first', () => {
+    const runs: TestRunResultSource[] = [
+      testRun('my/test', { outcome: 'pass' }),
+      testRun('my/test', { outcome: 'fail' }),
+    ];
+
+    expect(collectLatestTestRunResults(runs, new Map()).get('my/test')).toEqual(
+      {
+        outcome: 'pass',
+      },
+    );
+  });
+
+  it('uses the latest start error instead of an older completed result', () => {
+    const runs: TestRunResultSource[] = [
+      testRun('my/test', { outcome: 'pass' }),
+    ];
+
+    expect(
+      collectLatestTestRunResults(
+        runs,
+        new Map([['my/test', 'Could not start']]),
+      ).get('my/test'),
+    ).toEqual({
+      outcome: 'error',
+      error: 'Could not start',
+    });
+  });
+});
+
+function testRun(
+  testName: string,
+  result: RunStoreDisplayRun['result'],
+): TestRunResultSource {
+  return {
+    testName,
+    result,
+    error: null,
+    status: 'success',
+  };
+}

--- a/typescript2/pkg-playground/src/test-run-results.ts
+++ b/typescript2/pkg-playground/src/test-run-results.ts
@@ -1,0 +1,34 @@
+import type { RunStoreDisplayRun } from './run-store-projections';
+
+type TestRunResultSource = Pick<
+  RunStoreDisplayRun,
+  'testName' | 'result' | 'error' | 'status'
+>;
+
+export function collectLatestTestRunResults(
+  testRuns: TestRunResultSource[],
+  testStartErrors: ReadonlyMap<string, string>,
+): Map<string, unknown> {
+  const results = new Map<string, unknown>();
+
+  for (const [testName, error] of testStartErrors) {
+    results.set(testName, { outcome: 'error', error });
+  }
+
+  for (const run of testRuns) {
+    if (!run.testName || results.has(run.testName)) continue;
+
+    if (run.result != null) {
+      results.set(run.testName, run.result);
+    } else if (run.error) {
+      results.set(run.testName, { outcome: 'error', error: run.error });
+    } else if (run.status === 'cancelled') {
+      results.set(run.testName, {
+        outcome: 'error',
+        error: 'Cancelled',
+      });
+    }
+  }
+
+  return results;
+}


### PR DESCRIPTION
## Summary

- show each test's latest pass/fail status immediately to the left of its Run action in the current playground
- keep the newest result when the same test has multiple runs in newest-first history
- preserve right alignment for tests without a result and expose the latest status to assistive technology

## Validation

- `pnpm --filter @b/pkg-playground typecheck`
- `pnpm --filter @b/pkg-playground test` — 133 tests pass
- `pnpm --filter @b/pkg-playground build`
- real-browser QA in the live local `/explore` playground: ran a deterministic binary-search test, confirmed `test name → pass → run` ordering with a 4px gap, and observed no console errors

Linear: [B-1047](https://linear.app/boundaryml2/issue/B-1047/latest-test-run-status-should-be-shown-to-the-left-of-the-run-button)

## Before / after

Exact current base (`0f97c05b`) and final TypeScript2 head (`98ddc21d`) in the real playground, using the same deterministic testset and viewport.

| Before — status appears after Run | After — status is immediately left of Run |
| --- | --- |
| ![Before: the latest test status appears to the right of the Run action](https://github.com/user-attachments/assets/aecda8e0-0fdb-4f8f-bc04-55d0d56f0906) | ![After: the latest status appears immediately to the left of Run](https://github.com/user-attachments/assets/08e9a37e-8846-4425-a36e-d92a1604baa8) |

The after image runs `latest_status` first and `persistence_check` second: both statuses remain visible, and the measured status-to-Run gap is 4px.