### PR TITLE
fix(playground): render node errors nicely

### DIFF
--- a/issue-overview.md
+++ b/issue-overview.md
@@ -19,4 +19,6 @@ Linear: https://linear.app/boundaryml2/issue/B-1055/error-nodes-in-graph-are-for
 - `pnpm --filter app-vscode-webview build` passed.
 - `pnpm --filter app-vscode-webview typecheck` remains blocked by the worktree's absent generated `@b/bridge_wasm` module and its resulting pre-existing implicit-any errors in `src/bridge_wasm.test.ts`.
 - Opened ready-for-review PR https://github.com/BoundaryML/baml/pull/4271 against `canary` with before/after playground images in the description.
-- CI monitoring and CodeRabbit approval are in progress; Vercel checks are intentionally ignored.
+- Non-Vercel CI passed, including Biome, generated-artifact typecheck, jsdom unit tests, and Playwright browser tests.
+- CodeRabbit initially deferred review because of its temporary review limit; an explicit review will be requested when the stated cooldown expires.
+- CodeRabbit approval is pending; Vercel checks are intentionally ignored.

--- a/issue-overview.md
+++ b/issue-overview.md
@@ -10,8 +10,8 @@ Linear: https://linear.app/boundaryml2/issue/B-1055/error-nodes-in-graph-are-for
 - Before image: `artifacts/B-1055-before.jpg`.
 - Root cause: `CapturedValueCard` renders `value.diagnostic` at unlimited natural height while graph layout reserves only 18px for it, so multiline tracebacks overflow the fixed error node and overlap later nodes and edges.
 - The first fix constrained graph diagnostics to one ellipsized row; user review rejected that design because the traceback and structured values need to remain readable in the graph.
-- Revised graph cards to preserve each traceback line, render inputs and typed errors as expanded pretty JSON with separate key rows, and allocate graph height for every diagnostic line while leaving the detailed execution panel unchanged.
-- After image: `artifacts/B-1055-after.png`.
+- Revised graph cards to preserve and left-align each traceback line, render inputs and typed errors as expanded pretty JSON with separate key rows, and allocate graph height for every diagnostic line while leaving the detailed execution panel unchanged.
+- After image: `artifacts/B-1055-after-left-aligned.jpg`.
 - Uploaded the before and after images to Linear for embedding in the PR description.
 - Verified the real repro after the revision: input and `InvalidArgument` keys render on separate rows, every logical traceback line starts on its own row, long source lines wrap within the error card, and the graph layout reserves the resulting card height without overlap.
 - `pnpm format:ci --since=origin/canary --reporter=github` passed.

--- a/issue-overview.md
+++ b/issue-overview.md
@@ -18,4 +18,5 @@ Linear: https://linear.app/boundaryml2/issue/B-1055/error-nodes-in-graph-are-for
 - `pnpm --filter @b/pkg-playground test` passed: 16 files, 126 tests.
 - `pnpm --filter app-vscode-webview build` passed.
 - `pnpm --filter app-vscode-webview typecheck` remains blocked by the worktree's absent generated `@b/bridge_wasm` module and its resulting pre-existing implicit-any errors in `src/bridge_wasm.test.ts`.
-- PR, CI monitoring, and CodeRabbit approval are pending.
+- Opened ready-for-review PR https://github.com/BoundaryML/baml/pull/4271 against `canary` with before/after playground images in the description.
+- CI monitoring and CodeRabbit approval are in progress; Vercel checks are intentionally ignored.

--- a/issue-overview.md
+++ b/issue-overview.md
@@ -9,17 +9,18 @@ Linear: https://linear.app/boundaryml2/issue/B-1055/error-nodes-in-graph-are-for
 - Reproduced locally by serving `tools/sdk-parity-lint/baml_src`, selecting `main`, leaving `repo_root` omitted, and clicking Run.
 - Before image: `artifacts/B-1055-before.jpg`.
 - Root cause: `CapturedValueCard` renders `value.diagnostic` at unlimited natural height while graph layout reserves only 18px for it, so multiline tracebacks overflow the fixed error node and overlap later nodes and edges.
-- Implemented the fix in `typescript2/pkg-playground/src/CapturedValueCard.tsx` and `graph/nodes/NodeOutputPreview.tsx`: graph diagnostics now stay on one ellipsized row, matching the graph layout allocation while retaining multiline diagnostics in the detailed execution panel and the full graph text in the existing tooltip.
-- After image: `artifacts/B-1055-after.jpg`.
+- The first fix constrained graph diagnostics to one ellipsized row; user review rejected that design because the traceback and structured values need to remain readable in the graph.
+- Revised graph cards to preserve each traceback line, render inputs and typed errors as expanded pretty JSON with separate key rows, and allocate graph height for every diagnostic line while leaving the detailed execution panel unchanged.
+- After image: `artifacts/B-1055-after.png`.
 - Uploaded the before and after images to Linear for embedding in the PR description.
-- Verified the real repro after the change: the traceback is truncated in the graph card and the downstream node and edge no longer overlap it.
+- Verified the real repro after the revision: input and `InvalidArgument` keys render on separate rows, every logical traceback line starts on its own row, long source lines wrap within the error card, and the graph layout reserves the resulting card height without overlap.
 - `pnpm format:ci --since=origin/canary --reporter=github` passed.
 - `pnpm --filter @b/pkg-playground typecheck` passed.
-- `pnpm --filter @b/pkg-playground test` passed: 16 files, 126 tests.
+- `pnpm --filter @b/pkg-playground test` passed after rebasing onto current `origin/canary`: 20 files, 138 tests.
 - `pnpm --filter app-vscode-webview build` passed.
 - `pnpm --filter app-vscode-webview typecheck` remains blocked by the worktree's absent generated `@b/bridge_wasm` module and its resulting pre-existing implicit-any errors in `src/bridge_wasm.test.ts`.
 - Opened ready-for-review PR https://github.com/BoundaryML/baml/pull/4271 against `canary` with before/after playground images in the description.
 - Non-Vercel CI passed, including Biome, generated-artifact typecheck, jsdom unit tests, and Playwright browser tests.
 - CodeRabbit initially deferred review because of its temporary review limit; an explicit review will be requested when the stated cooldown expires.
-- Addressed review feedback by scoping diagnostic truncation to graph previews instead of every shared `CapturedValueCard` consumer.
+- Addressed automated review feedback by keeping graph-only presentation options out of the shared detailed execution panel.
 - CodeRabbit approval is pending; Vercel checks are intentionally ignored.

--- a/issue-overview.md
+++ b/issue-overview.md
@@ -1,20 +1,21 @@
-# B-1056: monaco dropdown has bad spacing
+# B-1055: error nodes in graph are formatted incorrectly
 
-Linear: https://linear.app/boundaryml2/issue/B-1056/monaco-dropdown-has-bad-spacing
+Linear: https://linear.app/boundaryml2/issue/B-1055/error-nodes-in-graph-are-formatted-incorrectly
 
 ## Status
 
