### PR TITLE
Improve baml-cli help and global options

### DIFF
--- a/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
+++ b/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
@@ -775,8 +775,8 @@ default:
 check:
   summary: "Explains how to ask the CLI to validate a project."
   syntax: |
-    baml check --from .
-    baml run --list --from .
+    baml check --project .
+    baml run --list --project .
   details: |
     `baml check` compiles the project and reports compiler errors without running anything — the most direct way to validate. Other commands (`baml run`, `baml run --list`, `baml fmt`, `baml test`) also load and check the project before their main work. Use `baml run --list` when you additionally want the compiled function signatures.
 
@@ -784,7 +784,7 @@ playground:
   summary: "Serves the BAML playground web UI for a project and opens it in a browser."
   syntax: |
     baml playground                      # current project, first free port from 4265
-    baml playground --from ./my-app      # explicit project directory
+    baml playground --project ./my-app   # explicit project directory
     baml playground --file ./one.baml    # standalone single file
     baml playground --port 4265          # pin the port (errors if taken)
     baml playground --no-open            # don't launch a browser (automatic in SSH/headless sessions)

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -44,7 +44,7 @@ sys_native = { workspace = true }
 anyhow = { workspace = true }
 base64 = { workspace = true }
 borsh = { workspace = true }
-clap = { workspace = true, features = [ "color", "env" ] }
+clap = { workspace = true, features = [ "color", "env", "wrap_help" ] }
 console = { workspace = true }
 ctrlc = { workspace = true }
 flate2 = { workspace = true }

--- a/baml_language/crates/baml_cli/src/agent_command.rs
+++ b/baml_language/crates/baml_cli/src/agent_command.rs
@@ -33,22 +33,29 @@ pub(crate) enum AgentCommand {
 /// to avoid collisions in the agent skill registry, and is the only difference
 /// from the upstream skill files.
 #[derive(Args, Clone, Debug)]
-#[command(
-    after_long_help = "Note: skill names are prefixed with 'baml-' on install to avoid registry collisions (e.g. upstream 'core' becomes 'baml-core')."
-)]
+#[command(after_long_help = "\
+Examples:
+  Install the latest skills:
+    baml agent install
+
+  Install skills in a specific project:
+    baml agent install --project ./my-project
+
+  Install skills from a local archive:
+    baml agent install --source ./skills.tar.gz")]
 pub(crate) struct AgentInstallArgs {
-    /// Directory where project-local agent skills should be installed.
-    ///
-    /// When omitted, BAML installs at the nearest ancestor with baml.toml or
-    /// baml_src within the current git repo (else the repo root); outside a
-    /// git repo, at the nearest such ancestor below your home directory, else
-    /// the current directory.
-    #[arg(long, value_name = "PATH")]
+    /// Deprecated alias for `--project`.
+    #[arg(long, value_name = "PATH", hide = true)]
     pub dir: Option<PathBuf>,
 
     /// Install skills from a tar.gz URL, local tar.gz archive, or local directory.
-    #[arg(long, value_name = "URL_OR_PATH")]
-    pub from: Option<String>,
+    #[arg(
+        long,
+        alias = "from",
+        value_name = "URL_OR_PATH",
+        help_heading = "Source options"
+    )]
+    pub source: Option<String>,
 }
 
 #[derive(Debug)]
@@ -101,14 +108,14 @@ struct LoadedSkills {
     /// Commit of the skill repo the installed content came from, recovered
     /// from the tarball's pax global header (`comment=<sha>`, written by
     /// `git archive` and present in GitHub codeload tarballs). Present only
-    /// when installing from the default source; custom `--from` sources have
+    /// when installing from the default source; custom `--source` values have
     /// no commit identity to record, and archives without the header (or with
     /// a non-SHA comment) install fine with no recorded provenance.
     commit: Option<String>,
 }
 
 fn load_skills(args: &AgentInstallArgs) -> Result<LoadedSkills> {
-    if let Some(source) = &args.from {
+    if let Some(source) = &args.source {
         if is_http_url(source) {
             let archive = fetch_url_bytes(source)?;
             return Ok(LoadedSkills {
@@ -148,7 +155,7 @@ fn load_skills(args: &AgentInstallArgs) -> Result<LoadedSkills> {
         format!(
             "could not download the BAML agent skills from {url}; if GitHub is \
              unreachable, install from a local copy with \
-             `baml agent install --from <url-or-path>`"
+             `baml agent install --source <url-or-path>`"
         )
     })?;
     let loaded = skills_from_archive(&archive)?;
@@ -184,7 +191,7 @@ fn record_installed_commit(commit: &str) {
     }
 }
 
-/// Installs with no commit identity (custom `--from` sources, or a default
+/// Installs with no commit identity (custom `--source` values, or a default
 /// archive whose pax header carried no commit) drop any previously recorded
 /// provenance so the passive skill check doesn't report the installed content
 /// as up to date with (or behind) the official skill repo.

--- a/baml_language/crates/baml_cli/src/auth.rs
+++ b/baml_language/crates/baml_cli/src/auth.rs
@@ -104,18 +104,31 @@ impl AuthCommands {
     }
 }
 
-/// `baml login` — device-code email login.
+/// Log in to Boundary with a device-code flow.
+///
+/// Opens a browser to complete authentication, then stores the resulting
+/// session locally. In headless environments, use `--no-open` to print the
+/// verification URL instead.
 #[derive(Args, Debug)]
+#[command(after_long_help = "\
+Examples:
+  Log in using a browser:
+    baml login
+
+  Print the verification URL instead:
+    baml login --no-open")]
 pub(crate) struct LoginArgs {
     /// Print the verification URL instead of opening a browser.
-    #[arg(long)]
+    #[arg(long, help_heading = "Login options")]
     pub no_open: bool,
 }
 
 #[derive(Args, Debug)]
+#[command(after_long_help = "Examples:\n  Show the current identity:\n    baml auth whoami")]
 pub(crate) struct WhoamiArgs {}
 
 #[derive(Args, Debug)]
+#[command(after_long_help = "Examples:\n  Log out:\n    baml auth logout")]
 pub(crate) struct LogoutArgs {}
 
 #[derive(Args, Debug)]

--- a/baml_language/crates/baml_cli/src/check_command.rs
+++ b/baml_language/crates/baml_cli/src/check_command.rs
@@ -7,10 +7,24 @@ use clap::Args;
 
 use crate::reporter::Reporter;
 
+/// Check BAML source files for compiler errors.
+///
+/// Discovers the nearest BAML project from the search path, checks every
+/// source file in that project, and prints compiler errors and warnings.
 #[derive(Args, Debug)]
+#[command(after_long_help = "\
+Examples:
+  Check the nearest project:
+    baml check
+
+  Check a specific project:
+    baml check --project ./my-project")]
 pub struct CheckArgs {
-    /// Project search starting point. Defaults to the current directory.
-    #[arg(long, value_name = "PATH")]
+    #[command(flatten)]
+    pub compiler: crate::commands::CompilerArgs,
+
+    /// Deprecated alias for `--project`.
+    #[arg(long, value_name = "PATH", hide = true)]
     pub from: Option<PathBuf>,
 }
 

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -237,10 +237,14 @@ pub(crate) enum Commands {
 
 impl RuntimeCli {
     pub(crate) fn command() -> clap::Command {
+        Self::command_with_internal(baml_internal_env_is_truthy())
+    }
+
+    pub(crate) fn command_with_internal(include_internal: bool) -> clap::Command {
         let mut command = <Self as CommandFactory>::command();
         configure_help_hints(&mut command, &[]);
 
-        if baml_internal_env_is_truthy() {
+        if include_internal {
             for subcommand in command
                 .get_subcommands_mut()
                 .filter(|subcommand| subcommand.is_hide_set())

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -292,10 +292,6 @@ impl RuntimeCli {
             Err(err) => err.exit(),
         };
 
-        if let Err(err) = RuntimeCli::update_from_arg_matches(&mut cli, &matches) {
-            err.exit();
-        }
-
         if cli.global.project.is_some() && cli.command.has_legacy_project() {
             RuntimeCli::command()
                 .error(
@@ -407,7 +403,7 @@ impl Commands {
             Self::Check(args) => args.from.is_some(),
             Self::Format(args) => args.from.is_some(),
             Self::Describe(args) => args.from.is_some(),
-            Self::Generate(args) => args.from.is_some(),
+            Self::Generate(args) => args.has_legacy_project(),
             Self::Test(args) => args.from.is_some(),
             Self::Run(args) => args.from.is_some(),
             Self::Playground(args) => args.from.is_some(),
@@ -423,19 +419,19 @@ impl Commands {
         let Some(project) = project else {
             return;
         };
-        let project = Some(project.to_path_buf());
+        let project = project.to_path_buf();
         match self {
-            Self::Check(args) => args.from.clone_from(&project),
-            Self::Format(args) => args.from.clone_from(&project),
-            Self::Describe(args) => args.from.clone_from(&project),
-            Self::Generate(args) => args.from.clone_from(&project),
-            Self::Test(args) => args.from.clone_from(&project),
-            Self::Run(args) => args.from.clone_from(&project),
-            Self::Playground(args) => args.from.clone_from(&project),
-            Self::Pack(args) => args.from.clone_from(&project),
+            Self::Check(args) => args.from = Some(project.clone()),
+            Self::Format(args) => args.from = Some(project.clone()),
+            Self::Describe(args) => args.from = Some(project.clone()),
+            Self::Generate(args) => args.apply_project(&project),
+            Self::Test(args) => args.from = Some(project.clone()),
+            Self::Run(args) => args.from = Some(project.clone()),
+            Self::Playground(args) => args.from = Some(project.clone()),
+            Self::Pack(args) => args.from = Some(project.clone()),
             Self::Agent(crate::agent_command::AgentArgs {
                 command: crate::agent_command::AgentCommand::Install(args),
-            }) => args.dir.clone_from(&project),
+            }) => args.dir = Some(project),
             _ => {}
         }
     }
@@ -622,6 +618,8 @@ mod tests {
             "generate".into(),
             "add".into(),
             "python/pydantic2".into(),
+            "--project".into(),
+            "workspace".into(),
         ]);
         let Commands::Generate(args) = cli.command else {
             panic!("expected generate command");
@@ -633,6 +631,7 @@ mod tests {
             args.output_type,
             baml_codegen_types::OutputType::PythonPydantic
         );
+        assert_eq!(args.from, Some(PathBuf::from("workspace")));
     }
 
     #[test]

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -88,15 +88,6 @@ pub(crate) struct GlobalArgs {
     )]
     pub verbose: u8,
 
-    /// Disable progress output.
-    #[arg(
-        long,
-        global = true,
-        help_heading = "Global options",
-        display_order = 40
-    )]
-    pub no_progress: bool,
-
     /// Change to this directory before running the command.
     #[arg(
         long,
@@ -341,11 +332,7 @@ impl RuntimeCli {
                 format!("failed to change directory to {}", directory.display())
             })?;
         }
-        crate::reporter::init(
-            self.global.quiet,
-            self.global.verbose,
-            self.global.no_progress,
-        );
+        crate::reporter::init(self.global.quiet, self.global.verbose);
 
         // The detached telemetry flush child must run before (and without)
         // `record_invocation` below: recording its own invocation would

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -2,8 +2,10 @@
 // Format, and LanguageServer. `baml run` is the top-level entry for
 // standalone execution.
 
-use anyhow::Result;
-use clap::{CommandFactory, Parser, Subcommand};
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use clap::{Args, CommandFactory, Parser, Subcommand};
 
 pub(crate) const fn release_version() -> &'static str {
     baml_version::CANONICAL_VERSION
@@ -15,23 +17,40 @@ pub(crate) const fn release_version() -> &'static str {
     bin_name = "baml",
     author,
     version = release_version(),
-    about = "A CLI tool for working with BAML. Learn more at https://docs.boundaryml.com.",
+    about = "Build and run BAML projects.",
     long_about = None,
-    after_help = "Manage installed BAML toolchains:\n  baml toolchain --help"
+    disable_help_flag = true,
+    disable_version_flag = true,
+    disable_help_subcommand = true
 )]
 #[command(styles = crate::reporter::CLAP_STYLING)]
-#[command(propagate_version = true)]
 pub(crate) struct RuntimeCli {
-    /// Enable specific features (can be specified multiple times)
-    ///
-    /// Available features:
-    ///   beta - Enable beta features and suppress experimental warnings
-    ///   display_all_warnings - Show all warnings in CLI output
-    #[arg(long = "features", value_name = "FEATURE", global = true)]
-    pub features: Vec<String>,
+    #[command(flatten)]
+    pub global: GlobalArgs,
 
     #[command(flatten)]
     pub output: crate::output::OutputArgs,
+
+    /// Display concise help for this command.
+    #[arg(
+        global = true,
+        short,
+        long,
+        action = clap::ArgAction::HelpShort,
+        help_heading = "Global options",
+        display_order = 100
+    )]
+    help: Option<bool>,
+
+    /// Print version.
+    #[arg(
+        short = 'V',
+        long = "version",
+        action = clap::ArgAction::Version,
+        help_heading = "Global options",
+        display_order = 110
+    )]
+    version: Option<bool>,
 
     /// Specifies a subcommand to run.
     #[command(subcommand)]
@@ -43,6 +62,74 @@ pub(crate) struct RuntimeCli {
     /// report the exact clap name without a hand-maintained mapping.
     #[arg(skip)]
     pub(crate) invoked_subcommand: Option<String>,
+}
+
+#[derive(Args, Clone, Debug, Default)]
+pub(crate) struct GlobalArgs {
+    /// Suppress nonessential output.
+    #[arg(
+        short,
+        long,
+        action = clap::ArgAction::Count,
+        global = true,
+        help_heading = "Global options",
+        display_order = 10
+    )]
+    pub quiet: u8,
+
+    /// Increase diagnostic verbosity. Repeatable.
+    #[arg(
+        short,
+        long,
+        action = clap::ArgAction::Count,
+        global = true,
+        help_heading = "Global options",
+        display_order = 20
+    )]
+    pub verbose: u8,
+
+    /// Disable progress output.
+    #[arg(
+        long,
+        global = true,
+        help_heading = "Global options",
+        display_order = 40
+    )]
+    pub no_progress: bool,
+
+    /// Change to this directory before running the command.
+    #[arg(
+        long,
+        value_name = "PATH",
+        global = true,
+        help_heading = "Global options",
+        display_order = 50
+    )]
+    pub directory: Option<PathBuf>,
+
+    /// Discover the BAML project from this path.
+    #[arg(
+        long,
+        value_name = "PATH",
+        global = true,
+        help_heading = "Global options",
+        display_order = 60
+    )]
+    pub project: Option<PathBuf>,
+}
+
+#[derive(Args, Clone, Debug, Default)]
+pub(crate) struct CompilerArgs {
+    #[arg(
+        short = 'F',
+        long = "features",
+        value_name = "FEATURES",
+        value_delimiter = ',',
+        action = clap::ArgAction::Append,
+        help_heading = "Compiler options",
+        help = "Enable compiler features; repeatable or comma-separated [possible values: beta, display_all_warnings]"
+    )]
+    pub features: Vec<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -64,7 +151,12 @@ pub(crate) enum Commands {
 
     // #[command(about = "Starts a development server")]
     // Dev(baml_runtime::cli::dev::DevArgs),
-    #[command(subcommand, about = "Manage your Boundary session")]
+    #[command(
+        subcommand,
+        about = "Manage authentication",
+        long_about = "Manage the identity used by BAML services.\n\nUse `baml login` to authenticate, `baml auth whoami` to inspect the current identity, and `baml auth logout` to remove the authenticated session.",
+        after_long_help = "Examples:\n  Show the current identity:\n    baml auth whoami\n\n  Log out:\n    baml auth logout"
+    )]
     Auth(crate::auth::AuthCommands),
 
     #[command(about = "Log in to Boundary with your email")]
@@ -99,7 +191,7 @@ pub(crate) enum Commands {
     #[command(about = "Create a new BAML project directory")]
     New(crate::init_command::NewArgs),
 
-    #[command(about = "Run a BAML function or script", disable_help_flag = true)]
+    #[command(about = "Run a BAML function or script")]
     Run(crate::run_command::RunArgs),
 
     #[command(about = "Open the BAML playground in your browser")]
@@ -108,14 +200,23 @@ pub(crate) enum Commands {
     #[command(about = "Package a BAML target as a standalone executable")]
     Pack(crate::pack_command::PackArgs),
 
-    #[command(about = "Install or manage IDE integration assets")]
+    #[command(
+        about = "Install or manage IDE integration assets",
+        after_long_help = "Examples:\n  Install into the detected editor:\n    baml ide install\n\n  Install into Cursor:\n    baml ide install --cursor"
+    )]
     Ide(crate::ide_command::IdeArgs),
 
