### PR TITLE
feat(cli): add generator configuration command

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -776,6 +776,7 @@ dependencies = [
  "text-size",
  "tokio",
  "toml 0.8.23",
+ "toml_edit 0.22.27",
  "uuid",
  "webbrowser",
  "yaml_serde",

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -66,6 +66,7 @@ tar = { workspace = true }
 text-size = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 uuid = { workspace = true }
 webbrowser = { workspace = true }
 

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -193,10 +193,6 @@ impl RuntimeCli {
             Err(err) => err.exit(),
         };
 
-        if let Err(err) = RuntimeCli::update_from_arg_matches(&mut cli, &matches) {
-            err.exit();
-        }
-
         // Record the invoked subcommand's clap name for telemetry, straight
         // from the parsed matches so it always matches what clap registered.
         cli.invoked_subcommand = matches.subcommand_name().map(str::to_string);
@@ -375,6 +371,48 @@ mod tests {
         assert!(
             help.contains("Project search starting point. Defaults to the current directory"),
             "{help}"
+        );
+    }
+
+    #[test]
+    fn generate_add_help_lists_every_output_type() {
+        let help = help_for(&["baml-cli", "generate", "add", "--help"]);
+        for &output_type in baml_codegen_types::OutputType::all() {
+            assert!(
+                help.contains(output_type.add_name()),
+                "missing {output_type:?} in:\n{help}"
+            );
+        }
+    }
+
+    #[test]
+    fn generate_accepts_bare_and_add_forms() {
+        let cli = RuntimeCli::parse_from_smart(vec![
+            "baml-cli".into(),
+            "generate".into(),
+            "--from".into(),
+            ".".into(),
+        ]);
+        let Commands::Generate(args) = cli.command else {
+            panic!("expected generate command");
+        };
+        assert!(args.command.is_none());
+
+        let cli = RuntimeCli::parse_from_smart(vec![
+            "baml-cli".into(),
+            "generate".into(),
+            "add".into(),
+            "python/pydantic2".into(),
+        ]);
+        let Commands::Generate(args) = cli.command else {
+            panic!("expected generate command");
+        };
+        let Some(crate::generate::GenerateCommand::Add(args)) = args.command else {
+            panic!("expected generate add command");
+        };
+        assert_eq!(
+            args.output_type,
+            baml_codegen_types::OutputType::PythonPydantic
         );
     }
 

--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -7,20 +7,28 @@ use std::{
 };
 
 use anyhow::{Context, Result, anyhow};
-use baml_codegen_types::{GeneratedOutputFile, write_generated_output};
+use baml_codegen_types::{
+    GeneratedOutputFile, Generator, NamingConvention, OutputType, write_generated_output,
+};
 use baml_db::{
     FileId, Span,
     baml_compiler_diagnostics::{Diagnostic, DiagnosticId, DiagnosticPhase, Severity, render},
 };
-use clap::Args;
-use sdkgen_python_pydantic2::{NamingConvention, OutputType};
+use clap::{
+    Args, Subcommand,
+    builder::{PossibleValuesParser, TypedValueParser},
+};
 use text_size::{TextRange, TextSize};
 use toml::Spanned;
+use toml_edit::{DocumentMut, Item, Table, value};
 
 use crate::{commands::release_version, reporter::Reporter};
 
 #[derive(Args, Clone, Debug)]
 pub struct GenerateArgs {
+    #[command(subcommand)]
+    pub command: Option<GenerateCommand>,
+
     /// Project search starting point. Defaults to the current directory.
     #[arg(long, value_name = "PATH")]
     pub from: Option<PathBuf>,
@@ -28,6 +36,26 @@ pub struct GenerateArgs {
     /// Output directory override (takes precedence over generator config)
     #[arg(long, short = 'o')]
     pub output: Option<PathBuf>,
+}
+
+#[derive(Subcommand, Clone, Debug)]
+pub enum GenerateCommand {
+    /// Add a client generator to baml.toml.
+    Add(AddGeneratorArgs),
+}
+
+#[derive(Args, Clone, Debug)]
+pub struct AddGeneratorArgs {
+    #[arg(value_name = "OUTPUT_TYPE", value_parser = add_output_type_parser())]
+    pub output_type: OutputType,
+
+    /// Project search starting point. Defaults to the current directory.
+    #[arg(long, value_name = "PATH")]
+    pub from: Option<PathBuf>,
+
+    /// Go module import path for the generated baml_sdk package.
+    #[arg(long, value_name = "IMPORT_PATH")]
+    pub sdk_import_path: Option<String>,
 }
 
 /// A validated generator, resolved from a `[generator.<name>]` section of
@@ -46,8 +74,127 @@ struct GeneratorDef {
     max_typed_union_arity: usize,
 }
 
+impl AddGeneratorArgs {
+    fn run(&self) -> Result<crate::ExitCode> {
+        let root = crate::project_load::find_project_root_from(self.from.as_deref())?.ok_or_else(
+            || anyhow!("no BAML project found; run `baml init` before adding a generator"),
+        )?;
+        let toml_path = root.join("baml.toml");
+        if !toml_path.is_file() {
+            anyhow::bail!(
+                "`{}` has no baml.toml; run `baml init` before adding a generator",
+                root.display()
+            );
+        }
+
+        let content = std::fs::read_to_string(&toml_path)
+            .with_context(|| format!("failed to read {}", toml_path.display()))?;
+        let manifest = crate::manifest::parse(&content)
+            .with_context(|| format!("failed to parse {}", toml_path.display()))?;
+        crate::manifest::package_name(&manifest, &toml_path)?;
+
+        let mut generator = Generator::from(self.output_type);
+        match (self.output_type, self.sdk_import_path.as_deref()) {
+            (OutputType::Go, Some(import_path)) if is_valid_go_import_path(import_path) => {
+                generator.sdk_import_path = Some(import_path.to_string());
+            }
+            (OutputType::Go, Some(import_path)) => {
+                anyhow::bail!("invalid Go SDK import path `{import_path}`");
+            }
+            (OutputType::Go, None) => {
+                anyhow::bail!("the Go generator requires `--sdk-import-path <MODULE>/baml_sdk`");
+            }
+            (_, Some(_)) => {
+                anyhow::bail!("`--sdk-import-path` is only valid for the Go generator");
+            }
+            (_, None) => {}
+        }
+
+        let (updated, name) = add_generator_to_manifest(&content, &generator)
+            .with_context(|| format!("failed to update {}", toml_path.display()))?;
+        std::fs::write(&toml_path, updated)
+            .with_context(|| format!("failed to write {}", toml_path.display()))?;
+
+        Reporter::new().finish(
+            "Added",
+            format!("generator.{name} to {}", toml_path.display()),
+        );
+        Ok(crate::ExitCode::Success)
+    }
+}
+
+fn parse_add_output_type(value: &str) -> Result<OutputType, String> {
+    OutputType::all()
+        .iter()
+        .copied()
+        .find(|output_type| value == output_type.add_name())
+        .ok_or_else(|| {
+            let expected = OutputType::all()
+                .iter()
+                .copied()
+                .map(OutputType::add_name)
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("unknown generator output type `{value}`; expected one of: {expected}")
+        })
+}
+
+fn add_output_type_parser() -> impl TypedValueParser<Value = OutputType> {
+    PossibleValuesParser::new(OutputType::all().iter().copied().map(OutputType::add_name)).map(
+        |value| parse_add_output_type(&value).expect("possible generator output type must parse"),
+    )
+}
+
+fn add_generator_to_manifest(content: &str, generator: &Generator) -> Result<(String, String)> {
+    let manifest = crate::manifest::parse(content).context("invalid baml.toml")?;
+    let name = (1..)
+        .map(|index| format!("client{index}"))
+        .find(|name| !manifest.generator.contains_key(name))
+        .expect("generator index space is unbounded");
+
+    let mut document = content
+        .parse::<DocumentMut>()
+        .context("invalid baml.toml")?;
+    if document.get("generator").is_none() {
+        let mut generators = Table::new();
+        generators.set_implicit(true);
+        document.insert("generator", Item::Table(generators));
+    }
+    let generators = document["generator"]
+        .as_table_mut()
+        .context("`generator` must be a TOML table")?;
+
+    let mut table = Table::new();
+    table.insert("output_type", value(generator.output_type.to_string()));
+    if let Some(output_dir) = &generator.output_dir {
+        table.insert("output_dir", value(output_dir));
+    }
+    table.insert(
+        "naming_convention",
+        value(generator.naming_convention.to_string()),
+    );
+    if let Some(sdk_import_path) = &generator.sdk_import_path {
+        table.insert("sdk_import_path", value(sdk_import_path));
+    }
+    if let Some(max_typed_union_arity) = generator.max_typed_union_arity {
+        let max_typed_union_arity = i64::try_from(max_typed_union_arity)
+            .context("max_typed_union_arity exceeds TOML's integer range")?;
+        table.insert("max_typed_union_arity", value(max_typed_union_arity));
+    }
+    generators.insert(&name, Item::Table(table));
+
+    Ok((document.to_string(), name))
+}
+
 impl GenerateArgs {
     pub fn run(&self) -> Result<crate::ExitCode> {
+        match &self.command {
+            Some(GenerateCommand::Add(args)) => args.run(),
+            None => self.run_generate(),
+        }
+    }
+
+    fn run_generate(&self) -> Result<crate::ExitCode> {
         let reporter = Reporter::new();
         reporter.status(
             "Generating",
@@ -631,7 +778,11 @@ fn to_text_range(span: std::ops::Range<usize>) -> TextRange {
 mod tests {
     use std::fs;
 
-    use super::{Diagnostic, GeneratorDef, discover_generators, is_valid_go_import_path};
+    use super::{
+        AddGeneratorArgs, Diagnostic, Generator, GeneratorDef, OutputType,
+        add_generator_to_manifest, discover_generators, is_valid_go_import_path,
+        parse_add_output_type,
+    };
 
     fn go_manifest(threshold: Option<i64>) -> String {
         let threshold = threshold
@@ -646,6 +797,90 @@ mod tests {
         let directory = tempfile::tempdir().unwrap();
         fs::write(directory.path().join("baml.toml"), content).unwrap();
         discover_generators(directory.path())
+    }
+
+    #[test]
+    fn add_parser_accepts_every_output_type_name() {
+        for &output_type in OutputType::all() {
+            assert_eq!(
+                parse_add_output_type(output_type.add_name()),
+                Ok(output_type)
+            );
+        }
+    }
+
+    #[test]
+    fn add_generator_preserves_manifest_and_uses_first_free_client_name() {
+        let content = "# keep this comment\n[package]\nname = \"test\"\n\n[generator.client1]\noutput_type = \"rust\"\nnaming_convention = \"preserve-case\"\n";
+        let generator = Generator::from(OutputType::PythonPydantic);
+
+        let (updated, name) = add_generator_to_manifest(content, &generator).unwrap();
+
+        assert_eq!(name, "client2");
+        assert!(updated.contains("# keep this comment"));
+        let manifest = crate::manifest::parse(&updated).unwrap();
+        let added = manifest.generator["client2"].get_ref();
+        assert_eq!(
+            added.output_type.as_ref().unwrap().get_ref(),
+            "python/pydantic"
+        );
+        assert_eq!(
+            added.naming_convention.as_ref().unwrap().get_ref(),
+            "preserve-case"
+        );
+    }
+
+    #[test]
+    fn add_go_generator_writes_required_import_path() {
+        let mut generator = Generator::from(OutputType::Go);
+        generator.sdk_import_path = Some("example.com/test/baml_sdk".to_string());
+
+        let (updated, name) =
+            add_generator_to_manifest("[package]\nname = \"test\"\n", &generator).unwrap();
+
+        assert_eq!(name, "client1");
+        let manifest = crate::manifest::parse(&updated).unwrap();
+        let added = manifest.generator["client1"].get_ref();
+        assert_eq!(added.output_type.as_ref().unwrap().get_ref(), "go");
+        assert_eq!(
+            added.naming_convention.as_ref().unwrap().get_ref(),
+            "language"
+        );
+        assert_eq!(
+            added.sdk_import_path.as_ref().unwrap().get_ref(),
+            "example.com/test/baml_sdk"
+        );
+    }
+
+    #[test]
+    fn add_command_updates_project_manifest() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(
+            directory.path().join("baml.toml"),
+            "[package]\nname = \"test\"\n",
+        )
+        .unwrap();
+
+        let result = AddGeneratorArgs {
+            output_type: OutputType::TypescriptNode,
+            from: Some(directory.path().to_path_buf()),
+            sdk_import_path: None,
+        }
+        .run()
+        .unwrap();
+
+        assert!(matches!(result, crate::ExitCode::Success));
+        let updated = fs::read_to_string(directory.path().join("baml.toml")).unwrap();
+        let manifest = crate::manifest::parse(&updated).unwrap();
+        assert_eq!(
+            manifest.generator["client1"]
+                .get_ref()
+                .output_type
+                .as_ref()
+                .unwrap()
+                .get_ref(),
+            "typescript/node"
+        );
     }
 
     #[test]

--- a/baml_language/crates/baml_cli/src/init_command.rs
+++ b/baml_language/crates/baml_cli/src/init_command.rs
@@ -170,40 +170,11 @@ name = "{name}"
 # [scripts]
 # dev = "-f main"
 
-# Uncomment this to generate the Python SDK.
+# Add a client generator, then generate its SDK:
+#   baml generate add python/pydantic2
+#   baml generate
 #
-# Note: you also need to install the BAML runtime bridge for Python:
-#   uv add baml_bridge
-#   pip install baml_bridge
-#   conda install -c conda-forge baml_bridge
-#
-# [generator.python_client]
-# output_type = "python/pydantic"
-# output_dir = "./baml_python"
-# naming_convention = "preserve-case"
-
-# Uncomment this to generate the Node SDK.
-#
-# Note: you also need to install the BAML runtime bridge for Node.js:
-#   npm install @boundaryml/baml-bridge
-#   pnpm add @boundaryml/baml-bridge
-#   yarn add @boundaryml/baml-bridge
-#   bun add @boundaryml/baml-bridge
-#
-# [generator.node_client]
-# output_type = "typescript/node"
-# output_dir = "./baml_ts"
-# naming_convention = "preserve-case"
-
-# Uncomment this to generate the Go SDK. `sdk_import_path` must match the
-# import path of the generated `baml_sdk` directory in your Go module.
-#
-# [generator.go_client]
-# output_type = "go"
-# output_dir = "."
-# naming_convention = "language"
-# sdk_import_path = "example.com/my-project/baml_sdk"
-# max_typed_union_arity = 3 # larger unions are generated as `any`
+# Run `baml generate add --help` to see every supported output type.
 "#,
     )
 }
@@ -229,6 +200,7 @@ mod tests {
         let toml = std::fs::read_to_string(tmp.path().join("baml.toml")).unwrap();
         assert!(toml.contains("[package]"));
         assert!(toml.contains("name = "));
+        assert!(toml.contains("baml generate add python/pydantic2"));
         assert!(tmp.path().join("baml_src/main.baml").exists());
     }
 

--- a/baml_language/crates/baml_codegen_types/src/generator_fields.rs
+++ b/baml_language/crates/baml_codegen_types/src/generator_fields.rs
@@ -1,11 +1,12 @@
 //! Strum enums for fields that appear inside a BAML `generator` block.
 //!
-//! Each field is required — there are deliberately no defaults while we
-//! settle on per-target rules. New backends or policies extend the enums
-//! here and the dispatch in `baml-cli generate`.
+//! New backends or policies extend the enums here and the dispatch in
+//! `baml-cli generate`.
 
 /// Code-generation target. Surfaces as `output_type = "python/pydantic"`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::EnumString, strum::Display)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, strum::EnumString, strum::Display, strum::VariantArray,
+)]
 pub enum OutputType {
     /// Python with Pydantic v2 models.
     #[strum(serialize = "python/pydantic")]
@@ -40,6 +41,27 @@ pub enum OutputType {
 }
 
 impl OutputType {
+    /// Every supported generator target.
+    pub const fn all() -> &'static [Self] {
+        <Self as strum::VariantArray>::VARIANTS
+    }
+
+    /// User-facing name accepted by `baml generate add`.
+    pub const fn add_name(self) -> &'static str {
+        match self {
+            Self::PythonPydantic => "python/pydantic2",
+            Self::PythonPydanticV1 => "python/pydantic/v1",
+            Self::TypescriptNode => "typescript/node",
+            Self::TypescriptWeb => "typescript/web",
+            Self::Swift => "swift",
+            Self::Go => "go",
+            Self::Rust => "rust",
+            Self::Java => "java",
+            Self::Cpp => "cpp",
+            Self::CSharp => "csharp",
+        }
+    }
+
     /// Conventional generated directory for this target.
     pub const fn generated_directory(self) -> &'static str {
         match self {
@@ -63,11 +85,43 @@ pub enum NamingConvention {
     Language,
 }
 
+/// Manifest-ready generator settings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Generator {
+    /// Code-generation target written as `output_type`.
+    pub output_type: OutputType,
+    /// Optional base directory written as `output_dir`.
+    pub output_dir: Option<String>,
+    /// Identifier-casing policy written as `naming_convention`.
+    pub naming_convention: NamingConvention,
+    /// Go module import path for the generated SDK.
+    pub sdk_import_path: Option<String>,
+    /// Maximum typed union arity for Go output.
+    pub max_typed_union_arity: Option<usize>,
+}
+
+impl From<OutputType> for Generator {
+    fn from(output_type: OutputType) -> Self {
+        let naming_convention = match output_type {
+            OutputType::Go | OutputType::CSharp => NamingConvention::Language,
+            _ => NamingConvention::PreserveCase,
+        };
+
+        Self {
+            output_type,
+            output_dir: None,
+            naming_convention,
+            sdk_import_path: None,
+            max_typed_union_arity: None,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::str::FromStr as _;
 
-    use super::OutputType;
+    use super::{Generator, NamingConvention, OutputType};
 
     #[test]
     fn csharp_generator_identity_is_canonical() {
@@ -75,5 +129,23 @@ mod tests {
         assert_eq!(OutputType::CSharp.to_string(), "csharp");
         assert_eq!(OutputType::CSharp.generated_directory(), "baml_client");
         assert_eq!(OutputType::Rust.generated_directory(), "baml_sdk");
+    }
+
+    #[test]
+    fn every_output_type_has_add_defaults() {
+        for &output_type in OutputType::all() {
+            let generator = Generator::from(output_type);
+            assert_eq!(generator.output_type, output_type);
+            assert!(!output_type.add_name().is_empty());
+        }
+
+        assert_eq!(
+            Generator::from(OutputType::Go).naming_convention,
+            NamingConvention::Language
+        );
+        assert_eq!(
+            Generator::from(OutputType::PythonPydantic).naming_convention,
+            NamingConvention::PreserveCase
+        );
     }
 }


### PR DESCRIPTION
## Changes

- add `baml generate add <output-type>` as a real CLI subcommand
- create the first available `[generator.clientN]` entry while preserving TOML comments and formatting
- derive generator defaults from `OutputType` and expose every supported bridge name
- add `baml generate add` guidance to newly initialized `baml.toml` files
- remove the redundant clap update pass that prevented optional nested subcommands

## Testing

- [x] `cargo test -p baml_cli --lib`
- [x] `cargo test -p baml_cli generate`
- [x] `cargo clippy -p baml_cli -p baml_codegen_types --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] manually tested `baml init` followed by `baml generate add python/pydantic2`

## Additional Notes

The Go target requires `--sdk-import-path`; target-specific naming defaults are centralized in `From<OutputType> for Generator`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `baml generate add` to configure a client generator directly in `baml.toml`.
  * Supports all available output targets, including Python, TypeScript, Go, Rust, Java, C++, C#, and Swift.
  * Automatically selects the next available client configuration and preserves existing TOML formatting and comments.
  * Added validation and support for Go SDK import paths.
* **Documentation**
  * Updated project initialization guidance with instructions for adding and running generators.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->