-- 2026-07-28: Created isolated Git worktree from the latest `origin/canary` commit `3f82a26f8d5361f531e2e8e8fc56838fe3ba8d6b`.
-- 2026-07-28: Reviewed the bug report: Monaco Explorer tree twisties for `sdk-parity-lint` and `baml_src` overlap adjacent text instead of maintaining normal spacing.
-- 2026-07-28: Reproduced the bug in the unmodified Prompt Fiddle at `http://localhost:3000/`: every Explorer tree twistie overlaps its adjacent label by 3px. The root `workspace` twistie rendered with a 16px outer width despite its 16px declared width plus 6px right padding, and its transformed right edge landed at x=67 while the label began at x=64.
-- 2026-07-28: Captured the before image at `typescript2/pkg-editor/docs/B-1056-before.png`.
-- 2026-07-28: Identified the root cause: Prompt Fiddle globally applies `box-sizing: border-box`, while the upstream VS Code tree stylesheet relies on the default `content-box` sizing for `.monaco-tl-twistie`. This causes the 6px spacing padding to consume the declared width instead of extending it.
-- 2026-07-28: Implemented a scoped `content-box` override for Monaco tree twisties inside `#workbench-container`, restoring the upstream width and padding contract without changing the Prompt Fiddle shell.
-- 2026-07-28: Verified the fix in the running Prompt Fiddle: the twistie computed style is now `content-box`, the Explorer labels shift right to preserve the intended padding, and `workspace`/`baml_src` no longer visually collide with their expanded-state arrows.
-- 2026-07-28: Captured the identically framed after image at `typescript2/pkg-editor/docs/B-1056-after.png`; both before and after artifacts are genuine 300x210 PNG files.
-- 2026-07-28: Automated validation passed with `pnpm --dir typescript2 --filter app-promptfiddle typecheck`, `pnpm --dir typescript2 --filter app-promptfiddle build`, and `pnpm --dir typescript2 exec biome check pkg-editor/src/views-workbench.css` from the repository root.
-- 2026-07-28: The narrower `pnpm --filter @b/pkg-editor typecheck` entry point cannot run in the clean workspace because that package's TypeScript configuration requests the undeclared `@types/node`; the Prompt Fiddle typecheck and production build both compile the shared editor successfully.
-- 2026-07-28: Committed the fix as `ed08692198cae2c729d024477fab2d12cdfbae5e` and pushed branch `sam/b-1056`.
-- 2026-07-28: Opened ready-for-review PR https://github.com/BoundaryML/baml/pull/4272 against `canary`; its description embeds the durable before and after PNGs from the branch.
-- 2026-07-28: CodeRabbit requested consistent Explorer terminology and an explicit working directory for the Biome validation command; both documentation quick wins are addressed.
-- 2026-07-28: CI monitoring and CodeRabbit re-approval are pending.
+- Worktree created from `origin/canary` commit `2d8da0cd1b9ec490765bbb29834ddd9b01a6b5ea`.
+- Linear report reviewed: an error preview expands vertically and renders a long traceback as unstructured wrapped text, obscuring downstream graph nodes and edges.
+- Reproduced locally by serving `tools/sdk-parity-lint/baml_src`, selecting `main`, leaving `repo_root` omitted, and clicking Run.
+- Before image: `artifacts/B-1055-before.jpg`.
+- Root cause: `CapturedValueCard` renders `value.diagnostic` at unlimited natural height while graph layout reserves only 18px for it, so multiline tracebacks overflow the fixed error node and overlap later nodes and edges.
+- Implemented the fix in `typescript2/pkg-playground/src/CapturedValueCard.tsx`: diagnostics now stay on one ellipsized row, matching the graph layout allocation while retaining the full diagnostic in the card tooltip and detailed run panel.
+- After image: `artifacts/B-1055-after.jpg`.
+- Uploaded the before and after images to Linear for embedding in the PR description.
+- Verified the real repro after the change: the traceback is truncated in the graph card and the downstream node and edge no longer overlap it.
+- `pnpm format:ci --since=origin/canary --reporter=github` passed.
+- `pnpm --filter @b/pkg-playground typecheck` passed.
+- `pnpm --filter @b/pkg-playground test` passed: 16 files, 126 tests.
+- `pnpm --filter app-vscode-webview build` passed.
+- `pnpm --filter app-vscode-webview typecheck` remains blocked by the worktree's absent generated `@b/bridge_wasm` module and its resulting pre-existing implicit-any errors in `src/bridge_wasm.test.ts`.
+- PR, CI monitoring, and CodeRabbit approval are pending.

--- a/issue-overview.md
+++ b/issue-overview.md
@@ -16,11 +16,11 @@ Linear: https://linear.app/boundaryml2/issue/B-1055/error-nodes-in-graph-are-for
 - Verified the real repro after the revision: input and `InvalidArgument` keys render on separate rows, every logical traceback line starts on its own row, long source lines wrap within the error card, and the graph layout reserves the resulting card height without overlap.
 - `pnpm format:ci --since=origin/canary --reporter=github` passed.
 - `pnpm --filter @b/pkg-playground typecheck` passed.
-- `pnpm --filter @b/pkg-playground test` passed after rebasing onto current `origin/canary`: 20 files, 138 tests.
+- `pnpm --filter @b/pkg-playground test` passed after rebasing onto current `origin/canary`: 20 files, 139 tests.
 - `pnpm --filter app-vscode-webview build` passed.
 - `pnpm --filter app-vscode-webview typecheck` remains blocked by the worktree's absent generated `@b/bridge_wasm` module and its resulting pre-existing implicit-any errors in `src/bridge_wasm.test.ts`.
 - Opened ready-for-review PR https://github.com/BoundaryML/baml/pull/4271 against `canary` with before/after playground images in the description.
 - Non-Vercel CI passed, including Biome, generated-artifact typecheck, jsdom unit tests, and Playwright browser tests.
 - CodeRabbit initially deferred review because of its temporary review limit; an explicit review will be requested when the stated cooldown expires.
 - Addressed automated review feedback by keeping graph-only presentation options out of the shared detailed execution panel.
-- CodeRabbit approval is pending; Vercel checks are intentionally ignored.
+- CodeRabbit's substantive review completed; its requested `+N more` footer sizing follow-up has been addressed with a five-preview regression test. Vercel checks are intentionally ignored.

--- a/issue-overview.md
+++ b/issue-overview.md
@@ -7,16 +7,16 @@ Linear: https://linear.app/boundaryml2/issue/B-1055/error-nodes-in-graph-are-for
 - Worktree created from `origin/canary` commit `2d8da0cd1b9ec490765bbb29834ddd9b01a6b5ea`.
 - Linear report reviewed: an error preview expands vertically and renders a long traceback as unstructured wrapped text, obscuring downstream graph nodes and edges.
 - Reproduced locally by serving `tools/sdk-parity-lint/baml_src`, selecting `main`, leaving `repo_root` omitted, and clicking Run.
-- Before image: `artifacts/B-1055-before.jpg`.
+- Before image: `artifacts/B-1055-before-braces.jpg`.
 - Root cause: `CapturedValueCard` renders `value.diagnostic` at unlimited natural height while graph layout reserves only 18px for it, so multiline tracebacks overflow the fixed error node and overlap later nodes and edges.
 - The first fix constrained graph diagnostics to one ellipsized row; user review rejected that design because the traceback and structured values need to remain readable in the graph.
 - Revised graph cards to preserve and left-align each traceback line, render inputs and typed errors as expanded pretty JSON with separate key rows, and allocate graph height for every diagnostic line while leaving the detailed execution panel unchanged.
-- After image: `artifacts/B-1055-after-left-aligned.jpg`.
-- Uploaded the before and after images to Linear for embedding in the PR description.
+- After image: `artifacts/B-1055-after-braces.jpg`.
+- Uploaded the before and after images as native GitHub user attachments embedded inline in the PR description.
 - Verified the real repro after the revision: input and `InvalidArgument` keys render on separate rows, every logical traceback line starts on its own row, long source lines wrap within the error card, and the graph layout reserves the resulting card height without overlap.
 - `pnpm format:ci --since=origin/canary --reporter=github` passed.
 - `pnpm --filter @b/pkg-playground typecheck` passed.
