### PR TITLE
fix(playground): improve default argument inputs

### DIFF
--- a/baml_language/crates/baml_project/src/param_schema.rs
+++ b/baml_language/crates/baml_project/src/param_schema.rs
@@ -849,7 +849,7 @@ function Plain(x: int) -> int { x }
         );
     }
 
-    /// Pins the exact wire bytes of `params` + `types` against the golden
+    /// Pins the exact wire shape of `params` + `types` against the golden
     /// fixture that the TS side (`param-schema-golden.test.ts` in
     /// pkg-playground) validates against its `worker-protocol.ts` mirror —
     /// the FQN and shape contracts are otherwise enforced only by convention.
@@ -873,21 +873,19 @@ function Plain(x: int) -> int { x }
             "#,
         )]);
         let listing = list_functions_with_metadata(&db);
-        let actual = serde_json::to_string_pretty(&serde_json::json!({
+        let actual = serde_json::json!({
             "params": params_json(&listing, "Golden"),
             "types": types_json(&listing),
-        }))
-        .unwrap();
-        let golden = include_str!(
+        });
+        let golden: serde_json::Value = serde_json::from_str(include_str!(
             "../../../../typescript2/pkg-playground/src/__fixtures__/param-schema-golden.json"
-        );
-        // .gitattributes pins the fixture to LF, but stale Windows checkouts
-        // (attribute added after the file) may still hold CRLF — normalize.
-        let golden = golden.replace("\r\n", "\n");
+        ))
+        .expect("golden fixture should contain valid JSON");
         assert_eq!(
             actual,
-            golden.trim_end(),
-            "wire shape drifted from the golden fixture; actual:\n{actual}"
+            golden,
+            "wire shape drifted from the golden fixture; actual:\n{}",
+            serde_json::to_string_pretty(&actual).unwrap()
         );
     }
 

--- a/baml_language/crates/baml_project/src/param_schema.rs
+++ b/baml_language/crates/baml_project/src/param_schema.rs
@@ -19,7 +19,7 @@
 
 use std::collections::BTreeMap;
 
