### PR TITLE
fix(ci): pin Ruff before 0.16 rule expansion

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -52,7 +52,7 @@ runs:
           uv sync --dev
 
           # Install ruff as a global tool so it's available in PATH
-          uv tool install ruff
+          uv tool install ruff==0.15.22
 
           cd - > /dev/null
           echo "Python dependencies installed successfully"

--- a/mise.toml
+++ b/mise.toml
@@ -40,7 +40,7 @@ protoc = "27.1"
 "spm:apple/swift-protobuf" = "1.38.1"
 
 # Python tools
-"pipx:ruff" = "latest"
+"pipx:ruff" = "0.15.22"
 "pipx:maturin" = "latest"
 
 # Node tools


### PR DESCRIPTION
## Summary

- pin Ruff to 0.15.22 in `mise.toml`
- install the same pinned Ruff version in the shared CI Python setup action

## Root cause

Ruff 0.16.0 expanded its default lint behavior and began rejecting generated Python fixtures with unsafe-fix-only B006 and C405 findings. The daily `canary` BAML Runtime workflow has failed in `tests (rust-unit)` since Ruff 0.16.0 replaced 0.15.22 on July 24; the last green daily run installed 0.15.22.

This surfaced while babysitting [#4266](https://github.com/BoundaryML/baml/pull/4266), which has already merged.

## Validation

- `mise install pipx:ruff`
- `mise exec -- ruff --version` → `ruff 0.15.22`
- `cargo test -p generators-python --lib` with the repository mise environment → 169 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the Ruff tool to version 0.15.22 for consistent development and integration environments.
  * No user-facing functionality or configuration behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->