### PR TITLE
chore: make size-gate tooling resilient to coderabbit

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -44,13 +44,13 @@ policy.max_delta_pct = 3.0
 # unformatted generated SDK output).
 # macOS arm64: baseline 21.00 MB file (21_002_656), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = 21_854_475
+max_file_bytes = 21_956_782
 # Linux x86_64: baseline 27.08 MB file (27_075_600), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 28_120_698
+max_file_bytes = 28_242_452
 # Windows x86_64: baseline 22.67 MB file (22_671_360), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 23_559_808
+max_file_bytes = 23_680_047
 
 [artifacts.packed-program]
 kind = "pack"
@@ -58,13 +58,13 @@ policy.max_delta_pct = 3.0
 
 # macOS arm64: baseline 13.77 MB file.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = 14_268_683
+max_file_bytes = 14_268_733
 # Linux x86_64: baseline 17.64 MB file.
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 18_251_048
+max_file_bytes = 18_282_558
 # Windows x86_64: baseline 14.70 MB file.
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 15_220_725
+max_file_bytes = 15_236_408
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"
@@ -88,4 +88,4 @@ policy.max_delta_pct = 3.0
 
 # Single platform; baseline 4.40 MB gzip.
 [artifacts.bridge_wasm.platform.wasm32-unknown-unknown]
-max_gzip_bytes = 4_667_528
+max_gzip_bytes = 4_717_309

--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -1,32 +1,68 @@
 baseline_dir = ".ci/size-gate"
 
+# The size gate tracks the three artifacts users actually ship:
+#   1. baml-cli       — the CLI binary (measured on every native platform)
+#   2. packed-program — a trivial program built with `baml pack`, i.e. the
+#                       pack-host binary + bytecode envelope a user ships
+#                       (measured on every native platform)
+#   3. bridge_wasm    — the WASM build
+#
+# Each artifact is gated on ONE metric (`gate`):
+#   * binaries (baml-cli, packed-program) gate on FILE size — the actual
+#     on-disk size a user installs/ships.
+#   * bridge_wasm gates on GZIP — what ships over the wire.
+# The non-gated size is still measured and shown in the report (clearly
+# marked), but it is not what we benchmark against.
+#
+# Two gates, both kept tight as we drive size down, applied to the gated
+# metric:
+#   * max_delta_pct — per-platform regression guard vs the committed
+#     baseline in `baseline_dir`. 3% absorbs normal build-to-build LTO
+#     jitter while still catching accidental growth.
+#   * max_file_bytes / max_gzip_bytes — an absolute hard ceiling. Set PER
+#     PLATFORM (binaries differ across OSes) so each platform is capped
+#     ~3% above its own recorded baseline — enough to absorb build-to-build
+#     and local-vs-CI build variance (observed ~2.4%), while the 3%
+#     max_delta_pct is the precise slippage guard. Bump a ceiling only as a
+#     deliberate, reviewed commit when a real size increase lands.
+#
+# When recording a new platform (`mise run size-gate-record`), commit the
+# baseline it writes and add the matching `max_file_bytes` ceiling here,
+# ~3% above that file size.
+
 [artifacts.baml-cli]
 kind = "bin"
 package = "baml_cli"
 bin = "baml-cli"
 policy.max_delta_pct = 3.0
 
+# baml-cli is larger than the python/node CLIs because `sdkgen_rust`
+# formats generated code with `quote` + `prettyplease`, which pulls `syn`
+# into the CLI's runtime graph (the string-template generators don't).
+# Baselines include the first-class C# generator now linked into baml-cli.
+# Reclaiming the `syn` cost would mean dropping prettyplease (raw,
+# unformatted generated SDK output).
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = "20.94 MiB"
+max_file_bytes = "20.9 MiB"
 
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = "26.94 MiB"
+max_file_bytes = "26.9 MiB"
 
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = "22.59 MiB"
+max_file_bytes = "22.6 MiB"
 
 [artifacts.packed-program]
 kind = "pack"
 policy.max_delta_pct = 3.0
 
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = "13.61 MiB"
+max_file_bytes = "13.6 MiB"
 
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = "17.44 MiB"
+max_file_bytes = "17.4 MiB"
 
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = "14.54 MiB"
+max_file_bytes = "14.5 MiB"
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"
@@ -36,6 +72,9 @@ host_bin = "baml-pack-host"
 fixture = "crates/tools_size_gate/fixtures/minimal.baml"
 function = "Identity"
 
+# WASM is gated on GZIP (the download size), not file size — that's what
+# actually ships over the wire. gate = "gzip" makes both the ceiling and
+# the delta use gzip, and the report flags it.
 [artifacts.bridge_wasm]
 kind = "cdylib"
 gate = "gzip"
@@ -46,4 +85,4 @@ wasm = true
 policy.max_delta_pct = 3.0
 
 [artifacts.bridge_wasm.platform.wasm32-unknown-unknown]
-max_gzip_bytes = "4.50 MiB"
+max_gzip_bytes = "4.5 MiB"

--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -1,70 +1,32 @@
 baseline_dir = ".ci/size-gate"
 