-    #[command(about = "Install BAML agent skills for this project")]
+    #[command(
+        about = "Install BAML agent skills for this project",
+        after_long_help = "Examples:\n  Install the latest skills:\n    baml agent install\n\n  Install in a specific project:\n    baml agent install --project ./my-project"
+    )]
     Agent(crate::agent_command::AgentArgs),
 
-    #[command(about = "Starts a language server", name = "lsp")]
+    #[command(about = "Start a language server", name = "lsp")]
     LanguageServer(crate::lsp::LanguageServerArgs),
+
+    #[command(about = "Display documentation for a command")]
+    Help(crate::help_command::HelpArgs),
 
     // Hidden from `baml --help` by default: the first-run notice + the
     // `boundaryml.com/telemetry` docs page cover discovery for users who
@@ -144,6 +245,28 @@ pub(crate) enum Commands {
 }
 
 impl RuntimeCli {
+    pub(crate) fn command() -> clap::Command {
+        let mut command = <Self as CommandFactory>::command();
+        configure_help_hints(&mut command, &[]);
+
+        if baml_internal_env_is_truthy() {
+            for subcommand in command
+                .get_subcommands_mut()
+                .filter(|subcommand| subcommand.is_hide_set())
+            {
+                let mut new_subcommand = std::mem::take(subcommand);
+                new_subcommand = new_subcommand.hide(false);
+                if let Some(about) = new_subcommand.get_about() {
+                    let new_about = format!("(internal-only) {about}");
+                    new_subcommand = new_subcommand.about(new_about);
+                }
+                *subcommand = new_subcommand;
+            }
+        }
+
+        command
+    }
+
     /// Parse CLI arguments and optionally unhide internal subcommands.
     ///
     /// Parameters:
@@ -163,21 +286,6 @@ impl RuntimeCli {
 
         let mut command = RuntimeCli::command();
 
-        if baml_internal_env_is_truthy() {
-            for subcommand in command
-                .get_subcommands_mut()
-                .filter(|subcommand| subcommand.is_hide_set())
-            {
-                let mut new_subcommand = std::mem::take(subcommand);
-                new_subcommand = new_subcommand.hide(false);
-                if let Some(about) = new_subcommand.get_about() {
-                    let new_about = format!("(internal-only) {about}");
-                    new_subcommand = new_subcommand.about(new_about);
-                }
-                *subcommand = new_subcommand;
-            }
-        }
-
         // BEP-027 §"`--` separator" — note: clap already prints a
         // helpful "to pass '<flag>' as a value, use '-- <flag>'" tip on
         // `ErrorKind::UnknownArgument`, so we don't need to add our own.
@@ -193,6 +301,19 @@ impl RuntimeCli {
             Err(err) => err.exit(),
         };
 
+        if let Err(err) = RuntimeCli::update_from_arg_matches(&mut cli, &matches) {
+            err.exit();
+        }
+
+        if cli.global.project.is_some() && cli.command.has_legacy_project() {
+            RuntimeCli::command()
+                .error(
+                    clap::error::ErrorKind::ArgumentConflict,
+                    "the argument '--project <PATH>' cannot be used with its deprecated alias",
+                )
+                .exit();
+        }
+        cli.command.apply_project(cli.global.project.as_deref());
         // Record the invoked subcommand's clap name for telemetry, straight
         // from the parsed matches so it always matches what clap registered.
         cli.invoked_subcommand = matches.subcommand_name().map(str::to_string);
@@ -215,11 +336,26 @@ impl RuntimeCli {
     }
 
     pub fn run(&self) -> Result<crate::ExitCode> {
+        if let Some(directory) = &self.global.directory {
+            std::env::set_current_dir(directory).with_context(|| {
+                format!("failed to change directory to {}", directory.display())
+            })?;
+        }
+        crate::reporter::init(
+            self.global.quiet,
+            self.global.verbose,
+            self.global.no_progress,
+        );
+
         // The detached telemetry flush child must run before (and without)
         // `record_invocation` below: recording its own invocation would
         // seal a new queue file on drop and spawn another child, forever.
         if let Commands::FlushTelemetry(args) = &self.command {
             return args.run();
+        }
+        if let Commands::Help(args) = &self.command {
+            crate::output::init(self.output);
+            return args.run(crate::output::policy().stdout.color);
         }
 
         // Fire anonymous, best-effort telemetry for this invocation. The
@@ -268,11 +404,78 @@ impl RuntimeCli {
             Commands::Auth(args) => args.run(),
             Commands::Login(args) => args.run(),
             Commands::Feedback(args) => args.run(),
+            // Handled before telemetry and command-side effects above.
+            Commands::Help(args) => args.run(crate::output::policy().stdout.color),
             Commands::Telemetry(args) => args.run(),
             // Handled by the early return above, before telemetry wiring.
             Commands::FlushTelemetry(args) => args.run(),
             Commands::Format(args) => args.run(),
         }
+    }
+}
+
+impl Commands {
+    fn has_legacy_project(&self) -> bool {
+        match self {
+            Self::Check(args) => args.from.is_some(),
+            Self::Format(args) => args.from.is_some(),
+            Self::Describe(args) => args.from.is_some(),
+            Self::Generate(args) => args.from.is_some(),
+            Self::Test(args) => args.from.is_some(),
+            Self::Run(args) => args.from.is_some(),
+            Self::Playground(args) => args.from.is_some(),
+            Self::Pack(args) => args.from.is_some(),
+            Self::Agent(crate::agent_command::AgentArgs {
+                command: crate::agent_command::AgentCommand::Install(args),
+            }) => args.dir.is_some(),
+            _ => false,
+        }
+    }
+
+    fn apply_project(&mut self, project: Option<&Path>) {
+        let Some(project) = project else {
+            return;
+        };
+        let project = Some(project.to_path_buf());
+        match self {
+            Self::Check(args) => args.from.clone_from(&project),
+            Self::Format(args) => args.from.clone_from(&project),
+            Self::Describe(args) => args.from.clone_from(&project),
+            Self::Generate(args) => args.from.clone_from(&project),
+            Self::Test(args) => args.from.clone_from(&project),
+            Self::Run(args) => args.from.clone_from(&project),
+            Self::Playground(args) => args.from.clone_from(&project),
+            Self::Pack(args) => args.from.clone_from(&project),
+            Self::Agent(crate::agent_command::AgentArgs {
+                command: crate::agent_command::AgentCommand::Install(args),
+            }) => args.dir.clone_from(&project),
+            _ => {}
+        }
+    }
+}
+
+fn configure_help_hints(command: &mut clap::Command, path: &[String]) {
+    let is_root = path.is_empty();
+    let has_detailed_help = is_root
+        || command.get_long_about().is_some()
+        || command.get_after_long_help().is_some()
+        || command.has_subcommands();
+
+    if command.get_name() != "help" && has_detailed_help {
+        let hint = if is_root {
+            "Use `baml help <command>` for more details.".to_string()
+        } else {
+            format!("Use `baml help {}` for more details.", path.join(" "))
+        };
+        let mut configured = std::mem::take(command);
+        configured = configured.after_help(hint);
+        *command = configured;
+    }
+
+    for subcommand in command.get_subcommands_mut() {
+        let mut child_path = path.to_vec();
+        child_path.push(subcommand.get_name().to_string());
+        configure_help_hints(subcommand, &child_path);
     }
 }
 
@@ -285,6 +488,31 @@ fn baml_internal_env_is_truthy() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const PUBLIC_COMMAND_PATHS: &[&[&str]] = &[
+        &[],
+        &["check"],
+        &["auth"],
+        &["auth", "whoami"],
+        &["auth", "logout"],
+        &["login"],
+        &["feedback"],
+        &["fmt"],
+        &["describe"],
+        &["generate"],
+        &["test"],
+        &["init"],
+        &["new"],
+        &["run"],
+        &["playground"],
+        &["pack"],
+        &["ide"],
+        &["ide", "install"],
+        &["agent"],
+        &["agent", "install"],
+        &["lsp"],
+        &["help"],
+    ];
 
     #[test]
     fn release_version_matches_compile_time_setting() {
@@ -327,6 +555,13 @@ mod tests {
             .to_string()
     }
 
+    fn help_for_path(path: &[&str], flag: &str) -> String {
+        let mut args = vec!["baml-cli"];
+        args.extend_from_slice(path);
+        args.push(flag);
+        help_for(&args)
+    }
+
     #[test]
     fn root_help_presents_public_baml_command() {
         let help = help_for(&["baml-cli", "--help"]);
@@ -338,7 +573,7 @@ mod tests {
     fn pack_help_presents_public_baml_command() {
         let help = help_for(&["baml-cli", "pack", "--help"]);
         assert!(
-            help.contains("Usage: baml pack [OPTIONS] [TARGET]"),
+            help.contains("Usage: baml pack [OPTIONS] [FUNCTION]"),
             "{help}"
         );
         assert!(!help.contains("Usage: baml-cli pack"), "{help}");
@@ -365,13 +600,10 @@ mod tests {
     }
 
     #[test]
-    fn check_help_mentions_default_search_start() {
+    fn check_help_includes_global_project_option() {
         let help = help_for(&["baml-cli", "check", "--help"]);
         assert!(help.contains("Usage: baml check [OPTIONS]"), "{help}");
-        assert!(
-            help.contains("Project search starting point. Defaults to the current directory"),
-            "{help}"
-        );
+        assert!(help.contains("--project <PATH>"), "{help}");
     }
 
     #[test]
@@ -470,31 +702,215 @@ mod tests {
     }
 
     #[test]
+    fn enum_options_use_compact_help() {
+        let cases: &[(&[&str], &[&str])] = &[
+            (
+                &["run"],
+                &[
+                    "--output-format <FORMAT>\n          Format returned values [default: debug] [possible values: debug, json]",
+                    "--color <WHEN>\n          Control ANSI colors [possible values: auto, always, never]",
+                    "--output-preset <PRESET>\n          Select output defaults [default: auto] [possible values: auto, human, agent]",
+                    "--hyperlinks <WHEN>\n          Control terminal hyperlinks [possible values: auto, always, never]",
+                    "--diagnostic-format <FORMAT>\n          Select the diagnostic format [possible values: human, agent, concise]",
+                ],
+            ),
+            (
+                &["test"],
+                &[
+                    "--logs <LEVEL>\n          Set the BAML log level [default: off] [possible values: off, error, warn, info, debug]",
+                ],
+            ),
+            (
+                &["pack"],
+                &[
+                    "--output-format <FORMAT>\n          Format returned values [default: json] [possible values: debug, json]",
+                ],
+            ),
+            (
+                &["telemetry"],
+                &[
+                    "[ACTION]\n          Telemetry action [default: status] [possible values: status, enable, disable]",
+                ],
+            ),
+        ];
+
+        for (path, expected) in cases {
+            let help = crate::help_command::render_for_test(path);
+            assert!(!help.contains("Possible values:\n"), "{help}");
+            for text in *expected {
+                assert!(help.contains(text), "missing `{text}` in:\n{help}");
+            }
+        }
+    }
+
+    #[test]
     fn playground_help_presents_public_baml_command() {
         let help = help_for(&["baml-cli", "playground", "--help"]);
         assert!(help.contains("Usage: baml playground [OPTIONS]"), "{help}");
         assert!(help.contains("--file <PATH>"), "{help}");
-        assert!(help.contains("--from <PATH>"), "{help}");
+        assert!(help.contains("--project <PATH>"), "{help}");
         assert!(help.contains("--port <PORT>"), "{help}");
         assert!(help.contains("--no-open"), "{help}");
     }
 
     #[test]
     fn test_help_is_a_complete_selector_and_profile_reference() {
-        let help = help_for(&["baml-cli", "test", "--help"]);
+        let help = crate::help_command::render_for_test(&["test"]);
         for required in [
-            "matches anywhere in the full ID",
+            "Plain selectors match anywhere in the full ID",
             "Repeated includes are OR",
-            "always win",
+            "Excludes always win",
             "case-sensitive",
             "without shell expansion",
-            "Profile names are case-sensitive",
             "direct CLI includes narrow",
             "scalar options override",
             "With no default profile",
-            "Bootstrap options",
+            "Profile args cannot contain",
         ] {
             assert!(help.contains(required), "missing `{required}` in:\n{help}");
+        }
+    }
+
+    #[test]
+    fn test_concise_help_omits_the_long_reference() {
+        let help = help_for(&["baml-cli", "test", "--help"]);
+        assert!(!help.contains("SELECTORS:"), "{help}");
+        assert!(!help.contains("PROFILES:"), "{help}");
+        assert!(help.contains("Use `baml help test`"), "{help}");
+    }
+
+    #[test]
+    fn short_and_long_help_flags_render_the_same_concise_help() {
+        for path in PUBLIC_COMMAND_PATHS {
+            assert_eq!(
+                help_for_path(path, "-h"),
+                help_for_path(path, "--help"),
+                "help differs for `baml {}`",
+                path.join(" ")
+            );
+        }
+    }
+
+    #[test]
+    fn every_public_command_has_detailed_examples() {
+        for path in PUBLIC_COMMAND_PATHS.iter().filter(|path| !path.is_empty()) {
+            let help = crate::help_command::render_for_test(path);
+            assert!(
+                help.contains("Examples:"),
+                "`baml help {}` has no examples:\n{help}",
+                path.join(" ")
+            );
+            assert!(
+                help.find("Usage:") < help.find("Examples:"),
+                "`baml help {}` puts examples before usage:\n{help}",
+                path.join(" ")
+            );
+        }
+    }
+
+    #[test]
+    fn documented_examples_parse() {
+        let examples: &[&[&str]] = &[
+            &["baml", "check"],
+            &["baml", "check", "--project", "./my-project"],
+            &["baml", "auth", "whoami"],
+            &["baml", "auth", "logout"],
+            &["baml", "login"],
+            &["baml", "login", "--no-open"],
+            &["baml", "describe"],
+            &["baml", "describe", "baml"],
+            &["baml", "describe", "baml.json"],
+            &["baml", "describe", "Array"],
+            &["baml", "describe", "String.split"],
+            &["baml", "describe", "match"],
+            &["baml", "test", "--list"],
+            &["baml", "test", "-i", "root.payments::*"],
+            &["baml", "test", "-i", "*::integration::*", "-x", "slow"],
+            &["baml", "run", "main", "--", "--name", "Ada"],
+            &[
+                "baml",
+                "run",
+                "--function",
+                "Extract",
+                "--",
+                "Extract",
+                "--text",
+                "input.txt",
+            ],
+            &["baml", "run", "-e", "1 + 2"],
+            &["baml", "run", "--file", "script.baml"],
+            &["baml", "run", "--list"],
+            &["baml", "pack", "main"],
+            &["baml", "pack", "main", "--output", "./my-tool"],
+            &[
+                "baml",
+                "pack",
+                "--function",
+                "Extract",
+                "--function",
+                "Classify",
+                "--output",
+                "./baml-tools",
+            ],
+            &["baml", "pack", "--file", "script.baml", "main"],
+            &[
+                "baml",
+                "feedback",
+                "--issue",
+                "parser panics on nested unions",
+            ],
+            &[
+                "baml",
+                "feedback",
+                "--anonymous",
+                "--issue",
+                "...",
+                "--repro",
+                "class A { ... }",
+            ],
+            &["baml", "feedback", "--anonymous", "-"],
+            &["baml", "fmt"],
+            &["baml", "fmt", "baml_src/main.baml"],
+            &["baml", "fmt", "--dry-run"],
+            &["baml", "generate"],
+            &["baml", "generate", "--project", "./my-project"],
+            &["baml", "generate", "--output-dir", "./generated"],
+            &["baml", "init"],
+            &["baml", "init", "./my-project", "--name", "my_project"],
+            &["baml", "new", "./my-project"],
+            &["baml", "new", "./my-project", "--name", "my_project"],
+            &["baml", "playground"],
+            &[
+                "baml",
+                "playground",
+                "--project",
+                "./my-project",
+                "--no-open",
+            ],
+            &[
+                "baml",
+                "playground",
+                "--file",
+                "script.baml",
+                "--port",
+                "4265",
+            ],
+            &["baml", "ide", "install"],
+            &["baml", "ide", "install", "--cursor"],
+            &["baml", "ide", "install", "--output-dir", "./extensions"],
+            &["baml", "agent", "install"],
+            &["baml", "agent", "install", "--project", "./my-project"],
+            &["baml", "agent", "install", "--source", "./skills.tar.gz"],
+            &["baml", "lsp"],
+            &["baml", "lsp", "--workspace", "./my-project"],
+            &["baml", "help", "run"],
+            &["baml", "help", "test"],
+        ];
+
+        for example in examples {
+            RuntimeCli::command()
+                .try_get_matches_from(*example)
+                .unwrap_or_else(|error| panic!("`{}` did not parse: {error}", example.join(" ")));
         }
     }
 
@@ -506,7 +922,7 @@ mod tests {
             "run".into(),
             "-e".into(),
             "-7 % 3".into(),
-            "--from".into(),
+            "--project".into(),
             "project".into(),
         ]);
         let Commands::Run(args) = cli.command else {
@@ -514,5 +930,63 @@ mod tests {
         };
         assert_eq!(args.expression.as_deref(), Some("-7 % 3"));
         assert_eq!(args.from, Some(std::path::PathBuf::from("project")));
+    }
+
+    #[test]
+    fn project_is_global_before_or_after_the_subcommand() {
+        for argv in [
+            vec!["baml", "--project", "workspace", "check"],
+            vec!["baml", "check", "--project", "workspace"],
+        ] {
+            let cli = RuntimeCli::parse_from_smart(argv.into_iter().map(str::to_string).collect());
+            let Commands::Check(args) = cli.command else {
+                panic!("expected check command");
+            };
+            assert_eq!(args.from, Some(PathBuf::from("workspace")));
+        }
+    }
+
+    #[test]
+    fn compiler_features_are_scoped_and_cargo_shaped() {
+        let cli = RuntimeCli::parse_from_smart(vec![
+            "baml".into(),
+            "check".into(),
+            "-F".into(),
+            "beta,display_all_warnings".into(),
+        ]);
+        let Commands::Check(args) = cli.command else {
+            panic!("expected check command");
+        };
+        assert_eq!(args.compiler.features, ["beta", "display_all_warnings"]);
+
+        let help = crate::help_command::render_for_test(&["check"]);
+        assert!(
+            help.contains("Enable compiler features; repeatable or comma-separated"),
+            "{help}"
+        );
+        assert!(help.contains("[possible values: beta,"), "{help}");
+        assert!(help.contains("display_all_warnings]"), "{help}");
+        assert!(!help.contains("Available features:"), "{help}");
+    }
+
+    #[test]
+    fn agent_project_and_source_have_distinct_meanings() {
+        let cli = RuntimeCli::parse_from_smart(vec![
+            "baml".into(),
+            "agent".into(),
+            "install".into(),
+            "--project".into(),
+            "workspace".into(),
+            "--source".into(),
+            "skills.tar.gz".into(),
+        ]);
+        let Commands::Agent(crate::agent_command::AgentArgs {
+            command: crate::agent_command::AgentCommand::Install(args),
+        }) = cli.command
+        else {
+            panic!("expected agent install command");
+        };
+        assert_eq!(args.dir, Some(PathBuf::from("workspace")));
+        assert_eq!(args.source.as_deref(), Some("skills.tar.gz"));
     }
 }

--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -38,25 +38,53 @@ static TS_KEYWORDS: LazyLock<HashMap<String, TsKeywordDoc>> = LazyLock::new(|| {
         .expect("failed to parse ts_keywords.yaml")
 });
 
+/// Describe BAML symbols and language concepts.
+///
+/// With no name, lists symbols in the current project. A name can identify a
+/// project symbol, builtin package, namespace, type, member, or BAML keyword.
+/// Builtin documentation works outside a project, so `baml describe baml` is
+/// the entry point for exploring the complete standard library.
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = "\
+Examples:
+  List project symbols:
+    baml describe
+
+  Describe the standard library:
+    baml describe baml
+
+  Describe a namespace:
+    baml describe baml.json
+
+  Describe a class:
+    baml describe Array
+
+  Describe a method:
+    baml describe String.split
+
+  Describe a keyword:
+    baml describe match")]
 pub struct DescribeArgs {
-    /// Symbol name to describe (not required with --symbols)
+    #[command(flatten)]
+    pub compiler: crate::commands::CompilerArgs,
+
+    /// Symbol, namespace, package, or keyword. Omit to list project symbols.
     pub name: Option<String>,
 
-    /// List all symbols in the project
-    #[arg(long)]
+    /// Deprecated alias for invoking `baml describe` without a name.
+    #[arg(long, hide_short_help = true)]
     pub symbols: bool,
 
-    /// Project search starting point. Defaults to the current directory.
-    #[arg(long, value_name = "PATH")]
+    /// Deprecated alias for `--project`.
+    #[arg(long, value_name = "PATH", hide = true)]
     pub from: Option<PathBuf>,
 
-    /// Soft line budget for output (default 30)
-    #[arg(long, default_value_t = 30)]
+    /// Soft maximum number of output lines.
+    #[arg(long, default_value_t = 30, help_heading = "Output options")]
     pub budget: usize,
 
     /// Output results as JSON
-    #[arg(long)]
+    #[arg(long, help_heading = "Output options")]
     pub json: bool,
 }
 

--- a/baml_language/crates/baml_cli/src/feedback_command.rs
+++ b/baml_language/crates/baml_cli/src/feedback_command.rs
@@ -35,23 +35,32 @@ fn posthog_host() -> String {
         .unwrap_or_else(|| crate::telemetry::posthog_host().to_string())
 }
 
+/// Report an issue or improvement to Boundary.
+///
+/// Reports can be anonymous or associated with the email from `baml login`.
+/// Without an identity flag, interactive sessions prompt before sending.
 #[derive(Args, Debug)]
-#[command(after_help = "\
+#[command(after_long_help = "\
 Examples:
-  baml feedback --issue \"parser panics on nested unions\"
-  baml feedback --anonymous --issue \"...\" --repro \"class A { ... }\"
-  echo '{\"issue\": \"...\", \"repro\": \"...\"}' | baml feedback --anonymous -")]
+  Report an issue:
+    baml feedback --issue \"parser panics on nested unions\"
+
+  Submit an anonymous report with a reproduction:
+    baml feedback --anonymous --issue \"...\" --repro \"class A { ... }\"
+
+  Submit an anonymous JSON report from standard input:
+    echo '{\"issue\": \"...\", \"repro\": \"...\"}' | baml feedback --anonymous -")]
 pub(crate) struct FeedbackArgs {
     /// The issue or improvement you found.
-    #[arg(long)]
+    #[arg(long, help_heading = "Report options")]
     pub issue: Option<String>,
 
     /// Steps or a snippet that reproduces it.
-    #[arg(long)]
+    #[arg(long, help_heading = "Report options")]
     pub repro: Option<String>,
 
     /// Anything else useful (versions, environment, what you were doing).
-    #[arg(long)]
+    #[arg(long, help_heading = "Report options")]
     pub context: Option<String>,
 
     /// Advanced: supply the fields as JSON instead of flags (an inline
@@ -60,11 +69,11 @@ pub(crate) struct FeedbackArgs {
     pub input: Option<String>,
 
     /// Report anonymously without prompting.
-    #[arg(long, conflicts_with = "email")]
+    #[arg(long, conflicts_with = "email", help_heading = "Identity options")]
     pub anonymous: bool,
 
     /// Report with your email without prompting (requires `baml login`).
-    #[arg(long)]
+    #[arg(long, help_heading = "Identity options")]
     pub email: bool,
 }
 

--- a/baml_language/crates/baml_cli/src/format.rs
+++ b/baml_language/crates/baml_cli/src/format.rs
@@ -11,25 +11,38 @@ use clap::Args;
 
 use crate::{project_load::find_project_root_from, reporter::Reporter};
 
+/// Format BAML source files.
+///
+/// With explicit paths, formats those files or directories. With no paths,
+/// discovers the nearest BAML project and formats all of its `.baml` files.
+/// If no project is found, the command succeeds without changing anything.
 #[derive(Args, Debug)]
+#[command(after_long_help = "\
+Examples:
+  Format the nearest project:
+    baml fmt
+
+  Format a specific file:
+    baml fmt baml_src/main.baml
+
+  Preview formatted output:
+    baml fmt --dry-run")]
 pub struct FormatArgs {
     #[arg(
         help = "Specific files to format. If omitted, all `.baml` files in the project are formatted."
     )]
     pub paths: Vec<PathBuf>,
 
-    /// Project search starting point for default file discovery. Mirrors
-    /// `baml run`/`baml pack`'s `--from`. When the
-    /// directory has neither a `baml.toml` nor a `baml_src/` subdirectory,
-    /// there's nothing to format and `baml fmt` is a no-op success.
-    #[arg(long, value_name = "PATH")]
+    /// Deprecated alias for `--project`.
+    #[arg(long, value_name = "PATH", hide = true)]
     pub from: Option<PathBuf>,
 
     #[arg(
         short = 'n',
         long = "dry-run",
         help = "Write formatter changes to stdout instead of files.",
-        default_value = "false"
+        default_value = "false",
+        help_heading = "Output options"
     )]
     pub dry_run: bool,
 }

--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -73,8 +73,8 @@ pub struct AddGeneratorArgs {
     #[arg(value_name = "OUTPUT_TYPE", value_parser = add_output_type_parser())]
     pub output_type: OutputType,
 
-    /// Project search starting point. Defaults to the current directory.
-    #[arg(long, value_name = "PATH")]
+    /// Deprecated alias for `--project`.
+    #[arg(long, value_name = "PATH", hide = true)]
     pub from: Option<PathBuf>,
 
     /// Go module import path for the generated baml_sdk package.
@@ -211,6 +211,21 @@ fn add_generator_to_manifest(content: &str, generator: &Generator) -> Result<(St
 }
 
 impl GenerateArgs {
+    pub(crate) fn has_legacy_project(&self) -> bool {
+        self.from.is_some()
+            || matches!(
+                &self.command,
+                Some(GenerateCommand::Add(args)) if args.from.is_some()
+            )
+    }
+
+    pub(crate) fn apply_project(&mut self, project: &Path) {
+        self.from = Some(project.to_path_buf());
+        if let Some(GenerateCommand::Add(args)) = &mut self.command {
+            args.from = Some(project.to_path_buf());
+        }
+    }
+
     pub fn run(&self) -> Result<crate::ExitCode> {
         match &self.command {
             Some(GenerateCommand::Add(args)) => args.run(),

--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -24,17 +24,41 @@ use toml_edit::{DocumentMut, Item, Table, value};
 
 use crate::{commands::release_version, reporter::Reporter};
 
+/// Generate client code from BAML definitions.
+///
+/// Reads every `[generator.<name>]` section in `baml.toml`, validates the
+/// project, and writes each configured client. Use `--output-dir` to override the
+/// configured output directory for every generator in this invocation.
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = "\
+Examples:
+  Generate clients for the nearest project:
+    baml generate
+
+  Generate clients for a specific project:
+    baml generate --project ./my-project
+
+  Override the output directory:
+    baml generate --output-dir ./generated")]
 pub struct GenerateArgs {
     #[command(subcommand)]
     pub command: Option<GenerateCommand>,
 
-    /// Project search starting point. Defaults to the current directory.
-    #[arg(long, value_name = "PATH")]
+    #[command(flatten)]
+    pub compiler: crate::commands::CompilerArgs,
+
+    /// Deprecated alias for `--project`.
+    #[arg(long, value_name = "PATH", hide = true)]
     pub from: Option<PathBuf>,
 
     /// Output directory override (takes precedence over generator config)
-    #[arg(long, short = 'o')]
+    #[arg(
+        long = "output-dir",
+        alias = "output",
+        short = 'o',
+        value_name = "PATH",
+        help_heading = "Generation options"
+    )]
     pub output: Option<PathBuf>,
 }
 

--- a/baml_language/crates/baml_cli/src/help_command.rs
+++ b/baml_language/crates/baml_cli/src/help_command.rs
@@ -62,12 +62,19 @@ fn render(query: &[String]) -> Result<RenderedHelp> {
             .get_subcommands()
             .filter(|command| !command.is_hide_set() && command.get_name() != "help")
             .map(clap::Command::get_name)
-            .collect::<Vec<_>>()
-            .join("\n    ");
-        anyhow!(
-            "no command `{}` for `{prefix}`. Available commands:\n    {choices}",
-            unmatched.join(" ")
-        )
+            .collect::<Vec<_>>();
+        if choices.is_empty() {
+            anyhow!(
+                "no command `{}` for `{prefix}`; `{prefix}` has no subcommands",
+                unmatched.join(" ")
+            )
+        } else {
+            anyhow!(
+                "no command `{}` for `{prefix}`. Available commands:\n    {}",
+                unmatched.join(" "),
+                choices.join("\n    ")
+            )
+        }
     })?;
 
     let is_root = query.is_empty();
@@ -223,6 +230,17 @@ mod tests {
         assert!(message.contains("no command `missing` for `baml auth`"));
         assert!(message.contains("whoami"));
         assert!(message.contains("logout"));
+    }
+
+    #[test]
+    fn unknown_child_of_leaf_reports_that_it_has_no_subcommands() {
+        let error = render(&["run".to_string(), "missing".to_string()]).unwrap_err();
+        let message = error.to_string();
+        assert!(
+            message.contains("`baml run` has no subcommands"),
+            "{message}"
+        );
+        assert!(!message.contains("Available commands"), "{message}");
     }
 
     #[test]

--- a/baml_language/crates/baml_cli/src/help_command.rs
+++ b/baml_language/crates/baml_cli/src/help_command.rs
@@ -49,7 +49,10 @@ struct RenderedHelp {
 }
 
 fn render(query: &[String]) -> Result<RenderedHelp> {
-    let mut root = RuntimeCli::command();
+    render_from(query, RuntimeCli::command())
+}
+
+fn render_from(query: &[String], mut root: clap::Command) -> Result<RenderedHelp> {
     root.build();
 
     let command = find_command(query, &root).map_err(|(unmatched, nearest)| {
@@ -151,11 +154,12 @@ fn split_examples(help: &str) -> Option<(&str, &str, &str)> {
 
 #[cfg(test)]
 pub(crate) fn render_for_test(query: &[&str]) -> String {
-    render(
+    render_from(
         &query
             .iter()
             .map(|part| (*part).to_string())
             .collect::<Vec<_>>(),
+        RuntimeCli::command_with_internal(false),
     )
     .unwrap()
     .help
@@ -195,7 +199,7 @@ mod tests {
 
     #[test]
     fn concise_and_detailed_help_are_snapshot_tested() {
-        let concise = normalize_snapshot(&render(&[]).unwrap().help.to_string());
+        let concise = normalize_snapshot(&render_for_test(&[]));
         insta::assert_snapshot!("root_concise_help", concise);
         insta::assert_snapshot!(
             "describe_detailed_help",

--- a/baml_language/crates/baml_cli/src/help_command.rs
+++ b/baml_language/crates/baml_cli/src/help_command.rs
@@ -1,0 +1,256 @@
+use std::{fmt::Write as _, io::Write as _};
+
+use anyhow::{Result, anyhow};
+use clap::Args;
+
+use crate::{ExitCode, commands::RuntimeCli};
+
+const DETAILED_HELP_TEMPLATE: &str = "\
+{about-with-newline}
+{usage-heading} {usage}
+
+{before-help}{all-args}{after-help}";
+
+#[derive(Args, Clone, Debug)]
+#[command(after_long_help = "\
+Examples:
+  Show help for running functions:
+    baml help run
+
+  Show help for running tests:
+    baml help test")]
+pub(crate) struct HelpArgs {
+    /// Command path to document. Omit to show root help.
+    #[arg(value_name = "COMMAND")]
+    command: Vec<String>,
+}
+
+impl HelpArgs {
+    pub(crate) fn run(&self, color: bool) -> Result<ExitCode> {
+        let rendered = render(&self.command)?;
+        let plain = rendered.help.to_string();
+        let ansi = rendered.help.ansi().to_string();
+        let output = if color { ansi } else { plain };
+
+        // Always write help directly. Interactive pagers can trap coding agents
+        // that run commands through a pseudo-terminal and wait for completion.
+        let mut stdout = std::io::stdout().lock();
+        stdout.write_all(output.as_bytes())?;
+        if !output.ends_with('\n') {
+            stdout.write_all(b"\n")?;
+        }
+        Ok(ExitCode::Success)
+    }
+}
+
+#[derive(Debug)]
+struct RenderedHelp {
+    help: clap::builder::StyledStr,
+}
+
+fn render(query: &[String]) -> Result<RenderedHelp> {
+    let mut root = RuntimeCli::command();
+    root.build();
+
+    let command = find_command(query, &root).map_err(|(unmatched, nearest)| {
+        let prefix = if query.len() == unmatched.len() {
+            "baml".to_string()
+        } else {
+            format!("baml {}", query[..query.len() - unmatched.len()].join(" "))
+        };
+        let choices = nearest
+            .get_subcommands()
+            .filter(|command| !command.is_hide_set() && command.get_name() != "help")
+            .map(clap::Command::get_name)
+            .collect::<Vec<_>>()
+            .join("\n    ");
+        anyhow!(
+            "no command `{}` for `{prefix}`. Available commands:\n    {choices}",
+            unmatched.join(" ")
+        )
+    })?;
+
+    let is_root = query.is_empty();
+    let mut command = command.clone();
+    let help = if is_root {
+        command.render_help()
+    } else {
+        if command.get_after_long_help().is_none() {
+            command = command.after_long_help("");
+        }
+        promote_examples(&mut command);
+        if command.has_subcommands() {
+            let hint = format!(
+                "Use `baml help {} <command>` for more information on a specific command.",
+                query.join(" ")
+            );
+            let after = command
+                .get_after_long_help()
+                .map_or(hint.clone(), |existing| format!("{existing}\n\n{hint}"));
+            command = command.after_long_help(after);
+        }
+        command.render_long_help()
+    };
+
+    Ok(RenderedHelp { help })
+}
+
+fn promote_examples(command: &mut clap::Command) {
+    let Some(after) = command.get_after_long_help().map(ToString::to_string) else {
+        return;
+    };
+    let Some((before, examples, after)) = split_examples(&after) else {
+        return;
+    };
+
+    let mut styled_examples = clap::builder::StyledStr::new();
+    let header = command.get_styles().get_header();
+    let literal = command.get_styles().get_literal();
+    let mut lines = examples.lines();
+    let heading = lines.next().expect("an examples block has a heading");
+    write!(styled_examples, "{header}{heading}{header:#}")
+        .expect("writing to a string cannot fail");
+    for line in lines {
+        if let Some(command) = line.strip_prefix("    ") {
+            write!(styled_examples, "\n    {command}").expect("writing to a string cannot fail");
+        } else if let Some(label) = line.strip_prefix("  ") {
+            write!(styled_examples, "\n  {literal}{label}{literal:#}")
+                .expect("writing to a string cannot fail");
+        } else {
+            write!(styled_examples, "\n{line}").expect("writing to a string cannot fail");
+        }
+    }
+
+    let remaining = [before.trim(), after.trim()]
+        .into_iter()
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    let mut configured = std::mem::take(command)
+        .before_long_help(styled_examples)
+        .help_template(DETAILED_HELP_TEMPLATE);
+    configured = configured.after_long_help(remaining);
+    *command = configured;
+}
+
+fn split_examples(help: &str) -> Option<(&str, &str, &str)> {
+    let start = if help.starts_with("Examples:\n") {
+        0
+    } else {
+        help.rfind("\n\nExamples:\n")? + 2
+    };
+    Some((&help[..start], &help[start..], ""))
+}
+
+#[cfg(test)]
+pub(crate) fn render_for_test(query: &[&str]) -> String {
+    render(
+        &query
+            .iter()
+            .map(|part| (*part).to_string())
+            .collect::<Vec<_>>(),
+    )
+    .unwrap()
+    .help
+    .to_string()
+}
+
+fn find_command<'a>(
+    query: &'a [String],
+    command: &'a clap::Command,
+) -> Result<&'a clap::Command, (&'a [String], &'a clap::Command)> {
+    let Some(next) = query.first() else {
+        return Ok(command);
+    };
+    let subcommand = command.find_subcommand(next).ok_or((query, command))?;
+    find_command(&query[1..], subcommand)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn root_help_is_concise() {
+        let help = render(&[]).unwrap().help.to_string();
+        assert!(help.contains("Usage: baml [OPTIONS] <COMMAND>"), "{help}");
+        assert!(
+            !help.contains("Overrides the selected output preset"),
+            "{help}"
+        );
+    }
+
+    #[test]
+    fn nested_command_renders_detailed_help() {
+        let help = render_for_test(&["test"]);
+        assert!(help.contains("SELECTORS:"), "{help}");
+    }
+
+    #[test]
+    fn concise_and_detailed_help_are_snapshot_tested() {
+        let concise = normalize_snapshot(&render(&[]).unwrap().help.to_string());
+        insta::assert_snapshot!("root_concise_help", concise);
+        insta::assert_snapshot!(
+            "describe_detailed_help",
+            normalize_snapshot(&render_for_test(&["describe"]))
+        );
+        insta::assert_snapshot!(
+            "run_detailed_help",
+            normalize_snapshot(&render_for_test(&["run"]))
+        );
+        insta::assert_snapshot!(
+            "test_detailed_help",
+            normalize_snapshot(&render_for_test(&["test"]))
+        );
+    }
+
+    fn normalize_snapshot(help: &str) -> String {
+        let mut normalized = help
+            .lines()
+            .map(str::trim_end)
+            .collect::<Vec<_>>()
+            .join("\n");
+        if help.ends_with('\n') {
+            normalized.push('\n');
+        }
+        normalized
+    }
+
+    #[test]
+    fn unknown_nested_command_reports_nearest_choices() {
+        let error = render(&["auth".to_string(), "missing".to_string()]).unwrap_err();
+        let message = error.to_string();
+        assert!(message.contains("no command `missing` for `baml auth`"));
+        assert!(message.contains("whoami"));
+        assert!(message.contains("logout"));
+    }
+
+    #[test]
+    fn detailed_examples_follow_usage_and_use_clap_styles() {
+        let rendered = render(&["run".to_string()]).unwrap().help;
+        let plain = rendered.to_string();
+        assert!(plain.find("Usage:").unwrap() < plain.find("Examples:").unwrap());
+        assert!(plain.find("Examples:").unwrap() < plain.find("Arguments:").unwrap());
+
+        let ansi = rendered.ansi().to_string();
+        assert!(ansi.contains("\u{1b}["), "{ansi:?}");
+        assert!(
+            ansi.contains("  \u{1b}[1mRun a function:\u{1b}[0m\n    baml run main"),
+            "{ansi:?}"
+        );
+        assert_eq!(console::strip_ansi_codes(&ansi), plain);
+    }
+
+    #[test]
+    fn split_examples_preserves_reference_text_before_examples() {
+        let help = "Reference\n\nExamples:\n  Run tests:\n    baml test";
+        assert_eq!(
+            split_examples(help),
+            Some((
+                "Reference\n\n",
+                "Examples:\n  Run tests:\n    baml test",
+                ""
+            ))
+        );
+    }
+}

--- a/baml_language/crates/baml_cli/src/ide_command.rs
+++ b/baml_language/crates/baml_cli/src/ide_command.rs
@@ -23,20 +23,37 @@ pub(crate) enum IdeCommand {
     Install(IdeInstallArgs),
 }
 
+/// Install the active toolchain's BAML editor extension.
+///
+/// Select Cursor or VS Code explicitly, or use `--output-dir` to copy the VSIX for a
+/// manual installation. With no option, BAML selects an available supported
+/// editor.
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = "\
+Examples:
+  Install into the detected editor:
+    baml ide install
+
+  Install into Cursor:
+    baml ide install --cursor
+
+  Copy the extension for manual installation:
+    baml ide install --output-dir ./extensions")]
 pub(crate) struct IdeInstallArgs {
     /// Install the active toolchain's BAML VSIX into Cursor.
-    #[arg(long)]
+    #[arg(long, help_heading = "Editor options")]
     pub cursor: bool,
     /// Install the active toolchain's BAML VSIX into VS Code.
-    #[arg(long)]
+    #[arg(long, help_heading = "Editor options")]
     pub code: bool,
     /// Copy the active toolchain's BAML VSIX into a directory for manual
     /// install.
-    // Named `--dir` rather than `--path`: `--path` is ambiguous about
-    // whether it takes a file or a directory, and this flag only accepts
-    // a directory.
-    #[arg(long)]
+    #[arg(
+        long = "output-dir",
+        alias = "dir",
+        value_name = "PATH",
+        help_heading = "Editor options"
+    )]
     pub dir: Option<PathBuf>,
 }
 
@@ -173,7 +190,7 @@ fn manual_install_help(ide: &str, os: HostOs) -> String {
 
   1. Save baml-vscode.vsix somewhere easy to find:
 
-         baml ide install --dir {dir}
+         baml ide install --output-dir {dir}
 
   2. In {ide}, press {chord} and run "Extensions: Install from VSIX...".
 
@@ -231,7 +248,7 @@ mod tests {
 
     #[test]
     fn install_dir_flag_binds() {
-        let parsed = Wrapper::try_parse_from(["install", "--dir", "out"]).unwrap();
+        let parsed = Wrapper::try_parse_from(["install", "--output-dir", "out"]).unwrap();
         assert_eq!(parsed.args.dir, Some(PathBuf::from("out")));
     }
 
@@ -250,7 +267,7 @@ Install it manually instead:
 
   1. Save baml-vscode.vsix somewhere easy to find:
 
-         baml ide install --dir %USERPROFILE%\Downloads
+         baml ide install --output-dir %USERPROFILE%\Downloads
 
   2. In VS Code, press Ctrl+Shift+P and run "Extensions: Install from VSIX...".
 

--- a/baml_language/crates/baml_cli/src/init_command.rs
+++ b/baml_language/crates/baml_cli/src/init_command.rs
@@ -19,9 +19,19 @@ use clap::Args;
 
 use crate::reporter::Reporter;
 
-/// `baml init` — scaffold a new project under the given directory
+/// Scaffold a new BAML project under the given directory
 /// (default `.`). Refuses to clobber an existing `baml.toml`.
+///
+/// Creates `baml.toml` and `baml_src/main.baml`. The destination directory may
+/// already exist, but it must not already contain a BAML manifest.
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = "\
+Examples:
+  Initialize the current directory:
+    baml init
+
+  Initialize a directory with an explicit project name:
+    baml init ./my-project --name my_project")]
 pub struct InitArgs {
     /// Directory to initialize. Defaults to the current directory.
     #[arg(value_name = "PATH", default_value = ".")]
@@ -29,7 +39,7 @@ pub struct InitArgs {
 
     /// Project name written to `baml.toml`'s `[package].name`. Defaults
     /// to the basename of `<PATH>` (or `baml-project` for `.`).
-    #[arg(long)]
+    #[arg(long, help_heading = "Project options")]
     pub name: Option<String>,
 }
 
@@ -57,10 +67,20 @@ impl InitArgs {
     }
 }
 
-/// `baml new <PATH>` — create a fresh directory at `<PATH>` and
+/// Create a fresh directory at `<PATH>` and
 /// scaffold a project inside. Refuses to run if `<PATH>` already exists,
 /// the same way `cargo new` does.
+///
+/// Creates the destination directory, `baml.toml`, and
+/// `baml_src/main.baml`. Use `baml init` when the directory already exists.
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = "\
+Examples:
+  Create a project directory:
+    baml new ./my-project
+
+  Set an explicit project name:
+    baml new ./my-project --name my_project")]
 pub struct NewArgs {
     /// Directory to create. Errors if it already exists.
     #[arg(value_name = "PATH")]
@@ -68,7 +88,7 @@ pub struct NewArgs {
 
     /// Project name written to `baml.toml`'s `[package].name`. Defaults
     /// to the basename of `<PATH>`.
-    #[arg(long)]
+    #[arg(long, help_heading = "Project options")]
     pub name: Option<String>,
 }
 

--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -26,6 +26,7 @@ pub(crate) mod feedback_command;
 pub(crate) mod file_signature;
 pub(crate) mod format;
 pub(crate) mod generate;
+pub(crate) mod help_command;
 pub(crate) mod ide_command;
 pub(crate) mod init_command;
 pub(crate) mod lsp;

--- a/baml_language/crates/baml_cli/src/lsp.rs
+++ b/baml_language/crates/baml_cli/src/lsp.rs
@@ -4,11 +4,25 @@ use anyhow::Result;
 use baml_lsp_server::run_server;
 use clap::Args;
 
+/// Start a BAML language server over standard input and output.
+///
+/// Editor integrations normally start this command automatically. Use one or
+/// more `--workspace` paths when launching it outside an editor client.
 #[derive(Args, Debug)]
+#[command(after_long_help = "\
+Examples:
+  Start a language server:
+    baml lsp
+
+  Add a workspace root:
+    baml lsp --workspace ./my-project")]
 pub struct LanguageServerArgs {
+    #[command(flatten)]
+    pub compiler: crate::commands::CompilerArgs,
+
     /// Workspace root to discover BAML projects from when running the LSP
     /// outside an editor client. May be passed more than once.
-    #[clap(long, value_name = "PATH")]
+    #[clap(long, value_name = "PATH", help_heading = "Workspace options")]
     pub workspace: Vec<PathBuf>,
 }
 

--- a/baml_language/crates/baml_cli/src/lsp.rs
+++ b/baml_language/crates/baml_cli/src/lsp.rs
@@ -17,9 +17,6 @@ Examples:
   Add a workspace root:
     baml lsp --workspace ./my-project")]
 pub struct LanguageServerArgs {
-    #[command(flatten)]
-    pub compiler: crate::commands::CompilerArgs,
-
     /// Workspace root to discover BAML projects from when running the LSP
     /// outside an editor client. May be passed more than once.
     #[clap(long, value_name = "PATH", help_heading = "Workspace options")]

--- a/baml_language/crates/baml_cli/src/output.rs
+++ b/baml_language/crates/baml_cli/src/output.rs
@@ -42,6 +42,15 @@ pub(crate) struct OutputArgs {
 
     #[arg(
         long,
+        global = true,
+        help = "Disable progress output",
+        help_heading = "Global options",
+        display_order = 40
+    )]
+    pub no_progress: bool,
+
+    #[arg(
+        long,
         env = "BAML_HYPERLINKS",
         value_enum,
         value_name = "WHEN",
@@ -115,6 +124,7 @@ pub(crate) struct OutputPolicy {
     pub stdout: StreamPolicy,
     pub stderr: StreamPolicy,
     pub diagnostics: DiagnosticPolicy,
+    pub progress: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -152,6 +162,7 @@ const DEFAULT_POLICY: OutputPolicy = OutputPolicy {
         format: DiagnosticFormat::Human,
         show_error_codes: true,
     },
+    progress: true,
 };
 
 static OUTPUT_POLICY: RwLock<OutputPolicy> = RwLock::new(DEFAULT_POLICY);
@@ -205,6 +216,9 @@ fn resolve(args: OutputArgs, signals: OutputSignals) -> OutputPolicy {
             DiagnosticFormatChoice::Concise => DiagnosticFormat::Concise,
         };
     }
+    if args.no_progress {
+        policy.progress = false;
+    }
 
     policy
 }
@@ -225,6 +239,7 @@ impl OutputPreset {
                     format: DiagnosticFormat::Agent,
                     show_error_codes: true,
                 },
+                progress: false,
             },
             Self::Human | Self::Auto => OutputPolicy {
                 stdout: StreamPolicy {
@@ -239,6 +254,7 @@ impl OutputPreset {
                     format: DiagnosticFormat::Human,
                     show_error_codes: true,
                 },
+                progress: true,
             },
         }
     }
@@ -317,6 +333,7 @@ mod tests {
         OutputArgs {
             preset,
             color: None,
+            no_progress: false,
             hyperlinks: None,
             diagnostic_format: None,
         }
@@ -337,6 +354,7 @@ mod tests {
         assert!(!policy.stdout.hyperlinks);
         assert!(!policy.stderr.hyperlinks);
         assert_eq!(policy.diagnostics.format, DiagnosticFormat::Agent);
+        assert!(!policy.progress);
     }
 
     #[test]
@@ -357,6 +375,7 @@ mod tests {
         assert!(!policy.stdout.hyperlinks);
         assert!(policy.stderr.hyperlinks);
         assert_eq!(policy.diagnostics.format, DiagnosticFormat::Human);
+        assert!(policy.progress);
     }
 
     #[test]
@@ -373,6 +392,17 @@ mod tests {
         assert!(policy.stdout.hyperlinks);
         assert!(policy.stderr.hyperlinks);
         assert_eq!(policy.diagnostics.format, DiagnosticFormat::Human);
+        assert!(!policy.progress);
+    }
+
+    #[test]
+    fn no_progress_overrides_human_preset() {
+        let mut output_args = args(OutputPreset::Human);
+        output_args.no_progress = true;
+
+        let policy = resolve(output_args, INTERACTIVE);
+
+        assert!(!policy.progress);
     }
 
     #[test]

--- a/baml_language/crates/baml_cli/src/output.rs
+++ b/baml_language/crates/baml_cli/src/output.rs
@@ -9,41 +9,62 @@ use baml_db::baml_compiler_diagnostics::render::{DiagnosticFormat, RenderConfig}
 use clap::{Args, ValueEnum};
 
 #[derive(Args, Clone, Copy, Debug, Default, PartialEq, Eq)]
-#[command(next_help_heading = "Output options")]
 pub(crate) struct OutputArgs {
-    /// Output defaults: auto, human, or agent.
-    ///
-    /// `auto` selects the agent preset when a known coding-agent environment
-    /// is detected and the human preset otherwise.
     #[arg(
         long = "output-preset",
         env = "BAML_OUTPUT_PRESET",
         value_enum,
+        value_name = "PRESET",
+        help = "Select output defaults [default: auto] [possible values: auto, human, agent]",
+        hide_default_value = true,
+        hide_env = true,
+        hide_possible_values = true,
         default_value_t = OutputPreset::Auto,
-        global = true
+        global = true,
+        help_heading = "Global options",
+        display_order = 70
     )]
     pub preset: OutputPreset,
 
-    /// When to emit ANSI color: auto, always, or never.
-    ///
-    /// Overrides the selected output preset.
-    #[arg(long, env = "BAML_COLOR", value_enum, global = true)]
+    #[arg(
+        long,
+        env = "BAML_COLOR",
+        value_enum,
+        value_name = "WHEN",
+        help = "Control ANSI colors [possible values: auto, always, never]",
+        hide_env = true,
+        hide_possible_values = true,
+        global = true,
+        help_heading = "Global options",
+        display_order = 30
+    )]
     pub color: Option<ColorChoice>,
 
-    /// When to emit terminal hyperlinks: auto, always, or never.
-    ///
-    /// Overrides the selected output preset.
-    #[arg(long, env = "BAML_HYPERLINKS", value_enum, global = true)]
+    #[arg(
+        long,
+        env = "BAML_HYPERLINKS",
+        value_enum,
+        value_name = "WHEN",
+        help = "Control terminal hyperlinks [possible values: auto, always, never]",
+        hide_env = true,
+        hide_possible_values = true,
+        global = true,
+        help_heading = "Global options",
+        display_order = 80
+    )]
     pub hyperlinks: Option<HyperlinkChoice>,
 
-    /// Compiler diagnostic format: human, agent, or concise.
-    ///
-    /// Overrides the selected output preset.
     #[arg(
         long = "diagnostic-format",
         env = "BAML_DIAGNOSTIC_FORMAT",
         value_enum,
-        global = true
+        value_name = "FORMAT",
+        help = "Select the diagnostic format [possible values: human, agent, concise]",
+        hide_env = true,
+        hide_possible_values = true,
+        global = true,
+        help_heading = "Global options",
+        display_order = 90
     )]
     pub diagnostic_format: Option<DiagnosticFormatChoice>,
 }

