### PR TITLE
feat(playground): show baml.io output in the run view

### DIFF
--- a/baml_language/crates/baml_lsp_server/src/playground_env.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_env.rs
@@ -3,10 +3,23 @@
 //! Resolution order:
 //! 1. User overrides (manual entries from the playground UI)
 //! 2. Process environment (`std::env::var`) — e.g. from direnv / .envrc
-//! 3. WebSocket roundtrip to the webview (shows dialog if needed)
+//! 3. For a key the project declares (`env.FOO` in a client): WebSocket
+//!    roundtrip to the webview, which prompts the user and blocks the run
+//!    until they answer.
+//! 4. For any other key: unset, immediately and without notifying the UI.
+//!
+//! The split at 3/4 is deliberate. A declared key is one the project cannot
+//! run without, so stopping to ask is worth it. A key discovered at runtime
+//! through `baml.env.get("...")` is usually optional (`?? "default"`), and
+//! freezing a live run behind a modal for one of those is worse than
+//! reporting it unset and letting the user set it and run again.
+//!
+//! Step 4 stays silent because the UI has no "just so you know" channel for
+//! env vars: `EnvVarRequest` both badges the key as required and opens the env
+//! dialog. Sending one for an optional key reopens that dialog on every run.
 
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{
         Arc,
         atomic::{AtomicU64, Ordering},
@@ -36,6 +49,11 @@ pub struct PlaygroundEnvState {
     broadcast_tx: broadcast::Sender<WsOutMessage>,
     run_store: Arc<InMemoryRunStore>,
     session_store: Arc<PlaygroundSessionStore>,
+    /// Env vars the compiled project declares (`env.FOO`). Only these are
+    /// worth blocking a run to ask about. Refreshed from the compiled project
+    /// rather than accumulated, so a key that stops being referenced stops
+    /// blocking.
+    declared_keys: Mutex<HashSet<String>>,
     next_id: AtomicU64,
 }
 
@@ -60,8 +78,18 @@ impl PlaygroundEnvState {
             broadcast_tx,
             run_store,
             session_store,
+            declared_keys: Mutex::new(HashSet::new()),
             next_id: AtomicU64::new(1),
         }
+    }
+
+    /// Record the env vars the compiled project references by name.
+    pub fn set_declared_keys(&self, names: &[String]) {
+        *self.declared_keys.lock() = names.iter().cloned().collect();
+    }
+
+    fn is_declared(&self, key: &str) -> bool {
+        self.declared_keys.lock().contains(key)
     }
 
     /// Resolve a pending env var request (called by WS handler on envVarResponse).
@@ -157,8 +185,8 @@ impl PlaygroundEnvState {
     }
 }
 