-# The size gate tracks the three artifacts users actually ship:
-#   1. baml-cli       — the CLI binary (measured on every native platform)
-#   2. packed-program — a trivial program built with `baml pack`, i.e. the
-#                       pack-host binary + bytecode envelope a user ships
-#                       (measured on every native platform)
-#   3. bridge_wasm    — the WASM build
-#
-# Each artifact is gated on ONE metric (`gate`):
-#   * binaries (baml-cli, packed-program) gate on FILE size — the actual
-#     on-disk size a user installs/ships.
-#   * bridge_wasm gates on GZIP — what ships over the wire.
-# The non-gated size is still measured and shown in the report (clearly
-# marked), but it is not what we benchmark against.
-#
-# Two gates, both kept tight as we drive size down, applied to the gated
-# metric:
-#   * max_delta_pct — per-platform regression guard vs the committed
-#     baseline in `baseline_dir`. 3% absorbs normal build-to-build LTO
-#     jitter while still catching accidental growth.
-#   * max_file_bytes / max_gzip_bytes — an absolute hard ceiling. Set PER
-#     PLATFORM (binaries differ across OSes) so each platform is capped
-#     ~3% above its own recorded baseline — enough to absorb build-to-build
-#     and local-vs-CI build variance (observed ~2.4%), while the 3%
-#     max_delta_pct is the precise slippage guard. Bump a ceiling only as a
-#     deliberate, reviewed commit when a real size increase lands.
-#
-# When recording a new platform (`mise run size-gate-record`), commit the
-# baseline it writes and add the matching `max_file_bytes` ceiling here,
-# ~3% above that file size.
-
 [artifacts.baml-cli]
 kind = "bin"
 package = "baml_cli"
 bin = "baml-cli"
 policy.max_delta_pct = 3.0
 
-# baml-cli is larger than the python/node CLIs because `sdkgen_rust`
-# formats generated code with `quote` + `prettyplease`, which pulls `syn`
-# into the CLI's runtime graph (the string-template generators don't).
-# Baselines include the first-class C# generator now linked into baml-cli.
-# Reclaiming the `syn` cost would mean dropping prettyplease (raw,
-# unformatted generated SDK output).
-# macOS arm64: baseline 21.00 MB file (21_002_656), ceiling = baseline x1.03.
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = 21_956_782
-# Linux x86_64: baseline 27.08 MB file (27_075_600), ceiling = baseline x1.03.
+max_file_bytes = "20.94 MiB"
+
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 28_242_452
-# Windows x86_64: baseline 22.67 MB file (22_671_360), ceiling = baseline x1.03.
+max_file_bytes = "26.94 MiB"
+
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 23_680_047
+max_file_bytes = "22.59 MiB"
 
 [artifacts.packed-program]
 kind = "pack"
 policy.max_delta_pct = 3.0
 
-# macOS arm64: baseline 13.77 MB file.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = 14_268_733
-# Linux x86_64: baseline 17.64 MB file.
+max_file_bytes = "13.61 MiB"
+
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = 18_282_558
-# Windows x86_64: baseline 14.70 MB file.
+max_file_bytes = "17.44 MiB"
+
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = 15_236_408
+max_file_bytes = "14.54 MiB"
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"
@@ -74,9 +36,6 @@ host_bin = "baml-pack-host"
 fixture = "crates/tools_size_gate/fixtures/minimal.baml"
 function = "Identity"
 
-# WASM is gated on GZIP (the download size), not file size — that's what
-# actually ships over the wire. gate = "gzip" makes both the ceiling and
-# the delta use gzip, and the report flags it.
 [artifacts.bridge_wasm]
 kind = "cdylib"
 gate = "gzip"
@@ -86,6 +45,5 @@ no_default_features = true
 wasm = true
 policy.max_delta_pct = 3.0
 
-# Single platform; baseline 4.40 MB gzip.
 [artifacts.bridge_wasm.platform.wasm32-unknown-unknown]
-max_gzip_bytes = 4_717_309
+max_gzip_bytes = "4.50 MiB"

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-28T10:11:38Z"
-git_sha = "6b237531a5b664a250c5823c4d6a6957b5f2d7f2"
+recorded_at = "2026-07-29T10:12:16Z"
+git_sha = "fc9cf16fa5a374f6287d13c421f28b29f9b52597"
 
 [artifacts.baml-cli]
-file_bytes = 21217936
-stripped_bytes = 21217984
-gzip_bytes = 10143229
+file_bytes = 21317264
+stripped_bytes = 21317312
+gzip_bytes = 10204749
 
 [artifacts.packed-program]
-file_bytes = 13853090
-gzip_bytes = 6415513
+file_bytes = 13853138
+gzip_bytes = 6435065

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -3,10 +3,10 @@ recorded_at = "2026-07-29T10:12:16Z"
 git_sha = "fc9cf16fa5a374f6287d13c421f28b29f9b52597"
 
 [artifacts.baml-cli]
-file_bytes = 21317264
-stripped_bytes = 21317312
-gzip_bytes = 10204749
+file_bytes = "20.3 MiB"
+stripped_bytes = "20.3 MiB"
+gzip_bytes = "9.7 MiB"
 
 [artifacts.packed-program]
-file_bytes = 13853138
-gzip_bytes = 6435065
+file_bytes = "13.2 MiB"
+gzip_bytes = "6.1 MiB"

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -3,5 +3,5 @@ recorded_at = "2026-07-29T10:12:16Z"
 git_sha = "fc9cf16fa5a374f6287d13c421f28b29f9b52597"
 
 [artifacts.bridge_wasm]
-file_bytes = 16756794
-gzip_bytes = 4579911
+file_bytes = "16.0 MiB"
+gzip_bytes = "4.4 MiB"

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -1,7 +1,7 @@
 version = 1
-recorded_at = "2026-07-28T10:11:38Z"
-git_sha = "6b237531a5b664a250c5823c4d6a6957b5f2d7f2"
+recorded_at = "2026-07-29T10:12:16Z"
+git_sha = "fc9cf16fa5a374f6287d13c421f28b29f9b52597"
 
 [artifacts.bridge_wasm]
-file_bytes = 16595890
-gzip_bytes = 4531580
+file_bytes = 16756794
+gzip_bytes = 4579911

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-28T10:11:38Z"
-git_sha = "6b237531a5b664a250c5823c4d6a6957b5f2d7f2"
+recorded_at = "2026-07-29T10:12:16Z"
+git_sha = "fc9cf16fa5a374f6287d13c421f28b29f9b52597"
 
 [artifacts.baml-cli]
