### PR TITLE
feat(toolchain): select a local baml-cli by path

### DIFF
--- a/baml_language/crates/baml/src/main.rs
+++ b/baml_language/crates/baml/src/main.rs
@@ -87,8 +87,8 @@ struct ProjectConfig {
 struct ProjectToolchain {
     version: Option<String>,
     channel: Option<String>,
-    /// Path to a `baml-cli` binary, relative to this `baml.toml` unless
-    /// absolute. Mutually exclusive with `version` and `channel`.
+    /// Rejected rather than ignored, so the refusal is explained where someone
+    /// would otherwise sit and wonder why their setting does nothing.
     path: Option<String>,
 }
 
@@ -125,12 +125,14 @@ Commands:
 
 Local toolchains:
   A selector containing a path separator is a baml-cli binary the wrapper does
-  not manage, for running a local build. It is accepted anywhere a selector is,
-  including $BAML_VERSION and [toolchain] path in baml.toml (resolved relative
-  to that file). install, update, and uninstall do not apply to it.
+  not manage, for running a local build. install, update, and uninstall do not
+  apply to it, and `baml ide install` needs a managed toolchain.
 
     baml toolchain use ~/repos/baml/target/debug/baml-cli
     BAML_VERSION=./target/debug/baml-cli baml check
+
+  It is deliberately not settable from baml.toml: a checked-out repository must
+  not be able to choose which binary runs on your machine.
 
 Network behavior:
   list is local-only.
@@ -459,24 +461,32 @@ fn pass_through(args: Vec<String>) -> Result<i32> {
 /// and no background manifest refresh. That also keeps the exec fast path
 /// unconditional, so a local build costs nothing extra to launch.
 fn exec_path_toolchain(cli: &Path, selector: &ResolvedSelector, args: Vec<String>) -> Result<i32> {
-    verify_path_toolchain(cli, &path_selector_origin(&selector.source))?;
+    let origin = path_selector_origin(&selector.source);
+    verify_path_toolchain(cli, &origin)?;
+    reject_self_exec(cli, &origin)?;
 
     let mut command = Command::new(cli);
     command.args(args);
     command.env("BAML_WRAPPER_EXEC", "1");
-    command.env("BAML_WRAPPER_RESOLVED_TOOLCHAIN", cli);
+    // Deliberately not BAML_WRAPPER_RESOLVED_TOOLCHAIN: that carries a version,
+    // and a local build has none. A separate variable also lets the toolchain
+    // binary tell the two situations apart, which `baml ide install` needs.
+    command.env("BAML_WRAPPER_LOCAL_TOOLCHAIN", cli);
 
+    // Anything verify_path_toolchain could not rule out (wrong architecture,
+    // a noexec mount, a missing interpreter) surfaces here, so this message
+    // carries the attribution too.
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
         let err = command.exec();
-        Err(anyhow!("failed to exec {}: {err}", cli.display()))
+        Err(anyhow!("failed to exec {}: {err}{origin}", cli.display()))
     }
     #[cfg(not(unix))]
     {
         let status = command
             .status()
-            .with_context(|| format!("failed to run {}", cli.display()))?;
+            .map_err(|err| anyhow!("failed to run {}: {err}{origin}", cli.display()))?;
         Ok(status.code().unwrap_or(1))
     }
 }
@@ -497,9 +507,21 @@ fn active_selector() -> Result<ResolvedSelector> {
         });
     }
     let config = read_config();