-use baml_compiler2_hir::package::PackageId;
+use baml_compiler2_hir::{loc::FunctionLoc, package::PackageId};
 use baml_compiler2_tir::{
     package_interface::{ExportedType, PackageInterface, package_interface},
     ty::{FunctionParamMode, LiteralValue, QualifiedTypeName, Ty},
@@ -53,6 +53,9 @@ pub struct ParamSchema {
     /// ([`FunctionParamMode::Optional`]). Distinct from a nullable type, which
     /// shows up as [`FieldSchema::Optional`] in `schema`.
     pub has_default: bool,
+    /// The exact, unevaluated source text of the parameter's default expression.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_expression: Option<String>,
     pub schema: FieldSchema,
 }
 
@@ -135,6 +138,7 @@ pub enum FieldSchema {
 /// `Some(vec![])` ("takes no arguments").
 pub(crate) fn function_param_schemas(
     db: &ProjectDatabase,
+    function: FunctionLoc<'_>,
     iface: &PackageInterface,
     namespace_path: &[Name],
     name: &Name,
@@ -159,6 +163,8 @@ pub(crate) fn function_param_schemas(
         user_iface: iface,
         table,
     };
+    let parameter_defaults = baml_compiler2_ppir::function_parameter_defaults(db, function);
+    let source = function.file(db).text(db);
     let params = params
         .iter()
         .enumerate()
@@ -168,6 +174,13 @@ pub(crate) fn function_param_schemas(
                 .as_ref()
                 .map_or_else(|| format!("arg{i}"), ToString::to_string),
             has_default: matches!(param.mode, FunctionParamMode::Optional),
+            default_expression: parameter_defaults.param_default(i).map(|default_ref| {
+                let range = parameter_defaults
+                    .defaults
+                    .source_map
+                    .expr_span(default_ref.expr.expr());
+                source[usize::from(range.start())..usize::from(range.end())].to_owned()
+            }),
             schema: cx.field_schema(&param.ty, 0),
         })
         .collect();
@@ -786,11 +799,15 @@ mod tests {
 
     #[test]
     fn param_with_default_sets_has_default() {
-        let db = db_with(&[("main.baml", "function Def(x: int, y: int = 3) -> int { 1 }")]);
+        let db = db_with(&[(
+            "main.baml",
+            "function pair(a: int, b: int) -> int { a + b }\nfunction Def(x: int, y: int = pair(b = 2, a = 1)) -> int { 1 }",
+        )]);
         let listing = list_functions_with_metadata(&db);
         let params = params_json(&listing, "Def");
         assert_eq!(params[0]["hasDefault"], false);
         assert_eq!(params[1]["hasDefault"], true);
+        assert_eq!(params[1]["defaultExpression"], "pair(b = 2, a = 1)");
         assert_eq!(params[1]["schema"], json!({ "type": "int" }));
     }
 

--- a/baml_language/crates/baml_project/src/symbols.rs
+++ b/baml_language/crates/baml_project/src/symbols.rs
@@ -136,6 +136,7 @@ pub fn list_functions_with_metadata(db: &ProjectDatabase) -> FunctionListing {
                 } else {
                     param_schema::function_param_schemas(
                         db,
+                        *func_loc,
                         iface,
                         namespace_path,
                         name,

--- a/baml_language/crates/bridge_wasm/src/wasm_playground.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_playground.rs
@@ -27,6 +27,8 @@ pub struct FunctionInfo {
 pub struct ParamSchema {
     pub name: String,
     pub has_default: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_expression: Option<String>,
     pub schema: FieldSchema,
 }
 
@@ -99,6 +101,7 @@ impl From<bex_project::ParamSchema> for ParamSchema {
         ParamSchema {
             name: p.name,
             has_default: p.has_default,
+            default_expression: p.default_expression,
             schema: p.schema.into(),
         }
     }
@@ -489,6 +492,7 @@ mod tests {
         let src = SrcParam {
             name: "p".to_string(),
             has_default: true,
+            default_expression: Some("constants.DEFAULT".to_string()),
             schema: Src::Union {
                 variants: vec![
                     Src::String,

--- a/typescript2/pkg-playground/src/ArgsForm.tsx
+++ b/typescript2/pkg-playground/src/ArgsForm.tsx
@@ -16,7 +16,7 @@
  * degrade to a per-field raw-JSON textarea.
  */
 
-import { ChevronRight, Plus, Trash2 } from 'lucide-react';
+import { ChevronRight, Plus, SquarePen, Trash2 } from 'lucide-react';
 import {
   createContext,
   type FC,
@@ -123,7 +123,7 @@ export const ArgsForm: FC<ArgsFormProps> = ({
   }
   return (
     <TypeLookupContext.Provider value={lookup}>
-      <div className="flex flex-col gap-1.5">
+      <div className="grid grid-cols-[minmax(8rem,max-content)_minmax(0,1fr)] items-start gap-x-2 gap-y-1.5">
         {params.map((param) => (
           <ParamRow
             key={param.name}
@@ -148,7 +148,7 @@ const FieldLabel: FC<{
   schema: FieldSchema;
   extra?: ReactNode;
 }> = ({ name, schema, extra }) => (
-  <div className="flex items-center gap-1.5">
+  <div className="flex min-h-7 items-center gap-1.5">
     <span className="font-vsc-mono text-xs text-foreground">{name}</span>
     <span className="font-vsc-mono text-[10px] text-vsc-text-faint">
       {schemaLabel(schema)}
@@ -171,26 +171,33 @@ const ParamRow: FC<{
     param.defaultExpression !== undefined &&
     !rendersDefaultPlaceholder(param.schema, lookup);
   return (
-    <div className="flex flex-col gap-0.5">
+    <div className="contents">
       <FieldLabel
         extra={
           param.hasDefault && (
-            <label
-              className="flex items-center gap-1 text-[10px] text-vsc-description"
-              htmlFor={`override-${param.name}`}
+            <Button
+              aria-label={
+                omitted
+                  ? `Set explicit value for ${param.name}`
+                  : `Use default value for ${param.name}`
+              }
+              aria-pressed={!omitted}
+              className="text-vsc-description aria-pressed:bg-accent aria-pressed:text-foreground"
+              onClick={() =>
+                omitted
+                  ? onChange(defaultValueForSchema(param.schema, lookup))
+                  : onOmit()
+              }
+              size="icon-xs"
+              title={
+                omitted
+                  ? `Set explicit value for ${param.name}`
+                  : `Use default value for ${param.name}`
+              }
+              variant="ghost"
             >
-              <Switch
-                aria-label={`Override ${param.name}`}
-                checked={!omitted}
-                id={`override-${param.name}`}
-                onCheckedChange={(on) =>
-                  on
-                    ? onChange(defaultValueForSchema(param.schema, lookup))
-                    : onOmit()
-                }
-              />
-              override
-            </label>
+              <SquarePen aria-hidden="true" />
+            </Button>
           )
         }
         name={param.name}

--- a/typescript2/pkg-playground/src/ArgsForm.tsx
+++ b/typescript2/pkg-playground/src/ArgsForm.tsx
@@ -136,9 +136,13 @@ const ParamRow: FC<{
         schema={param.schema}
         extra={
           param.hasDefault && (
-            <label className="ml-auto flex items-center gap-1 text-[10px] text-vsc-description">
-              set
+            <label
+              className="flex items-center gap-1 text-[10px] text-vsc-description"
+              htmlFor={`override-${param.name}`}
+            >
               <Switch
+                id={`override-${param.name}`}
+                aria-label={`Override ${param.name}`}
                 checked={!omitted}
                 onCheckedChange={(on) =>
                   on
@@ -146,22 +150,24 @@ const ParamRow: FC<{
                     : onOmit()
                 }
               />
+              override
             </label>
           )
         }
       />
-      {omitted ? (
-        <div className="text-[10px] text-vsc-text-faint pl-0.5">
-          omitted — uses the declared default
-        </div>
-      ) : (
+      <fieldset
+        className="m-0 min-w-0 border-0 p-0 disabled:opacity-60"
+        disabled={omitted}
+      >
         <FieldInput
           schema={param.schema}
           value={value}
           onChange={onChange}
           depth={0}
+          disabled={omitted}
+          placeholder={param.defaultExpression}
         />
-      )}
+      </fieldset>
     </div>
   );
 };
@@ -171,6 +177,10 @@ interface FieldInputProps {
   value: unknown;
   onChange: (v: unknown) => void;
   depth: number;
+  /** Whether this field is inside a disabled default-argument control. */
+  disabled?: boolean;
+  /** Placeholder for a top-level declared default expression. */
+  placeholder?: string;
   /** Ref names already unwrapped without descending into a child value —
    *  guards self-referential alias schemas (`type A = A | int` compiles
    *  clean) from recursing the render unboundedly. Same-value hops
@@ -272,11 +282,15 @@ function useDraft(canonical: string) {
   return [draft, setDraft] as const;
 }
 
-const StringField: FC<FieldInputProps> = ({ value, onChange }) => (
+const StringField: FC<FieldInputProps> = ({
+  value,
+  onChange,
+  placeholder = 'text',
+}) => (
   <Input
     className="h-7 text-xs font-vsc-mono"
     value={typeof value === 'string' ? value : ''}
-    placeholder="text"
+    placeholder={placeholder}
     onChange={(e) => onChange(e.target.value)}
   />
 );
@@ -285,6 +299,8 @@ const NumberField: FC<FieldInputProps & { integer?: boolean }> = ({
   value,
   onChange,
   integer,
+  disabled,
+  placeholder,
 }) => {
   const canonical =
     typeof value === 'number' || typeof value === 'bigint'
@@ -307,8 +323,8 @@ const NumberField: FC<FieldInputProps & { integer?: boolean }> = ({
       className="h-7 text-xs font-vsc-mono"
       inputMode={integer ? 'numeric' : 'decimal'}
       value={draft}
-      placeholder={integer ? '0' : '0.0'}
-      aria-invalid={parse(draft) === null}
+      placeholder={placeholder ?? (integer ? '0' : '0.0')}
+      aria-invalid={!disabled && parse(draft) === null}
       onChange={(e) => {
         setDraft(e.target.value);
         const num = parse(e.target.value);
@@ -537,7 +553,7 @@ const MapField: FC<
 
 const OptionalField: FC<
   FieldInputProps & { schema: Extract<FieldSchema, { type: 'optional' }> }
-> = ({ schema, value, onChange, depth, refPath }) => {
+> = ({ schema, value, onChange, depth, refPath, placeholder }) => {
   const lookup = useContext(TypeLookupContext);
   const isSet = value !== null && value !== undefined;
   return (
@@ -558,6 +574,7 @@ const OptionalField: FC<
           onChange={onChange}
           depth={depth}
           refPath={refPath}
+          placeholder={placeholder}
         />
       )}
     </div>
@@ -566,7 +583,7 @@ const OptionalField: FC<
 
 const UnionField: FC<
   FieldInputProps & { schema: Extract<FieldSchema, { type: 'union' }> }
-> = ({ schema, value, onChange, depth, refPath }) => {
+> = ({ schema, value, onChange, depth, refPath, placeholder }) => {
   const lookup = useContext(TypeLookupContext);
   const detected = activeUnionVariant(value, schema.variants, lookup);
   const [chosen, setChosen] = useState(0);
@@ -603,6 +620,7 @@ const UnionField: FC<
           onChange={onChange}
           depth={depth}
           refPath={refPath}
+          placeholder={placeholder}
         />
       )}
     </div>
@@ -614,7 +632,13 @@ const UnionField: FC<
  *  draft is an error state, not a deletion — the last committed value stays
  *  in place (so e.g. emptying a map value doesn't delete the row) and the
  *  invalid style flags the draft. */
-const RawJsonField: FC<FieldInputProps> = ({ schema, value, onChange }) => {
+const RawJsonField: FC<FieldInputProps> = ({
+  schema,
+  value,
+  onChange,
+  disabled,
+  placeholder,
+}) => {
   const canonical = value === undefined ? '' : JSON.stringify(value);
   const [draft, setDraft] = useDraft(canonical);
   const parse = (text: string): { ok: true; value: unknown } | { ok: false } => {
@@ -630,8 +654,8 @@ const RawJsonField: FC<FieldInputProps> = ({ schema, value, onChange }) => {
       className="min-h-[28px] px-2 py-1 font-vsc-mono text-xs resize-y"
       rows={1}
       value={draft}
-      placeholder={`JSON (${schemaLabel(schema)})`}
-      aria-invalid={!parse(draft).ok}
+      placeholder={placeholder ?? `JSON (${schemaLabel(schema)})`}
+      aria-invalid={!disabled && !parse(draft).ok}
       onChange={(e) => {
         setDraft(e.target.value);
         const parsed = parse(e.target.value);

--- a/typescript2/pkg-playground/src/ArgsForm.tsx
+++ b/typescript2/pkg-playground/src/ArgsForm.tsx
@@ -65,6 +65,39 @@ const AUTO_COLLAPSE_DEPTH = 2;
 
 const TypeLookupContext = createContext<TypeLookup>(() => undefined);
 
+/** Whether the rendered widget exposes a native text placeholder. */
+function rendersDefaultPlaceholder(
+  schema: FieldSchema,
+  lookup: TypeLookup,
+  refPath: readonly string[] = [],
+): boolean {
+  if (isRawJsonSchema(schema, lookup)) return true;
+  switch (schema.type) {
+    case 'string':
+    case 'int':
+    case 'bigint':
+    case 'float':
+      return true;
+    case 'ref': {
+      if (refPath.includes(schema.name)) return true;
+      const resolved = resolveRef(schema.name, lookup);
+      return resolved?.kind === 'schema'
+        ? rendersDefaultPlaceholder(resolved.schema, lookup, [
+            ...refPath,
+            schema.name,
+          ])
+        : false;
+    }
+    case 'union':
+      return (
+        schema.variants[0] !== undefined &&
+        rendersDefaultPlaceholder(schema.variants[0], lookup, refPath)
+      );
+    default:
+      return false;
+  }
+}
+
 export interface ArgsFormProps {
   params: ParamSchema[];
   /** Per-project named-type table the schemas' refs resolve against. */
@@ -133,6 +166,10 @@ const ParamRow: FC<{
 }> = ({ param, value, present, onChange, onOmit }) => {
   const lookup = useContext(TypeLookupContext);
   const omitted = param.hasDefault && !present;
+  const showDefaultHint =
+    omitted &&
+    param.defaultExpression !== undefined &&
+    !rendersDefaultPlaceholder(param.schema, lookup);
   return (
     <div className="flex flex-col gap-0.5">
       <FieldLabel
@@ -171,6 +208,11 @@ const ParamRow: FC<{
           schema={param.schema}
           value={value}
         />
+        {showDefaultHint && (
+          <div className="mt-0.5 font-vsc-mono text-[10px] text-vsc-description">
+            default: {param.defaultExpression}
+          </div>
+        )}
       </fieldset>
     </div>
   );

--- a/typescript2/pkg-playground/src/ArgsForm.tsx
+++ b/typescript2/pkg-playground/src/ArgsForm.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/style/useFilenamingConvention: Preserve the existing public component filename.
 /**
  * Dynamic args form for the Run tab.
  *
@@ -15,15 +16,15 @@
  * degrade to a per-field raw-JSON textarea.
  */
 
+import { ChevronRight, Plus, Trash2 } from 'lucide-react';
 import {
   createContext,
+  type FC,
+  type ReactNode,
   useContext,
   useMemo,
   useState,
-  type FC,
-  type ReactNode,
 } from 'react';
-import { ChevronRight, Plus, Trash2 } from 'lucide-react';
 
 import {
   activeUnionVariant,
@@ -34,9 +35,9 @@ import {
   isRawJsonSchema,
   resolveRef,
   schemaLabel,
+  type TypeLookup,
   typeLookupFrom,
   valueMatchesSchema,
-  type TypeLookup,
 } from './args-form-model';
 import { Button } from './components/ui/button';
 import {
@@ -93,14 +94,14 @@ export const ArgsForm: FC<ArgsFormProps> = ({
         {params.map((param) => (
           <ParamRow
             key={param.name}
-            param={param}
-            value={value[param.name]}
-            present={param.name in value}
             onChange={(v) => onChange({ ...value, [param.name]: v })}
             onOmit={() => {
               const { [param.name]: _omitted, ...rest } = value;
               onChange(rest);
             }}
+            param={param}
+            present={param.name in value}
+            value={value[param.name]}
           />
         ))}
       </div>
@@ -109,16 +110,19 @@ export const ArgsForm: FC<ArgsFormProps> = ({
 };
 
 /** Shared field header: name plus a faint type label. */
-const FieldLabel: FC<{ name: string; schema: FieldSchema; extra?: ReactNode }> =
-  ({ name, schema, extra }) => (
-    <div className="flex items-center gap-1.5">
-      <span className="font-vsc-mono text-xs text-foreground">{name}</span>
-      <span className="font-vsc-mono text-[10px] text-vsc-text-faint">
-        {schemaLabel(schema)}
-      </span>
-      {extra}
-    </div>
-  );
+const FieldLabel: FC<{
+  name: string;
+  schema: FieldSchema;
+  extra?: ReactNode;
+}> = ({ name, schema, extra }) => (
+  <div className="flex items-center gap-1.5">
+    <span className="font-vsc-mono text-xs text-foreground">{name}</span>
+    <span className="font-vsc-mono text-[10px] text-vsc-text-faint">
+      {schemaLabel(schema)}
+    </span>
+    {extra}
+  </div>
+);
 
 const ParamRow: FC<{
   param: ParamSchema;
@@ -132,8 +136,6 @@ const ParamRow: FC<{
   return (
     <div className="flex flex-col gap-0.5">
       <FieldLabel
-        name={param.name}
-        schema={param.schema}
         extra={
           param.hasDefault && (
             <label
@@ -141,9 +143,9 @@ const ParamRow: FC<{
               htmlFor={`override-${param.name}`}
             >
               <Switch
-                id={`override-${param.name}`}
                 aria-label={`Override ${param.name}`}
                 checked={!omitted}
+                id={`override-${param.name}`}
                 onCheckedChange={(on) =>
                   on
                     ? onChange(defaultValueForSchema(param.schema, lookup))
@@ -154,18 +156,20 @@ const ParamRow: FC<{
             </label>
           )
         }
+        name={param.name}
+        schema={param.schema}
       />
       <fieldset
         className="m-0 min-w-0 border-0 p-0 disabled:opacity-60"
         disabled={omitted}
       >
         <FieldInput
-          schema={param.schema}
-          value={value}
-          onChange={onChange}
           depth={0}
           disabled={omitted}
+          onChange={onChange}
           placeholder={param.defaultExpression}
+          schema={param.schema}
+          value={value}
         />
       </fieldset>
     </div>
@@ -209,7 +213,9 @@ const FieldInput: FC<FieldInputProps> = (props) => {
     case 'bool':
       return <BoolField {...props} />;
     case 'null':
-      return <span className="font-vsc-mono text-xs text-vsc-text-faint">null</span>;
+      return (
+        <span className="font-vsc-mono text-xs text-vsc-text-faint">null</span>
+      );
     case 'literal':
       return (
         <span className="font-vsc-mono text-xs text-vsc-description">
@@ -218,11 +224,7 @@ const FieldInput: FC<FieldInputProps> = (props) => {
       );
     case 'enumVariant':
       return (
-        <EnumField
-          {...props}
-          enumName={schema.name}
-          values={[schema.value]}
-        />
+        <EnumField {...props} enumName={schema.name} values={[schema.value]} />
       );
     case 'ref': {
       // isRawJsonSchema handled dangling refs above, so this resolves.
@@ -244,16 +246,16 @@ const FieldInput: FC<FieldInputProps> = (props) => {
         return (
           <FieldInput
             {...props}
-            schema={resolved.schema}
             refPath={[...refPath, schema.name]}
+            schema={resolved.schema}
           />
         );
       }
       return (
         <ClassSection
           {...props}
-          typeName={resolved.name}
           fields={resolved.fields}
+          typeName={resolved.name}
         />
       );
     }
@@ -289,9 +291,9 @@ const StringField: FC<FieldInputProps> = ({
 }) => (
   <Input
     className="h-7 text-xs font-vsc-mono"
-    value={typeof value === 'string' ? value : ''}
-    placeholder={placeholder}
     onChange={(e) => onChange(e.target.value)}
+    placeholder={placeholder}
+    value={typeof value === 'string' ? value : ''}
   />
 );
 
@@ -303,9 +305,7 @@ const NumberField: FC<FieldInputProps & { integer?: boolean }> = ({
   placeholder,
 }) => {
   const canonical =
-    typeof value === 'number' || typeof value === 'bigint'
-      ? String(value)
-      : '';
+    typeof value === 'number' || typeof value === 'bigint' ? String(value) : '';
   const [draft, setDraft] = useDraft(canonical);
   const parse = (text: string): number | null => {
     const trimmed = text.trim();
@@ -320,16 +320,16 @@ const NumberField: FC<FieldInputProps & { integer?: boolean }> = ({
   // of argsJson.
   return (
     <Input
+      aria-invalid={!disabled && parse(draft) === null}
       className="h-7 text-xs font-vsc-mono"
       inputMode={integer ? 'numeric' : 'decimal'}
-      value={draft}
-      placeholder={placeholder ?? (integer ? '0' : '0.0')}
-      aria-invalid={!disabled && parse(draft) === null}
       onChange={(e) => {
         setDraft(e.target.value);
         const num = parse(e.target.value);
         if (num !== null) onChange(num);
       }}
+      placeholder={placeholder ?? (integer ? '0' : '0.0')}
+      value={draft}
     />
   );
 };
@@ -348,22 +348,22 @@ const EnumField: FC<
   if (values.length <= ENUM_TOGGLE_MAX) {
     return (
       <ToggleGroup
+        onValueChange={(v) => onChange(enumValue(enumName, v))}
+        options={values.map((v) => ({ label: v, value: v }))}
         size="sm"
         value={current ?? ''}
-        options={values.map((v) => ({ value: v, label: v }))}
-        onValueChange={(v) => onChange(enumValue(enumName, v))}
       />
     );
   }
   return (
     <div className="max-w-[240px]">
       <Select
-        value={current ?? ''}
         onChange={(e) => {
           // The empty value is the "select…" placeholder, not a variant.
           if (e.target.value === '') return;
           onChange(enumValue(enumName, e.target.value));
         }}
+        value={current ?? ''}
       >
         {current === undefined && <option value="">select…</option>}
         {values.map((v) => (
@@ -384,11 +384,11 @@ const ClassSection: FC<
   const setField = (name: string, v: unknown) =>
     onChange({ ...obj, $baml: { type: typeName }, [name]: v });
   return (
-    <Collapsible open={open} onOpenChange={setOpen}>
+    <Collapsible onOpenChange={setOpen} open={open}>
       <CollapsibleTrigger className="flex items-center gap-1 cursor-pointer text-xs text-vsc-description hover:text-foreground">
         <ChevronRight
-          size={12}
           className={cn('transition-transform', open && 'rotate-90')}
+          size={12}
         />
         <span className="font-vsc-mono">{schemaLabel(schema)}</span>
       </CollapsibleTrigger>
@@ -397,13 +397,13 @@ const ClassSection: FC<
       <CollapsibleContent>
         <div className="flex flex-col gap-1 border-l border-vsc-border ml-1.5 pl-2.5 pt-1">
           {fields.map((field) => (
-            <div key={field.name} className="flex flex-col gap-0.5">
+            <div className="flex flex-col gap-0.5" key={field.name}>
               <FieldLabel name={field.name} schema={field.schema} />
               <FieldInput
+                depth={depth + 1}
+                onChange={(v) => setField(field.name, v)}
                 schema={field.schema}
                 value={obj[field.name]}
-                onChange={(v) => setField(field.name, v)}
-                depth={depth + 1}
               />
             </div>
           ))}
@@ -421,35 +421,36 @@ const ListField: FC<
   return (
     <div className="flex flex-col gap-1">
       {items.map((item, i) => (
-        <div key={i} className="flex items-start gap-1">
+        // biome-ignore lint/suspicious/noArrayIndexKey: Argument list values do not have stable identities.
+        <div className="flex items-start gap-1" key={i}>
           <div className="flex-1 min-w-0">
             <FieldInput
-              schema={schema.item}
-              value={item}
+              depth={depth + 1}
               onChange={(v) =>
                 onChange(items.map((cur, j) => (j === i ? v : cur)))
               }
-              depth={depth + 1}
+              schema={schema.item}
+              value={item}
             />
           </div>
           <Button
-            variant="ghost"
-            size="icon-xs"
-            className="text-vsc-red shrink-0"
             aria-label="Remove item"
+            className="text-vsc-red shrink-0"
             onClick={() => onChange(items.filter((_, j) => j !== i))}
+            size="icon-xs"
+            variant="ghost"
           >
             <Trash2 />
           </Button>
         </div>
       ))}
       <Button
-        variant="ghost"
-        size="xs"
         className="self-start text-vsc-link"
         onClick={() =>
           onChange([...items, defaultValueForSchema(schema.item, lookup)])
         }
+        size="xs"
+        variant="ghost"
       >
         <Plus /> add item
       </Button>
@@ -467,10 +468,8 @@ const MapKeyInput: FC<{
   const collides = draft !== mapKey && siblingKeys.includes(draft);
   return (
     <Input
-      className="h-7 text-xs font-vsc-mono w-[130px] shrink-0"
-      value={draft}
-      placeholder="key"
       aria-invalid={collides}
+      className="h-7 text-xs font-vsc-mono w-[130px] shrink-0"
       onChange={(e) => {
         setDraft(e.target.value);
         if (
@@ -480,6 +479,8 @@ const MapKeyInput: FC<{
           onRename(e.target.value);
         }
       }}
+      placeholder="key"
+      value={draft}
     />
   );
 };
@@ -509,34 +510,33 @@ const MapField: FC<
   return (
     <div className="flex flex-col gap-1">
       {entries.map(([k, v], i) => (
-        <div key={i} className="flex items-start gap-1">
+        // biome-ignore lint/suspicious/noArrayIndexKey: Map keys are editable and cannot identify component state.
+        <div className="flex items-start gap-1" key={i}>
           <MapKeyInput
             mapKey={k}
-            siblingKeys={entries.map(([sk]) => sk)}
             onRename={(nk) => rebuild((e, j) => (j === i ? [nk, e[1]] : e))}
+            siblingKeys={entries.map(([sk]) => sk)}
           />
           <div className="flex-1 min-w-0">
             <FieldInput
+              depth={depth + 1}
+              onChange={(nv) => rebuild((e, j) => (j === i ? [e[0], nv] : e))}
               schema={schema.value}
               value={v}
-              onChange={(nv) => rebuild((e, j) => (j === i ? [e[0], nv] : e))}
-              depth={depth + 1}
             />
           </div>
           <Button
-            variant="ghost"
-            size="icon-xs"
-            className="text-vsc-red shrink-0"
             aria-label="Remove entry"
+            className="text-vsc-red shrink-0"
             onClick={() => rebuild((e, j) => (j === i ? null : e))}
+            size="icon-xs"
+            variant="ghost"
           >
             <Trash2 />
           </Button>
         </div>
       ))}
       <Button
-        variant="ghost"
-        size="xs"
         className="self-start text-vsc-link"
         onClick={() =>
           onChange({
@@ -544,6 +544,8 @@ const MapField: FC<
             [freshKey()]: defaultValueForSchema(schema.value, lookup),
           })
         }
+        size="xs"
+        variant="ghost"
       >
         <Plus /> add entry
       </Button>
@@ -558,7 +560,7 @@ const OptionalField: FC<
   const isSet = value !== null && value !== undefined;
   return (
     <div className="flex flex-col gap-1">
-      <label className="flex items-center gap-1.5 text-[10px] text-vsc-description">
+      <div className="flex items-center gap-1.5 text-[10px] text-vsc-description">
         <Switch
           checked={isSet}
           onCheckedChange={(on) =>
@@ -566,15 +568,15 @@ const OptionalField: FC<
           }
         />
         {isSet ? 'set' : 'null'}
-      </label>
+      </div>
       {isSet && (
         <FieldInput
+          depth={depth}
+          onChange={onChange}
+          placeholder={placeholder}
+          refPath={refPath}
           schema={schema.inner}
           value={value}
-          onChange={onChange}
-          depth={depth}
-          refPath={refPath}
-          placeholder={placeholder}
         />
       )}
     </div>
@@ -601,26 +603,26 @@ const UnionField: FC<
   return (
     <div className="flex flex-col gap-1">
       <ToggleGroup
-        size="sm"
-        value={String(active)}
-        options={schema.variants.map((v, i) => ({
-          value: String(i),
-          label: schemaLabel(v),
-        }))}
         onValueChange={(v) => {
           const index = Number(v);
           setChosen(index);
           onChange(defaultValueForSchema(schema.variants[index], lookup));
         }}
+        options={schema.variants.map((v, i) => ({
+          label: schemaLabel(v),
+          value: String(i),
+        }))}
+        size="sm"
+        value={String(active)}
       />
       {schema.variants[active] && (
         <FieldInput
+          depth={depth}
+          onChange={onChange}
+          placeholder={placeholder}
+          refPath={refPath}
           schema={schema.variants[active]}
           value={value}
-          onChange={onChange}
-          depth={depth}
-          refPath={refPath}
-          placeholder={placeholder}
         />
       )}
     </div>
@@ -641,7 +643,9 @@ const RawJsonField: FC<FieldInputProps> = ({
 }) => {
   const canonical = value === undefined ? '' : JSON.stringify(value);
   const [draft, setDraft] = useDraft(canonical);
-  const parse = (text: string): { ok: true; value: unknown } | { ok: false } => {
+  const parse = (
+    text: string,
+  ): { ok: true; value: unknown } | { ok: false } => {
     if (text.trim() === '') return { ok: false };
     try {
       return { ok: true, value: JSON.parse(text) };
@@ -651,16 +655,16 @@ const RawJsonField: FC<FieldInputProps> = ({
   };
   return (
     <Textarea
-      className="min-h-[28px] px-2 py-1 font-vsc-mono text-xs resize-y"
-      rows={1}
-      value={draft}
-      placeholder={placeholder ?? `JSON (${schemaLabel(schema)})`}
       aria-invalid={!disabled && !parse(draft).ok}
+      className="min-h-[28px] px-2 py-1 font-vsc-mono text-xs resize-y"
       onChange={(e) => {
         setDraft(e.target.value);
         const parsed = parse(e.target.value);
         if (parsed.ok) onChange(parsed.value);
       }}
+      placeholder={placeholder ?? `JSON (${schemaLabel(schema)})`}
+      rows={1}
+      value={draft}
     />
   );
 };

--- a/typescript2/pkg-playground/src/ArgsForm.tsx
+++ b/typescript2/pkg-playground/src/ArgsForm.tsx
@@ -50,6 +50,12 @@ import { Select } from './components/ui/select';
 import { Switch } from './components/ui/switch';
 import { Textarea } from './components/ui/textarea';
 import { ToggleGroup } from './components/ui/toggle-group';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './components/ui/tooltip';
 import { cn } from './lib/utils';
 import type {
   FieldSchema,
@@ -175,29 +181,35 @@ const ParamRow: FC<{
       <FieldLabel
         extra={
           param.hasDefault && (
-            <Button
-              aria-label={
-                omitted
-                  ? `Set explicit value for ${param.name}`
-                  : `Use default value for ${param.name}`
-              }
-              aria-pressed={!omitted}
-              className="text-vsc-description aria-pressed:bg-accent aria-pressed:text-foreground"
-              onClick={() =>
-                omitted
-                  ? onChange(defaultValueForSchema(param.schema, lookup))
-                  : onOmit()
-              }
-              size="icon-xs"
-              title={
-                omitted
-                  ? `Set explicit value for ${param.name}`
-                  : `Use default value for ${param.name}`
-              }
-              variant="ghost"
-            >
-              <SquarePen aria-hidden="true" />
-            </Button>
+            <div className="ml-auto flex items-center gap-1.5">
+              <TooltipProvider delayDuration={300}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <input
+                      aria-label={`Use an explicit value for ${param.name} instead of its default`}
+                      checked={!omitted}
+                      className="relative size-3.5 shrink-0 cursor-pointer appearance-none rounded-[3px] border border-vsc-description bg-background after:absolute after:inset-0 after:hidden after:place-items-center after:text-[10px] after:font-bold after:leading-none after:text-vsc-accent-fg after:content-['✓'] checked:border-vsc-accent checked:bg-vsc-accent checked:after:grid focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-vsc-accent/50"
+                      onChange={(event) =>
+                        event.currentTarget.checked
+                          ? onChange(
+                              defaultValueForSchema(param.schema, lookup),
+                            )
+                          : onOmit()
+                      }
+                      type="checkbox"
+                    />
+                  </TooltipTrigger>
+                  <TooltipContent className="max-w-72" side="top">
+                    Checked: send an explicitly provided value. Unchecked: use
+                    the argument&apos;s default value.
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              <SquarePen
+                aria-hidden="true"
+                className="size-3.5 shrink-0 text-vsc-description"
+              />
+            </div>
           )
         }
         name={param.name}

--- a/typescript2/pkg-playground/src/__fixtures__/param-schema-golden.json
+++ b/typescript2/pkg-playground/src/__fixtures__/param-schema-golden.json
@@ -82,6 +82,7 @@
     {
       "name": "x",
       "hasDefault": true,
+      "defaultExpression": "3",
       "schema": {
         "type": "int"
       }

--- a/typescript2/pkg-playground/src/__fixtures__/param-schema-golden.json
+++ b/typescript2/pkg-playground/src/__fixtures__/param-schema-golden.json
@@ -1,64 +1,64 @@
 {
   "params": [
     {
+      "hasDefault": false,
       "name": "p",
-      "hasDefault": false,
       "schema": {
-        "type": "ref",
-        "name": "user.Person"
+        "name": "user.Person",
+        "type": "ref"
       }
     },
     {
+      "hasDefault": false,
       "name": "c",
-      "hasDefault": false,
       "schema": {
-        "type": "ref",
-        "name": "user.Color"
+        "name": "user.Color",
+        "type": "ref"
       }
     },
     {
+      "hasDefault": false,
       "name": "j",
-      "hasDefault": false,
       "schema": {
-        "type": "ref",
-        "name": "user.JSON"
+        "name": "user.JSON",
+        "type": "ref"
       }
     },
     {
-      "name": "s",
       "hasDefault": false,
+      "name": "s",
       "schema": {
-        "type": "enumVariant",
         "name": "user.Status",
+        "type": "enumVariant",
         "value": "Active"
       }
     },
     {
-      "name": "l",
       "hasDefault": false,
+      "name": "l",
       "schema": {
-        "type": "list",
         "item": {
           "type": "string"
-        }
+        },
+        "type": "list"
       }
     },
     {
-      "name": "m",
       "hasDefault": false,
+      "name": "m",
       "schema": {
-        "type": "map",
         "key": {
           "type": "string"
         },
+        "type": "map",
         "value": {
           "type": "float"
         }
       }
     },
     {
-      "name": "u",
       "hasDefault": false,
+      "name": "u",
       "schema": {
         "type": "union",
         "variants": [
@@ -72,17 +72,17 @@
       }
     },
     {
-      "name": "i",
       "hasDefault": false,
+      "name": "i",
       "schema": {
-        "type": "media",
-        "kind": "image"
+        "kind": "image",
+        "type": "media"
       }
     },
     {
-      "name": "x",
-      "hasDefault": true,
       "defaultExpression": "3",
+      "hasDefault": true,
+      "name": "x",
       "schema": {
         "type": "int"
       }
@@ -91,11 +91,7 @@
   "types": {
     "user.Color": {
       "kind": "enum",
-      "values": [
-        "Red",
-        "Green",
-        "Blue"
-      ]
+      "values": ["Red", "Green", "Blue"]
     },
     "user.JSON": {
       "kind": "alias",
@@ -106,17 +102,16 @@
             "type": "string"
           },
           {
-            "type": "list",
             "item": {
-              "type": "ref",
-              "name": "user.JSON"
-            }
+              "name": "user.JSON",
+              "type": "ref"
+            },
+            "type": "list"
           }
         ]
       }
     },
     "user.Nested": {
-      "kind": "class",
       "fields": [
         {
           "name": "x",
@@ -124,10 +119,10 @@
             "type": "int"
           }
         }
-      ]
+      ],
+      "kind": "class"
     },
     "user.Person": {
-      "kind": "class",
       "fields": [
         {
           "name": "name",
@@ -138,27 +133,28 @@
         {
           "name": "age",
           "schema": {
-            "type": "optional",
             "inner": {
               "type": "int"
-            }
+            },
+            "type": "optional"
           }
         },
         {
           "name": "color",
           "schema": {
-            "type": "ref",
-            "name": "user.Color"
+            "name": "user.Color",
+            "type": "ref"
           }
         },
         {
           "name": "nested",
           "schema": {
-            "type": "ref",
-            "name": "user.Nested"
+            "name": "user.Nested",
+            "type": "ref"
           }
         }
-      ]
+      ],
+      "kind": "class"
     }
   }
 }

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -69,6 +69,8 @@ export interface ParamSchema {
    *  from a nullable type, which appears as `{ type: 'optional' }` in
    *  `schema`. */
   hasDefault: boolean;
+  /** Exact, unevaluated source text for the declared default expression. */
+  defaultExpression?: string;
   schema: FieldSchema;
 }
 

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -333,7 +333,11 @@ export type RunTarget =
   | { kind: 'function'; functionName: string }
   | { kind: 'test'; generation: number; testName: string }
   | { kind: 'preview'; parentFunctionName: string; helper: string }
-  | { kind: 'companion'; parentBoundaryId: BoundaryId | null; functionName: string }
+  | {
+      kind: 'companion';
+      parentBoundaryId: BoundaryId | null;
+      functionName: string;
+    }
   | { kind: 'internal'; name: string };
 
 export type RunVisibility =
@@ -396,7 +400,13 @@ export interface CallNode {
   parentId: string | null;
   functionId: number;
   functionName: string | null;
-  functionOrigin: 'user' | 'builtin' | 'companion' | 'internal' | 'unknown' | null;
+  functionOrigin:
+    | 'user'
+    | 'builtin'
+    | 'companion'
+    | 'internal'
+    | 'unknown'
+    | null;
   calleeSource: RunSourceLocation | null;
   callSiteSource: RunSourceLocation | null;
   startedAtNs: string | null;
@@ -635,7 +645,12 @@ export type WebSocketOutMessage =
   | { type: 'commandError'; requestId: number; code: string; message: string }
   | { type: 'runList'; requestId: number; runs: RunSummary[] }
   | { type: 'historyList'; requestId: number; runs: RunSummary[] }
-  | { type: 'runSnapshot'; requestId?: number; boundaryId: BoundaryId; snapshot: Run }
+  | {
+      type: 'runSnapshot';
+      requestId?: number;
+      boundaryId: BoundaryId;
+      snapshot: Run;
+    }
   | ({ type: 'valueBody' } & ValueBodyResponse)
   | {
       type: 'runCursorExpired';
@@ -790,7 +805,12 @@ export type WorkerOutMessage =
   | { type: 'commandError'; requestId: number; code: string; message: string }
   | { type: 'runList'; requestId: number; runs: RunSummary[] }
   | { type: 'historyList'; requestId: number; runs: RunSummary[] }
-  | { type: 'runSnapshot'; requestId?: number; boundaryId: BoundaryId; snapshot: Run }
+  | {
+      type: 'runSnapshot';
+      requestId?: number;
+      boundaryId: BoundaryId;
+      snapshot: Run;
+    }
   | ({ type: 'valueBody' } & ValueBodyResponse)
   | {
       type: 'runCursorExpired';


### PR DESCRIPTION
## Summary

- keep required and defaulted argument inputs aligned in a shared column to the right of their argument names
- use a checkbox to toggle between the declared default and an explicitly entered value, with hover help explaining both modes and a bare `SquarePen` icon beside the input
- carry the exact unevaluated default expression from the source map to the playground and display it as the disabled control placeholder

## Root cause

The typed args form represented a default only as `hasDefault`. When the argument was omitted, the form replaced its control with explanatory text, and no source expression was available for a useful placeholder.

## Playground UI

### Before

![Before: defaulted inputs are replaced by omission text](https://uploads.linear.app/17f201ee-07c9-4c00-bec2-4d5b8f1f17a7/0baf29dc-c5b0-4a3e-98b5-63b3bbdb7d35/253145e0-a0d4-4f8d-a486-3dd5a1fd405c?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzE3ZjIwMWVlLTA3YzktNGMwMC1iZWMyLTRkNWI4ZjFmMTdhNy8wYmFmMjlkYy1jNWIwLTRhM2UtOThiNS02M2IzYmJkYjdkMzUvMjUzMTQ1ZTAtYTBkNC00ZjhkLWE0ODYtM2RkNWExZmQ0MDVjIiwiaWF0IjoxNzg1MzAxNjI5LCJleHAiOjE3ODUzMDE5Mjl9.VkLHPiNxgryEYTIfemoQijaiKdwotJW3nIf0kZL5j3o)

### After

![After: checkbox toggles explicit values, SquarePen is decorative, and inputs align to the right](https://uploads.linear.app/17f201ee-07c9-4c00-bec2-4d5b8f1f17a7/40cef3e1-cee7-4e63-b4f4-8a54511bd342/efe4a3bd-9e9c-415d-868c-a3b42b3967bc?signature=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwYXRoIjoiLzE3ZjIwMWVlLTA3YzktNGMwMC1iZWMyLTRkNWI4ZjFmMTdhNy80MGNlZjNlMS1jZWU3LTRlNjMtYjRmNC04YTU0NTExYmQzNDIvZWZlNGEzYmQtOWU5Yy00MTVkLTg2OGMtYTNiNDJiMzk2N2JjIiwiaWF0IjoxNzg1MzAzMzMyLCJleHAiOjE3ODUzMDM2MzJ9.irKVPO4W3d1K1oJAE6-KiFY4TLW8S0LKJhV9gUotH2g)

## Validation

- `cargo test -p baml_project param_schema --lib` (22 passed)
- `cargo test -p bridge_wasm schema_twins_serialize_identically_to_source_types --lib`
- `pnpm --dir typescript2 format:ci --since=origin/canary`
- `pnpm --dir typescript2 --filter @b/pkg-playground typecheck`
- `pnpm --dir typescript2 --filter @b/pkg-playground test` (137 passed)
- browser validation of horizontal alignment, disabled exact-default placeholders, checkbox hover help, and explicit/default payload behavior

Linear: [B-1054](https://linear.app/boundaryml2/issue/B-1054/default-args-ui-is-unintuitive)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Parameter schemas now expose the exact source text for declared default values.
  - Playground forms clearly indicate when a parameter uses its default, with checkbox controls and tooltip guidance.
  - Inputs display helpful default-value placeholders and consistently support disabled states across field types.

- **Bug Fixes**
  - Improved parameter form rendering and validation behavior for optional, numeric, union, list, map, and JSON inputs.
  - Updated schema serialization to keep default-expression data consistent across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->