-file_bytes = 22873600
-stripped_bytes = 22873600
-gzip_bytes = 10349862
+file_bytes = 22990336
+stripped_bytes = 22990336
+gzip_bytes = 10413994
 
 [artifacts.packed-program]
-file_bytes = 14777402
-gzip_bytes = 6511861
+file_bytes = 14792629
+gzip_bytes = 6521193

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -3,10 +3,10 @@ recorded_at = "2026-07-29T10:12:16Z"
 git_sha = "fc9cf16fa5a374f6287d13c421f28b29f9b52597"
 
 [artifacts.baml-cli]
-file_bytes = 22990336
-stripped_bytes = 22990336
-gzip_bytes = 10413994
+file_bytes = "21.9 MiB"
+stripped_bytes = "21.9 MiB"
+gzip_bytes = "9.9 MiB"
 
 [artifacts.packed-program]
-file_bytes = 14792629
-gzip_bytes = 6521193
+file_bytes = "14.1 MiB"
+gzip_bytes = "6.2 MiB"

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-07-28T10:11:38Z"
-git_sha = "6b237531a5b664a250c5823c4d6a6957b5f2d7f2"
+recorded_at = "2026-07-29T10:12:16Z"
+git_sha = "fc9cf16fa5a374f6287d13c421f28b29f9b52597"
 
 [artifacts.baml-cli]
-file_bytes = 27301648
-stripped_bytes = 27301640
-gzip_bytes = 11610256
+file_bytes = 27419856
+stripped_bytes = 27419848
+gzip_bytes = 11668803
 
 [artifacts.packed-program]
-file_bytes = 17719464
-gzip_bytes = 7313803
+file_bytes = 17750056
+gzip_bytes = 7327218

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -3,10 +3,10 @@ recorded_at = "2026-07-29T10:12:16Z"
 git_sha = "fc9cf16fa5a374f6287d13c421f28b29f9b52597"
 
 [artifacts.baml-cli]
-file_bytes = 27419856
-stripped_bytes = 27419848
-gzip_bytes = 11668803
+file_bytes = "26.1 MiB"
+stripped_bytes = "26.1 MiB"
+gzip_bytes = "11.1 MiB"
 
 [artifacts.packed-program]
-file_bytes = 17750056
-gzip_bytes = 7327218
+file_bytes = "16.9 MiB"
+gzip_bytes = "7.0 MiB"

--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -1816,6 +1816,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytesize"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
+
+[[package]]
 name = "calloop"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1890,6 +1896,7 @@ name = "cargo-size-gate"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bytesize",
  "clap",
  "flate2",
  "serde",

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -171,6 +171,7 @@ bitflags = "2"
 # HeapPtr) that need to refuse or proxy their on-disk form.
 borsh = { version = "1.5", features = [ "derive", "indexmap" ] }
 bytes = "1"
+bytesize = "2.4.2"
 cargo_metadata = { version = "0.23.1" }
 cbindgen = "=0.29.0"
 clap = { version = "4.4.6", features = [ "cargo", "derive" ] }

--- a/baml_language/crates/tools_size_gate/Cargo.toml
+++ b/baml_language/crates/tools_size_gate/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+bytesize = { workspace = true }
 clap = { workspace = true, features = [ "derive" ] }
 flate2 = { workspace = true }
 serde = { workspace = true, features = [ "derive" ] }

--- a/baml_language/crates/tools_size_gate/src/baseline.rs
+++ b/baml_language/crates/tools_size_gate/src/baseline.rs
@@ -4,9 +4,9 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use crate::measure::ArtifactMeasurement;
+use crate::{human_size, measure::ArtifactMeasurement};
 
 /// A platform baseline file containing measurements for all artifacts on that platform.
 #[derive(Debug, Serialize, Deserialize)]
@@ -17,8 +17,110 @@ pub(crate) struct PlatformBaseline {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub git_sha: Option<String>,
 
-    #[serde(default)]
+    #[serde(
+        default,
+        serialize_with = "serialize_artifacts",
+        deserialize_with = "deserialize_artifacts"
+    )]
     pub artifacts: BTreeMap<String, ArtifactMeasurement>,