-    if !config.default.selector.trim().is_empty() {
+    let selector = config.default.selector.trim();
+    if !selector.is_empty() {
+        // A machine-global default resolved against cwd would run a different
+        // binary from each directory, so it has to stand on its own.
+        if is_path_selector(selector)
+            && !selector.starts_with('~')
+            && !Path::new(selector).is_absolute()
+        {
+            return Err(anyhow!(
+                "{} sets default.selector to a relative path ({selector}), which would depend on the current directory.\nUse an absolute path, or run: baml toolchain use <path>",
+                config_path().display()
+            ));
+        }
         return Ok(ResolvedSelector {
-            selector: normalize_selector(config.default.selector.trim(), &env::current_dir()?),
+            selector: normalize_selector(selector, &env::current_dir()?),
             source: SelectorSource::Config,
         });
     }
@@ -519,24 +541,11 @@ fn project_toolchain_selector() -> Result<Option<(PathBuf, String)>> {
             let config = toml::from_str::<ProjectConfig>(&text)
                 .with_context(|| format!("failed to parse {}", candidate.display()))?;
             if let Some(toolchain) = config.toolchain {
-                let declared: Vec<&str> = [
-                    ("path", toolchain.path.is_some()),
-                    ("version", toolchain.version.is_some()),
-                    ("channel", toolchain.channel.is_some()),
-                ]
-                .into_iter()
-                .filter_map(|(key, set)| set.then_some(key))
-                .collect();
-                if declared.len() > 1 {
+                if toolchain.path.is_some() {
                     return Err(anyhow!(
-                        "{} [toolchain] sets {}, which are mutually exclusive",
-                        candidate.display(),
-                        declared.join(" and ")
+                        "{} sets [toolchain] path, which is not supported.\nA checked-out repository must not be able to choose which binary runs on your machine.\nTo use a local build, run: baml toolchain use <path>\nOr set $BAML_VERSION to it for a single command.",
+                        candidate.display()
                     ));
-                }
-                if let Some(path) = toolchain.path {
-                    let selector = resolve_selector_path(&path, &dir).display().to_string();
-                    return Ok(Some((candidate, selector)));
                 }
                 if let Some(version) = toolchain.version {
                     return Ok(Some((candidate, version)));
@@ -678,10 +687,8 @@ fn path_selector(selector: &str) -> Option<&Path> {
     is_path_selector(selector).then(|| Path::new(selector))
 }
 
-/// Expand a leading `~` and absolutize against `base`, the directory that
-/// declared the path (the containing `baml.toml` for project config, the cwd
-/// otherwise). Relative paths are what make a committed `[toolchain] path`
-/// usable by everyone on a team.
+/// Expand a leading `~` and absolutize against `base`, the directory the path
+/// was written in.
 fn resolve_selector_path(raw: &str, base: &Path) -> PathBuf {
     let home = env::var_os("HOME")
         .or_else(|| env::var_os("USERPROFILE"))
@@ -691,11 +698,61 @@ fn resolve_selector_path(raw: &str, base: &Path) -> PathBuf {
 
 fn resolve_selector_path_with_home(raw: &str, base: &Path, home: Option<&Path>) -> PathBuf {
     let joined = join_selector_path(raw, base, home);
-    // Collapse the `..` segments a relative selector leaves behind, so the path
-    // reads cleanly everywhere it is echoed back. Done through the filesystem
-    // rather than lexically so it stays correct across symlinks; a path that
-    // does not exist yet keeps its joined form for the error message.
-    joined.canonicalize().unwrap_or(joined)
+    let normalized = lexically_normalize(&joined);
+    // Lexical `..` removal disagrees with the filesystem only when a symlinked
+    // directory is followed by `..`. Keep the joined form in that case, so
+    // tidying a path can never turn a working one into a broken one.
+    let tidy = if normalized.exists() || !joined.exists() {
+        normalized
+    } else {
+        joined
+    };
+    with_exe_suffix(tidy)
+}
+
+/// Collapse `.` and `..` without consulting the filesystem, so the path reads
+/// cleanly wherever it is echoed back while any symlink in it survives.
+/// Canonicalizing instead would resolve a `current -> release-N` symlink down
+/// to its physical target, freezing the selector on whatever it pointed at the
+/// day it was set, and on Windows would hand back a `\\?\C:\...` verbatim path.
+fn lexically_normalize(path: &Path) -> PathBuf {
+    use std::path::Component;
+
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => match out.components().next_back() {
+                Some(Component::Normal(_)) => {
+                    out.pop();
+                }
+                // `..` above the root is the root.
+                Some(Component::RootDir | Component::Prefix(_)) => {}
+                _ => out.push(component),
+            },
+            other => out.push(other),
+        }
+    }
+    if out.as_os_str().is_empty() {
+        PathBuf::from(".")
+    } else {
+        out
+    }
+}
+
+/// Windows developers type `baml-cli`; the file on disk is `baml-cli.exe`.
+#[cfg(windows)]
+fn with_exe_suffix(path: PathBuf) -> PathBuf {
+    if path.extension().is_some() || path.exists() {
+        return path;
+    }
+    let candidate = path.with_extension("exe");
+    if candidate.is_file() { candidate } else { path }
+}
+
+#[cfg(not(windows))]
+fn with_exe_suffix(path: PathBuf) -> PathBuf {
+    path
 }
 
 fn join_selector_path(raw: &str, base: &Path, home: Option<&Path>) -> PathBuf {
@@ -734,6 +791,28 @@ fn path_selector_origin(source: &SelectorSource) -> String {
             format!("\n  set by default.selector in {}", config_path().display())
         }
     }
+}
+
+/// Refuse to exec the wrapper itself. `baml` and `baml-cli` are built into the
+/// same directory, so pointing at the wrapper is a one-character slip; without
+/// this it re-resolves the same selector and execs itself forever, silently on
+/// unix and as an unbounded process tree everywhere else.
+fn reject_self_exec(cli: &Path, origin: &str) -> Result<()> {
+    let Ok(current) = env::current_exe() else {
+        return Ok(());
+    };
+    let same = match (current.canonicalize(), cli.canonicalize()) {
+        (Ok(current), Ok(cli)) => current == cli,
+        _ => current == cli,
+    };
+    if same {
+        return Err(anyhow!(
+            "toolchain path points at the baml wrapper itself: {}{origin}\nPoint at the {} binary instead, which is built alongside it.",
+            cli.display(),
+            cli_exe_name()
+        ));
+    }
+    Ok(())
 }
 
 /// Check that a path selector points at something runnable. `origin` is a
@@ -1226,13 +1305,18 @@ fn list_toolchains() {
     let config = read_config();
     let state = read_state();
     println!("default selector: {}", config.default.selector);
-    if let Ok(active) = active_selector() {
-        if active.selector != config.default.selector {
-            println!(
-                "active selector: {}{}",
-                active.selector,
-                selector_annotation(&active)
-            );
+    // `list` is what a user runs to work out why nothing runs, so a broken
+    // baml.toml or config has to show up here rather than be swallowed.
+    match active_selector() {
+        Ok(active) if active.selector != config.default.selector => println!(
+            "active selector: {}{}",
+            active.selector,
+            selector_annotation(&active)
+        ),
+        Ok(_) => {}
+        Err(err) => {
+            println!("active selector: (unresolved)");
+            println!("{err:#}");
         }
     }
     for (channel, state) in state.channels {
@@ -1547,9 +1631,10 @@ mod tests {
 
     #[test]
     fn relative_path_resolves_against_the_declaring_directory() {
+        let base = Path::new(TEST_BASE);
         assert_eq!(
-            resolve_selector_path("../baml/target/debug/baml-cli", Path::new(TEST_BASE)),
-            Path::new(TEST_BASE).join("../baml/target/debug/baml-cli")
+            resolve_selector_path("../baml/target/debug/baml-cli", base),
+            base.parent().unwrap().join("baml/target/debug/baml-cli")
         );
     }
 
@@ -1573,10 +1658,10 @@ mod tests {
         );
     }
 
-    /// An existing target loses its `..` segments, so the path reads cleanly in
-    /// `--version`, `status`, and the config file it gets written to.
+    /// `..` is collapsed so the path reads cleanly in `--version`, `status`,
+    /// and the config file it gets written to.
     #[test]
-    fn existing_path_is_canonicalized() {
+    fn resolved_path_loses_its_parent_segments() {
         let tmp = tempfile::tempdir().unwrap();
         let build = tmp.path().join("build");
         let proj = tmp.path().join("proj");
@@ -1586,17 +1671,56 @@ mod tests {
         fs::write(&cli, "").unwrap();
 
         let resolved = resolve_selector_path(&format!("../build/{}", cli_exe_name()), &proj);
-        assert_eq!(resolved, cli.canonicalize().unwrap());
+        assert_eq!(resolved, cli);
         assert!(!resolved.to_string_lossy().contains(".."), "{resolved:?}");
     }
 
-    /// A path that does not exist yet keeps its joined form, so the error names
-    /// what the developer actually asked for.
+    /// A path that does not exist yet is still tidied, so the error names a
+    /// readable path rather than one full of `..`.
     #[test]
-    fn missing_path_keeps_its_joined_form() {
+    fn missing_path_is_still_tidied() {
         let tmp = tempfile::tempdir().unwrap();
         let resolved = resolve_selector_path("../build/baml-cli", tmp.path());
-        assert_eq!(resolved, tmp.path().join("../build/baml-cli"));
+        assert_eq!(
+            resolved,
+            tmp.path().parent().unwrap().join("build/baml-cli")
+        );
+    }
+
+    /// Tidying must not resolve symlinks. A `current -> release-N` indirection
+    /// has to keep following repoints instead of being frozen to whatever it
+    /// pointed at when the selector was set.
+    #[test]
+    #[cfg(unix)]
+    fn symlinked_path_is_preserved() {
+        let tmp = tempfile::tempdir().unwrap();
+        let release = tmp.path().join("release-1");
+        fs::create_dir_all(&release).unwrap();
+        fs::write(release.join("baml-cli"), "").unwrap();
+        let current = tmp.path().join("current");
+        std::os::unix::fs::symlink(&release, &current).unwrap();
+
+        let resolved = resolve_selector_path("current/baml-cli", tmp.path());
+        assert_eq!(resolved, current.join("baml-cli"));
+        assert!(
+            !resolved.starts_with(&release),
+            "symlink was resolved away: {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn parent_segments_above_the_root_are_dropped() {
+        let root = Path::new(TEST_BASE)
+            .components()
+            .next()
+            .unwrap()
+            .as_os_str();
+        let mut deep = PathBuf::from(root);
+        deep.push("a");
+        deep.push("..");
+        deep.push("..");
+        deep.push("b");
+        assert_eq!(lexically_normalize(&deep), Path::new(root).join("b"));
     }
 
     /// Without a home directory the `~` stays literal rather than silently

--- a/baml_language/crates/baml/src/main.rs
+++ b/baml_language/crates/baml/src/main.rs
@@ -87,6 +87,9 @@ struct ProjectConfig {
 struct ProjectToolchain {
     version: Option<String>,
     channel: Option<String>,
+    /// Path to a `baml-cli` binary, relative to this `baml.toml` unless
+    /// absolute. Mutually exclusive with `version` and `channel`.
+    path: Option<String>,
 }
 
 enum SelectorSource {
@@ -113,16 +116,26 @@ Usage:
   baml toolchain <command>
 
 Commands:
-  use <canary|nightly|version>       Install if needed and select as default
+  use <canary|nightly|version|path>  Install if needed and select as default
   install <canary|nightly|version>   Download without selecting
   update                             Advance the active channel
   status                             Check latest remote version without installing
   list                               Show installed toolchains, local only
   uninstall <version>                Remove an installed concrete version
 
+Local toolchains:
+  A selector containing a path separator is a baml-cli binary the wrapper does
+  not manage, for running a local build. It is accepted anywhere a selector is,
+  including $BAML_VERSION and [toolchain] path in baml.toml (resolved relative
+  to that file). install, update, and uninstall do not apply to it.
+
+    baml toolchain use ~/repos/baml/target/debug/baml-cli
+    BAML_VERSION=./target/debug/baml-cli baml check
+
 Network behavior:
   list is local-only.
   status checks remote metadata but does not install or change selection.
+  status is local-only for a path toolchain, which has nothing remote to check.
   use, install, and update may download toolchains or change local state.
 
 Wrapper updates:
@@ -191,6 +204,20 @@ fn print_version() {
             return;
         }
     };
+    if let Some(cli) = path_selector(&selector.selector) {
+        match verify_path_toolchain(cli, "") {
+            Ok(()) => println!(
+                "baml toolchain {}{}",
+                cli.display(),
+                selector_annotation(&selector)
+            ),
+            Err(err) => {
+                println!("baml toolchain not usable");
+                println!("{err:#}");
+            }
+        }
+        return;
+    }
     let version = match concrete_version_for_selector(&selector) {
         Ok(version) => version,
         Err(_) if is_channel(&selector.selector) => {
@@ -328,9 +355,9 @@ fn toolchain(args: Vec<String>) -> Result<()> {
             install_toolchain(selector, false, manifest_base_url.as_deref(), force)
         }
         Some("use") => {
-            let selector = args
-                .get(1)
-                .ok_or_else(|| anyhow!("usage: baml toolchain use <canary|nightly|version>"))?;
+            let selector = args.get(1).ok_or_else(|| {
+                anyhow!("usage: baml toolchain use <canary|nightly|version|path>")
+            })?;
             use_toolchain(selector, manifest_base_url.as_deref())
         }
         Some("update") => update_toolchain(manifest_base_url.as_deref()),
@@ -376,6 +403,9 @@ fn parse_manifest_base_url(mut args: Vec<String>) -> Result<(Vec<String>, Option
 
 fn pass_through(args: Vec<String>) -> Result<i32> {
     let selector = active_selector()?;
+    if let Some(cli) = path_selector(&selector.selector) {
+        return exec_path_toolchain(cli, &selector, args);
+    }
     let version = concrete_version_for_selector(&selector)?;
     let cli = toolchain_cli_path(&version);
     if !cli.exists() {
@@ -424,11 +454,38 @@ fn pass_through(args: Vec<String>) -> Result<i32> {
     Ok(status.code().unwrap_or(1))
 }
 
+/// Run a path toolchain. None of the version bookkeeping applies to a binary
+/// the wrapper did not install: no VERSION file, no channel freshness warning,
+/// and no background manifest refresh. That also keeps the exec fast path
+/// unconditional, so a local build costs nothing extra to launch.
+fn exec_path_toolchain(cli: &Path, selector: &ResolvedSelector, args: Vec<String>) -> Result<i32> {
+    verify_path_toolchain(cli, &path_selector_origin(&selector.source))?;
+
+    let mut command = Command::new(cli);
+    command.args(args);
+    command.env("BAML_WRAPPER_EXEC", "1");
+    command.env("BAML_WRAPPER_RESOLVED_TOOLCHAIN", cli);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let err = command.exec();
+        Err(anyhow!("failed to exec {}: {err}", cli.display()))
+    }
+    #[cfg(not(unix))]
+    {
+        let status = command
+            .status()
+            .with_context(|| format!("failed to run {}", cli.display()))?;
+        Ok(status.code().unwrap_or(1))
+    }
+}
+
 fn active_selector() -> Result<ResolvedSelector> {
     if let Ok(value) = env::var("BAML_VERSION") {
         if !value.trim().is_empty() {
             return Ok(ResolvedSelector {
-                selector: value,
+                selector: normalize_selector(value.trim(), &env::current_dir()?),
                 source: SelectorSource::Env,
             });
         }
@@ -442,7 +499,7 @@ fn active_selector() -> Result<ResolvedSelector> {
     let config = read_config();
     if !config.default.selector.trim().is_empty() {
         return Ok(ResolvedSelector {
-            selector: config.default.selector,
+            selector: normalize_selector(config.default.selector.trim(), &env::current_dir()?),
             source: SelectorSource::Config,
         });
     }
@@ -462,6 +519,25 @@ fn project_toolchain_selector() -> Result<Option<(PathBuf, String)>> {
             let config = toml::from_str::<ProjectConfig>(&text)
                 .with_context(|| format!("failed to parse {}", candidate.display()))?;
             if let Some(toolchain) = config.toolchain {
+                let declared: Vec<&str> = [
+                    ("path", toolchain.path.is_some()),
+                    ("version", toolchain.version.is_some()),
+                    ("channel", toolchain.channel.is_some()),
+                ]
+                .into_iter()
+                .filter_map(|(key, set)| set.then_some(key))
+                .collect();
+                if declared.len() > 1 {
+                    return Err(anyhow!(
+                        "{} [toolchain] sets {}, which are mutually exclusive",
+                        candidate.display(),
+                        declared.join(" and ")
+                    ));
+                }
+                if let Some(path) = toolchain.path {
+                    let selector = resolve_selector_path(&path, &dir).display().to_string();
+                    return Ok(Some((candidate, selector)));
+                }
                 if let Some(version) = toolchain.version {
                     return Ok(Some((candidate, version)));
                 }
@@ -485,6 +561,12 @@ fn concrete_version_for_selector_with_base(
     selector: &ResolvedSelector,
     current_base: &str,
 ) -> Result<String> {
+    if is_path_selector(&selector.selector) {
+        return Err(anyhow!(
+            "active toolchain is a local path and has no version: {}",
+            selector.selector
+        ));
+    }
     if is_channel(&selector.selector) {
         let state = read_state();
         if let Some(channel) = state.channels.get(&selector.selector) {
@@ -539,13 +621,19 @@ fn missing_toolchain_error(selector: &ResolvedSelector, version: &str) -> anyhow
     }
 }
 
-fn toolchain_cli_path(version: &str) -> PathBuf {
-    let exe = if cfg!(windows) {
+fn cli_exe_name() -> &'static str {
+    if cfg!(windows) {
         "baml-cli.exe"
     } else {
         "baml-cli"
-    };
-    toolchains_dir().join(version).join("bin").join(exe)
+    }
+}
+
+fn toolchain_cli_path(version: &str) -> PathBuf {
+    toolchains_dir()
+        .join(version)
+        .join("bin")
+        .join(cli_exe_name())
 }
 
 fn verify_toolchain_version_file(version: &str) -> Result<()> {
@@ -567,6 +655,120 @@ fn verify_toolchain_version_file(version: &str) -> Result<()> {
 
 fn is_channel(selector: &str) -> bool {
     selector == "canary" || selector == "nightly"
+}
+
+/// Whether a selector names a local `baml-cli` binary rather than a channel or
+/// a version. Channels and versions never contain a path separator, so a bare
+/// path is unambiguous and needs no prefix or flag to mark it.
+fn is_path_selector(selector: &str) -> bool {
+    is_path_selector_on(selector, cfg!(windows))
+}
+
+/// Split out so the Windows rule is exercised by tests on every platform,
+/// rather than only where `cfg(windows)` holds.
+fn is_path_selector_on(selector: &str, windows: bool) -> bool {
+    selector.starts_with('~')
+        || selector.starts_with('.')
+        || selector.contains('/')
+        || (windows && selector.contains('\\'))
+}
+
+/// The binary a selector points at, if it is a path selector.
+fn path_selector(selector: &str) -> Option<&Path> {
+    is_path_selector(selector).then(|| Path::new(selector))
+}
+
+/// Expand a leading `~` and absolutize against `base`, the directory that
+/// declared the path (the containing `baml.toml` for project config, the cwd
+/// otherwise). Relative paths are what make a committed `[toolchain] path`
+/// usable by everyone on a team.
+fn resolve_selector_path(raw: &str, base: &Path) -> PathBuf {
+    let home = env::var_os("HOME")
+        .or_else(|| env::var_os("USERPROFILE"))
+        .map(PathBuf::from);
+    resolve_selector_path_with_home(raw, base, home.as_deref())
+}
+
+fn resolve_selector_path_with_home(raw: &str, base: &Path, home: Option<&Path>) -> PathBuf {
+    let joined = join_selector_path(raw, base, home);
+    // Collapse the `..` segments a relative selector leaves behind, so the path
+    // reads cleanly everywhere it is echoed back. Done through the filesystem
+    // rather than lexically so it stays correct across symlinks; a path that
+    // does not exist yet keeps its joined form for the error message.
+    joined.canonicalize().unwrap_or(joined)
+}
+
+fn join_selector_path(raw: &str, base: &Path, home: Option<&Path>) -> PathBuf {
+    let raw = raw.trim();
+    if raw == "~" || raw.starts_with("~/") {
+        if let Some(home) = home {
+            return home.join(raw.trim_start_matches('~').trim_start_matches('/'));
+        }
+    }
+    let path = PathBuf::from(raw);
+    if path.is_absolute() {
+        path
+    } else {
+        base.join(path)
+    }
+}
+
+/// Absolutize a path selector, so every later consumer (exec, error text,
+/// status output) sees the same path regardless of cwd. Channels and versions
+/// pass through untouched. Absolutizing is idempotent: the result still reads
+/// as a path selector.
+fn normalize_selector(selector: &str, base: &Path) -> String {
+    if is_path_selector(selector) {
+        return resolve_selector_path(selector, base).display().to_string();
+    }
+    selector.to_string()
+}
+
+/// The `set by ...` line appended to path-toolchain errors, so a stale
+/// override is traceable to whatever set it.
+fn path_selector_origin(source: &SelectorSource) -> String {
+    match source {
+        SelectorSource::Env => "\n  set by $BAML_VERSION".to_string(),
+        SelectorSource::Project(path) => format!("\n  set by path in {}", path.display()),
+        SelectorSource::Config | SelectorSource::Fallback => {
+            format!("\n  set by default.selector in {}", config_path().display())
+        }
+    }
+}
+
+/// Check that a path selector points at something runnable. `origin` is a
+/// pre-formatted `set by ...` line, or empty when the path came straight from
+/// the command line and needs no attribution.
+fn verify_path_toolchain(cli: &Path, origin: &str) -> Result<()> {
+    if cli.is_dir() {
+        return Err(anyhow!(
+            "toolchain path is a directory: {}{origin}\nPoint at the {} binary, e.g. {}",
+            cli.display(),
+            cli_exe_name(),
+            cli.join("bin").join(cli_exe_name()).display()
+        ));
+    }
+    if !cli.exists() {
+        return Err(anyhow!(
+            "toolchain binary not found: {}{origin}",
+            cli.display()
+        ));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = fs::metadata(cli)
+            .with_context(|| format!("failed to read {}", cli.display()))?
+            .permissions()
+            .mode();
+        if mode & 0o111 == 0 {
+            return Err(anyhow!(
+                "toolchain binary is not executable: {}{origin}",
+                cli.display()
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Bold-yellow lowercase `warning` prefix, matching the styled diagnostics the
@@ -796,6 +998,11 @@ fn install_toolchain(
     override_url: Option<&str>,
     force: bool,
 ) -> Result<()> {
+    if is_path_selector(selector) {
+        return Err(anyhow!(
+            "{selector} is a local path; there is nothing to install.\nRun: baml toolchain use {selector}"
+        ));
+    }
     install_toolchain_with_policy(
         selector,
         activate_channel,
@@ -865,6 +1072,15 @@ fn install_manifest_artifact(
 }
 
 fn use_toolchain(selector: &str, override_url: Option<&str>) -> Result<()> {
+    if is_path_selector(selector) {
+        let cli = resolve_selector_path(selector, &env::current_dir()?);
+        verify_path_toolchain(&cli, "")?;
+        let mut config = read_config();
+        config.default.selector = cli.display().to_string();
+        write_config(&config)?;
+        println!("selected BAML toolchain {}", cli.display());
+        return Ok(());
+    }
     if is_channel(selector) {
         install_toolchain(selector, true, override_url, false)?;
     } else {
@@ -885,6 +1101,13 @@ fn use_toolchain(selector: &str, override_url: Option<&str>) -> Result<()> {
 
 fn update_toolchain(override_url: Option<&str>) -> Result<()> {
     let config = read_config();
+    if is_path_selector(&config.default.selector) {
+        println!(
+            "active selector {} is a local path and is not managed by the wrapper.\nRun: baml toolchain use canary",
+            config.default.selector
+        );
+        return Ok(());
+    }
     if !is_channel(&config.default.selector) {
         println!(
             "active selector {} is an exact version and does not advance automatically.\nRun: baml toolchain use canary\nOr:  baml toolchain use nightly",
@@ -912,6 +1135,18 @@ fn status_toolchain(override_url: Option<&str>) -> Result<()> {
     let selector = active_selector()?;
     let base = manifest_base_url(override_url);
     println!("active selector: {}", selector.selector);
+
+    if let Some(cli) = path_selector(&selector.selector) {
+        if let Some(origin) = selector_origin(&selector.source) {
+            println!("source: {origin}");
+        }
+        match verify_path_toolchain(cli, "") {
+            Ok(()) => println!("status: local toolchain binary, not managed by the wrapper"),
+            Err(err) => println!("status: local toolchain binary is unusable\n{err:#}"),
+        }
+        println!("Remote versions were not checked.");
+        return Ok(());
+    }
 
     if is_channel(&selector.selector) {
         match concrete_version_for_selector_with_base(&selector, &base) {
@@ -991,6 +1226,15 @@ fn list_toolchains() {
     let config = read_config();
     let state = read_state();
     println!("default selector: {}", config.default.selector);
+    if let Ok(active) = active_selector() {
+        if active.selector != config.default.selector {
+            println!(
+                "active selector: {}{}",
+                active.selector,
+                selector_annotation(&active)
+            );
+        }
+    }
     for (channel, state) in state.channels {
         println!("{channel}: {}", state.active_version);
     }
@@ -1009,6 +1253,11 @@ fn list_toolchains() {
 }
 
 fn uninstall_toolchain(version: &str) -> Result<()> {
+    if is_path_selector(version) {
+        return Err(anyhow!(
+            "{version} is a local path; the wrapper does not manage it.\nRun: baml toolchain use canary to stop using it"
+        ));
+    }
     let dir = toolchains_dir().join(version);
     if !dir.exists() {
         return Err(anyhow!("BAML toolchain {version} is not installed"));
@@ -1227,6 +1476,188 @@ mod tests {
             selector_annotation(&resolved("nightly", SelectorSource::Env)),
             " (nightly, from $BAML_VERSION)"
         );
+    }
+
+    #[test]
+    fn channels_and_versions_are_not_path_selectors() {
+        for selector in ["canary", "nightly", "0.412.0", "5.0.0-pre.20210317.1"] {
+            assert!(!is_path_selector(selector), "{selector}");
+        }
+    }
+
+    #[test]
+    fn anything_with_a_path_shape_is_a_path_selector() {
+        for selector in [
+            "~/repos/baml/target/debug/baml-cli",
+            "./target/debug/baml-cli",
+            "../baml/target/debug/baml-cli",
+            "/usr/local/bin/baml-cli",
+            "target/debug/baml-cli",
+            // Forward slashes are a path on Windows too, so a drive-letter
+            // path in this form is detected on every platform.
+            "C:/repos/baml/target/debug/baml-cli.exe",
+        ] {
+            assert!(is_path_selector(selector), "{selector}");
+        }
+    }
+
+    /// Backslash counts as a separator only on Windows, where a channel or
+    /// version can never contain one.
+    #[test]
+    fn windows_backslash_paths_are_path_selectors() {
+        for selector in [
+            r"C:\repos\baml\target\debug\baml-cli.exe",
+            r".\target\debug\baml-cli.exe",
+            r"..\baml\target\debug\baml-cli.exe",
+            r"\\server\share\baml-cli.exe",
+        ] {
+            assert!(is_path_selector_on(selector, true), "{selector}");
+        }
+    }
+
+    #[test]
+    fn backslash_alone_is_not_a_separator_off_windows() {
+        assert!(!is_path_selector_on(r"weird\name", false));
+    }
+
+    /// Channels and versions stay non-paths under the Windows rule too.
+    #[test]
+    fn windows_rule_still_admits_channels_and_versions() {
+        for selector in ["canary", "nightly", "0.412.0"] {
+            assert!(!is_path_selector_on(selector, true), "{selector}");
+        }
+    }
+
+    // Absoluteness is platform-defined (`/opt` has a root but no prefix on
+    // Windows, so it is not absolute there), so the resolution tests build
+    // their paths from platform-appropriate roots.
+    #[cfg(not(windows))]
+    const TEST_BASE: &str = "/work/demo";
+    #[cfg(not(windows))]
+    const TEST_ABSOLUTE: &str = "/opt/baml-cli";
+    #[cfg(not(windows))]
+    const TEST_HOME: &str = "/home/tester";
+
+    #[cfg(windows)]
+    const TEST_BASE: &str = r"C:\work\demo";
+    #[cfg(windows)]
+    const TEST_ABSOLUTE: &str = r"C:\opt\baml-cli.exe";
+    #[cfg(windows)]
+    const TEST_HOME: &str = r"C:\Users\tester";
+
+    #[test]
+    fn relative_path_resolves_against_the_declaring_directory() {
+        assert_eq!(
+            resolve_selector_path("../baml/target/debug/baml-cli", Path::new(TEST_BASE)),
+            Path::new(TEST_BASE).join("../baml/target/debug/baml-cli")
+        );
+    }
+
+    #[test]
+    fn absolute_path_ignores_the_declaring_directory() {
+        assert_eq!(
+            resolve_selector_path(TEST_ABSOLUTE, Path::new(TEST_BASE)),
+            PathBuf::from(TEST_ABSOLUTE)
+        );
+    }
+
+    #[test]
+    fn tilde_expands_to_home() {
+        assert_eq!(
+            resolve_selector_path_with_home(
+                "~/builds/baml-cli",
+                Path::new(TEST_BASE),
+                Some(Path::new(TEST_HOME))
+            ),
+            Path::new(TEST_HOME).join("builds/baml-cli")
+        );
+    }
+
+    /// An existing target loses its `..` segments, so the path reads cleanly in
+    /// `--version`, `status`, and the config file it gets written to.
+    #[test]
+    fn existing_path_is_canonicalized() {
+        let tmp = tempfile::tempdir().unwrap();
+        let build = tmp.path().join("build");
+        let proj = tmp.path().join("proj");
+        fs::create_dir_all(&build).unwrap();
+        fs::create_dir_all(&proj).unwrap();
+        let cli = build.join(cli_exe_name());
+        fs::write(&cli, "").unwrap();
+
+        let resolved = resolve_selector_path(&format!("../build/{}", cli_exe_name()), &proj);
+        assert_eq!(resolved, cli.canonicalize().unwrap());
+        assert!(!resolved.to_string_lossy().contains(".."), "{resolved:?}");
+    }
+
+    /// A path that does not exist yet keeps its joined form, so the error names
+    /// what the developer actually asked for.
+    #[test]
+    fn missing_path_keeps_its_joined_form() {
+        let tmp = tempfile::tempdir().unwrap();
+        let resolved = resolve_selector_path("../build/baml-cli", tmp.path());
+        assert_eq!(resolved, tmp.path().join("../build/baml-cli"));
+    }
+
+    /// Without a home directory the `~` stays literal rather than silently
+    /// resolving somewhere unintended.
+    #[test]
+    fn tilde_without_home_is_left_relative() {
+        assert_eq!(
+            resolve_selector_path_with_home("~/builds/baml-cli", Path::new(TEST_BASE), None),
+            Path::new(TEST_BASE).join("~/builds/baml-cli")
+        );
+    }
+
+    #[test]
+    fn normalizing_an_absolute_path_selector_is_idempotent() {
+        let once = normalize_selector("./target/debug/baml-cli", Path::new(TEST_BASE));
+        assert!(Path::new(&once).is_absolute(), "{once}");
+        assert!(is_path_selector(&once), "{once}");
+        assert_eq!(normalize_selector(&once, Path::new("/elsewhere")), once);
+    }
+
+    #[test]
+    fn normalizing_leaves_channels_and_versions_alone() {
+        assert_eq!(normalize_selector("canary", Path::new(TEST_BASE)), "canary");
+        assert_eq!(
+            normalize_selector("0.412.0", Path::new(TEST_BASE)),
+            "0.412.0"
+        );
+    }
+
+    #[test]
+    fn path_toolchain_pointing_at_a_directory_is_rejected() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = verify_path_toolchain(dir.path(), "")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("is a directory"), "{err}");
+        assert!(err.contains("baml-cli"), "{err}");
+    }
+
+    #[test]
+    fn missing_path_toolchain_reports_its_origin() {
+        let missing = Path::new(TEST_BASE).join("missing").join(cli_exe_name());
+        let manifest = Path::new(TEST_BASE).join("baml.toml");
+        let origin = path_selector_origin(&SelectorSource::Project(manifest.clone()));
+        let err = verify_path_toolchain(&missing, &origin)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("toolchain binary not found"), "{err}");
+        assert!(
+            err.contains(&format!("set by path in {}", manifest.display())),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn path_selector_has_no_version_to_resolve() {
+        let selector = resolved(TEST_ABSOLUTE, SelectorSource::Config);
+        let err = concrete_version_for_selector_with_base(&selector, "https://example.test")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("has no version"), "{err}");
     }
 
     fn write_cached_manifest(version: &str) -> tempfile::NamedTempFile {

--- a/baml_language/crates/baml/src/main.rs
+++ b/baml_language/crates/baml/src/main.rs
@@ -22,6 +22,9 @@ const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 /// Short timeout for the passive background freshness checks that run before
 /// normal commands, so an unreachable network can't stall the actual work.
 const AUTO_CHECK_TIMEOUT: Duration = Duration::from_secs(5);
+/// How long `baml --version` waits for a local toolchain to report its own
+/// version before giving up and printing just the path.
+const LOCAL_VERSION_TIMEOUT: Duration = Duration::from_secs(3);
 
 #[derive(Debug, Default, Serialize, Deserialize)]
 struct Config {
@@ -207,12 +210,15 @@ fn print_version() {
         }
     };
     if let Some(cli) = path_selector(&selector.selector) {
-        match verify_path_toolchain(cli, "") {
-            Ok(()) => println!(
-                "baml toolchain {}{}",
-                cli.display(),
-                selector_annotation(&selector)
-            ),
+        // The failure branch needs the origin most: a broken local toolchain is
+        // useless to diagnose without knowing which setting chose it.
+        match verify_path_toolchain(cli, &path_selector_origin(&selector.source)) {
+            Ok(()) => {
+                let version =
+                    local_toolchain_version(cli).unwrap_or_else(|| "version unknown".to_string());
+                println!("baml toolchain {version} (local: {})", cli.display());
+                println!("  {}", path_source_label(&selector.source));
+            }
             Err(err) => {
                 println!("baml toolchain not usable");
                 println!("{err:#}");
@@ -511,10 +517,7 @@ fn active_selector() -> Result<ResolvedSelector> {
     if !selector.is_empty() {
         // A machine-global default resolved against cwd would run a different
         // binary from each directory, so it has to stand on its own.
-        if is_path_selector(selector)
-            && !selector.starts_with('~')
-            && !Path::new(selector).is_absolute()
-        {
+        if is_path_selector(selector) && !is_cwd_independent(selector) {
             return Err(anyhow!(
                 "{} sets default.selector to a relative path ({selector}), which would depend on the current directory.\nUse an absolute path, or run: baml toolchain use <path>",
                 config_path().display()
@@ -690,10 +693,30 @@ fn path_selector(selector: &str) -> Option<&Path> {
 /// Expand a leading `~` and absolutize against `base`, the directory the path
 /// was written in.
 fn resolve_selector_path(raw: &str, base: &Path) -> PathBuf {
-    let home = env::var_os("HOME")
-        .or_else(|| env::var_os("USERPROFILE"))
-        .map(PathBuf::from);
+    let home = home_dir();
     resolve_selector_path_with_home(raw, base, home.as_deref())
+}
+
+fn home_dir() -> Option<PathBuf> {
+    env::var_os("HOME")
+        .or_else(|| env::var_os("USERPROFILE"))
+        .map(PathBuf::from)
+}
+
+/// Whether a path selector stands on its own, independent of the directory it
+/// is read from. Only absolute paths and a `~` that can actually be expanded
+/// qualify: with no home directory `~/x` falls back to being joined onto the
+/// current one, and `~user` is not a form we expand at all, so both would leave
+/// a global default meaning something different in every directory.
+fn is_cwd_independent(selector: &str) -> bool {
+    is_cwd_independent_with_home(selector, home_dir().as_deref())
+}
+
+fn is_cwd_independent_with_home(selector: &str, home: Option<&Path>) -> bool {
+    if Path::new(selector).is_absolute() {
+        return true;
+    }
+    (selector == "~" || selector.starts_with("~/")) && home.is_some()
 }
 
 fn resolve_selector_path_with_home(raw: &str, base: &Path, home: Option<&Path>) -> PathBuf {
@@ -781,16 +804,65 @@ fn normalize_selector(selector: &str, base: &Path) -> String {
     selector.to_string()
 }
 
+/// Where a path toolchain came from. Unlike [`selector_origin`], this always
+/// answers, including for the global config: with a local toolchain the whole
+/// question is which forgotten setting picked this binary.
+fn path_source_label(source: &SelectorSource) -> String {
+    match source {
+        SelectorSource::Env => "set by $BAML_VERSION".to_string(),
+        SelectorSource::Project(path) => format!("set by {}", path.display()),
+        SelectorSource::Config | SelectorSource::Fallback => {
+            format!("set by default.selector in {}", config_path().display())
+        }
+    }
+}
+
 /// The `set by ...` line appended to path-toolchain errors, so a stale
 /// override is traceable to whatever set it.
 fn path_selector_origin(source: &SelectorSource) -> String {
-    match source {
-        SelectorSource::Env => "\n  set by $BAML_VERSION".to_string(),
-        SelectorSource::Project(path) => format!("\n  set by path in {}", path.display()),
-        SelectorSource::Config | SelectorSource::Fallback => {
-            format!("\n  set by default.selector in {}", config_path().display())
+    format!("\n  {}", path_source_label(source))
+}
+
+/// Ask a local toolchain what version it is. There is no manifest to consult
+/// for a binary the wrapper did not install, and reporting only a path would
+/// leave `baml --version` with no version at all for anything reading it.
+/// Returns `None` if the binary fails, answers with nothing, or does not answer
+/// promptly, in which case the caller falls back to reporting just the path.
+fn local_toolchain_version(cli: &Path) -> Option<String> {
+    use std::process::Stdio;
+
+    let mut child = Command::new(cli)
+        .arg("--version")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .env("BAML_WRAPPER_EXEC", "1")
+        .env("BAML_WRAPPER_LOCAL_TOOLCHAIN", cli)
+        .spawn()
+        .ok()?;
+
+    let deadline = std::time::Instant::now() + LOCAL_VERSION_TIMEOUT;
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            // A binary that will not answer promptly is not worth blocking
+            // `--version` on, and a hung child must not outlive us.
+            _ => {
+                let _ = child.kill();
+                return None;
+            }
         }
+    };
+    if !status.success() {
+        return None;
     }
+    let output = child.wait_with_output().ok()?;
+    let text = String::from_utf8(output.stdout).ok()?;
+    let line = text.lines().next()?.trim();
+    (!line.is_empty()).then(|| line.to_string())
 }
 
 /// Refuse to exec the wrapper itself. `baml` and `baml-cli` are built into the
@@ -1216,14 +1288,18 @@ fn status_toolchain(override_url: Option<&str>) -> Result<()> {
     println!("active selector: {}", selector.selector);
 
     if let Some(cli) = path_selector(&selector.selector) {
-        if let Some(origin) = selector_origin(&selector.source) {
-            println!("source: {origin}");
-        }
+        println!("source: {}", path_source_label(&selector.source));
         match verify_path_toolchain(cli, "") {
-            Ok(()) => println!("status: local toolchain binary, not managed by the wrapper"),
+            Ok(()) => {
+                let version =
+                    local_toolchain_version(cli).unwrap_or_else(|| "version unknown".to_string());
+                println!("reported version: {version}");
+                println!("status: local toolchain binary, not managed by the wrapper");
+            }
             Err(err) => println!("status: local toolchain binary is unusable\n{err:#}"),
         }
         println!("Remote versions were not checked.");
+        println!("Run: baml toolchain use canary to go back to a managed toolchain");
         return Ok(());
     }
 
@@ -1339,7 +1415,7 @@ fn list_toolchains() {
 fn uninstall_toolchain(version: &str) -> Result<()> {
     if is_path_selector(version) {
         return Err(anyhow!(
-            "{version} is a local path; the wrapper does not manage it.\nRun: baml toolchain use canary to stop using it"
+            "{version} is a local path and is not managed by the wrapper, so there is nothing to uninstall.\nTo stop using it, select a managed toolchain instead.\nRun: baml toolchain use canary\nOr:  baml toolchain use nightly"
         ));
     }
     let dir = toolchains_dir().join(version);
@@ -1763,15 +1839,64 @@ mod tests {
     #[test]
     fn missing_path_toolchain_reports_its_origin() {
         let missing = Path::new(TEST_BASE).join("missing").join(cli_exe_name());
-        let manifest = Path::new(TEST_BASE).join("baml.toml");
-        let origin = path_selector_origin(&SelectorSource::Project(manifest.clone()));
+        let origin = path_selector_origin(&SelectorSource::Env);
         let err = verify_path_toolchain(&missing, &origin)
             .unwrap_err()
             .to_string();
         assert!(err.contains("toolchain binary not found"), "{err}");
+        assert!(err.contains("set by $BAML_VERSION"), "{err}");
+    }
+
+    #[test]
+    fn absolute_selectors_stand_on_their_own() {
+        assert!(is_cwd_independent_with_home(TEST_ABSOLUTE, None));
+        assert!(is_cwd_independent_with_home(
+            TEST_ABSOLUTE,
+            Some(Path::new(TEST_HOME))
+        ));
+    }
+
+    /// `~/x` only stands on its own if there is a home directory to expand it
+    /// to; otherwise it falls back to being joined onto the current directory.
+    #[test]
+    fn tilde_stands_on_its_own_only_with_a_home() {
+        assert!(is_cwd_independent_with_home(
+            "~/builds/baml-cli",
+            Some(Path::new(TEST_HOME))
+        ));
+        assert!(!is_cwd_independent_with_home("~/builds/baml-cli", None));
+    }
+
+    /// `~user` is not a form we expand, so it must not be waved through by a
+    /// bare `~` prefix check.
+    #[test]
+    fn other_users_tilde_does_not_stand_on_its_own() {
+        assert!(!is_cwd_independent_with_home(
+            "~alice/builds/baml-cli",
+            Some(Path::new(TEST_HOME))
+        ));
+    }
+
+    #[test]
+    fn relative_selectors_never_stand_on_their_own() {
+        for selector in ["./target/debug/baml-cli", "../build/baml-cli"] {
+            assert!(
+                !is_cwd_independent_with_home(selector, Some(Path::new(TEST_HOME))),
+                "{selector}"
+            );
+        }
+    }
+
+    /// The global config is the source most likely to be forgotten, and the one
+    /// `selector_origin` stays quiet about, so a path toolchain must still name
+    /// it.
+    #[test]
+    fn config_sourced_path_still_names_its_origin() {
+        let label = path_source_label(&SelectorSource::Config);
+        assert!(label.contains("default.selector"), "{label}");
         assert!(
-            err.contains(&format!("set by path in {}", manifest.display())),
-            "{err}"
+            label.contains(&config_path().display().to_string()),
+            "{label}"
         );
     }
 

--- a/baml_language/crates/baml_cli/src/ide_command.rs
+++ b/baml_language/crates/baml_cli/src/ide_command.rs
@@ -191,6 +191,14 @@ fn active_toolchain_vsix() -> Result<PathBuf> {
         .ok_or_else(|| anyhow!("failed to determine active BAML toolchain root"))?;
     let vsix = toolchain_root.join("assets").join("baml-vscode.vsix");
     if !vsix.exists() {
+        // A local build has no assets/ next to it, so say that plainly rather
+        // than reporting a missing file the developer never expected to exist.
+        if let Some(local) = env::var_os("BAML_WRAPPER_LOCAL_TOOLCHAIN") {
+            anyhow::bail!(
+                "baml ide install needs a managed BAML toolchain, but the active one is a local binary at {}.\nThe VS Code extension ships with released toolchains only.\nRun: baml toolchain use canary",
+                Path::new(&local).display()
+            );
+        }
         anyhow::bail!(
             "active BAML toolchain does not include assets/baml-vscode.vsix at {}",
             vsix.display()


### PR DESCRIPTION
Lets you point the `baml` wrapper at a locally built `baml-cli`.

## Why

Today the only ways to run a local build are repointing `BAML_HOME` and hand-seeding `toolchains/<v>/bin/baml-cli` + `VERSION` (what `freshness_e2e.rs` does), or bypassing the wrapper entirely with `BAML_CLI_ALLOW_DIRECT`. Neither survives a project that pins `[toolchain]`.

## Design

**A path is recognized by shape, not by a prefix.** A selector containing a path separator (or starting with `~` or `.`) is a binary path. Channels and versions never contain one, so no `path:` prefix, subcommand, or flag is needed to disambiguate.

The one input this does not catch is a bare filename with no separator: `baml toolchain use baml-cli` reads as a version. `./baml-cli` is the answer, same convention as running any local executable.

**Two places to set it**, both typed by the developer, with precedence unchanged (`BAML_VERSION` > `baml.toml` > `~/.baml/config.toml` > `canary`):

```bash
# point at a local build
export BAML_VERSION=~/repos/baml/target/debug/baml-cli
baml check

# one-off
BAML_VERSION=./target/debug/baml-cli baml check

# persist to ~/.baml/config.toml
baml toolchain use ~/repos/baml/target/debug/baml-cli
baml toolchain use canary          # back to normal
```

**Deliberately not settable from `baml.toml`.** A committed `path` plus a mode-755 file (git preserves the exec bit) would execute on any `baml` invocation in that tree, with no prompt and nothing on stderr. rustup avoids this by requiring `path` to be an absolute path, which also makes the field useless to a teammate, so there is little left to want. The field is refused with a message pointing at the two supported ways:

```
/work/demo/baml.toml sets [toolchain] path, which is not supported.
A checked-out repository must not be able to choose which binary runs on your machine.
To use a local build, run: baml toolchain use <path>
Or set $BAML_VERSION to it for a single command.
```

**Refuses to exec the wrapper itself.** `baml` and `baml-cli` build into the same directory, so pointing at `baml` is a one-character slip. Without a guard it re-resolves the same selector and execs itself forever: silent on unix, an unbounded process tree on Windows where the non-unix branch spawns a child per iteration.

**Paths are tidied lexically, not canonicalized.** Canonicalizing resolves symlinks, which would freeze a `current -> release-N` indirection to whatever it pointed at the day it was set. It also yields `\\?\C:\...` verbatim paths on Windows, which would land in `config.toml` and in `--version` output. Lexical `..` removal keeps the symlink and reads the same on every platform. If lexical tidying would produce a path that does not exist while the untidied one does (a symlinked directory followed by `..`), the untidied form is kept, so tidying can never break a working path.

**Path toolchains skip the version bookkeeping**: no `VERSION` check, no channel-outdated warning, no background manifest refresh. That keeps the `exec()` fast path unconditional and keeps stderr clean for parsed output.

**Subcommands**: `install` and `uninstall` reject a path, `update` no-ops, `status` and `list` report the path and its origin without touching the network. `list` surfaces resolution errors rather than swallowing them, since it is what you run to find out why nothing works.

**`baml ide install` needs a managed toolchain** and now says so. A local build has no `assets/` beside it, so it previously reported a missing file the developer never expected to exist. `baml playground` and `baml pack` also degrade under a local toolchain: both look for siblings of the executable, which only exist in the installed layout.

**Errors name the source**, so a forgotten override is traceable:

```
toolchain binary not found: /Users/vbv/build/nope
  set by default.selector in /Users/vbv/.baml/config.toml

toolchain path points at the baml wrapper itself: /repos/baml/target/debug/baml
  set by $BAML_VERSION
Point at the baml-cli binary instead, which is built alongside it.
```

Failures that cannot be caught up front (wrong architecture, a `noexec` mount, a missing interpreter) carry the same attribution.

## Windows

The separator rule is split into `is_path_selector_on(selector, windows)` so the Windows behavior is exercised by tests on every platform rather than only compiling under `cfg(windows)`. A path with no extension falls back to `.exe`, so `baml toolchain use .\target\debug\baml-cli` works. A local Windows compile-check was not possible here (the target needs mingw for a TLS dependency's build script); the `cargo test (windows)` CI job covers it, since it runs `baml` as part of `--workspace`.

## Testing

34 unit tests and the 2 existing e2e tests pass; `cargo fmt` and `cargo clippy` are clean.

Manually exercised end to end against both a stub and the real `baml-cli`: env var with relative and `~` paths, `toolchain use <path>` followed by a plain invocation, a symlinked path surviving a repoint, the self-exec guard (direct and through a symlink), the `baml.toml` refusal, a relative `default.selector` being refused, `list` surfacing that error, `baml ide install` refusing a local toolchain, and the directory / missing / non-executable errors. Channels and pinned versions still resolve exactly as before.

## Review note

The security, self-exec, symlink, Windows `.exe`, `list`, and global-config issues above were found by an adversarial review pass over the first commit and fixed in the second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y9aTrkwDQgGr9HSvdEcq61


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for using a local `baml-cli` binary as an active toolchain.
  * Expanded path-based selection via `baml toolchain use <path>` and `$BAML_VERSION`, including local version detection.
  * Toolchain status, listing, and `--version` now identify active local binaries and usability.
* **Bug Fixes**
  * Improved selector normalization and validation (including platform-specific path handling) and more consistent error messaging.
  * Added safeguards for local toolchain execution and verification (with attribution), plus a timeout for local version checks.
  * Updated IDE VS Code extension checks to explicitly guide use of managed toolchains when assets are missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->