-/// `IoNamespaceEnv` implementation with three-tier resolution:
-/// user overrides → process env → WebSocket roundtrip.
+/// `IoNamespaceEnv` implementation: user overrides → process env → prompt the
+/// UI (declared keys only) → unset.
 pub struct PlaygroundEnv(pub Arc<PlaygroundEnvState>);
 
 impl sys_ops::io::IoNamespaceEnv for PlaygroundEnv {
@@ -212,7 +240,29 @@ impl sys_ops::io::IoNamespaceEnv for PlaygroundEnv {
             return SysOpOutput::ok(Some(value));
         }
 
-        // 3. Fall back to the WebSocket roundtrip (may show dialog in the UI).
+        // 3. Not set anywhere, and the project never declared it — almost
+        //    always an optional lookup with a `??` fallback behind it. Report
+        //    unset and move on.
+        //
+        //    Deliberately silent: `EnvVarRequest` is the UI's signal to mark a
+        //    key required and open the env dialog, so sending one here would
+        //    reopen that dialog on every run and badge an optional key as
+        //    required. The resolution still lands in the run store, so the run
+        //    view shows the key was looked up and came back unset.
+        if !self.0.is_declared(&key) {
+            if let Some(patch) = self.0.run_store.ingest_env_resolved(
+                &host_call_id,
+                request_id,
+                key,
+                EnvResolutionStatus::DeclinedMissing,
+                None,
+            ) {
+                broadcast_run_patch(&self.0.broadcast_tx, &patch);
+            }
+            return SysOpOutput::ok(None);
+        }
+
+        // 4. A declared key the run cannot proceed without: ask, and wait.
         let state = self.0.clone();
         SysOpOutput::async_op(async move {
             let (tx, rx) = oneshot::channel();
@@ -293,6 +343,63 @@ mod tests {
         assert_eq!(
             state.resolve_for_run(start.boundary_id, 1, Some("secret".to_string())),
             RequestCommandOutcome::Missing.as_wire_str()
+        );
+    }
+
+    /// An undeclared key must not park the run on a UI prompt, and must not
+    /// emit `EnvVarRequest` — that message reopens the env dialog every run
+    /// and badges an optional key as required.
+    #[test]
+    fn undeclared_key_resolves_to_unset_without_waiting_or_prompting() {
+        use sys_ops::io::IoNamespaceEnv;
+
+        let (broadcast_tx, mut rx) = broadcast::channel(8);
+        let run_store = Arc::new(InMemoryRunStore::default());
+        let session_store = Arc::new(PlaygroundSessionStore::default());
+        let state = Arc::new(PlaygroundEnvState::new(
+            broadcast_tx,
+            run_store.clone(),
+            session_store,
+        ));
+        state.set_declared_keys(&["ANTHROPIC_API_KEY".to_string()]);
+
+        let key = "BAMLCODE_MEMORY_DIR_TEST_UNSET";
+        assert!(std::env::var(key).is_err(), "test key must be unset");
+
+        let heap = Arc::new(BexHeap::build_unsealed_default(Vec::new()));
+        let out =
+            PlaygroundEnv(state).get(&heap, CallId(42), key.to_string(), &SysOpContext::empty());
+
+        match out {
+            SysOpOutput::Ready(Ok(value)) => assert_eq!(value, None),
+            SysOpOutput::Ready(Err(_)) => panic!("undeclared key must not fail"),
+            SysOpOutput::Async(_) => {
+                panic!("undeclared key must resolve synchronously, not park on the UI")
+            }
+        }
+
+        while let Ok(msg) = rx.try_recv() {
+            assert!(
+                !matches!(msg, WsOutMessage::EnvVarRequest { .. }),
+                "an undeclared key must not prompt the UI"
+            );
+        }
+    }
+
+    #[test]
+    fn declared_keys_are_replaced_not_accumulated() {
+        let (broadcast_tx, _rx) = broadcast::channel(8);
+        let run_store = Arc::new(InMemoryRunStore::default());
+        let session_store = Arc::new(PlaygroundSessionStore::default());
+        let state = PlaygroundEnvState::new(broadcast_tx, run_store, session_store);
+
+        state.set_declared_keys(&["OLD_KEY".to_string()]);
+        state.set_declared_keys(&["NEW_KEY".to_string()]);
+
+        assert!(state.is_declared("NEW_KEY"));
+        assert!(
+            !state.is_declared("OLD_KEY"),
+            "a key the project stopped referencing must stop blocking runs"
         );
     }
 }

--- a/baml_language/crates/baml_lsp_server/src/playground_io.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_io.rs
@@ -1,4 +1,4 @@
-//! Playground IO input resolution via WebSocket.
+//! Playground `baml.io` host: input resolution and stream output.
 //!
 //! When `baml.io.input(prompt)` is called during a playground function
 //! execution, we send an `InputRequest` to all connected playground
@@ -6,6 +6,11 @@
 //!
 //! If no playground client is connected (`receiver_count() == 0`),
 //! we return an IO error immediately.
+//!
+//! `print` / `println` / `eprint` / `eprintln` become `Output` payloads on the
+//! run, streamed to clients over the same channel. Process stdout is never
+//! written: under `baml lsp` it carries the JSON-RPC frames, and under
+//! `baml playground` the user is watching a browser tab, not the terminal.
 
 use std::{
     collections::HashMap,
@@ -16,7 +21,7 @@ use std::{
 };
 
 use bex_events::run::{
-    BoundaryId, HostCallId, InMemoryRunStore, RequestCommandOutcome, RunRequestState,
+    BoundaryId, HostCallId, InMemoryRunStore, OutputStream, RequestCommandOutcome, RunRequestState,
 };
 use bex_heap::BexHeap;
 use parking_lot::Mutex;
@@ -126,6 +131,26 @@ impl PlaygroundIoState {
             .broadcast_tx
             .send(WsOutMessage::InputResolved { id, call_id });
         RequestCommandOutcome::Accepted.as_wire_str()
+    }
+
+    /// Record a `baml.io` stream write and push it to connected clients.
+    ///
+    /// Process stdout is never touched. Under `baml lsp` it carries the
+    /// JSON-RPC frames, so a stray byte desynchronizes the client; under
+    /// `baml playground` the user is looking at a browser tab, not the
+    /// terminal.
+    ///
+    /// A write that cannot be attributed to a live run is dropped rather than
+    /// failed. Panicking a program over an unroutable debug print costs more
+    /// than the lost line.
+    pub fn write_output(&self, call_id: CallId, stream: OutputStream, text: String) {
+        if text.is_empty() {
+            return;
+        }
+        let host_call_id = HostCallId::Native(call_id);
+        if let Some(patch) = self.run_store.ingest_output(&host_call_id, stream, text) {
+            broadcast_run_patch(&self.broadcast_tx, &patch);
+        }
     }
 
     /// Drop pending input waiters for a cancelled host call and notify
@@ -243,48 +268,44 @@ impl sys_ops::io::IoNamespaceIo for PlaygroundIo {
     fn print(
         &self,
         _heap: &Arc<BexHeap>,
-        _call_id: CallId,
-        _s: String,
+        call_id: CallId,
+        s: String,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<()> {
-        // Playground UI currently has no stdout channel; surface as Unsupported
-        // so user code can `catch` and fall back.
-        SysOpOutput::err(VmBamlError::Unsupported {
-            message: "Operation not supported on this platform".to_string(),
-        })
+        self.0.write_output(call_id, OutputStream::Stdout, s);
+        SysOpOutput::ok(())
     }
     fn println(
         &self,
         _heap: &Arc<BexHeap>,
-        _call_id: CallId,
-        _s: String,
+        call_id: CallId,
+        mut s: String,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<()> {
-        SysOpOutput::err(VmBamlError::Unsupported {
-            message: "Operation not supported on this platform".to_string(),
-        })
+        s.push('\n');
+        self.0.write_output(call_id, OutputStream::Stdout, s);
+        SysOpOutput::ok(())
     }
     fn eprint(
         &self,
         _heap: &Arc<BexHeap>,
-        _call_id: CallId,
-        _s: String,
+        call_id: CallId,
+        s: String,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<()> {
-        SysOpOutput::err(VmBamlError::Unsupported {
-            message: "Operation not supported on this platform".to_string(),
-        })
+        self.0.write_output(call_id, OutputStream::Stderr, s);
+        SysOpOutput::ok(())
     }
     fn eprintln(
         &self,
         _heap: &Arc<BexHeap>,
-        _call_id: CallId,
-        _s: String,
+        call_id: CallId,
+        mut s: String,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<()> {
-        SysOpOutput::err(VmBamlError::Unsupported {
-            message: "Operation not supported on this platform".to_string(),
-        })
+        s.push('\n');
+        self.0.write_output(call_id, OutputStream::Stderr, s);
+        SysOpOutput::ok(())
     }
 }
 
@@ -324,5 +345,83 @@ mod tests {
             state.resolve_for_run(start.boundary_id, 1, "answer".to_string()),
             RequestCommandOutcome::Missing.as_wire_str()
         );
+    }
+
+    fn start_run(run_store: &InMemoryRunStore, call_id: u64) -> (BoundaryId, HostCallId) {
+        let start = run_store.create_run(
+            BoundaryId::new_random(),
+            ExecutionRequest {
+                project_id: ProjectId("project".to_string()),
+                project_generation: ProjectGeneration(1),
+                target: RunTarget::Function {
+                    function_name: "main".to_string(),
+                },
+                args_summary: None,
+                options_summary: None,
+            },
+            RequestId(1),
+        );
+        let host = HostCallId::Native(CallId(call_id));
+        run_store.attach_host_call(start.boundary_id, host.clone());
+        (start.boundary_id, host)
+    }
+
+    fn output_payloads(
+        run_store: &InMemoryRunStore,
+        boundary_id: BoundaryId,
+    ) -> Vec<(String, String)> {
+        run_store
+            .snapshot(boundary_id)
+            .expect("run snapshot")
+            .payloads
+            .iter()
+            .filter_map(|payload| match &payload.kind {
+                bex_events::run::PayloadKind::Output(output) => {
+                    Some((output.stream.as_wire_str().to_string(), output.text.clone()))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn print_writes_are_recorded_verbatim_on_the_run() {
+        let (broadcast_tx, _rx) = broadcast::channel(8);
+        let run_store = Arc::new(InMemoryRunStore::default());
+        let state = Arc::new(PlaygroundIoState::new(broadcast_tx, run_store.clone()));
+        let (boundary_id, _host) = start_run(&run_store, 7);
+
+        // ANSI escapes must survive untouched, including a sequence split
+        // across two calls the way a `print`-per-token program emits them.
+        state.write_output(CallId(7), OutputStream::Stdout, "\u{1b}[3".to_string());
+        state.write_output(
+            CallId(7),
+            OutputStream::Stdout,
+            "1mred\u{1b}[0m".to_string(),
+        );
+        state.write_output(CallId(7), OutputStream::Stderr, "boom\n".to_string());
+
+        assert_eq!(
+            output_payloads(&run_store, boundary_id),
+            vec![
+                ("stdout".to_string(), "\u{1b}[3".to_string()),
+                ("stdout".to_string(), "1mred\u{1b}[0m".to_string()),
+                ("stderr".to_string(), "boom\n".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn print_from_an_unattached_call_is_dropped_not_failed() {
+        let (broadcast_tx, _rx) = broadcast::channel(8);
+        let run_store = Arc::new(InMemoryRunStore::default());
+        let state = Arc::new(PlaygroundIoState::new(broadcast_tx, run_store.clone()));
+        let (boundary_id, _host) = start_run(&run_store, 7);
+
+        // A call id that belongs to no run: the write disappears rather than
+        // taking the program down with it.
+        state.write_output(CallId(999), OutputStream::Stdout, "orphan".to_string());
+
+        assert!(output_payloads(&run_store, boundary_id).is_empty());
     }
 }

--- a/baml_language/crates/baml_lsp_server/src/playground_server.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_server.rs
@@ -1541,6 +1541,14 @@ async fn update_source_file_handler(
         .playground_update_source_file(&request.project, &request.path, request.content)
     {
         Ok(()) => {
+            // The edit may have added or removed an `env.FOO` reference, and
+            // the declared set decides which keys are worth blocking a run to
+            // prompt for. Without this refresh a removed key keeps prompting
+            // and a newly added one resolves silently until the session
+            // reconnects.
+            state
+                .env_state
+                .set_declared_keys(&state.bex.all_env_var_names());
             state.bex.request_playground_state();
             json_response(StatusCode::OK, &UpdateSourceFileResponse { ok: true })
         }

--- a/baml_language/crates/baml_lsp_server/src/playground_server.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_server.rs
@@ -1609,6 +1609,9 @@ async fn playground_ws_session(socket: WebSocket, state: WsState) {
     // round-trip (playground_env.rs).
     {
         let names = state.bex.all_env_var_names();
+        // Only these keys are worth blocking a run to prompt for; everything
+        // else resolves to unset without stalling. See `playground_env`.
+        state.env_state.set_declared_keys(&names);
         let vars = collect_referenced_env_vars(&names, |name| std::env::var(name).ok());
         if let Some(msg) = to_ws_text(&WsOutMessage::ProcessEnvVars { vars })
             && sink.send(msg).await.is_err()

--- a/baml_language/crates/bex_events/src/run.rs
+++ b/baml_language/crates/bex_events/src/run.rs
@@ -388,6 +388,7 @@ pub enum PayloadKind {
     EnvRequested(EnvRequested),
     EnvResolved(EnvResolved),
     Log(LogPayload),
+    Output(OutputPayload),
     CapturedValue(CapturedValuePayload),
 }
 
@@ -496,6 +497,33 @@ pub struct LogPayload {
     pub source: Option<SourceLocation>,
     pub value_ref: Option<ValueRef>,
     pub trace_call: Option<TraceCallKey>,
+}
+
+/// A chunk written by `baml.io.print` / `println` / `eprint` / `eprintln`.
+///
+/// These are raw stream writes, not structured log records: `print` carries no
+/// trailing newline, so consumers must concatenate consecutive chunks on the
+/// same stream rather than treating each payload as one line.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OutputPayload {
+    pub stream: OutputStream,
+    pub text: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OutputStream {
+    Stdout,
+    Stderr,
+}
+
+impl OutputStream {
+    #[must_use]
+    pub fn as_wire_str(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout",
+            Self::Stderr => "stderr",
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -848,7 +876,14 @@ struct RunRecord {
     domain_diagnostics: Vec<RunDiagnostic>,
     pending_input_requests: HashSet<u64>,
     pending_env_requests: HashSet<u64>,
+    output_bytes: usize,
+    output_truncated: bool,
 }
+
+/// Per-run byte budget for `baml.io` stream output. A tight print loop must not
+/// be able to grow the run store without bound; past the budget we emit one
+/// truncation notice and drop the rest.
+const MAX_RUN_OUTPUT_BYTES: usize = 1 << 20;
 
 impl Default for InMemoryRunStore {
     fn default() -> Self {
@@ -940,6 +975,8 @@ impl InMemoryRunStore {
             domain_diagnostics: Vec::new(),
             pending_input_requests: HashSet::new(),
             pending_env_requests: HashSet::new(),
+            output_bytes: 0,
+            output_truncated: false,
         };
         self.inner
             .lock()
@@ -1007,6 +1044,8 @@ impl InMemoryRunStore {
                 domain_diagnostics,
                 pending_input_requests: HashSet::new(),
                 pending_env_requests: HashSet::new(),
+                output_bytes: 0,
+                output_truncated: false,
             },
         );
         true
@@ -1413,6 +1452,49 @@ impl InMemoryRunStore {
                 value_ref,
                 trace_call: Some(call),
             }),
+            redaction: RedactionMetadata::display_safe(),
+            body: None,
+        };
+        Some(push_payload_patch(record, &retention, payload, None))
+    }
+
+    /// Record a `baml.io` stream write against the run owning `host_call_id`.
+    ///
+    /// Returns `None` when the write cannot be attributed to a live run (no
+    /// attached host call, or the run is already evicted). Callers should treat
+    /// that as "nothing to broadcast" rather than as a failure: panicking a
+    /// program over an unroutable debug print costs more than the lost line.
+    pub fn ingest_output(
+        &self,
+        host_call_id: &HostCallId,
+        stream: OutputStream,
+        text: String,
+    ) -> Option<RunPatch> {
+        let mut inner = self
+            .inner
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let boundary_id = *inner.host_call_index.get(host_call_id)?;
+        let payload_id = inner.allocate_payload_id();
+        let retention = inner.retention.clone();
+        let record = inner.runs.get_mut(&boundary_id)?;
+
+        if record.output_truncated {
+            return None;
+        }
+        let text = if record.output_bytes.saturating_add(text.len()) > MAX_RUN_OUTPUT_BYTES {
+            record.output_truncated = true;
+            format!("\n[output truncated: run exceeded {MAX_RUN_OUTPUT_BYTES} bytes]\n")
+        } else {
+            record.output_bytes = record.output_bytes.saturating_add(text.len());
+            text
+        };
+
+        let payload = PayloadEvent {
+            id: payload_id,
+            call_node_id: None,
+            timestamp_ms: epoch_ms(),
+            kind: PayloadKind::Output(OutputPayload { stream, text }),
             redaction: RedactionMetadata::display_safe(),
             body: None,
         };
@@ -5901,5 +5983,64 @@ mod tests {
         trim_profile_events(&mut events);
         assert_eq!(events.len(), PROFILE_EVENTS_CAP);
         assert_eq!(events[0].event.timestamp_ns, 5);
+    }
+
+    fn output_texts(store: &InMemoryRunStore, boundary_id: BoundaryId) -> Vec<String> {
+        store
+            .snapshot(boundary_id)
+            .expect("run snapshot")
+            .payloads
+            .iter()
+            .filter_map(|payload| match &payload.kind {
+                PayloadKind::Output(output) => Some(output.text.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn ingest_output_caps_a_runaway_print_loop() {
+        let store = InMemoryRunStore::default();
+        let start = create_test_run(&store, request("output"), RequestId(1));
+        let host = HostCallId::Native(sys_types::CallId(1));
+        store.attach_host_call(start.boundary_id, host.clone());
+
+        let chunk = "x".repeat(64 * 1024);
+        // Well past MAX_RUN_OUTPUT_BYTES worth of writes.
+        for _ in 0..64 {
+            store.ingest_output(&host, OutputStream::Stdout, chunk.clone());
+        }
+
+        let texts = output_texts(&store, start.boundary_id);
+        let notices = texts
+            .iter()
+            .filter(|text| text.contains("output truncated"))
+            .count();
+        assert_eq!(notices, 1, "exactly one truncation notice");
+        assert!(
+            texts
+                .last()
+                .is_some_and(|text| text.contains("output truncated")),
+            "the notice is the last thing recorded"
+        );
+        let total: usize = texts.iter().map(String::len).sum();
+        assert!(
+            total < MAX_RUN_OUTPUT_BYTES * 2,
+            "retained output stays bounded, got {total} bytes"
+        );
+    }
+
+    #[test]
+    fn ingest_output_without_an_attached_host_call_records_nothing() {
+        let store = InMemoryRunStore::default();
+        let start = create_test_run(&store, request("output"), RequestId(1));
+        let orphan = HostCallId::Native(sys_types::CallId(99));
+
+        assert!(
+            store
+                .ingest_output(&orphan, OutputStream::Stdout, "hi".to_string())
+                .is_none()
+        );
+        assert!(output_texts(&store, start.boundary_id).is_empty());
     }
 }

--- a/baml_language/crates/bex_events/src/run_wire.rs
+++ b/baml_language/crates/bex_events/src/run_wire.rs
@@ -295,6 +295,11 @@ fn payload_kind_to_wire(kind: &PayloadKind) -> Value {
             "source": log.source.as_ref().map(source_location_to_wire),
             "valueRef": log.value_ref.as_ref().map(value_ref_to_wire),
         }),
+        PayloadKind::Output(output) => json!({
+            "type": "output",
+            "stream": output.stream.as_wire_str(),
+            "text": &output.text,
+        }),
         PayloadKind::CapturedValue(captured) => json!({
             "type": "capturedValue",
             "role": captured_value_role_to_wire(captured.role),

--- a/baml_language/crates/bridge_wasm/src/wasm_io.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_io.rs
@@ -9,7 +9,9 @@ use std::sync::{
     atomic::{AtomicU64, Ordering},
 };
 
-use bex_events::run::{HostCallId, InMemoryRunStore, RequestCommandOutcome, RunRequestState};
+use bex_events::run::{
+    HostCallId, InMemoryRunStore, OutputStream, RequestCommandOutcome, RunRequestState,
+};
 use js_sys::{Function, Promise};
 use sys_ops::io::IoNamespaceIo;
 use sys_types::{BexHeap, CallId, SysOpContext, SysOpOutput, VmBamlError, VmRustFnError};
@@ -44,6 +46,23 @@ impl WasmIo {
 
     fn input_fn(&self) -> &Function {
         self.input_fn.inner()
+    }
+
+    /// Record a `baml.io` stream write and notify the webview.
+    ///
+    /// A write that cannot be attributed to a live run is dropped rather than
+    /// failed. Panicking a program over an unroutable debug print costs more
+    /// than the lost line.
+    fn write_output(&self, call_id: CallId, stream: OutputStream, text: String) {
+        if text.is_empty() {
+            return;
+        }
+        let Some(host_call_id) = crate::wasm_host_call_id(call_id) else {
+            return;
+        };
+        if let Some(patch) = self.run_store.ingest_output(&host_call_id, stream, text) {
+            crate::send_run_patch(&self.notification_callback, &patch);
+        }
     }
 }
 
@@ -130,46 +149,44 @@ impl IoNamespaceIo for WasmIo {
     fn print(
         &self,
         _heap: &Arc<BexHeap>,
-        _call_id: CallId,
-        _s: String,
+        call_id: CallId,
+        s: String,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<()> {
-        SysOpOutput::err(VmBamlError::Unsupported {
-            message: "Operation not supported on this platform".to_string(),
-        })
+        self.write_output(call_id, OutputStream::Stdout, s);
+        SysOpOutput::ok(())
     }
     fn println(
         &self,
         _heap: &Arc<BexHeap>,
-        _call_id: CallId,
-        _s: String,
+        call_id: CallId,
+        mut s: String,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<()> {
-        SysOpOutput::err(VmBamlError::Unsupported {
-            message: "Operation not supported on this platform".to_string(),
-        })
+        s.push('\n');
+        self.write_output(call_id, OutputStream::Stdout, s);
+        SysOpOutput::ok(())
     }
     fn eprint(
         &self,
         _heap: &Arc<BexHeap>,
-        _call_id: CallId,
-        _s: String,
+        call_id: CallId,
+        s: String,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<()> {
-        SysOpOutput::err(VmBamlError::Unsupported {
-            message: "Operation not supported on this platform".to_string(),
-        })
+        self.write_output(call_id, OutputStream::Stderr, s);
+        SysOpOutput::ok(())
     }
     fn eprintln(
         &self,
         _heap: &Arc<BexHeap>,
-        _call_id: CallId,
-        _s: String,
+        call_id: CallId,
+        mut s: String,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<()> {
-        SysOpOutput::err(VmBamlError::Unsupported {
-            message: "Operation not supported on this platform".to_string(),
-        })
+        s.push('\n');
+        self.write_output(call_id, OutputStream::Stderr, s);
+        SysOpOutput::ok(())
     }
 }
 

--- a/typescript2/pkg-playground/package.json
+++ b/typescript2/pkg-playground/package.json
@@ -38,6 +38,8 @@
     "@b/pkg-proto": "workspace:*",
     "@radix-ui/react-collapsible": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.6",
+    "@xterm/addon-fit": "^0.10.0",
+    "@xterm/xterm": "^5.5.0",
     "@xyflow/react": "^12.10.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -3107,6 +3107,17 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                           />
                         </div>
                       ))}
+                      {run.outputChunks.length > 0 && (
+                        <div className="py-1.5 pr-2.5 pl-[22px] border-b border-vsc-border-subtle">
+                          <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">
+                            Output
+                          </div>
+                          <RunOutputTerminal
+                            chunks={run.outputChunks}
+                            runKey={run.id}
+                          />
+                        </div>
+                      )}
                       {run.status === 'cancelled' && (
                         <div className="py-1.5 pr-2.5 pl-[22px]">
                           <div className="text-[11px] text-vsc-text-faint italic">

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -97,6 +97,7 @@ import {
   type RunTraceLog,
   type RunStoreDisplayRun,
 } from './run-store-projections';
+import { RunOutputTerminal } from './RunOutputTerminal';
 import {
   selectDefaultFunctionName,
   selectMainFunctionName,
@@ -3593,6 +3594,22 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                               />
                             </div>
                           ))}
+
+                          {/* baml.io stream output, rendered as a terminal so
+                              the program's own ANSI colors and cursor control
+                              land the way they would in a shell. */}
+                          {run.outputChunks.length > 0 && (
+                            <div className="py-1.5 pr-2.5 pl-[22px] border-b border-vsc-border-subtle">
+                              <div className="text-[10px] font-semibold text-vsc-text-muted mb-0.5 uppercase tracking-wide">
+                                Output
+                              </div>
+                              <RunOutputTerminal
+                                chunks={run.outputChunks}
+                                runKey={run.id}
+                              />
+                            </div>
+                          )}
+
                           {/* Result / Error / Cancelled for this run */}
                           {run.status === 'cancelled' && (
                             <div className="py-1.5 pr-2.5 pl-[22px]">

--- a/typescript2/pkg-playground/src/RunOutputTerminal.tsx
+++ b/typescript2/pkg-playground/src/RunOutputTerminal.tsx
@@ -1,0 +1,151 @@
+/**
+ * RunOutputTerminal — renders a run's `baml.io` stream writes.
+ *
+ * This is a real terminal emulator, not a log list, because BAML programs
+ * print real terminal output: SGR color, cursor movement, `\r` progress bars,
+ * `\x1b[2J` screen clears. Those need a screen buffer to interpret, which an
+ * escape-to-HTML converter cannot provide.
+ *
+ * xterm.js is fed chunks verbatim and in order. It buffers partial escape
+ * sequences across `write()` calls, so a sequence split across two `print`
+ * calls still resolves correctly.
+ *
+ * It lives inline in the run strip alongside INPUT/RESULT, so it sizes itself
+ * to the output it holds rather than filling its parent: short output gets a
+ * short box, and past MAX_ROWS it stops growing and scrolls internally.
+ */
+import type { FC } from 'react';
+import { useEffect, useRef, useState } from 'react';
+
+import type { RunOutputChunk } from './run-store-projections';
+
+import '@xterm/xterm/css/xterm.css';
+
+const FONT_SIZE = 12;
+const LINE_HEIGHT = 1.4;
+const ROW_PX = Math.ceil(FONT_SIZE * LINE_HEIGHT);
+const MIN_ROWS = 3;
+const MAX_ROWS = 24;
+
+type TerminalHandle = {
+  write: (data: string) => void;
+  reset: () => void;
+  dispose: () => void;
+  buffer: { active: { length: number } };
+};
+
+export type RunOutputTerminalProps = {
+  chunks: RunOutputChunk[];
+  /** Reset the screen when this changes (i.e. when a different run is shown). */
+  runKey: string | null;
+};
+
+export const RunOutputTerminal: FC<RunOutputTerminalProps> = ({ chunks, runKey }) => {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  // Loaded lazily so xterm stays out of the bundle until a run actually
+  // prints, and so this module remains importable during SSR.
+  const termRef = useRef<TerminalHandle | null>(null);
+  const fitRef = useRef<{ fit: () => void } | null>(null);
+  // How many chunks have already been written, so re-renders append rather
+  // than replay. Reset alongside the terminal when the run changes.
+  const writtenRef = useRef(0);
+  const pendingRef = useRef<string[]>([]);
+  const [rows, setRows] = useState(MIN_ROWS);
+
+  useEffect(() => {
+    let disposed = false;
+    const host = hostRef.current;
+    if (!host) return;
+
+    void (async () => {
+      const [{ Terminal }, { FitAddon }] = await Promise.all([
+        import('@xterm/xterm'),
+        import('@xterm/addon-fit'),
+      ]);
+      if (disposed) return;
+
+      const term = new Terminal({
+        convertEol: true,
+        cursorBlink: false,
+        cursorStyle: 'bar',
+        disableStdin: true,
+        fontSize: FONT_SIZE,
+        lineHeight: LINE_HEIGHT,
+        fontFamily:
+          'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+        scrollback: 10_000,
+        theme: { background: '#00000000' },
+        allowTransparency: true,
+      });
+      const fit = new FitAddon();
+      term.loadAddon(fit);
+      term.open(host);
+      fit.fit();
+
+      termRef.current = term as unknown as TerminalHandle;
+      fitRef.current = fit;
+      for (const text of pendingRef.current) term.write(text);
+      pendingRef.current = [];
+    })();
+
+    return () => {
+      disposed = true;
+      termRef.current?.dispose();
+      termRef.current = null;
+      fitRef.current = null;
+    };
+  }, []);
+
+  // Keep the emulator sized to its container; a wrong column count wraps
+  // output in places the program never intended.
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(() => fitRef.current?.fit());
+    observer.observe(host);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    termRef.current?.reset();
+    writtenRef.current = 0;
+    pendingRef.current = [];
+    setRows(MIN_ROWS);
+  }, [runKey]);
+
+  useEffect(() => {
+    // A shorter list than we've written means the run was replaced by an
+    // older/other one; start over rather than dropping the leading output.
+    if (chunks.length < writtenRef.current) {
+      termRef.current?.reset();
+      writtenRef.current = 0;
+      pendingRef.current = [];
+    }
+    for (let i = writtenRef.current; i < chunks.length; i++) {
+      const text = chunks[i]!.text;
+      if (termRef.current) {
+        termRef.current.write(text);
+      } else {
+        pendingRef.current.push(text);
+      }
+    }
+    writtenRef.current = chunks.length;
+
+    // Grow to fit the buffer. Reading the emulator's own line count rather
+    // than counting newlines keeps this honest for output that moves the
+    // cursor or clears the screen instead of appending lines.
+    const used = termRef.current?.buffer.active.length;
+    if (used != null) {
+      const next = Math.min(MAX_ROWS, Math.max(MIN_ROWS, used));
+      setRows((prev) => (prev === next ? prev : next));
+    }
+  }, [chunks]);
+
+  return (
+    <div
+      ref={hostRef}
+      className="w-full overflow-hidden"
+      style={{ height: rows * ROW_PX }}
+    />
+  );
+};

--- a/typescript2/pkg-playground/src/RunOutputTerminal.tsx
+++ b/typescript2/pkg-playground/src/RunOutputTerminal.tsx
@@ -28,7 +28,7 @@ const MIN_ROWS = 3;
 const MAX_ROWS = 24;
 
 type TerminalHandle = {
-  write: (data: string) => void;
+  write: (data: string, callback?: () => void) => void;
   reset: () => void;
   dispose: () => void;
   buffer: { active: { length: number } };
@@ -93,6 +93,14 @@ export const RunOutputTerminal: FC<RunOutputTerminalProps> = ({ chunks, runKey }
       termRef.current?.dispose();
       termRef.current = null;
       fitRef.current = null;
+      // Rewind the write cursor with the terminal. Refs outlive the emulator
+      // (React StrictMode double-invokes effects in dev, and any parent
+      // remount does the same), so leaving the cursor at N would replay
+      // nothing into the fresh, empty screen and the user would see output
+      // that starts mid-stream. Pending writes go too: they were already
+      // flushed into the instance we just disposed.
+      writtenRef.current = 0;
+      pendingRef.current = [];
     };
   }, []);
 
@@ -121,24 +129,34 @@ export const RunOutputTerminal: FC<RunOutputTerminalProps> = ({ chunks, runKey }
       writtenRef.current = 0;
       pendingRef.current = [];
     }
-    for (let i = writtenRef.current; i < chunks.length; i++) {
+    const first = writtenRef.current;
+    for (let i = first; i < chunks.length; i++) {
       const text = chunks[i]!.text;
       if (termRef.current) {
-        termRef.current.write(text);
+        // Grow to fit the buffer once the parser has caught up. `write` is
+        // async (the callback fires "when the data was processed by the
+        // parser"), so measuring right after the call would size against the
+        // previous frame's buffer and lag one update behind. Reading the
+        // emulator's own line count rather than counting newlines keeps this
+        // honest for output that moves the cursor or clears the screen
+        // instead of appending lines.
+        const isLast = i === chunks.length - 1;
+        termRef.current.write(
+          text,
+          isLast
+            ? () => {
+                const used = termRef.current?.buffer.active.length;
+                if (used == null) return;
+                const next = Math.min(MAX_ROWS, Math.max(MIN_ROWS, used));
+                setRows((prev) => (prev === next ? prev : next));
+              }
+            : undefined,
+        );
       } else {
         pendingRef.current.push(text);
       }
     }
     writtenRef.current = chunks.length;
-
-    // Grow to fit the buffer. Reading the emulator's own line count rather
-    // than counting newlines keeps this honest for output that moves the
-    // cursor or clears the screen instead of appending lines.
-    const used = termRef.current?.buffer.active.length;
-    if (used != null) {
-      const next = Math.min(MAX_ROWS, Math.max(MIN_ROWS, used));
-      setRows((prev) => (prev === next ? prev : next));
-    }
   }, [chunks]);
 
   return (

--- a/typescript2/pkg-playground/src/run-store-projections.test.ts
+++ b/typescript2/pkg-playground/src/run-store-projections.test.ts
@@ -8,6 +8,7 @@ import {
   filterExecutionProfileProjection,
   runToGraphNodeValues,
   runToDisplayRun,
+  runToOutputChunks,
   runToTraceRows,
 } from './run-store-projections';
 import type { GraphRuntimeOverlay, Run, ValueRef } from './worker-protocol';
@@ -1244,6 +1245,51 @@ describe('run-store-projections', () => {
     );
     expect(executionProfileColorKey(block, 'origin')).toBe('user');
     expect(executionProfileColorKey(block, 'thread')).toBe('thread-a');
+  });
+
+  it('keeps baml.io output chunks verbatim, in order, with streams interleaved', () => {
+    const run = runFixture({
+      payloads: [
+        payloadFixture({
+          id: 'out-1',
+          timestampMs: 100,
+          // An escape sequence split across two print calls: reshaping or
+          // reordering chunks would corrupt it.
+          kind: { type: 'output', stream: 'stdout', text: '[3' },
+        }),
+        payloadFixture({
+          id: 'out-2',
+          timestampMs: 101,
+          kind: { type: 'output', stream: 'stderr', text: 'warn\n' },
+        }),
+        payloadFixture({
+          id: 'out-3',
+          timestampMs: 102,
+          kind: { type: 'output', stream: 'stdout', text: '1mred[0m' },
+        }),
+        payloadFixture({
+          id: 'log-1',
+          timestampMs: 103,
+          kind: {
+            type: 'log',
+            level: 'info',
+            message: 'not output',
+            source: null,
+            valueRef: null,
+          },
+        }),
+      ],
+    });
+
+    expect(runToOutputChunks(run)).toEqual([
+      { id: 'out-1', stream: 'stdout', text: '[3', timestampMs: 100 },
+      { id: 'out-2', stream: 'stderr', text: 'warn\n', timestampMs: 101 },
+      { id: 'out-3', stream: 'stdout', text: '1mred[0m', timestampMs: 102 },
+    ]);
+  });
+
+  it('returns no output chunks for a run that never printed', () => {
+    expect(runToOutputChunks(runFixture({ payloads: [] }))).toEqual([]);
   });
 });
 

--- a/typescript2/pkg-playground/src/run-store-projections.ts
+++ b/typescript2/pkg-playground/src/run-store-projections.ts
@@ -21,6 +21,7 @@ export type RunStoreDisplayRun = {
   testName?: string;
   argsJson: string;
   fetchLogs: FetchLogEntry[];
+  outputChunks: RunOutputChunk[];
   inputRequests: Array<{ id: string; prompt: string | null }>;
   rootInput: BamlJsValue | null;
   result: BamlJsValue | null;
@@ -70,6 +71,24 @@ export type RunTraceLog = {
 
 type LogPayloadEvent = PayloadEvent & {
   kind: Extract<PayloadEvent['kind'], { type: 'log' }>;
+};
+
+/**
+ * One `baml.io` stream write, exactly as the VM produced it.
+ *
+ * Deliberately not split into lines or otherwise reshaped. The text may carry
+ * ANSI escape sequences, and a single sequence can straddle two chunks, so the
+ * only safe consumer is a terminal emulator fed the chunks in order.
+ */
+export type RunOutputChunk = {
+  id: string;
+  stream: 'stdout' | 'stderr';
+  text: string;
+  timestampMs: number;
+};
+
+type OutputPayloadEvent = PayloadEvent & {
+  kind: Extract<PayloadEvent['kind'], { type: 'output' }>;
 };
 
 export type RunTraceCallValueRole = 'callInput' | 'callOutput' | 'callError';
@@ -162,6 +181,7 @@ export function runToDisplayRun(
     testName: identity.testName,
     argsJson: argsJsonByBoundaryId[run.boundaryId] ?? run.request.argsSummary ?? '',
     fetchLogs: payloadsToFetchLogs(run.payloads),
+    outputChunks: runToOutputChunks(run),
     inputRequests: payloadsToPendingInputs(run.payloads),
     rootInput: decodeRootInputValue(run, valueBodyCache),
     result: decodeRunResultValue(run, valueBodyCache),
@@ -828,6 +848,27 @@ function traceLogsByCallId(
   return logsByCallId;
 }
 
+/**
+ * Ordered `baml.io` stream writes for a run.
+ *
+ * stdout and stderr stay interleaved in emission order, the way a real
+ * terminal shows them. The `stream` tag is kept for filtering, not for
+ * reordering: pulling one stream out on its own would scramble the sequence.
+ */
+export function runToOutputChunks(run: Run): RunOutputChunk[] {
+  const chunks: RunOutputChunk[] = [];
+  for (const payload of run.payloads) {
+    if (!isOutputPayload(payload)) continue;
+    chunks.push({
+      id: payload.id,
+      stream: payload.kind.stream,
+      text: payload.kind.text,
+      timestampMs: payload.timestampMs,
+    });
+  }
+  return chunks;
+}
+
 function traceCallValuesByCallId(
   run: Run,
   valueBodyCache?: ValueBodyCache,
@@ -1066,6 +1107,10 @@ function projectPayloadBodyState(
 
 function isLogPayload(payload: PayloadEvent): payload is LogPayloadEvent {
   return payload.kind.type === 'log';
+}
+
+function isOutputPayload(payload: PayloadEvent): payload is OutputPayloadEvent {
+  return payload.kind.type === 'output';
 }
 
 function isCallValuePayload(payload: PayloadEvent): payload is CallValuePayloadEvent {

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -497,6 +497,14 @@ export interface PayloadEvent {
         valueRef: ValueRef | null;
       }
     | {
+        // A chunk written by baml.io.print/println/eprint/eprintln. `print`
+        // carries no trailing newline, so consecutive chunks on one stream
+        // must be concatenated rather than rendered one row each.
+        type: 'output';
+        stream: 'stdout' | 'stderr';
+        text: string;
+      }
+    | {
         type: 'capturedValue';
         role: 'rootInput' | 'callInput' | 'callOutput' | 'callError';
         label: string | null;

--- a/typescript2/pnpm-lock.yaml
+++ b/typescript2/pnpm-lock.yaml
@@ -934,6 +934,12 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.6
         version: 1.1.15(@types/react-dom@18.3.7(@types/react@18.3.26))(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@xterm/addon-fit':
+        specifier: ^0.10.0
+        version: 0.10.0(@xterm/xterm@5.5.0)
+      '@xterm/xterm':
+        specifier: ^5.5.0
+        version: 5.5.0
       '@xyflow/react':
         specifier: ^12.10.1
         version: 12.10.1(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5180,6 +5186,14 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+
+  '@xterm/addon-fit@0.10.0':
+    resolution: {integrity: sha512-UFYkDm4HUahf2lnEyHvio51TNGiLK66mqP2JoATy7hRZeXaGMRDr00JiSF7m63vR5WKATF605yEggJKsw0JpMQ==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
+
+  '@xterm/xterm@5.5.0':
+    resolution: {integrity: sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==}
 
   '@xyflow/react@12.10.1':
     resolution: {integrity: sha512-5eSWtIK/+rkldOuFbOOz44CRgQRjtS9v5nufk77DV+XBnfCGL9HAQ8PG00o2ZYKqkEU/Ak6wrKC95Tu+2zuK3Q==}
@@ -14504,6 +14518,12 @@ snapshots:
   '@vscode/iconv-lite-umd@0.7.1': {}
 
   '@xmldom/xmldom@0.9.10': {}
+
+  '@xterm/addon-fit@0.10.0(@xterm/xterm@5.5.0)':
+    dependencies:
+      '@xterm/xterm': 5.5.0
+
+  '@xterm/xterm@5.5.0': {}
 
   '@xyflow/react@12.10.1(@types/react@18.3.26)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:


### PR DESCRIPTION
## The bug, in one line

Any BAML program with a `print` in it worked under `baml run` and **crashed** in the playground.

```baml
function main() -> string {
    baml.io.println("hello");   // baml run: prints. playground: panics the run.
    "done"
}
```

`baml.io.print` / `println` / `eprint` / `eprintln` returned `Unsupported` in the playground/LSP host (`playground_io.rs`) and the wasm/webview host (`wasm_io.rs`). Those builtins can't throw a user value, so the error came out as a panic and took the run down.

Real programs worked around it by escaping BAML entirely:

```baml
// bamlcode, before this PR
// "baml captures normal stdout, so we bypass it via /dev/tty"
function say(text: string) -> void {
    let opts = baml.sys.ProcessOptions { stdin: text, .. };
    baml.sys.shell("cat > /dev/tty 2>/dev/null", opts);
}
```

`/dev/tty` targets the *host process's* controlling terminal, so output landed in whatever terminal launched `baml playground` and was invisible to the UI.

## What it does now

Stream writes become run events and render inline in the run strip, between the request rows and `RESULT`:

```
agent.main() {}
  INPUT   {}
  ...     POST https://api.anthropic.com/v1/messages
  OUTPUT  ┌────────────────────────────────────────────┐
          │   bamlcode · a tiny Claude Code, in BAML    │
          └────────────────────────────────────────────┘
            Ask me to read, edit, or build code in this dir.
            type a task       run it now
          you ›
  RESULT  "session ended"
```

> **Screenshot:** drag the run-view screenshot in here.

**Process stdout is never touched.** Under `baml lsp` it carries the JSON-RPC frames, so one stray byte desyncs the editor's language client. Under `baml playground` the user is looking at a browser tab, not a terminal. Both hosts route to the run instead.

## Why a terminal emulator and not escape-to-HTML

BAML programs emit real terminal control, not just colors. Cursor movement, `\r` progress bars, and `\x1b[2J` screen clears need a **screen buffer** to interpret. `anser` / `ansi-to-react` (already used in app-website) only translate SGR color codes, so those sequences would render as garbage.

xterm.js is lazily imported, so it stays out of the bundle until a run actually prints (`dist/assets/xterm-*.js` is its own chunk).

The corollary is that the projection must stay dumb. Chunks are passed through **verbatim and in order**, never split into lines or regrouped per stream, because a single escape sequence can straddle two `print` calls:

```
print("\x1b[3")  →  chunk 1
print("1mred")   →  chunk 2   // "\x1b[31m" only exists across the boundary
```

`xterm.write()` buffers partial sequences across calls, so this resolves correctly. There's a test for exactly this case.

## Data flow

```mermaid
flowchart LR
    A["baml.io.println"] --> B["PlaygroundIo::write_output<br/>(or WasmIo)"]
    B --> C["run_store.ingest_output<br/>PayloadKind::Output"]
    C --> D["broadcast_run_patch"]
    D --> E["runToOutputChunks"]
    E --> F["RunOutputTerminal<br/>xterm.js"]
    B -.->|never| G["process stdout<br/>= JSON-RPC under baml lsp"]
```

## Env vars: stop blocking runs on optional keys

Second fix, same area. The env dialog popped on **every run** and blocked until answered, including for keys with a `??` fallback that the program didn't need.

Resolution is now: user overrides → process env → **prompt only if the project declares the key** → unset.

"Declared" means it came from `all_env_var_names()`, i.e. `env.FOO` in a client. A key reached through `baml.env.get("...")` resolves to unset immediately **and silently**. The silence is load-bearing: `EnvVarRequest` is what makes the UI badge a key as required and open the dialog, so there's no notify-only channel. Sending one "just so you know" reopens the modal every run.

| Key | How it's reached | Before | After |
|---|---|---|---|
| `ANTHROPIC_API_KEY` | `env.X` in a client | prompt + block | prompt + block |
| `BAMLCODE_MEMORY_DIR` | `baml.env.get("...")` | prompt + block, every run | unset, no prompt |
| `NO_COLOR` | `baml.env.get("...")` | prompt + block, every run | unset, no prompt |

Declared keys are replaced rather than accumulated on each project compile, so a key you stop referencing stops blocking.

## Bounded by construction

`record.run.payloads` is unbounded per run, so a tight print loop could grow the run store without limit. Output is capped at 1 MiB per run with exactly one truncation notice, then further writes are dropped. Tested.

A write that can't be attributed to a live run is dropped rather than failed: panicking a program over an unroutable debug print costs more than the lost line.

## Test plan

- [x] `cargo test -p bex_events` — 154 pass
- [x] `cargo test -p baml_lsp_server` — 68 pass
- [x] `pnpm --filter @b/pkg-playground test` — 128 pass
- [x] `cargo clippy -p bex_events -p baml_lsp_server --all-targets` — clean
- [x] `cargo clippy -p bridge_wasm --target wasm32-unknown-unknown` — clean
- [x] `tsc --noEmit` — clean
- [x] Manually run against a real project (`bamlcode`), output renders with ANSI intact

New tests:

| Test | Guards |
|---|---|
| `print_writes_are_recorded_verbatim_on_the_run` | escape sequence split across two calls survives |
| `print_from_an_unattached_call_is_dropped_not_failed` | orphan write doesn't kill the run |
| `ingest_output_caps_a_runaway_print_loop` | one notice, bounded retention |
| `ingest_output_without_an_attached_host_call_records_nothing` | no phantom payloads |
| `undeclared_key_resolves_to_unset_without_waiting_or_prompting` | returns `Ready`, not `Async`; emits no `EnvVarRequest` |
| `declared_keys_are_replaced_not_accumulated` | stale keys stop blocking |
| `keeps baml.io output chunks verbatim, in order` (TS) | no reshaping in the projection |

## Not in this PR

- **History replay.** Live output works, but reopening a past run won't show it. Persisted history has its own on-disk record types for value captures and logs (`bex_events/src/history`); output needs a new one.
- **`baml.sys.shell` inheriting the host's stdin.** With no `stdin` option, `run_process` leaves the child's stdin inherited (`io_impls.rs:1128`). Under `baml lsp` that's the JSON-RPC stream, so a shell command that reads stdin steals protocol bytes. Same shape as the stdout problem, opposite direction. Worth a follow-up.
- **Trace/flame bar min-width.** `Math.max(1.5, ...)` in `run-store-projections.ts` floors bar width at 1.5% of the *whole run*, so in a 100s trace everything under ~1.5s renders identically. The floor belongs in CSS as a pixel minimum, not in data space. Separate change.

## Callers must update

Programs using the `/dev/tty` workaround should switch to `baml.io.print` (note: `print`, not `println`, if the strings already carry their own `\n`). The one thing that doesn't port cleanly is EOF: `shell` signalled it via exit code, and `baml.io.input` has no EOF channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VWbXTcLbNVtm3Xmd5aWajK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live terminal output for `baml.io` `print`, `println`, `eprint`, and `eprintln`, rendered in a streaming terminal view.
  * Run details now include an “Output” section with streamed stdout/stderr, preserving ANSI escape sequences.
  * Added output-chunk capture with byte-budget limits to keep runs responsive (including controlled truncation behavior).

* **Bug Fixes**
  * Undeclared environment variables now resolve silently without unnecessary prompts/blocking.
  * Output from unattached or completed runs is safely ignored/dropped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->