### PR TITLE
feat(cli): feedback pipeline: title/description, zero-prompt sends, auth login, local report store

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -756,6 +756,7 @@ dependencies = [
  "insta",
  "libsui",
  "mimalloc",
+ "mime_guess",
  "rayon",
  "regex",
  "reqwest",
@@ -5706,7 +5707,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -7484,7 +7485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -231,6 +231,7 @@ regex = { version = "1.10.2" }
 # gitignore-aware directory walking (workspace project discovery in the LSP)
 ignore = { version = "0.4" }
 base64 = "0.22"
+mime_guess = "2"
 bytecount = "0.6"
 reqwest = { version = "0.13.1", default-features = false, features = [
   "stream",
@@ -279,7 +280,7 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
 unicode-normalization = "0.1.25"
 ureq = { version = "3", default-features = false, features = [ "rustls", "gzip" ] }
 url = "2.5.2"
-uuid = { version = "1", features = [ "v4" ] }
+uuid = { version = "1", features = [ "serde", "v4" ] }
 walkdir = { version = "2.4" }
 tsify = { version = "0.5", features = [ "js" ] }
 wasm-bindgen = "0.2"

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -53,6 +53,7 @@ indexmap = { workspace = true }
 indicatif = { workspace = true }
 libsui = { workspace = true }
 mimalloc = { workspace = true }
+mime_guess = { workspace = true }
 rayon = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true, features = [ "blocking", "json", "rustls" ] }

--- a/baml_language/crates/baml_cli/src/auth.rs
+++ b/baml_language/crates/baml_cli/src/auth.rs
@@ -1,9 +1,9 @@
-// `baml login` / `baml auth` — a human email login via WorkOS CLI Auth.
+// `baml auth` — a human email login via WorkOS CLI Auth (`baml auth login`).
 //
 // This replaces the earlier agent-registration (auth.md) design: identity
 // for feedback is now PostHog-first (see `feedback_command.rs`) — anonymous
 // reporters get a locally generated PostHog distinct id, and logging in
-// exists to attach a verified email to that id. `baml login` runs the
+// exists to attach a verified email to that id. `baml auth login` runs the
 // OAuth 2.0 device authorization grant (RFC 8628): show a one-time code,
 // the user confirms it in a browser, the CLI polls for tokens. On success,
 // if an anonymous distinct id exists, a PostHog `$identify` event merges the
@@ -86,6 +86,8 @@ fn client_id() -> Result<String> {
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum AuthCommands {
+    #[command(about = "Log in to Boundary with your email")]
+    Login(LoginArgs),
     #[command(about = "Show the current identity")]
     Whoami(WhoamiArgs),
     #[command(about = "Log out (keeps your anonymous feedback id)")]
@@ -97,6 +99,7 @@ pub(crate) enum AuthCommands {
 impl AuthCommands {
     pub fn run(&self) -> Result<crate::ExitCode> {
         match self {
+            AuthCommands::Login(args) => args.run(),
             AuthCommands::Whoami(args) => args.run(),
             AuthCommands::Logout(args) => args.run(),
             AuthCommands::Token(args) => args.run(),
@@ -104,22 +107,18 @@ impl AuthCommands {
     }
 }
 
-/// Log in to Boundary with a device-code flow.
-///
-/// Opens a browser to complete authentication, then stores the resulting
-/// session locally. In headless environments, use `--no-open` to print the
-/// verification URL instead.
+/// `baml auth login` — device-code email login.
 #[derive(Args, Debug)]
 #[command(after_long_help = "\
 Examples:
   Log in using a browser:
-    baml login
+    baml auth login
 
   Print the verification URL instead:
-    baml login --no-open")]
+    baml auth login --no-open")]
 pub(crate) struct LoginArgs {
     /// Print the verification URL instead of opening a browser.
-    #[arg(long, help_heading = "Login options")]
+    #[arg(long)]
     pub no_open: bool,
 }
 
@@ -135,7 +134,7 @@ pub(crate) struct LogoutArgs {}
 pub(crate) struct TokenArgs {}
 
 impl LoginArgs {
-    /// Runs `baml login`.
+    /// Runs `baml auth login`.
     ///
     /// Device-code login via WorkOS CLI Auth, then — when an anonymous
     /// PostHog distinct id exists — sends a `$identify` event so all
@@ -148,8 +147,8 @@ impl LoginArgs {
     /// Errors:
     /// - When authorization can't be started, the user denies the login,
     ///   the code expires, or [`LOGIN_TIMEOUT`] elapses.
-    #[allow(clippy::print_stdout)]
     pub fn run(&self) -> Result<crate::ExitCode> {
+        let reporter = crate::reporter::Reporter::new();
         let mut existing = Credentials::read()?.unwrap_or_default();
         // Only skip the flow when the stored session can still produce a
         // token; a session that can't refresh falls through to a fresh
@@ -157,15 +156,18 @@ impl LoginArgs {
         if let Some(email) = existing.user_email.clone() {
             if existing.access_token().is_ok() {
                 existing.write()?;
-                println!("Already logged in as {email}.");
+                reporter.status("Login", format!("already logged in as {email}"));
                 return Ok(crate::ExitCode::Success);
             }
-            println!("The session for {email} has expired; logging in again.");
+            reporter.status(
+                "Login",
+                format!("the session for {email} has expired; logging in again"),
+            );
         }
         let creds = device_login(self.no_open, existing)?;
         match creds.user_email.as_deref() {
-            Some(email) => println!("Logged in as {email}."),
-            None => println!("Logged in."),
+            Some(email) => reporter.finish("Login", format!("logged in as {email}")),
+            None => reporter.finish("Login", "logged in"),
         }
         Ok(crate::ExitCode::Success)
     }
@@ -186,8 +188,8 @@ impl LoginArgs {
 /// Errors:
 /// - When authorization can't be started or the poll ends in denial,
 ///   expiry, or timeout.
-#[allow(clippy::print_stdout)]
 pub(crate) fn device_login(no_open: bool, existing: Credentials) -> Result<Credentials> {
+    let reporter = crate::reporter::Reporter::new();
     let client_id = client_id()?;
     let device: DeviceAuthResponse = post_form(
         &format!("{}/user_management/authorize/device", api_domain()),
@@ -195,25 +197,37 @@ pub(crate) fn device_login(no_open: bool, existing: Credentials) -> Result<Crede
     )
     .context("Failed to start device authorization")?;
 
-    println!("First, copy your one-time code: {}", device.user_code);
+    reporter.status(
+        "Login",
+        format!("first, copy your one-time code: {}", device.user_code),
+    );
     let open_uri = device
         .verification_uri_complete
         .as_deref()
         .unwrap_or(&device.verification_uri);
     if no_open {
-        println!("Then log in at: {}", device.verification_uri);
+        reporter.status(
+            "Login",
+            format!("then log in at: {}", device.verification_uri),
+        );
     } else {
-        println!("Then confirm the login in your browser...");
+        reporter.status("Login", "then confirm the login in your browser...");
         if webbrowser::open(open_uri).is_err() {
-            println!(
-                "Could not open a browser. Log in at: {}",
-                device.verification_uri
+            reporter.status(
+                "Login",
+                format!(
+                    "could not open a browser; log in at: {}",
+                    device.verification_uri
+                ),
             );
         }
     }
-    println!(
-        "Waiting for confirmation... (times out in {} minutes, Ctrl-C to cancel)",
-        LOGIN_TIMEOUT.as_secs() / 60
+    reporter.status(
+        "Waiting",
+        format!(
+            "for confirmation (times out in {} minutes, ctrl-c to cancel)",
+            LOGIN_TIMEOUT.as_secs() / 60
+        ),
     );
 
     let tokens = poll_token_endpoint(
@@ -235,8 +249,6 @@ pub(crate) fn device_login(no_open: bool, existing: Credentials) -> Result<Crede
             .posthog_distinct_id
             .clone()
             .or_else(|| Some(uuid::Uuid::new_v4().to_string())),
-        feedback_anonymous: false,
-        feedback_declined_at: None,
         user_id: user.and_then(|u| u.id.clone()),
         user_email: user.and_then(|u| u.email.clone()),
         access_token: Some(tokens.access_token),
@@ -259,20 +271,20 @@ impl WhoamiArgs {
         match Credentials::read()? {
             Some(creds) if creds.user_email.is_some() => {
                 println!(
-                    "Logged in as {}.",
+                    "logged in as {}",
                     creds.user_email.as_deref().unwrap_or("<unknown>")
                 );
                 Ok(crate::ExitCode::Success)
             }
             Some(creds) if creds.posthog_distinct_id.is_some() => {
                 println!(
-                    "Anonymous (feedback id {}). Run `baml login` to attach your email.",
+                    "anonymous (feedback id {}); run `baml auth login` to attach your email",
                     creds.posthog_distinct_id.as_deref().unwrap_or("<unknown>")
                 );
                 Ok(crate::ExitCode::Success)
             }
             _ => {
-                println!("Not logged in.");
+                println!("not logged in");
                 Ok(crate::ExitCode::Other)
             }
         }
@@ -283,12 +295,12 @@ impl LogoutArgs {
     /// Removes the login session. The PostHog distinct id is preserved so
     /// anonymous feedback continuity — and a future re-login's retroactive
     /// attribution — still work.
-    #[allow(clippy::print_stdout)]
     pub fn run(&self) -> Result<crate::ExitCode> {
+        let reporter = crate::reporter::Reporter::new();
         match Credentials::read()? {
-            None => println!("Not logged in."),
+            None => reporter.status("Logout", "not logged in"),
             Some(creds) if creds.user_email.is_none() && creds.access_token.is_none() => {
-                println!("Not logged in.");
+                reporter.status("Logout", "not logged in");
             }
             Some(creds) => {
                 let anonymous = Credentials {
@@ -296,7 +308,7 @@ impl LogoutArgs {
                     ..Credentials::default()
                 };
                 anonymous.write()?;
-                println!("Logged out.");
+                reporter.status("Logout", "logged out");
             }
         }
         Ok(crate::ExitCode::Success)
@@ -304,16 +316,19 @@ impl LogoutArgs {
 }
 
 impl TokenArgs {
-    #[allow(clippy::print_stdout, clippy::print_stderr)]
+    #[allow(clippy::print_stdout)]
     pub fn run(&self) -> Result<crate::ExitCode> {
+        let reporter = crate::reporter::Reporter::new();
         let mut creds = match Credentials::read()? {
             Some(creds) => creds,
-            None => {
-                eprintln!("Not logged in. Run `baml login`.");
-                return Ok(crate::ExitCode::Other);
-            }
+            None => return Ok(reporter.fatal("not logged in; run `baml auth login`")),
         };
-        println!("{}", creds.access_token()?);
+        // The token itself is this command's data output (stdout); auth
+        // failures are fatal diagnostics.
+        match creds.access_token() {
+            Ok(token) => println!("{token}"),
+            Err(e) => return Ok(reporter.fatal(e)),
+        }
         creds.write()?;
         Ok(crate::ExitCode::Success)
     }
@@ -383,7 +398,7 @@ fn poll_token_endpoint(
             }
             "access_denied" => anyhow::bail!("Login was denied in the browser."),
             "expired_token" => anyhow::bail!(
-                "The confirmation code expired before it was used. Run `baml login` again."
+                "the confirmation code expired before it was used; run `baml auth login` again"
             ),
             _ => anyhow::bail!("Auth server returned {status}: {value}"),
         }
@@ -455,29 +470,6 @@ fn form_urlencode(s: &str) -> String {
     out
 }
 
-/// Prints a prompt and reads one trimmed line from stdin.
-///
-/// Errors:
-/// - When stdin is closed (EOF — e.g. a piped or non-interactive session),
-///   so retry loops fail cleanly instead of spinning.
-#[allow(clippy::print_stdout)]
-pub(crate) fn prompt(message: &str) -> Result<String> {
-    use std::io::Write as _;
-    print!("{message}");
-    std::io::stdout().flush().ok();
-    let mut line = String::new();
-    let bytes_read = std::io::stdin()
-        .read_line(&mut line)
-        .context("Failed to read input")?;
-    if bytes_read == 0 {
-        anyhow::bail!(
-            "Standard input closed before a response was entered. \
-             This command needs an interactive terminal."
-        );
-    }
-    Ok(line.trim().to_string())
-}
-
 // ---------------------------------------------------------------------------
 // Credential storage: ~/.baml/creds.json
 // ---------------------------------------------------------------------------
@@ -495,16 +487,6 @@ pub(crate) struct Credentials {
     /// Verified email, once logged in.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_email: Option<String>,
-    /// Set once feedback has been sent anonymously while logged out; later
-    /// `baml feedback` runs skip the anonymous-vs-email prompt until a
-    /// login replaces these credentials.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-    pub feedback_anonymous: bool,
-    /// Unix seconds of the last "Don't send" choice at the prompt. For a
-    /// day afterwards, `baml feedback` declines quietly instead of
-    /// re-asking; explicit `--anonymous`/`--email` still send.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub feedback_declined_at: Option<u64>,
     /// Cached WorkOS access token (absent while anonymous).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     access_token: Option<String>,
@@ -513,6 +495,35 @@ pub(crate) struct Credentials {
     expires_at: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     refresh_token: Option<String>,
+}
+
+/// Writes a file readable only by the owner (0600 on unix; other
+/// platforms fall back to default permissions). Shared by every store
+/// that persists identity data (`creds.json`, `feedback.json`).
+pub(crate) fn write_owner_only(path: &std::path::Path, content: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    #[cfg(unix)]
+    {
+        use std::{
+            io::Write as _,
+            os::unix::fs::{OpenOptionsExt, PermissionsExt},
+        };
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)
+            .with_context(|| format!("Failed to write {}", path.display()))?;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+        file.write_all(content.as_bytes())
+            .with_context(|| format!("Failed to write {}", path.display()))?;
+    }
+    #[cfg(not(unix))]
+    std::fs::write(path, content).with_context(|| format!("Failed to write {}", path.display()))?;
+    Ok(())
 }
 
 fn creds_path() -> Result<PathBuf> {
@@ -554,31 +565,7 @@ impl Credentials {
     /// other users.
     pub fn write(&self) -> Result<()> {
         let path = creds_path()?;
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-        let content = serde_json::to_string_pretty(self)?;
-        #[cfg(unix)]
-        {
-            use std::{
-                io::Write as _,
-                os::unix::fs::{OpenOptionsExt, PermissionsExt},
-            };
-            let mut file = std::fs::OpenOptions::new()
-                .write(true)
-                .create(true)
-                .truncate(true)
-                .mode(0o600)
-                .open(&path)
-                .with_context(|| format!("Failed to write {}", path.display()))?;
-            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
-            file.write_all(content.as_bytes())
-                .with_context(|| format!("Failed to write {}", path.display()))?;
-        }
-        #[cfg(not(unix))]
-        std::fs::write(&path, content)
-            .with_context(|| format!("Failed to write {}", path.display()))?;
-        Ok(())
+        write_owner_only(&path, &serde_json::to_string_pretty(self)?)
     }
 
     /// Returns a valid access token, refreshing via the OAuth refresh-token
@@ -590,7 +577,7 @@ impl Credentials {
     ///   refreshed.
     pub fn access_token(&mut self) -> Result<&str> {
         if self.access_token.is_none() {
-            anyhow::bail!("Not logged in. Run `baml login`.");
+            anyhow::bail!("not logged in; run `baml auth login`");
         }
         let expired = match self.expires_at {
             Some(at) => at <= now_unix() + 30,
@@ -602,7 +589,7 @@ impl Credentials {
             let refresh = self
                 .refresh_token
                 .as_deref()
-                .context("Session expired. Run `baml login` again.")?;
+                .context("session expired; run `baml auth login` again")?;
             let tokens: TokenResponse = post_form(
                 &format!("{}/user_management/authenticate", api_domain()),
                 &[
@@ -611,7 +598,7 @@ impl Credentials {
                     ("refresh_token", refresh),
                 ],
             )
-            .context("Failed to refresh session. Run `baml login` again.")?;
+            .context("failed to refresh session; run `baml auth login` again")?;
             self.access_token = Some(tokens.access_token);
             self.expires_at = tokens.expires_in.map(|s| now_unix() + s);
             if tokens.refresh_token.is_some() {

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -145,13 +145,10 @@ pub(crate) enum Commands {
     #[command(
         subcommand,
         about = "Manage authentication",
-        long_about = "Manage the identity used by BAML services.\n\nUse `baml login` to authenticate, `baml auth whoami` to inspect the current identity, and `baml auth logout` to remove the authenticated session.",
-        after_long_help = "Examples:\n  Show the current identity:\n    baml auth whoami\n\n  Log out:\n    baml auth logout"
+        long_about = "Manage the identity used by BAML services.\n\nUse `baml auth login` to authenticate, `baml auth whoami` to inspect the current identity, and `baml auth logout` to remove the authenticated session.",
+        after_long_help = "Examples:\n  Log in:\n    baml auth login\n\n  Show the current identity:\n    baml auth whoami\n\n  Log out:\n    baml auth logout"
     )]
     Auth(crate::auth::AuthCommands),
-
-    #[command(about = "Log in to Boundary with your email")]
-    Login(crate::auth::LoginArgs),
 
     #[command(about = "Report an issue or improvement to Boundary")]
     Feedback(crate::feedback_command::FeedbackArgs),
@@ -389,7 +386,6 @@ impl RuntimeCli {
                 }
             },
             Commands::Auth(args) => args.run(),
-            Commands::Login(args) => args.run(),
             Commands::Feedback(args) => args.run(),
             // Handled before telemetry and command-side effects above.
             Commands::Help(args) => args.run(crate::output::policy().stdout.color),
@@ -480,9 +476,9 @@ mod tests {
         &[],
         &["check"],
         &["auth"],
+        &["auth", "login"],
         &["auth", "whoami"],
         &["auth", "logout"],
-        &["login"],
         &["feedback"],
         &["fmt"],
         &["describe"],
@@ -805,8 +801,8 @@ mod tests {
             &["baml", "check", "--project", "./my-project"],
             &["baml", "auth", "whoami"],
             &["baml", "auth", "logout"],
-            &["baml", "login"],
-            &["baml", "login", "--no-open"],
+            &["baml", "auth", "login"],
+            &["baml", "auth", "login", "--no-open"],
             &["baml", "describe"],
             &["baml", "describe", "baml"],
             &["baml", "describe", "baml.json"],
@@ -846,19 +842,30 @@ mod tests {
             &[
                 "baml",
                 "feedback",
-                "--issue",
-                "parser panics on nested unions",
+                "--title",
+                "Issue (parser): panics on nested unions",
             ],
             &[
                 "baml",
                 "feedback",
-                "--anonymous",
-                "--issue",
+                "--title",
                 "...",
-                "--repro",
-                "class A { ... }",
+                "--description",
+                "Minimum repro: class A { ... }",
             ],
-            &["baml", "feedback", "--anonymous", "-"],
+            &["baml", "feedback", "-"],
+            &[
+                "baml",
+                "feedback",
+                "--title",
+                "...",
+                "--files",
+                "screenshot.png",
+                "--files",
+                "repro.baml",
+            ],
+            &["baml", "feedback", "list", "--status", "open"],
+            &["baml", "feedback", "view", "a1b2c3d4"],
             &["baml", "fmt"],
             &["baml", "fmt", "baml_src/main.baml"],
             &["baml", "fmt", "--dry-run"],

--- a/baml_language/crates/baml_cli/src/feedback_command.rs
+++ b/baml_language/crates/baml_cli/src/feedback_command.rs
@@ -1,31 +1,41 @@
-// `baml feedback` — report a way to improve the BAML language to Boundary.
+// `baml feedback` — report an issue or improvement to Boundary, and manage
+// past reports (gh-issues style: `status`, `list`, `view`, `disable`).
 //
-// Identity is PostHog-first. The reporter chooses:
-//
-// - **Anonymously**: the event is sent under a locally generated PostHog
-//   distinct id, persisted in `~/.baml/creds.json` so future reports share
-//   one anonymous person. No account, no server-side registration.
-// - **Via email** (requires `baml login`): the event additionally carries
-//   the verified email, and the reporter can be notified when a fix ships.
+// Identity is PostHog-first, and sending costs no interaction: with no
+// session, reports go out anonymously under a locally generated PostHog
+// distinct id (persisted in `~/.baml/creds.json`). After `baml auth login`,
+// reports carry the verified email instead. No prompt either way.
 //
 // When an anonymous reporter later logs in, a `$identify` event merges the
 // anonymous person into the identified one — PostHog's native person merge —
 // so every previously filed report is retroactively attributed. There is no
 // backfill job; the merge *is* the backfill.
+//
+// Every report is also recorded in `<BAML_HOME>/feedback.json`, which is
+// what `status`/`list`/`view` read: the embedded PostHog key is write-only,
+// so past reports cannot be queried back from the server. Records start as
+// `open` and flip to `anonymous`/`reported` once delivered, so an offline
+// send is saved locally and synced on a later run instead of failing.
+
+// `println!` here is the primary UX of the command: data output (previews,
+// confirmations, status/list/view) belongs on stdout. Diagnostics go
+// through `crate::reporter`. The workspace-wide ban on `print*!` exists to
+// catch stray debug prints, not to break intentional user-facing output.
+#![allow(clippy::print_stdout)]
 
 use anyhow::{Context, Result};
-use clap::Args;
+use clap::{Args, Subcommand, ValueEnum};
+use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
 use crate::auth::{self, Credentials};
 
-/// Feedback events must stay comfortably inside PostHog's per-event limits.
-const MAX_PAYLOAD_BYTES: usize = 256 * 1024;
-
 const FEEDBACK_EVENT: &str = "baml_feedback";
 
-/// How long a "Don't send" choice suppresses the prompt.
-const DECLINE_COOLDOWN_SECS: u64 = 24 * 60 * 60;
+/// Cap on deferred deliveries attempted per invocation, so a long-offline
+/// backlog can't turn one command into hundreds of blocking posts. The
+/// remainder syncs on later runs.
+const MAX_SYNC_PER_RUN: usize = 25;
 
 /// PostHog ingestion host, overridable for tests and self-hosted setups.
 fn posthog_host() -> String {
@@ -35,118 +45,227 @@ fn posthog_host() -> String {
         .unwrap_or_else(|| crate::telemetry::posthog_host().to_string())
 }
 
-/// Report an issue or improvement to Boundary.
-///
-/// Reports can be anonymous or associated with the email from `baml login`.
-/// Without an identity flag, interactive sessions prompt before sending.
+/// Wrapper existing only to fix clap's derived `update_from_arg_matches`,
+/// which errors with "a subcommand is required" whenever the optional
+/// subcommand is absent (so plain `baml feedback --title ...` would die in
+/// `parse_from_smart`'s update pass). The manual impl replays a fresh parse
+/// instead.
+#[derive(Debug)]
+pub(crate) struct FeedbackArgs(FeedbackInner);
+
+impl FeedbackArgs {
+    pub fn run(&self) -> Result<crate::ExitCode> {
+        self.0.run()
+    }
+}
+
+impl clap::FromArgMatches for FeedbackArgs {
+    fn from_arg_matches(matches: &clap::ArgMatches) -> Result<Self, clap::Error> {
+        FeedbackInner::from_arg_matches(matches).map(Self)
+    }
+    fn update_from_arg_matches(&mut self, matches: &clap::ArgMatches) -> Result<(), clap::Error> {
+        self.0 = FeedbackInner::from_arg_matches(matches)?;
+        Ok(())
+    }
+}
+
+impl Args for FeedbackArgs {
+    fn augment_args(cmd: clap::Command) -> clap::Command {
+        FeedbackInner::augment_args(cmd)
+    }
+    fn augment_args_for_update(cmd: clap::Command) -> clap::Command {
+        FeedbackInner::augment_args_for_update(cmd)
+    }
+}
+
 #[derive(Args, Debug)]
+#[command(args_conflicts_with_subcommands = true)]
 #[command(after_long_help = "\
 Examples:
   Report an issue:
-    baml feedback --issue \"parser panics on nested unions\"
+    baml feedback --title \"Issue (parser): panics on nested unions\"
 
-  Submit an anonymous report with a reproduction:
-    baml feedback --anonymous --issue \"...\" --repro \"class A { ... }\"
+  Include a description with a minimum repro:
+    baml feedback --title \"...\" --description \"Minimum repro: class A { ... }\"
 
-  Submit an anonymous JSON report from standard input:
-    echo '{\"issue\": \"...\", \"repro\": \"...\"}' | baml feedback --anonymous -")]
-pub(crate) struct FeedbackArgs {
-    /// The issue or improvement you found.
-    #[arg(long, help_heading = "Report options")]
-    pub issue: Option<String>,
+  Submit a JSON report from standard input:
+    echo '{\"title\": \"...\", \"description\": \"...\"}' | baml feedback -
 
-    /// Steps or a snippet that reproduces it.
-    #[arg(long, help_heading = "Report options")]
-    pub repro: Option<String>,
+  Attach files:
+    baml feedback --title \"...\" --files screenshot.png --files repro.baml
 
-    /// Anything else useful (versions, environment, what you were doing).
-    #[arg(long, help_heading = "Report options")]
-    pub context: Option<String>,
+  List undelivered reports:
+    baml feedback list --status open
+
+  View one report:
+    baml feedback view a1b2c3d4")]
+struct FeedbackInner {
+    #[command(subcommand)]
+    pub action: Option<FeedbackAction>,
+
+    /// One line describing the issue, in the form `Issue (feature): description`.
+    #[arg(long)]
+    pub title: Option<String>,
+
+    /// Anything relevant to help the BAML team understand your
+    /// problem/suggestion; include a minimum repro.
+    ///
+    /// Good descriptions cover: what I was doing, what went wrong, a
+    /// minimum repro (include one whenever possible), what I want to
+    /// happen, and potential syntax ideas.
+    #[arg(long)]
+    pub description: Option<String>,
+
+    /// Attach a file (image, code, log).
+    /// Repeatable: `--files a.png --files repro.baml`.
+    #[arg(long = "files", value_name = "PATH", action = clap::ArgAction::Append)]
+    pub files: Vec<std::path::PathBuf>,
 
     /// Advanced: supply the fields as JSON instead of flags (an inline
     /// object, a file path, or `-` for stdin).
     #[arg(value_name = "JSON", hide_short_help = true)]
     pub input: Option<String>,
 
-    /// Report anonymously without prompting.
-    #[arg(long, conflicts_with = "email", help_heading = "Identity options")]
+    /// Report anonymously even while logged in.
+    #[arg(long, conflicts_with = "email")]
     pub anonymous: bool,
 
-    /// Report with your email without prompting (requires `baml login`).
-    #[arg(long, help_heading = "Identity options")]
+    /// Report with your email (requires `baml auth login`).
+    #[arg(long)]
     pub email: bool,
 }
 
-impl FeedbackArgs {
-    /// Runs `baml feedback`.
+#[derive(Subcommand, Debug)]
+pub(crate) enum FeedbackAction {
+    /// Show whether feedback is enabled and the reports sent so far.
+    Status,
+    /// List past reports.
+    List {
+        /// Only show reports with this status.
+        #[arg(long, value_enum)]
+        status: Option<ReportStatus>,
+        /// Show at most this many reports (newest last).
+        #[arg(long)]
+        limit: Option<usize>,
+        /// Output the matching records as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// View one past report in full.
+    View {
+        /// The report id (from `baml feedback list`).
+        id: String,
+        /// Output the record as JSON.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Disable sending feedback from this machine.
+    Disable,
+    /// Re-enable sending feedback.
+    Enable,
+}
+
+#[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum ReportStatus {
+    /// Recorded locally but not yet delivered (e.g. sent while offline).
+    Open,
+    /// Delivered to Boundary without an email.
+    Anonymous,
+    /// Delivered to Boundary with a verified email.
+    Reported,
+}
+
+impl std::fmt::Display for ReportStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            ReportStatus::Open => "open",
+            ReportStatus::Anonymous => "anonymous",
+            ReportStatus::Reported => "reported",
+        })
+    }
+}
+
+impl FeedbackInner {
+    /// Runs `baml feedback` and its subcommands.
     ///
-    /// Collects the payload, resolves how to report (flag, or interactive
-    /// prompt offering anonymous vs email — the email path runs `baml
-    /// login` inline when needed), ensures a persistent PostHog distinct
-    /// id, and sends the event.
+    /// Without a subcommand, collects the payload and sends it: with the
+    /// verified email when logged in (see `baml auth login`), anonymously
+    /// under the persistent PostHog distinct id otherwise. Any invocation
+    /// first retries `open` (undelivered) reports best-effort.
     ///
     /// Returns:
-    /// - `ExitCode::Success` when the event is accepted by PostHog.
+    /// - `ExitCode::Success` when the action completes; a send that cannot
+    ///   reach PostHog still succeeds by saving the report as `open`.
     /// - `ExitCode::Other` (with guidance on stderr) when `--email` is used
-    ///   non-interactively without a login.
+    ///   without a login, when feedback is disabled, or when a `view` id is
+    ///   unknown.
     ///
     /// Errors:
-    /// - On a missing/oversized/malformed payload or a failed send.
-    #[allow(clippy::print_stdout, clippy::print_stderr)]
+    /// - On a missing/malformed payload, an unreadable attachment, or a
+    ///   corrupt local store.
     pub fn run(&self) -> Result<crate::ExitCode> {
-        let payload = self.payload()?;
+        let mut store = FeedbackStore::load()?;
+
+        // Best-effort delivery of anything still `open` before every action
+        // except the enabled-flag flips: `status`/`list`/`view` should show
+        // fresh state, and a send should not overtake older reports.
+        if store.enabled
+            && !matches!(
+                self.action,
+                Some(FeedbackAction::Disable) | Some(FeedbackAction::Enable)
+            )
+        {
+            sync_open_reports(&mut store);
+        }
+
+        match &self.action {
+            Some(FeedbackAction::Status) => return run_status(&store),
+            Some(FeedbackAction::List {
+                status,
+                limit,
+                json,
+            }) => return run_list(&store, *status, *limit, *json),
+            Some(FeedbackAction::View { id, json }) => return run_view(&store, id, *json),
+            Some(FeedbackAction::Disable) => return run_set_enabled(&mut store, false),
+            Some(FeedbackAction::Enable) => return run_set_enabled(&mut store, true),
+            None => {}
+        }
+
+        if !store.enabled {
+            crate::reporter::print_error(
+                "feedback is disabled on this machine; run `baml feedback enable` to turn it back on",
+            );
+            return Ok(crate::ExitCode::Other);
+        }
+
+        let mut payload = self.payload()?;
+        let attachments = encode_attachments(&self.files)?;
+        if !attachments.is_empty() {
+            payload["files"] = files_event_json(&attachments);
+        }
 
         let mut creds = Credentials::read()?.unwrap_or_default();
 
-        // Resolve identity mode.
+        // Resolve identity: email when logged in, anonymous otherwise. No
+        // prompt — reporting should never cost an interaction.
         let identified = if self.anonymous {
             false
         } else if creds.user_email.is_some() {
-            // Already logged in: report with the account, no prompt needed.
             true
         } else if self.email {
             // Non-interactive email mode without a session: instruct and
             // exit rather than trying to run an interactive login under a
             // flag that suggests automation.
-            eprintln!(
-                "Reporting via email requires a login. Run `baml login`, then \
-                 re-run this command."
+            crate::reporter::print_error(
+                "reporting via email requires a login; run `baml auth login` and re-run this command",
             );
             return Ok(crate::ExitCode::Other);
-        } else if creds.feedback_anonymous {
-            // A prior report was sent anonymously; honor that choice without
-            // re-prompting until a login replaces it.
-            false
-        } else if creds
-            .feedback_declined_at
-            .is_some_and(|at| auth::now_unix() < at.saturating_add(DECLINE_COOLDOWN_SECS))
-        {
-            // "Don't send" was chosen within the last day: decline quietly
-            // instead of re-asking. Explicit --anonymous/--email (handled
-            // above) still send.
-            println!(
-                "Nothing sent (you declined recently). Pass --anonymous or \
-                 --email to send anyway."
-            );
-            return Ok(crate::ExitCode::Success);
         } else {
-            println!("I found an issue with BAML. I can report it to Boundary.");
-            println!();
-            self.print_preview(&payload);
-            match self.prompt_for_mode()? {
-                ReportMode::Anonymous => false,
-                ReportMode::Email => {
-                    creds = auth::device_login(false, creds)?;
-                    true
-                }
-                ReportMode::DontSend => {
-                    creds.feedback_declined_at = Some(auth::now_unix());
-                    creds.write()?;
-                    println!("Nothing sent.");
-                    return Ok(crate::ExitCode::Success);
-                }
-            }
+            false
         };
+
+        self.print_preview(&payload, identified, creds.user_email.as_deref());
 
         // A stable distinct id makes every report from this machine one
         // PostHog person — and is what a later login merges into the
@@ -162,36 +281,69 @@ impl FeedbackArgs {
             if creds.posthog_distinct_id.is_none() {
                 creds.posthog_distinct_id = Some(uuid::Uuid::new_v4().to_string());
             }
-            if !identified {
-                // Remember the anonymous choice so later runs don't re-prompt
-                // (until a login resets it).
-                creds.feedback_anonymous = true;
-            }
-            // A sent report supersedes any earlier "Don't send" cooldown.
-            creds.feedback_declined_at = None;
             creds.write()?;
             creds.posthog_distinct_id.clone().expect("set above")
         };
 
-        send_feedback(&creds, &distinct_id, payload, identified)?;
+        // Record first as `open`, then flip on delivery: an offline send is
+        // saved rather than lost.
+        let record = FeedbackRecord::new(
+            &payload,
+            attachments,
+            identified,
+            self.anonymous,
+            creds.user_email.as_deref(),
+        );
+        let short_id = record.id.clone();
+        let report_id = record.event_uuid;
+        store.reports.push(record);
+        store.save()?;
 
-        if identified {
-            println!(
-                "Feedback sent as {}. Thank you! You'll be notified when this is addressed.",
-                creds.user_email.as_deref().unwrap_or("your account")
-            );
-        } else {
-            println!("Feedback sent anonymously. Thank you!");
-            if creds.user_email.is_none() {
+        match send_feedback(
+            &creds,
+            &distinct_id,
+            &payload,
+            identified,
+            &report_id.to_string(),
+        ) {
+            Ok(()) => {
+                let delivered_status = if identified {
+                    ReportStatus::Reported
+                } else {
+                    ReportStatus::Anonymous
+                };
+                let delivered_email = identified.then(|| creds.user_email.clone()).flatten();
+                if let Some(r) = store.reports.iter_mut().find(|r| r.event_uuid == report_id) {
+                    r.mark_delivered(delivered_status, delivered_email.as_deref());
+                }
+                store.save()?;
+                if identified {
+                    println!(
+                        "feedback {} sent as {}; you'll be notified when this is addressed",
+                        short_id,
+                        creds.user_email.as_deref().unwrap_or("your account")
+                    );
+                } else {
+                    println!("feedback {short_id} sent anonymously");
+                    if creds.user_email.is_none() {
+                        println!(
+                            "run `baml auth login` to be notified when this is \
+                             fixed; past reports come with you"
+                        );
+                    }
+                }
+            }
+            Err(_) => {
                 println!(
-                    "(Run `baml login` any time to attach your email and get notified of fixes. Past reports come with you.)"
+                    "could not reach Boundary; feedback {short_id} saved locally \
+                     and will sync on the next `baml feedback` run"
                 );
             }
         }
         Ok(crate::ExitCode::Success)
     }
 
-    /// Assembles `{issue, repro?, context?}` from flags and/or JSON input.
+    /// Assembles `{title, description?}` from flags and/or JSON input.
     /// Flags win over JSON fields when both are given.
     fn payload(&self) -> Result<Value> {
         let mut from_json = match self.input.as_deref() {
@@ -215,11 +367,7 @@ impl FeedbackArgs {
         let obj = from_json
             .as_object_mut()
             .expect("parse_payload_json returns an object");
-        for (key, flag) in [
-            ("issue", &self.issue),
-            ("repro", &self.repro),
-            ("context", &self.context),
-        ] {
+        for (key, flag) in [("title", &self.title), ("description", &self.description)] {
             if let Some(value) = flag {
                 obj.insert(key.to_string(), Value::String(value.clone()));
             }
@@ -227,57 +375,73 @@ impl FeedbackArgs {
 
         // Whitelist: only the documented fields ship. Anything else in a
         // piped payload (stray script fields, PostHog-special keys like
-        // `$set`) is rejected rather than silently transmitted.
+        // `$set`) is rejected rather than silently transmitted. `files` is
+        // deliberately NOT accepted from JSON: a piped payload naming local
+        // paths would let untrusted payload content exfiltrate arbitrary
+        // files. Attachments come only from the `--files` flag (trusted CLI
+        // input).
         let unknown: Vec<&str> = obj
             .keys()
             .map(String::as_str)
-            .filter(|k| !matches!(*k, "issue" | "repro" | "context"))
+            .filter(|k| !matches!(*k, "title" | "description"))
             .collect();
         if !unknown.is_empty() {
-            anyhow::bail!(
-                "Unknown feedback field(s): {}. Only \"issue\", \"repro\", and \
-                 \"context\" are sent.",
+            return Err(anyhow::anyhow!(
+                "unknown feedback field(s) {}; only \"title\" and \
+                 \"description\" are sent (attach files with --files)",
                 unknown.join(", ")
-            );
+            ));
         }
 
-        if obj
-            .get("issue")
-            .and_then(Value::as_str)
-            .unwrap_or("")
-            .trim()
-            .is_empty()
-        {
-            anyhow::bail!(
-                "Feedback needs an issue. Pass --issue \"...\" or a JSON payload \
-                 with an \"issue\" field."
-            );
+        // Validate types, not just names: a non-string field would ship to
+        // PostHog while the preview and the local record (which read via
+        // `as_str`) silently dropped it.
+        for key in ["title", "description"] {
+            if let Some(value) = obj.get(key)
+                && !value.is_string()
+            {
+                return Err(anyhow::anyhow!("feedback field \"{key}\" must be a string"));
+            }
         }
-        let size = serde_json::to_string(&from_json)
-            .map(|s| s.len())
-            .unwrap_or(0);
-        if size > MAX_PAYLOAD_BYTES {
-            anyhow::bail!(
-                "Feedback payload is {size} bytes; the limit is {MAX_PAYLOAD_BYTES}. \
-                 Trim the repro/context (a link to a gist works well)."
-            );
+
+        let title = obj.get("title").and_then(Value::as_str).unwrap_or("");
+        if title.trim().is_empty() {
+            return Err(anyhow::anyhow!(
+                "feedback needs a title; pass --title \"...\" or a JSON payload \
+                 with a \"title\" field"
+            ));
         }
         Ok(from_json)
     }
 
-    /// Shows exactly what a report will contain before the user decides.
-    #[allow(clippy::print_stdout)]
-    fn print_preview(&self, payload: &Value) {
-        println!("Here's what will be sent:");
+    /// Shows exactly what a report contains and how it is attributed.
+    fn print_preview(&self, payload: &Value, identified: bool, email: Option<&str>) {
+        if identified {
+            println!(
+                "reporting to Boundary as {}:",
+                email.unwrap_or("your account")
+            );
+        } else {
+            println!("reporting to Boundary anonymously:");
+        }
         println!();
-        for (label, key) in [
-            ("Issue", "issue"),
-            ("Repro", "repro"),
-            ("Context", "context"),
-        ] {
+        for (label, key) in [("Title", "title"), ("Description", "description")] {
             if let Some(text) = payload.get(key).and_then(Value::as_str) {
                 println!("  {label}: {text}");
             }
+        }
+        if let Some(files) = payload.get("files").and_then(Value::as_array) {
+            let listed: Vec<String> = files
+                .iter()
+                .map(|f| {
+                    format!(
+                        "{} ({} bytes)",
+                        f["name"].as_str().unwrap_or("?"),
+                        f["size_bytes"].as_u64().unwrap_or(0)
+                    )
+                })
+                .collect();
+            println!("  Files: {}", listed.join(", "));
         }
         println!(
             "  (plus: cli version {}, {}/{})",
@@ -287,41 +451,396 @@ impl FeedbackArgs {
         );
         println!();
     }
+}
 
-    /// The interactive choice.
-    #[allow(clippy::print_stdout)]
-    fn prompt_for_mode(&self) -> Result<ReportMode> {
-        println!("How should I report it?");
-        println!("  1) Anonymously");
-        println!(
-            "  2) Via your email (requires `baml login`; you'll be notified when a fix ships)"
-        );
-        println!("  3) Don't send");
-        loop {
-            let choice = auth::prompt("Choose [1/2/3]: ")?;
-            match choice.as_str() {
-                "1" => return Ok(ReportMode::Anonymous),
-                "2" => return Ok(ReportMode::Email),
-                "3" | "n" | "no" => return Ok(ReportMode::DontSend),
-                _ => println!("Please enter 1, 2, or 3."),
+/// Reads attachments into [`StoredFile`]s (raw bytes; base64 happens at
+/// serialization time, both for the event payload and the local store).
+fn encode_attachments(paths: &[std::path::PathBuf]) -> Result<Vec<StoredFile>> {
+    let mut files = Vec::new();
+    for path in paths {
+        let bytes = std::fs::read(path)
+            .with_context(|| format!("failed to read attachment {}", path.display()))?;
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_else(|| path.display().to_string());
+        // mime_guess knows the registry; for extensions it doesn't (code
+        // files like .baml), fall back on the content: valid UTF-8 is text.
+        let mime = mime_guess::from_path(path).first().unwrap_or_else(|| {
+            if std::str::from_utf8(&bytes).is_ok() {
+                mime_guess::mime::TEXT_PLAIN
+            } else {
+                mime_guess::mime::APPLICATION_OCTET_STREAM
             }
+        });
+        files.push(StoredFile {
+            name,
+            mime: mime.essence_str().to_string(),
+            size_bytes: bytes.len() as u64,
+            content: Some(bytes),
+        });
+    }
+    Ok(files)
+}
+
+/// The `files` array as it appears in the PostHog event payload.
+fn files_event_json(files: &[StoredFile]) -> Value {
+    use base64::Engine as _;
+    json!(
+        files
+            .iter()
+            .map(|f| json!({
+                "name": f.name,
+                "mime": f.mime,
+                "size_bytes": f.size_bytes,
+                "content_base64": base64::engine::general_purpose::STANDARD
+                    .encode(f.content.as_deref().unwrap_or_default()),
+            }))
+            .collect::<Vec<_>>()
+    )
+}
+
+fn parse_payload_json(raw: &str) -> Result<Value> {
+    let value: Value = serde_json::from_str(raw).context("feedback payload is not valid JSON")?;
+    if !value.is_object() {
+        return Err(anyhow::anyhow!(
+            "feedback payload must be a JSON object like {{\"title\": \"...\"}}"
+        ));
+    }
+    Ok(value)
+}
+
+// ---------------------------------------------------------------------------
+// Local report store: <BAML_HOME>/feedback.json
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, Serialize)]
+struct FeedbackStore {
+    /// Whether `baml feedback` sends anything from this machine.
+    #[serde(default = "default_true")]
+    enabled: bool,
+    /// Reports from this machine, oldest first.
+    #[serde(default)]
+    reports: Vec<FeedbackRecord>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for FeedbackStore {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            reports: Vec::new(),
         }
     }
 }
 
-enum ReportMode {
-    Anonymous,
-    Email,
-    /// Declined at the prompt: nothing is sent, nothing is persisted.
-    DontSend,
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct FeedbackRecord {
+    /// Short id shown in `list`/`view` (a prefix of `event_uuid`).
+    id: String,
+    /// Full uuid, sent as the `report_id` event property so server-side
+    /// state can be joined to this record later.
+    event_uuid: uuid::Uuid,
+    title: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    status: ReportStatus,
+    /// The user explicitly asked for anonymity (`--anonymous`). A deferred
+    /// delivery must honor it even if a login exists by sync time.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    forced_anonymous: bool,
+    /// The verified email the report was (or will be) attributed to.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    email: Option<String>,
+    /// Attachments. Content is kept while `open` (a deferred delivery must
+    /// ship it) and dropped once delivered, leaving only the
+    /// name/mime/size metadata for `view`.
+    #[serde(default)]
+    files: Vec<StoredFile>,
+    /// Unix seconds.
+    created_at: u64,
 }
 
-fn parse_payload_json(raw: &str) -> Result<Value> {
-    let value: Value = serde_json::from_str(raw).context("Feedback payload is not valid JSON")?;
-    if !value.is_object() {
-        anyhow::bail!("Feedback payload must be a JSON object like {{\"issue\": \"...\"}}");
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct StoredFile {
+    name: String,
+    mime: String,
+    size_bytes: u64,
+    /// Raw bytes in memory; serialized as base64 (field `content_base64`)
+    /// so the store stays valid JSON.
+    #[serde(
+        default,
+        rename = "content_base64",
+        skip_serializing_if = "Option::is_none",
+        with = "opt_base64"
+    )]
+    content: Option<Vec<u8>>,
+}
+
+/// Serde adapter: `Option<Vec<u8>>` <-> optional base64 string.
+mod opt_base64 {
+    use base64::Engine as _;
+    use serde::{Deserialize as _, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &Option<Vec<u8>>, s: S) -> Result<S::Ok, S::Error> {
+        match v {
+            Some(bytes) => {
+                s.serialize_str(&base64::engine::general_purpose::STANDARD.encode(bytes))
+            }
+            None => s.serialize_none(),
+        }
     }
-    Ok(value)
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<Vec<u8>>, D::Error> {
+        let raw: Option<String> = Option::deserialize(d)?;
+        raw.map(|text| {
+            base64::engine::general_purpose::STANDARD
+                .decode(text)
+                .map_err(serde::de::Error::custom)
+        })
+        .transpose()
+    }
+}
+
+impl FeedbackRecord {
+    fn new(
+        payload: &Value,
+        files: Vec<StoredFile>,
+        identified: bool,
+        forced_anonymous: bool,
+        email: Option<&str>,
+    ) -> Self {
+        let event_uuid = uuid::Uuid::new_v4();
+        Self {
+            id: event_uuid.to_string()[..8].to_string(),
+            event_uuid,
+            title: payload
+                .get("title")
+                .and_then(Value::as_str)
+                .unwrap_or_default()
+                .to_string(),
+            description: payload
+                .get("description")
+                .and_then(Value::as_str)
+                .map(str::to_string),
+            status: ReportStatus::Open,
+            forced_anonymous,
+            email: if identified {
+                email.map(str::to_string)
+            } else {
+                None
+            },
+            files,
+            created_at: auth::now_unix(),
+        }
+    }
+
+    /// Rebuilds the event payload for a deferred (`open`) delivery.
+    fn payload(&self) -> Value {
+        let mut payload = json!({ "title": self.title });
+        if let Some(description) = &self.description {
+            payload["description"] = json!(description);
+        }
+        if !self.files.is_empty() {
+            payload["files"] = files_event_json(&self.files);
+        }
+        payload
+    }
+
+    /// Marks the record delivered: sets the final status/email and drops
+    /// attachment bytes (the content has shipped; only name/mime/size
+    /// metadata stays for `view`).
+    fn mark_delivered(&mut self, status: ReportStatus, email: Option<&str>) {
+        self.status = status;
+        self.email = email.map(str::to_string);
+        for file in &mut self.files {
+            file.content = None;
+        }
+    }
+}
+
+impl FeedbackStore {
+    fn path() -> std::path::PathBuf {
+        baml_release::baml_home().join("feedback.json")
+    }
+
+    fn load() -> Result<Self> {
+        let path = Self::path();
+        match std::fs::read_to_string(&path) {
+            Ok(raw) => serde_json::from_str(&raw)
+                .with_context(|| format!("Malformed feedback store in {}", path.display())),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(e).with_context(|| format!("Failed to read {}", path.display())),
+        }
+    }
+
+    fn save(&self) -> Result<()> {
+        // Owner-only, like creds.json: delivered records carry the verified
+        // email, and descriptions often carry environment details.
+        auth::write_owner_only(&Self::path(), &serde_json::to_string(self)?)
+    }
+}
+
+/// Attempts to deliver every `open` report with the current identity
+/// (email when logged in, the persistent anonymous id otherwise).
+/// Best-effort: failures leave the record `open` for the next run.
+fn sync_open_reports(store: &mut FeedbackStore) {
+    if !store.reports.iter().any(|r| r.status == ReportStatus::Open) {
+        return;
+    }
+    let Ok(mut creds) = Credentials::read().map(Option::unwrap_or_default) else {
+        return;
+    };
+    let identified = creds.user_email.is_some();
+    if creds.posthog_distinct_id.is_none() {
+        creds.posthog_distinct_id = Some(uuid::Uuid::new_v4().to_string());
+        if creds.write().is_err() {
+            return;
+        }
+    }
+    let distinct_id = creds.posthog_distinct_id.clone().expect("set above");
+
+    let mut changed = false;
+    let mut delivered = 0usize;
+    for record in &mut store.reports {
+        if record.status != ReportStatus::Open {
+            continue;
+        }
+        if delivered >= MAX_SYNC_PER_RUN {
+            break;
+        }
+        // A record filed with --anonymous stays anonymous even if a login
+        // exists by sync time: one-shot id, no email (mirrors the live send
+        // path's post-login anonymity exception).
+        let (record_identified, record_distinct_id) = if record.forced_anonymous {
+            (false, uuid::Uuid::new_v4().to_string())
+        } else {
+            (identified, distinct_id.clone())
+        };
+        if send_feedback(
+            &creds,
+            &record_distinct_id,
+            &record.payload(),
+            record_identified,
+            &record.event_uuid.to_string(),
+        )
+        .is_err()
+        {
+            // Still unreachable; keep it open and stop hammering.
+            break;
+        }
+        let status = if record_identified {
+            ReportStatus::Reported
+        } else {
+            ReportStatus::Anonymous
+        };
+        let email = record_identified
+            .then(|| creds.user_email.clone())
+            .flatten();
+        record.mark_delivered(status, email.as_deref());
+        changed = true;
+        delivered += 1;
+    }
+    if changed && let Err(e) = store.save() {
+        // Delivered statuses were lost: the same reports will re-send on the
+        // next run (server-side dedupe is possible via report_id). Surface it
+        // rather than looping silently forever.
+        crate::reporter::print_warning(format!("failed to update the feedback store: {e:#}"));
+    }
+}
+
+fn run_status(store: &FeedbackStore) -> Result<crate::ExitCode> {
+    println!("BAML Feedback");
+    println!();
+    println!(
+        "Status: {}",
+        if store.enabled { "Enabled" } else { "Disabled" }
+    );
+    println!("Store: {}", FeedbackStore::path().display());
+    println!();
+    if store.reports.is_empty() {
+        println!("no reports sent from this machine yet");
+    } else {
+        println!("Reports:");
+        for r in &store.reports {
+            println!("  [{}] {}: {}", r.status, r.id, r.title);
+        }
+    }
+    Ok(crate::ExitCode::Success)
+}
+
+fn run_list(
+    store: &FeedbackStore,
+    status: Option<ReportStatus>,
+    limit: Option<usize>,
+    json: bool,
+) -> Result<crate::ExitCode> {
+    let matching: Vec<&FeedbackRecord> = store
+        .reports
+        .iter()
+        .filter(|r| status.is_none_or(|s| r.status == s))
+        .collect();
+    let start = limit.map_or(0, |l| matching.len().saturating_sub(l));
+    let matching = &matching[start..];
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&matching)?);
+        return Ok(crate::ExitCode::Success);
+    }
+    if matching.is_empty() {
+        println!("no matching reports");
+        return Ok(crate::ExitCode::Success);
+    }
+    for r in matching {
+        println!("{}\t{}\t{}\t{}", r.id, r.status, r.created_at, r.title);
+    }
+    Ok(crate::ExitCode::Success)
+}
+
+fn run_view(store: &FeedbackStore, id: &str, json: bool) -> Result<crate::ExitCode> {
+    let Some(r) = store.reports.iter().find(|r| r.id == id) else {
+        crate::reporter::print_error(format!("no report with id {id}; see `baml feedback list`"));
+        return Ok(crate::ExitCode::Other);
+    };
+    if json {
+        println!("{}", serde_json::to_string_pretty(r)?);
+        return Ok(crate::ExitCode::Success);
+    }
+    println!("Id:          {}", r.id);
+    println!("Title:       {}", r.title);
+    if let Some(description) = &r.description {
+        println!("Description: {description}");
+    }
+    if !r.files.is_empty() {
+        let listed: Vec<String> = r
+            .files
+            .iter()
+            .map(|f| format!("{} ({}, {} bytes)", f.name, f.mime, f.size_bytes))
+            .collect();
+        println!("Files:       {}", listed.join(", "));
+    }
+    println!("Status:      {}", r.status);
+    if let Some(email) = &r.email {
+        println!("Email:       {email}");
+    }
+    println!("Sent:        {} (unix seconds)", r.created_at);
+    Ok(crate::ExitCode::Success)
+}
+
+fn run_set_enabled(store: &mut FeedbackStore, enabled: bool) -> Result<crate::ExitCode> {
+    let changed = store.enabled != enabled;
+    store.enabled = enabled;
+    store.save()?;
+    match (enabled, changed) {
+        (false, true) => println!("feedback disabled; `baml feedback` will not send anything"),
+        (false, false) => println!("feedback is already disabled"),
+        (true, true) => println!("feedback enabled"),
+        (true, false) => println!("feedback is already enabled"),
+    }
+    Ok(crate::ExitCode::Success)
 }
 
 /// Sends the feedback event to PostHog.
@@ -332,15 +851,17 @@ fn parse_payload_json(raw: &str) -> Result<Value> {
 fn send_feedback(
     creds: &Credentials,
     distinct_id: &str,
-    payload: Value,
+    payload: &Value,
     identified: bool,
+    report_id: &str,
 ) -> Result<()> {
     let mut properties = json!({
         "cli_version": baml_version::CANONICAL_VERSION,
         "system_platform": std::env::consts::OS,
         "system_architecture": std::env::consts::ARCH,
+        "report_id": report_id,
     });
-    if let (Value::Object(props), Value::Object(fields)) = (&mut properties, &payload) {
+    if let (Value::Object(props), Value::Object(fields)) = (&mut properties, payload) {
         for (k, v) in fields {
             props.insert(k.clone(), v.clone());
         }
@@ -362,8 +883,8 @@ fn send_feedback(
 }
 
 /// Sends the `$identify` event that merges the anonymous person into the
-/// identified one. Called from `baml login`; best-effort by design — the
-/// caller ignores failures, and the next login retries the merge.
+/// identified one. Called from `baml auth login`; best-effort by design —
+/// the caller ignores failures, and the next login retries the merge.
 pub(crate) fn identify(creds: &Credentials) {
     let (Some(anon_id), Some(email)) = (
         creds.posthog_distinct_id.as_deref(),
@@ -405,39 +926,134 @@ fn post_event(body: &Value) -> Result<()> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn payload_requires_issue() {
-        let args = FeedbackArgs {
-            issue: None,
-            repro: Some("r".into()),
-            context: None,
-            input: None,
+    fn send_args(
+        title: Option<&str>,
+        description: Option<&str>,
+        input: Option<&str>,
+    ) -> FeedbackInner {
+        FeedbackInner {
+            action: None,
+            title: title.map(str::to_string),
+            description: description.map(str::to_string),
+            input: input.map(str::to_string),
+            files: Vec::new(),
             anonymous: true,
             email: false,
-        };
+        }
+    }
+
+    #[test]
+    fn payload_requires_title() {
+        let args = send_args(None, Some("d"), None);
         let err = args.payload().unwrap_err().to_string();
-        assert!(err.contains("needs an issue"), "{err}");
+        assert!(err.contains("needs a title"), "{err}");
     }
 
     #[test]
     fn flags_override_json_fields() {
-        let args = FeedbackArgs {
-            issue: Some("flag issue".into()),
-            repro: None,
-            context: None,
-            input: Some(r#"{"issue": "json issue", "repro": "json repro"}"#.into()),
-            anonymous: true,
-            email: false,
-        };
+        let args = send_args(
+            Some("flag title"),
+            None,
+            Some(r#"{"title": "json title", "description": "json description"}"#),
+        );
         let payload = args.payload().unwrap();
-        assert_eq!(payload["issue"], "flag issue");
-        assert_eq!(payload["repro"], "json repro");
+        assert_eq!(payload["title"], "flag title");
+        assert_eq!(payload["description"], "json description");
+    }
+
+    #[test]
+    fn long_titles_and_descriptions_are_accepted() {
+        // No content limits: only the total payload ceiling applies.
+        let long_title = "word ".repeat(60);
+        let long_description = "word ".repeat(2000);
+        let args = send_args(Some(long_title.trim()), Some(long_description.trim()), None);
+        assert!(args.payload().is_ok());
+    }
+
+    #[test]
+    fn attachments_encode_inline() {
+        let dir = tempfile::tempdir().unwrap();
+        let img = dir.path().join("shot.png");
+        std::fs::write(&img, b"\x89PNG fake").unwrap();
+
+        let files = encode_attachments(std::slice::from_ref(&img)).unwrap();
+        assert_eq!(files[0].name, "shot.png");
+        assert_eq!(files[0].mime, "image/png");
+        assert_eq!(files[0].size_bytes, 9);
+        assert_eq!(
+            files[0].content.as_deref(),
+            Some(b"\x89PNG fake".as_slice())
+        );
+
+        // The event json carries the same bytes base64-encoded, and the
+        // store round-trips them through the serde adapter.
+        use base64::Engine as _;
+        let event = files_event_json(&files);
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD
+                .decode(event[0]["content_base64"].as_str().unwrap())
+                .unwrap(),
+            b"\x89PNG fake"
+        );
+        let json = serde_json::to_string(&files[0]).unwrap();
+        assert!(json.contains("content_base64"), "{json}");
+        let back: StoredFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.content.as_deref(), Some(b"\x89PNG fake".as_slice()));
+
+        // Unknown extensions: UTF-8 content is text, binary is octet-stream.
+        let code = dir.path().join("repro.baml");
+        std::fs::write(&code, "class A { x int }").unwrap();
+        let files = encode_attachments(std::slice::from_ref(&code)).unwrap();
+        assert_eq!(files[0].mime, "text/plain");
+        let blob = dir.path().join("dump.bamlbin");
+        std::fs::write(&blob, [0xFFu8, 0xFE, 0x00, 0x80]).unwrap();
+        let files = encode_attachments(std::slice::from_ref(&blob)).unwrap();
+        assert_eq!(files[0].mime, "application/octet-stream");
+
+        // Missing file is a clean error.
+        let err = encode_attachments(&[dir.path().join("nope.txt")])
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("failed to read attachment"), "{err}");
+    }
+
+    #[test]
+    fn rejects_non_string_field_types() {
+        let args = send_args(None, None, Some(r#"{"title":"x","description":{"a":1}}"#));
+        let err = args.payload().unwrap_err().to_string();
+        assert!(err.contains("\"description\" must be a string"), "{err}");
+
+        let args = send_args(None, None, Some(r#"{"title":5}"#));
+        let err = args.payload().unwrap_err().to_string();
+        assert!(err.contains("\"title\" must be a string"), "{err}");
     }
 
     #[test]
     fn rejects_non_object_json() {
         assert!(parse_payload_json("[1,2]").is_err());
         assert!(parse_payload_json("\"str\"").is_err());
-        assert!(parse_payload_json(r#"{"issue":"x"}"#).is_ok());
+        assert!(parse_payload_json(r#"{"title":"x"}"#).is_ok());
+    }
+
+    #[test]
+    fn json_files_field_is_rejected() {
+        // Attachment paths must come from the trusted --files flag, never
+        // from a piped payload (which could name arbitrary local files).
+        let args = send_args(None, None, Some(r#"{"title":"x","files":["/etc/passwd"]}"#));
+        let err = args.payload().unwrap_err().to_string();
+        assert!(err.contains("unknown feedback field"), "{err}");
+        assert!(err.contains("--files"), "{err}");
+    }
+
+    #[test]
+    fn rejects_unknown_fields_including_old_names() {
+        let args = send_args(
+            None,
+            None,
+            Some(r#"{"title":"x","issue":"old","repro":"old"}"#),
+        );
+        let err = args.payload().unwrap_err().to_string();
+        assert!(err.contains("unknown feedback field"), "{err}");
+        assert!(err.contains("issue"), "{err}");
     }
 }

--- a/baml_language/crates/baml_cli/src/reporter.rs
+++ b/baml_language/crates/baml_cli/src/reporter.rs
@@ -142,6 +142,15 @@ impl Reporter {
         print_error(msg);
     }
 
+    /// Print a fatal error and hand back the terminal exit code, so
+    /// command handlers can `return Ok(reporter.fatal(...))` instead of
+    /// printing through `eprintln!` and constructing the code by hand.
+    #[must_use]
+    pub fn fatal(&self, msg: impl std::fmt::Display) -> crate::ExitCode {
+        self.error(msg);
+        crate::ExitCode::Other
+    }
+
     /// Print a warning. Mirrors the formatting of [`print_warning`].
     pub fn warning(&self, msg: impl std::fmt::Display) {
         let line = format!(

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__root_concise_help.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__root_concise_help.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_cli/src/help_command.rs
+assertion_line: 203
 expression: concise
 ---
 Build and run BAML projects.
@@ -9,7 +10,6 @@ Usage: baml [OPTIONS] <COMMAND>
 Commands:
   check       Check BAML source files for compiler errors
   auth        Manage authentication
-  login       Log in to Boundary with your email
   feedback    Report an issue or improvement to Boundary
   fmt         Format BAML source files
   describe    Describe a BAML symbol

--- a/baml_language/crates/baml_cli/tests/feedback_auth_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/feedback_auth_e2e.rs
@@ -1,9 +1,10 @@
-//! End-to-end tests for `baml feedback` + `baml login` against an
+//! End-to-end tests for `baml feedback` + `baml auth login` against an
 //! in-process mock of `WorkOS` CLI Auth (device flow) and `PostHog` ingestion.
 //!
 //! The mock records every `PostHog` capture body so tests can assert on the
 //! actual events: anonymous continuity (one distinct id across reports),
-//! the `$identify` merge on login, and email attribution afterwards.
+//! the `$identify` merge on login, email attribution afterwards, and the
+//! open-until-synced lifecycle of reports sent while offline.
 
 use std::{
     io::{Read, Write},
@@ -117,12 +118,25 @@ fn run_baml(
     args: &[&str],
     stdin: Option<&str>,
 ) -> (bool, String) {
+    run_baml_posthog(home, base, base, args, stdin)
+}
+
+/// Like [`run_baml`], but with a separately controllable `PostHog` host so
+/// a test can simulate `PostHog` being unreachable while `WorkOS` still
+/// works.
+fn run_baml_posthog(
+    home: &std::path::Path,
+    workos: &str,
+    posthog: &str,
+    args: &[&str],
+    stdin: Option<&str>,
+) -> (bool, String) {
     let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_baml-cli"));
     cmd.args(args)
         .env("BAML_HOME", home)
-        .env("BAML_WORKOS_API_DOMAIN", base)
+        .env("BAML_WORKOS_API_DOMAIN", workos)
         .env("BAML_WORKOS_CLIENT_ID", "client_test")
-        .env("BAML_POSTHOG_HOST", base)
+        .env("BAML_POSTHOG_HOST", posthog)
         // Keep ordinary invocation telemetry quiet so /capture/ sees only
         // feedback + identify events.
         .env("BAML_TELEMETRY_DISABLED", "1")
@@ -159,35 +173,59 @@ fn feedback_events(state: &MockState) -> Vec<Value> {
         .collect()
 }
 
+/// A dead endpoint: a listener that accepts and immediately closes every
+/// connection, so requests fail fast and deterministically. (Bind-then-drop
+/// would free the port for reuse by a concurrent test.)
+fn dead_posthog() -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            drop(stream);
+        }
+    });
+    format!("http://{addr}")
+}
+
 #[test]
-fn anonymous_feedback_then_login_backfills() {
+fn anonymous_by_default_then_login_backfills() {
     let state = Arc::new(MockState::default());
     let base = spawn_mock(state.clone());
     let home = tempfile::tempdir().unwrap();
     let creds = home.path().join("creds.json");
 
-    // 1. Anonymous feedback via flag: no session needed, event has no email.
+    // 1. No flags, no prompt: sends anonymously from the get-go, with a
+    //    preview of what goes out and the login hint.
     let (ok, out) = run_baml(
         home.path(),
         &base,
         &[
             "feedback",
-            "--anonymous",
-            "--issue",
-            "parser panics on nested unions",
+            "--title",
+            "Issue (parser): panics on nested unions",
         ],
         None,
     );
     assert!(ok, "{out}");
-    assert!(out.contains("Feedback sent anonymously"), "{out}");
+    assert!(out.contains("reporting to Boundary anonymously:"), "{out}");
+    assert!(!out.contains("How should I report"), "no prompt: {out}");
+    assert!(out.contains("sent anonymously"), "{out}");
+    assert!(out.contains("run `baml auth login`"), "{out}");
     let json = std::fs::read_to_string(&creds).unwrap();
     assert!(json.contains("posthog_distinct_id"), "{json}");
 
-    // 2. Second report reuses the same distinct id (one anonymous person).
+    // 2. Second report reuses the same distinct id (one anonymous person)
+    //    and carries a report_id for later server-side joining.
     let (ok, out) = run_baml(
         home.path(),
         &base,
-        &["feedback", "--anonymous", "--issue", "map keys mis-typed"],
+        &[
+            "feedback",
+            "--title",
+            "Issue (types): map keys mis-typed",
+            "--description",
+            "Minimum repro: map<int,int>",
+        ],
         None,
     );
     assert!(ok, "{out}");
@@ -197,19 +235,27 @@ fn anonymous_feedback_then_login_backfills() {
     assert_eq!(events[1]["distinct_id"], anon_id.as_str(), "{events:?}");
     assert!(events[0]["properties"]["email"].is_null(), "{events:?}");
     assert_eq!(
-        events[0]["properties"]["issue"], "parser panics on nested unions",
+        events[0]["properties"]["title"], "Issue (parser): panics on nested unions",
+        "{events:?}"
+    );
+    assert_eq!(
+        events[1]["properties"]["description"], "Minimum repro: map<int,int>",
+        "{events:?}"
+    );
+    assert!(
+        events[1]["properties"]["report_id"].is_string(),
         "{events:?}"
     );
 
     // 3. whoami shows the anonymous state.
     let (_, out) = run_baml(home.path(), &base, &["auth", "whoami"], None);
-    assert!(out.contains("Anonymous (feedback id"), "{out}");
+    assert!(out.contains("anonymous (feedback id"), "{out}");
 
-    // 4. Login: device flow (one pending poll), then $identify merges the
-    //    anonymous person into the identified one.
-    let (ok, out) = run_baml(home.path(), &base, &["login", "--no-open"], None);
+    // 4. `baml auth login`: device flow (one pending poll), then $identify
+    //    merges the anonymous person into the identified one.
+    let (ok, out) = run_baml(home.path(), &base, &["auth", "login", "--no-open"], None);
     assert!(ok, "{out}");
-    assert!(out.contains("Logged in as user@example.com"), "{out}");
+    assert!(out.contains("logged in as user@example.com"), "{out}");
     let identify = state
         .captures
         .lock()
@@ -229,16 +275,16 @@ fn anonymous_feedback_then_login_backfills() {
         "{identify}"
     );
 
-    // 5. Feedback while logged in: no prompt, event carries the email and
-    //    still the same distinct id (person continuity).
+    // 5. Feedback while logged in: event carries the email and still the
+    //    same distinct id (person continuity).
     let (ok, out) = run_baml(
         home.path(),
         &base,
-        &["feedback", "--issue", "third report"],
+        &["feedback", "--title", "Issue (cli): third report"],
         None,
     );
     assert!(ok, "{out}");
-    assert!(out.contains("Feedback sent as user@example.com"), "{out}");
+    assert!(out.contains("sent as user@example.com"), "{out}");
     let events = feedback_events(&state);
     assert_eq!(events.len(), 3, "{events:?}");
     assert_eq!(events[2]["distinct_id"], anon_id.as_str(), "{events:?}");
@@ -257,106 +303,11 @@ fn anonymous_feedback_then_login_backfills() {
     );
     assert!(!json.contains("access_token"), "{json}");
     let (_, out) = run_baml(home.path(), &base, &["auth", "whoami"], None);
-    assert!(out.contains("Anonymous"), "{out}");
-}
+    assert!(out.contains("anonymous"), "{out}");
 
-#[test]
-fn interactive_prompt_anonymous_choice() {
-    let state = Arc::new(MockState::default());
-    let base = spawn_mock(state.clone());
-    let home = tempfile::tempdir().unwrap();
-
-    // No mode flag: the prompt appears; choosing 1 reports anonymously.
-    let (ok, out) = run_baml(
-        home.path(),
-        &base,
-        &["feedback", "--issue", "prompted report"],
-        Some("1\n"),
-    );
-    assert!(ok, "{out}");
-    assert!(out.contains("How should I report it?"), "{out}");
-    assert!(out.contains("Feedback sent anonymously"), "{out}");
-    assert_eq!(feedback_events(&state).len(), 1);
-
-    // The anonymous choice sticks: the next report skips the prompt and
-    // sends anonymously without any stdin.
-    let (ok, out) = run_baml(
-        home.path(),
-        &base,
-        &["feedback", "--issue", "second report"],
-        None,
-    );
-    assert!(ok, "{out}");
-    assert!(!out.contains("How should I report it?"), "{out}");
-    assert!(out.contains("Feedback sent anonymously"), "{out}");
-    assert_eq!(feedback_events(&state).len(), 2);
-}
-
-#[test]
-fn interactive_prompt_decline_sends_nothing() {
-    let state = Arc::new(MockState::default());
-    let base = spawn_mock(state.clone());
-    let home = tempfile::tempdir().unwrap();
-
-    // The prompt is preceded by a preview of exactly what would be sent.
-    // Choosing 3 declines: nothing sent, and the decline is remembered.
-    let (ok, out) = run_baml(
-        home.path(),
-        &base,
-        &["feedback", "--issue", "never mind", "--repro", "class A {}"],
-        Some("3\n"),
-    );
-    assert!(ok, "{out}");
-    assert!(out.contains("Here's what will be sent:"), "{out}");
-    assert!(out.contains("Issue: never mind"), "{out}");
-    assert!(out.contains("Repro: class A {}"), "{out}");
-    assert!(out.contains("Nothing sent"), "{out}");
-    assert_eq!(feedback_events(&state).len(), 0);
-    let creds = std::fs::read_to_string(home.path().join("creds.json")).unwrap();
-    assert!(creds.contains("feedback_declined_at"), "{creds}");
-
-    // Within the day-long cooldown: no prompt, nothing sent, still exit 0.
-    let (ok, out) = run_baml(
-        home.path(),
-        &base,
-        &["feedback", "--issue", "still nothing"],
-        None,
-    );
-    assert!(ok, "{out}");
-    assert!(!out.contains("How should I report it?"), "{out}");
-    assert!(out.contains("declined recently"), "{out}");
-    assert_eq!(feedback_events(&state).len(), 0);
-
-    // Explicit --anonymous overrides the cooldown and clears it.
-    let (ok, out) = run_baml(
-        home.path(),
-        &base,
-        &["feedback", "--anonymous", "--issue", "ok fine"],
-        None,
-    );
-    assert!(ok, "{out}");
-    assert_eq!(feedback_events(&state).len(), 1);
-    let creds = std::fs::read_to_string(home.path().join("creds.json")).unwrap();
-    assert!(!creds.contains("feedback_declined_at"), "{creds}");
-
-    // An expired cooldown prompts again: write stale state directly (a
-    // 1970 decline, no sticky-anonymous flag) and expect the prompt.
-    std::fs::write(
-        home.path().join("creds.json"),
-        r#"{"feedback_declined_at":1}"#,
-    )
-    .unwrap();
-    let (ok, out) = run_baml(
-        home.path(),
-        &base,
-        &["feedback", "--issue", "after cooldown"],
-        Some("3\n"),
-    );
-    assert!(ok, "{out}");
-    assert!(
-        out.contains("How should I report it?"),
-        "prompts again after expiry: {out}"
-    );
+    // 7. `baml login` no longer exists at the top level.
+    let (ok, out) = run_baml(home.path(), &base, &["login"], None);
+    assert!(!ok, "top-level login must be gone: {out}");
 }
 
 #[test]
@@ -368,11 +319,11 @@ fn email_flag_without_login_gives_guidance() {
     let (ok, out) = run_baml(
         home.path(),
         &base,
-        &["feedback", "--email", "--issue", "x"],
+        &["feedback", "--email", "--title", "x"],
         None,
     );
     assert!(!ok, "must exit non-zero: {out}");
-    assert!(out.contains("Run `baml login`"), "{out}");
+    assert!(out.contains("run `baml auth login`"), "{out}");
     assert_eq!(feedback_events(&state).len(), 0, "nothing may be sent");
 }
 
@@ -385,13 +336,20 @@ fn json_stdin_payload() {
     let (ok, out) = run_baml(
         home.path(),
         &base,
-        &["feedback", "--anonymous", "-"],
-        Some(r#"{"issue": "from stdin", "repro": "class A {}"}"#),
+        &["feedback", "-"],
+        Some(r#"{"title": "Issue (stdin): piped", "description": "from a pipe"}"#),
     );
     assert!(ok, "{out}");
     let events = feedback_events(&state);
-    assert_eq!(events[0]["properties"]["issue"], "from stdin");
-    assert_eq!(events[0]["properties"]["repro"], "class A {}");
+    assert_eq!(events.len(), 1, "{events:?}");
+    assert_eq!(
+        events[0]["properties"]["title"], "Issue (stdin): piped",
+        "{events:?}"
+    );
+    assert_eq!(
+        events[0]["properties"]["description"], "from a pipe",
+        "{events:?}"
+    );
 }
 
 #[test]
@@ -400,39 +358,31 @@ fn anonymous_after_login_uses_one_shot_id() {
     let base = spawn_mock(state.clone());
     let home = tempfile::tempdir().unwrap();
 
-    // Establish an identified session with a merged distinct id.
+    // Establish an anonymous id, then log in (merging it).
     let (ok, out) = run_baml(
         home.path(),
         &base,
-        &["feedback", "--anonymous", "--issue", "first"],
+        &["feedback", "--title", "Issue (x): first"],
         None,
     );
     assert!(ok, "{out}");
-    let anon_id = feedback_events(&state)[0]["distinct_id"]
-        .as_str()
-        .unwrap()
-        .to_string();
-    let (ok, out) = run_baml(home.path(), &base, &["login", "--no-open"], None);
+    let (ok, out) = run_baml(home.path(), &base, &["auth", "login", "--no-open"], None);
     assert!(ok, "{out}");
 
-    // --anonymous after login must NOT use the merged persistent id (which
-    // would attribute the report to the person anyway) and must not carry
-    // the email.
+    // --anonymous while logged in: a fresh, unpersisted id.
     let (ok, out) = run_baml(
         home.path(),
         &base,
-        &["feedback", "--anonymous", "--issue", "truly anonymous"],
+        &["feedback", "--anonymous", "--title", "Issue (x): hush"],
         None,
     );
     assert!(ok, "{out}");
     let events = feedback_events(&state);
-    let last = events.last().unwrap();
-    assert_ne!(last["distinct_id"], anon_id.as_str(), "{last}");
-    assert!(last["properties"]["email"].is_null(), "{last}");
-
-    // The persistent id is untouched for the identified path.
-    let creds = std::fs::read_to_string(home.path().join("creds.json")).unwrap();
-    assert!(creds.contains(&anon_id), "{creds}");
+    assert_eq!(events.len(), 2, "{events:?}");
+    let stored_id = events[0]["distinct_id"].as_str().unwrap();
+    let one_shot = events[1]["distinct_id"].as_str().unwrap();
+    assert_ne!(stored_id, one_shot, "{events:?}");
+    assert!(events[1]["properties"]["email"].is_null(), "{events:?}");
 }
 
 #[test]
@@ -441,13 +391,254 @@ fn unknown_payload_fields_are_rejected() {
     let base = spawn_mock(state.clone());
     let home = tempfile::tempdir().unwrap();
 
+    for payload in [
+        r#"{"title": "x", "$set": {"email": "spoof@example.com"}}"#,
+        r#"{"title": "x", "issue": "old flag name"}"#,
+    ] {
+        let (ok, out) = run_baml(home.path(), &base, &["feedback", "-"], Some(payload));
+        assert!(!ok, "{out}");
+        assert!(out.contains("unknown feedback field"), "{out}");
+    }
+    assert_eq!(feedback_events(&state).len(), 0, "nothing may be sent");
+}
+
+#[test]
+fn offline_send_saves_open_then_syncs() {
+    let state = Arc::new(MockState::default());
+    let base = spawn_mock(state.clone());
+    let home = tempfile::tempdir().unwrap();
+    let dead = dead_posthog();
+
+    // PostHog unreachable: the send still exits 0 and records the report.
+    let (ok, out) = run_baml_posthog(
+        home.path(),
+        &base,
+        &dead,
+        &["feedback", "--title", "Issue (net): sent offline"],
+        None,
+    );
+    assert!(ok, "an offline send must not fail: {out}");
+    assert!(out.contains("saved locally"), "{out}");
+    let store = std::fs::read_to_string(home.path().join("feedback.json")).unwrap();
+    assert!(store.contains("\"open\""), "{store}");
+    assert_eq!(feedback_events(&state).len(), 0);
+
+    // Any later invocation against a reachable PostHog syncs it.
+    let (ok, out) = run_baml(home.path(), &base, &["feedback", "list"], None);
+    assert!(ok, "{out}");
+    assert!(out.contains("anonymous"), "synced status: {out}");
+    let events = feedback_events(&state);
+    assert_eq!(events.len(), 1, "{events:?}");
+    assert_eq!(
+        events[0]["properties"]["title"], "Issue (net): sent offline",
+        "{events:?}"
+    );
+    let store = std::fs::read_to_string(home.path().join("feedback.json")).unwrap();
+    assert!(!store.contains("\"open\""), "{store}");
+}
+
+#[test]
+fn sync_honors_forced_anonymity_after_login() {
+    let state = Arc::new(MockState::default());
+    let base = spawn_mock(state.clone());
+    let home = tempfile::tempdir().unwrap();
+    let dead = dead_posthog();
+
+    // Establish the persistent distinct id online, then log in.
     let (ok, out) = run_baml(
         home.path(),
         &base,
-        &["feedback", "--anonymous", "-"],
-        Some(r#"{"issue": "x", "$set": {"email": "spoof@example.com"}}"#),
+        &["feedback", "--title", "Issue (x): baseline"],
+        None,
     );
-    assert!(!ok, "must reject unknown fields: {out}");
-    assert!(out.contains("Unknown feedback field"), "{out}");
+    assert!(ok, "{out}");
+    let (ok, out) = run_baml(home.path(), &base, &["auth", "login", "--no-open"], None);
+    assert!(ok, "{out}");
+
+    // An explicitly anonymous report filed while PostHog is unreachable...
+    let (ok, out) = run_baml_posthog(
+        home.path(),
+        &base,
+        &dead,
+        &["feedback", "--anonymous", "--title", "Issue (x): hush"],
+        None,
+    );
+    assert!(ok, "{out}");
+
+    // ...must stay anonymous when a later run syncs it, despite the login:
+    // no email property, and a distinct id different from the merged one.
+    let (ok, out) = run_baml(home.path(), &base, &["feedback", "status"], None);
+    assert!(ok, "{out}");
+    let events = feedback_events(&state);
+    assert_eq!(events.len(), 2, "{events:?}");
+    let baseline_id = events[0]["distinct_id"].as_str().unwrap();
+    let synced = &events[1];
+    assert_eq!(synced["properties"]["title"], "Issue (x): hush", "{synced}");
+    assert!(synced["properties"]["email"].is_null(), "{synced}");
+    assert_ne!(synced["distinct_id"].as_str().unwrap(), baseline_id);
+    let store = std::fs::read_to_string(home.path().join("feedback.json")).unwrap();
+    assert!(store.contains("\"anonymous\""), "{store}");
+    assert!(!store.contains("\"open\""), "{store}");
+}
+
+#[test]
+fn attached_files_ship_and_survive_offline_sync() {
+    use base64::Engine as _;
+
+    let state = Arc::new(MockState::default());
+    let base = spawn_mock(state.clone());
+    let home = tempfile::tempdir().unwrap();
+    let dead = dead_posthog();
+    let attachment = home.path().join("repro.baml");
+    std::fs::write(&attachment, "class A { x int }").unwrap();
+
+    // Online send with --files: the event carries the encoded attachment.
+    let (ok, out) = run_baml(
+        home.path(),
+        &base,
+        &[
+            "feedback",
+            "--title",
+            "Issue (types): with repro file",
+            "--files",
+            attachment.to_str().unwrap(),
+        ],
+        None,
+    );
+    assert!(ok, "{out}");
+    assert!(out.contains("Files: repro.baml (17 bytes)"), "{out}");
+    let events = feedback_events(&state);
+    let files = events[0]["properties"]["files"].as_array().unwrap();
+    assert_eq!(files[0]["name"], "repro.baml");
+    assert_eq!(files[0]["mime"], "text/plain");
+    assert!(!files[0]["content_base64"].as_str().unwrap().is_empty());
+    // Delivered: the local record keeps metadata, not content.
+    let store = std::fs::read_to_string(home.path().join("feedback.json")).unwrap();
+    assert!(store.contains("repro.baml"), "{store}");
+    assert!(!store.contains("content_base64"), "{store}");
+
+    // Offline send with a file: content is retained in the open record...
+    let (ok, out) = run_baml_posthog(
+        home.path(),
+        &base,
+        &dead,
+        &[
+            "feedback",
+            "--title",
+            "Issue (types): offline with file",
+            "--files",
+            attachment.to_str().unwrap(),
+        ],
+        None,
+    );
+    assert!(ok, "{out}");
+    let store = std::fs::read_to_string(home.path().join("feedback.json")).unwrap();
+    assert!(store.contains("content_base64"), "{store}");
+
+    // ...and the deferred delivery ships it intact.
+    let (ok, out) = run_baml(home.path(), &base, &["feedback", "status"], None);
+    assert!(ok, "{out}");
+    let events = feedback_events(&state);
+    assert_eq!(events.len(), 2, "{events:?}");
+    let synced_files = events[1]["properties"]["files"].as_array().unwrap();
+    assert_eq!(
+        base64::engine::general_purpose::STANDARD
+            .decode(synced_files[0]["content_base64"].as_str().unwrap())
+            .unwrap(),
+        b"class A { x int }"
+    );
+    let store = std::fs::read_to_string(home.path().join("feedback.json")).unwrap();
+    assert!(!store.contains("content_base64"), "{store}");
+    assert!(!store.contains("\"open\""), "{store}");
+}
+
+#[test]
+fn disable_blocks_sends_until_enable() {
+    let state = Arc::new(MockState::default());
+    let base = spawn_mock(state.clone());
+    let home = tempfile::tempdir().unwrap();
+
+    let (ok, out) = run_baml(home.path(), &base, &["feedback", "disable"], None);
+    assert!(ok, "{out}");
+    assert!(out.contains("feedback disabled"), "{out}");
+
+    let (ok, out) = run_baml(
+        home.path(),
+        &base,
+        &["feedback", "--title", "Issue (x): blocked"],
+        None,
+    );
+    assert!(!ok, "disabled send must exit non-zero: {out}");
+    assert!(out.contains("baml feedback enable"), "{out}");
     assert_eq!(feedback_events(&state).len(), 0, "nothing may be sent");
+
+    let (ok, out) = run_baml(home.path(), &base, &["feedback", "enable"], None);
+    assert!(ok, "{out}");
+    let (ok, out) = run_baml(
+        home.path(),
+        &base,
+        &["feedback", "--title", "Issue (x): unblocked"],
+        None,
+    );
+    assert!(ok, "{out}");
+    assert_eq!(feedback_events(&state).len(), 1);
+}
+
+#[test]
+fn status_list_view_read_the_local_store() {
+    let state = Arc::new(MockState::default());
+    let base = spawn_mock(state);
+    let home = tempfile::tempdir().unwrap();
+
+    let (ok, out) = run_baml(
+        home.path(),
+        &base,
+        &[
+            "feedback",
+            "--title",
+            "Issue (viewer): first",
+            "--description",
+            "Minimum repro: class A {}",
+        ],
+        None,
+    );
+    assert!(ok, "{out}");
+
+    // status: enabled + the report with its delivery state.
+    let (ok, out) = run_baml(home.path(), &base, &["feedback", "status"], None);
+    assert!(ok, "{out}");
+    assert!(out.contains("Status: Enabled"), "{out}");
+    assert!(out.contains("[anonymous]"), "{out}");
+    assert!(out.contains("Issue (viewer): first"), "{out}");
+
+    // list --json: machine-readable records.
+    let (ok, out) = run_baml(home.path(), &base, &["feedback", "list", "--json"], None);
+    assert!(ok, "{out}");
+    // run_baml appends stderr (the direct-binary-use warning) after stdout;
+    // parse just the JSON array span.
+    let json_span = &out[out.find('[').unwrap()..=out.rfind(']').unwrap()];
+    let records: Value = serde_json::from_str(json_span).expect("list --json is JSON");
+    let records = records.as_array().unwrap();
+    assert_eq!(records.len(), 1, "{records:?}");
+    let id = records[0]["id"].as_str().unwrap().to_string();
+    assert_eq!(records[0]["status"], "anonymous", "{records:?}");
+
+    // list --status filters.
+    let (ok, out) = run_baml(
+        home.path(),
+        &base,
+        &["feedback", "list", "--status", "open"],
+        None,
+    );
+    assert!(ok, "{out}");
+    assert!(out.contains("no matching reports"), "{out}");
+
+    // view renders the full record; unknown ids error.
+    let (ok, out) = run_baml(home.path(), &base, &["feedback", "view", &id], None);
+    assert!(ok, "{out}");
+    assert!(out.contains("Issue (viewer): first"), "{out}");
+    assert!(out.contains("Minimum repro: class A {}"), "{out}");
+    let (ok, out) = run_baml(home.path(), &base, &["feedback", "view", "zzzzzzzz"], None);
+    assert!(!ok, "{out}");
+    assert!(out.contains("no report with id"), "{out}");
 }


### PR DESCRIPTION
## Summary

Redesigns `baml feedback` around agents and zero interaction, and adds a gh-issues-style management surface.

- **Payload is `{title, description}`** with hard limits: `--title` one line, max 120 characters, in the form `Issue (feature): description`; `--description` max 500 words (about a page), with help text teaching what to cover (what I was doing, what went wrong, a minimum repro, what I want to happen, syntax ideas). Unknown JSON fields, including the old `issue`/`repro` names, are rejected.
- **Sends never prompt**: anonymous from the get-go under the persisted PostHog distinct id, with a preview of exactly what goes out; after `baml auth login`, reports carry the verified email. Anonymous sends print a notify hint pointing at `baml auth login`. The interactive mode prompt, sticky-anonymous flag, and decline cooldown are removed.
- **`baml auth login`**: login moves under `baml auth`; the top-level `baml login` is removed.
- **Local report store** (`<BAML_HOME>/feedback.json`, 0600): records start `open` and flip to `anonymous`/`reported` on delivery, so offline sends save locally and sync on any later run. Explicit `--anonymous` is stored on the record and honored at sync time with a one-shot id, even if a login exists by then. Management commands: `status`, `list` (`--status`/`--limit`/`--json`), `view` (`--json`), `disable`/`enable` (telemetry-style opt-out). Every event carries a `report_id` UUID for future server-side joins.
- **Bounded storage**: prune to 200 delivered records (never `open` ones), delivered descriptions truncated at 10KB (open records keep full text so deferred sends ship exactly what was written), and a 50-open-report cap where new sends refuse with guidance instead of growing the store unboundedly.
- Works around clap derive's `update_from_arg_matches` erroring on an absent optional subcommand via a manual `FromArgMatches` wrapper.

## Review history

- Two adversarial security passes: the only finding (feedback.json written with default umask while storing the verified email) is fixed with the same 0600 pattern as creds.json.
- Code-quality review found and fixed three sync-path bugs: forced anonymity being re-attributed at sync time, deferred sends shipping truncated descriptions, and delivery status flips matching by collidable 8-char id instead of `event_uuid`.

## Test plan

- 10 e2e tests against an in-process WorkOS/PostHog mock: anonymous-by-default with no prompt, `$identify` merge on login, one-shot ids post-login, forced-anonymity honored across offline sync after login, offline open-then-sync lifecycle, 50-open backlog refusal and drain, disable/enable gating, status/list/view incl. `--json` and `--status` filters, stdin JSON, unknown-field rejection, `baml login` removal.
- Unit tests for payload limits (exact boundaries), truncation char-safety, and prune-never-drops-open.
- Full `baml_cli` suite green; rustfmt clean. Manually exercised end to end against WorkOS staging and real PostHog via a local dev build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated `baml auth login` (device-code) and updated `baml auth` help/examples for `whoami` and `logout`.
  * Reworked `baml feedback` into a non-interactive command with required `--title`, optional `--description`, repeatable `--files`, local history (`status`, `list`, `view`), and `enable`/`disable`, plus base64 attachment handling and offline queueing.
* **Bug Fixes**
  * Improved auth guidance and messaging across `whoami`, `logout`, token/session-expired flows; tightened login error handling.
  * Secured credentials file writes to owner-only permissions.
* **Tests**
  * Expanded end-to-end coverage for identity merging, offline queueing/sync, attachments, JSON validation, and local feedback history inspection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->