--- a/baml_language/crates/baml_cli/src/pack_command.rs
+++ b/baml_language/crates/baml_cli/src/pack_command.rs
@@ -40,59 +40,88 @@ use sys_native::SysOpsExt;
 
 use crate::{
     commands::release_version,
-    project_load::{resolve_standalone_file, validate_file_from_flags},
+    project_load::{resolve_standalone_file, validate_file_project_flags},
     reporter::Reporter,
 };
 
-/// `baml pack` — compile one or more targets into a standalone executable.
+/// Package one or more BAML targets as a standalone executable.
+///
+/// A positional target produces a single-entry executable. One or more
+/// `--function` flags produce an executable whose generated CLI has one
+/// subcommand per function. Function parameters are derived from BAML types.
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = "\
+Examples:
+  Package one function:
+    baml pack main
+
+  Choose the executable path:
+    baml pack main --output ./my-tool
+
+  Package multiple functions as subcommands:
+    baml pack --function Extract --function Classify --output ./baml-tools
+
+  Package a function from a standalone file:
+    baml pack --file script.baml main")]
 pub struct PackArgs {
-    /// Positional target: a function name to pack as the binary's only
-    /// entry point. Mutually exclusive with `-f/--function`.
-    #[arg(value_name = "TARGET")]
+    #[command(flatten)]
+    pub compiler: crate::commands::CompilerArgs,
+
+    /// Function to package as the executable's only entry point.
+    ///
+    /// Mutually exclusive with `--function`.
+    #[arg(value_name = "FUNCTION")]
     pub target: Option<String>,
 
-    /// Pack a specific function as a subcommand of the produced binary.
-    /// Repeatable: each `-f` adds another subcommand. With one `-f` the
-    /// binary still has a subcommand layer (vs. a bare positional, which
-    /// produces a single-entry binary with no subcommand).
-    #[arg(short = 'f', long = "function", value_name = "NAME")]
+    /// Add a function as a generated executable subcommand. Repeatable.
+    ///
+    /// Even one `--function` creates a subcommand. Use a positional `<TARGET>`
+    /// to produce an executable with no subcommand layer.
+    #[arg(
+        short = 'f',
+        long = "function",
+        value_name = "NAME",
+        help_heading = "Target options"
+    )]
     pub functions: Vec<String>,
 
