### PR TITLE
test(csharp): ignore flaky phase 12 resource test

### DIFF
--- a/baml_language/sdk_tests/crates/csharp/src/lib.rs
+++ b/baml_language/sdk_tests/crates/csharp/src/lib.rs
@@ -389,6 +389,7 @@ mod tests {
 
     // SDK_PARITY_LINT(skip): exercises C#-specific native SDK integration coverage
     #[test]
+    #[ignore = "flaky: B-1059 - CancelToken.any intermittently fails to preserve native state"]
     fn test_phase12_executes_native_typed_resource_apis_lifetimes_and_state() {
         assert_eq!(
             env::var("SDK_TEST_CSHARP_SETUP").as_deref(),


### PR DESCRIPTION
## Summary

Ignore only `tests::test_phase12_executes_native_typed_resource_apis_lifetimes_and_state`, which intermittently fails when `CancelToken.any` does not preserve native state.

The C# workflow and all Linux, macOS, and Windows matrix entries remain enabled.

## Tracking

- [B-1059: C# CancelToken.any intermittently loses native state](https://linear.app/boundaryml2/issue/B-1059/c-canceltokenany-intermittently-loses-native-state)

## Evidence

The same test failed in three independent macOS CI runs while the other 14 C# SDK tests passed. The originally linked merge-queue job failed earlier during a transient sccache/R2 fetch and did not execute tests.

## Validation

- `cargo test --no-run -p sdk_test_csharp --all-features`
- `cargo test -p sdk_test_csharp --all-features tests::test_phase12_executes_native_typed_resource_apis_lifetimes_and_state -- --exact`
- `cargo fmt --all -- --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Skipped the flaky Phase 12 native typed resource integration test by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->