### PR TITLE
fix(playground): render workflows when selecting tests

### DIFF
--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -666,6 +666,119 @@ impl ProjectDatabase {
     ) -> Option<baml_compiler2_visualization::control_flow::ControlFlowGraph> {
         let mut ctx = CfgExpansionCtx::default();
         self.ast_control_flow_graph_impl(function_name, &mut ctx)
+            .or_else(|| self.ast_test_control_flow_graph_impl(function_name, &mut ctx))
+    }
+
+    /// Build a graph for a statically named top-level `test "..." { ... }`
+    /// declaration. New-style tests are lowered into lambdas passed to the
+    /// per-file `$init_test_*` function, so they do not appear in
+    /// `file_functions`. The test registry exposes their canonical names to
+    /// the playground (`root[.namespace]::name`); recover the matching lambda
+    /// from that synthesized registration and graph its body directly.
+    fn ast_test_control_flow_graph_impl(
+        &self,
+        test_name: &str,
+        ctx: &mut CfgExpansionCtx,
+    ) -> Option<baml_compiler2_visualization::control_flow::ControlFlowGraph> {
+        use baml_compiler2_ast::{Expr, FunctionBodyDef, Item};
+        use baml_compiler2_visualization::control_flow::{
+            NodeType, build_control_flow_graph_from_ast,
+        };
+        use baml_type::Literal;
+
+        if !ctx.expanding.insert(test_name.to_string()) {
+            return None;
+        }
+
+        let mut result = None;
+        'files: for source_file in self.file_map.values().copied() {
+            let ast = baml_compiler2_hir::file_ast(self, source_file);
+            for item in &ast.items {
+                let Item::Function(init_function) = item else {
+                    continue;
+                };
+                if !init_function.name.as_str().starts_with("$init_test") {
+                    continue;
+                }
+                let Some(FunctionBodyDef::Expr(registration_body, registration_source_map)) =
+                    init_function.body.as_ref()
+                else {
+                    continue;
+                };
+
+                let mut duplicate_counts = HashMap::<String, usize>::new();
+                for (_, expr) in registration_body.exprs.iter() {
+                    let Expr::Call { callee, args, .. } = expr else {
+                        continue;
+                    };
+                    let Expr::Path(callee_segments) = &registration_body.exprs[*callee] else {
+                        continue;
+                    };
+                    if callee_segments.last().map(AsRef::<str>::as_ref) != Some("register_test_at")
+                        || args.len() != 4
+                    {
+                        continue;
+                    }
+
+                    let Expr::Literal(Literal::String(owner)) =
+                        &registration_body.exprs[args[0].expr]
+                    else {
+                        continue;
+                    };
+                    let Expr::Literal(Literal::String(name)) =
+                        &registration_body.exprs[args[1].expr]
+                    else {
+                        // Runtime-computed test names cannot be identified
+                        // statically from the canonical registry name.
+                        continue;
+                    };
+                    let canonical_base = format!("{owner}::{name}");
+                    let duplicate_count = duplicate_counts
+                        .entry(canonical_base.clone())
+                        .and_modify(|count| *count += 1)
+                        .or_insert(1);
+                    let canonical_name = if *duplicate_count == 1 {
+                        canonical_base
+                    } else {
+                        format!("{canonical_base}#{duplicate_count}")
+                    };
+                    if canonical_name != test_name {
+                        continue;
+                    }
+
+                    let Expr::Lambda(test_lambda) = &registration_body.exprs[args[2].expr] else {
+                        continue;
+                    };
+                    let Some(FunctionBodyDef::Expr(test_body, test_source_map)) =
+                        test_lambda.body.as_ref()
+                    else {
+                        continue;
+                    };
+
+                    let mut graph = build_control_flow_graph_from_ast(test_name, test_body);
+                    self.attach_source_spans_to_graph(&mut graph, source_file, test_source_map);
+
+                    let test_name_span =
+                        Self::source_map_expr_range(registration_source_map, args[1].expr)
+                            .and_then(|range| self.source_span_for_range(source_file, range));
+                    if let Some(root) = graph
+                        .nodes
+                        .values_mut()
+                        .find(|node| node.node_type == NodeType::FunctionRoot)
+                    {
+                        root.source_span = test_name_span
+                            .or_else(|| self.source_span_for_range(source_file, test_lambda.span));
+                    }
+
+                    self.expand_user_function_calls_in_graph(&mut graph, test_body, ctx);
+                    result = Some(graph);
+                    break 'files;
+                }
+            }
+        }
+
+        ctx.expanding.remove(test_name);
+        result
     }
 
     fn ast_control_flow_graph_impl(
@@ -1032,6 +1145,18 @@ impl ProjectDatabase {
         let span_idx =
             la_arena::Idx::<text_size::TextRange>::from_raw(la_arena::RawIdx::from_u32(raw));
         self.source_span_for_range(source_file, spans[span_idx])
+    }
+
+    fn source_map_expr_range(
+        source_map: &baml_compiler2_ast::AstSourceMap,
+        expr_id: baml_compiler2_ast::ExprId,
+    ) -> Option<text_size::TextRange> {
+        let raw = expr_id.into_raw();
+        if raw.into_u32() as usize >= source_map.expr_spans.len() {
+            return None;
+        }
+        let span_idx = la_arena::Idx::<text_size::TextRange>::from_raw(raw);
+        Some(source_map.expr_spans[span_idx])
     }
 
     fn source_span_for_range(
@@ -2406,6 +2531,75 @@ function Early(x: int) -> string {
         assert!(
             graph.nodes.values().all(|n| n.label != "helper body"),
             "callee body headers should not be expanded below a terminal return"
+        );
+    }
+
+    #[test]
+    fn ast_control_flow_graph_builds_new_style_test_bodies() {
+        use baml_compiler2_visualization::control_flow::NodeType;
+
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(std::path::Path::new("/tmp"));
+        let src = r#"
+function Workflow(input: int) -> int {
+  //# Choose result
+  input + 1
+}
+
+test "renders workflow" {
+  let result = Workflow(41)
+  assert.equal(result, 42)
+}
+"#;
+        db.add_or_update_file(std::path::Path::new("/tmp/tests.baml"), src);
+
+        let workflow_graph = db
+            .ast_control_flow_graph("Workflow")
+            .expect("workflow should have a graph");
+        assert!(
+            workflow_graph
+                .nodes
+                .values()
+                .any(|node| node.node_type == NodeType::HeaderContextEnter),
+            "fixture workflow must have control flow: {:#?}",
+            workflow_graph.nodes
+        );
+        let graph = db
+            .ast_control_flow_graph("root::renders workflow")
+            .expect("new-style test should have a graph");
+        let root = graph
+            .nodes
+            .values()
+            .find(|node| node.node_type == NodeType::FunctionRoot)
+            .expect("test graph should have a root");
+        let root_span = root
+            .source_span
+            .as_ref()
+            .expect("test graph root should navigate to its declaration");
+        let name_start = src.find("\"renders workflow\"").unwrap();
+        assert_eq!(root_span.start_offset as usize, name_start);
+        assert_eq!(
+            root_span.end_offset as usize,
+            name_start + "\"renders workflow\"".len()
+        );
+        assert!(
+            graph
+                .nodes
+                .values()
+                .any(|node| node.label.contains("Workflow")),
+            "the test body's workflow call should be represented"
+        );
+        let prepared =
+            baml_compiler2_visualization::control_flow::prepare_control_flow_graph_for_visualization(
+                &graph,
+            );
+        assert!(
+            prepared.nodes.values().any(|node| {
+                node.node_type == NodeType::HeaderContextEnter && node.label == "Choose result"
+            }),
+            "the selected test should render the called workflow's control flow; raw={:#?}; prepared={:#?}",
+            graph.nodes,
+            prepared.nodes
         );
     }
 

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -781,6 +781,8 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     useState<PendingTestTarget | null>(null);
 
   const [selectedFn, setSelectedFn] = useState<string | null>(null);
+  const [selectedTestName, setSelectedTestName] = useState<string | null>(null);
+  const graphTargetName = selectedTestName ?? selectedFn;
   const [selectedPreviewTestKey, setSelectedPreviewTestKey] = useState<
     string | null
   >(null);
@@ -961,6 +963,21 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
   useEffect(() => {
     selectedFnRef.current = selectedFn;
   }, [selectedFn]);
+  useEffect(() => {
+    if (selectedFn && selectedTestName) {
+      setSelectedTestName(null);
+    }
+  }, [selectedFn, selectedTestName]);
+  const selectedTestNameRef = useRef(selectedTestName);
+  useEffect(() => {
+    selectedTestNameRef.current = selectedTestName;
+  }, [selectedTestName]);
+  const graphTargetNameRef = useRef(graphTargetName);
+  useEffect(() => {
+    graphTargetNameRef.current = graphTargetName;
+  }, [graphTargetName]);
+  const testGraphRequestsRef = useRef(new Set<string>());
+  const pendingTestSourceNavigationRef = useRef<string | null>(null);
   const controlFlowGraphRef = useRef(controlFlowGraph);
   useEffect(() => {
     controlFlowGraphRef.current = controlFlowGraph;
@@ -1243,6 +1260,36 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
 
   // ── Port message handler ─────────────────────────────────────────────
 
+  function handleControlFlowGraphResult(
+    targetName: string,
+    graph: ControlFlowGraph | null,
+  ) {
+    const isTestGraph = testGraphRequestsRef.current.has(targetName);
+    if (!isTestGraph) {
+      workflowCfgResponsesRef.current.set(targetName, graph);
+      setWorkflowCacheVersion((version) => version + 1);
+      if (graph) {
+        workflowCfgCacheRef.current.set(targetName, graph);
+      }
+    }
+
+    if (!graph || targetName !== graphTargetNameRef.current) return;
+    setControlFlowGraph(graph);
+    const pendingHighlight = pendingHighlightRef.current;
+    if (pendingHighlight && pendingHighlight.fn === targetName) {
+      pendingHighlightRef.current = null;
+      setHighlightedNodeId(pendingHighlight.nodeId);
+    }
+
+    if (pendingTestSourceNavigationRef.current === targetName) {
+      pendingTestSourceNavigationRef.current = null;
+      const source = Object.values(graph.nodes).find(
+        (node) => node.nodeType === 'functionRoot',
+      )?.sourceSpan;
+      if (source) onNavigateToSource?.(source);
+    }
+  }
+
   useEffect(() => {
     const unsubscribe = port.onMessage((data: WorkerOutMessage) => {
       switch (data.type) {
@@ -1333,21 +1380,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
               }
               break;
             case 'controlFlowGraphResult':
-              workflowCfgResponsesRef.current.set(n.functionName, n.graph);
-              setWorkflowCacheVersion((v) => v + 1);
-              if (n.graph) {
-                workflowCfgCacheRef.current.set(n.functionName, n.graph);
-                // Only the selected function's graph drives the display —
-                // prefetched graphs for other functions just fill the cache.
-                if (n.functionName === selectedFnRef.current) {
-                  setControlFlowGraph(n.graph);
-                  const pending = pendingHighlightRef.current;
-                  if (pending && pending.fn === n.functionName) {
-                    pendingHighlightRef.current = null;
-                    setHighlightedNodeId(pending.nodeId);
-                  }
-                }
-              }
+              handleControlFlowGraphResult(n.functionName, n.graph);
               break;
           }
           break;
@@ -1478,19 +1511,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
           break;
 
         case 'controlFlowGraphResult':
-          workflowCfgResponsesRef.current.set(data.functionName, data.graph);
-          setWorkflowCacheVersion((v) => v + 1);
-          if (data.graph) {
-            workflowCfgCacheRef.current.set(data.functionName, data.graph);
-            if (data.functionName === selectedFnRef.current) {
-              setControlFlowGraph(data.graph);
-              const pending = pendingHighlightRef.current;
-              if (pending && pending.fn === data.functionName) {
-                pendingHighlightRef.current = null;
-                setHighlightedNodeId(pending.nodeId);
-              }
-            }
-          }
+          handleControlFlowGraphResult(data.functionName, data.graph);
           break;
 
         case 'cursorContext':
@@ -1519,32 +1540,41 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     return unsubscribe;
   }, [port]);
 
-  // Request control flow graph when selected function changes OR code is edited.
-  // On function/project switch: clear the graph (shows loading state).
+  // Request a control flow graph when the selected function/test changes OR code is edited.
+  // On target/project switch: clear the graph (shows loading state).
   // On code edit (projectUpdateVersion): keep old graph visible, swap when new one arrives.
-  const prevGraphFnRef = useRef(selectedFn);
+  const prevGraphTargetRef = useRef(graphTargetName);
   const prevGraphProjectRef = useRef(selectedProject);
   const projectUpdateVersion = selectedProject
     ? projectUpdates[selectedProject]
     : undefined;
 
   useEffect(() => {
-    const fnChanged = prevGraphFnRef.current !== selectedFn;
+    const targetChanged = prevGraphTargetRef.current !== graphTargetName;
     const projChanged = prevGraphProjectRef.current !== selectedProject;
-    prevGraphFnRef.current = selectedFn;
+    prevGraphTargetRef.current = graphTargetName;
     prevGraphProjectRef.current = selectedProject;
 
-    if (fnChanged || projChanged) {
+    if (targetChanged || projChanged) {
       setControlFlowGraph(null);
       setHighlightedNodeId(null);
     }
-    if (!selectedFn || !selectedProject) return;
+    if (!graphTargetName || !selectedProject) return;
+    if (selectedTestName) {
+      testGraphRequestsRef.current.add(selectedTestName);
+    }
     port.postMessage({
       type: 'requestControlFlowGraph',
       project: selectedProject,
-      functionName: selectedFn,
+      functionName: graphTargetName,
     });
-  }, [port, selectedFn, selectedProject, projectUpdateVersion]);
+  }, [
+    port,
+    graphTargetName,
+    selectedProject,
+    selectedTestName,
+    projectUpdateVersion,
+  ]);
 
   // Clear preview results when selected function changes
   useEffect(() => {
@@ -2091,6 +2121,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     const key = previewTestKey(test);
     typedArgsByFnRef.current[test.functionName] = test.argsJson;
     setArgsJson(test.argsJson);
+    setSelectedTestName(null);
     setSelectedPreviewTestKey(key);
     setSelectedFn(test.functionName);
     setViewingCollection(false);
@@ -2098,6 +2129,39 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     setHighlightedNodeId(null);
     setWorkflowContext(null);
   }, []);
+
+  const handleSelectTest = useCallback(
+    (name: string) => {
+      const currentGraph =
+        graphTargetNameRef.current === name
+          ? controlFlowGraphRef.current
+          : null;
+      const currentSource = currentGraph
+        ? Object.values(currentGraph.nodes).find(
+            (node) => node.nodeType === 'functionRoot',
+          )?.sourceSpan
+        : null;
+      if (currentSource) {
+        pendingTestSourceNavigationRef.current = null;
+        onNavigateToSource?.(currentSource);
+      } else {
+        pendingTestSourceNavigationRef.current = name;
+      }
+
+      selectedTestNameRef.current = name;
+      graphTargetNameRef.current = name;
+      testGraphRequestsRef.current.add(name);
+      setSelectedPreviewTestKey(null);
+      setSelectedFn(null);
+      setSelectedTestName(name);
+      setViewingCollection(false);
+      setViewingTestRun(false);
+      setHighlightedNodeId(null);
+      setWorkflowContext(null);
+      setActiveTab('graph');
+    },
+    [onNavigateToSource],
+  );
 
   // Keep a selected preview case synchronized with source edits. If the test
   // is deleted, retain the current function/args as an ordinary manual draft.
@@ -2586,6 +2650,19 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
             </Tooltip>
           </TooltipProvider>
 
+          {selectedTestName && !viewingCollection && !viewingTestRun && (
+            <>
+              <span className="max-w-64 truncate text-[11px] font-vsc-mono text-vsc-accent font-semibold">
+                {selectedTestName}
+              </span>
+              <TabsList className="bg-transparent border-b-0 ml-1 h-7">
+                <TabsTrigger value="graph" className="py-1 h-7">
+                  Graph
+                </TabsTrigger>
+              </TabsList>
+            </>
+          )}
+
           {selectedFn && !viewingCollection && !viewingTestRun && (
             <>
               <span className="text-[11px] font-vsc-mono text-vsc-accent font-semibold whitespace-nowrap">
@@ -2887,8 +2964,11 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                   previewTests={previewTests}
                   selectedPreviewTestKey={selectedPreviewTestKey}
                   onSelectPreviewTest={handleSelectPreviewTest}
+                  selectedTestName={selectedTestName}
+                  onSelectTest={handleSelectTest}
                   selectedFn={selectedFn}
                   onSelectFn={(fn) => {
+                    setSelectedTestName(null);
                     setSelectedPreviewTestKey(null);
                     setViewingCollection(false);
                     setViewingTestRun(false);
@@ -2906,6 +2986,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                   onSelectCollectionView={() => {
                     setViewingCollection(true);
                     setViewingTestRun(false);
+                    setSelectedTestName(null);
                     setSelectedFn(null);
                   }}
                 />
@@ -3144,7 +3225,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                   );
                 })}
               </div>
-            ) : selectedFn ? (
+            ) : graphTargetName ? (
               <>
                 {/* Graph view */}
                 <TabsContent
@@ -3156,7 +3237,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                   {controlFlowGraph ? (
                     <GraphView
                       graph={controlFlowGraph}
-                      functionName={selectedFn}
+                      functionName={graphTargetName}
                       graphRuntimeOverlay={
                         latestGraphRunSnapshot?.graphRuntimeOverlay
                       }
@@ -3356,7 +3437,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                     {controlFlowGraph ? (
                       <GraphView
                         graph={controlFlowGraph}
-                        functionName={selectedFn}
+                        functionName={graphTargetName}
                         graphRuntimeOverlay={
                           latestGraphRunSnapshot?.graphRuntimeOverlay
                         }

--- a/typescript2/pkg-playground/src/FunctionSidebar.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.tsx
@@ -47,6 +47,8 @@ interface TestTreeNodeProps {
   depth?: number;
   /** Disable run/retry actions while the runtime is unavailable. */
   disabled?: boolean;
+  selectedTestName?: string | null;
+  onSelectTest?: (name: string) => void;
   onRunTest?: (name: string) => void;
   testRunResults?: Map<string, unknown>;
   failedExpands?: Set<string>;
@@ -57,6 +59,8 @@ function TestTreeNode({
   def,
   depth = 0,
   disabled = false,
+  selectedTestName,
+  onSelectTest,
   onRunTest,
   testRunResults,
   failedExpands,
@@ -114,10 +118,29 @@ function TestTreeNode({
         : null;
     const outcome =
       typeof reportObj?.outcome === 'string' ? reportObj.outcome : undefined;
+    const isSelected = selectedTestName === def.name;
     return (
       <div
-        className={cn(SIDEBAR_LEAF_ROW_CLASS, 'text-vsc-text-muted')}
+        role={onSelectTest ? 'button' : undefined}
+        tabIndex={onSelectTest ? 0 : undefined}
+        aria-pressed={onSelectTest ? isSelected : undefined}
+        className={cn(
+          SIDEBAR_LEAF_ROW_CLASS,
+          onSelectTest && 'cursor-pointer',
+          isSelected
+            ? 'bg-vsc-accent/15 text-vsc-text font-semibold'
+            : 'text-vsc-text-muted hover:bg-vsc-hover',
+        )}
         style={{ paddingLeft: leafIndent }}
+        onClick={() => onSelectTest?.(def.name)}
+        onKeyDown={(event) => {
+          if (!onSelectTest || (event.key !== 'Enter' && event.key !== ' ')) {
+            return;
+          }
+          event.preventDefault();
+          onSelectTest(def.name);
+        }}
+        title={`Show workflow for test: ${def.name}`}
       >
         <FlaskConical className={SIDEBAR_LEAF_ICON_CLASS} />
         <span className="truncate">{def.name.split('/').pop()}</span>
@@ -181,6 +204,8 @@ function TestTreeNode({
             def={child}
             depth={depth + 1}
             disabled={disabled}
+            selectedTestName={selectedTestName}
+            onSelectTest={onSelectTest}
             onRunTest={onRunTest}
             testRunResults={testRunResults}
             failedExpands={failedExpands}
@@ -209,6 +234,8 @@ export interface FunctionSidebarProps {
   previewTests?: TestInfo[];
   selectedPreviewTestKey?: string | null;
   onSelectPreviewTest?: (test: TestInfo) => void;
+  selectedTestName?: string | null;
+  onSelectTest?: (name: string) => void;
   selectedFn: string | null;
   onSelectFn: (name: string | null) => void;
   onRefreshTests: () => void;
@@ -354,6 +381,8 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
   previewTests = [],
   selectedPreviewTestKey,
   onSelectPreviewTest,
+  selectedTestName,
+  onSelectTest,
   selectedFn,
   onSelectFn,
   onRefreshTests,
@@ -552,6 +581,8 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
                   key={`${'name' in def ? def.name : i}-${i}`}
                   def={def}
                   disabled={runtimeControlsDisabled}
+                  selectedTestName={selectedTestName}
+                  onSelectTest={onSelectTest}
                   onRunTest={onRunTest}
                   testRunResults={testRunResults}
                   failedExpands={failedExpands}


### PR DESCRIPTION
## Summary

- make collected new-style test rows select and render that test body's control-flow graph
- navigate the editor to the selected test declaration
- keep test graphs isolated from the function workflow-prefetch cache

## Validation

- `cargo test -p baml_project`
- `cargo fmt -p baml_project -- --check`
- `pnpm --filter @b/pkg-playground typecheck`
- `pnpm --filter @b/pkg-playground test`
- browser QA in promptfiddle with two collected tests; verified graph and source selection switched independently for each row

Linear: [B-1048](https://linear.app/boundaryml2/issue/B-1048/clicking-on-a-test-should-show-the-workflow-rendered-for-the-test)

## Before / after

**Before:** on the exact PR base, clicking the collected `root::renders workflow` test row does not select it or navigate to its declaration; the playground remains on `Workflow()` and renders only the function graph.

<img width="1152" height="720" alt="Before: clicking the test row leaves the Workflow function graph and source context unchanged" src="https://github.com/user-attachments/assets/25df0a30-d4a3-44fa-b656-ee1cf599ddf8" />

**After:** on the replacement head, clicking the same row selects the test, navigates the editor to `"renders workflow"`, and renders the test-body graph from `root::renders workflow` through `Workflow(41)` to `Choose result`.

<img width="1152" height="720" alt="After: selected test row, highlighted test declaration, and rendered test-body workflow graph" src="https://github.com/user-attachments/assets/e0c89a0b-d9e1-40b1-a73f-f5582b7c0b32" />