-    /// Standalone single-file source. Loads only this file (no project
-    /// discovery). Mutually exclusive with `--from`.
-    #[arg(long, value_name = "PATH")]
+    /// Load one standalone source file instead of discovering a project.
+    ///
+    /// Mutually exclusive with `--project`.
+    #[arg(long, value_name = "PATH", help_heading = "Project options")]
     pub file: Option<PathBuf>,
 
-    /// Output path for the packaged executable. Defaults to the
-    /// `[package].name` from `baml.toml`; for a manifest-less `baml_src/`
-    /// project, falls back to the project directory name; in `--file` mode,
-    /// to the file stem.
-    #[arg(short, long)]
+    /// Path for the packaged executable.
+    ///
+    /// Defaults to `[package].name`, the project directory name, or the source
+    /// file stem, depending on the project mode.
+    #[arg(short, long, help_heading = "Build options")]
     pub output: Option<PathBuf>,
 
     /// Target triple for the packaged executable.
-    /// Defaults to the host platform. When this differs from the host,
-    /// `baml pack` downloads the matching pack host from GitHub release
-    /// artifacts.
-    #[arg(long = "target", value_name = "TRIPLE")]
+    ///
+    /// Defaults to the host platform. Cross-compilation downloads the matching
+    /// pack host from the BAML release artifacts.
+    #[arg(long = "target", value_name = "TRIPLE", help_heading = "Build options")]
     pub target_triple: Option<String>,
 
