### PR TITLE
fix(playground): clamp width on group node titles by default

### DIFF
--- a/typescript2/pkg-playground/src/graph/nodes/group-node.test.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/group-node.test.tsx
@@ -17,8 +17,9 @@ vi.mock('@xyflow/react', () => ({
 
 const label = 'build_parity_report_with_tests_sdk_envs_inventories';
 const reactGlobal = globalThis as typeof globalThis & {
-  IS_REACT_ACT_ENVIRONMENT: boolean;
+  IS_REACT_ACT_ENVIRONMENT?: boolean;
 };
+const previousActEnvironment = reactGlobal.IS_REACT_ACT_ENVIRONMENT;
 
 reactGlobal.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -41,7 +42,11 @@ afterEach(() => {
 });
 
 afterAll(() => {
-  reactGlobal.IS_REACT_ACT_ENVIRONMENT = false;
+  if (previousActEnvironment === undefined) {
+    delete reactGlobal.IS_REACT_ACT_ENVIRONMENT;
+  } else {
+    reactGlobal.IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+  }
 });
 
 describe('GroupNode', () => {
@@ -51,6 +56,7 @@ describe('GroupNode', () => {
     expect(markup).toContain('class="baml-graph-group-label"');
     expect(markup).toContain('class="baml-graph-group-label__text"');
     expect(markup).toContain(`title="${label} (3 iterations)"`);
+    expect(markup).toContain(`>${label}</span>`);
     expect(markup).toContain('max-width:calc(100% - 28px)');
     expect(markup).toContain('text-overflow:ellipsis');
     expect(markup).toContain('title="Click to collapse"');
@@ -77,6 +83,7 @@ describe('GroupNode', () => {
 
     expect(chip).not.toBeNull();
     expect(text).not.toBeNull();
+    expect(text?.textContent).toBe(label);
     expect(collapseBadge?.textContent).toBe('−');
     expect(chip?.style.maxWidth).toBe('calc(100% - 28px)');
     expect(text?.style.textOverflow).toBe('ellipsis');
@@ -89,6 +96,7 @@ describe('GroupNode', () => {
     expect(chip?.style.overflow).toBe('visible');
     expect(text?.style.overflow).toBe('visible');
     expect(text?.style.textOverflow).toBe('clip');
+    expect(text?.textContent).toBe(label);
     expect(collapseBadge?.textContent).toBe('−');
 
     act(() => {
@@ -99,6 +107,7 @@ describe('GroupNode', () => {
     expect(chip?.style.overflow).toBe('hidden');
     expect(text?.style.overflow).toBe('hidden');
     expect(text?.style.textOverflow).toBe('ellipsis');
+    expect(text?.textContent).toBe(label);
 
     act(() => root.unmount());
   });

--- a/typescript2/pkg-playground/src/graph/nodes/group-node.test.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/group-node.test.tsx
@@ -1,6 +1,10 @@
+// @vitest-environment jsdom
+
 import type { NodeProps } from '@xyflow/react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 import { GroupNode } from './group-node';
 
 vi.mock('@xyflow/react', () => ({
@@ -11,31 +15,91 @@ vi.mock('@xyflow/react', () => ({
   },
 }));
 
+const label = 'build_parity_report_with_tests_sdk_envs_inventories';
+const reactGlobal = globalThis as typeof globalThis & {
+  IS_REACT_ACT_ENVIRONMENT: boolean;
+};
+
+reactGlobal.IS_REACT_ACT_ENVIRONMENT = true;
+
+const groupNodeProps = (): NodeProps =>
+  ({
+    data: {
+      executionState: 'not-started',
+      expanded: true,
+      graphNodeType: 'scope',
+      iterationCount: 3,
+      label,
+      logFilterKey: 'group',
+      selected: false,
+    },
+    id: 'group',
+  }) as unknown as NodeProps;
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+afterAll(() => {
+  reactGlobal.IS_REACT_ACT_ENVIRONMENT = false;
+});
+
 describe('GroupNode', () => {
   it('constrains long labels while preserving the full text for hover', () => {
-    const label = 'build_parity_report_with_tests_sdk_envs_inventories';
-    const markup = renderToStaticMarkup(
-      <GroupNode
-        {...({
-          data: {
-            executionState: 'not-started',
-            expanded: true,
-            graphNodeType: 'scope',
-            iterationCount: 3,
-            label,
-            logFilterKey: 'group',
-            selected: false,
-          },
-          id: 'group',
-        } as unknown as NodeProps)}
-      />,
-    );
+    const markup = renderToStaticMarkup(<GroupNode {...groupNodeProps()} />);
 
     expect(markup).toContain('class="baml-graph-group-label"');
     expect(markup).toContain('class="baml-graph-group-label__text"');
     expect(markup).toContain(`title="${label} (3 iterations)"`);
     expect(markup).toContain('max-width:calc(100% - 28px)');
     expect(markup).toContain('text-overflow:ellipsis');
+    expect(markup).toContain('title="Click to collapse"');
+    expect(markup).toContain('>−</span>');
     expect(markup).toContain('>3</span>');
+  });
+
+  it('expands the full label on hover and restores the ambient clamp', () => {
+    const container = document.createElement('div');
+    document.body.append(container);
+    const root = createRoot(container);
+
+    act(() => root.render(<GroupNode {...groupNodeProps()} />));
+
+    const chip = container.querySelector<HTMLElement>(
+      '.baml-graph-group-label',
+    );
+    const text = container.querySelector<HTMLElement>(
+      '.baml-graph-group-label__text',
+    );
+    const collapseBadge = container.querySelector<HTMLElement>(
+      '[title="Click to collapse"]',
+    );
+
+    expect(chip).not.toBeNull();
+    expect(text).not.toBeNull();
+    expect(collapseBadge?.textContent).toBe('−');
+    expect(chip?.style.maxWidth).toBe('calc(100% - 28px)');
+    expect(text?.style.textOverflow).toBe('ellipsis');
+
+    act(() => {
+      chip?.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    });
+
+    expect(chip?.style.maxWidth).toBe('none');
+    expect(chip?.style.overflow).toBe('visible');
+    expect(text?.style.overflow).toBe('visible');
+    expect(text?.style.textOverflow).toBe('clip');
+    expect(collapseBadge?.textContent).toBe('−');
+
+    act(() => {
+      chip?.dispatchEvent(new MouseEvent('mouseout', { bubbles: true }));
+    });
+
+    expect(chip?.style.maxWidth).toBe('calc(100% - 28px)');
+    expect(chip?.style.overflow).toBe('hidden');
+    expect(text?.style.overflow).toBe('hidden');
+    expect(text?.style.textOverflow).toBe('ellipsis');
+
+    act(() => root.unmount());
   });
 });

--- a/typescript2/pkg-playground/src/graph/nodes/group-node.test.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/group-node.test.tsx
@@ -1,0 +1,41 @@
+import type { NodeProps } from '@xyflow/react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { GroupNode } from './group-node';
+
+vi.mock('@xyflow/react', () => ({
+  Handle: () => null,
+  Position: {
+    Bottom: 'bottom',
+    Top: 'top',
+  },
+}));
+
+describe('GroupNode', () => {
+  it('constrains long labels while preserving the full text for hover', () => {
+    const label = 'build_parity_report_with_tests_sdk_envs_inventories';
+    const markup = renderToStaticMarkup(
+      <GroupNode
+        {...({
+          data: {
+            executionState: 'not-started',
+            expanded: true,
+            graphNodeType: 'scope',
+            iterationCount: 3,
+            label,
+            logFilterKey: 'group',
+            selected: false,
+          },
+          id: 'group',
+        } as unknown as NodeProps)}
+      />,
+    );
+
+    expect(markup).toContain('class="baml-graph-group-label"');
+    expect(markup).toContain('class="baml-graph-group-label__text"');
+    expect(markup).toContain(`title="${label} (3 iterations)"`);
+    expect(markup).toContain('max-width:calc(100% - 28px)');
+    expect(markup).toContain('text-overflow:ellipsis');
+    expect(markup).toContain('>3</span>');
+  });
+});

--- a/typescript2/pkg-playground/src/graph/nodes/group-node.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/group-node.tsx
@@ -1,6 +1,6 @@
-import { type NodeProps } from '@xyflow/react';
+import type { NodeProps } from '@xyflow/react';
 import { Repeat } from 'lucide-react';
-import { type ComponentType, memo } from 'react';
+import { type ComponentType, memo, useState } from 'react';
 import { getChrome, stateStyle } from '../constants';
 import { depthScale } from '../lod';
 import { useGraphThemeContext } from '../theme';
@@ -19,6 +19,13 @@ import { NodeOutputPreview } from './NodeOutputPreview';
  */
 export const GroupNode: ComponentType<NodeProps> = memo(({ data, id }) => {
   const d = data as WorkflowNodeData;
+  const label = d.label || id;
+  const iterationCount = d.iterationCount ?? 0;
+  const title =
+    iterationCount > 0
+      ? `${label} (${iterationCount} iteration${iterationCount === 1 ? '' : 's'})`
+      : label;
+  const [isLabelHovered, setIsLabelHovered] = useState(false);
   const isHighlighted = d.selected;
   // Set by the level-of-detail pass when the user expanded this container.
   const expandable = d.expanded === true;
@@ -41,130 +48,150 @@ export const GroupNode: ComponentType<NodeProps> = memo(({ data, id }) => {
   return (
     <div
       style={{
-        width: '100%',
-        height: '100%',
-        position: 'relative',
-        pointerEvents: 'none',
-        borderRadius: 12,
         // Frame-only: no fill, so the canvas reads through. Nested groups
         // never stack into a darker patch — they just compose hairline frames.
         background: 'transparent',
         border: `1.5px ${isStateful || isHighlighted ? 'solid' : 'dashed'} ${borderColor}`,
+        borderRadius: 12,
         boxShadow: isHighlighted
           ? `0 0 0 1px ${chrome.selectionRing.glow}`
           : undefined,
+        height: '100%',
+        pointerEvents: 'none',
+        position: 'relative',
         transition: 'border-color 150ms ease, box-shadow 150ms ease',
+        width: '100%',
       }}
     >
       <NodeHandles />
 
       {/* Floating label chip — sits on the top edge of the frame */}
       <div
+        className="baml-graph-group-label"
+        onMouseEnter={() => setIsLabelHovered(true)}
+        onMouseLeave={() => setIsLabelHovered(false)}
         style={{
-          position: 'absolute',
-          top: 0,
-          left: 14,
-          transform: 'translateY(-50%)',
-          zIndex: 5,
-          pointerEvents: 'auto',
-          // Manually-expanded containers collapse on click of this chip.
-          cursor: expandable ? 'zoom-out' : 'pointer',
-          display: 'inline-flex',
           alignItems: 'center',
-          gap: 6,
-          whiteSpace: 'nowrap',
-          padding: `${3 * s}px ${10 * s}px`,
-          borderRadius: 999,
-          fontWeight: 600,
-          fontSize: 11 * s,
-          letterSpacing: '-0.005em',
-          color: isHighlighted
-            ? chrome.groupLabelTextSelected
-            : chrome.groupLabelText,
+          backdropFilter: 'blur(8px)',
           background: isHighlighted
             ? chrome.groupLabelBgSelected
             : chrome.groupLabelBg,
           border: `1px solid ${isHighlighted ? chrome.selectionRing.color : chrome.groupLabelBorder}`,
-          backdropFilter: 'blur(8px)',
-          WebkitBackdropFilter: 'blur(8px)',
+          borderRadius: 999,
           boxShadow: isHighlighted
             ? `0 0 0 2px ${chrome.selectionRing.glow}, ${chrome.groupLabelShadow}`
             : chrome.groupLabelShadow,
-          transition: 'all 150ms ease',
+          boxSizing: 'border-box',
+          color: isHighlighted
+            ? chrome.groupLabelTextSelected
+            : chrome.groupLabelText,
+          // Manually-expanded containers collapse on click of this chip.
+          cursor: expandable ? 'zoom-out' : 'pointer',
+          display: 'inline-flex',
           fontFamily:
             'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
+          fontSize: 11 * s,
+          fontWeight: 600,
+          gap: 6,
+          left: 14,
+          letterSpacing: '-0.005em',
+          maxWidth: isLabelHovered ? 'none' : 'calc(100% - 28px)',
+          overflow: isLabelHovered ? 'visible' : 'hidden',
+          padding: `${3 * s}px ${10 * s}px`,
+          pointerEvents: 'auto',
+          position: 'absolute',
+          top: 0,
+          transform: 'translateY(-50%)',
+          transition: 'all 150ms ease',
+          WebkitBackdropFilter: 'blur(8px)',
+          whiteSpace: 'nowrap',
+          width: 'max-content',
+          zIndex: 5,
         }}
+        title={title}
       >
         {/* State accent dot (only for stateful runs) */}
         {isStateful && (
           <span
             style={{
-              width: 6,
-              height: 6,
-              borderRadius: '50%',
               background: stateAccent,
+              borderRadius: '50%',
               boxShadow: `0 0 6px ${stateAccent}`,
               flexShrink: 0,
+              height: 6,
+              width: 6,
             }}
           />
         )}
-        <span>{d.label || id}</span>
+        <span
+          className="baml-graph-group-label__text"
+          style={{
+            flex: '1 1 auto',
+            minWidth: 0,
+            overflow: isLabelHovered ? 'visible' : 'hidden',
+            textOverflow: isLabelHovered ? 'clip' : 'ellipsis',
+          }}
+        >
+          {label}
+        </span>
         {expandable && (
           <span
             aria-hidden
-            title="Click to collapse"
             style={{
-              display: 'inline-flex',
               alignItems: 'center',
-              justifyContent: 'center',
-              width: 14,
-              height: 14,
-              borderRadius: '50%',
-              fontSize: 13,
-              lineHeight: 1,
-              fontWeight: 700,
-              color: chrome.groupLabelText,
               border: `1px solid ${chrome.groupLabelBorder}`,
+              borderRadius: '50%',
+              color: chrome.groupLabelText,
+              display: 'inline-flex',
+              flexShrink: 0,
+              fontSize: 13,
+              fontWeight: 700,
+              height: 14,
+              justifyContent: 'center',
+              lineHeight: 1,
+              width: 14,
             }}
+            title="Click to collapse"
           >
             {'−'}
           </span>
         )}
-        {(d.iterationCount ?? 0) > 0 && (
+        {iterationCount > 0 && (
           <span
             style={{
-              display: 'inline-flex',
               alignItems: 'center',
+              background: chrome.iterationBg,
+              border: `1px solid ${chrome.iterationBorder}`,
+              borderRadius: 999,
+              color: chrome.iterationText,
+              display: 'inline-flex',
+              flexShrink: 0,
+              fontSize: 10,
+              fontVariantNumeric: 'tabular-nums',
+              fontWeight: 600,
               gap: 3,
               marginLeft: 2,
               padding: '1px 6px',
-              borderRadius: 999,
-              background: chrome.iterationBg,
-              color: chrome.iterationText,
-              fontSize: 10,
-              fontWeight: 600,
-              fontVariantNumeric: 'tabular-nums',
-              border: `1px solid ${chrome.iterationBorder}`,
             }}
           >
             <Repeat size={9} strokeWidth={2.5} />
-            {d.iterationCount}
+            {iterationCount}
           </span>
         )}
       </div>
       {hasValuePreviews ? (
         <div
           style={{
+            left: 14,
+            pointerEvents: 'auto',
             position: 'absolute',
             top: 16,
-            left: 14,
             zIndex: 4,
-            pointerEvents: 'auto',
           }}
         >
           <NodeOutputPreview
-            valuePreviews={d.valuePreviews}
             customRenderers={d.customRenderers}
+            valuePreviews={d.valuePreviews}
           />
         </div>
       ) : null}

--- a/typescript2/pkg-playground/src/graph/nodes/index.ts
+++ b/typescript2/pkg-playground/src/graph/nodes/index.ts
@@ -1,14 +1,14 @@
 import type { NodeTypes } from '@xyflow/react';
 import { BaseNode } from './BaseNode';
-import { LLMNode } from './LLMNode';
 import { DiamondNode } from './DiamondNode';
+import { GroupNode } from './group-node';
 import { HexagonNode } from './HexagonNode';
-import { GroupNode } from './GroupNode';
+import { LLMNode } from './LLMNode';
 
 export const kNodeTypes: NodeTypes = {
   base: BaseNode,
-  group: GroupNode,
   diamond: DiamondNode,
+  group: GroupNode,
   hexagon: HexagonNode,
   llm: LLMNode,
 };


### PR DESCRIPTION
## Summary

- Clamp floating group-label chips to their graph frame during ambient rendering.
- Ellipsize long labels while preserving the full label in the title and expanding it on hover.
- Keep expand and iteration badges visible when label text is constrained.
- Add focused static and hover-interaction coverage for the long-label rendering contract.

## Verification

- `pnpm --dir typescript2/pkg-playground test` (128 tests passed)
- `pnpm --dir typescript2/pkg-playground typecheck`
- `pnpm --dir typescript2/pkg-playground build`
- `pnpm --dir typescript2/app-promptfiddle typecheck`
- `pnpm --dir typescript2 format:ci --since=origin/canary`
- Real-browser TypeScript2 playground QA at `729f90edb9837b3cfd285bc5cab304af9d444d16`: a long group chip stayed inside its 297 px frame at 251.4 px ambient width, then expanded to 471.6 px on hover.

## Before / after

Before — the full label overflows the group frame during ambient rendering.

![Before: long group label overflowing its graph frame](https://github.com/user-attachments/assets/525cd0d3-77bd-46b7-ac4f-4d0311c9b7cb)

After — ambient rendering clamps and ellipsizes the label; hovering reveals the complete label without resizing the frame.

![After: clamped ambient group label and hover-expanded full label](https://github.com/user-attachments/assets/4b9eae68-fa80-4664-8b85-dd29965ac3c5)

## Tracking

Linear: [B-1049](https://linear.app/boundaryml2/issue/B-1049/graph-nodes-should-have-a-max-width)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced group node label behavior: improved truncation, hover-to-expand with ellipsis removed temporarily, and full-label tooltips.
  * Added iteration counts to the label tooltip with correct singular/plural wording.
  * Updated group node and value preview styling, including refined positioning.
* **Tests**
  * Added/expanded tests covering long-label clamping, tooltip content, hover expansion/restoration, and iteration count wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->