+}
+
+#[derive(Serialize, Deserialize)]
+struct HumanReadableArtifactMeasurement {
+    #[serde(with = "human_size::required")]
+    file_bytes: u64,
+
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        with = "human_size::optional"
+    )]
+    stripped_bytes: Option<u64>,
+
+    #[serde(with = "human_size::required")]
+    gzip_bytes: u64,
+
+    #[serde(
+        default,
+        skip_serializing_if = "BTreeMap::is_empty",
+        with = "human_size::map"
+    )]
+    sections: BTreeMap<String, u64>,
+}
+
+impl From<&ArtifactMeasurement> for HumanReadableArtifactMeasurement {
+    fn from(measurement: &ArtifactMeasurement) -> Self {
+        Self {
+            file_bytes: measurement.file_bytes,
+            stripped_bytes: measurement.stripped_bytes,
+            gzip_bytes: measurement.gzip_bytes,
+            sections: measurement.sections.clone(),
+        }
+    }
+}
+
+impl From<HumanReadableArtifactMeasurement> for ArtifactMeasurement {
+    fn from(measurement: HumanReadableArtifactMeasurement) -> Self {
+        Self {
+            file_bytes: measurement.file_bytes,
+            stripped_bytes: measurement.stripped_bytes,
+            gzip_bytes: measurement.gzip_bytes,
+            sections: measurement.sections,
+        }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+struct DisplayedArtifactMeasurement {
+    file_bytes: String,
+    stripped_bytes: Option<String>,
+    gzip_bytes: String,
+    sections: BTreeMap<String, String>,
+}
+
+impl From<&ArtifactMeasurement> for DisplayedArtifactMeasurement {
+    fn from(measurement: &ArtifactMeasurement) -> Self {
+        Self {
+            file_bytes: human_size::format(measurement.file_bytes),
+            stripped_bytes: measurement.stripped_bytes.map(human_size::format),
+            gzip_bytes: human_size::format(measurement.gzip_bytes),
+            sections: measurement
+                .sections
+                .iter()
+                .map(|(name, bytes)| (name.clone(), human_size::format(*bytes)))
+                .collect(),
+        }
+    }
+}
+
+fn serialize_artifacts<S>(
+    artifacts: &BTreeMap<String, ArtifactMeasurement>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    artifacts
+        .iter()
+        .map(|(name, measurement)| (name, HumanReadableArtifactMeasurement::from(measurement)))
+        .collect::<BTreeMap<_, _>>()
+        .serialize(serializer)
+}
+
+fn deserialize_artifacts<'de, D>(
+    deserializer: D,
+) -> Result<BTreeMap<String, ArtifactMeasurement>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    BTreeMap::<String, HumanReadableArtifactMeasurement>::deserialize(deserializer).map(
+        |artifacts| {
+            artifacts
+                .into_iter()
+                .map(|(name, measurement)| (name, measurement.into()))
+                .collect()
+        },
+    )
 }
 
 impl PlatformBaseline {
@@ -45,6 +147,20 @@ impl PlatformBaseline {
         std::fs::write(path, content)
             .with_context(|| format!("failed to write baseline: {}", path.display()))?;
         Ok(())
+    }
+
+    /// Whether `measurements` would serialize to the sizes already stored in this baseline.
+    pub(crate) fn measurements_match(
+        &self,
+        measurements: &BTreeMap<String, ArtifactMeasurement>,
+    ) -> bool {
+        self.artifacts.len() == measurements.len()
+            && self.artifacts.iter().all(|(name, existing)| {
+                measurements.get(name).is_some_and(|measurement| {
+                    DisplayedArtifactMeasurement::from(existing)
+                        == DisplayedArtifactMeasurement::from(measurement)
+                })
+            })
     }
 }
 