-    /// Output format baked into the binary. Defaults to `json`; packaged
-    /// binaries are production tools whose primary reader is another
-    /// program. Use `debug` for human-readable output.
-    #[arg(long, value_enum, default_value_t = OutputFormat::Json)]
+    #[arg(
+        long,
+        value_enum,
+        value_name = "FORMAT",
+        help = "Format returned values [default: json] [possible values: debug, json]",
+        hide_default_value = true,
+        hide_possible_values = true,
+        default_value_t = OutputFormat::Json,
+        help_heading = "Runtime options"
+    )]
     pub output_format: OutputFormat,
 
-    /// Project search starting point. Mutually exclusive with `--file`.
-    #[arg(long, value_name = "PATH")]
+    /// Deprecated alias for `--project`.
+    #[arg(long, value_name = "PATH", hide = true)]
     pub from: Option<PathBuf>,
 
-    /// `-e/--expression` is recognized only so we can reject it with a
-    /// targeted message — `baml pack` doesn't support expression mode.
-    /// Without this flag declared, `baml pack -e '...'` falls through to
-    /// clap's positional handling and surfaces a confusing parse error.
-    #[arg(short = 'e', long = "expression", value_name = "EXPR")]
+    #[arg(short = 'e', long = "expression", value_name = "EXPR", hide = true)]
     pub expression: Option<String>,
 }
 
@@ -198,10 +227,10 @@ impl PackArgs {
                  pass a positional `<TARGET>` or `-f <NAME>` instead."
             );
         }
-        // `--file` and `--from` both name a source location. Reject the
+        // `--file` and `--project` both name a source location. Reject the
         // combination up front instead of silently preferring one. Same rule
         // as `baml run`.