-- `pnpm --filter @b/pkg-playground test` passed after rebasing onto current `origin/canary`: 20 files, 139 tests.
+- `pnpm --filter @b/pkg-playground test` passed after rebasing onto current `origin/canary`: 21 files, 150 tests.
 - `pnpm --filter app-vscode-webview build` passed.
 - `pnpm --filter app-vscode-webview typecheck` remains blocked by the worktree's absent generated `@b/bridge_wasm` module and its resulting pre-existing implicit-any errors in `src/bridge_wasm.test.ts`.
 - Opened ready-for-review PR https://github.com/BoundaryML/baml/pull/4271 against `canary` with before/after playground images in the description.
@@ -24,3 +24,5 @@ Linear: https://linear.app/boundaryml2/issue/B-1055/error-nodes-in-graph-are-for
 - CodeRabbit initially deferred review because of its temporary review limit; an explicit review will be requested when the stated cooldown expires.
 - Addressed automated review feedback by keeping graph-only presentation options out of the shared detailed execution panel.
 - CodeRabbit's substantive review completed; its requested `+N more` footer sizing follow-up has been addressed with a five-preview regression test. Vercel checks are intentionally ignored.
+- Fixed closing-brace alignment in group nodes by making pretty-printed graph value containers explicitly left-aligned instead of inheriting React Flow's centered group-node text alignment.
+- Added a regression test for the graph-only alignment style and captured the corrected UI at `artifacts/B-1055-after-braces.jpg`.

--- a/issue-overview.md
+++ b/issue-overview.md
@@ -9,7 +9,7 @@ Linear: https://linear.app/boundaryml2/issue/B-1055/error-nodes-in-graph-are-for
 - Reproduced locally by serving `tools/sdk-parity-lint/baml_src`, selecting `main`, leaving `repo_root` omitted, and clicking Run.
 - Before image: `artifacts/B-1055-before.jpg`.
 - Root cause: `CapturedValueCard` renders `value.diagnostic` at unlimited natural height while graph layout reserves only 18px for it, so multiline tracebacks overflow the fixed error node and overlap later nodes and edges.
-- Implemented the fix in `typescript2/pkg-playground/src/CapturedValueCard.tsx`: diagnostics now stay on one ellipsized row, matching the graph layout allocation while retaining the full diagnostic in the card tooltip and detailed run panel.
+- Implemented the fix in `typescript2/pkg-playground/src/CapturedValueCard.tsx` and `graph/nodes/NodeOutputPreview.tsx`: graph diagnostics now stay on one ellipsized row, matching the graph layout allocation while retaining multiline diagnostics in the detailed execution panel and the full graph text in the existing tooltip.
 - After image: `artifacts/B-1055-after.jpg`.
 - Uploaded the before and after images to Linear for embedding in the PR description.
 - Verified the real repro after the change: the traceback is truncated in the graph card and the downstream node and edge no longer overlap it.
@@ -21,4 +21,5 @@ Linear: https://linear.app/boundaryml2/issue/B-1055/error-nodes-in-graph-are-for
 - Opened ready-for-review PR https://github.com/BoundaryML/baml/pull/4271 against `canary` with before/after playground images in the description.
 - Non-Vercel CI passed, including Biome, generated-artifact typecheck, jsdom unit tests, and Playwright browser tests.
 - CodeRabbit initially deferred review because of its temporary review limit; an explicit review will be requested when the stated cooldown expires.
+- Addressed review feedback by scoping diagnostic truncation to graph previews instead of every shared `CapturedValueCard` consumer.
 - CodeRabbit approval is pending; Vercel checks are intentionally ignored.

--- a/typescript2/pkg-playground/src/CapturedValueCard.tsx
+++ b/typescript2/pkg-playground/src/CapturedValueCard.tsx
@@ -1,5 +1,6 @@
-import type { FC } from 'react';
+// biome-ignore-all lint/style/useFilenamingConvention: Preserve the existing public component filename.
 import type { BamlJsValue } from '@b/pkg-proto';
+import type { FC } from 'react';
 import type { ResultRendererProps } from './result-renderers';
 import type { RunTraceCallValue } from './run-store-projections';
 import { findImageMedia, mediaToSrc } from './shared/media-values';
@@ -15,25 +16,25 @@ export const CAPTURED_VALUE_CARD_HEADER_HEIGHT = 21;
 export const CAPTURED_VALUE_CARD_PADDING_Y = 16;
 
 const ROLE_LABELS: Record<RunTraceCallValue['role'], string> = {
+  callError: 'Error',
   callInput: 'Input',
   callOutput: 'Output',
-  callError: 'Error',
 };
 
 const ROLE_COLORS: Record<RunTraceCallValue['role'], string> = {
+  callError: '#fda4af',
   callInput: '#a1a1aa',
   callOutput: '#7dd3fc',
-  callError: '#fda4af',
 };
 
 const STATE_LABELS: Partial<Record<RunTraceCallValue['state'], string>> = {
-  loading: 'loading',
-  pending: 'pending',
-  omitted: 'omitted',
-  truncated: 'truncated',
-  missing: 'missing',
-  lost: 'lost',
   error: 'error',
+  loading: 'loading',
+  lost: 'lost',
+  missing: 'missing',
+  omitted: 'omitted',
+  pending: 'pending',
+  truncated: 'truncated',
   unavailable: 'unavailable',
 };
 
@@ -43,10 +44,15 @@ interface CapturedValueCardProps {
   customRenderers?: Record<string, FC<ResultRendererProps>>;
 }
 