@@ -79,5 +195,55 @@ pub(crate) fn now_iso8601() -> String {
     match output {
         Ok(o) if o.status.success() => String::from_utf8_lossy(&o.stdout).trim().to_owned(),
         _ => "unknown".to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn baseline_round_trips_human_readable_sizes() {
+        let baseline = PlatformBaseline {
+            version: 1,
+            recorded_at: "2026-07-29T10:12:16Z".to_owned(),
+            git_sha: Some("abc123".to_owned()),
+            artifacts: BTreeMap::from([(
+                "baml-cli".to_owned(),
+                ArtifactMeasurement {
+                    file_bytes: 22_990_336,
+                    stripped_bytes: Some(22_990_336),
+                    gzip_bytes: 10_413_994,
+                    sections: BTreeMap::from([(".text".to_owned(), 1_024)]),
+                },
+            )]),
+        };
+
+        let toml = toml::to_string_pretty(&baseline).unwrap();
+        assert!(toml.contains(r#"file_bytes = "21.9 MiB""#));
+        assert!(toml.contains(r#"stripped_bytes = "21.9 MiB""#));
+        assert!(toml.contains(r#"gzip_bytes = "9.9 MiB""#));
+        assert!(toml.contains(r#"".text" = "1.0 KiB""#));
+
+        let parsed: PlatformBaseline = toml::from_str(&toml).unwrap();
+        let artifact = &parsed.artifacts["baml-cli"];
+        assert_eq!(artifact.file_bytes, 22_963_814);
+        assert_eq!(artifact.stripped_bytes, Some(22_963_814));
+        assert_eq!(artifact.gzip_bytes, 10_380_902);
+        assert_eq!(artifact.sections[".text"], 1_024);
+        assert_ne!(parsed.artifacts, baseline.artifacts);
+        assert!(parsed.measurements_match(&baseline.artifacts));
+    }
+
+    #[test]
+    fn checked_in_baselines_use_human_readable_sizes() {
+        for content in [
+            include_str!("../../../.ci/size-gate/aarch64-apple-darwin.toml"),
+            include_str!("../../../.ci/size-gate/wasm32-unknown-unknown.toml"),
+            include_str!("../../../.ci/size-gate/x86_64-pc-windows-msvc.toml"),
+            include_str!("../../../.ci/size-gate/x86_64-unknown-linux-gnu.toml"),
+        ] {
+            toml::from_str::<PlatformBaseline>(content).unwrap();
+        }
     }
 }

--- a/baml_language/crates/tools_size_gate/src/ceilings.rs
+++ b/baml_language/crates/tools_size_gate/src/ceilings.rs
@@ -9,11 +9,11 @@
 use std::{collections::BTreeMap, path::Path};
 
 use anyhow::{Context, Result};
-use bytesize::{ByteSize, Unit};
 use toml_edit::{DocumentMut, Item, Table, Value};
 
 use crate::{
     config::{Config, GateMetric},
+    human_size,
     measure::ArtifactMeasurement,
 };
 
@@ -56,7 +56,7 @@ pub(crate) fn sync_ceilings(
             let ceiling = ceiling_for(gated_bytes, margin_pct);
             set_ceiling(&mut doc, name, platform, key, ceiling);
             updates += 1;
-            let formatted_ceiling = format_size(ceiling);
+            let formatted_ceiling = human_size::format(ceiling);
             eprintln!(
                 "  ceiling {name} [{platform}] {key} = {formatted_ceiling} ({gated_bytes} + {margin_pct}%)"
             );
@@ -125,40 +125,10 @@ fn implicit_table() -> Item {
 }
 
 fn human_readable_size(bytes: u64) -> Value {
-    let mut v = Value::from(format_size(bytes));
+    let mut v = Value::from(human_size::format(bytes));
     v.decor_mut().set_prefix(" ");
     v.decor_mut().set_suffix("");
     v
-}
-
-fn format_size(bytes: u64) -> String {
-    let render = |value| format!("{:.2}", ByteSize::b(value).display().iec());
-    let rendered = render(bytes);
-    let parsed = rendered
-        .parse::<ByteSize>()
-        .expect("bytesize output is valid bytesize input")
-        .as_u64();
-    if parsed >= bytes {
-        return rendered;
-    }
-
-    let unit = rendered
-        .rsplit_once(' ')
-        .expect("bytesize IEC output includes a unit")
-        .1
-        .parse::<Unit>()
-        .expect("bytesize IEC output uses a known unit");
-    let display_step = (unit * 1).div_ceil(100);
-    let rounded_up = render(bytes.saturating_add(display_step));
-    let rounded_up_bytes = rounded_up
-        .parse::<ByteSize>()
-        .expect("bytesize output is valid bytesize input")
-        .as_u64();
-    assert!(
-        rounded_up_bytes >= bytes,
-        "human-readable ceiling must not be lower than its byte value"
-    );
-    rounded_up
 }
 
 #[cfg(test)]
@@ -174,20 +144,6 @@ mod tests {
     }
 
     #[test]
-    fn formats_human_readable_binary_sizes_without_lowering_the_ceiling() {
-        assert_eq!(format_size(15_519_843), "14.81 MiB");
-        assert_eq!(format_size(1_024), "1.00 KiB");
-        assert_eq!(format_size(1_073_741_824), "1.00 GiB");
-        assert_eq!(format_size(0), "0 B");
-
-        for bytes in [1, 1_023, 1_025, 1_048_577, 21_956_782, 1_073_741_825] {
-            let formatted = format_size(bytes);
-            let parsed = formatted.parse::<ByteSize>().unwrap().as_u64();
-            assert!(parsed >= bytes, "{formatted} is lower than {bytes} bytes");
-        }
-    }
-
-    #[test]
     fn set_ceiling_writes_a_human_readable_toml_string() {
         let mut doc = DocumentMut::new();
         set_ceiling(
@@ -199,7 +155,7 @@ mod tests {
         );
         assert_eq!(
             doc.to_string(),
-            "[artifacts.baml-cli.platform.aarch64-apple-darwin]\nmax_file_bytes = \"20.94 MiB\"\n"
+            "[artifacts.baml-cli.platform.aarch64-apple-darwin]\nmax_file_bytes = \"20.9 MiB\"\n"
         );
     }
 }

--- a/baml_language/crates/tools_size_gate/src/ceilings.rs
+++ b/baml_language/crates/tools_size_gate/src/ceilings.rs
@@ -1,5 +1,5 @@
 //! Rewrite the absolute size ceilings in `.cargo/size-gate.toml` in place,
-//! preserving the file's comments and structure via `toml_edit`.
+//! preserving the file's structure via `toml_edit`.
 //!
 //! This is the write-side counterpart to the per-platform `max_file_bytes`
 //! / `max_gzip_bytes` ceilings that `compare.rs` reads. The daily baseline
@@ -9,6 +9,7 @@
 use std::{collections::BTreeMap, path::Path};
 
 use anyhow::{Context, Result};
+use bytesize::{ByteSize, Unit};
 use toml_edit::{DocumentMut, Item, Table, Value};
 
 use crate::{
@@ -22,7 +23,7 @@ use crate::{
 /// For each (platform, artifact) pair we write the ceiling for the
 /// artifact's *gated* metric only: `max_file_bytes` for file-gated
 /// artifacts (binaries) and `max_gzip_bytes` for gzip-gated ones (WASM).
-/// Existing tables and comments are preserved; only the numeric value on
+/// Existing tables are preserved; only the value on
 /// the ceiling key is replaced.
 ///
 /// Returns `true` if the config file was changed on disk.
@@ -55,8 +56,9 @@ pub(crate) fn sync_ceilings(
             let ceiling = ceiling_for(gated_bytes, margin_pct);
             set_ceiling(&mut doc, name, platform, key, ceiling);
             updates += 1;
+            let formatted_ceiling = format_size(ceiling);
             eprintln!(
-                "  ceiling {name} [{platform}] {key} = {ceiling} ({gated_bytes} + {margin_pct}%)"
+                "  ceiling {name} [{platform}] {key} = {formatted_ceiling} ({gated_bytes} + {margin_pct}%)"
             );
         }
     }
@@ -109,7 +111,7 @@ fn set_ceiling(doc: &mut DocumentMut, name: &str, platform: &str, key: &str, val
         });
 
     if let Some(table) = platform_table {
-        table[key] = Item::Value(underscored_int(value));
+        table[key] = Item::Value(human_readable_size(value));
     }
 }
 
@@ -122,36 +124,41 @@ fn implicit_table() -> Item {
     Item::Table(t)
 }
 
-/// An integer value rendered with `_` digit grouping (e.g. `15_519_843`)
-/// to match the hand-written style of the rest of the config.
-///
-/// `toml_edit`'s repr setters are private, so we mint the formatted value by
-/// parsing a one-line fragment, then normalise its decor to a single
-/// leading space so it renders as `key = 15_519_843`.
-fn underscored_int(n: u64) -> Value {
-    let fragment = format!("x = {}", group_digits(n));
-    let doc: DocumentMut = fragment.parse().expect("grouped integer is valid TOML");
-    let mut v = doc["x"]
-        .as_value()
-        .expect("parsed fragment has a value")
-        .clone();
+fn human_readable_size(bytes: u64) -> Value {
+    let mut v = Value::from(format_size(bytes));
     v.decor_mut().set_prefix(" ");
     v.decor_mut().set_suffix("");
     v
 }
 
-/// Insert `_` separators every three digits from the right.
-fn group_digits(n: u64) -> String {
-    let s = n.to_string();
-    let len = s.len();
-    let mut out = String::with_capacity(len + len / 3);
-    for (i, c) in s.chars().enumerate() {
-        if i > 0 && (len - i).is_multiple_of(3) {
-            out.push('_');
-        }
-        out.push(c);
+fn format_size(bytes: u64) -> String {
+    let render = |value| format!("{:.2}", ByteSize::b(value).display().iec());
+    let rendered = render(bytes);
+    let parsed = rendered
+        .parse::<ByteSize>()
+        .expect("bytesize output is valid bytesize input")
+        .as_u64();
+    if parsed >= bytes {
+        return rendered;
     }
-    out
+
+    let unit = rendered
+        .rsplit_once(' ')
+        .expect("bytesize IEC output includes a unit")
+        .1
+        .parse::<Unit>()
+        .expect("bytesize IEC output uses a known unit");
+    let display_step = (unit * 1).div_ceil(100);
+    let rounded_up = render(bytes.saturating_add(display_step));
+    let rounded_up_bytes = rounded_up
+        .parse::<ByteSize>()
+        .expect("bytesize output is valid bytesize input")
+        .as_u64();
+    assert!(
+        rounded_up_bytes >= bytes,
+        "human-readable ceiling must not be lower than its byte value"
+    );
+    rounded_up
 }
 
 #[cfg(test)]
@@ -167,9 +174,32 @@ mod tests {
     }
 
     #[test]
-    fn group_digits_inserts_separators() {
-        assert_eq!(group_digits(15_519_843), "15_519_843");
-        assert_eq!(group_digits(100), "100");
-        assert_eq!(group_digits(1_000), "1_000");
+    fn formats_human_readable_binary_sizes_without_lowering_the_ceiling() {
+        assert_eq!(format_size(15_519_843), "14.81 MiB");
+        assert_eq!(format_size(1_024), "1.00 KiB");
+        assert_eq!(format_size(1_073_741_824), "1.00 GiB");
+        assert_eq!(format_size(0), "0 B");
+
+        for bytes in [1, 1_023, 1_025, 1_048_577, 21_956_782, 1_073_741_825] {
+            let formatted = format_size(bytes);
+            let parsed = formatted.parse::<ByteSize>().unwrap().as_u64();
+            assert!(parsed >= bytes, "{formatted} is lower than {bytes} bytes");
+        }
+    }
+
+    #[test]
+    fn set_ceiling_writes_a_human_readable_toml_string() {
+        let mut doc = DocumentMut::new();
+        set_ceiling(
+            &mut doc,
+            "baml-cli",
+            "aarch64-apple-darwin",
+            "max_file_bytes",
+            21_956_782,
+        );
+        assert_eq!(
+            doc.to_string(),
+            "[artifacts.baml-cli.platform.aarch64-apple-darwin]\nmax_file_bytes = \"20.94 MiB\"\n"
+        );
     }
 }

--- a/baml_language/crates/tools_size_gate/src/config.rs
+++ b/baml_language/crates/tools_size_gate/src/config.rs
@@ -4,7 +4,8 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use serde::Deserialize;
+use bytesize::ByteSize;
+use serde::{Deserialize, Deserializer, de};
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Config {
@@ -197,13 +198,16 @@ impl ArtifactConfig {
 pub(crate) struct Policy {
     /// Maximum allowed on-disk file bytes (absolute ceiling). This is the
     /// primary gate — the actual size a user installs/ships.
+    #[serde(default, deserialize_with = "deserialize_optional_size")]
     pub max_file_bytes: Option<u64>,
 
     /// Maximum allowed gzip bytes (absolute ceiling). Optional secondary
     /// gate; gzip is recorded and displayed for visibility either way.
+    #[serde(default, deserialize_with = "deserialize_optional_size")]
     pub max_gzip_bytes: Option<u64>,
 
     /// Maximum allowed stripped file bytes (absolute ceiling).
+    #[serde(default, deserialize_with = "deserialize_optional_size")]
     pub max_stripped_bytes: Option<u64>,
 
     /// Maximum allowed file-size delta in bytes vs baseline.
@@ -212,6 +216,34 @@ pub(crate) struct Policy {
     /// Maximum allowed file-size growth percentage vs baseline
     /// (e.g., 3.0 = 3%).
     pub max_delta_pct: Option<f64>,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum SizeThreshold {
+    Bytes(u64),
+    HumanReadable(String),
+}
+
+fn deserialize_optional_size<'de, D>(deserializer: D) -> std::result::Result<Option<u64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let threshold = Option::<SizeThreshold>::deserialize(deserializer)?;
+    threshold
+        .map(|threshold| match threshold {
+            SizeThreshold::Bytes(bytes) => Ok(bytes),
+            SizeThreshold::HumanReadable(value) => parse_size(&value).map_err(de::Error::custom),
+        })
+        .transpose()
+}
+
+fn parse_size(value: &str) -> Result<u64> {
+    value
+        .parse::<ByteSize>()
+        .map(|size| size.as_u64())
+        .map_err(anyhow::Error::msg)
+        .with_context(|| format!("invalid size threshold `{value}`"))
 }
 
 impl Config {
@@ -282,5 +314,44 @@ pub(crate) fn host_triple() -> String {
         ("x86_64", "windows") => "x86_64-pc-windows-msvc".to_owned(),
         ("aarch64", "windows") => "aarch64-pc-windows-msvc".to_owned(),
         _ => format!("{arch}-unknown-{os}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_human_readable_size_thresholds() {
+        assert_eq!(parse_size("1.5 KiB").unwrap(), 1536);
+        assert_eq!(parse_size("20.94 MiB").unwrap(), 21_957_181);
+        assert_eq!(parse_size("2 GiB").unwrap(), 2_147_483_648);
+        assert_eq!(parse_size("1 MB").unwrap(), 1_000_000);
+        assert_eq!(parse_size("1024").unwrap(), 1024);
+    }
+
+    #[test]
+    fn rejects_invalid_size_thresholds() {
+        assert!(parse_size("-1 MiB").is_err());
+        assert!(parse_size("not a size").is_err());
+    }
+
+    #[test]
+    fn policy_accepts_human_readable_and_legacy_byte_thresholds() {
+        let human: Policy = toml::from_str(r#"max_file_bytes = "1.5 MiB""#).unwrap();
+        assert_eq!(human.max_file_bytes, Some(1_572_864));
+
+        let legacy: Policy = toml::from_str("max_file_bytes = 1_572_864").unwrap();
+        assert_eq!(legacy.max_file_bytes, Some(1_572_864));
+    }
+
+    #[test]
+    fn checked_in_config_uses_valid_human_readable_thresholds() {
+        let config: Config =
+            toml::from_str(include_str!("../../../.cargo/size-gate.toml")).unwrap();
+        config.validate().unwrap();
+
+        let macos = &config.artifacts["baml-cli"].platform["aarch64-apple-darwin"];
+        assert_eq!(macos.max_file_bytes, Some(21_957_181));
     }
 }

--- a/baml_language/crates/tools_size_gate/src/config.rs
+++ b/baml_language/crates/tools_size_gate/src/config.rs
@@ -4,8 +4,9 @@ use std::{
 };
 
 use anyhow::{Context, Result};
-use bytesize::ByteSize;
 use serde::{Deserialize, Deserializer, de};
+
+use crate::human_size;
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct Config {
@@ -218,30 +219,17 @@ pub(crate) struct Policy {
     pub max_delta_pct: Option<f64>,
 }
 
-#[derive(Deserialize)]
-#[serde(untagged)]
-enum SizeThreshold {
-    Bytes(u64),
-    HumanReadable(String),
-}
-
 fn deserialize_optional_size<'de, D>(deserializer: D) -> std::result::Result<Option<u64>, D::Error>
 where
     D: Deserializer<'de>,
 {
-    let threshold = Option::<SizeThreshold>::deserialize(deserializer)?;
-    threshold
-        .map(|threshold| match threshold {
-            SizeThreshold::Bytes(bytes) => Ok(bytes),
-            SizeThreshold::HumanReadable(value) => parse_size(&value).map_err(de::Error::custom),
-        })
+    Option::<String>::deserialize(deserializer)?
+        .map(|value| parse_size(&value).map_err(de::Error::custom))
         .transpose()
 }
 
 fn parse_size(value: &str) -> Result<u64> {
-    value
-        .parse::<ByteSize>()
-        .map(|size| size.as_u64())
+    human_size::parse(value)
         .map_err(anyhow::Error::msg)
         .with_context(|| format!("invalid size threshold `{value}`"))
 }
@@ -337,12 +325,14 @@ mod tests {
     }
 
     #[test]
-    fn policy_accepts_human_readable_and_legacy_byte_thresholds() {
+    fn policy_accepts_human_readable_thresholds() {
         let human: Policy = toml::from_str(r#"max_file_bytes = "1.5 MiB""#).unwrap();
         assert_eq!(human.max_file_bytes, Some(1_572_864));
+    }
 
-        let legacy: Policy = toml::from_str("max_file_bytes = 1_572_864").unwrap();
-        assert_eq!(legacy.max_file_bytes, Some(1_572_864));
+    #[test]
+    fn policy_rejects_integer_thresholds() {
+        assert!(toml::from_str::<Policy>("max_file_bytes = 1_572_864").is_err());
     }
 
     #[test]
@@ -352,6 +342,6 @@ mod tests {
         config.validate().unwrap();
 
         let macos = &config.artifacts["baml-cli"].platform["aarch64-apple-darwin"];
-        assert_eq!(macos.max_file_bytes, Some(21_957_181));
+        assert_eq!(macos.max_file_bytes, Some(21_915_238));
     }
 }

--- a/baml_language/crates/tools_size_gate/src/human_size.rs
+++ b/baml_language/crates/tools_size_gate/src/human_size.rs
@@ -1,0 +1,120 @@
+use bytesize::ByteSize;
+
+pub(crate) fn format(bytes: u64) -> String {
+    ByteSize::b(bytes).display().iec().to_string()
+}
+
+pub(crate) fn parse(value: &str) -> Result<u64, String> {
+    value
+        .parse::<ByteSize>()
+        .map(|size| size.as_u64())
+        .map_err(|error| format!("invalid size `{value}`: {error}"))
+}
+
+pub(crate) mod required {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+    use super::{format, parse};
+
+    #[allow(
+        clippy::trivially_copy_pass_by_ref,
+        reason = "serde serialize_with requires a reference to the field"
+    )]
+    pub(crate) fn serialize<S>(bytes: &u64, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        format(*bytes).serialize(serializer)
+    }
+
+    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<u64, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        parse(&value).map_err(de::Error::custom)
+    }
+}
+
+pub(crate) mod optional {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+    use super::{format, parse};
+
+    #[allow(
+        clippy::ref_option,
+        reason = "serde serialize_with requires a reference to the field"
+    )]
+    pub(crate) fn serialize<S>(bytes: &Option<u64>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        bytes.map(format).serialize(serializer)
+    }
+
+    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Option::<String>::deserialize(deserializer)?
+            .map(|value| parse(&value).map_err(de::Error::custom))
+            .transpose()
+    }
+}
+
+pub(crate) mod map {
+    use std::collections::BTreeMap;
+
+    use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+
+    use super::{format, parse};
+    pub(crate) fn serialize<S>(
+        sizes: &BTreeMap<String, u64>,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        sizes
+            .iter()
+            .map(|(name, bytes)| (name, format(*bytes)))
+            .collect::<BTreeMap<_, _>>()
+            .serialize(serializer)
+    }
+
+    pub(crate) fn deserialize<'de, D>(deserializer: D) -> Result<BTreeMap<String, u64>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        BTreeMap::<String, String>::deserialize(deserializer)?
+            .into_iter()
+            .map(|(name, value)| {
+                parse(&value)
+                    .map(|bytes| (name, bytes))
+                    .map_err(de::Error::custom)
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytesize::ByteSize;
+
+    use super::{format, parse};
+
+    #[test]
+    fn uses_bytesize_iec_display() {
+        assert_eq!("518.0 GiB", ByteSize::gib(518).display().iec().to_string());
+        assert_eq!("14.8 MiB", format(15_519_843));
+        assert_eq!("1.0 KiB", format(1_024));
+        assert_eq!("0 B", format(0));
+    }
+
+    #[test]
+    fn parses_bytesize_strings() {
+        assert_eq!(parse("1.5 KiB").unwrap(), 1_536);
+        assert_eq!(parse("2 GiB").unwrap(), 2_147_483_648);
+        assert!(parse("not a size").is_err());
+    }
+}

--- a/baml_language/crates/tools_size_gate/src/main.rs
+++ b/baml_language/crates/tools_size_gate/src/main.rs
@@ -99,8 +99,8 @@ enum Command {
     ///
     /// Writes `.ci/size-gate/<platform>.toml` from each report's measured
     /// sizes and rewrites the per-platform ceilings in `.cargo/size-gate.toml`
-    /// to `--margin-pct` above them (comments preserved). Idempotent: when the
-    /// sizes already match, nothing is written.
+    /// to `--margin-pct` above them as human-readable KiB/MiB/GiB values.
+    /// Idempotent: when the sizes already match, nothing is written.
     Bake {
         /// JSON report files produced by `check --format json`. When omitted,
         /// reports are fetched from `--branch` instead.

--- a/baml_language/crates/tools_size_gate/src/main.rs
+++ b/baml_language/crates/tools_size_gate/src/main.rs
@@ -11,6 +11,7 @@ mod ceilings;
 mod compare;
 mod config;
 mod fetch;
+mod human_size;
 mod measure;
 mod output;
 
@@ -454,7 +455,10 @@ fn cmd_bake(args: BakeArgs) -> Result<i32> {
             merged.insert(name.clone(), measurement.clone());
         }
 
-        if existing.as_ref().is_some_and(|e| e.artifacts == merged) {
+        if existing
+            .as_ref()
+            .is_some_and(|baseline| baseline.measurements_match(&merged))
+        {
             eprintln!("baseline unchanged: {}", path.display());
             continue;
         }


### PR DESCRIPTION
Adopted from CI run [`fc9cf16fa5a374f6287d13c421f28b29f9b52597`](https://github.com/BoundaryML/baml/actions/runs/30438969840).

# Binary size checks passed

✅ **7** passed

| | Artifact | Platform | File | Gzip | Gated on | Baseline | Delta | Status |
|---|----------|----------|------|------|----------|----------|-------|--------|
| :white_check_mark: | `baml-cli` | Linux | 🔒 27.4 MB | 11.7 MB | **file** | 27.3 MB | +118.2 KB (+0.4%) | OK |
| :white_check_mark: | `packed-program` | Linux | 🔒 17.8 MB | 7.3 MB | **file** | 17.7 MB | +30.6 KB (+0.2%) | OK |
| :white_check_mark: | `baml-cli` | macOS | 🔒 21.3 MB | 10.2 MB | **file** | 21.2 MB | +99.3 KB (+0.5%) | OK |
| :white_check_mark: | `packed-program` | macOS | 🔒 13.9 MB | 6.4 MB | **file** | 13.9 MB | +48 B (+0.0%) | OK |
| :white_check_mark: | `bridge_wasm` | WASM | 16.8 MB | 🔒 4.6 MB | **gzip** | 4.5 MB | +48.3 KB (+1.1%) | OK |
| :white_check_mark: | `baml-cli` | Windows | 🔒 23.0 MB | 10.4 MB | **file** | 22.9 MB | +116.7 KB (+0.5%) | OK |
| :white_check_mark: | `packed-program` | Windows | 🔒 14.8 MB | 6.5 MB | **file** | 14.8 MB | +15.2 KB (+0.1%) | OK |

> 🔒 = the size this artifact is GATED on (ceiling + delta). Binaries gate on **file** size (installed binary); WASM gates on **gzip** (download size). The other size is shown for information only.

---
*Generated by `cargo size-gate`*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated size-gate ceiling values and CI baseline snapshots for macOS, Linux, Windows, and WebAssembly, switching thresholds and recorded measurements to human-readable KiB/MiB/GiB formats.
  * Refreshed build metadata and artifact size baselines across platforms.
  * Updated the size-gate tool’s output/serialization and baseline comparison behavior to align with the checked-in human-readable formats.
* **Tests**
  * Expanded coverage for parsing/formatting size thresholds, including rejection of invalid inputs and verification against checked-in baseline fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->