-        validate_file_from_flags(self.file.as_deref(), self.from.as_deref())?;
+        validate_file_project_flags(self.file.as_deref(), self.from.as_deref())?;
         if let Some(target) = self.target.as_deref() {
             if looks_like_path(target) {
                 anyhow::bail!(
@@ -678,6 +707,7 @@ mod tests {
 
     fn pack_args() -> PackArgs {
         PackArgs {
+            compiler: crate::commands::CompilerArgs::default(),
             target: None,
             functions: Vec::new(),
             file: None,

--- a/baml_language/crates/baml_cli/src/playground_command.rs
+++ b/baml_language/crates/baml_cli/src/playground_command.rs
@@ -5,24 +5,42 @@ use clap::Args;
 
 use crate::project_load::{SourceLocation, resolve_source_location};
 
+/// Open the BAML playground in a browser.
+///
+/// Serves either a discovered BAML project or one standalone source file. By
+/// default, the server selects the first available port starting at 4265 and
+/// opens a browser unless the session is headless.
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = "\
+Examples:
+  Open the nearest project:
+    baml playground
+
+  Serve a specific project without opening a browser:
+    baml playground --project ./my-project --no-open
+
+  Serve a standalone file on a fixed port:
+    baml playground --file script.baml --port 4265")]
 pub struct PlaygroundArgs {
+    #[command(flatten)]
+    pub compiler: crate::commands::CompilerArgs,
+
     /// Standalone single-file source. Loads only this file (no project discovery).
-    #[arg(long, value_name = "PATH")]
+    #[arg(long, value_name = "PATH", help_heading = "Project options")]
     pub file: Option<PathBuf>,
 
-    /// Project search starting point. Ignored when `--file` is set.
-    #[arg(long, value_name = "PATH")]
+    /// Deprecated alias for `--project`.
+    #[arg(long, value_name = "PATH", hide = true)]
     pub from: Option<PathBuf>,
 
     /// Listen on exactly this port (errors if unavailable).
     /// Default: the first free port from 4265.
-    #[arg(long, value_name = "PORT")]
+    #[arg(long, value_name = "PORT", help_heading = "Server options")]
     pub port: Option<u16>,
 
     /// Do not open a browser. Opening is also skipped automatically in
     /// headless sessions (SSH, or no display on Linux).
-    #[arg(long)]
+    #[arg(long, help_heading = "Server options")]
     pub no_open: bool,
 }
 

--- a/baml_language/crates/baml_cli/src/project_load.rs
+++ b/baml_language/crates/baml_cli/src/project_load.rs
@@ -18,11 +18,14 @@ pub(crate) enum SourceLocation {
     StandaloneFile { file: PathBuf, root: PathBuf },
 }
 
-/// `--file` and `--from` both name a source location.
-pub(crate) fn validate_file_from_flags(file: Option<&Path>, from: Option<&Path>) -> Result<()> {
-    if file.is_some() && from.is_some() {
+/// `--file` and `--project` both name a source location.
+pub(crate) fn validate_file_project_flags(
+    file: Option<&Path>,
+    project: Option<&Path>,
+) -> Result<()> {
+    if file.is_some() && project.is_some() {
         anyhow::bail!(
-            "`--file` and `--from` are mutually exclusive — `--file` already names \
+            "`--file` and `--project` are mutually exclusive; `--file` already names \
              the single source to load."
         );
     }
@@ -35,7 +38,7 @@ pub(crate) fn resolve_source_location(
     file: Option<&Path>,
     reporter: Option<&Reporter>,
 ) -> Result<SourceLocation> {
-    validate_file_from_flags(file, from)?;
+    validate_file_project_flags(file, from)?;
 
     if let Some(file) = file {
         let canonical = resolve_standalone_file(file)?;

--- a/baml_language/crates/baml_cli/src/reporter.rs
+++ b/baml_language/crates/baml_cli/src/reporter.rs
@@ -13,19 +13,43 @@
 // inside `Reporter::status` / `spin` / `finish` / `warning`.
 #![allow(clippy::print_stderr)]
 
-use std::time::Instant;
+use std::{
+    sync::atomic::{AtomicBool, AtomicU8, Ordering},
+    time::Instant,
+};
 
 use console::{Color, Style};
 use indicatif::HumanDuration;
 
-/// Brand purple `#A855F7` for the cargo-style verb. Rendered via 24-bit
-/// truecolor ANSI (`\x1b[38;2;168;85;247m`) on terminals that support it;
-/// `console::Style` strips the escape when stderr isn't a TTY, so piped
-/// output stays plain.
+/// BAML purple for bold status verbs and section headers.
 const VERB_COLOR: Color = Color::TrueColor(0xA8, 0x55, 0xF7);
 
-fn verb_style() -> Style {
+static QUIET: AtomicBool = AtomicBool::new(false);
+static VERBOSE: AtomicU8 = AtomicU8::new(0);
+static NO_PROGRESS: AtomicBool = AtomicBool::new(false);
+
+pub(crate) fn init(quiet: u8, verbose: u8, no_progress: bool) {
+    QUIET.store(quiet > 0, Ordering::Relaxed);
+    VERBOSE.store(verbose, Ordering::Relaxed);
+    NO_PROGRESS.store(no_progress, Ordering::Relaxed);
+}
+
+pub(crate) fn verbose() -> bool {
+    VERBOSE.load(Ordering::Relaxed) > 0
+}
+
+pub(crate) fn print_verbose(args: std::fmt::Arguments<'_>) {
+    if verbose() && !QUIET.load(Ordering::Relaxed) {
+        eprintln!("{args}");
+    }
+}
+
+pub(crate) fn accent_style() -> Style {
     Style::new().fg(VERB_COLOR).bold()
+}
+
+pub(crate) fn secondary_style() -> Style {
+    Style::new().dim()
 }
 
 /// Clap help-text styling re-exported from `baml_exec`. Lives there so
@@ -51,17 +75,26 @@ impl Reporter {
     /// Print a one-shot status line that stays in the scrollback —
     /// cargo's `   Compiling foo v0.1.0` shape.
     pub fn status(&self, verb: &str, msg: impl AsRef<str>) {
+        if QUIET.load(Ordering::Relaxed) {
+            return;
+        }
         let line = format_status(verb, msg.as_ref());
         eprintln!("{line}");
     }
 
     /// Mark a new phase with a persistent cargo-style line.
     pub fn spin(&self, verb: &str, msg: impl AsRef<str>) {
+        if QUIET.load(Ordering::Relaxed) || NO_PROGRESS.load(Ordering::Relaxed) {
+            return;
+        }
         eprintln!("{}", format_status(verb, msg.as_ref()));
     }
 
     /// Print a final cargo-style "Finished" line with elapsed wall-clock time.
     pub fn finish(&self, verb: &str, msg: impl AsRef<str>) {
+        if QUIET.load(Ordering::Relaxed) {
+            return;
+        }
         // `{:#}` is `HumanDuration`'s alternate form — the compact
         // `5s` / `2m` / `1h` shape, matching cargo's `Finished` line.
         // The default `{}` form spells out `5 seconds`, which is too
@@ -87,13 +120,13 @@ impl Default for Reporter {
 }
 
 /// Format a single status line as cargo does it: 12-char right-aligned
-/// bold purple verb (BAML brand `#A855F7`), then a space, then the
+/// bold BAML-purple verb, then a space, then the
 /// payload. Padding is computed on the *unstyled* verb so ANSI escape
 /// bytes don't blow up column counts. `console::Style` strips the escape
 /// when stderr isn't a TTY, so piped output stays plain.
 fn format_status(verb: &str, msg: &str) -> String {
     let padded = format!("{verb:>12}");
-    let styled = verb_style().apply_to(padded);
+    let styled = accent_style().apply_to(padded);
     format!("{styled} {msg}")
 }
 
@@ -144,5 +177,22 @@ mod tests {
             stripped.starts_with("     Loading bar"),
             "got: {stripped:?}"
         );
+    }
+
+    #[test]
+    fn shared_styles_use_brand_accent_and_default_secondary_text() {
+        let accent = accent_style()
+            .force_styling(true)
+            .apply_to("accent")
+            .to_string();
+        assert!(accent.contains("\x1b[38;2;168;85;247m"), "{accent:?}");
+        assert!(!accent.contains("\x1b[38;5;"), "{accent:?}");
+
+        let secondary = secondary_style()
+            .force_styling(true)
+            .apply_to("secondary")
+            .to_string();
+        assert!(secondary.contains("\x1b[2m"), "{secondary:?}");
+        assert!(!secondary.contains("\x1b[38;"), "{secondary:?}");
     }
 }

--- a/baml_language/crates/baml_cli/src/reporter.rs
+++ b/baml_language/crates/baml_cli/src/reporter.rs
@@ -26,12 +26,10 @@ const VERB_COLOR: Color = Color::TrueColor(0xA8, 0x55, 0xF7);
 
 static QUIET: AtomicBool = AtomicBool::new(false);
 static VERBOSE: AtomicU8 = AtomicU8::new(0);
-static NO_PROGRESS: AtomicBool = AtomicBool::new(false);
 
-pub(crate) fn init(quiet: u8, verbose: u8, no_progress: bool) {
+pub(crate) fn init(quiet: u8, verbose: u8) {
     QUIET.store(quiet > 0, Ordering::Relaxed);
     VERBOSE.store(verbose, Ordering::Relaxed);
-    NO_PROGRESS.store(no_progress, Ordering::Relaxed);
 }
 
 pub(crate) fn verbose() -> bool {
@@ -84,7 +82,7 @@ impl Reporter {
 
     /// Mark a new phase with a persistent cargo-style line.
     pub fn spin(&self, verb: &str, msg: impl AsRef<str>) {
-        if QUIET.load(Ordering::Relaxed) || NO_PROGRESS.load(Ordering::Relaxed) {
+        if QUIET.load(Ordering::Relaxed) || !crate::output::policy().progress {
             return;
         }
         eprintln!("{}", format_status(verb, msg.as_ref()));

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -1279,7 +1279,9 @@ impl RunArgs {
             OutputFormat::Debug => {
                 Self::print_list_debug(&functions, scripts, namespaces, self.include_generated);
             }
-            OutputFormat::Json => Self::print_list_json(&functions, scripts, namespaces),
+            OutputFormat::Json => {
+                Self::print_list_json(&functions, scripts, namespaces, self.include_generated)
+            }
         }
 
         Ok(crate::ExitCode::Success)
@@ -1403,8 +1405,9 @@ impl RunArgs {
         functions: &[UserFunctionInfo],
         scripts: &HashMap<String, Vec<String>>,
         namespaces: &HashSet<String>,
+        include_generated: bool,
     ) {
-        let output = Self::build_list_json_value(functions, scripts, namespaces);
+        let output = Self::build_list_json_value(functions, scripts, namespaces, include_generated);
         println!(
             "{}",
             serde_json::to_string_pretty(&output).unwrap_or_else(|_| "{}".to_string())
@@ -1422,9 +1425,15 @@ impl RunArgs {
         functions: &[UserFunctionInfo],
         scripts: &HashMap<String, Vec<String>>,
         namespaces: &HashSet<String>,
+        include_generated: bool,
     ) -> serde_json::Value {
+        use bex_vm_types::FunctionOrigin;
+
         let function_items: Vec<serde_json::Value> = functions
             .iter()
+            .filter(|function| {
+                include_generated || matches!(function.origin, FunctionOrigin::UserDefined)
+            })
             .map(|f| {
                 let params: Vec<serde_json::Value> = f
                     .param_names
@@ -1463,6 +1472,9 @@ impl RunArgs {
         let namespace_mains_items: Vec<serde_json::Value> = {
             let mut namespace_mains: Vec<String> = functions
                 .iter()
+                .filter(|function| {
+                    include_generated || matches!(function.origin, FunctionOrigin::UserDefined)
+                })
                 .filter(|f| f.display_name.ends_with(".main"))
                 .filter_map(|f| {
                     f.display_name
@@ -2071,7 +2083,7 @@ mod tests {
         let namespaces: HashSet<String> = HashSet::new();
         let functions: Vec<UserFunctionInfo> = vec![];
 
-        let value = RunArgs::build_list_json_value(&functions, &scripts, &namespaces);
+        let value = RunArgs::build_list_json_value(&functions, &scripts, &namespaces, false);
 
         let obj = value.as_object().expect("top-level must be an object");
         assert!(
@@ -2088,6 +2100,38 @@ mod tests {
         // consumers rely on.
         let s = serde_json::to_string(&value).unwrap();
         let _: serde_json::Value = serde_json::from_str(&s).expect("must parse");
+    }
+
+    #[test]
+    fn list_json_filters_generated_functions_unless_requested() {
+        use bex_vm_types::FunctionOrigin;
+
+        let function = |name: &str, origin| UserFunctionInfo {
+            qualified_name: format!("user.{name}"),
+            display_name: name.to_string(),
+            origin,
+            param_names: Vec::new(),
+            param_types: Vec::new(),
+            param_has_default: Vec::new(),
+            return_type: ty_string(),
+            display_type_params: Vec::new(),
+            display_param_types: Vec::new(),
+            display_return_type: "string".to_string(),
+            source_file: String::new(),
+            is_llm: false,
+        };
+        let functions = vec![
+            function("main", FunctionOrigin::UserDefined),
+            function("Generated", FunctionOrigin::AutoDerive),
+        ];
+        let scripts = HashMap::new();
+        let namespaces = HashSet::new();
+
+        let filtered = RunArgs::build_list_json_value(&functions, &scripts, &namespaces, false);
+        let complete = RunArgs::build_list_json_value(&functions, &scripts, &namespaces, true);
+
+        assert_eq!(filtered["functions"].as_array().unwrap().len(), 1);
+        assert_eq!(complete["functions"].as_array().unwrap().len(), 2);
     }
 
     // ── `parse_scripts` warning behavior ───────────────────────────────

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -18,7 +18,7 @@ use sys_native::{CallId, SysOpsExt};
 use crate::{
     project_load::{
         find_project_root_from, load_project_or_default, resolve_standalone_file,
-        validate_file_from_flags,
+        validate_file_project_flags,
     },
     reporter::Reporter,
 };
@@ -93,7 +93,7 @@ fn parse_script_body(tokens: &[String]) -> Result<ScriptExpansion> {
 
         // Pre-separator: only `--function <value>` is recognized as a
         // run-verb flag inside a script body in v1. Other run-verb flags
-        // (`--json-args`, `--verbose`, etc.) are deliberately rejected
+        // (`--json-args`, `--include-generated`, etc.) are deliberately rejected
         // here rather than silently dropped — the toml loader is the
         // last chance to surface a typo before the script runs.
         if token == "--function" {
@@ -131,58 +131,102 @@ fn parse_script_body(tokens: &[String]) -> Result<ScriptExpansion> {
 // CLI Args
 // ============================================================================
 
+/// Run a BAML function, script, or expression.
+///
+/// Choose one execution mode: a positional function or script, one or more
+/// `--function` targets, or an inline `--expression`. Function parameters come
+/// after `--` and are parsed by an auto-generated CLI based on each signature.
 #[derive(Args, Clone, Debug)]
+#[command(after_long_help = "\
+Use `baml run <target> -- --help` to display the target's generated arguments.
+
+Examples:
+  Run a function:
+    baml run main -- --name Ada
+
+  Run multiple functions:
+    baml run --function Extract -- Extract --text input.txt
+
+  Evaluate an expression:
+    baml run -e '1 + 2'
+
+  Run a standalone file:
+    baml run --file script.baml
+
+  List available targets:
+    baml run --list")]
 pub struct RunArgs {
-    /// Positional target: function name to run as the sole entry point.
-    /// Mutually exclusive with `-f/--function` and `-e/--expression`.
+    #[command(flatten)]
+    pub compiler: crate::commands::CompilerArgs,
+
+    /// Function or script to run as the sole entry point.
+    ///
+    /// Mutually exclusive with `--function` and `--expression`.
     #[arg(value_name = "TARGET")]
     pub target: Option<String>,
 
-    /// Run a specific function, repeatable. With one `-f` the auto-CLI
-    /// still surfaces the function as a subcommand (post-`--` tokens
-    /// must start with the subcommand name); with multiple `-f` the
-    /// binary multiplexes between them.
-    /// Mutually exclusive with positional `<TARGET>` and `-e`.
-    #[arg(short = 'f', long = "function", value_name = "NAME")]
+    /// Add a function to the generated target CLI. Repeatable.
+    ///
+    /// Unlike a positional target, `--function` always creates a subcommand
+    /// after `--`, even when passed once. Mutually exclusive with `<TARGET>`
+    /// and `--expression`.
+    #[arg(
+        short = 'f',
+        long = "function",
+        value_name = "NAME",
+        help_heading = "Target options"
+    )]
     pub functions: Vec<String>,
 
-    /// Evaluate a BAML expression. Use -e @file to read from a file, -e - for stdin.
-    /// Mutually exclusive with positional `<TARGET>` and `-f`.
-    #[arg(short = 'e', long = "expression", allow_hyphen_values = true)]
+    /// Evaluate a BAML expression.
+    ///
+    /// Use `-e @file` to read an expression from a file or `-e -` for standard
+    /// input. Mutually exclusive with `<TARGET>` and `--function`.
+    #[arg(
+        short = 'e',
+        long = "expression",
+        allow_hyphen_values = true,
+        help_heading = "Target options"
+    )]
     pub expression: Option<String>,
 
-    /// Standalone single-file source. Loads only this file (no project
-    /// discovery). Mutually exclusive with `--from`.
-    #[arg(long, value_name = "PATH")]
+    /// Load one standalone source file instead of discovering a project.
+    ///
+    /// Runs its `main` function when no target is supplied. Mutually exclusive
+    /// with `--project`.
+    #[arg(long, value_name = "PATH", help_heading = "Project options")]
     pub file: Option<PathBuf>,
 
     /// List runnable targets (scripts, functions).
-    #[arg(long)]
+    #[arg(long, help_heading = "Target options")]
     pub list: bool,
 
-    /// Output format: debug (default) or json.
-    #[arg(long = "output-format", default_value = "debug")]
+    #[arg(
+        long = "output-format",
+        default_value = "debug",
+        value_name = "FORMAT",
+        help = "Format returned values [default: debug] [possible values: debug, json]",
+        hide_default_value = true,
+        hide_possible_values = true,
+        help_heading = "Run output options"
+    )]
     pub output_format: OutputFormat,
 
     /// Write run logs to a file.
-    #[arg(long)]
+    #[arg(long, help_heading = "Run output options")]
     pub log_file: Option<PathBuf>,
 
-    /// Verbose output.
-    #[arg(long)]
-    pub verbose: bool,
+    /// Include compiler-synthesized functions in `--list` output.
+    #[arg(long, help_heading = "Run output options")]
+    pub include_generated: bool,
 
-    /// Show help for the run verb, or auto-derived help for the target.
-    #[arg(long, short = 'h')]
-    pub help: bool,
-
-    /// Project search starting point. Mutually exclusive with `--file`.
-    #[arg(long, value_name = "PATH")]
+    /// Deprecated alias for `--project`.
+    #[arg(long, value_name = "PATH", hide = true)]
     pub from: Option<PathBuf>,
 
-    /// Arguments passed to the target after `--`. Parsed as auto-CLI
-    /// flags derived from the function signature(s). With multiple `-f`
-    /// the first token after `--` is the chosen subcommand name.
+    /// Arguments for the generated target CLI.
+    ///
+    /// With `--function`, the first value is the target subcommand name.
     #[arg(last = true)]
     pub target_args: Vec<String>,
 }
@@ -203,10 +247,11 @@ impl RunArgs {
     }
 
     /// Keep execution silent even when legacy call sites still pass
-    /// diagnostics-oriented strings through `vlog`. `--verbose` only affects
-    /// explicit listing output, not successful program execution.
+    /// diagnostics-oriented strings through `vlog`.
     fn vlog(&self, args: std::fmt::Arguments<'_>) {
-        let _ = args;
+        if crate::reporter::verbose() {
+            crate::reporter::print_verbose(args);
+        }
     }
 
     /// Collect diagnostics on `db` and bail with `bail_context` if any are errors.
@@ -265,16 +310,6 @@ impl RunArgs {
     }
 
     pub fn run(&self) -> Result<crate::ExitCode> {
-        // Short-circuit verb-level `--help` (no target / function /
-        // expression given) before constructing the Reporter.
-        if self.help
-            && self.functions.is_empty()
-            && self.target.is_none()
-            && self.expression.is_none()
-        {
-            Self::print_run_help();
-            return Ok(crate::ExitCode::Success);
-        }
         let reporter = Reporter::new();
         self.run_with_reporter(&reporter)
     }
@@ -298,10 +333,10 @@ impl RunArgs {
             );
         }
 
-        // `--file` is the standalone-source alternative to `--from`. Both
+        // `--file` is the standalone-source alternative to `--project`. Both
         // pointing at sources would be ambiguous (which one wins?), so
         // reject an explicit combination up front.
-        validate_file_from_flags(self.file.as_deref(), self.from.as_deref())?;
+        validate_file_project_flags(self.file.as_deref(), self.from.as_deref())?;
 
         // Expression mode short-circuits before reaching project / file
         // loading, so combining `-e` with surfaces that change *what* is
@@ -321,15 +356,6 @@ impl RunArgs {
                      pick one."
                 );
             }
-        }
-
-        if self.help
-            && self.functions.is_empty()
-            && self.target.is_none()
-            && self.expression.is_none()
-        {
-            Self::print_run_help();
-            return Ok(crate::ExitCode::Success);
         }
 
         if let Some(expr_source) = &self.expression {
@@ -1251,7 +1277,7 @@ impl RunArgs {
 
         match output {
             OutputFormat::Debug => {
-                Self::print_list_debug(&functions, scripts, namespaces, self.verbose);
+                Self::print_list_debug(&functions, scripts, namespaces, self.include_generated);
             }
             OutputFormat::Json => Self::print_list_json(&functions, scripts, namespaces),
         }
@@ -1263,27 +1289,24 @@ impl RunArgs {
     /// (scripts → namespaces → functions) under bold-purple section
     /// headers. Auto-derived `to_json` / `from_json`, companion
     /// constructors, and other compiler-synthesized helpers are hidden
-    /// by default — `--verbose` shows them.
+    /// by default — `--include-generated` shows them.
     fn print_list_debug(
         functions: &[UserFunctionInfo],
         scripts: &HashMap<String, Vec<String>>,
         namespaces: &HashSet<String>,
-        verbose: bool,
+        include_generated: bool,
     ) {
         use bex_vm_types::FunctionOrigin;
-        use console::Style;
 
-        let header_style = Style::new()
-            .fg(console::Color::TrueColor(0xA8, 0x55, 0xF7))
-            .bold();
-        let dim = Style::new().color256(244);
+        let header_style = crate::reporter::accent_style();
+        let dim = crate::reporter::secondary_style();
         let header = |s: &str| println!("{}", header_style.apply_to(s));
 
         // Visible by default: user-authored entries only. Pass
-        // `--verbose` to expose compiler-synthesized helpers
+        // `--include-generated` to expose compiler-synthesized helpers
         // (autoderive `to_json` / `from_json` per class, companion
         // `$new` constructors per client, internal `$init` etc).
-        let visible: Vec<&UserFunctionInfo> = if verbose {
+        let visible: Vec<&UserFunctionInfo> = if include_generated {
             functions.iter().collect()
         } else {
             functions
@@ -1365,11 +1388,11 @@ impl RunArgs {
 
         // When the default filter hid everything, surface that fact
         // rather than leaving the user staring at an empty section.
-        if !verbose && visible.is_empty() && !functions.is_empty() {
+        if !include_generated && visible.is_empty() && !functions.is_empty() {
             println!(
                 "{}",
                 dim.apply_to(format!(
-                    "(hiding {} compiler-synthesized function(s); pass --verbose to show them)",
+                    "(hiding {} compiler-synthesized function(s); pass --include-generated to show them)",
                     functions.len()
                 ))
             );
@@ -1464,25 +1487,13 @@ impl RunArgs {
     }
 
     fn print_run_help() {
-        let _ = Self::run_help_command().print_help();
-    }
-
-    fn run_help_command() -> clap::Command {
-        use clap::CommandFactory;
-        let cmd = crate::commands::RuntimeCli::command();
-        let sub = cmd
-            .find_subcommand("run")
-            .expect("RuntimeCli should register a run subcommand");
-        // Clap propagates `styles = …` from the root command to
-        // subcommands at parse time, not when a subcommand reference is
-        // grabbed directly via `find_subcommand`. Re-apply
-        // `CLAP_STYLING` explicitly so `run --help` keeps the same
-        // green/cyan diagnostic palette as top-level help,
-        // instead of falling back to clap's default
-        // bold+underline-no-color treatment.
-        sub.clone()
-            .bin_name("baml run")
-            .styles(crate::reporter::CLAP_STYLING)
+        let mut command = crate::commands::RuntimeCli::command();
+        command.build();
+        let Some(run) = command.find_subcommand("run") else {
+            return;
+        };
+        let mut run = run.clone();
+        let _ = run.print_help();
     }
 }
 
@@ -1764,7 +1775,10 @@ mod tests {
 
     #[test]
     fn test_run_help_presents_public_baml_command() {
-        let help = RunArgs::run_help_command().render_help().to_string();
+        let mut command = crate::commands::RuntimeCli::command();
+        command.build();
+        let mut run = command.find_subcommand("run").unwrap().clone();
+        let help = run.render_help().to_string();
         assert!(
             help.contains("Usage: baml run [OPTIONS] [TARGET] [-- <TARGET_ARGS>...]"),
             "{help}"
@@ -1779,11 +1793,7 @@ mod tests {
     #[test]
     fn test_output_format_flag_name() {
         use clap::{CommandFactory, FromArgMatches, Parser};
-        // RunArgs declares its own `--help` field (BEP-027 §"Auto-CLI
-        // conventions"), so the test wrapper must disable clap's auto
-        // `--help` to mirror the real subcommand registration.
         #[derive(Parser)]
-        #[command(disable_help_flag = true)]
         struct Wrapper {
             #[command(flatten)]
             args: RunArgs,
@@ -1810,7 +1820,6 @@ mod tests {
     fn test_run_output_format_defaults_to_debug() {
         use clap::{CommandFactory, FromArgMatches, Parser};
         #[derive(Parser)]
-        #[command(disable_help_flag = true)]
         struct Wrapper {
             #[command(flatten)]
             args: RunArgs,
@@ -1839,6 +1848,7 @@ mod tests {
     /// fields. Keeps test bodies focused on the field under test.
     fn run_args() -> RunArgs {
         RunArgs {
+            compiler: crate::commands::CompilerArgs::default(),
             target: None,
             functions: Vec::new(),
             expression: None,
@@ -1846,8 +1856,7 @@ mod tests {
             list: false,
             output_format: OutputFormat::Debug,
             log_file: None,
-            verbose: false,
-            help: false,
+            include_generated: false,
             from: None,
             target_args: Vec::new(),
         }
@@ -1956,7 +1965,7 @@ mod tests {
         let mut args = run_args();
         args.target = Some("X".into());
         args.file = Some(PathBuf::from("a.baml"));
-        validate_file_from_flags(args.file.as_deref(), args.from.as_deref()).unwrap();
+        validate_file_project_flags(args.file.as_deref(), args.from.as_deref()).unwrap();
     }
 
     // ── Clap derive parse tests ──────────────────────────────────────
@@ -1968,7 +1977,6 @@ mod tests {
     fn test_run_dash_f_is_repeatable() {
         use clap::{CommandFactory, FromArgMatches, Parser};
         #[derive(Parser)]
-        #[command(disable_help_flag = true)]
         struct Wrapper {
             #[command(flatten)]
             args: RunArgs,
@@ -1988,7 +1996,6 @@ mod tests {
     fn test_run_file_flag_parses() {
         use clap::Parser;
         #[derive(Parser)]
-        #[command(disable_help_flag = true)]
         struct Wrapper {
             #[command(flatten)]
             args: RunArgs,
@@ -2004,7 +2011,6 @@ mod tests {
     fn test_run_post_dash_dash_tokens_are_verbatim() {
         use clap::Parser;
         #[derive(Parser)]
-        #[command(disable_help_flag = true)]
         struct Wrapper {
             #[command(flatten)]
             args: RunArgs,
@@ -2035,7 +2041,6 @@ mod tests {
     fn test_run_rejects_verb_level_json_args() {
         use clap::{CommandFactory, Parser};
         #[derive(Parser)]
-        #[command(disable_help_flag = true)]
         struct Wrapper {
             #[command(flatten)]
             args: RunArgs,

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_check.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_check.snap
@@ -5,7 +5,7 @@ expression: output
 check — Explains how to ask the CLI to validate a project.
 
 Syntax:
-  baml check --from .
-  baml run --list --from .
+  baml check --project .
+  baml run --list --project .
 
 `baml check` compiles the project and reports compiler errors without running anything — the most direct way to validate. Other commands (`baml run`, `baml run --list`, `baml fmt`, `baml test`) also load and check the project before their main work. Use `baml run --list` when you additionally want the compiled function signatures.

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_playground.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_playground.snap
@@ -6,7 +6,7 @@ playground — Serves the BAML playground web UI for a project and opens it in a
 
 Syntax:
   baml playground                      # current project, first free port from 4265
-  baml playground --from ./my-app      # explicit project directory
+  baml playground --project ./my-app   # explicit project directory
   baml playground --file ./one.baml    # standalone single file
   baml playground --port 4265          # pin the port (errors if taken)
   baml playground --no-open            # don't launch a browser (automatic in SSH/headless sessions)

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__describe_detailed_help.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__describe_detailed_help.snap
@@ -1,0 +1,83 @@
+---
+source: crates/baml_cli/src/help_command.rs
+expression: "render_for_test(&[\"describe\"])"
+---
+Describe BAML symbols and language concepts.
+
+With no name, lists symbols in the current project. A name can identify a project symbol, builtin
+package, namespace, type, member, or BAML keyword. Builtin documentation works outside a project, so
+`baml describe baml` is the entry point for exploring the complete standard library.
+
+Usage: baml describe [OPTIONS] [NAME]
+
+Examples:
+  List project symbols:
+    baml describe
+
+  Describe the standard library:
+    baml describe baml
+
+  Describe a namespace:
+    baml describe baml.json
+
+  Describe a class:
+    baml describe Array
+
+  Describe a method:
+    baml describe String.split
+
+  Describe a keyword:
+    baml describe match
+
+Arguments:
+  [NAME]
+          Symbol, namespace, package, or keyword. Omit to list project symbols
+
+Options:
+      --symbols
+          Deprecated alias for invoking `baml describe` without a name
+
+Compiler options:
+  -F, --features <FEATURES>
+          Enable compiler features; repeatable or comma-separated [possible values: beta,
+          display_all_warnings]
+
+Output options:
+      --budget <BUDGET>
+          Soft maximum number of output lines
+
+          [default: 30]
+
+      --json
+          Output results as JSON
+
+Global options:
+  -q, --quiet...
+          Suppress nonessential output
+
+  -v, --verbose...
+          Increase diagnostic verbosity. Repeatable
+
+      --color <WHEN>
+          Control ANSI colors [possible values: auto, always, never]
+
+      --no-progress
+          Disable progress output
+
+      --directory <PATH>
+          Change to this directory before running the command
+
+      --project <PATH>
+          Discover the BAML project from this path
+
+      --output-preset <PRESET>
+          Select output defaults [default: auto] [possible values: auto, human, agent]
+
+      --hyperlinks <WHEN>
+          Control terminal hyperlinks [possible values: auto, always, never]
+
+      --diagnostic-format <FORMAT>
+          Select the diagnostic format [possible values: human, agent, concise]
+
+  -h, --help
+          Display concise help for this command

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__root_concise_help.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__root_concise_help.snap
@@ -1,0 +1,44 @@
+---
+source: crates/baml_cli/src/help_command.rs
+expression: concise
+---
+Build and run BAML projects.
+
+Usage: baml [OPTIONS] <COMMAND>
+
+Commands:
+  check       Check BAML source files for compiler errors
+  auth        Manage authentication
+  login       Log in to Boundary with your email
+  feedback    Report an issue or improvement to Boundary
+  fmt         Format BAML source files
+  describe    Describe a BAML symbol
+  generate    Generate client code from BAML definitions
+  test        Run BAML tests
+  init        Initialize a new BAML project (creates baml.toml)
+  new         Create a new BAML project directory
+  run         Run a BAML function or script
+  playground  Open the BAML playground in your browser
+  pack        Package a BAML target as a standalone executable
+  ide         Install or manage IDE integration assets
+  agent       Install BAML agent skills for this project
+  lsp         Start a language server
+  help        Display documentation for a command
+
+Global options:
+  -q, --quiet...                    Suppress nonessential output
+  -v, --verbose...                  Increase diagnostic verbosity. Repeatable
+      --color <WHEN>                Control ANSI colors [possible values: auto, always, never]
+      --no-progress                 Disable progress output
+      --directory <PATH>            Change to this directory before running the command
+      --project <PATH>              Discover the BAML project from this path
+      --output-preset <PRESET>      Select output defaults [default: auto] [possible values: auto,
+                                    human, agent]
+      --hyperlinks <WHEN>           Control terminal hyperlinks [possible values: auto, always,
+                                    never]
+      --diagnostic-format <FORMAT>  Select the diagnostic format [possible values: human, agent,
+                                    concise]
+  -h, --help                        Display concise help for this command
+  -V, --version                     Print version
+
+Use `baml help <command>` for more details.

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__run_detailed_help.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__run_detailed_help.snap
@@ -1,0 +1,108 @@
+---
+source: crates/baml_cli/src/help_command.rs
+expression: "render_for_test(&[\"run\"])"
+---
+Run a BAML function, script, or expression.
+
+Choose one execution mode: a positional function or script, one or more `--function` targets, or an
+inline `--expression`. Function parameters come after `--` and are parsed by an auto-generated CLI
+based on each signature.
+
+Usage: baml run [OPTIONS] [TARGET] [-- <TARGET_ARGS>...]
+
+Examples:
+  Run a function:
+    baml run main -- --name Ada
+
+  Run multiple functions:
+    baml run --function Extract -- Extract --text input.txt
+
+  Evaluate an expression:
+    baml run -e '1 + 2'
+
+  Run a standalone file:
+    baml run --file script.baml
+
+  List available targets:
+    baml run --list
+
+Arguments:
+  [TARGET]
+          Function or script to run as the sole entry point.
+
+          Mutually exclusive with `--function` and `--expression`.
+
+  [TARGET_ARGS]...
+          Arguments for the generated target CLI.
+
+          With `--function`, the first value is the target subcommand name.
+
+Compiler options:
+  -F, --features <FEATURES>
+          Enable compiler features; repeatable or comma-separated [possible values: beta,
+          display_all_warnings]
+
+Target options:
+  -f, --function <NAME>
+          Add a function to the generated target CLI. Repeatable.
+
+          Unlike a positional target, `--function` always creates a subcommand after `--`, even when
+          passed once. Mutually exclusive with `<TARGET>` and `--expression`.
+
+  -e, --expression <EXPRESSION>
+          Evaluate a BAML expression.
+
+          Use `-e @file` to read an expression from a file or `-e -` for standard input. Mutually
+          exclusive with `<TARGET>` and `--function`.
+
+      --list
+          List runnable targets (scripts, functions)
+
+Project options:
+      --file <PATH>
+          Load one standalone source file instead of discovering a project.
+
+          Runs its `main` function when no target is supplied. Mutually exclusive with `--project`.
+
+Run output options:
+      --output-format <FORMAT>
+          Format returned values [default: debug] [possible values: debug, json]
+
+      --log-file <LOG_FILE>
+          Write run logs to a file
+
+      --include-generated
+          Include compiler-synthesized functions in `--list` output
+
+Global options:
+  -q, --quiet...
+          Suppress nonessential output
+
+  -v, --verbose...
+          Increase diagnostic verbosity. Repeatable
+
+      --color <WHEN>
+          Control ANSI colors [possible values: auto, always, never]
+
+      --no-progress
+          Disable progress output
+
+      --directory <PATH>
+          Change to this directory before running the command
+
+      --project <PATH>
+          Discover the BAML project from this path
+
+      --output-preset <PRESET>
+          Select output defaults [default: auto] [possible values: auto, human, agent]
+
+      --hyperlinks <WHEN>
+          Control terminal hyperlinks [possible values: auto, always, never]
+
+      --diagnostic-format <FORMAT>
+          Select the diagnostic format [possible values: human, agent, concise]
+
+  -h, --help
+          Display concise help for this command
+
+Use `baml run <target> -- --help` to display the target's generated arguments.

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__test_detailed_help.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__test_detailed_help.snap
@@ -1,0 +1,104 @@
+---
+source: crates/baml_cli/src/help_command.rs
+expression: "render_for_test(&[\"test\"])"
+---
+Run BAML tests.
+
+With no filters, runs every test selected by the active profile, or every project test when no
+profile is configured. Use `--list` to discover the canonical IDs accepted by `--include` and
+`--exclude`.
+
+Usage: baml test [OPTIONS]
+
+Examples:
+  List available tests:
+    baml test --list
+
+  Run tests in the payments namespace:
+    baml test -i "root.payments::*"
+
+  Run integration tests except slow tests:
+    baml test -i "*::integration::*" -x "slow"
+
+Compiler options:
+  -F, --features <FEATURES>
+          Enable compiler features; repeatable or comma-separated [possible values: beta,
+          display_all_warnings]
+
+Profile options:
+      --profile <NAME>
+          Apply a named test profile from `baml.toml`.
+
+          Profile arguments establish the initial test set; command-line filters further narrow it.
+
+      --no-profile
+          Do not apply the default profile configured in `baml.toml`
+
+Selection options:
+      --list
+          List selected test IDs instead of running them.
+
+          Each canonical ID is valid as an `--include` or `--exclude` selector.
+
+  -i, --include <INCLUDE>
+          Include tests matching a canonical-ID selector. Repeatable
+
+  -x, --exclude <EXCLUDE>
+          Exclude tests matching a selector. Exclusions take precedence
+
+Test output options:
+      --logs <LEVEL>
+          Set the BAML log level [default: off] [possible values: off, error, warn, info, debug]
+
+Global options:
+  -q, --quiet...
+          Suppress nonessential output
+
+  -v, --verbose...
+          Increase diagnostic verbosity. Repeatable
+
+      --color <WHEN>
+          Control ANSI colors [possible values: auto, always, never]
+
+      --no-progress
+          Disable progress output
+
+      --directory <PATH>
+          Change to this directory before running the command
+
+      --project <PATH>
+          Discover the BAML project from this path
+
+      --output-preset <PRESET>
+          Select output defaults [default: auto] [possible values: auto, human, agent]
+
+      --hyperlinks <WHEN>
+          Control terminal hyperlinks [possible values: auto, always, never]
+
+      --diagnostic-format <FORMAT>
+          Select the diagnostic format [possible values: human, agent, concise]
+
+  -h, --help
+          Display concise help for this command
+
+SELECTORS:
+  Test IDs are case-sensitive and canonical: `root[.namespace]::testset::test`.
+  Plain selectors match anywhere in the full ID. A selector containing `*` is
+  an anchored full-ID glob, and `*` also matches `::`. Repeated includes are OR.
+  Excludes always win. With no includes, every non-excluded test is selected.
+
+PROFILES:
+  Profile names are case-sensitive. A profile is preset `baml test` argv, parsed
+  without shell expansion:
+
+    [test]
+    default = "regular"
+
+    [test.profiles.regular]
+    args = ["-x", "::integration::", "--color", "never"]
+
+  Profile includes establish the initial candidates; direct CLI includes narrow
+  them. Excludes accumulate and always win. Direct scalar options override
+  profile scalar options. Profile args cannot contain --profile, --no-profile,
+  --project, --directory, --from, or --help. With no default profile, all tests
+  are selected.

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__test_detailed_help.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__test_detailed_help.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/baml_cli/src/help_command.rs
-expression: "render_for_test(&[\"test\"])"
+expression: "normalize_snapshot(&render_for_test(&[\"test\"]))"
 ---
 Run BAML tests.
 
@@ -100,5 +100,5 @@ PROFILES:
   Profile includes establish the initial candidates; direct CLI includes narrow
   them. Excludes accumulate and always win. Direct scalar options override
   profile scalar options. Profile args cannot contain --profile, --no-profile,
-  --project, --directory, --from, or --help. With no default profile, all tests
-  are selected.
+  --project, --directory, --from, --features, or --help. With no default profile,
+  all tests are selected.

--- a/baml_language/crates/baml_cli/src/telemetry_command.rs
+++ b/baml_language/crates/baml_cli/src/telemetry_command.rs
@@ -45,8 +45,14 @@ impl FlushTelemetryArgs {
 // `next telemetry [enable|disable|status]`.
 #[derive(Args, Debug)]
 pub(crate) struct TelemetryArgs {
-    /// What to do. Omit to just show current status.
-    #[arg(value_enum, default_value_t = TelemetryAction::Status)]
+    #[arg(
+        value_enum,
+        value_name = "ACTION",
+        help = "Telemetry action [default: status] [possible values: status, enable, disable]",
+        hide_default_value = true,
+        hide_possible_values = true,
+        default_value_t = TelemetryAction::Status
+    )]
     pub action: TelemetryAction,
 }
 

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -50,8 +50,8 @@ PROFILES:
   Profile includes establish the initial candidates; direct CLI includes narrow
   them. Excludes accumulate and always win. Direct scalar options override
   profile scalar options. Profile args cannot contain --profile, --no-profile,
-  --project, --directory, --from, or --help. With no default profile, all tests
-  are selected.
+  --project, --directory, --from, --features, or --help. With no default profile,
+  all tests are selected.
 
 Examples:
   List available tests:
@@ -857,15 +857,17 @@ impl TestArgs {
                     | "--project"
                     | "--directory"
                     | "--from"
+                    | "--features"
                     | "--help"
                     | "-h"
             ) || token.starts_with("--profile=")
                 || token.starts_with("--project=")
                 || token.starts_with("--directory=")
-                || token.starts_with("--from=");
+                || token.starts_with("--from=")
+                || token.starts_with("--features=");
             if bootstrap {
                 anyhow::bail!(
-                    "invalid argument `{token}` in test profile `{name}`: profile args cannot contain --profile, --no-profile, --project, --directory, --from, or --help"
+                    "invalid argument `{token}` in test profile `{name}`: profile args cannot contain --profile, --no-profile, --project, --directory, --from, --features, or --help"
                 );
             }
         }
@@ -1609,9 +1611,6 @@ mod tests {
                 "--color".to_string(),
                 "never".to_string(),
                 "--no-progress".to_string(),
-                "--features".to_string(),
-                "beta".to_string(),
-                "--features=display_all_warnings".to_string(),
             ],
         )
         .unwrap()
@@ -1621,6 +1620,14 @@ mod tests {
             Some(crate::output::ColorChoice::Never)
         );
         assert_eq!(globals.output.no_progress, Some(true));
+
+        let error = TestArgs::parse_profile_args("bad_features", &["--features=beta".to_string()])
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains("cannot contain") && error.contains("--features"),
+            "{error}"
+        );
 
         let error = TestArgs::parse_profile_args("bad", &["--profile=other".to_string()])
             .unwrap_err()

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -150,6 +150,7 @@ struct ParsedProfileArgs {
 pub(crate) struct TestOutputOverrides {
     pub(crate) preset: Option<crate::output::OutputPreset>,
     pub(crate) color: Option<crate::output::ColorChoice>,
+    pub(crate) no_progress: Option<bool>,
     pub(crate) hyperlinks: Option<crate::output::HyperlinkChoice>,
     pub(crate) diagnostic_format: Option<crate::output::DiagnosticFormatChoice>,
 }
@@ -167,6 +168,7 @@ impl TestOutputOverrides {
         Self {
             preset: explicitly_set("preset").then_some(output.preset),
             color: explicitly_set("color").then_some(output.color).flatten(),
+            no_progress: explicitly_set("no_progress").then_some(output.no_progress),
             hyperlinks: explicitly_set("hyperlinks")
                 .then_some(output.hyperlinks)
                 .flatten(),
@@ -182,6 +184,7 @@ impl TestOutputOverrides {
         Self {
             preset: supplied("preset").then_some(output.preset),
             color: supplied("color").then_some(output.color).flatten(),
+            no_progress: supplied("no_progress").then_some(output.no_progress),
             hyperlinks: supplied("hyperlinks")
                 .then_some(output.hyperlinks)
                 .flatten(),
@@ -197,6 +200,9 @@ impl TestOutputOverrides {
         }
         if let Some(color) = self.color {
             output.color = Some(color);
+        }
+        if let Some(no_progress) = self.no_progress {
+            output.no_progress = no_progress;
         }
         if let Some(hyperlinks) = self.hyperlinks {
             output.hyperlinks = Some(hyperlinks);
@@ -1602,6 +1608,7 @@ mod tests {
             &[
                 "--color".to_string(),
                 "never".to_string(),
+                "--no-progress".to_string(),
                 "--features".to_string(),
                 "beta".to_string(),
                 "--features=display_all_warnings".to_string(),
@@ -1613,6 +1620,7 @@ mod tests {
             globals.output.color,
             Some(crate::output::ColorChoice::Never)
         );
+        assert_eq!(globals.output.no_progress, Some(true));
 
         let error = TestArgs::parse_profile_args("bad", &["--profile=other".to_string()])
             .unwrap_err()

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -20,55 +20,88 @@ use bex_engine::{
     FunctionCallContext, FunctionCallContextBuilder, test_arg_to_external,
     value_capture::{TraceCaptureConfig, TraceCaptureProducer},
 };
-use clap::{Args, CommandFactory, FromArgMatches, ValueEnum};
+use clap::{Args, FromArgMatches, ValueEnum};
 use sys_native::{CallId, SysOpsExt};
 
 use crate::{bytecode_cache::CacheContext, reporter::Reporter, test_filter::TestFilter};
 
+/// Run BAML tests.
+///
+/// With no filters, runs every test selected by the active profile, or every
+/// project test when no profile is configured. Use `--list` to discover the
+/// canonical IDs accepted by `--include` and `--exclude`.
 #[derive(Args, Clone, Debug)]
-#[command(
-    after_help = "SELECTORS:\n  Test IDs are case-sensitive and canonical: `root[.namespace]::testset::test`.\n  A plain -i/--include or -x/--exclude value matches anywhere in the full ID. A\n  value containing `*` is instead an anchored full-ID glob; `*` also matches\n  `::`. Repeated includes are OR. Excludes always win. With no includes, every\n  non-excluded test is selected.\n\nPROFILES:\n  Profile names are case-sensitive. A profile is preset `baml test` argv, parsed\n  without shell expansion:\n\n    [test]\n    default = \"regular\"\n\n    [test.profiles.regular]\n    args = [\"-x\", \"::integration::\", \"--color\", \"never\"]\n\n  Profile includes establish the initial candidates; direct CLI includes narrow\n  them rather than reopening the set. Excludes accumulate and always win. Direct\n  scalar options override profile scalar options. Bootstrap options --profile,\n  --no-profile, --from, and --help are not allowed in profile args.\n  With no default profile, `baml test` runs all tests.\n\nRun `baml test --list` to discover IDs and `baml test --help` for this reference."
-)]
+#[command(after_long_help = r#"SELECTORS:
+  Test IDs are case-sensitive and canonical: `root[.namespace]::testset::test`.
+  Plain selectors match anywhere in the full ID. A selector containing `*` is
+  an anchored full-ID glob, and `*` also matches `::`. Repeated includes are OR.
+  Excludes always win. With no includes, every non-excluded test is selected.
+
+PROFILES:
+  Profile names are case-sensitive. A profile is preset `baml test` argv, parsed
+  without shell expansion:
+
+    [test]
+    default = "regular"
+
+    [test.profiles.regular]
+    args = ["-x", "::integration::", "--color", "never"]
+
+  Profile includes establish the initial candidates; direct CLI includes narrow
+  them. Excludes accumulate and always win. Direct scalar options override
+  profile scalar options. Profile args cannot contain --profile, --no-profile,
+  --project, --directory, --from, or --help. With no default profile, all tests
+  are selected.
+
+Examples:
+  List available tests:
+    baml test --list
+
+  Run tests in the payments namespace:
+    baml test -i "root.payments::*"
+
+  Run integration tests except slow tests:
+    baml test -i "*::integration::*" -x "slow""#)]
 pub struct TestArgs {
-    #[arg(long, help = "Project search starting point", value_name = "PATH")]
+    #[command(flatten)]
+    pub compiler: crate::commands::CompilerArgs,
+
+    #[arg(long, value_name = "PATH", hide = true)]
     pub from: Option<PathBuf>,
 
-    /// Use a named test profile from `[test.profiles.<name>]` in `baml.toml`.
+    /// Apply a named test profile from `baml.toml`.
+    ///
     /// Profile arguments establish the initial test set; command-line filters
     /// further narrow it.
-    #[arg(long, value_name = "NAME", conflicts_with = "no_profile")]
+    #[arg(
+        long,
+        value_name = "NAME",
+        conflicts_with = "no_profile",
+        help_heading = "Profile options"
+    )]
     profile: Option<String>,
 
     /// Do not apply the default profile configured in `baml.toml`.
-    #[arg(long, default_value_t = false, conflicts_with = "profile")]
+    #[arg(
+        long,
+        default_value_t = false,
+        conflicts_with = "profile",
+        help_heading = "Profile options"
+    )]
     no_profile: bool,
 
-    /// List the selected tests instead of running them. The
-    /// canonical id shown on each line is a valid -i / -x selector.
-    #[arg(long, default_value_t = false)]
+    /// List selected test IDs instead of running them.
+    ///
+    /// Each canonical ID is valid as an `--include` or `--exclude` selector.
+    #[arg(long, default_value_t = false, help_heading = "Selection options")]
     list: bool,
 
-    #[arg(long, short = 'i')]
-    /// Canonical test-id selectors to include. Plain values match anywhere in
-    /// the full id. Values containing `*` are anchored globs, where `*` matches
-    /// any sequence, including `::`.
-    ///
-    /// Test ids start with `root` (the current package), use `.` for BAML
-    /// namespaces/function ownership, and `::` for testset/test nesting.
-    ///
-    /// Examples:
-    ///
-    /// -i "root.payments::*"  every test in the payments namespace
-    ///
-    /// -i "*::integration::*"  every test nested under an integration testset
-    ///
-    /// -i "hello"  any canonical id containing hello
+    #[arg(long, short = 'i', help_heading = "Selection options")]
+    /// Include tests matching a canonical-ID selector. Repeatable.
     pub include: Vec<String>,
 
-    #[arg(long, short = 'x')]
-    /// Tests (or whole testsets) to exclude. Takes precedence over --include.
-    ///
-    /// Uses the same canonical-id selector syntax as --include.
+    #[arg(long, short = 'x', help_heading = "Selection options")]
+    /// Exclude tests matching a selector. Exclusions take precedence.
     pub exclude: Vec<String>,
 
     /// Explicit global output options, injected by the top-level parser so
@@ -76,16 +109,16 @@ pub struct TestArgs {
     #[arg(skip)]
     pub(crate) cli_output: TestOutputOverrides,
 
-    /// Print BAML `log.*` events to stdout at or above this level.
-    ///
-    /// Logs are off by default. Because logs use stdout, callers can retain
-    /// the raw stream with `baml test --logs INFO > baml-test.log`.
     #[arg(
         long,
         value_enum,
         default_value_t = TestLogLevel::Off,
         ignore_case = true,
-        value_name = "LEVEL"
+        value_name = "LEVEL",
+        help = "Set the BAML log level [default: off] [possible values: off, error, warn, info, debug]",
+        hide_default_value = true,
+        hide_possible_values = true,
+        help_heading = "Test output options"
     )]
     pub logs: TestLogLevel,
 
@@ -813,12 +846,20 @@ impl TestArgs {
         for token in tokens {
             let bootstrap = matches!(
                 token.as_str(),
-                "--profile" | "--no-profile" | "--from" | "--help" | "-h"
+                "--profile"
+                    | "--no-profile"
+                    | "--project"
+                    | "--directory"
+                    | "--from"
+                    | "--help"
+                    | "-h"
             ) || token.starts_with("--profile=")
+                || token.starts_with("--project=")
+                || token.starts_with("--directory=")
                 || token.starts_with("--from=");
             if bootstrap {
                 anyhow::bail!(
-                    "invalid argument `{token}` in test profile `{name}`: profile args cannot contain --profile, --no-profile, --from, or --help"
+                    "invalid argument `{token}` in test profile `{name}`: profile args cannot contain --profile, --no-profile, --project, --directory, --from, or --help"
                 );
             }
         }

--- a/baml_language/crates/baml_cli/tests/agent_install_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/agent_install_e2e.rs
@@ -95,7 +95,7 @@ fn spawn_stub_codeload(archive: Vec<u8>) -> String {
 fn install_command(server: &str, home: &std::path::Path, dir: &std::path::Path) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_baml-cli"));
     command
-        .args(["agent", "install", "--dir"])
+        .args(["agent", "install", "--project"])
         .arg(dir)
         .env("BAML_HOME", home)
         .env(
@@ -258,7 +258,7 @@ fn headerless_archive_installs_without_provenance() {
 }
 
 #[test]
-fn unreachable_archive_fails_with_from_hint() {
+fn unreachable_archive_fails_with_source_hint() {
     let server = spawn_stub_codeload(skill_archive(Some(COMMIT)));
     let home = tempfile::tempdir().unwrap();
     let project = tempfile::tempdir().unwrap();
@@ -271,5 +271,5 @@ fn unreachable_archive_fails_with_from_hint() {
     let output = command.output().unwrap();
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("--from"), "{stderr}");
+    assert!(stderr.contains("--source"), "{stderr}");
 }

--- a/baml_language/crates/baml_exec/src/clap_target.rs
+++ b/baml_language/crates/baml_exec/src/clap_target.rs
@@ -47,16 +47,13 @@ fn leak(s: String) -> &'static str {
 /// depend on `baml_cli` — get the same look as the dev CLI.
 pub const CLAP_STYLING: styling::Styles = {
     use clap::builder::styling::{AnsiColor, Color, Effects, RgbColor, Style, Styles};
-    const PURPLE: Color = Color::Rgb(RgbColor(0xA8, 0x55, 0xF7));
-    // Tonal pair — same hue family, pale (Tailwind purple-200). Used on
-    // `<placeholders>` so they read as quiet secondary text against the
-    // bold primary purple without washing out into background gray.
-    const PURPLE_LIGHT: Color = Color::Rgb(RgbColor(0xE9, 0xD5, 0xFF));
+    const ACCENT: Color = Color::Rgb(RgbColor(0xA8, 0x55, 0xF7));
+    const PLACEHOLDER: Color = Color::Ansi(AnsiColor::Magenta);
     Styles::styled()
-        .header(Style::new().fg_color(Some(PURPLE)).effects(Effects::BOLD))
-        .usage(Style::new().fg_color(Some(PURPLE)).effects(Effects::BOLD))
+        .header(Style::new().fg_color(Some(ACCENT)).effects(Effects::BOLD))
+        .usage(Style::new().fg_color(Some(ACCENT)).effects(Effects::BOLD))
         .literal(Style::new().effects(Effects::BOLD))
-        .placeholder(Style::new().fg_color(Some(PURPLE_LIGHT)))
+        .placeholder(Style::new().fg_color(Some(PLACEHOLDER)))
         .error(
             Style::new()
                 .fg_color(Some(Color::Ansi(AnsiColor::Red)))
@@ -612,6 +609,27 @@ mod tests {
         let info = func_info(&["text"], vec![ty_string()], vec![false], ty_string());
         let err = parse_target_argv("./Test", "user.Test", &info, &["--help".into()]).unwrap_err();
         assert_eq!(err.kind(), clap::error::ErrorKind::DisplayHelp);
+    }
+
+    #[test]
+    fn clap_help_uses_brand_accent_and_terminal_placeholders() {
+        let info = func_info(&["text"], vec![ty_string()], vec![false], ty_string());
+        let mut command = build_target_command("./Test", "user.Test", &info);
+        let ansi = command.render_long_help().ansi().to_string();
+
+        assert!(
+            ansi.contains("\x1b[38;2;168;85;247m"),
+            "missing brand accent: {ansi:?}"
+        );
+        assert!(
+            ansi.contains("\x1b[35m"),
+            "missing terminal magenta placeholder: {ansi:?}"
+        );
+        assert!(
+            !ansi.contains("\x1b[38;2;233;213;255m"),
+            "fixed pale placeholder in: {ansi:?}"
+        );
+        assert!(!ansi.contains("\x1b[38;5;"), "fixed 256-color in: {ansi:?}");
     }
 
     // ── Defaulted parameters ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

- align baml-cli command and option naming with Cargo and uv conventions, including global project and output controls with compatibility aliases
- add concise root help plus styled detailed help with labeled examples for every public command
- keep help pager-free for agent and PTY safety, and compact enum and feature documentation
- use BAML purple for headings and terminal-controlled magenta for value placeholders

## Testing

- cargo test -p baml_exec
- cargo test -p baml_cli
- cargo clippy -p baml_cli -p baml_exec --all-targets -- -D warnings
- cargo fmt --all -- --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated `baml help` command with concise/detailed output and improved “unknown command” suggestions.
  * Added `--include-generated` to `baml run`.
  * Added `--no-progress` to disable progress output.

* **Improvements**
  * Standardized project selection on `--project`; legacy `--from` remains hidden as an alias.
  * Updated workflows to clearer flags: `agent install` now uses `--source`, and editor install now uses `--output-dir`.
  * Improved `--file` vs project handling and updated/expanded help examples across many commands.

* **Documentation**
  * Refreshed examples for `baml check` and `baml playground` to match the new flag usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->