-export function capturedValueCardContentHeight(value: RunTraceCallValue): number {
+export function capturedValueCardContentHeight(
+  value: RunTraceCallValue,
+): number {
   const images = valueToImagePreviews(value.value);
   if (images.length > 0) {
-    const visibleCount = Math.min(images.length, CAPTURED_VALUE_CARD_MAX_IMAGES);
+    const visibleCount = Math.min(
+      images.length,
+      CAPTURED_VALUE_CARD_MAX_IMAGES,
+    );
     if (visibleCount === 1) return CAPTURED_VALUE_CARD_SINGLE_IMAGE_HEIGHT;
     const rows = Math.ceil(visibleCount / 2);
     return (
@@ -66,7 +72,8 @@ export function CapturedValueCard({
   const images = valueToImagePreviews(value.value);
   const visibleImages = images.slice(0, CAPTURED_VALUE_CARD_MAX_IMAGES);
   const remainingImages = images.length - visibleImages.length;
-  const stateLabel = value.state === 'available' ? null : STATE_LABELS[value.state];
+  const stateLabel =
+    value.state === 'available' ? null : STATE_LABELS[value.state];
   const roleColor = ROLE_COLORS[value.role];
   const isError = value.role === 'callError' || value.state === 'error';
 
@@ -74,36 +81,36 @@ export function CapturedValueCard({
     <div
       className="nodrag nopan"
       style={{
-        borderRadius: 6,
+        background: isError ? 'rgba(64,21,30,0.72)' : 'rgba(15,23,42,0.72)',
         border: `1px solid ${
           isError ? 'rgba(244,63,94,0.35)' : 'rgba(255,255,255,0.10)'
         }`,
-        background: isError ? 'rgba(64,21,30,0.72)' : 'rgba(15,23,42,0.72)',
-        padding: compact ? 7 : 8,
+        borderRadius: 6,
         overflow: 'hidden',
+        padding: compact ? 7 : 8,
       }}
       title={value.diagnostic ?? undefined}
     >
       <div
         style={{
-          display: 'flex',
-          minWidth: 0,
           alignItems: 'center',
+          display: 'flex',
           gap: 6,
           minHeight: 13,
+          minWidth: 0,
         }}
       >
         <span
           style={{
-            borderRadius: 4,
             border: `1px solid ${roleColor}55`,
+            borderRadius: 4,
             color: roleColor,
-            padding: '1px 4px',
+            flexShrink: 0,
             fontSize: 9,
             fontWeight: 700,
-            textTransform: 'uppercase',
             lineHeight: 1.4,
-            flexShrink: 0,
+            padding: '1px 4px',
+            textTransform: 'uppercase',
           }}
         >
           {ROLE_LABELS[value.role]}
@@ -111,13 +118,13 @@ export function CapturedValueCard({
         {value.label ? (
           <span
             style={{
+              color: '#a1a1aa',
+              fontSize: 10,
+              lineHeight: 1.4,
               minWidth: 0,
               overflow: 'hidden',
               textOverflow: 'ellipsis',
               whiteSpace: 'nowrap',
-              color: '#a1a1aa',
-              fontSize: 10,
-              lineHeight: 1.4,
             }}
           >
             {value.label}
@@ -126,15 +133,15 @@ export function CapturedValueCard({
         {stateLabel ? (
           <span
             style={{
-              marginLeft: 'auto',
-              flexShrink: 0,
-              borderRadius: 4,
               border: '1px solid rgba(255,255,255,0.10)',
+              borderRadius: 4,
               color: '#a1a1aa',
-              padding: '1px 4px',
+              flexShrink: 0,
               fontSize: 9,
               fontWeight: 600,
               lineHeight: 1.4,
+              marginLeft: 'auto',
+              padding: '1px 4px',
             }}
           >
             {stateLabel}
@@ -145,11 +152,9 @@ export function CapturedValueCard({
         <div
           style={{
             display: 'grid',
-            gridTemplateColumns:
-              visibleImages.length === 1
-                ? '1fr'
-                : 'repeat(2, minmax(0, 1fr))',
             gap: CAPTURED_VALUE_CARD_IMAGE_GAP,
+            gridTemplateColumns:
+              visibleImages.length === 1 ? '1fr' : 'repeat(2, minmax(0, 1fr))',
             marginTop: 6,
           }}
         >
@@ -161,40 +166,40 @@ export function CapturedValueCard({
               <div
                 key={`${image.content_type}-${image.mime_type ?? ''}-${index}`}
                 style={{
-                  position: 'relative',
-                  width: '100%',
+                  alignItems: 'center',
+                  background: '#09090b',
+                  border: '1px solid rgba(255,255,255,0.14)',
+                  borderRadius: 6,
+                  display: 'flex',
                   height:
                     visibleImages.length === 1
                       ? CAPTURED_VALUE_CARD_SINGLE_IMAGE_HEIGHT
                       : CAPTURED_VALUE_CARD_TILE_IMAGE_HEIGHT,
-                  borderRadius: 6,
-                  overflow: 'hidden',
-                  background: '#09090b',
-                  border: '1px solid rgba(255,255,255,0.14)',
-                  display: 'flex',
-                  alignItems: 'center',
                   justifyContent: 'center',
+                  overflow: 'hidden',
+                  position: 'relative',
+                  width: '100%',
                 }}
               >
                 {src ? (
                   <img
-                    src={src}
-                    alt="BAML captured image"
+                    alt="BAML captured value"
                     loading="lazy"
+                    src={src}
                     style={{
-                      width: '100%',
+                      display: 'block',
                       height: '100%',
                       objectFit: 'contain',
-                      display: 'block',
+                      width: '100%',
                     }}
                   />
                 ) : (
                   <span
                     style={{
                       color: '#9ca3af',
-                      fontSize: 10,
                       fontFamily:
                         'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace',
+                      fontSize: 10,
                     }}
                   >
                     &lt;image&gt;
@@ -203,15 +208,15 @@ export function CapturedValueCard({
                 {isLastWithRemainder ? (
                   <div
                     style={{
-                      position: 'absolute',
-                      inset: 0,
+                      alignItems: 'center',
                       background: 'rgba(0,0,0,0.58)',
                       color: '#fff',
                       display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
                       fontSize: 12,
                       fontWeight: 700,
+                      inset: 0,
+                      justifyContent: 'center',
+                      position: 'absolute',
                     }}
                   >
                     +{remainingImages}
@@ -224,27 +229,30 @@ export function CapturedValueCard({
       ) : value.value !== null ? (
         <div
           style={{
+            color: isError ? '#fecdd3' : '#e5e7eb',
+            fontSize: 10,
             marginTop: 6,
             maxHeight: compact ? CAPTURED_VALUE_CARD_TEXT_HEIGHT : 180,
             overflow: 'auto',
-            color: isError ? '#fecdd3' : '#e5e7eb',
-            fontSize: 10,
           }}
         >
           <ValueRenderer
-            value={value.value}
-            displayMode={compact ? 'inline' : 'expanded'}
             customRenderers={customRenderers}
+            displayMode={compact ? 'inline' : 'expanded'}
+            value={value.value}
           />
         </div>
       ) : null}
       {value.diagnostic ? (
         <div
           style={{
-            marginTop: 5,
             color: '#a1a1aa',
             fontSize: 10,
             lineHeight: 1.35,
+            marginTop: 5,
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
           }}
         >
           {value.diagnostic}

--- a/typescript2/pkg-playground/src/CapturedValueCard.tsx
+++ b/typescript2/pkg-playground/src/CapturedValueCard.tsx
@@ -264,6 +264,7 @@ export function CapturedValueCard({
             marginTop: 6,
             maxHeight: compact ? CAPTURED_VALUE_CARD_TEXT_HEIGHT : 180,
             overflow: 'auto',
+            textAlign: prettyPrintValue ? 'left' : undefined,
           }}
         >
           <ValueRenderer

--- a/typescript2/pkg-playground/src/CapturedValueCard.tsx
+++ b/typescript2/pkg-playground/src/CapturedValueCard.tsx
@@ -42,6 +42,7 @@ interface CapturedValueCardProps {
   value: RunTraceCallValue;
   compact?: boolean;
   customRenderers?: Record<string, FC<ResultRendererProps>>;
+  truncateDiagnostic?: boolean;
 }
 
 export function capturedValueCardContentHeight(
@@ -68,6 +69,7 @@ export function CapturedValueCard({
   value,
   compact = false,
   customRenderers,
+  truncateDiagnostic = false,
 }: CapturedValueCardProps) {
   const images = valueToImagePreviews(value.value);
   const visibleImages = images.slice(0, CAPTURED_VALUE_CARD_MAX_IMAGES);
@@ -250,9 +252,9 @@ export function CapturedValueCard({
             fontSize: 10,
             lineHeight: 1.35,
             marginTop: 5,
-            overflow: 'hidden',
-            textOverflow: 'ellipsis',
-            whiteSpace: 'nowrap',
+            overflow: truncateDiagnostic ? 'hidden' : undefined,
+            textOverflow: truncateDiagnostic ? 'ellipsis' : undefined,
+            whiteSpace: truncateDiagnostic ? 'nowrap' : undefined,
           }}
         >
           {value.diagnostic}

--- a/typescript2/pkg-playground/src/CapturedValueCard.tsx
+++ b/typescript2/pkg-playground/src/CapturedValueCard.tsx
@@ -286,6 +286,7 @@ export function CapturedValueCard({
             lineHeight: 1.35,
             marginTop: 5,
             overflowWrap: preserveDiagnosticLines ? 'anywhere' : undefined,
+            textAlign: preserveDiagnosticLines ? 'left' : undefined,
             whiteSpace: preserveDiagnosticLines ? 'pre-wrap' : undefined,
           }}
         >

--- a/typescript2/pkg-playground/src/CapturedValueCard.tsx
+++ b/typescript2/pkg-playground/src/CapturedValueCard.tsx
@@ -11,9 +11,11 @@ export const CAPTURED_VALUE_CARD_MAX_IMAGES = 4;
 export const CAPTURED_VALUE_CARD_IMAGE_GAP = 6;
 export const CAPTURED_VALUE_CARD_SINGLE_IMAGE_HEIGHT = 240;
 export const CAPTURED_VALUE_CARD_TILE_IMAGE_HEIGHT = 126;
-export const CAPTURED_VALUE_CARD_TEXT_HEIGHT = 96;
+export const CAPTURED_VALUE_CARD_TEXT_HEIGHT = 120;
 export const CAPTURED_VALUE_CARD_HEADER_HEIGHT = 21;
 export const CAPTURED_VALUE_CARD_PADDING_Y = 16;
+export const CAPTURED_VALUE_CARD_DIAGNOSTIC_LINE_HEIGHT = 14;
+const CAPTURED_VALUE_CARD_DIAGNOSTIC_CHARACTERS_PER_LINE = 54;
 
 const ROLE_LABELS: Record<RunTraceCallValue['role'], string> = {
   callError: 'Error',
@@ -42,7 +44,8 @@ interface CapturedValueCardProps {
   value: RunTraceCallValue;
   compact?: boolean;
   customRenderers?: Record<string, FC<ResultRendererProps>>;
-  truncateDiagnostic?: boolean;
+  preserveDiagnosticLines?: boolean;
+  prettyPrintValue?: boolean;
 }
 
 export function capturedValueCardContentHeight(
@@ -61,15 +64,40 @@ export function capturedValueCardContentHeight(
       (rows - 1) * CAPTURED_VALUE_CARD_IMAGE_GAP
     );
   }
-  if (value.value !== null) return CAPTURED_VALUE_CARD_TEXT_HEIGHT;
+  if (value.value !== null) {
+    return Math.min(
+      CAPTURED_VALUE_CARD_TEXT_HEIGHT,
+      expandedValueRowCount(value.value) * 24,
+    );
+  }
   return 0;
+}
+
+export function capturedValueCardDiagnosticHeight(
+  diagnostic: string | null | undefined,
+): number {
+  if (!diagnostic) return 0;
+  const lines = diagnostic.split(/\r?\n/);
+  const visualRows = lines.reduce(
+    (rows, line) =>
+      rows +
+      Math.max(
+        1,
+        Math.ceil(
+          line.length / CAPTURED_VALUE_CARD_DIAGNOSTIC_CHARACTERS_PER_LINE,
+        ),
+      ),
+    0,
+  );
+  return 5 + visualRows * CAPTURED_VALUE_CARD_DIAGNOSTIC_LINE_HEIGHT;
 }
 
 export function CapturedValueCard({
   value,
   compact = false,
   customRenderers,
-  truncateDiagnostic = false,
+  preserveDiagnosticLines = false,
+  prettyPrintValue = false,
 }: CapturedValueCardProps) {
   const images = valueToImagePreviews(value.value);
   const visibleImages = images.slice(0, CAPTURED_VALUE_CARD_MAX_IMAGES);
@@ -240,7 +268,9 @@ export function CapturedValueCard({
         >
           <ValueRenderer
             customRenderers={customRenderers}
-            displayMode={compact ? 'inline' : 'expanded'}
+            displayMode={
+              prettyPrintValue ? 'expanded' : compact ? 'inline' : 'expanded'
+            }
             value={value.value}
           />
         </div>
@@ -249,12 +279,14 @@ export function CapturedValueCard({
         <div
           style={{
             color: '#a1a1aa',
+            fontFamily: preserveDiagnosticLines
+              ? 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace'
+              : undefined,
             fontSize: 10,
             lineHeight: 1.35,
             marginTop: 5,
-            overflow: truncateDiagnostic ? 'hidden' : undefined,
-            textOverflow: truncateDiagnostic ? 'ellipsis' : undefined,
-            whiteSpace: truncateDiagnostic ? 'nowrap' : undefined,
+            overflowWrap: preserveDiagnosticLines ? 'anywhere' : undefined,
+            whiteSpace: preserveDiagnosticLines ? 'pre-wrap' : undefined,
           }}
         >
           {value.diagnostic}
@@ -266,4 +298,30 @@ export function CapturedValueCard({
 
 function valueToImagePreviews(value: BamlJsValue | null) {
   return value == null ? [] : findImageMedia(value, { maxItems: 24 });
+}
+
+function expandedValueRowCount(value: BamlJsValue, depth = 0): number {
+  if (value == null || typeof value !== 'object') return 1;
+  if (depth >= 2) return 1;
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return 1;
+    return (
+      1 +
+      value.reduce<number>(
+        (rows, item) => rows + expandedValueRowCount(item, depth + 1),
+        0,
+      )
+    );
+  }
+
+  const entries = Object.entries(value).filter(([key]) => key !== '$baml');
+  if (entries.length === 0) return 1;
+  return (
+    1 +
+    entries.reduce<number>((rows, [, nested]) => {
+      if (nested == null || typeof nested !== 'object') return rows + 1;
+      return rows + 1 + expandedValueRowCount(nested as BamlJsValue, depth + 1);
+    }, 0)
+  );
 }

--- a/typescript2/pkg-playground/src/captured-value-card.test.ts
+++ b/typescript2/pkg-playground/src/captured-value-card.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  capturedValueCardContentHeight,
+  capturedValueCardDiagnosticHeight,
+} from './CapturedValueCard';
+import type { RunTraceCallValue } from './run-store-projections';
+
+describe('captured value card graph sizing', () => {
+  it('allocates one row per traceback line plus wrapped rows', () => {
+    expect(capturedValueCardDiagnosticHeight('header\nshort')).toBe(33);
+    expect(capturedValueCardDiagnosticHeight(`header\n${'x'.repeat(55)}`)).toBe(
+      47,
+    );
+  });
+
+  it('allocates expanded rows for nested input values', () => {
+    expect(
+      capturedValueCardContentHeight(
+        preview({
+          repo_root: {
+            $baml: { type: 'baml.trace.OmittedValue' },
+            message: 'omitted argument',
+            reason: 'omittedArgument',
+          },
+        }),
+      ),
+    ).toBe(120);
+  });
+
+  it('uses the smaller expanded height for a one-field typed error', () => {
+    expect(
+      capturedValueCardContentHeight(
+        preview({
+          $baml: { type: 'baml.errors.InvalidArgument' },
+          message: 'invalid argument',
+        }),
+      ),
+    ).toBe(48);
+  });
+});
+
+function preview(value: unknown): RunTraceCallValue {
+  return {
+    diagnostic: null,
+    id: 'preview',
+    label: 'input',
+    role: 'callInput',
+    state: 'available',
+    timestampMs: 0,
+    value: value as RunTraceCallValue['value'],
+    valueRef: null,
+  };
+}

--- a/typescript2/pkg-playground/src/captured-value-card.test.ts
+++ b/typescript2/pkg-playground/src/captured-value-card.test.ts
@@ -4,6 +4,12 @@ import {
   capturedValueCardContentHeight,
   capturedValueCardDiagnosticHeight,
 } from './CapturedValueCard';
+import { graphValuePreviewHeight } from './graph/layout';
+import {
+  NODE_VALUE_PREVIEW_FOOTER_HEIGHT,
+  NODE_VALUE_PREVIEW_GAP,
+} from './graph/nodes/NodeOutputPreview';
+import type { WorkflowNode } from './graph/types';
 import type { RunTraceCallValue } from './run-store-projections';
 
 describe('captured value card graph sizing', () => {
@@ -38,6 +44,15 @@ describe('captured value card graph sizing', () => {
       ),
     ).toBe(48);
   });
+
+  it('reserves a gap and footer row when five previews are truncated to four', () => {
+    const fourPreviewsHeight = graphValuePreviewHeight(nodeWithPreviews(4));
+    const fivePreviewsHeight = graphValuePreviewHeight(nodeWithPreviews(5));
+
+    expect(fivePreviewsHeight - fourPreviewsHeight).toBe(
+      NODE_VALUE_PREVIEW_GAP + NODE_VALUE_PREVIEW_FOOTER_HEIGHT,
+    );
+  });
 });
 
 function preview(value: unknown): RunTraceCallValue {
@@ -50,5 +65,23 @@ function preview(value: unknown): RunTraceCallValue {
     timestampMs: 0,
     value: value as RunTraceCallValue['value'],
     valueRef: null,
+  };
+}
+
+function nodeWithPreviews(count: number): WorkflowNode {
+  return {
+    data: {
+      executionState: 'success',
+      graphNodeType: 'function',
+      label: 'preview',
+      logFilterKey: 'preview',
+      selected: false,
+      valuePreviews: Array.from({ length: count }, (_, index) =>
+        preview(`value-${index}`),
+      ),
+    },
+    id: 'preview',
+    position: { x: 0, y: 0 },
+    type: 'base',
   };
 }

--- a/typescript2/pkg-playground/src/captured-value-card.test.ts
+++ b/typescript2/pkg-playground/src/captured-value-card.test.ts
@@ -1,6 +1,9 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
 import {
+  CapturedValueCard,
   capturedValueCardContentHeight,
   capturedValueCardDiagnosticHeight,
 } from './CapturedValueCard';
@@ -43,6 +46,17 @@ describe('captured value card graph sizing', () => {
         }),
       ),
     ).toBe(48);
+  });
+
+  it('left-aligns pretty-printed graph values inside centered React Flow groups', () => {
+    const markup = renderToStaticMarkup(
+      createElement(CapturedValueCard, {
+        prettyPrintValue: true,
+        value: preview({ message: 'invalid argument' }),
+      }),
+    );
+
+    expect(markup).toContain('text-align:left');
   });
 
   it('reserves a gap and footer row when five previews are truncated to four', () => {

--- a/typescript2/pkg-playground/src/graph/layout.ts
+++ b/typescript2/pkg-playground/src/graph/layout.ts
@@ -1,18 +1,19 @@
 import ELK from 'elkjs/lib/elk.bundled.js';
-import type { ElkNode, ElkExtendedEdge } from 'elkjs/lib/elk-api';
+import type { ElkExtendedEdge, ElkNode } from 'elkjs/lib/elk-api';
 import {
-  capturedValueCardContentHeight,
   CAPTURED_VALUE_CARD_HEADER_HEIGHT,
   CAPTURED_VALUE_CARD_PADDING_Y,
   CAPTURED_VALUE_CARD_TEXT_HEIGHT,
+  capturedValueCardContentHeight,
+  capturedValueCardDiagnosticHeight,
 } from '../CapturedValueCard';
 import { depthScale } from './lod';
-import type { WorkflowNode, WorkflowEdge } from './types';
 import {
   NODE_VALUE_PREVIEW_GAP,
   NODE_VALUE_PREVIEW_MAX,
   NODE_VALUE_PREVIEW_WIDTH,
 } from './nodes/NodeOutputPreview';
+import type { WorkflowEdge, WorkflowNode } from './types';
 
 const elk = new ELK();
 
@@ -20,10 +21,10 @@ const elk = new ELK();
 // uses for routing. The visible card sits NODE_BUFFER px inside on each
 // side so arrow tips and selection rings have clearance.
 const NODE_SIZES: Record<string, { w: number; h: number }> = {
-  base: { w: 180, h: 50 },
-  llm: { w: 200, h: 60 },
-  diamond: { w: 180, h: 50 },
-  hexagon: { w: 180, h: 50 },
+  base: { h: 50, w: 180 },
+  diamond: { h: 50, w: 180 },
+  hexagon: { h: 50, w: 180 },
+  llm: { h: 60, w: 200 },
 };
 
 /**
@@ -65,13 +66,13 @@ function wrappingOptions(
 ): Record<string, string> {
   if (!wrap || childCount <= WRAP_CHILD_THRESHOLD) return {};
   return {
-    'org.eclipse.elk.layered.wrapping.strategy': 'SINGLE_EDGE',
-    // Aspect-ratio-driven cutting honours elk.aspectRatio below.
-    'org.eclipse.elk.layered.wrapping.cutting.strategy': 'ARD',
     'org.eclipse.elk.aspectRatio': String(WRAP_ASPECT_RATIO),
     // Tighten the corridor reserved for the wrap-around edges (default 10)
     // so stacked rows sit closer together.
     'org.eclipse.elk.layered.wrapping.additionalEdgeSpacing': '5',
+    // Aspect-ratio-driven cutting honours elk.aspectRatio below.
+    'org.eclipse.elk.layered.wrapping.cutting.strategy': 'ARD',
+    'org.eclipse.elk.layered.wrapping.strategy': 'SINGLE_EDGE',
   };
 }
 
@@ -91,25 +92,34 @@ function nodeSize(node: WorkflowNode): { w: number; h: number } {
         ) +
         Math.max(0, visibleValues.length - 1) * NODE_VALUE_PREVIEW_GAP;
       return {
-        w: Math.max(base.w, NODE_VALUE_PREVIEW_WIDTH),
         h: base.h + previewHeight + 14,
+        w: Math.max(base.w, NODE_VALUE_PREVIEW_WIDTH),
       };
     }
 
     if (node.data.errorMessage) {
       return {
+        h:
+          base.h +
+          capturedValueCardHeightForContent(
+            0,
+            capturedValueCardDiagnosticHeight(node.data.errorMessage),
+          ) +
+          14,
         w: Math.max(base.w, NODE_VALUE_PREVIEW_WIDTH),
-        h: base.h + capturedValueCardHeightForContent(0, true) + 14,
       };
     }
 
     if (node.data.hasResult) {
       return {
-        w: Math.max(base.w, NODE_VALUE_PREVIEW_WIDTH),
         h:
           base.h +
-          capturedValueCardHeightForContent(CAPTURED_VALUE_CARD_TEXT_HEIGHT, false) +
+          capturedValueCardHeightForContent(
+            CAPTURED_VALUE_CARD_TEXT_HEIGHT,
+            0,
+          ) +
           14,
+        w: Math.max(base.w, NODE_VALUE_PREVIEW_WIDTH),
       };
     }
 
@@ -125,8 +135,8 @@ function nodeSize(node: WorkflowNode): { w: number; h: number } {
     ? 1
     : depthScale(typeof node.data.depth === 'number' ? node.data.depth : 0);
   return {
-    w: visualSize.w * s + 2 * NODE_BUFFER,
     h: visualSize.h * s + 2 * NODE_BUFFER,
+    w: visualSize.w * s + 2 * NODE_BUFFER,
   };
 }
 
@@ -135,20 +145,20 @@ function capturedValueCardHeight(
 ): number {
   return capturedValueCardHeightForContent(
     capturedValueCardContentHeight(value),
-    value.diagnostic != null,
+    capturedValueCardDiagnosticHeight(value.diagnostic),
   );
 }
 
 function capturedValueCardHeightForContent(
   contentHeight: number,
-  hasDiagnostic: boolean,
+  diagnosticHeight: number,
 ): number {
   return (
     CAPTURED_VALUE_CARD_HEADER_HEIGHT +
     CAPTURED_VALUE_CARD_PADDING_Y +
     contentHeight +
     (contentHeight > 0 ? 6 : 0) +
-    (hasDiagnostic ? 18 : 0)
+    diagnosticHeight
   );
 }
 
@@ -195,9 +205,9 @@ function buildElkNodes(
       };
       elkNode.labels = [
         {
+          height: 20,
           text: node.data.label,
           width: Math.max(80, previewHeight > 0 ? NODE_VALUE_PREVIEW_WIDTH : 0),
-          height: 20,
         },
       ];
       if (children.length > 0) {
@@ -240,10 +250,16 @@ function buildElkNodes(
 }
 
 function graphValuePreviewHeight(node: WorkflowNode): number {
-  const values = (node.data.valuePreviews ?? []).slice(0, NODE_VALUE_PREVIEW_MAX);
+  const values = (node.data.valuePreviews ?? []).slice(
+    0,
+    NODE_VALUE_PREVIEW_MAX,
+  );
   if (values.length === 0) return 0;
   return (
-    values.reduce((height, value) => height + capturedValueCardHeight(value), 0) +
+    values.reduce(
+      (height, value) => height + capturedValueCardHeight(value),
+      0,
+    ) +
     Math.max(0, values.length - 1) * NODE_VALUE_PREVIEW_GAP
   );
 }
@@ -288,7 +304,7 @@ export async function layoutGraph(
   direction: 'horizontal' | 'vertical' = 'horizontal',
   wrap = true,
 ): Promise<{ nodes: WorkflowNode[]; edges: WorkflowEdge[] }> {
-  if (nodes.length === 0) return { nodes, edges };
+  if (nodes.length === 0) return { edges, nodes };
 
   const isHorizontal = direction === 'horizontal';
   const nodeIds = new Set(nodes.map((n) => n.id));
@@ -364,21 +380,21 @@ export async function layoutGraph(
   );
 
   const elkGraph: ElkNode = {
+    children: rootChildren,
+    edges: edgesByOwner.get('root') ?? [],
     id: 'root',
     layoutOptions: {
       'elk.algorithm': 'layered',
       'elk.direction': isHorizontal ? 'RIGHT' : 'DOWN',
+      'elk.edgeRouting': 'ORTHOGONAL',
       'elk.hierarchyHandling': 'INCLUDE_CHILDREN',
+      'spacing.edgeEdge': '15',
+      'spacing.edgeNode': '20',
       'spacing.nodeNode': '30',
       'spacing.nodeNodeBetweenLayers': '50',
-      'spacing.edgeNode': '20',
-      'spacing.edgeEdge': '15',
-      'elk.edgeRouting': 'ORTHOGONAL',
       // Wrap a long top-level chain (function with many sequential steps).
       ...wrappingOptions(rootChildren.length, wrap),
     },
-    children: rootChildren,
-    edges: edgesByOwner.get('root') ?? [],
   };
 
   const layouted = await elk.layout(elkGraph);
@@ -394,10 +410,10 @@ export async function layoutGraph(
     if (!elkNodes) return;
     for (const en of elkNodes) {
       positionMap.set(en.id, {
+        h: en.height ?? 0,
+        w: en.width ?? 0,
         x: en.x ?? 0,
         y: en.y ?? 0,
-        w: en.width ?? 0,
-        h: en.height ?? 0,
       });
       if (en.children) extractPositions(en.children);
     }
@@ -423,10 +439,10 @@ export async function layoutGraph(
     }
     const pos = positionMap.get(n.id);
     absPositions.set(n.id, {
+      h: pos?.h ?? 0,
+      w: pos?.w ?? 0,
       x: absX,
       y: absY,
-      w: pos?.w ?? 0,
-      h: pos?.h ?? 0,
     });
   }
 
@@ -505,9 +521,9 @@ export async function layoutGraph(
 
       return {
         ...edge,
+        data: { ...edge.data, points: deduped },
         sourceHandle,
         targetHandle,
-        data: { ...edge.data, points: deduped },
       };
     }
 
@@ -540,14 +556,14 @@ export async function layoutGraph(
       position: { x: pos.x, y: pos.y },
       style: {
         ...node.style,
-        width: pos.w,
         height: pos.h,
+        width: pos.w,
         ...(isGroup
           ? {}
-          : { padding: NODE_BUFFER, boxSizing: 'border-box' as const }),
+          : { boxSizing: 'border-box' as const, padding: NODE_BUFFER }),
       },
     };
   });
 
-  return { nodes: laidNodes, edges: laidEdges };
+  return { edges: laidEdges, nodes: laidNodes };
 }

--- a/typescript2/pkg-playground/src/graph/layout.ts
+++ b/typescript2/pkg-playground/src/graph/layout.ts
@@ -9,6 +9,7 @@ import {
 } from '../CapturedValueCard';
 import { depthScale } from './lod';
 import {
+  NODE_VALUE_PREVIEW_FOOTER_HEIGHT,
   NODE_VALUE_PREVIEW_GAP,
   NODE_VALUE_PREVIEW_MAX,
   NODE_VALUE_PREVIEW_WIDTH,
@@ -78,19 +79,9 @@ function wrappingOptions(
 
 function nodeSize(node: WorkflowNode): { w: number; h: number } {
   const base = NODE_SIZES[node.type ?? 'base'] ?? NODE_SIZES.base;
-  const valuePreviewCount = node.data.valuePreviews?.length ?? 0;
+  const previewHeight = graphValuePreviewHeight(node);
   const visualSize = (() => {
-    if (valuePreviewCount > 0) {
-      const visibleValues = (node.data.valuePreviews ?? []).slice(
-        0,
-        NODE_VALUE_PREVIEW_MAX,
-      );
-      const previewHeight =
-        visibleValues.reduce(
-          (height, value) => height + capturedValueCardHeight(value),
-          0,
-        ) +
-        Math.max(0, visibleValues.length - 1) * NODE_VALUE_PREVIEW_GAP;
+    if (previewHeight > 0) {
       return {
         h: base.h + previewHeight + 14,
         w: Math.max(base.w, NODE_VALUE_PREVIEW_WIDTH),
@@ -130,7 +121,7 @@ function nodeSize(node: WorkflowNode): { w: number; h: number } {
   // that render a result/image/error preview, whose content doesn't shrink, so
   // the box stays sized to it. Groups auto-size from children. Buffer is fixed.
   const hasPreview =
-    valuePreviewCount > 0 || !!node.data.errorMessage || !!node.data.hasResult;
+    previewHeight > 0 || !!node.data.errorMessage || !!node.data.hasResult;
   const s = hasPreview
     ? 1
     : depthScale(typeof node.data.depth === 'number' ? node.data.depth : 0);
@@ -249,18 +240,21 @@ function buildElkNodes(
   });
 }
 
-function graphValuePreviewHeight(node: WorkflowNode): number {
-  const values = (node.data.valuePreviews ?? []).slice(
-    0,
-    NODE_VALUE_PREVIEW_MAX,
-  );
+export function graphValuePreviewHeight(node: WorkflowNode): number {
+  const allValues = node.data.valuePreviews ?? [];
+  const values = allValues.slice(0, NODE_VALUE_PREVIEW_MAX);
   if (values.length === 0) return 0;
+  const footerHeight =
+    allValues.length > NODE_VALUE_PREVIEW_MAX
+      ? NODE_VALUE_PREVIEW_GAP + NODE_VALUE_PREVIEW_FOOTER_HEIGHT
+      : 0;
   return (
     values.reduce(
       (height, value) => height + capturedValueCardHeight(value),
       0,
     ) +
-    Math.max(0, values.length - 1) * NODE_VALUE_PREVIEW_GAP
+    Math.max(0, values.length - 1) * NODE_VALUE_PREVIEW_GAP +
+    footerHeight
   );
 }
 

--- a/typescript2/pkg-playground/src/graph/nodes/NodeOutputPreview.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/NodeOutputPreview.tsx
@@ -1,8 +1,9 @@
-import type { FC } from 'react';
+// biome-ignore-all lint/style/useFilenamingConvention: Preserve the existing public component filename.
 import type { BamlJsValue } from '@b/pkg-proto';
+import type { FC } from 'react';
 import {
-  CapturedValueCard,
   CAPTURED_VALUE_CARD_WIDTH,
+  CapturedValueCard,
 } from '../../CapturedValueCard';
 import type { ResultRendererProps } from '../../result-renderers';
 import type { GraphNodeValuePreview } from '../../run-store-projections';
@@ -26,7 +27,12 @@ export function NodeOutputPreview({
   errorMessage,
   customRenderers,
 }: NodeOutputPreviewProps) {
-  const values = graphPreviewValues(valuePreviews, result, hasResult, errorMessage);
+  const values = graphPreviewValues(
+    valuePreviews,
+    result,
+    hasResult,
+    errorMessage,
+  );
   if (values.length === 0) return null;
 
   const visible = values.slice(0, NODE_VALUE_PREVIEW_MAX);
@@ -40,16 +46,17 @@ export function NodeOutputPreview({
         flexDirection: 'column',
         gap: NODE_VALUE_PREVIEW_GAP,
         marginTop: 6,
-        width: '100%',
         maxWidth: NODE_VALUE_PREVIEW_WIDTH,
+        width: '100%',
       }}
     >
       {visible.map((value) => (
         <CapturedValueCard
-          key={value.id}
-          value={value}
           compact
           customRenderers={customRenderers}
+          key={value.id}
+          truncateDiagnostic
+          value={value}
         />
       ))}
       {remaining > 0 ? (
@@ -79,14 +86,14 @@ function graphPreviewValues(
   if (errorMessage) {
     return [
       {
-        id: 'node-error',
-        timestampMs: 0,
-        role: 'callError',
-        label: 'error',
-        valueRef: null,
-        value: null,
-        state: 'error',
         diagnostic: errorMessage,
+        id: 'node-error',
+        label: 'error',
+        role: 'callError',
+        state: 'error',
+        timestampMs: 0,
+        value: null,
+        valueRef: null,
       },
     ];
   }
@@ -94,14 +101,14 @@ function graphPreviewValues(
   if (hasResult) {
     return [
       {
-        id: 'node-result',
-        timestampMs: 0,
-        role: 'callOutput',
-        label: 'output',
-        valueRef: null,
-        value: result ?? null,
-        state: result == null ? 'unavailable' : 'available',
         diagnostic: null,
+        id: 'node-result',
+        label: 'output',
+        role: 'callOutput',
+        state: result == null ? 'unavailable' : 'available',
+        timestampMs: 0,
+        value: result ?? null,
+        valueRef: null,
       },
     ];
   }

--- a/typescript2/pkg-playground/src/graph/nodes/NodeOutputPreview.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/NodeOutputPreview.tsx
@@ -46,8 +46,7 @@ export function NodeOutputPreview({
         flexDirection: 'column',
         gap: NODE_VALUE_PREVIEW_GAP,
         marginTop: 6,
-        maxWidth: NODE_VALUE_PREVIEW_WIDTH,
-        width: '100%',
+        width: NODE_VALUE_PREVIEW_WIDTH,
       }}
     >
       {visible.map((value) => (
@@ -55,7 +54,8 @@ export function NodeOutputPreview({
           compact
           customRenderers={customRenderers}
           key={value.id}
-          truncateDiagnostic
+          preserveDiagnosticLines
+          prettyPrintValue
           value={value}
         />
       ))}

--- a/typescript2/pkg-playground/src/graph/nodes/NodeOutputPreview.tsx
+++ b/typescript2/pkg-playground/src/graph/nodes/NodeOutputPreview.tsx
@@ -19,6 +19,7 @@ interface NodeOutputPreviewProps {
 export const NODE_VALUE_PREVIEW_MAX = 4;
 export const NODE_VALUE_PREVIEW_WIDTH = CAPTURED_VALUE_CARD_WIDTH;
 export const NODE_VALUE_PREVIEW_GAP = 6;
+export const NODE_VALUE_PREVIEW_FOOTER_HEIGHT = 14;
 
 export function NodeOutputPreview({
   result,
@@ -65,6 +66,7 @@ export function NodeOutputPreview({
             color: '#a1a1aa',
             fontSize: 10,
             fontWeight: 600,
+            lineHeight: `${NODE_VALUE_PREVIEW_FOOTER_HEIGHT}px`,
             paddingLeft: 2,
           }}
         >


### PR DESCRIPTION
## Summary

- render graph inputs and typed errors as expanded structured values with each key on its own row
- preserve every logical traceback line, left-align the traceback block, and wrap long source lines inside the error card
- keep pretty-printed graph values left-aligned so React Flow group nodes cannot center their closing braces
- size graph nodes for expanded values, tracebacks, and truncated-preview footers so downstream nodes and edges stay unobstructed
- keep the detailed execution panel’s existing presentation unchanged

## Root cause

`CapturedValueCard` rendered structured graph values inline and rendered `value.diagnostic` at unlimited natural height, while graph layout reserved a fixed text block and only 18px for diagnostics. Multiline tracebacks therefore escaped the error node and covered downstream graph content. React Flow group wrappers also inherit `text-align: center`; flex-based opening-brace rows were unaffected, but plain closing-brace rows inherited the centering and became misaligned.

## Playground UI

### Before

<img width="1069" height="743" alt="Before: multiline traceback overflows the error node and overlaps the downstream graph" src="https://github.com/user-attachments/assets/e0ae058c-96eb-4d9c-9ad8-74d7fe608b0b" />

### After

<img width="1069" height="743" alt="After: structured values and braces are left-aligned, traceback lines remain separate, and the error node no longer overlaps downstream graph content" src="https://github.com/user-attachments/assets/bbfb578b-ee02-4623-abdb-1a80b5f8abbf" />

## Validation

- reproduced in the real playground with `tools/sdk-parity-lint/baml_src`, `main`, and omitted `repo_root`
- verified input and `InvalidArgument` keys render on separate rows, opening and closing braces remain left-aligned in React Flow group nodes, traceback newlines are preserved and left-aligned, and long source lines wrap within the graph card
- `pnpm format:ci --since=origin/canary --reporter=github`
- `pnpm --filter @b/pkg-playground typecheck`
- `pnpm --filter @b/pkg-playground test` (21 files, 150 tests passed)
- `pnpm --filter app-vscode-webview build`

Linear: [B-1055](https://linear.app/boundaryml2/issue/B-1055/error-nodes-in-graph-are-formatted-incorrectly)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graph error-node formatting to prevent multiline diagnostics from overlapping nodes and edges.
  * Tracebacks now preserve line breaks and allocate sufficient vertical space.
  * Inputs and typed errors display as expanded, readable JSON.
  * Improved graph value previews, image tiles, and truncated-value indicators.
* **Tests**
  * Added coverage for diagnostic sizing, expanded values, graph alignment, and preview truncation behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->