### PR TITLE
Virtual field accesses

### DIFF
--- a/baml_language/crates/baml_builtins2_codegen/src/extract.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/extract.rs
@@ -400,11 +400,7 @@ fn extract_class_fields(
         .iter()
         .enumerate()
         .map(|(index, field)| {
-            let field_type = field
-                .type_expr
-                .as_ref()
-                .map(|te| type_expr_to_baml_type(te, &generic_params))
-                .unwrap_or(BamlType::Named("unknown".to_string()));
+            let field_type = type_expr_to_baml_type(&field.type_expr, &generic_params);
             NativeClassField {
                 name: field.name.as_str().to_string(),
                 field_type,

--- a/baml_language/crates/baml_cli/src/bytecode_cache.rs
+++ b/baml_language/crates/baml_cli/src/bytecode_cache.rs
@@ -927,7 +927,7 @@ fn syntactic_type_names(db: &ProjectDatabase, file: SourceFile) -> HashSet<Strin
     }
     for &loc in file_classes(db, file) {
         let class = class_data(db, loc);
-        for id in class.fields.iter().filter_map(|f| f.type_ref) {
+        for id in class.fields.iter().map(|f| f.type_ref) {
             add_type_ref_display(&class.type_refs, id, &mut names);
         }
         for id in class.generic_param_bounds.iter().flatten() {
@@ -939,7 +939,7 @@ fn syntactic_type_names(db: &ProjectDatabase, file: SourceFile) -> HashSet<Strin
     }
     for &loc in file_interfaces(db, file) {
         let iface = interface_data(db, loc);
-        for id in iface.fields.iter().filter_map(|f| f.type_ref) {
+        for id in iface.fields.iter().map(|f| f.type_ref) {
             add_type_ref_display(&iface.type_refs, id, &mut names);
         }
         for id in &iface.requires {

--- a/baml_language/crates/baml_cli/src/file_signature.rs
+++ b/baml_language/crates/baml_cli/src/file_signature.rs
@@ -83,9 +83,11 @@ pub(crate) fn file_signature_hash(db: &ProjectDatabase, file: SourceFile) -> [u8
 ///
 /// This is [`file_signature_hash`] narrowed to the declarations whose *shape* a
 /// type's layout is baked from — class field order/types, enum variant
-/// order/discriminants, interface method-signature order (vtable slots), type
-/// alias targets, generic-parameter lists, and the `cleanup`-method signature —
-/// and nothing else. A free function's signature, a client, a test, a template
+/// order/discriminants, interface method-signature order (vtable slots),
+/// interface *field* order and the in-body `implements` field links (together
+/// these fix `RuntimeImplRule::field_links`, the interface-field-index → class-slot
+/// table a virtual field access indexes), type alias targets, generic-parameter
+/// lists, and the `cleanup`-method signature — and nothing else. A free function's signature, a client, a test, a template
 /// string, and every function body are all excluded. Blanking bodies matches
 /// the signature hash's body-invariance: a field offset, a discriminant, a type
 /// tag, and a vtable slot are all fixed by *declarations*, never by a body

--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -1771,7 +1771,10 @@ pub struct AssociatedTypeBindingDef {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldDef {
     pub name: Name,
-    pub type_expr: Option<TypeExpr>,
+    /// Always present. A field written without a type is reported by the parser and
+    /// recovers as [`TypeExprKind::Error`] — "no type" is not a kind of type, so it is
+    /// not representable here.
+    pub type_expr: TypeExpr,
     pub attributes: Vec<RawAttribute>,
     /// Joined `///` doc-comment lines preceding this declaration.
     pub docstring: Option<std::string::String>,

--- a/baml_language/crates/baml_compiler2_ast/src/disambiguate.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/disambiguate.rs
@@ -44,11 +44,9 @@ pub(crate) fn validate_field_attrs(items: &[Item]) -> Vec<(String, text_size::Te
 
 fn validate_class(class: &ClassDef, diagnostics: &mut Vec<(String, text_size::TextRange)>) {
     for field in &class.fields {
-        if let Some(ref spanned_type) = field.type_expr {
-            // After hoisting, the outermost TypeExpr should have no field attrs left.
-            // Any remaining field attrs are in invalid positions.
-            validate_type_expr_tree(spanned_type, diagnostics);
-        }
+        // After hoisting, the outermost TypeExpr should have no field attrs left.
+        // Any remaining field attrs are in invalid positions.
+        validate_type_expr_tree(&field.type_expr, diagnostics);
     }
     // Also validate method signatures
     for method in &class.methods {

--- a/baml_language/crates/baml_compiler2_ast/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lib.rs
@@ -1143,14 +1143,7 @@ class InterfaceTwo {
 
         let field = class.fields.first().expect("expected field");
         assert_eq!(field.name.as_str(), "interface");
-        assert_eq!(
-            field
-                .type_expr
-                .as_ref()
-                .map(std::string::ToString::to_string)
-                .as_deref(),
-            Some("string")
-        );
+        assert_eq!(field.type_expr.to_string(), "string");
     }
 
     #[test]
@@ -1513,12 +1506,9 @@ class Media {
             .find(|f| f.name.as_str() == "_data")
             .expect("expected _data field");
 
-        match &field.type_expr {
-            Some(spanned) => match &spanned.kind {
-                TypeExprKind::Rust { .. } => {}
-                other => panic!("expected TypeExprKind::Rust, got {other:?}"),
-            },
-            None => panic!("expected a type expression for _data field"),
+        match &field.type_expr.kind {
+            TypeExprKind::Rust { .. } => {}
+            other => panic!("expected TypeExprKind::Rust, got {other:?}"),
         }
     }
 
@@ -1630,8 +1620,8 @@ class Media {
             assert!(data_field.is_some(), "expected _data field");
             assert!(
                 matches!(
-                    data_field.unwrap().type_expr.as_ref().map(|te| &te.kind),
-                    Some(TypeExprKind::Rust { .. })
+                    &data_field.unwrap().type_expr.kind,
+                    TypeExprKind::Rust { .. }
                 ),
                 "_data field should have TypeExprKind::Rust"
             );
@@ -2110,7 +2100,7 @@ class Foo {
         assert_eq!(field.attributes[0].name.as_str(), "alias");
 
         // Type attribute: @stream.done should be on the TypeExpr
-        let type_expr = &field.type_expr.as_ref().expect("expected type expr");
+        let type_expr = &field.type_expr;
         let type_attrs = type_expr.attrs();
         assert_eq!(
             type_attrs.len(),
@@ -2148,7 +2138,7 @@ class Foo {
 
         // Type attribute: @stream.done stays on the TypeExpr
         assert_eq!(
-            strip_spans(field.type_expr.as_ref().expect("expected type expr")),
+            strip_spans(&field.type_expr),
             type_expr!(Path("Fizz", Attr("stream.done")))
         );
     }
@@ -2167,7 +2157,7 @@ class Foo {
             .find(|f| f.name.as_str() == "bar")
             .expect("expected field 'bar'");
 
-        let type_expr = &field.type_expr.as_ref().expect("expected type expr");
+        let type_expr = &field.type_expr;
         // Type should be Optional(Int)
         assert!(
             matches!(type_expr.kind, TypeExprKind::Optional { .. }),
@@ -2197,7 +2187,7 @@ class Foo {
             .find(|f| f.name.as_str() == "items")
             .expect("expected field 'items'");
 
-        let type_expr = &field.type_expr.as_ref().expect("expected type expr");
+        let type_expr = &field.type_expr;
         assert!(
             matches!(type_expr.kind, TypeExprKind::List { .. }),
             "expected List type, got {type_expr:?}",
@@ -2211,7 +2201,7 @@ class Foo {
         assert_eq!(type_attrs[0].name.as_str(), "stream.done");
         // Type attribute: @stream.done stays on the TypeExpr
         assert_eq!(
-            strip_spans(field.type_expr.as_ref().expect("expected type expr")),
+            strip_spans(&field.type_expr),
             type_expr!(WithAttrs((List(String)), Attr("stream.done")))
         );
     }
@@ -2265,7 +2255,7 @@ class C {
         let field = &class.fields[0];
         assert_eq!(field.attributes.len(), 1);
         assert_eq!(field.attributes[0].name.as_str(), "alias");
-        let te = &field.type_expr.as_ref().unwrap();
+        let te = &field.type_expr;
         assert_eq!(te.attrs().len(), 1);
         assert_eq!(te.attrs()[0].name.as_str(), "stream.done");
     }
@@ -2285,7 +2275,7 @@ class C {
         assert_eq!(field.attributes.len(), 1);
         assert_eq!(field.attributes[0].name.as_str(), "alias");
         assert!(matches!(
-            &field.type_expr.as_ref().unwrap().kind,
+            &field.type_expr.kind,
             TypeExprKind::Union { attrs, .. } if attrs.is_empty()
         ));
     }
@@ -2315,7 +2305,7 @@ class C {
         let class = first_class(parse_and_lower(source));
         let field = &class.fields[0];
         assert_eq!(
-            strip_spans(field.type_expr.as_ref().expect("expected type expr")),
+            strip_spans(&field.type_expr),
             type_expr!(Union(
                 (Union((Path("A")), (Path("B", Attr("stream.done"))))),
                 (Path("C"))
@@ -2338,7 +2328,7 @@ class C {
         let field = &class.fields[0];
 
         assert_eq!(
-            strip_spans(field.type_expr.as_ref().expect("expected type expr")),
+            strip_spans(&field.type_expr),
             type_expr!(Union(
                 (Path("A")),
                 (Path("B")),

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -1103,50 +1103,60 @@ fn lower_class(
             };
             let field_name_str = fname.text().to_string();
             let mut hoisted_field_attrs = Vec::new();
-            let type_expr = f.ty().map(|te| {
-                let mut expr = lower_type_expr::lower_type_expr_node(&te, diags);
-                let te_span = te.syntax().span_range();
-                check_unknown_type(
-                    &expr,
-                    format!("field `{class_name}.{field_name_str}`"),
-                    te_span,
-                    diags,
-                );
-                lower_type_expr::check_void_type(
-                    &expr,
-                    "a class field type".to_string(),
-                    te_span,
-                    false,
-                    diags,
-                );
-                lower_type_expr::check_wildcard_type(
-                    &mut expr,
-                    "a class field type",
-                    te_span,
-                    diags,
-                );
+            // A field with no type is already reported by the parser ("field '<name>'
+            // is missing a type annotation"), so recover with the error sentinel rather
+            // than making the type optional: an absent type is not a kind of type, and
+            // leaving it representable downstream forces every consumer to invent its
+            // own stand-in. `Error` suppresses follow-on diagnostics while the rest of
+            // the declaration still type-checks.
+            let type_expr = f.ty().map_or_else(
+                || TypeExprKind::Error { attrs: Vec::new() }.at(f.syntax().span_range()),
+                |te| {
+                    let mut expr = lower_type_expr::lower_type_expr_node(&te, diags);
+                    let te_span = te.syntax().span_range();
+                    check_unknown_type(
+                        &expr,
+                        format!("field `{class_name}.{field_name_str}`"),
+                        te_span,
+                        diags,
+                    );
+                    lower_type_expr::check_void_type(
+                        &expr,
+                        "a class field type".to_string(),
+                        te_span,
+                        false,
+                        diags,
+                    );
+                    lower_type_expr::check_wildcard_type(
+                        &mut expr,
+                        "a class field type",
+                        te_span,
+                        diags,
+                    );
 
-                // Hoist field attrs from the outermost TypeExpr to FieldDef.
-                // Only attrs that are direct ATTRIBUTE children of the outermost
-                // CST TYPE_EXPR are hoistable — attrs nested inside parens or
-                // generics are not (and will be flagged by validate_field_attrs).
-                let direct_attr_spans: std::collections::HashSet<text_size::TextRange> = te
-                    .syntax()
-                    .children()
-                    .filter_map(ast::Attribute::cast)
-                    .map(|a| a.syntax().span_range())
-                    .collect();
+                    // Hoist field attrs from the outermost TypeExpr to FieldDef.
+                    // Only attrs that are direct ATTRIBUTE children of the outermost
+                    // CST TYPE_EXPR are hoistable — attrs nested inside parens or
+                    // generics are not (and will be flagged by validate_field_attrs).
+                    let direct_attr_spans: std::collections::HashSet<text_size::TextRange> = te
+                        .syntax()
+                        .children()
+                        .filter_map(ast::Attribute::cast)
+                        .map(|a| a.syntax().span_range())
+                        .collect();
 
-                let all_outer_attrs = std::mem::take(expr.attrs_mut());
-                let (hoist, keep): (Vec<_>, Vec<_>) = all_outer_attrs.into_iter().partition(|a| {
-                    crate::disambiguate::is_field_attr(a.name.as_str())
-                        && direct_attr_spans.contains(&a.span)
-                });
-                *expr.attrs_mut() = keep;
-                hoisted_field_attrs = hoist;
+                    let all_outer_attrs = std::mem::take(expr.attrs_mut());
+                    let (hoist, keep): (Vec<_>, Vec<_>) =
+                        all_outer_attrs.into_iter().partition(|a| {
+                            crate::disambiguate::is_field_attr(a.name.as_str())
+                                && direct_attr_spans.contains(&a.span)
+                        });
+                    *expr.attrs_mut() = keep;
+                    hoisted_field_attrs = hoist;
 
-                expr.with_span(te_span)
-            });
+                    expr.with_span(te_span)
+                },
+            );
             let field_docstring = crate::docstring::extract_docstring(f.syntax());
             Some(FieldDef {
                 name: Name::new(&field_name_str),
@@ -1409,30 +1419,35 @@ fn lower_interface(
                 return None;
             };
             let field_name_str = fname.text().to_string();
-            let type_expr = f.ty().map(|te| {
-                let mut expr = lower_type_expr::lower_type_expr_node(&te, diags);
-                let te_span = te.syntax().span_range();
-                check_unknown_type(
-                    &expr,
-                    format!("interface field `{iface_name}.{field_name_str}`"),
-                    te_span,
-                    diags,
-                );
-                lower_type_expr::check_void_type(
-                    &expr,
-                    "an interface field type".to_string(),
-                    te_span,
-                    false,
-                    diags,
-                );
-                lower_type_expr::check_wildcard_type(
-                    &mut expr,
-                    "an interface field type",
-                    te_span,
-                    diags,
-                );
-                expr.with_span(te_span)
-            });
+            // See the class-field site: the parser already reports a missing type, so
+            // recover with the error sentinel instead of an optional type.
+            let type_expr = f.ty().map_or_else(
+                || TypeExprKind::Error { attrs: Vec::new() }.at(f.syntax().span_range()),
+                |te| {
+                    let mut expr = lower_type_expr::lower_type_expr_node(&te, diags);
+                    let te_span = te.syntax().span_range();
+                    check_unknown_type(
+                        &expr,
+                        format!("interface field `{iface_name}.{field_name_str}`"),
+                        te_span,
+                        diags,
+                    );
+                    lower_type_expr::check_void_type(
+                        &expr,
+                        "an interface field type".to_string(),
+                        te_span,
+                        false,
+                        diags,
+                    );
+                    lower_type_expr::check_wildcard_type(
+                        &mut expr,
+                        "an interface field type",
+                        te_span,
+                        diags,
+                    );
+                    expr.with_span(te_span)
+                },
+            );
             Some(FieldDef {
                 name: Name::new(&field_name_str),
                 type_expr,

--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -578,6 +578,12 @@ fn collect_def_use(body: &MirFunctionBody) -> HashMap<Local, LocalDefUse> {
                     // Record uses in the rvalue
                     collect_uses_in_rvalue(value, block.id, stmt_ref, &mut def_use);
                 }
+                StatementKind::VirtualFieldStore {
+                    receiver, value, ..
+                } => {
+                    collect_uses_in_operand(receiver, block.id, stmt_ref, &mut def_use);
+                    collect_uses_in_operand(value, block.id, stmt_ref, &mut def_use);
+                }
                 StatementKind::Drop(place) => {
                     collect_uses_in_place(place, block.id, stmt_ref, &mut def_use);
                 }
@@ -708,7 +714,8 @@ fn walk_rvalue_locals(rvalue: &Rvalue, f: &mut impl FnMut(Local)) {
             }
         }
         Rvalue::MakeBoundMethod { receiver, .. }
-        | Rvalue::MakeVirtualBoundMethod { receiver, .. } => {
+        | Rvalue::MakeVirtualBoundMethod { receiver, .. }
+        | Rvalue::VirtualFieldAccess { receiver, .. } => {
             walk_operand_locals(receiver, f);
         }
         Rvalue::LoadType(_) | Rvalue::MakeGenericFunction { .. } => {
@@ -1214,6 +1221,10 @@ fn is_stack_neutral_statement(kind: &StatementKind) -> bool {
         // These modify the stack
         StatementKind::Assign { .. } => false,
         StatementKind::Drop(_) => false,
+        // Pushes receiver, value and the interface type, then the opcode pops all
+        // three — net neutral, but it touches the stack in between, so a value
+        // parked there for `Return` would be buried.
+        StatementKind::VirtualFieldStore { .. } => false,
     }
 }
 
@@ -1538,7 +1549,8 @@ fn rvalue_has_projection_reads(rvalue: &Rvalue) -> bool {
         }
         Rvalue::MakeClosure { captures, .. } => captures.iter().any(operand_has_projection),
         Rvalue::MakeBoundMethod { receiver, .. }
-        | Rvalue::MakeVirtualBoundMethod { receiver, .. } => operand_has_projection(receiver),
+        | Rvalue::MakeVirtualBoundMethod { receiver, .. }
+        | Rvalue::VirtualFieldAccess { receiver, .. } => operand_has_projection(receiver),
         Rvalue::LoadType(_) | Rvalue::MakeGenericFunction { .. } => false,
         Rvalue::MakeGenericFunctionFromValue { value, .. } => operand_has_projection(value),
     }
@@ -1639,6 +1651,8 @@ fn has_side_effect(kind: &StatementKind, rvalue_reads: &HashSet<Local>) -> bool 
         StatementKind::FreshCell(local) => rvalue_reads.contains(local),
         StatementKind::VizEnter(_) | StatementKind::VizExit(_) => true, // VizEnter/VizExit emit notifications
         StatementKind::Intrinsic { .. } => true, // Intrinsics emit events — observable side effect
+        // A write through an interface field mutates the receiver.
+        StatementKind::VirtualFieldStore { .. } => true,
         StatementKind::Nop => false,
     }
 }

--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -1857,7 +1857,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                 let inst = self.emit(Instruction::LoadType(const_idx));
                 self.set_operand(inst, OperandMeta::Const(template.to_string()));
             }
-            let iface_const = self.add_constant(ConstValue::Type(iface.clone()));
+            let iface_const = self.add_constant(ConstValue::Type(iface.to_template()));
             let inst = self.emit(Instruction::LoadType(iface_const));
             self.set_operand(inst, OperandMeta::Const(iface.to_string()));
             self.emit_constant(&Constant::String(method.clone()));
@@ -2271,7 +2271,7 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                 // interface, then the `ntypeargs` method type args, then reads the
                 // receiver (first value arg) to resolve the impl at runtime.
                 unwrap_infallible(pull_semantics::walk_call_direct_args(self, args));
-                let iface_const = self.add_constant(ConstValue::Type(iface.clone()));
+                let iface_const = self.add_constant(ConstValue::Type(iface.to_template()));
                 let inst = self.emit(Instruction::LoadType(iface_const));
                 self.set_operand(inst, OperandMeta::Const(iface.to_string()));
                 self.emit_constant(&Constant::String(method.clone()));

--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -818,6 +818,9 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
             }
             | Rvalue::MakeVirtualBoundMethod {
                 receiver: operand, ..
+            }
+            | Rvalue::VirtualFieldAccess {
+                receiver: operand, ..
             } => self.operand_reads_spawn_captured_local(operand, seen),
             Rvalue::MakeClosure { captures, .. } => captures
                 .iter()
@@ -1432,6 +1435,23 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                     Place::Field { .. } | Place::Index { .. } => unreachable!(),
                 }
             }
+            StatementKind::VirtualFieldStore {
+                iface,
+                receiver,
+                field_index,
+                field,
+                value,
+            } => {
+                // Stack: receiver, value, then the interface type — the opcode pops
+                // the interface, the value, and the receiver in that order.
+                self.emit_operand_pull(receiver);
+                self.emit_operand_pull(value);
+                let iface_const = self.add_constant(ConstValue::Type(iface.to_template()));
+                let inst = self.emit(Instruction::LoadType(iface_const));
+                self.set_operand(inst, OperandMeta::Const(iface.to_string()));
+                let inst = self.emit(Instruction::VirtualStoreField(*field_index as usize));
+                self.set_operand(inst, OperandMeta::Field(field.to_string()));
+            }
             StatementKind::Drop(place) => {
                 unwrap_infallible(pull_semantics::walk_drop_statement(self, place));
             }
@@ -1865,6 +1885,23 @@ impl<'ctx, 'obj> StackifyCodegen<'ctx, 'obj> {
                 ntypeargs: u16::try_from(type_args.len()).expect("ntypeargs fits in u16"),
             });
             self.set_operand(inst, OperandMeta::Callable(method.clone()));
+            return;
+        }
+        if let Rvalue::VirtualFieldAccess {
+            iface,
+            receiver,
+            field_index,
+            field,
+        } = rvalue
+        {
+            // Stack: receiver, then the interface type (resolved against the frame
+            // by `LoadType`) — the opcode pops the interface, then the receiver.
+            self.emit_operand_pull(receiver);
+            let iface_const = self.add_constant(ConstValue::Type(iface.to_template()));
+            let inst = self.emit(Instruction::LoadType(iface_const));
+            self.set_operand(inst, OperandMeta::Const(iface.to_string()));
+            let inst = self.emit(Instruction::VirtualLoadField(*field_index as usize));
+            self.set_operand(inst, OperandMeta::Field(field.to_string()));
             return;
         }
         // `MakeGenericFunction` needs no special handling here (it has no value
@@ -3099,9 +3136,9 @@ impl PullSink for StackifyCodegen<'_, '_> {
                 // cell pointers (LoadVar) not cell values (LoadDeref). We intercept
                 // here so that `emit_rvalue_pull` (which sets loading_for_closure_capture)
                 // is called rather than the generic `walk_rvalue_pull` inlining path.
-                // MakeBoundMethod / MakeVirtualBoundMethod must also be handled specially:
-                // neither is handled by `walk_rvalue_pull` (which panics on them), so route
-                // through `emit_rvalue_pull`.
+                // MakeBoundMethod / MakeVirtualBoundMethod / VirtualFieldAccess must
+                // also be handled specially: none is handled by `walk_rvalue_pull`
+                // (which panics on them), so route through `emit_rvalue_pull`.
                 // BinaryOp must be routed through `emit_rvalue_pull` so that the
                 // type-aware specialization in `try_specialize_binary_op` can fire
                 // (e.g. emitting `CmpBigintOp` instead of the generic `CmpOp`).
@@ -3112,6 +3149,7 @@ impl PullSink for StackifyCodegen<'_, '_> {
                     Rvalue::MakeClosure { .. }
                         | Rvalue::MakeBoundMethod { .. }
                         | Rvalue::MakeVirtualBoundMethod { .. }
+                        | Rvalue::VirtualFieldAccess { .. }
                         | Rvalue::BinaryOp { .. }
                         | Rvalue::Aggregate {
                             kind: baml_compiler2_mir::AggregateKind::Class { .. },

--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -85,7 +85,7 @@ fn build_interface_def(
         ty,
     };
     use baml_type::RuntimeInterface;
-    use bex_vm_types::types::{InterfaceDef, InterfaceMethodDef};
+    use bex_vm_types::types::{InterfaceDef, InterfaceFieldDef, InterfaceMethodDef};
 
     let file = iface_loc.file(db);
     let interface = interface_data(db, iface_loc);
@@ -261,18 +261,15 @@ fn build_interface_def(
                 .map(|ri| (at.name.clone(), ri))
         })
         .collect();
-    // A field always carries a type — an untyped one is a syntax-level error that
-    // cannot reach emit — so every field appears here.
+    // This list is the interface's field *index space*: `RuntimeImplRule::field_links`
+    // is baked parallel to it, so every declared field keeps its slot. A field always
+    // carries a type — an untyped one is a syntax-level error that cannot reach emit.
     let fields = interface
         .fields
         .iter()
-        .filter_map(|f| {
-            f.type_ref.map(|id| {
-                (
-                    f.name.clone(),
-                    lower_rt(store, id, &interface_frame_params, &decl_bounds),
-                )
-            })
+        .map(|f| InterfaceFieldDef {
+            name: f.name.clone(),
+            ty: lower_rt(store, f.type_ref, &interface_frame_params, &decl_bounds),
         })
         .collect();
     let mut methods: Vec<InterfaceMethodDef> = interface
@@ -1151,7 +1148,7 @@ pub use bex_vm_types::Program as ProgramAlias;
 /// `TypeRefId` into the owning class's `TypeRefStore` (carried alongside).
 type MergedFieldEntry = (
     String,
-    Option<baml_compiler2_hir::type_ref::TypeRefId>,
+    baml_compiler2_hir::type_ref::TypeRefId,
     Vec<baml_compiler2_hir::item_tree::Attribute>,
     Vec<Name>,
     Vec<Name>,
@@ -2901,8 +2898,9 @@ fn emit_file_group(
             for (idx, (name, type_ref, attrs, _gen_params, ns)) in merged_fields.iter().enumerate()
             {
                 field_indices.insert(name.clone(), idx);
-                let (field_type, field_template) = match type_ref {
-                    Some(id) => {
+                let (field_type, field_template) = {
+                    let id = type_ref;
+                    {
                         let mut diags = Vec::new();
                         // Pass `class_generic_params` as the binding context so
                         // `T`-references inside `class Container<T> { item: T }`
@@ -2933,17 +2931,6 @@ fn emit_file_group(
                             &class_generic_params,
                         );
                         (resolved_ty, template)
-                    }
-                    None => {
-                        let null_ty = baml_type::RuntimeTy::Null {
-                            attr: baml_type::TyAttr::default(),
-                        };
-                        (
-                            null_ty.clone(),
-                            baml_type::TyTemplate::from(baml_type::RealizedTy::Null {
-                                attr: baml_type::TyAttr::default(),
-                            }),
-                        )
                     }
                 };
                 let (field_desc, field_alias, field_skip) = extract_schema_attrs(attrs.as_slice());

--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -346,6 +346,11 @@ fn build_packages(
     alias_caches: &HashMap<Name, ResolvedAliases>,
     function_indices: &HashMap<String, usize>,
     interface_indices: &HashMap<baml_type::TypeName, usize>,
+    // Field-name → slot for every emitted class, keyed by rendered fully-qualified
+    // name. This is the *same* map the class pass built `Class::fields` from, threaded
+    // in rather than recomputed: a second derivation of the layout that drifted would
+    // make every virtual field access read the wrong slot, silently.
+    class_field_indices: &HashMap<String, HashMap<String, usize>>,
     program_packages: &mut indexmap::IndexMap<Name, bex_vm_types::types::ProgramPackage>,
 ) {
     use baml_compiler2_hir::type_ref::{TypeRefId, TypeRefStore};
@@ -432,10 +437,21 @@ fn build_packages(
     // binding in every slot.
     let mut iface_assoc_decls: indexmap::IndexMap<baml_type::TypeName, IfaceAssocDecls> =
         indexmap::IndexMap::new();
+    // Per field-bearing interface, its declared field names **in declaration order** —
+    // the index space `RuntimeImplRule::field_links` is baked against, and the same
+    // order `build_interface_def` gives `InterfaceDef::fields`. Interfaces with no
+    // fields are absent (their impls get an empty table).
+    let mut iface_field_decls: indexmap::IndexMap<baml_type::TypeName, Vec<Name>> =
+        indexmap::IndexMap::new();
     for file in all_files {
         for &iface_loc in file_interfaces(db, *file) {
             let iface_data = interface_data(db, iface_loc);
             let iface_tn = qualify_def(db, Definition::Interface(iface_loc), &iface_data.name);
+            if !iface_data.fields.is_empty() {
+                iface_field_decls
+                    .entry(iface_tn.clone())
+                    .or_insert_with(|| iface_data.fields.iter().map(|f| f.name.clone()).collect());
+            }
             if !iface_data.associated_types.is_empty() {
                 iface_assoc_decls
                     .entry(iface_tn.clone())
@@ -791,6 +807,17 @@ fn build_packages(
                     interface_args,
                     interface_assoc,
                     methods,
+                    // An out-of-body impl of a field-bearing interface is E0126, so a
+                    // rule built here never has fields to link — its `for` target need
+                    // not even be a class.
+                    field_links: {
+                        debug_assert!(
+                            !iface_field_decls.contains_key(&iface_tn),
+                            "out-of-body impl of field-bearing interface `{iface_tn}` should be \
+                             rejected by E0126",
+                        );
+                        Box::default()
+                    },
                 });
         }
 
@@ -945,6 +972,46 @@ fn build_packages(
                     &interface_assoc,
                 );
                 merge_defaults(&mut methods, &iface_tn, &iface_frame);
+                // The field table for this block, positional over the interface's own
+                // declared fields. Each entry is the class slot the interface field
+                // reads: the block's explicit `field as class_field` link, else the
+                // same-named class field (the default that
+                // `concrete_interface_field_sources` applies in TIR).
+                //
+                // A name that resolves to no class slot means the class does not cover
+                // the interface field — already E0124, so this program has diagnostics
+                // and cannot reach a runnable artifact. Drop the whole rule rather than
+                // bake a partial table: losing a dispatch is recoverable, a table whose
+                // positions no longer line up with the interface silently reads the
+                // wrong field. Matches the `resolve_fqn` convention above.
+                let field_links: Option<Box<[u32]>> = match iface_field_decls.get(&iface_tn) {
+                    None => Some(Box::default()),
+                    Some(declared) => {
+                        let class_slots = class_field_indices.get(&class_tn.to_string());
+                        declared
+                            .iter()
+                            .map(|iface_field| {
+                                let class_field = block
+                                    .field_links
+                                    .iter()
+                                    .find(|link| link.interface_field == *iface_field)
+                                    .map_or(iface_field, |link| &link.class_field);
+                                let slot = class_slots
+                                    .and_then(|slots| slots.get(class_field.as_str()))
+                                    .copied();
+                                debug_assert!(
+                                    slot.is_some(),
+                                    "interface `{iface_tn}` field `{iface_field}` links to \
+                                     `{class_tn}.{class_field}`, which has no runtime slot",
+                                );
+                                slot.map(|s| u32::try_from(s).expect("class field count fits u32"))
+                            })
+                            .collect()
+                    }
+                };
+                let Some(field_links) = field_links else {
+                    continue;
+                };
                 program_packages
                     .entry(pkg_info.package.clone())
                     .or_default()
@@ -958,6 +1025,7 @@ fn build_packages(
                         interface_args,
                         interface_assoc,
                         methods,
+                        field_links,
                     });
             }
         }
@@ -2246,6 +2314,7 @@ fn build_package_fragment(
                 interface_args: rule.interface_args.clone(),
                 interface_assoc: rule.interface_assoc.clone(),
                 methods,
+                field_links: rule.field_links.clone(),
             });
         }
         frag.impl_rules.push((iface_fq, rule_frags));
@@ -2576,6 +2645,7 @@ fn generate_impl(
         &alias_caches,
         &program.function_indices,
         &tables.interface_object_indices,
+        &tables.classes,
         &mut tables.program_packages,
     );
     tables.program_packages.sort_keys();

--- a/baml_language/crates/baml_compiler2_emit/src/pull_semantics.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/pull_semantics.rs
@@ -457,6 +457,10 @@ pub(crate) fn walk_rvalue_pull<S: PullSink>(sink: &mut S, rvalue: &Rvalue) -> Re
             // Handled specially in emit_rvalue_pull before this function is called.
             unreachable!("MakeVirtualBoundMethod must be handled in emit_rvalue_pull")
         }
+        Rvalue::VirtualFieldAccess { .. } => {
+            // Handled specially in emit_rvalue_pull before this function is called.
+            unreachable!("VirtualFieldAccess must be handled in emit_rvalue_pull")
+        }
         Rvalue::MakeGenericFunction {
             item,
             type_arg_templates,

--- a/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
@@ -456,6 +456,10 @@ fn simulate_statement_stack(
                 pull_semantics::walk_projection_store(&mut sink, destination, value).is_ok()
             }
         },
+        // Receiver, value and the interface type are pushed then all consumed by the
+        // opcode. Rather than simulate that, opt out of stack carry across it — the
+        // statement is materialized correctly by `emit_statement`.
+        StatementKind::VirtualFieldStore { .. } => false,
         StatementKind::Drop(place) => {
             let mut sink = StackCarryPullSink {
                 sim,
@@ -914,7 +918,12 @@ fn simulate_rvalue_pull_stack(
     // type args + interface type + method name). Rather than simulate it, opt out of
     // the stack-carry optimization for it — `walk_rvalue_pull` panics on it, and it is
     // materialized correctly through `emit_rvalue_pull`.
-    if matches!(rvalue, Rvalue::MakeVirtualBoundMethod { .. }) {
+    // `VirtualFieldAccess` joins it: `walk_rvalue_pull` panics on both, and both are
+    // materialized correctly through `emit_rvalue_pull`.
+    if matches!(
+        rvalue,
+        Rvalue::MakeVirtualBoundMethod { .. } | Rvalue::VirtualFieldAccess { .. }
+    ) {
         return false;
     }
     let mut sink = StackCarryPullSink {

--- a/baml_language/crates/baml_compiler2_hir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/builder.rs
@@ -1706,9 +1706,8 @@ impl<'db> SemanticIndexBuilder<'db> {
                 );
                 self.validate_schema_attributes(&class.attributes);
                 for field in &class.fields {
-                    if let Some(type_expr) = &field.type_expr {
-                        self.validate_type_expr_phase1(type_expr, type_expr.span, is_builtin_file);
-                    }
+                    let type_expr = &field.type_expr;
+                    self.validate_type_expr_phase1(type_expr, type_expr.span, is_builtin_file);
                     self.validate_internal_attributes(
                         &field.attributes,
                         is_builtin_file,

--- a/baml_language/crates/baml_compiler2_hir/src/item_tree/classes.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/item_tree/classes.rs
@@ -11,7 +11,9 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ClassField {
     pub name: Name,
-    pub type_expr: Option<ast::TypeExpr>,
+    /// Always present — see [`ast::FieldDef::type_expr`]. A field written without a
+    /// type recovers as `TypeExprKind::Error`, not as an absent type.
+    pub type_expr: ast::TypeExpr,
     pub attributes: Vec<Attribute>,
     /// Joined `///` doc-comment lines preceding this declaration.
     pub docstring: Option<String>,

--- a/baml_language/crates/baml_compiler2_mir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/builder.rs
@@ -385,7 +385,7 @@ impl MirBuilder {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn virtual_call(
         &mut self,
-        iface: baml_type::TyTemplate,
+        iface: baml_type::TyTemplateInterface,
         method: String,
         args: Vec<Operand>,
         ntypeargs: usize,
@@ -410,7 +410,7 @@ impl MirBuilder {
     #[expect(clippy::too_many_arguments)]
     pub(crate) fn virtual_call_with_runtime_id(
         &mut self,
-        iface: baml_type::TyTemplate,
+        iface: baml_type::TyTemplateInterface,
         method: String,
         args: Vec<Operand>,
         ntypeargs: usize,

--- a/baml_language/crates/baml_compiler2_mir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/builder.rs
@@ -206,6 +206,27 @@ impl MirBuilder {
         self.push_statement(StatementKind::Assign { destination, value }, Some(span));
     }
 
+    /// Emit an open-world interface-field store.
+    pub(crate) fn virtual_field_store(
+        &mut self,
+        iface: baml_type::TyTemplateInterface,
+        receiver: Operand,
+        field_index: u32,
+        field: baml_base::Name,
+        value: Operand,
+    ) {
+        self.push_statement(
+            StatementKind::VirtualFieldStore {
+                iface,
+                receiver,
+                field_index,
+                field,
+                value,
+            },
+            None,
+        );
+    }
+
     /// Emit a drop statement.
     pub(crate) fn drop(&mut self, place: Place) {
         self.push_statement(StatementKind::Drop(place), None);

--- a/baml_language/crates/baml_compiler2_mir/src/ir.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/ir.rs
@@ -7,7 +7,7 @@ use std::fmt;
 
 use baml_base::{Name, Span};
 pub use baml_compiler2_ast::BuiltinKind;
-use baml_type::{RealizedTy, RuntimeTy, TyTemplate};
+use baml_type::{RealizedTy, RuntimeTy, TyTemplate, TyTemplateInterface};
 
 // ============================================================================
 // Optimization Level
@@ -420,7 +420,7 @@ pub enum Terminator {
         /// The interface to resolve against, as a template the emitter pushes
         /// with `LoadType`. Non-generic today (`baml.ops.Equals`/`Compare`); a
         /// parameterized interface bakes its arguments into the template.
-        iface: TyTemplate,
+        iface: TyTemplateInterface,
         /// The interface method to dispatch (e.g. `"eq"`, `"lt"`, `"neq"`).
         method: String,
         /// `args[..ntypeargs]` are the method-level type-argument values
@@ -818,7 +818,7 @@ pub enum Rvalue {
     MakeVirtualBoundMethod {
         /// The interface to resolve against, as a template the emitter pushes
         /// with `LoadType` (like [`Terminator::VirtualCall`]'s `iface`).
-        iface: TyTemplate,
+        iface: TyTemplateInterface,
         /// The interface method's name.
         method: String,
         /// The receiver whose runtime concrete type is the `Self` to resolve on.

--- a/baml_language/crates/baml_compiler2_mir/src/ir.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/ir.rs
@@ -321,6 +321,20 @@ pub enum StatementKind {
     /// Lowered from calls to `$compiler_intrinsic` functions.
     Intrinsic { op: IntrinsicOp, args: Vec<Operand> },
 
+    /// Write an interface field on a receiver whose concrete type is not known
+    /// statically — the store counterpart of [`Rvalue::VirtualFieldAccess`], with
+    /// the same operand meaning and the same resolution.
+    ///
+    /// A statement rather than an `Assign` to a `Place`, because the destination
+    /// slot is only known once the receiver's impl is resolved at run time.
+    VirtualFieldStore {
+        iface: TyTemplateInterface,
+        receiver: Operand,
+        field_index: u32,
+        field: Name,
+        value: Operand,
+    },
+
     /// No-op (placeholder for removed statements).
     Nop,
 }
@@ -828,6 +842,31 @@ pub enum Rvalue {
         /// Appended to the resolved impl frame by the VM — dropping them would
         /// lose the method's own generics.
         type_args: Vec<TyTemplate>,
+    },
+
+    /// Read an interface field from a receiver whose concrete type is not known
+    /// statically — the field analogue of [`Terminator::VirtualCall`], and the
+    /// structural twin of [`Rvalue::MakeVirtualBoundMethod`].
+    ///
+    /// A `Place::Field` cannot express this: its index is a slot in the receiver's
+    /// own layout, and two classes implementing the same interface link the same
+    /// interface field to different slots. `field_index` is instead the field's
+    /// position in the *interface's* declared field list, which the VM maps to a
+    /// slot through the resolved impl's `field_links`.
+    VirtualFieldAccess {
+        /// The interface resolved through, pushed by the emitter with `LoadType` —
+        /// so an interface argument that is an enclosing generic (`Slot<T>`)
+        /// arrives at the resolver realized against the caller's frame, which is
+        /// what discriminates a class implementing one interface family at several
+        /// instantiations with different links.
+        iface: TyTemplateInterface,
+        /// The receiver whose runtime concrete type is the `Self` to resolve on.
+        receiver: Operand,
+        /// Index into `iface`'s declared fields.
+        field_index: u32,
+        /// The field's name — for the pretty-printer and the emitter's
+        /// `OperandMeta` only. Dispatch reads `field_index`.
+        field: Name,
     },
 
     /// Create a generic-function value (`foo<T>`) whose type arguments depend on

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -2383,7 +2383,7 @@ impl<'db> LoweringContext<'db> {
                         let mut idx_counter = 0usize;
                         let mut insert_field =
                             |name: &str,
-                             type_ref: Option<baml_compiler2_hir::type_ref::TypeRefId>,
+                             type_ref: baml_compiler2_hir::type_ref::TypeRefId,
                              generic_params: &[ParamTy],
                              ns: &[Name],
                              fields: &mut IndexMap<String, usize>,
@@ -2396,26 +2396,20 @@ impl<'db> LoweringContext<'db> {
                                 let idx = idx_counter;
                                 fields.insert(name.to_string(), idx);
                                 idx_counter += 1;
-                                let field_ty = type_ref
-                                    .map(|id| {
-                                        let tir_ty = baml_compiler2_tir::lower_type_expr::lower_type_ref(
-                                            &class_data.type_refs,
-                                            id,
-                                            &baml_compiler2_tir::lower_type_expr::ScopeCtx {
-                                                db,
-                                                package_items: pkg_items,
-                                                ns_context: ns,
-                                                generic_params,
-                                                bounds: baml_compiler2_tir::lower_type_expr::class_generic_param_bounds(db, *class_loc),
-                                                self_ty: None,
-                                            },
-                                            diags,
-                                        );
-                                        resolved_aliases.convert(&tir_ty)
-                                    })
-                                    .unwrap_or(RuntimeTy::Null {
-                                        attr: TyAttr::default(),
-                                    });
+                                let tir_ty = baml_compiler2_tir::lower_type_expr::lower_type_ref(
+                                    &class_data.type_refs,
+                                    type_ref,
+                                    &baml_compiler2_tir::lower_type_expr::ScopeCtx {
+                                        db,
+                                        package_items: pkg_items,
+                                        ns_context: ns,
+                                        generic_params,
+                                        bounds: baml_compiler2_tir::lower_type_expr::class_generic_param_bounds(db, *class_loc),
+                                        self_ty: None,
+                                    },
+                                    diags,
+                                );
+                                let field_ty = resolved_aliases.convert(&tir_ty);
                                 field_types.insert(name.to_string(), field_ty.clone());
                                 Some((idx, field_ty))
                             };
@@ -6679,11 +6673,7 @@ impl<'db> LoweringContext<'db> {
                 attr: TyAttr::default(),
             };
         };
-        let Some(type_ref) = field.type_ref else {
-            return RuntimeTy::Null {
-                attr: TyAttr::default(),
-            };
-        };
+        let type_ref = field.type_ref;
 
         let pkg_ns =
             baml_compiler2_hir::file_package::file_package(db, class_loc.file(db)).namespace_path;
@@ -13267,44 +13257,36 @@ impl LoweringContext<'_> {
         let mut result = IndexMap::new();
         for field in &class_data.fields {
             let mut diags = Vec::new();
-            let field_ty = field
-                .type_ref
-                .map(|id| {
-                    if bindings.is_empty() {
-                        baml_compiler2_tir::lower_type_expr::lower_type_ref(
-                            &class_data.type_refs,
-                            id,
-                            &baml_compiler2_tir::lower_type_expr::ScopeCtx {
-                                db: self.db,
-                                package_items: pkg_items_for_class,
-                                ns_context: &ns_context,
-                                generic_params: &class_generic_params,
-                                bounds:
-                                    baml_compiler2_tir::lower_type_expr::class_generic_param_bounds(
-                                        self.db, class_loc,
-                                    ),
-                                self_ty: None,
-                            },
-                            &mut diags,
-                        )
-                    } else {
-                        lower_ref_with_bindings(
-                            self.db,
-                            &class_data.type_refs,
-                            id,
-                            pkg_items_for_class,
-                            &ns_context,
-                            &bindings,
-                            baml_compiler2_tir::lower_type_expr::class_generic_param_bounds(
-                                self.db, class_loc,
-                            ),
-                            &mut diags,
-                        )
-                    }
-                })
-                .unwrap_or(Tir2Ty::Unknown {
-                    attr: baml_compiler2_tir::ty::TyAttr::default(),
-                });
+            let field_ty = if bindings.is_empty() {
+                baml_compiler2_tir::lower_type_expr::lower_type_ref(
+                    &class_data.type_refs,
+                    field.type_ref,
+                    &baml_compiler2_tir::lower_type_expr::ScopeCtx {
+                        db: self.db,
+                        package_items: pkg_items_for_class,
+                        ns_context: &ns_context,
+                        generic_params: &class_generic_params,
+                        bounds: baml_compiler2_tir::lower_type_expr::class_generic_param_bounds(
+                            self.db, class_loc,
+                        ),
+                        self_ty: None,
+                    },
+                    &mut diags,
+                )
+            } else {
+                lower_ref_with_bindings(
+                    self.db,
+                    &class_data.type_refs,
+                    field.type_ref,
+                    pkg_items_for_class,
+                    &ns_context,
+                    &bindings,
+                    baml_compiler2_tir::lower_type_expr::class_generic_param_bounds(
+                        self.db, class_loc,
+                    ),
+                    &mut diags,
+                )
+            };
             result.insert(field.name.clone(), field_ty);
         }
         result

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use baml_base::{Name, TypePath};
 use baml_type::{
     ParamTy, PrimitiveType, RealizedTy, ResolvedAliases, RuntimeGenericLayout, RuntimeTy, TyAttr,
-    TyTemplate, TypeName, normalize::TypeContext as _,
+    TyTemplate, TyTemplateInterface, TypeName, normalize::TypeContext as _,
 };
 use indexmap::IndexMap;
 
@@ -1011,6 +1011,36 @@ fn tir2_to_template_in_frame(
         return None;
     }
     lower_tir_template(&ty, resolved, &generic_layout, TemplateMode::Value)
+}
+
+/// Lower a realized interface **constraint** to its template form: each generic
+/// argument and associated binding lowered individually, so an argument that is an
+/// enclosing generic becomes a `TypeArgRef` and reaches the runtime resolver
+/// realized against the caller's frame.
+///
+/// Deliberately not `tir2_to_template` over a `Ty::Interface`. That lowers the
+/// interface as a *type*, and yields two different shapes for one meaning — a
+/// `TyTemplate::Interface` when some argument is symbolic, a `Concrete` leaf when
+/// none is. A dispatch site names the interface it resolves *through*, which is a
+/// constraint, not an existential; carrying it as one gives a single shape and
+/// makes a non-interface in that position unrepresentable.
+pub(crate) fn tir2_interface_to_template(
+    name: &baml_type::TypeName,
+    args: &[Tir2Ty],
+    assoc: &[(Name, Tir2Ty)],
+    resolved: &ResolvedAliases,
+    generic_params: &[ParamTy],
+) -> TyTemplateInterface {
+    TyTemplateInterface::new(
+        name.clone(),
+        args.iter()
+            .map(|a| tir2_to_template(a, resolved, generic_params))
+            .collect(),
+        assoc
+            .iter()
+            .map(|(n, t)| (n.clone(), tir2_to_template(t, resolved, generic_params)))
+            .collect(),
+    )
 }
 
 /// A resolved `RuntimeTy` with no residual type variables, as a leaf template:
@@ -10597,13 +10627,10 @@ impl<'db> LoweringContext<'db> {
         // slot and arrives at the resolver realized, disambiguating a type
         // implementing the same interface at several instantiations.
         let generic_params = self.enclosing_generic_params();
-        let iface_template = tir2_to_template(
-            &Tir2Ty::Interface(
-                iface_tn.clone(),
-                iface_type_args.to_vec(),
-                iface_assoc.to_vec(),
-                TyAttr::default(),
-            ),
+        let iface_template = tir2_interface_to_template(
+            iface_tn,
+            iface_type_args,
+            iface_assoc,
             self.resolved_aliases,
             &generic_params,
         );
@@ -10657,8 +10684,10 @@ impl<'db> LoweringContext<'db> {
         // that is an enclosing generic lowers to its `TypeArgRef` frame slot and
         // arrives at the bind-time resolver realized.
         let generic_params = self.enclosing_generic_params();
-        let iface_template = tir2_to_template(
-            &Tir2Ty::Interface(decl_tn, decl_args, decl_assoc, TyAttr::default()),
+        let iface_template = tir2_interface_to_template(
+            &decl_tn,
+            &decl_args,
+            &decl_assoc,
             self.resolved_aliases,
             &generic_params,
         );

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -3,7 +3,7 @@ use std::collections::{HashMap, HashSet};
 use baml_base::{Name, TypePath};
 use baml_type::{
     ParamTy, PrimitiveType, RealizedTy, ResolvedAliases, RuntimeGenericLayout, RuntimeTy, TyAttr,
-    TyTemplate, TyTemplateInterface, TypeName, normalize::TypeContext as _,
+    TyTemplate, TyTemplateInterface, TypeName,
 };
 use indexmap::IndexMap;
 
@@ -85,575 +85,7 @@ pub fn resolved_aliases_for_package(
     ResolvedAliases { aliases, recursive }
 }
 
-fn interface_tir_type_args_match_preserving_typevars(
-    impl_iface_args: &[Tir2Ty],
-    iface_type_args: &[Tir2Ty],
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
-) -> bool {
-    impl_iface_args.len() == iface_type_args.len()
-        && impl_iface_args
-            .iter()
-            .zip(iface_type_args.iter())
-            .all(|(impl_arg, iface_arg)| {
-                // A requested type-var (e.g. dispatching `b.get()` where
-                // `b: Box<T>` inside `fn read<T>(..)`) is unconstrained at this
-                // site — it matches any implementor instantiation, and the
-                // runtime `IsType` guard on the concrete instance discriminates.
-                (matches!(iface_arg, Tir2Ty::TypeVar(_, _))
-                    && !matches!(impl_arg, Tir2Ty::TypeVar(_, _)))
-                    || baml_compiler2_tir::type_context::AliasEquivCtx(aliases)
-                        .equivalent(impl_arg, iface_arg)
-            })
-}
-
-fn tir_type_satisfies_dispatch_request(
-    actual: &Tir2Ty,
-    requested: &Tir2Ty,
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
-) -> bool {
-    if baml_compiler2_tir::type_context::AliasEquivCtx(aliases).equivalent(actual, requested) {
-        return true;
-    }
-
-    match (actual, requested) {
-        (_, Tir2Ty::TypeVar(_, _) | Tir2Ty::AssociatedTypeProjection { .. }) => true,
-        (Tir2Ty::List(actual, _), Tir2Ty::List(requested, _))
-        | (Tir2Ty::EvolvingList(actual, _), Tir2Ty::EvolvingList(requested, _)) => {
-            tir_type_satisfies_dispatch_request(actual, requested, aliases)
-        }
-        (
-            Tir2Ty::Map {
-                key: actual_key,
-                value: actual_value,
-                ..
-            },
-            Tir2Ty::Map {
-                key: requested_key,
-                value: requested_value,
-                ..
-            },
-        )
-        | (
-            Tir2Ty::EvolvingMap(actual_key, actual_value, _),
-            Tir2Ty::EvolvingMap(requested_key, requested_value, _),
-        ) => {
-            tir_type_satisfies_dispatch_request(actual_key, requested_key, aliases)
-                && tir_type_satisfies_dispatch_request(actual_value, requested_value, aliases)
-        }
-        (
-            Tir2Ty::Future(actual_value, actual_error, _),
-            Tir2Ty::Future(requested_value, requested_error, _),
-        ) => {
-            tir_type_satisfies_dispatch_request(actual_value, requested_value, aliases)
-                && tir_type_satisfies_dispatch_request(actual_error, requested_error, aliases)
-        }
-        (Tir2Ty::Union(actual, _), Tir2Ty::Union(requested, _))
-            if actual.len() == requested.len() =>
-        {
-            actual
-                .iter()
-                .zip(requested.iter())
-                .all(|(actual, requested)| {
-                    tir_type_satisfies_dispatch_request(actual, requested, aliases)
-                })
-        }
-        (
-            Tir2Ty::Class(actual_qtn, actual_args, _),
-            Tir2Ty::Class(requested_qtn, requested_args, _),
-        ) if actual_qtn == requested_qtn && actual_args.len() == requested_args.len() => {
-            actual_args
-                .iter()
-                .zip(requested_args.iter())
-                .all(|(actual, requested)| {
-                    tir_type_satisfies_dispatch_request(actual, requested, aliases)
-                })
-        }
-        (
-            Tir2Ty::Interface(actual_qtn, actual_args, actual_assoc, _),
-            Tir2Ty::Interface(requested_qtn, requested_args, requested_assoc, _),
-        ) if actual_qtn == requested_qtn && actual_args.len() == requested_args.len() => {
-            actual_args
-                .iter()
-                .zip(requested_args.iter())
-                .all(|(actual, requested)| {
-                    tir_type_satisfies_dispatch_request(actual, requested, aliases)
-                })
-                && requested_assoc
-                    .iter()
-                    .all(|(requested_name, requested_ty)| {
-                        actual_assoc
-                            .iter()
-                            .find(|(actual_name, _)| actual_name == requested_name)
-                            .is_some_and(|(_, actual_ty)| {
-                                tir_type_satisfies_dispatch_request(
-                                    actual_ty,
-                                    requested_ty,
-                                    aliases,
-                                )
-                            })
-                    })
-        }
-        (
-            Tir2Ty::Function {
-                params: actual_params,
-                ret: actual_ret,
-                throws: actual_throws,
-                ..
-            },
-            Tir2Ty::Function {
-                params: requested_params,
-                ret: requested_ret,
-                throws: requested_throws,
-                ..
-            },
-        ) if actual_params.len() == requested_params.len()
-            && actual_params
-                .iter()
-                .zip(requested_params.iter())
-                .all(|(actual, requested)| actual.mode == requested.mode) =>
-        {
-            actual_params
-                .iter()
-                .zip(requested_params.iter())
-                .all(|(actual, requested)| {
-                    tir_type_satisfies_dispatch_request(&actual.ty, &requested.ty, aliases)
-                })
-                && tir_type_satisfies_dispatch_request(actual_ret, requested_ret, aliases)
-                && tir_type_satisfies_dispatch_request(actual_throws, requested_throws, aliases)
-        }
-        _ => false,
-    }
-}
-
-fn bind_interface_class_type_arg(
-    param: &ParamTy,
-    actual: &Tir2Ty,
-    bindings: &mut FxHashMap<ParamTy, Tir2Ty>,
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
-) -> bool {
-    match bindings.get(param) {
-        Some(existing) => {
-            baml_compiler2_tir::type_context::AliasEquivCtx(aliases).equivalent(existing, actual)
-        }
-        None => {
-            bindings.insert(param.clone(), actual.clone());
-            true
-        }
-    }
-}
-
-fn infer_interface_class_bindings(
-    formal: &Tir2Ty,
-    actual: &Tir2Ty,
-    class_params: &[ParamTy],
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
-    bindings: &mut FxHashMap<ParamTy, Tir2Ty>,
-    // Associated-type bindings tolerate an unpinnable typevar union
-    // (`Error = E | E2` vs a normalized request) by leaving the params
-    // unpinned; positional interface args must keep strict pairwise
-    // decomposition, where pinning is what discriminates between blocks.
-    assoc_union_wildcard: bool,
-) -> bool {
-    match (formal, actual) {
-        // A dispatch request like `Iterator<Item = Self.Item, Error = Self.Error>`
-        // inside an interface default method is receiver-relative evidence, not
-        // a concrete type to compare against every implementor. The runtime
-        // class guard chooses the implementor; concrete associated bindings
-        // such as `Error = never` are valid for that implementor.
-        (_, Tir2Ty::AssociatedTypeProjection { .. }) => true,
-        // The requested arg is an open type-var from the dispatch site, not
-        // necessarily the candidate class's parameter even if it has the same
-        // spelling (`T`, `E`, ...). If the formal side was not a bindable
-        // candidate parameter, treat it as a wildcard; this lets
-        // `Iterator<R, E | E2>` satisfy an open `Iterator<T, E>` request.
-        (Tir2Ty::TypeVar(name, _), Tir2Ty::TypeVar(_, _)) if !class_params.contains(name) => true,
-        (Tir2Ty::TypeVar(name, _), _) => {
-            bind_interface_class_type_arg(name, actual, bindings, aliases)
-        }
-        (_, Tir2Ty::TypeVar(_, _)) => true,
-        (Tir2Ty::List(f, _), Tir2Ty::List(a, _))
-        | (Tir2Ty::EvolvingList(f, _), Tir2Ty::EvolvingList(a, _))
-        | (Tir2Ty::Future(f, _, _), Tir2Ty::Future(a, _, _)) => infer_interface_class_bindings(
-            f,
-            a,
-            class_params,
-            aliases,
-            bindings,
-            assoc_union_wildcard,
-        ),
-        (
-            Tir2Ty::Map {
-                key: fk, value: fv, ..
-            },
-            Tir2Ty::Map {
-                key: ak, value: av, ..
-            },
-        )
-        | (Tir2Ty::EvolvingMap(fk, fv, _), Tir2Ty::EvolvingMap(ak, av, _)) => {
-            infer_interface_class_bindings(
-                fk,
-                ak,
-                class_params,
-                aliases,
-                bindings,
-                assoc_union_wildcard,
-            ) && infer_interface_class_bindings(
-                fv,
-                av,
-                class_params,
-                aliases,
-                bindings,
-                assoc_union_wildcard,
-            )
-        }
-        (
-            Tir2Ty::Function {
-                params: fp,
-                ret: fr,
-                throws: fth,
-                ..
-            },
-            Tir2Ty::Function {
-                params: ap,
-                ret: ar,
-                throws: ath,
-                ..
-            },
-        ) => {
-            fp.len() == ap.len()
-                && fp.iter().zip(ap.iter()).all(|(fp, ap)| {
-                    fp.mode == ap.mode
-                        && infer_interface_class_bindings(
-                            &fp.ty,
-                            &ap.ty,
-                            class_params,
-                            aliases,
-                            bindings,
-                            assoc_union_wildcard,
-                        )
-                })
-                && infer_interface_class_bindings(
-                    fr,
-                    ar,
-                    class_params,
-                    aliases,
-                    bindings,
-                    assoc_union_wildcard,
-                )
-                && infer_interface_class_bindings(
-                    fth,
-                    ath,
-                    class_params,
-                    aliases,
-                    bindings,
-                    assoc_union_wildcard,
-                )
-        }
-        (Tir2Ty::Class(fqtn, fargs, _), Tir2Ty::Class(aqtn, aargs, _))
-            if fqtn == aqtn && fargs.len() == aargs.len() =>
-        {
-            fargs.iter().zip(aargs.iter()).all(|(f, a)| {
-                infer_interface_class_bindings(
-                    f,
-                    a,
-                    class_params,
-                    aliases,
-                    bindings,
-                    assoc_union_wildcard,
-                )
-            })
-        }
-        (
-            Tir2Ty::Interface(fqtn, fargs, f_assoc, _),
-            Tir2Ty::Interface(aqtn, aargs, a_assoc, _),
-        ) if fqtn == aqtn && fargs.len() == aargs.len() => {
-            fargs.iter().zip(aargs.iter()).all(|(f, a)| {
-                infer_interface_class_bindings(
-                    f,
-                    a,
-                    class_params,
-                    aliases,
-                    bindings,
-                    assoc_union_wildcard,
-                )
-            }) && a_assoc.iter().all(|(name, actual_ty)| {
-                f_assoc
-                    .iter()
-                    .find(|(formal_name, _)| formal_name == name)
-                    .is_some_and(|(_, formal_ty)| {
-                        infer_interface_class_bindings(
-                            formal_ty,
-                            actual_ty,
-                            class_params,
-                            aliases,
-                            bindings,
-                            assoc_union_wildcard,
-                        )
-                    })
-            })
-        }
-        (Tir2Ty::Union(fparts, _), actual @ Tir2Ty::Never { .. }) => fparts.iter().all(|f| {
-            infer_interface_class_bindings(
-                f,
-                actual,
-                class_params,
-                aliases,
-                bindings,
-                assoc_union_wildcard,
-            )
-        }),
-        (Tir2Ty::Union(fparts, _), Tir2Ty::Union(aparts, _)) => {
-            let is_class_param =
-                |ty: &Tir2Ty| matches!(ty, Tir2Ty::TypeVar(name, _) if class_params.contains(name));
-            // For ASSOCIATED-type bindings, pairwise decomposition is only
-            // trustworthy when it cannot mis-pin: with two or more class-param
-            // members (`E | E2`), the assignment of requested members to
-            // params is not unique — the requested union is already normalized
-            // (deduped, `never` dropped), so e.g. `E | E2` vs `A | B` may
-            // really be `E = A | B, E2 = never` at runtime. POSITIONAL args
-            // keep the strict pairwise zip: their pinning is what
-            // discriminates between same-class implements blocks, and the
-            // guard post-check re-validates them.
-            if fparts.len() == aparts.len()
-                && (!assoc_union_wildcard
-                    || fparts.iter().filter(|f| is_class_param(f)).count() <= 1)
-            {
-                let mut trial = bindings.clone();
-                if fparts.iter().zip(aparts.iter()).all(|(f, a)| {
-                    infer_interface_class_bindings(
-                        f,
-                        a,
-                        class_params,
-                        aliases,
-                        &mut trial,
-                        assoc_union_wildcard,
-                    )
-                }) {
-                    *bindings = trial;
-                    return true;
-                }
-            }
-            // Wildcard fallback (assoc bindings only): leave class-param
-            // members unpinned — the guard keeps `None` for them and the
-            // callee frame seeds from the matched runtime instance's
-            // `class_type_args` (its TRUE args, not the guard's) — while
-            // every concrete formal member must still be present in the
-            // request.
-            //
-            // Unpinned assoc bindings are safe because dispatch never relies
-            // on them for correctness:
-            // 1. every selected candidate's runtime guard checks the
-            //    receiver's concrete class identity, so an unpinned binding
-            //    can never capture another class's instance;
-            // 2. two candidates for the SAME class can only coexist when their
-            //    positional interface args differ — blocks differing only in
-            //    assoc bindings are rejected at HIR (E0114; pinned by
-            //    `duplicate_implements_differing_only_in_assoc_bindings_is_compile_error`)
-            //    — and positional args keep strict pairwise pinning above
-            //    precisely so they stay discriminating at *selection* time;
-            // 3. a receiver whose runtime bindings don't satisfy the request
-            //    cannot reach the switch in a well-typed program (the
-            //    receiver's static type IS the requested view); selection
-            //    discriminates among candidates, the runtime guard is not a
-            //    soundness barrier.
-            assoc_union_wildcard
-                && fparts.iter().any(&is_class_param)
-                && fparts.iter().all(|f| {
-                    is_class_param(f)
-                        || aparts.iter().any(|a| {
-                            baml_compiler2_tir::type_context::AliasEquivCtx(aliases)
-                                .equivalent(f, a)
-                        })
-                })
-        }
-        _ => baml_compiler2_tir::type_context::AliasEquivCtx(aliases).equivalent(formal, actual),
-    }
-}
-
-/// Whether one in-body `implements` block provides the *requested* interface
-/// view — the compile-time candidate selection for the interface field switch.
-///
-/// This selection is the whole discrimination story; the runtime guard per
-/// selected candidate is bare class identity. That is sufficient because:
-///
-/// - field links exist only in **in-body** blocks (E0126 forces field-declaring
-///   interfaces in-body), and an in-body block always covers the class's whole
-///   type constructor;
-/// - coherence rejects overlapping same-interface blocks, so for a given
-///   *concrete* request at most one block per class unifies here — there is
-///   never a same-class sibling arm for a runtime guard to tell apart;
-/// - a receiver that doesn't satisfy the request cannot reach the switch in a
-///   well-typed program (its static type IS the requested view), so re-checking
-///   the pinned positions at runtime proved nothing.
-fn implements_block_matches_request(
-    impl_iface_args: &[Tir2Ty],
-    impl_iface_assoc: &[(Name, Tir2Ty)],
-    requested_iface_args: &[Tir2Ty],
-    requested_iface_assoc: &[(Name, Tir2Ty)],
-    class_params: &[ParamTy],
-    aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
-) -> bool {
-    // An *uninstantiated* request (no type args) matches any implementor
-    // instantiation — e.g. `self: Container` inside a generic interface's
-    // default method dispatches to `IntBox` (which implements `Container<int>`).
-    // The runtime IsType on the concrete class still discriminates.
-    let request_omits_type_args = requested_iface_args.is_empty() && !impl_iface_args.is_empty();
-    if request_omits_type_args && requested_iface_assoc.is_empty() {
-        return true;
-    }
-    let mut bindings = FxHashMap::default();
-    if !request_omits_type_args {
-        if impl_iface_args.len() != requested_iface_args.len() {
-            return false;
-        }
-        for (impl_arg, requested_arg) in impl_iface_args.iter().zip(requested_iface_args.iter()) {
-            if !infer_interface_class_bindings(
-                impl_arg,
-                requested_arg,
-                class_params,
-                aliases,
-                &mut bindings,
-                false,
-            ) {
-                return false;
-            }
-        }
-    }
-    for (requested_name, requested_ty) in requested_iface_assoc {
-        let Some((_, impl_ty)) = impl_iface_assoc
-            .iter()
-            .find(|(impl_name, _)| impl_name == requested_name)
-        else {
-            return false;
-        };
-        if !infer_interface_class_bindings(
-            impl_ty,
-            requested_ty,
-            class_params,
-            aliases,
-            &mut bindings,
-            true,
-        ) {
-            return false;
-        }
-    }
-    let substituted_args: Vec<_> = impl_iface_args
-        .iter()
-        .map(|arg| baml_compiler2_tir::generics::substitute_ty(arg, &bindings))
-        .collect();
-    if !request_omits_type_args
-        && !interface_tir_type_args_match_preserving_typevars(
-            &substituted_args,
-            requested_iface_args,
-            aliases,
-        )
-    {
-        return false;
-    }
-    let substituted_assoc: Vec<_> = impl_iface_assoc
-        .iter()
-        .map(|(name, ty)| {
-            (
-                name.clone(),
-                baml_compiler2_tir::generics::substitute_ty(ty, &bindings),
-            )
-        })
-        .collect();
-    for (requested_name, requested_ty) in requested_iface_assoc {
-        let Some((_, impl_ty)) = substituted_assoc
-            .iter()
-            .find(|(impl_name, _)| impl_name == requested_name)
-        else {
-            return false;
-        };
-        // A substituted binding still containing class params is deliberately
-        // left unpinned (unpinnable typevar union): the runtime class guard plus
-        // instance-seeded frame args carry the discrimination instead. This
-        // skip is only reachable after `infer_interface_class_bindings` has
-        // structurally vetted the same (formal, requested) pairs above — it
-        // never admits a pair that binding inference rejected.
-        if baml_compiler2_tir::generics::contains_typevar(impl_ty) {
-            continue;
-        }
-        if !tir_type_satisfies_dispatch_request(impl_ty, requested_ty, aliases) {
-            return false;
-        }
-    }
-    true
-}
-
 // ─── RuntimeTy → TyTemplate conversion for already-resolved RuntimeTy values ──────────────
-
-/// Depth cap for recursive blanket-impl bound checking (guards pathological
-/// `requires`/blanket cycles; real chains are short).
-const BLANKET_BOUND_DEPTH: u32 = 16;
-
-/// Recursively decide whether `actual` satisfies `bound`. For an interface
-/// `bound` this re-enters `type_implements_interface_via_rule` so a blanket
-/// impl whose bound is itself satisfied by *another* blanket impl verifies
-/// (BEP-044 wf3 #2 `blanket-on-blanket`). Previously the bound callback was a
-/// hard `|_,_| false`, which made `implements<T: Printable> Loud for T` fail to
-/// see a blanket-provided `Printable` and crash the VM. Non-interface bounds
-/// fall back to normalized-type equality, matching TIR's subtyping.
-fn type_satisfies_bound(
-    db: &dyn crate::Db,
-    actual: &Tir2Ty,
-    bound: &Tir2Ty,
-    aliases: &std::collections::HashMap<QualifiedTypeName, Tir2Ty>,
-    default_pkg: &baml_base::Name,
-    depth: u32,
-) -> bool {
-    if depth == 0 {
-        return false;
-    }
-    if let Tir2Ty::Interface(..) = bound {
-        // Membership via the canonical L1 resolver: it walks `impl_data` for a block whose head
-        // matches `(actual, bound)` and whose pinned bounds hold. The recursive closure lets a
-        // blanket's bound be satisfied by another blanket (BEP-044 wf3 #2 blanket-on-blanket),
-        // replacing the deleted registry's `type_implements_interface_via_rule`.
-        let Some(iface) = bound.as_interface() else {
-            return false;
-        };
-        baml_compiler2_tir::interfaces::implements_interface(
-            db,
-            actual,
-            &iface,
-            aliases,
-            |na, nb| type_satisfies_bound(db, na, nb, aliases, default_pkg, depth - 1),
-        )
-    } else {
-        // `equivalent` normalizes both sides, which reduces determinable projections — the
-        // canonical algebra subsumes the old resolver's `resolve_deep` + `types_equivalent`.
-        let pkg_id = baml_compiler2_hir::package::PackageId::new(db, default_pkg.clone());
-        let empty_bounds = FxHashMap::default();
-        with_global_ctx(db, pkg_id, aliases, &empty_bounds, |ctx| {
-            baml_type::normalize::equivalent(actual, bound, ctx)
-        })
-    }
-}
-
-/// Every class declared in `pkg_name`, as a qualified type name — the L1 rebuild of the deleted
-/// registry's `class_implements` key set (which held an entry per package class). Used to sweep a
-/// package's classes against a blanket impl's bound.
-fn package_class_qtns(db: &dyn crate::Db, pkg_name: &Name) -> Vec<QualifiedTypeName> {
-    use baml_compiler2_ppir::item_data::{class_data, file_classes};
-    let mut out = Vec::new();
-    for file in compiler2_all_files(db) {
-        let pkg_info = file_package(db, file);
-        if pkg_info.package != *pkg_name {
-            continue;
-        }
-        for class_loc in file_classes(db, file) {
-            let class = class_data(db, *class_loc);
-            out.push(QualifiedTypeName::new(
-                pkg_info.package.clone(),
-                pkg_info.namespace_path.clone(),
-                class.name.clone(),
-            ));
-        }
-    }
-    out
-}
 
 /// Run `f` with a [`GlobalTypeContext`](baml_compiler2_tir::type_context::GlobalTypeContext) over
 /// `pkg_id`'s canonical facts — the checker's own type context — so MIR reduces projections and
@@ -1587,7 +1019,6 @@ use rustc_hash::{FxHashMap, FxHashSet};
 type ClassFieldIndices = IndexMap<TypeName, IndexMap<String, usize>>;
 type ClassFieldTypes = IndexMap<TypeName, IndexMap<String, RuntimeTy>>;
 type EnumVariantIndices = IndexMap<QualifiedTypeName, IndexMap<String, usize>>;
-type ImplementorsByInterface = IndexMap<TypeName, Vec<TypeName>>;
 type InterfaceTypeView = (TypeName, Vec<Tir2Ty>, Vec<(Name, Tir2Ty)>);
 /// Lower the generic arguments of an interface target held as a `TypeRefId` in
 /// `store` (e.g. the `<int>` in `implements Slot<int>`). Non-`Path` targets
@@ -1629,19 +1060,6 @@ fn lower_ref_interface_target_args<'db>(
     }
 }
 
-fn class_type_name_from_qtn(db: &dyn crate::Db, class_qtn: &QualifiedTypeName) -> Option<TypeName> {
-    let class_pkg_id = baml_compiler2_hir::package::PackageId::new(db, class_qtn.package().clone());
-    let class_pkg_items = baml_compiler2_hir::package::package_items(db, class_pkg_id);
-    let class_ns: Vec<Name> = class_qtn.namespace().clone();
-    let Some(baml_compiler2_hir::contributions::Definition::Class(_)) =
-        class_pkg_items.lookup_type(&class_ns, class_qtn.name())
-    else {
-        return None;
-    };
-
-    Some(class_qtn.clone())
-}
-
 fn interface_type_name_from_loc<'db>(
     db: &'db dyn crate::Db,
     iface_loc: baml_compiler2_hir::loc::InterfaceLoc<'db>,
@@ -1654,43 +1072,10 @@ fn interface_type_name_from_loc<'db>(
     )
 }
 
-fn push_unique_interface_implementor(
-    interface_implementors: &mut ImplementorsByInterface,
-    iface_tn: TypeName,
-    class_tn: &TypeName,
-) {
-    let entry = interface_implementors.entry(iface_tn).or_default();
-    if !entry.contains(class_tn) {
-        entry.push(class_tn.clone());
-    }
-}
-
-fn register_class_for_interface_closure<'db>(
-    db: &'db dyn crate::Db,
-    root_iface_loc: baml_compiler2_hir::loc::InterfaceLoc<'db>,
-    root_iface_args: &[Tir2Ty],
-    class_tn: &TypeName,
-    interface_implementors: &mut ImplementorsByInterface,
-) {
-    for (iface_loc, _iface_args, _iface_assoc) in
-        baml_compiler2_tir::interfaces::interface_closure_locs_with_args_and_assoc(
-            db,
-            root_iface_loc,
-            root_iface_args,
-            &[],
-            true,
-        )
-    {
-        let iface_tn = interface_type_name_from_loc(db, iface_loc);
-        push_unique_interface_implementor(interface_implementors, iface_tn, class_tn);
-    }
-}
-
 struct PackagePopulation<'a> {
     class_fields: &'a mut ClassFieldIndices,
     class_field_types: &'a mut ClassFieldTypes,
     enum_variants: &'a mut EnumVariantIndices,
-    interface_implementors: &'a mut ImplementorsByInterface,
 }
 
 /// All package-invariant data needed to construct a [`LoweringContext`]: the
@@ -1709,7 +1094,6 @@ struct PackageLoweringData {
     class_fields: ClassFieldIndices,
     class_field_types: ClassFieldTypes,
     enum_variants: EnumVariantIndices,
-    interface_implementors: ImplementorsByInterface,
     resolved_aliases: ResolvedAliases,
     /// Every method name any in-scope interface (own package + dependency
     /// closure) declares, required or default. Fast pre-filter for
@@ -1832,13 +1216,11 @@ fn package_lowering_data<'db>(
     let mut class_fields = ClassFieldIndices::default();
     let mut class_field_types = ClassFieldTypes::default();
     let mut enum_variants = EnumVariantIndices::default();
-    let mut interface_implementors = ImplementorsByInterface::default();
     {
         let mut population = PackagePopulation {
             class_fields: &mut class_fields,
             class_field_types: &mut class_field_types,
             enum_variants: &mut enum_variants,
-            interface_implementors: &mut interface_implementors,
         };
 
         // Dependency packages first (e.g., "baml" builtins); current-package
@@ -1906,7 +1288,6 @@ fn package_lowering_data<'db>(
         class_fields,
         class_field_types,
         enum_variants,
-        interface_implementors,
         resolved_aliases,
         interface_method_names,
     }
@@ -1918,16 +1299,6 @@ struct DispatchCallLowering<'a> {
     args: &'a [AstExprId],
     runtime_id: Option<AstExprId>,
     dest: &'a Place,
-}
-
-/// One selected candidate for an interface field read: the implementor class
-/// (its runtime guard is bare class identity — see
-/// [`implements_block_matches_request`] for why that suffices) and the linked
-/// class field's slot.
-#[derive(Clone)]
-struct InterfaceFieldCandidate {
-    impl_tn: TypeName,
-    field_idx: usize,
 }
 
 type PatMetadataKey = (MetadataScope, AstPatId);
@@ -2020,7 +1391,6 @@ struct LoweringContext<'db> {
     /// (directly or transitively through interface `requires`). Lets the field-access
     /// and method-call lowering paths emit a type-tag switch over the
     /// implementor set when the static receiver type is an interface.
-    interface_implementors: &'db ImplementorsByInterface,
     /// BEP-044: non-class concrete implementors, such as
     /// `implements Debuggable for int`. These are kept separate from
     /// `interface_implementors` because reflection/runtime metadata stores
@@ -2457,32 +1827,6 @@ impl<'db> LoweringContext<'db> {
                         }
                         out.class_fields.insert(tn.clone(), fields);
                         out.class_field_types.insert(tn.clone(), field_types);
-
-                        // BEP-044: register this class as an implementor of
-                        // every interface its `implements` block targets,
-                        // transitively through interface `requires`.
-                        for impl_target in &class_data.implements {
-                            let Some(iface_loc) =
-                                baml_compiler2_tir::interfaces::resolve_ref_to_interface(
-                                    db,
-                                    &class_data.type_refs,
-                                    impl_target.target,
-                                    pkg_items,
-                                    &pkg_ns,
-                                )
-                            else {
-                                continue;
-                            };
-                            for iface_loc in baml_compiler2_tir::interfaces::interface_closure_locs(
-                                db, iface_loc,
-                            ) {
-                                let iface_tn = interface_type_name_from_loc(db, iface_loc);
-                                let entry = out.interface_implementors.entry(iface_tn).or_default();
-                                if !entry.contains(&tn) {
-                                    entry.push(tn.clone());
-                                }
-                            }
-                        }
                     }
                     Definition::Enum(enum_loc) => {
                         let enum_data = baml_compiler2_ppir::item_data::enum_data(db, *enum_loc);
@@ -2499,148 +1843,6 @@ impl<'db> LoweringContext<'db> {
                         out.enum_variants.insert(enum_qtn, variants);
                     }
                     _ => {}
-                }
-            }
-        }
-
-        for file in compiler2_all_files(db) {
-            let pkg_info = file_package(db, file);
-            if pkg_info.package != *pkg_name {
-                continue;
-            }
-            for impl_loc in baml_compiler2_ppir::item_data::file_free_impls(db, file) {
-                let imp = baml_compiler2_ppir::item_data::impl_block_data(db, *impl_loc);
-                let baml_compiler2_ppir::item_data::ImplSubjectData::Free {
-                    for_target,
-                    generics,
-                } = &imp.subject
-                else {
-                    continue;
-                };
-                let imp_generic_params = baml_compiler2_tir::impl_generic_params(db, *impl_loc);
-                let imp_generic_param_bounds: Vec<Option<baml_compiler2_hir::type_ref::TypeRefId>> =
-                    generics.iter().map(|g| g.bounds.first().copied()).collect();
-                let impl_bounds =
-                    baml_compiler2_tir::lower_type_expr::impl_generic_param_bounds(db, *impl_loc);
-                let Some(root_iface_loc) = baml_compiler2_tir::interfaces::resolve_ref_to_interface(
-                    db,
-                    &imp.type_refs,
-                    imp.interface_target,
-                    pkg_items,
-                    &pkg_info.namespace_path,
-                ) else {
-                    continue;
-                };
-
-                let mut diags = Vec::new();
-                let target_ty_tir = baml_compiler2_tir::lower_type_expr::lower_type_ref(
-                    &imp.type_refs,
-                    *for_target,
-                    &baml_compiler2_tir::lower_type_expr::ScopeCtx {
-                        db,
-                        package_items: pkg_items,
-                        ns_context: &pkg_info.namespace_path,
-                        generic_params: &imp_generic_params,
-                        bounds: impl_bounds,
-                        self_ty: None,
-                    },
-                    &mut diags,
-                );
-                let is_generic_rule = !imp_generic_params.is_empty();
-
-                if is_generic_rule {
-                    if let baml_compiler2_tir::ty::Ty::Class(ref class_qtn, ref class_args, _) =
-                        target_ty_tir
-                    {
-                        if class_args
-                            .iter()
-                            .any(|a| matches!(a, baml_compiler2_tir::ty::Ty::TypeVar(..)))
-                        {
-                            let root_iface_args_tir = lower_ref_interface_target_args(
-                                db,
-                                &imp.type_refs,
-                                imp.interface_target,
-                                pkg_items,
-                                &pkg_info.namespace_path,
-                                &imp_generic_params,
-                                impl_bounds,
-                                &mut diags,
-                            );
-                            if let Some(class_tn) = class_type_name_from_qtn(db, class_qtn) {
-                                register_class_for_interface_closure(
-                                    db,
-                                    root_iface_loc,
-                                    &root_iface_args_tir,
-                                    &class_tn,
-                                    out.interface_implementors,
-                                );
-                            }
-                            continue;
-                        }
-                    }
-                    if let baml_compiler2_tir::ty::Ty::TypeVar(type_var, _) = &target_ty_tir {
-                        let Some(bound_ty) = usize::try_from(type_var.index())
-                            .ok()
-                            .and_then(|idx| imp_generic_param_bounds.get(idx))
-                            .and_then(|bound| bound.as_ref())
-                            .map(|bound| {
-                                baml_compiler2_tir::lower_type_expr::lower_type_ref(
-                                    &imp.type_refs,
-                                    *bound,
-                                    &baml_compiler2_tir::lower_type_expr::ScopeCtx {
-                                        db,
-                                        package_items: pkg_items,
-                                        ns_context: &pkg_info.namespace_path,
-                                        generic_params: &imp_generic_params,
-                                        bounds: impl_bounds,
-                                        self_ty: None,
-                                    },
-                                    &mut diags,
-                                )
-                            })
-                        else {
-                            continue;
-                        };
-                        if !matches!(bound_ty, baml_compiler2_tir::ty::Ty::Interface(..)) {
-                            continue;
-                        }
-                        let root_iface_args_tir = lower_ref_interface_target_args(
-                            db,
-                            &imp.type_refs,
-                            imp.interface_target,
-                            pkg_items,
-                            &pkg_info.namespace_path,
-                            &imp_generic_params,
-                            impl_bounds,
-                            &mut diags,
-                        );
-                        for class_qtn in package_class_qtns(db, &pkg_info.package) {
-                            let actual = baml_compiler2_tir::ty::Ty::Class(
-                                class_qtn.clone(),
-                                Vec::new(),
-                                baml_compiler2_tir::ty::TyAttr::default(),
-                            );
-                            if !type_satisfies_bound(
-                                db,
-                                &actual,
-                                &bound_ty,
-                                &resolved_aliases.aliases,
-                                &pkg_info.package,
-                                BLANKET_BOUND_DEPTH,
-                            ) {
-                                continue;
-                            }
-                            let class_tn = class_qtn.clone();
-                            register_class_for_interface_closure(
-                                db,
-                                root_iface_loc,
-                                &root_iface_args_tir,
-                                &class_tn,
-                                out.interface_implementors,
-                            );
-                        }
-                        continue;
-                    }
                 }
             }
         }
@@ -2909,7 +2111,6 @@ impl<'db> LoweringContext<'db> {
             class_field_types: &pkg_data.class_field_types,
             enum_variants: &pkg_data.enum_variants,
             class_type_tags,
-            interface_implementors: &pkg_data.interface_implementors,
             pending_lambdas: Vec::new(),
             lambda_generic_params: Vec::new(),
             capture_indices: None,
@@ -3002,7 +2203,6 @@ impl<'db> LoweringContext<'db> {
             class_field_types: &pkg_data.class_field_types,
             enum_variants: &pkg_data.enum_variants,
             class_type_tags,
-            interface_implementors: &pkg_data.interface_implementors,
             resolved_aliases: &pkg_data.resolved_aliases,
             interface_method_names: &pkg_data.interface_method_names,
             defer_stack: Vec::new(),
@@ -3319,6 +2519,29 @@ impl<'db> LoweringContext<'db> {
                 self.inference_for(fsi)?.default_resolution(key.expr)
             }
         }
+    }
+
+    /// TIR's recorded resolution for a virtual interface-field access: the realized
+    /// declaring-interface view plus the field's index in it.
+    ///
+    /// Authoritative, and preferred over re-deriving a view from the receiver's type.
+    /// It is what the type checker actually resolved through — which is the only
+    /// thing that answers a *union* receiver, where the serving interface is the one
+    /// every arm shares and is not recoverable from the receiver type alone.
+    fn tir_virtual_field_view(&self, key: ExprMetadataKey) -> Option<(InterfaceTypeView, u32)> {
+        use baml_compiler2_tir::inference::MemberResolution;
+        let MemberResolution::InterfaceVirtualField {
+            interface,
+            field_index,
+            ..
+        } = self.tir_resolution(key)?
+        else {
+            return None;
+        };
+        let Tir2Ty::Interface(tn, args, assoc, _) = interface else {
+            return None;
+        };
+        Some(((tn.clone(), args.clone(), assoc.clone()), *field_index))
     }
 
     fn tir_is_exhaustive_match(&self, key: ExprMetadataKey) -> bool {
@@ -3834,6 +3057,20 @@ impl<'db> LoweringContext<'db> {
     /// Whether `iface_tn` declares `method` *directly* — in its own required or
     /// default methods, not via its `requires` closure. (Unlike
     /// [`Self::mir_interface_declares_method`], which walks the whole closure.)
+    /// Whether `tn` names an interface declaration.
+    ///
+    /// A direct question about the name, not a lookup in a set of known
+    /// implementors: an interface with no implementors in this compilation is still
+    /// an interface, and one with implementors elsewhere is not more of one.
+    fn is_interface_type_name(&self, tn: &TypeName) -> bool {
+        let pkg_id = baml_compiler2_hir::package::PackageId::new(self.db, tn.package().clone());
+        let pkg_items = baml_compiler2_hir::package::package_items(self.db, pkg_id);
+        matches!(
+            pkg_items.lookup_type(tn.namespace(), tn.name()),
+            Some(baml_compiler2_hir::contributions::Definition::Interface(_))
+        )
+    }
+
     fn interface_declares_method_directly(&self, iface_tn: &TypeName, method: &Name) -> bool {
         use baml_compiler2_ppir::item_data::{function_data, interface_data};
         let pkg_id =
@@ -3870,6 +3107,52 @@ impl<'db> LoweringContext<'db> {
     /// (BEP-044 method disambiguation: the receiver's interface picks its own
     /// version), then the nearest required ancestor. Falls back to `view`
     /// unchanged when nothing in the closure declares it.
+    /// `field`'s position in `iface_tn`'s own declared field list — the index space
+    /// every implementation's `RuntimeImplRule::field_links` is baked against.
+    /// `None` when this interface does not itself declare the field.
+    ///
+    /// Reads the same `interface_data` query, in the same order, that the bake and
+    /// TIR's `MemberResolution::InterfaceVirtualField` read, so the three cannot
+    /// disagree about what index a field has.
+    fn interface_field_index_directly(&self, iface_tn: &TypeName, field: &Name) -> Option<u32> {
+        use baml_compiler2_ppir::item_data::interface_data;
+        let pkg_id =
+            baml_compiler2_hir::package::PackageId::new(self.db, iface_tn.package().clone());
+        let pkg_items = baml_compiler2_hir::package::package_items(self.db, pkg_id);
+        let baml_compiler2_hir::contributions::Definition::Interface(loc) =
+            pkg_items.lookup_type(iface_tn.namespace(), iface_tn.name())?
+        else {
+            return None;
+        };
+        let index = interface_data(self.db, loc)
+            .fields
+            .iter()
+            .position(|f| f.name == *field)?;
+        Some(u32::try_from(index).expect("interface field count fits u32"))
+    }
+
+    /// Narrow an interface view to the interface that *declares* `field`, paired with
+    /// that field's index there. `requires` is a bound rather than inheritance, so a
+    /// parent-declared field is served by the implementor's separate impl of the
+    /// parent, at the parent's own index — never the child's numbering.
+    ///
+    /// The field counterpart of [`Self::interface_view_declaring_method`].
+    fn interface_view_declaring_field(
+        &self,
+        view: &InterfaceTypeView,
+        field: &Name,
+    ) -> Option<(InterfaceTypeView, u32)> {
+        if let Some(index) = self.interface_field_index_directly(&view.0, field) {
+            return Some((view.clone(), index));
+        }
+        self.interface_closure_type_name_views(&view.0, &view.1, &view.2)?
+            .into_iter()
+            .find_map(|v| {
+                let index = self.interface_field_index_directly(&v.0, field)?;
+                Some((v, index))
+            })
+    }
+
     fn interface_view_declaring_method(
         &self,
         view: &InterfaceTypeView,
@@ -6616,21 +5899,6 @@ impl<'db> LoweringContext<'db> {
                 seg,
                 &target_place,
             ) {
-                if is_last {
-                    return;
-                }
-                current_place = target_place;
-                current_ty = target_ty;
-                continue;
-            }
-            // Receiver prefix may be a union containing an interface member
-            // (`(Dog | Named).name`): dispatch the field read on the runtime
-            // class across all members' implementors.
-            if let Some(members) = self
-                .tir_path_segment_type((self.current_metadata_scope, expr_id, seg_idx - 1))
-                .and_then(Self::tir_union_members)
-                && self.lower_union_iface_field_access(base_local, &members, seg, &target_place)
-            {
                 if is_last {
                     return;
                 }
@@ -10219,18 +9487,26 @@ impl<'db> LoweringContext<'db> {
                 })),
             );
         } else {
-            let handled_interface_field = self
-                .interface_receiver_for_field_access(base, &unwrapped_ty)
-                .is_some_and(|(iface_tn, iface_type_args, iface_assoc)| {
-                    self.try_lower_interface_field_access(
-                        base_local,
-                        &iface_tn,
-                        &iface_type_args,
-                        &iface_assoc,
-                        field,
-                        &dest,
-                    )
-                });
+            // TIR's own resolution first — it names the interface the access was
+            // *checked* through, including the shared interface of a union receiver,
+            // which no inspection of the receiver's type can recover.
+            let handled_interface_field = if let Some(((tn, args, assoc), _index)) =
+                self.tir_virtual_field_view(self.expr_metadata_key(expr_id))
+            {
+                self.try_lower_interface_field_access(base_local, &tn, &args, &assoc, field, &dest)
+            } else {
+                self.interface_receiver_for_field_access(base, &unwrapped_ty)
+                    .is_some_and(|(iface_tn, iface_type_args, iface_assoc)| {
+                        self.try_lower_interface_field_access(
+                            base_local,
+                            &iface_tn,
+                            &iface_type_args,
+                            &iface_assoc,
+                            field,
+                            &dest,
+                        )
+                    })
+            };
             let handled_union_field = handled_interface_field
                 || self.lower_union_class_field_access(
                     expr_id,
@@ -10238,13 +9514,7 @@ impl<'db> LoweringContext<'db> {
                     &unwrapped_ty,
                     field,
                     &dest,
-                )
-                || self
-                    .tir_expr_type(self.expr_metadata_key(base))
-                    .and_then(Self::tir_union_members)
-                    .is_some_and(|members| {
-                        self.lower_union_iface_field_access(base_local, &members, field, &dest)
-                    });
+                );
             if handled_union_field {
                 return;
             }
@@ -10291,10 +9561,10 @@ impl<'db> LoweringContext<'db> {
         }
 
         match unwrapped_ty {
-            RuntimeTy::Class(tn, _, _) if self.interface_implementors.contains_key(tn) => {
+            RuntimeTy::Class(tn, _, _) if self.is_interface_type_name(tn) => {
                 Some((tn.clone(), Vec::new(), Vec::new()))
             }
-            RuntimeTy::Interface(tn, _, _, _) if self.interface_implementors.contains_key(tn) => {
+            RuntimeTy::Interface(tn, _, _, _) if self.is_interface_type_name(tn) => {
                 Some((tn.clone(), Vec::new(), Vec::new()))
             }
             _ => None,
@@ -10322,10 +9592,10 @@ impl<'db> LoweringContext<'db> {
         }
 
         match current_ty {
-            RuntimeTy::Class(tn, _, _) if self.interface_implementors.contains_key(tn) => {
+            RuntimeTy::Class(tn, _, _) if self.is_interface_type_name(tn) => {
                 Some((tn.clone(), Vec::new(), Vec::new()))
             }
-            RuntimeTy::Interface(tn, _, _, _) if self.interface_implementors.contains_key(tn) => {
+            RuntimeTy::Interface(tn, _, _, _) if self.is_interface_type_name(tn) => {
                 Some((tn.clone(), Vec::new(), Vec::new()))
             }
             _ => None,
@@ -10416,10 +9686,10 @@ impl<'db> LoweringContext<'db> {
         ty: &RuntimeTy,
         field: &Name,
     ) -> Option<Vec<(i64, TypeName, usize)>> {
-        // Collect candidate (class_name) entries to search for the field on.
-        // For `RuntimeTy::Union`, every member must be `RuntimeTy::Class`. For `RuntimeTy::Class`
-        // whose name is actually a BEP-044 interface, use the registered
-        // implementor set.
+        // A union's arms are the whole candidate set — the type itself closes it, so
+        // a runtime switch over them is complete by construction. That is the only
+        // legitimate shape here: an interface's implementor set is open, and with
+        // generic impls unbounded, so it is never enumerable.
         let class_names: Vec<TypeName> = match ty {
             RuntimeTy::Union(members, _) => members
                 .iter()
@@ -10428,9 +9698,6 @@ impl<'db> LoweringContext<'db> {
                     _ => None,
                 })
                 .collect(),
-            RuntimeTy::Class(class_name, _, _) => {
-                self.interface_implementors.get(class_name)?.clone()
-            }
             _ => return None,
         };
         if class_names.is_empty() {
@@ -10843,38 +10110,6 @@ impl<'db> LoweringContext<'db> {
         Some(self.interface_view_declaring_method(&view, method))
     }
 
-    /// Field-read candidates for a concrete-class union member whose `field` is
-    /// supplied by an interface view (`implements Named { name as full }`) rather
-    /// than a class-owned slot. Mirrors [`class_member_method_candidates`].
-    #[deprecated = "Fails to handle generic parameters when resolving interface members"]
-    fn class_member_field_candidates(
-        &self,
-        class_tn: &TypeName,
-        field: &Name,
-    ) -> Vec<InterfaceFieldCandidate> {
-        let Some(class_loc) = self.resolve_class_loc_by_type_name(class_tn) else {
-            return Vec::new();
-        };
-        let class_data = baml_compiler2_ppir::item_data::class_data(self.db, class_loc);
-        let mut out = Vec::new();
-        for impl_block in &class_data.implements {
-            if let Some((iface_tn, iface_args, iface_assoc)) = self.resolve_implements_target_view(
-                impl_block.target,
-                &impl_block.associated_type_bindings,
-                class_loc,
-            ) {
-                out.extend(self.resolve_implementor_interface_field_candidates(
-                    class_tn,
-                    &iface_tn,
-                    &iface_args,
-                    &iface_assoc,
-                    field,
-                ));
-            }
-        }
-        out
-    }
-
     /// Emit a class-tag dispatch switch for a method call whose receiver
     /// (`recv_local`) has the union type `members`. Returns false (lowering
     /// nothing) unless every member is a class declaring `method`.
@@ -10968,6 +10203,13 @@ impl<'db> LoweringContext<'db> {
             })
     }
 
+    /// Read `field` through an interface view whose receiver's concrete type is not
+    /// known statically, as an open-world [`Rvalue::VirtualFieldAccess`].
+    ///
+    /// Returns `false` only when no interface in the view's `requires` closure
+    /// declares `field` — a resolution failure the caller falls through on. It never
+    /// enumerates implementors: an interface's implementor set is open, and with
+    /// generic impls unbounded, so no compile-time candidate list could be complete.
     fn try_lower_interface_field_access(
         &mut self,
         recv_local: Local,
@@ -10977,169 +10219,180 @@ impl<'db> LoweringContext<'db> {
         field: &Name,
         dest: &Place,
     ) -> bool {
-        let Some(impls) = self.interface_implementors.get(iface_tn).cloned() else {
+        let view = (
+            iface_tn.clone(),
+            iface_type_args.to_vec(),
+            iface_assoc.to_vec(),
+        );
+        let Some(((decl_tn, decl_args, decl_assoc), field_index)) =
+            self.interface_view_declaring_field(&view, field)
+        else {
             return false;
         };
-        let resolved: Vec<InterfaceFieldCandidate> = impls
-            .iter()
-            .flat_map(|impl_tn| {
-                self.resolve_implementor_interface_field_candidates(
-                    impl_tn,
-                    iface_tn,
-                    iface_type_args,
-                    iface_assoc,
-                    field,
-                )
-            })
-            .collect();
-        self.emit_interface_field_candidate_switch(recv_local, &resolved, dest)
+        let generic_params = self.enclosing_generic_params();
+        let iface = tir2_interface_to_template(
+            &decl_tn,
+            &decl_args,
+            &decl_assoc,
+            self.resolved_aliases,
+            &generic_params,
+        );
+        self.builder.assign(
+            dest.clone(),
+            Rvalue::VirtualFieldAccess {
+                iface,
+                receiver: Operand::Copy(Place::Local(recv_local)),
+                field_index,
+                field: field.clone(),
+            },
+        );
+        true
     }
 
-    /// A field read whose receiver is a union with at least one interface member
-    /// (e.g. `(Dog | Named).name`). Each member contributes the concrete classes
-    /// it can be at runtime — a class member is itself; an interface member is
-    /// every implementor (reading the linked field view) — and we dispatch on
-    /// the runtime class. Returns false (caller falls through) if any member
-    /// contributes no candidate.
-    fn lower_union_iface_field_access(
-        &mut self,
-        recv_local: Local,
-        members: &[Tir2Ty],
-        field: &Name,
-        dest: &Place,
-    ) -> bool {
-        // Runs only after `lower_union_class_field_access` declines, so it also
-        // covers a pure class union whose `field` is supplied by an interface
-        // view rather than a class-owned slot.
-        let mut resolved: Vec<InterfaceFieldCandidate> = Vec::new();
-        for member in members {
-            match member {
-                Tir2Ty::Class(qtn, _, _) => {
-                    let class_tn = qtn.clone();
-                    if let Some(field_idx) = self
-                        .class_fields
-                        .get(&class_tn)
-                        .and_then(|fields| fields.get(field.as_str()))
-                        .copied()
-                    {
-                        resolved.push(InterfaceFieldCandidate {
-                            impl_tn: class_tn,
-                            field_idx,
-                        });
-                    } else {
-                        // The field may be supplied by an interface view
-                        // (`implements Named { name as full }`) rather than a
-                        // class-owned slot. Resolve it through the class's
-                        // implemented interfaces, mirroring the method path.
-                        #[expect(deprecated)]
-                        let member_candidates =
-                            self.class_member_field_candidates(&class_tn, field);
-                        if member_candidates.is_empty() {
-                            return false;
-                        }
-                        resolved.extend(member_candidates);
-                    }
-                }
-                Tir2Ty::Interface(..) => {
-                    let Some((iface_tn, iface_type_args, iface_assoc)) =
-                        self.interface_dispatch_target_for_tir_ty(member)
-                    else {
-                        return false;
-                    };
-                    let Some(impls) = self.interface_implementors.get(&iface_tn).cloned() else {
-                        return false;
-                    };
-                    let member_candidates: Vec<InterfaceFieldCandidate> = impls
-                        .iter()
-                        .flat_map(|impl_tn| {
-                            self.resolve_implementor_interface_field_candidates(
-                                impl_tn,
-                                &iface_tn,
-                                &iface_type_args,
-                                &iface_assoc,
-                                field,
-                            )
-                        })
-                        .collect();
-                    if member_candidates.is_empty() {
-                        return false;
-                    }
-                    resolved.extend(member_candidates);
-                }
-                _ => return false,
-            }
-        }
-        self.emit_interface_field_candidate_switch(recv_local, &resolved, dest)
-    }
-
-    /// Emit a runtime class-tag switch that reads `field` from `recv_local`
-    /// using whichever `InterfaceFieldCandidate` matches. Returns false
-    /// (emitting nothing) when there are no candidates.
+    /// The interface view an assignment *target* `recv.field` resolves through, when
+    /// the field is served by an interface rather than a slot on the receiver's own
+    /// class.
     ///
-    /// BUG(symbolic-view-field-read): two axes matter here, and only one is
-    /// handled. The *class*-instantiation axis is fully covered by the coarse
-    /// per-candidate class test: an in-body block spans the class's whole type
-    /// constructor, so the receiver's class args can never affect which field
-    /// is linked. The unhandled axis is the *interface* instantiation: a class
-    /// may carry several same-family in-body blocks at disjoint interface args
-    /// with different links (`implements Slot<int> { value as int_value }` /
-    /// `implements Slot<string> { value as string_value }`), and the block is
-    /// selected by the requested *view*, not by anything on the receiver. A
-    /// compile-time-concrete view selects its block during candidate
-    /// resolution; a symbolic view (`function read<T>(g: Slot<T>) { g.value }`)
-    /// cannot be selected there, and no runtime test of the receiver — coarse
-    /// or arg-precise — can discriminate either, because the receiver is the
-    /// same object under both views. The discriminant is the frame's `T`;
-    /// today this switch takes the first same-class arm and reads the wrong
-    /// field for the other view. Fix: open-world resolution (virtual field
-    /// access reading the requested view off the wire), or a compile error on
-    /// symbolic-view field reads of multi-block classes until then.
-    fn emit_interface_field_candidate_switch(
+    /// TIR records a resolution for field *reads*; an assignment target does not go
+    /// through that path, so this falls back to deriving the view from the
+    /// receiver's type — the same derivation the read path uses when TIR has nothing
+    /// recorded. `None` means the target is an ordinary place and the caller should
+    /// lower it as one.
+    fn virtual_field_assign_view(
         &mut self,
-        recv_local: Local,
-        resolved: &[InterfaceFieldCandidate],
-        dest: &Place,
+        target: AstExprId,
+        base: AstExprId,
+    ) -> Option<InterfaceTypeView> {
+        if let Some((view, _index)) = self.tir_virtual_field_view(self.expr_metadata_key(target)) {
+            return Some(view);
+        }
+        let base_ty = self.expr_ty(base).strip_null();
+        self.interface_receiver_for_field_access(base, &base_ty)
+    }
+
+    /// The `(receiver local, field, interface view)` an assignment target denotes when
+    /// it is an interface-field access, for either spelling: `a.b` reaches MIR as a
+    /// multi-segment `Path` when its root is a local, and as a `MemberAccess` when the
+    /// base is a general expression. `None` for an ordinary place.
+    fn virtual_field_assign_target(
+        &mut self,
+        target: AstExprId,
+    ) -> Option<(Local, Name, InterfaceTypeView)> {
+        match &self.body.exprs[target] {
+            AstExpr::MemberAccess { base, member } => {
+                let (base, member) = (*base, member.clone());
+                let view = self.virtual_field_assign_view(target, base)?;
+                let recv_op = self.lower_to_operand(base);
+                let recv_local = self.operand_to_local(recv_op, self.expr_ty(base));
+                Some((recv_local, member, view))
+            }
+            AstExpr::Path(segments) if segments.len() >= 2 => {
+                let segments = segments.clone();
+                let field = segments.last().expect("checked non-empty").clone();
+                let prefix_idx = segments.len() - 2;
+                let prefix_ty = self
+                    .tir_path_segment_type((self.current_metadata_scope, target, prefix_idx))
+                    .cloned()
+                    .map(|t| self.convert_tir_ty_for_runtime(&t))?;
+                let view =
+                    self.interface_receiver_for_path_prefix(target, prefix_idx, &prefix_ty)?;
+                let root_local = self.local_for_path(target, &segments[0])?;
+                let recv_local = self.lower_path_receiver_to_local(
+                    target,
+                    &segments[..segments.len() - 1],
+                    root_local,
+                );
+                Some((recv_local, field, view))
+            }
+            _ => None,
+        }
+    }
+
+    /// Lower `recv.field = value` where `recv.field` is an interface field, as a
+    /// [`StatementKind::VirtualFieldStore`]. Returns `false` when the target is not
+    /// a virtual interface-field access, leaving the ordinary `Place` path to it.
+    ///
+    /// This has to bypass `lower_lvalue` entirely: the destination slot depends on
+    /// the receiver's impl, so there is no `Place` to build. Before this existed the
+    /// target fell through to a dynamic map-key store and the VM rejected it with
+    /// `expected Map, got Instance`.
+    fn try_lower_virtual_field_assign(&mut self, target: AstExprId, value: AstExprId) -> bool {
+        let Some((recv_local, member, view)) = self.virtual_field_assign_target(target) else {
+            return false;
+        };
+        // Take the value as an operand rather than parking it in a temp: a temp
+        // defined here is a single-use local the emitter may classify as inlinable
+        // and drop the store for, while this statement still emits a plain load of
+        // it — reading an uninitialized slot.
+        let value_op = self.lower_to_operand(value);
+        self.try_lower_interface_field_store(recv_local, &view, &member, value_op)
+    }
+
+    /// `recv.field op= value` on an interface field: read through the virtual
+    /// access, apply the operator, then write back through the virtual store.
+    /// A `Place`-based read-modify-write is unavailable for the same reason as
+    /// [`Self::try_lower_virtual_field_assign`].
+    fn try_lower_virtual_field_assign_op(
+        &mut self,
+        target: AstExprId,
+        op: AstAssignOp,
+        value: AstExprId,
     ) -> bool {
-        if resolved.is_empty() {
+        let Some((recv_local, member, view)) = self.virtual_field_assign_target(target) else {
+            return false;
+        };
+        let current = self.builder.temp(self.expr_ty(target));
+        if !self.try_lower_interface_field_access(
+            recv_local,
+            &view.0,
+            &view.1,
+            &view.2,
+            &member,
+            &Place::local(current),
+        ) {
             return false;
         }
+        // Apply the operator to the temp through the ordinary path, so union
+        // operator drivers and overload dispatch behave exactly as they do for a
+        // class field; only the read and the write-back are virtual.
+        self.emit_assign_op(Place::local(current), target, op, value);
+        self.try_lower_interface_field_store(
+            recv_local,
+            &view,
+            &member,
+            Operand::Copy(Place::Local(current)),
+        )
+    }
 
-        let bb_entry = self.builder.current_block();
-        let bb_join = self.builder.create_block();
-        let bb_otherwise = self.builder.create_block();
-        let mut next_check = bb_entry;
-
-        for (idx, candidate) in resolved.iter().enumerate() {
-            let bb_body = self.builder.create_block();
-            let bb_next = if idx + 1 == resolved.len() {
-                bb_otherwise
-            } else {
-                self.builder.create_block()
-            };
-
-            self.builder.set_current_block(next_check);
-            self.emit_interface_class_guard_branch(
-                recv_local,
-                &candidate.impl_tn,
-                bb_body,
-                bb_next,
-            );
-            self.builder.set_current_block(bb_body);
-            self.builder.assign(
-                dest.clone(),
-                Rvalue::Use(Operand::Copy(Place::Field {
-                    base: Box::new(Place::Local(recv_local)),
-                    field: candidate.field_idx,
-                })),
-            );
-            self.builder.goto(bb_join);
-            next_check = bb_next;
-        }
-
-        self.builder.set_current_block(bb_otherwise);
-        self.builder.unreachable();
-
-        self.builder.set_current_block(bb_join);
+    /// Write `value` to `field` through an interface view — the store counterpart of
+    /// [`Self::try_lower_interface_field_access`].
+    fn try_lower_interface_field_store(
+        &mut self,
+        recv_local: Local,
+        view: &InterfaceTypeView,
+        field: &Name,
+        value: Operand,
+    ) -> bool {
+        let Some(((decl_tn, decl_args, decl_assoc), field_index)) =
+            self.interface_view_declaring_field(view, field)
+        else {
+            return false;
+        };
+        let generic_params = self.enclosing_generic_params();
+        let iface = tir2_interface_to_template(
+            &decl_tn,
+            &decl_args,
+            &decl_assoc,
+            self.resolved_aliases,
+            &generic_params,
+        );
+        self.builder.virtual_field_store(
+            iface,
+            Operand::Copy(Place::Local(recv_local)),
+            field_index,
+            field.clone(),
+            value,
+        );
         true
     }
 
@@ -11332,134 +10585,6 @@ impl<'db> LoweringContext<'db> {
             })
             .collect();
         Some((target_qtn, target_args, associated_bindings))
-    }
-
-    /// True iff the interface named by `iface_tn` declares `field` directly in
-    /// its own body (not via `requires`).
-    fn interface_declares_field(&self, iface_tn: &TypeName, field: &Name) -> bool {
-        let pkg_name = iface_tn.package();
-        let pkg_items = self.resolve_class_pkg_items_by_name(pkg_name);
-        let ns: Vec<Name> = iface_tn.namespace().clone();
-        let Some(Definition::Interface(loc)) = pkg_items.lookup_type(&ns, iface_tn.name()) else {
-            return false;
-        };
-        baml_compiler2_ppir::item_data::interface_data(self.db, loc)
-            .fields
-            .iter()
-            .any(|f| &f.name == field)
-    }
-
-    fn resolve_implementor_interface_field_candidates(
-        &self,
-        impl_tn: &TypeName,
-        iface_tn: &TypeName,
-        iface_type_args: &[Tir2Ty],
-        iface_assoc: &[(Name, Tir2Ty)],
-        field: &Name,
-    ) -> Vec<InterfaceFieldCandidate> {
-        let Some(class_loc) = self.resolve_class_loc_by_type_name(impl_tn) else {
-            return Vec::new();
-        };
-        let class_data = baml_compiler2_ppir::item_data::class_data(self.db, class_loc);
-        let Some(requested_views) =
-            self.interface_closure_type_name_views(iface_tn, iface_type_args, iface_assoc)
-        else {
-            return Vec::new();
-        };
-        // BEP-044: when the requested interface and a `requires` parent both
-        // declare `field`, `.as<Requested>.field` must use the *most-derived*
-        // declaration. The closure is root-first, so resolve the field against
-        // the first view that declares it and ignore the others — otherwise an
-        // inherited parent view (e.g. `A` behind `B requires A`) could win by
-        // impl-block ordering and read the wrong class field.
-        let owning_view_tn: Option<TypeName> = requested_views
-            .iter()
-            .find(|(tn, _, _)| self.interface_declares_field(tn, field))
-            .map(|(tn, _, _)| tn.clone());
-        let mut out = Vec::new();
-
-        for impl_block in &class_data.implements {
-            let Some((target_tn, target_args, target_assoc)) = self.resolve_implements_target_view(
-                impl_block.target,
-                &impl_block.associated_type_bindings,
-                class_loc,
-            ) else {
-                continue;
-            };
-            let Some(target_views) =
-                self.interface_closure_type_name_views(&target_tn, &target_args, &target_assoc)
-            else {
-                continue;
-            };
-
-            for (target_view_tn, target_view_args, target_view_assoc) in target_views {
-                for (requested_tn, requested_args, requested_assoc) in &requested_views {
-                    if target_view_tn != *requested_tn {
-                        continue;
-                    }
-                    // Restrict to the field's owning (most-derived) view.
-                    if let Some(owning) = &owning_view_tn
-                        && requested_tn != owning
-                    {
-                        continue;
-                    }
-                    if !implements_block_matches_request(
-                        &target_view_args,
-                        &target_view_assoc,
-                        requested_args,
-                        requested_assoc,
-                        &baml_compiler2_tir::class_generic_params(self.db, class_loc),
-                        &self.resolved_aliases.aliases,
-                    ) {
-                        continue;
-                    }
-                    let class_field = impl_block
-                        .field_links
-                        .iter()
-                        .find(|link| &link.interface_field == field)
-                        .map(|link| link.class_field.clone())
-                        .unwrap_or_else(|| field.clone());
-                    if let Some(field_idx) = self
-                        .class_fields
-                        .get(impl_tn)
-                        .and_then(|fields| fields.get(class_field.as_str()))
-                        .copied()
-                    {
-                        out.push(InterfaceFieldCandidate {
-                            impl_tn: impl_tn.clone(),
-                            field_idx,
-                        });
-                    }
-                }
-            }
-        }
-
-        out
-    }
-
-    /// Branch on the receiver being an instance of `impl_tn` — the per-candidate
-    /// runtime guard of the interface field switch, bare class-pointer identity.
-    /// Type-arg discrimination happens at compile time (candidate selection in
-    /// [`implements_block_matches_request`]); coherence guarantees a concrete
-    /// request selects at most one block per class, so there is never a
-    /// same-class sibling arm to tell apart at runtime.
-    fn emit_interface_class_guard_branch(
-        &mut self,
-        recv_local: Local,
-        impl_tn: &TypeName,
-        success: BlockId,
-        failure: BlockId,
-    ) {
-        let test = Rvalue::IsType {
-            operand: Operand::Copy(Place::Local(recv_local)),
-            ty_template: TyTemplate::class(impl_tn.clone(), Vec::new()),
-        };
-        let test_local = self.builder.temp(RuntimeTy::Bool {
-            attr: TyAttr::default(),
-        });
-        self.builder.assign(Place::local(test_local), test);
-        self.builder
-            .branch(Operand::Copy(Place::Local(test_local)), success, failure);
     }
 
     /// BEP-044: when the enclosing function is the override declared
@@ -11978,6 +11103,10 @@ impl LoweringContext<'_> {
                 } else if let AstExpr::OptionalChain { expr: inner } = target_expr {
                     let inner = *inner;
                     self.lower_assign_optional_chain(inner, value);
+                } else if self.try_lower_virtual_field_assign(target, value) {
+                    // Handled: the destination slot is only known once the
+                    // receiver's impl is resolved, so there is no `Place` to
+                    // assign through.
                 } else {
                     let place = self.lower_lvalue(target);
                     self.lower_expr(value, place);
@@ -11989,6 +11118,8 @@ impl LoweringContext<'_> {
                 if let AstExpr::OptionalChain { expr: inner } = target_expr {
                     let inner = *inner;
                     self.lower_assign_op_optional_chain(inner, op, value);
+                } else if self.try_lower_virtual_field_assign_op(target, op, value) {
+                    // Handled — see `AstStmt::Assign`.
                 } else {
                     let place = self.lower_lvalue(target);
                     self.emit_assign_op(place, target, op, value);
@@ -14872,80 +14003,5 @@ pub fn lower_function<'db>(
             lambdas: vec![],
             signature: None,
         },
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use baml_compiler2_tir::ty::{MediaKind, PrimitiveType};
-
-    use super::*;
-
-    fn type_var(name: &str) -> Tir2Ty {
-        Tir2Ty::TypeVar(
-            ParamTy::new(0, Name::new(name)),
-            baml_compiler2_tir::ty::TyAttr::default(),
-        )
-    }
-
-    fn primitive(primitive: PrimitiveType) -> Tir2Ty {
-        let attr = baml_compiler2_tir::ty::TyAttr::default();
-        match primitive {
-            PrimitiveType::Int => Tir2Ty::Int { attr },
-            PrimitiveType::Bigint => Tir2Ty::Bigint { attr },
-            PrimitiveType::Float => Tir2Ty::Float { attr },
-            PrimitiveType::String => Tir2Ty::String { attr },
-            PrimitiveType::Bool => Tir2Ty::Bool { attr },
-            PrimitiveType::Null => Tir2Ty::Null { attr },
-            PrimitiveType::Uint8Array => Tir2Ty::Uint8Array { attr },
-            PrimitiveType::Image => Tir2Ty::Media(MediaKind::Image, attr),
-            PrimitiveType::Audio => Tir2Ty::Media(MediaKind::Audio, attr),
-            PrimitiveType::Video => Tir2Ty::Media(MediaKind::Video, attr),
-            PrimitiveType::Pdf => Tir2Ty::Media(MediaKind::Pdf, attr),
-        }
-    }
-
-    #[test]
-    fn interface_tir_type_args_match_preserves_type_var_identity() {
-        let aliases = HashMap::new();
-
-        assert!(interface_tir_type_args_match_preserving_typevars(
-            &[type_var("L"), type_var("R")],
-            &[type_var("L"), type_var("R")],
-            &aliases,
-        ));
-        assert!(!interface_tir_type_args_match_preserving_typevars(
-            &[type_var("L"), type_var("R")],
-            &[type_var("R"), type_var("L")],
-            &aliases,
-        ));
-    }
-
-    #[test]
-    fn block_selection_checks_assoc_when_request_omits_generic_args() {
-        let aliases = HashMap::new();
-        let impl_args = vec![primitive(PrimitiveType::String)];
-        let requested_args = Vec::new();
-        let requested_assoc = vec![(Name::new("Value"), primitive(PrimitiveType::Int))];
-
-        let int_impl_assoc = vec![(Name::new("Value"), primitive(PrimitiveType::Int))];
-        assert!(implements_block_matches_request(
-            &impl_args,
-            &int_impl_assoc,
-            &requested_args,
-            &requested_assoc,
-            &[],
-            &aliases,
-        ));
-
-        let string_impl_assoc = vec![(Name::new("Value"), primitive(PrimitiveType::String))];
-        assert!(!implements_block_matches_request(
-            &impl_args,
-            &string_impl_assoc,
-            &requested_args,
-            &requested_assoc,
-            &[],
-            &aliases,
-        ));
     }
 }

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1020,6 +1020,22 @@ type ClassFieldIndices = IndexMap<TypeName, IndexMap<String, usize>>;
 type ClassFieldTypes = IndexMap<TypeName, IndexMap<String, RuntimeTy>>;
 type EnumVariantIndices = IndexMap<QualifiedTypeName, IndexMap<String, usize>>;
 type InterfaceTypeView = (TypeName, Vec<Tir2Ty>, Vec<(Name, Tir2Ty)>);
+
+/// A virtual field access resolved down to what the instruction actually carries:
+/// the receiver, the interface the access travels on the wire, and the field's index
+/// in *that* interface's own declared field list.
+///
+/// Holding these together is what lets the write path resolve every fallible step
+/// before it lowers a single operand — see [`LoweringContext::virtual_field_assign_target`].
+struct VirtualFieldTarget {
+    receiver: Local,
+    field: Name,
+    /// The interface that *declares* `field`, realized at the receiver — never the
+    /// child interface a `requires` closure was entered through.
+    iface: TyTemplateInterface,
+    field_index: u32,
+}
+
 /// Lower the generic arguments of an interface target held as a `TypeRefId` in
 /// `store` (e.g. the `<int>` in `implements Slot<int>`). Non-`Path` targets
 /// contribute no arguments.
@@ -10224,19 +10240,50 @@ impl<'db> LoweringContext<'db> {
             iface_type_args.to_vec(),
             iface_assoc.to_vec(),
         );
-        let Some(((decl_tn, decl_args, decl_assoc), field_index)) =
-            self.interface_view_declaring_field(&view, field)
-        else {
+        let Some((iface, field_index)) = self.virtual_field_wire_target(&view, field) else {
             return false;
         };
+        self.emit_virtual_field_access(recv_local, iface, field_index, field, dest);
+        true
+    }
+
+    /// What a virtual access to `field` through `view` puts on the wire: `view` narrowed
+    /// to the interface that *declares* `field`, lowered to the constraint template the
+    /// instruction carries, paired with the field's index in that interface.
+    ///
+    /// `None` when no interface in the view's `requires` closure declares `field`. This
+    /// is the only fallible step in a virtual field access, which is why both the read
+    /// and the write path funnel through it — the write path calls it before lowering
+    /// any operand so its fall-through stays side-effect-free.
+    fn virtual_field_wire_target(
+        &mut self,
+        view: &InterfaceTypeView,
+        field: &Name,
+    ) -> Option<(TyTemplateInterface, u32)> {
+        let ((decl_tn, decl_args, decl_assoc), field_index) =
+            self.interface_view_declaring_field(view, field)?;
         let generic_params = self.enclosing_generic_params();
-        let iface = tir2_interface_to_template(
-            &decl_tn,
-            &decl_args,
-            &decl_assoc,
-            self.resolved_aliases,
-            &generic_params,
-        );
+        Some((
+            tir2_interface_to_template(
+                &decl_tn,
+                &decl_args,
+                &decl_assoc,
+                self.resolved_aliases,
+                &generic_params,
+            ),
+            field_index,
+        ))
+    }
+
+    /// Emit the open-world read of `field` off `recv_local` through `iface`.
+    fn emit_virtual_field_access(
+        &mut self,
+        recv_local: Local,
+        iface: TyTemplateInterface,
+        field_index: u32,
+        field: &Name,
+        dest: &Place,
+    ) {
         self.builder.assign(
             dest.clone(),
             Rvalue::VirtualFieldAccess {
@@ -10246,7 +10293,6 @@ impl<'db> LoweringContext<'db> {
                 field: field.clone(),
             },
         );
-        true
     }
 
     /// The interface view an assignment *target* `recv.field` resolves through, when
@@ -10270,21 +10316,30 @@ impl<'db> LoweringContext<'db> {
         self.interface_receiver_for_field_access(base, &base_ty)
     }
 
-    /// The `(receiver local, field, interface view)` an assignment target denotes when
-    /// it is an interface-field access, for either spelling: `a.b` reaches MIR as a
+    /// The [`VirtualFieldTarget`] an assignment target denotes when it is an
+    /// interface-field access, for either spelling: `a.b` reaches MIR as a
     /// multi-segment `Path` when its root is a local, and as a `MemberAccess` when the
     /// base is a general expression. `None` for an ordinary place.
-    fn virtual_field_assign_target(
-        &mut self,
-        target: AstExprId,
-    ) -> Option<(Local, Name, InterfaceTypeView)> {
+    ///
+    /// Every fallible step runs *before* any operand is lowered, so a `None` leaves no
+    /// emitted code behind. That ordering is load-bearing: the caller falls through to
+    /// `lower_lvalue` + `lower_expr`, which re-lower the target and the value from the
+    /// AST, so a receiver materialized here would be a side-effecting expression
+    /// evaluated twice plus a block of dead statements.
+    fn virtual_field_assign_target(&mut self, target: AstExprId) -> Option<VirtualFieldTarget> {
         match &self.body.exprs[target] {
             AstExpr::MemberAccess { base, member } => {
-                let (base, member) = (*base, member.clone());
+                let (base, field) = (*base, member.clone());
                 let view = self.virtual_field_assign_view(target, base)?;
+                let (iface, field_index) = self.virtual_field_wire_target(&view, &field)?;
                 let recv_op = self.lower_to_operand(base);
-                let recv_local = self.operand_to_local(recv_op, self.expr_ty(base));
-                Some((recv_local, member, view))
+                let receiver = self.operand_to_local(recv_op, self.expr_ty(base));
+                Some(VirtualFieldTarget {
+                    receiver,
+                    field,
+                    iface,
+                    field_index,
+                })
             }
             AstExpr::Path(segments) if segments.len() >= 2 => {
                 let segments = segments.clone();
@@ -10296,13 +10351,19 @@ impl<'db> LoweringContext<'db> {
                     .map(|t| self.convert_tir_ty_for_runtime(&t))?;
                 let view =
                     self.interface_receiver_for_path_prefix(target, prefix_idx, &prefix_ty)?;
+                let (iface, field_index) = self.virtual_field_wire_target(&view, &field)?;
                 let root_local = self.local_for_path(target, &segments[0])?;
-                let recv_local = self.lower_path_receiver_to_local(
+                let receiver = self.lower_path_receiver_to_local(
                     target,
                     &segments[..segments.len() - 1],
                     root_local,
                 );
-                Some((recv_local, field, view))
+                Some(VirtualFieldTarget {
+                    receiver,
+                    field,
+                    iface,
+                    field_index,
+                })
             }
             _ => None,
         }
@@ -10317,7 +10378,7 @@ impl<'db> LoweringContext<'db> {
     /// target fell through to a dynamic map-key store and the VM rejected it with
     /// `expected Map, got Instance`.
     fn try_lower_virtual_field_assign(&mut self, target: AstExprId, value: AstExprId) -> bool {
-        let Some((recv_local, member, view)) = self.virtual_field_assign_target(target) else {
+        let Some(field_target) = self.virtual_field_assign_target(target) else {
             return false;
         };
         // Take the value as an operand rather than parking it in a temp: a temp
@@ -10325,7 +10386,8 @@ impl<'db> LoweringContext<'db> {
         // and drop the store for, while this statement still emits a plain load of
         // it — reading an uninitialized slot.
         let value_op = self.lower_to_operand(value);
-        self.try_lower_interface_field_store(recv_local, &view, &member, value_op)
+        self.emit_interface_field_store(&field_target, value_op);
+        true
     }
 
     /// `recv.field op= value` on an interface field: read through the virtual
@@ -10338,62 +10400,40 @@ impl<'db> LoweringContext<'db> {
         op: AstAssignOp,
         value: AstExprId,
     ) -> bool {
-        let Some((recv_local, member, view)) = self.virtual_field_assign_target(target) else {
+        let Some(field_target) = self.virtual_field_assign_target(target) else {
             return false;
         };
         let current = self.builder.temp(self.expr_ty(target));
-        if !self.try_lower_interface_field_access(
-            recv_local,
-            &view.0,
-            &view.1,
-            &view.2,
-            &member,
+        self.emit_virtual_field_access(
+            field_target.receiver,
+            field_target.iface.clone(),
+            field_target.field_index,
+            &field_target.field,
             &Place::local(current),
-        ) {
-            return false;
-        }
+        );
         // Apply the operator to the temp through the ordinary path, so union
         // operator drivers and overload dispatch behave exactly as they do for a
         // class field; only the read and the write-back are virtual.
         self.emit_assign_op(Place::local(current), target, op, value);
-        self.try_lower_interface_field_store(
-            recv_local,
-            &view,
-            &member,
-            Operand::Copy(Place::Local(current)),
-        )
+        self.emit_interface_field_store(&field_target, Operand::Copy(Place::Local(current)));
+        true
     }
 
     /// Write `value` to `field` through an interface view — the store counterpart of
-    /// [`Self::try_lower_interface_field_access`].
-    fn try_lower_interface_field_store(
-        &mut self,
-        recv_local: Local,
-        view: &InterfaceTypeView,
-        field: &Name,
-        value: Operand,
-    ) -> bool {
-        let Some(((decl_tn, decl_args, decl_assoc), field_index)) =
-            self.interface_view_declaring_field(view, field)
-        else {
-            return false;
-        };
-        let generic_params = self.enclosing_generic_params();
-        let iface = tir2_interface_to_template(
-            &decl_tn,
-            &decl_args,
-            &decl_assoc,
-            self.resolved_aliases,
-            &generic_params,
-        );
+    /// [`Self::emit_virtual_field_access`].
+    ///
+    /// Infallible, like `emit_virtual_call`: the wire interface and field index were
+    /// resolved by [`Self::virtual_field_assign_target`] before any operand was
+    /// lowered, so nothing is left to fail on and there is no fall-through to leave
+    /// half-emitted.
+    fn emit_interface_field_store(&mut self, target: &VirtualFieldTarget, value: Operand) {
         self.builder.virtual_field_store(
-            iface,
-            Operand::Copy(Place::Local(recv_local)),
-            field_index,
-            field.clone(),
+            target.iface.clone(),
+            Operand::Copy(Place::Local(target.receiver)),
+            target.field_index,
+            target.field.clone(),
             value,
         );
-        true
     }
 
     /// The package this lowering context is lowering into — the "local" package for the

--- a/baml_language/crates/baml_compiler2_mir/src/optimize.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/optimize.rs
@@ -393,7 +393,8 @@ fn collect_place_index_locals(body: &MirFunctionBody) -> HashSet<Local> {
                 }
             }
             crate::Rvalue::MakeBoundMethod { receiver, .. }
-            | crate::Rvalue::MakeVirtualBoundMethod { receiver, .. } => {
+            | crate::Rvalue::MakeVirtualBoundMethod { receiver, .. }
+            | crate::Rvalue::VirtualFieldAccess { receiver, .. } => {
                 scan_operand(receiver, set);
             }
             crate::Rvalue::MakeGenericFunctionFromValue { value, .. } => {
@@ -667,7 +668,8 @@ fn count_in_rvalue(rv: &crate::Rvalue, uses: &mut [usize]) {
             }
         }
         crate::Rvalue::MakeBoundMethod { receiver, .. }
-        | crate::Rvalue::MakeVirtualBoundMethod { receiver, .. } => {
+        | crate::Rvalue::MakeVirtualBoundMethod { receiver, .. }
+        | crate::Rvalue::VirtualFieldAccess { receiver, .. } => {
             count_in_operand(receiver, uses);
         }
         crate::Rvalue::MakeGenericFunctionFromValue { value, .. } => {
@@ -690,6 +692,12 @@ fn count_in_statement(stmt: &crate::Statement, uses: &mut [usize]) {
                 count_in_place(destination, uses);
             }
             count_in_rvalue(value, uses);
+        }
+        crate::StatementKind::VirtualFieldStore {
+            receiver, value, ..
+        } => {
+            count_in_operand(receiver, uses);
+            count_in_operand(value, uses);
         }
         crate::StatementKind::Drop(p) => count_in_place(p, uses),
         crate::StatementKind::FreshCell(l) => {
@@ -1021,7 +1029,8 @@ fn apply_subst_to_rvalue(rv: &mut crate::Rvalue, subst: &HashMap<Local, Operand>
             }
         }
         crate::Rvalue::MakeBoundMethod { receiver, .. }
-        | crate::Rvalue::MakeVirtualBoundMethod { receiver, .. } => {
+        | crate::Rvalue::MakeVirtualBoundMethod { receiver, .. }
+        | crate::Rvalue::VirtualFieldAccess { receiver, .. } => {
             apply_subst_to_operand(receiver, subst);
         }
         crate::Rvalue::MakeGenericFunctionFromValue { value, .. } => {
@@ -1043,7 +1052,21 @@ fn apply_subst_to_statement(stmt: &mut crate::Statement, subst: &HashMap<Local, 
                 apply_subst_to_operand(arg, subst);
             }
         }
-        _ => {}
+        crate::StatementKind::VirtualFieldStore {
+            receiver, value, ..
+        } => {
+            apply_subst_to_operand(receiver, subst);
+            apply_subst_to_operand(value, subst);
+        }
+        // Deliberately exhaustive over operand-carrying kinds: a statement whose
+        // operands are missed here keeps referring to a local that copy
+        // propagation has already retired, and the emitter then loads a slot
+        // nothing ever stored to.
+        crate::StatementKind::Drop(_)
+        | crate::StatementKind::VizEnter(_)
+        | crate::StatementKind::VizExit(_)
+        | crate::StatementKind::FreshCell(_)
+        | crate::StatementKind::Nop => {}
     }
 }
 
@@ -1302,7 +1325,8 @@ fn remap_rvalue(rv: &mut crate::Rvalue, map: &[Option<Local>]) {
             }
         }
         crate::Rvalue::MakeBoundMethod { receiver, .. }
-        | crate::Rvalue::MakeVirtualBoundMethod { receiver, .. } => {
+        | crate::Rvalue::MakeVirtualBoundMethod { receiver, .. }
+        | crate::Rvalue::VirtualFieldAccess { receiver, .. } => {
             remap_operand(receiver, map);
         }
         crate::Rvalue::MakeGenericFunctionFromValue { value, .. } => {
@@ -1319,6 +1343,12 @@ fn rewrite_locals_in_statement(stmt: &mut crate::Statement, map: &[Option<Local>
         crate::StatementKind::Assign { destination, value } => {
             remap_place(destination, map);
             remap_rvalue(value, map);
+        }
+        crate::StatementKind::VirtualFieldStore {
+            receiver, value, ..
+        } => {
+            remap_operand(receiver, map);
+            remap_operand(value, map);
         }
         crate::StatementKind::Drop(p) => remap_place(p, map),
         crate::StatementKind::FreshCell(l) => remap_local(l, map),
@@ -1567,7 +1597,8 @@ fn verify_mir(body: &MirFunctionBody, name: &crate::ItemRef) {
                             }
                         }
                         crate::Rvalue::MakeBoundMethod { receiver, .. }
-                        | crate::Rvalue::MakeVirtualBoundMethod { receiver, .. } => {
+                        | crate::Rvalue::MakeVirtualBoundMethod { receiver, .. }
+                        | crate::Rvalue::VirtualFieldAccess { receiver, .. } => {
                             check_operand(receiver, &blk);
                         }
                         crate::Rvalue::MakeGenericFunctionFromValue { value, .. } => {

--- a/baml_language/crates/baml_compiler2_mir/src/optimize.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/optimize.rs
@@ -410,12 +410,33 @@ fn collect_place_index_locals(body: &MirFunctionBody) -> HashSet<Local> {
 
     for block in &body.blocks {
         for stmt in &block.statements {
-            if let crate::StatementKind::Assign {
-                destination, value, ..
-            } = &stmt.kind
-            {
-                scan_place(destination, &mut set);
-                scan_rvalue(value, &mut set);
+            match &stmt.kind {
+                crate::StatementKind::Assign { destination, value } => {
+                    scan_place(destination, &mut set);
+                    scan_rvalue(value, &mut set);
+                }
+                crate::StatementKind::VirtualFieldStore {
+                    receiver, value, ..
+                } => {
+                    scan_operand(receiver, &mut set);
+                    scan_operand(value, &mut set);
+                }
+                crate::StatementKind::Intrinsic { args, .. } => {
+                    for arg in args {
+                        scan_operand(arg, &mut set);
+                    }
+                }
+                crate::StatementKind::Drop(p) => scan_place(p, &mut set),
+                // Exhaustive for the same reason the substitution walk is: a
+                // projected operand missed here lets copy propagation pick a
+                // constant for a local that `apply_subst_to_place_locals` then
+                // declines to write into the `Local`-typed position, while the
+                // defining assignment is dropped regardless — leaving the
+                // projection pointing at a local nothing defines.
+                crate::StatementKind::FreshCell(_)
+                | crate::StatementKind::VizEnter(_)
+                | crate::StatementKind::VizExit(_)
+                | crate::StatementKind::Nop => {}
             }
         }
         if let Some(term) = &block.terminator {
@@ -1609,9 +1630,25 @@ fn verify_mir(body: &MirFunctionBody, name: &crate::ItemRef) {
                         }
                     }
                 }
+                crate::StatementKind::VirtualFieldStore {
+                    receiver, value, ..
+                } => {
+                    check_operand(receiver, &blk);
+                    check_operand(value, &blk);
+                }
+                crate::StatementKind::Intrinsic { args, .. } => {
+                    for arg in args {
+                        check_operand(arg, &blk);
+                    }
+                }
                 crate::StatementKind::Drop(p) => check_place(p, &blk),
                 crate::StatementKind::FreshCell(l) => check_local(*l, &blk),
-                _ => {}
+                // Exhaustive rather than wildcarded: an operand-carrying
+                // statement kind that skips this check loses the one cheap
+                // tripwire for a reference to a retired local.
+                crate::StatementKind::VizEnter(_)
+                | crate::StatementKind::VizExit(_)
+                | crate::StatementKind::Nop => {}
             }
         }
     }

--- a/baml_language/crates/baml_compiler2_mir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/pretty.rs
@@ -696,7 +696,11 @@ mod tests {
     #[test]
     fn virtual_call_runtime_id_without_visible_args_has_no_leading_comma() {
         let terminator = Terminator::VirtualCall {
-            iface: baml_type::TyTemplate::TypeArgRef(0),
+            iface: baml_type::TyTemplateInterface::new(
+                baml_type::TypeName::from_dotted_path("baml.ops.Equals"),
+                Vec::new(),
+                Vec::new(),
+            ),
             method: "eq".to_string(),
             args: Vec::new(),
             ntypeargs: 0,
@@ -708,7 +712,7 @@ mod tests {
 
         assert_eq!(
             render_terminator(&terminator),
-            "_0 = virtual_call eq as #0($id = copy _9) -> [bb1];"
+            "_0 = virtual_call eq as baml.ops.Equals($id = copy _9) -> [bb1];"
         );
     }
 

--- a/baml_language/crates/baml_compiler2_mir/src/pretty.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/pretty.rs
@@ -157,6 +157,18 @@ fn write_statement(f: &mut impl Write, stmt: &Statement) -> fmt::Result {
             write_rvalue(f, value)?;
             write!(f, ";")
         }
+        StatementKind::VirtualFieldStore {
+            iface,
+            receiver,
+            field_index,
+            field,
+            value,
+        } => {
+            write_operand(f, receiver)?;
+            write!(f, ".{field}#{field_index} as {iface} = ")?;
+            write_operand(f, value)?;
+            write!(f, ";")
+        }
         StatementKind::Drop(place) => {
             write!(f, "drop({place});")
         }
@@ -448,6 +460,15 @@ fn write_runtime_id_arg(
 fn write_rvalue(f: &mut impl Write, rvalue: &Rvalue) -> fmt::Result {
     match rvalue {
         Rvalue::Use(operand) => write_operand(f, operand),
+        Rvalue::VirtualFieldAccess {
+            iface,
+            receiver,
+            field_index,
+            field,
+        } => {
+            write_operand(f, receiver)?;
+            write!(f, ".{field}#{field_index} as {iface}")
+        }
         Rvalue::BinaryOp { op, left, right } => {
             write_operand(f, left)?;
             write!(f, " {op} ")?;

--- a/baml_language/crates/baml_compiler2_ppir/src/item_data/classes.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/item_data/classes.rs
@@ -103,7 +103,7 @@ fn lower<'db>(db: &'db dyn crate::Db, class: ClassLoc<'db>) -> (ClassData<'db>, 
         .iter()
         .map(|field| FieldData {
             name: field.name.clone(),
-            type_ref: field.type_expr.as_ref().map(|te| type_refs.lower(te)),
+            type_ref: type_refs.lower(&field.type_expr),
             attributes: field.attributes.clone(),
             docstring: field.docstring.clone(),
         })

--- a/baml_language/crates/baml_compiler2_ppir/src/item_data/common.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/item_data/common.rs
@@ -20,7 +20,12 @@ pub struct FunctionParamData {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldData {
     pub name: Name,
-    pub type_ref: Option<TypeRefId>,
+    /// Always present. A field written without a type is reported by the parser and
+    /// recovers as [`TypeRefKind::Error`](baml_compiler2_hir::type_ref::TypeRefKind::Error),
+    /// which suppresses follow-on diagnostics while the rest of the declaration still
+    /// type-checks. "No type" is not a kind of type, so it is not representable here —
+    /// otherwise every consumer has to invent its own stand-in, and they disagree.
+    pub type_ref: TypeRefId,
     pub attributes: Vec<Attribute>,
     pub docstring: Option<String>,
 }

--- a/baml_language/crates/baml_compiler2_ppir/src/item_data/interfaces.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/item_data/interfaces.rs
@@ -142,7 +142,7 @@ fn lower<'db>(
         .iter()
         .map(|field| FieldData {
             name: field.name.clone(),
-            type_ref: field.type_expr.as_ref().map(|te| type_refs.lower(te)),
+            type_ref: type_refs.lower(&field.type_expr),
             attributes: field.attributes.clone(),
             docstring: field.docstring.clone(),
         })

--- a/baml_language/crates/baml_compiler2_ppir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/lib.rs
@@ -248,14 +248,7 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
 
                 // Transform each field in-place
                 stream_class.fields.retain_mut(|field| {
-                    let ppir_ty = field
-                        .type_expr
-                        .as_ref()
-                        .map(PpirTy::from_type_expr)
-                        .unwrap_or(PpirTy::CannotBeStreamed {
-                            origin: ty::CannotBeStreamedOrigin::Unknown,
-                            attrs: PpirTypeAttrs::default(),
-                        });
+                    let ppir_ty = PpirTy::from_type_expr(&field.type_expr);
                     let ctx = ExpandCtx {
                         package_name: &package_name,
                         namespace_path: &pkg_info.namespace_path,
@@ -287,22 +280,17 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
                     }
 
                     // Preserve non-stream type attributes from the original outermost TypeExpr
-                    if let Some(orig_spanned) = &field.type_expr {
-                        for attr in orig_spanned.attrs() {
-                            if !attr.name.starts_with("stream.") && !attr.name.starts_with("sap.") {
-                                type_expr.attrs_mut().push(attr.clone());
-                            }
+                    for attr in field.type_expr.attrs() {
+                        if !attr.name.starts_with("stream.") && !attr.name.starts_with("sap.") {
+                            type_expr.attrs_mut().push(attr.clone());
                         }
                     }
 
                     // Replace the field's type expr (preserves field.name, field.attributes, field.span, etc.)
-                    field.type_expr = Some(ast::TypeExpr {
-                        span: field
-                            .type_expr
-                            .as_ref()
-                            .map_or(TextRange::default(), |s| s.span),
+                    field.type_expr = ast::TypeExpr {
+                        span: field.type_expr.span,
                         ..type_expr
-                    });
+                    };
 
                     // Strip stream.* from field-level attributes (preserve @alias, @description, @skip, etc.)
                     field.attributes.retain(|a| !a.name.starts_with("stream."));

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -12450,57 +12450,61 @@ impl<'db> TypeInferenceBuilder<'db> {
         // in the field type resolves `T`'s declaring interface.
         let iface_bounds =
             crate::lower_type_expr::interface_generic_param_bounds(db, source.iface_loc);
-        let declared_ty = field
-            .type_ref
-            .map(|type_ref| {
-                let mut diags = Vec::new();
-                let ty = if bindings.is_empty() {
-                    crate::lower_type_expr::lower_type_ref(
+        // BUG(interface-field-self-scope): both branches below lower with `self_ty: None`,
+        // so a field type naming `Self`/`Self.Assoc` (`key: Self.Key`) takes the unresolved
+        // path and lands as an error-recovery type instead of a `TypeVar` /
+        // `AssociatedTypeProjection`. The fix is the scope emit's `build_interface_def`
+        // builds: `Self` as a rigid type variable bounded by the interface itself, so a
+        // projection through it resolves. Low impact here: the caller has already reported
+        // `InterfaceFieldRequiresQualifiedConstruction`, and this type only feeds the
+        // follow-on `check_expr` that suppresses cascading errors.
+        let declared_ty = {
+            let type_ref = field.type_ref;
+            let mut diags = Vec::new();
+            let ty = if bindings.is_empty() {
+                crate::lower_type_expr::lower_type_ref(
+                    &iface_data.type_refs,
+                    type_ref,
+                    &crate::lower_type_expr::ScopeCtx {
+                        db,
+                        package_items: iface_pkg_items,
+                        ns_context: &iface_ns,
+                        generic_params: iface_generic_params,
+                        bounds: iface_bounds,
+                        self_ty: None,
+                    },
+                    &mut diags,
+                )
+            } else {
+                let generic_params: Vec<_> = bindings.keys().cloned().collect();
+                crate::generics::substitute_ty(
+                    &crate::lower_type_expr::lower_type_ref(
                         &iface_data.type_refs,
                         type_ref,
                         &crate::lower_type_expr::ScopeCtx {
                             db,
                             package_items: iface_pkg_items,
                             ns_context: &iface_ns,
-                            generic_params: iface_generic_params,
+                            generic_params: &generic_params,
                             bounds: iface_bounds,
                             self_ty: None,
                         },
                         &mut diags,
-                    )
-                } else {
-                    let generic_params: Vec<_> = bindings.keys().cloned().collect();
-                    crate::generics::substitute_ty(
-                        &crate::lower_type_expr::lower_type_ref(
-                            &iface_data.type_refs,
-                            type_ref,
-                            &crate::lower_type_expr::ScopeCtx {
-                                db,
-                                package_items: iface_pkg_items,
-                                ns_context: &iface_ns,
-                                generic_params: &generic_params,
-                                bounds: iface_bounds,
-                                self_ty: None,
-                            },
-                            &mut diags,
-                        ),
-                        &bindings,
-                    )
-                };
-                if !diags.is_empty() {
-                    let span =
-                        baml_compiler2_ppir::item_data::interface_source_map(db, source.iface_loc)
-                            .type_refs
-                            .span(type_ref);
-                    for diag in diags {
-                        self.context.report_at_span(diag, span);
-                    }
+                    ),
+                    &bindings,
+                )
+            };
+            if !diags.is_empty() {
+                let span =
+                    baml_compiler2_ppir::item_data::interface_source_map(db, source.iface_loc)
+                        .type_refs
+                        .span(type_ref);
+                for diag in diags {
+                    self.context.report_at_span(diag, span);
                 }
-                ty
-            })
-            .unwrap_or(Ty::Unknown {
-                attr: TyAttr::default(),
-            });
+            }
+            ty
+        };
         Some((source.class_field, declared_ty))
     }
 
@@ -13217,30 +13221,23 @@ impl<'db> TypeInferenceBuilder<'db> {
         for field in &class_data.fields {
             if field.name == *member_name {
                 let mut diags = Vec::new();
-                let field_ty = field
-                    .type_ref
-                    .map(|type_ref| {
-                        let generic_params: Vec<_> = bindings.keys().cloned().collect();
-                        crate::generics::substitute_ty(
-                            &crate::lower_type_expr::lower_type_ref(
-                                &class_data.type_refs,
-                                type_ref,
-                                &crate::lower_type_expr::ScopeCtx {
-                                    db,
-                                    package_items: self.package_items,
-                                    ns_context: stub_ns,
-                                    generic_params: &generic_params,
-                                    bounds: class_bounds,
-                                    self_ty: None,
-                                },
-                                &mut diags,
-                            ),
-                            &bindings,
-                        )
-                    })
-                    .unwrap_or(Ty::Unknown {
-                        attr: TyAttr::default(),
-                    });
+                let generic_params: Vec<_> = bindings.keys().cloned().collect();
+                let field_ty = crate::generics::substitute_ty(
+                    &crate::lower_type_expr::lower_type_ref(
+                        &class_data.type_refs,
+                        field.type_ref,
+                        &crate::lower_type_expr::ScopeCtx {
+                            db,
+                            package_items: self.package_items,
+                            ns_context: stub_ns,
+                            generic_params: &generic_params,
+                            bounds: class_bounds,
+                            self_ty: None,
+                        },
+                        &mut diags,
+                    ),
+                    &bindings,
+                );
                 drop(diags);
                 return Some(BuiltinResolution::Field(field_ty));
             }

--- a/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
@@ -873,8 +873,9 @@ impl<'db> TypeInferenceBuilder<'db> {
         let db = self.context.db();
         let iface_data = baml_compiler2_ppir::item_data::interface_data(db, view.loc);
 
-        // Field lookup: this interface's own fields (no closure).
-        for field in &iface_data.fields {
+        // Field lookup: this interface's own fields (no closure). The enumeration index
+        // *is* the field's dispatch index — see `MemberResolution::InterfaceVirtualField`.
+        for (field_index, field) in iface_data.fields.iter().enumerate() {
             if &field.name != access.member {
                 continue;
             }
@@ -890,47 +891,45 @@ impl<'db> TypeInferenceBuilder<'db> {
                     attr: TyAttr::default(),
                 });
             }
-            let ty = field
-                .type_ref
-                .map(|type_ref| {
-                    // A field lowers in the same environment as a method signature — so
-                    // `key: Self.Key` resolves through the receiver's pins/impls exactly
-                    // as a `-> Self.Key` return would. Fields require a bound receiver
-                    // (checked above), so no fresh receiver generic is ever needed.
-                    let env = self.interface_member_lowering_env(view, recv, &[], false);
-                    let mut diags = env.diags;
-                    let ns = view.namespace(db);
-                    let ty = crate::generics::substitute_ty(
-                        &crate::lower_type_expr::lower_type_ref(
-                            &iface_data.type_refs,
-                            type_ref,
-                            &crate::lower_type_expr::ScopeCtx {
-                                db,
-                                package_items: view.pkg_items(db),
-                                ns_context: &ns,
-                                generic_params: &env.all_generic_params,
-                                bounds: &env.bounds,
-                                self_ty: Some(env.self_ty.clone()),
-                            },
-                            &mut diags,
-                        ),
-                        &env.bindings,
-                    );
-                    let span = baml_compiler2_ppir::item_data::interface_source_map(db, view.loc)
-                        .type_refs
-                        .span(type_ref);
-                    for diag in diags {
-                        self.context.report_at_span(diag, span);
-                    }
-                    ty
-                })
-                .unwrap_or(Ty::Unknown {
-                    attr: TyAttr::default(),
-                });
+            let ty = {
+                // A field lowers in the same environment as a method signature — so
+                // `key: Self.Key` resolves through the receiver's pins/impls exactly
+                // as a `-> Self.Key` return would. Fields require a bound receiver
+                // (checked above), so no fresh receiver generic is ever needed.
+                let env = self.interface_member_lowering_env(view, recv, &[], false);
+                let mut diags = env.diags;
+                let ns = view.namespace(db);
+                let ty = crate::generics::substitute_ty(
+                    &crate::lower_type_expr::lower_type_ref(
+                        &iface_data.type_refs,
+                        field.type_ref,
+                        &crate::lower_type_expr::ScopeCtx {
+                            db,
+                            package_items: view.pkg_items(db),
+                            ns_context: &ns,
+                            generic_params: &env.all_generic_params,
+                            bounds: &env.bounds,
+                            self_ty: Some(env.self_ty.clone()),
+                        },
+                        &mut diags,
+                    ),
+                    &env.bindings,
+                );
+                let span = baml_compiler2_ppir::item_data::interface_source_map(db, view.loc)
+                    .type_refs
+                    .span(field.type_ref);
+                for diag in diags {
+                    self.context.report_at_span(diag, span);
+                }
+                ty
+            };
             self.resolutions.insert(
                 access.at,
                 crate::inference::MemberResolution::InterfaceVirtualField {
                     iface_loc: view.loc,
+                    interface: view.realized.to_ty(),
+                    field_index: u32::try_from(field_index)
+                        .expect("interface field count fits u32"),
                     field: access.member.clone(),
                 },
             );
@@ -1013,29 +1012,22 @@ impl<'db> TypeInferenceBuilder<'db> {
                 if !seen.insert(field.name.clone()) {
                     continue;
                 }
-                let ty = field
-                    .type_ref
-                    .map(|type_ref| {
-                        crate::generics::substitute_ty(
-                            &crate::lower_type_expr::lower_type_ref(
-                                &iface_data.type_refs,
-                                type_ref,
-                                &crate::lower_type_expr::ScopeCtx {
-                                    db,
-                                    package_items: view.pkg_items(db),
-                                    ns_context: &ns,
-                                    generic_params: &env.all_generic_params,
-                                    bounds: &env.bounds,
-                                    self_ty: Some(env.self_ty.clone()),
-                                },
-                                &mut diags,
-                            ),
-                            &env.bindings,
-                        )
-                    })
-                    .unwrap_or(Ty::Unknown {
-                        attr: TyAttr::default(),
-                    });
+                let ty = crate::generics::substitute_ty(
+                    &crate::lower_type_expr::lower_type_ref(
+                        &iface_data.type_refs,
+                        field.type_ref,
+                        &crate::lower_type_expr::ScopeCtx {
+                            db,
+                            package_items: view.pkg_items(db),
+                            ns_context: &ns,
+                            generic_params: &env.all_generic_params,
+                            bounds: &env.bounds,
+                            self_ty: Some(env.self_ty.clone()),
+                        },
+                        &mut diags,
+                    ),
+                    &env.bindings,
+                );
                 out.push((field.name.clone(), ty));
             }
         }

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -751,6 +751,18 @@ pub enum MemberResolution<'db> {
     /// case needs its own variant.
     InterfaceVirtualField {
         iface_loc: InterfaceLoc<'db>,
+        /// The realized interface-existential this access resolves *through* — the
+        /// interface that declares `field` (which may be a `requires` parent of the
+        /// receiver's own interface), with its type args and associated bindings
+        /// realized at the receiver. This is the view the runtime resolver keys on:
+        /// a class may implement one interface family at several instantiations with
+        /// different field links, and only the requested view discriminates them.
+        interface: Ty,
+        /// `field`'s position in `interface`'s own declared field list
+        /// (`InterfaceData::fields`) — the index space every implementation of that
+        /// interface is baked against. Deliberately *not* a `requires`-closure
+        /// position: the closure flattening dedups by name and numbers differently.
+        field_index: u32,
         field: Name,
     },
 }
@@ -2152,10 +2164,10 @@ pub fn infer_scope_types<'db>(
                 );
                 let resolved = resolve_class_fields(db, class_loc);
                 for (field, (_, ty, _)) in class_data.fields.iter().zip(resolved.fields.iter()) {
-                    if let Some(id) = field.type_ref {
-                        builder
-                            .validate_type_generic_bounds_at_span(class_sm.type_refs.span(id), ty);
-                    }
+                    builder.validate_type_generic_bounds_at_span(
+                        class_sm.type_refs.span(field.type_ref),
+                        ty,
+                    );
                 }
             }
             if let Some(baml_compiler2_ppir::item_data::ScopeOwner::Interface(iface_loc)) =
@@ -2241,18 +2253,16 @@ pub fn infer_scope_types<'db>(
                 // once the implementor binds the associated type it denotes a concrete field
                 // type (`value: Self.Item` with `type Item = int` is an `int` field).
                 for field in &iface_data.fields {
-                    if let Some(type_ref) = field.type_ref
-                        && crate::builder::TypeInferenceBuilder::type_ref_contains_bare_self(
-                            &iface_data.type_refs,
-                            type_ref,
-                        )
-                    {
+                    if crate::builder::TypeInferenceBuilder::type_ref_contains_bare_self(
+                        &iface_data.type_refs,
+                        field.type_ref,
+                    ) {
                         builder.report_at_span(
                             crate::infer_context::TirTypeError::SelfInInterfaceField {
                                 interface: iface_qtn.clone(),
                                 field: field.name.clone(),
                             },
-                            iface_sm.type_refs.span(type_ref),
+                            iface_sm.type_refs.span(field.type_ref),
                         );
                     }
                 }
@@ -2397,20 +2407,18 @@ pub fn infer_scope_types<'db>(
                     }
                 }
                 for field in &iface_data.fields {
-                    if let Some(type_ref) = field.type_ref {
-                        validate_type_ref_generic_bounds_at_span(
-                            db,
-                            &mut builder,
-                            pkg_items,
-                            &pkg_info.namespace_path,
-                            &iface_env,
-                            &iface_env_bounds,
-                            &iface_data.type_refs,
-                            type_ref,
-                            iface_sm.type_refs.span(type_ref),
-                            Some(self_ty.clone()),
-                        );
-                    }
+                    validate_type_ref_generic_bounds_at_span(
+                        db,
+                        &mut builder,
+                        pkg_items,
+                        &pkg_info.namespace_path,
+                        &iface_env,
+                        &iface_env_bounds,
+                        &iface_data.type_refs,
+                        field.type_ref,
+                        iface_sm.type_refs.span(field.type_ref),
+                        Some(self_ty.clone()),
+                    );
                 }
                 for (sig_idx, sig) in iface_data.required_methods.iter().enumerate() {
                     let sig_span = iface_sm.required_method_spans[sig_idx].span;
@@ -2901,24 +2909,16 @@ pub fn resolve_class_fields<'db>(
         .fields
         .iter()
         .map(|f| {
-            let ty = f
-                .type_ref
-                .map(|id| {
-                    let mut diags = Vec::new();
-                    let ty = crate::lower_type_expr::lower_type_ref(
-                        &class_data.type_refs,
-                        id,
-                        &field_scope,
-                        &mut diags,
-                    );
-                    for d in diags {
-                        all_diags.push((d, class_spans.type_refs.span(id)));
-                    }
-                    ty
-                })
-                .unwrap_or(Ty::Unknown {
-                    attr: TyAttr::default(),
-                });
+            let mut diags = Vec::new();
+            let ty = crate::lower_type_expr::lower_type_ref(
+                &class_data.type_refs,
+                f.type_ref,
+                &field_scope,
+                &mut diags,
+            );
+            for d in diags {
+                all_diags.push((d, class_spans.type_refs.span(f.type_ref)));
+            }
             (f.name.clone(), ty, f.attributes.clone())
         })
         .collect();

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
@@ -1102,9 +1102,6 @@ pub fn validate_impl_signatures<'db>(
         let self_bound =
             baml_type::Interface::new(iface_qtn.clone(), data.interface_args.clone(), vec![]);
         for iface_field in &iface_data.fields {
-            let Some(iface_field_ref) = iface_field.type_ref else {
-                continue;
-            };
             // The satisfying class field: explicit link, else same name. Absent → E0124 (impl_data).
             let class_field_name = block
                 .field_links
@@ -1132,7 +1129,7 @@ pub fn validate_impl_signatures<'db>(
                 |scope| {
                     crate::lower_type_expr::lower_type_ref(
                         &iface_data.type_refs,
-                        iface_field_ref,
+                        iface_field.type_ref,
                         scope,
                         &mut lower_diags,
                     )

--- a/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
@@ -404,22 +404,13 @@ fn lower_class_export<'db>(
     let mut fields = Vec::new();
     let mut diags = Vec::new();
     for field in &class_data.fields {
-        if let Some(type_ref) = field.type_ref {
-            let field_ty = crate::lower_type_expr::lower_type_ref(
-                &class_data.type_refs,
-                type_ref,
-                &field_scope,
-                &mut diags,
-            );
-            fields.push((field.name.clone(), field_ty));
-        } else {
-            fields.push((
-                field.name.clone(),
-                Ty::Unknown {
-                    attr: TyAttr::default(),
-                },
-            ));
-        }
+        let field_ty = crate::lower_type_expr::lower_type_ref(
+            &class_data.type_refs,
+            field.type_ref,
+            &field_scope,
+            &mut diags,
+        );
+        fields.push((field.name.clone(), field_ty));
     }
 
     // Lower methods

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -1386,18 +1386,13 @@ fn build_jinja_types(
             .fields
             .iter()
             .map(|field| {
-                let ty = field
-                    .type_ref
-                    .map(|id| {
-                        jinja_type_from_type_ref(
-                            db,
-                            &class_data.type_refs,
-                            id,
-                            pkg_items,
-                            &class_namespace,
-                        )
-                    })
-                    .unwrap_or(sys_jinja_types::Type::Unknown);
+                let ty = jinja_type_from_type_ref(
+                    db,
+                    &class_data.type_refs,
+                    field.type_ref,
+                    pkg_items,
+                    &class_namespace,
+                );
                 (field.name.to_string(), ty)
             })
             .collect::<IndexMap<_, _>>();

--- a/baml_language/crates/baml_lsp2_actions/src/definition.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/definition.rs
@@ -445,16 +445,19 @@ fn resolve_field_access_at(
                 range: name_span,
             })
         }
-        MemberResolution::InterfaceVirtualField { iface_loc, field } => {
+        MemberResolution::InterfaceVirtualField {
+            iface_loc,
+            field_index,
+            ..
+        } => {
             // A virtual interface-field access: navigate to the field declaration
-            // in the declaring interface.
+            // in the declaring interface. `field_index` indexes the interface's own
+            // field list, which `field_name_spans` is parallel to.
             let target_file = iface_loc.file(db);
-            let iface = item_data::interface_data(db, *iface_loc);
-            let field_idx = iface.fields.iter().position(|f| f.name == *field)?;
             let source_map = item_data::interface_source_map(db, *iface_loc);
             Some(Location {
                 file: target_file,
-                range: source_map.field_name_spans[field_idx],
+                range: *source_map.field_name_spans.get(*field_index as usize)?,
             })
         }
     }

--- a/baml_language/crates/baml_lsp2_actions/src/describe.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/describe.rs
@@ -1384,9 +1384,14 @@ fn find_dependencies(
         baml_compiler2_hir::contributions::Definition::Interface(iface_loc) => {
             let iface = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
             for field in &iface.fields {
-                if let Some(id) = field.type_ref {
-                    collect_type_ref_deps(db, file, &iface.type_refs, id, &mut deps, &mut seen);
-                }
+                collect_type_ref_deps(
+                    db,
+                    file,
+                    &iface.type_refs,
+                    field.type_ref,
+                    &mut deps,
+                    &mut seen,
+                );
             }
             for &parent in &iface.requires {
                 collect_type_ref_deps(db, file, &iface.type_refs, parent, &mut deps, &mut seen);

--- a/baml_language/crates/baml_lsp2_actions/src/type_info.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/type_info.rs
@@ -691,10 +691,7 @@ fn declaration_type_info_at(
                 continue;
             };
             if field.name == *name && range_contains(*name_span, offset) {
-                let ty = field
-                    .type_ref
-                    .map(|id| utils::display_type_ref(&class.type_refs, id))
-                    .unwrap_or_else(|| "unknown".to_string());
+                let ty = utils::display_type_ref(&class.type_refs, field.type_ref);
                 return Some(TypeInfo::LocalVar {
                     name: name.as_str().to_string(),
                     ty,
@@ -732,10 +729,7 @@ fn declaration_type_info_at(
                 continue;
             };
             if field.name == *name && range_contains(*name_span, offset) {
-                let ty = field
-                    .type_ref
-                    .map(|id| utils::display_type_ref(&iface.type_refs, id))
-                    .unwrap_or_else(|| "unknown".to_string());
+                let ty = utils::display_type_ref(&iface.type_refs, field.type_ref);
                 return Some(TypeInfo::LocalVar {
                     name: name.as_str().to_string(),
                     ty,

--- a/baml_language/crates/baml_project/src/client_codegen.rs
+++ b/baml_language/crates/baml_project/src/client_codegen.rs
@@ -169,7 +169,7 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
                     let ty = resolve_type_ref(
                         db,
                         &class.type_refs,
-                        field.type_ref,
+                        Some(field.type_ref),
                         pkg_items,
                         &pkg_info.namespace_path,
                         &class_generic_params,

--- a/baml_language/crates/baml_tests/baml_src/ns_interfaces/interfaces.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_interfaces/interfaces.baml
@@ -133,6 +133,80 @@ test "same_generic_interface_field_links_select_matching_type_args_runtime" {
     assert.is_true(sgif_main())
 }
 
+// symbolic_interface_view_selects_per_instantiation_link_runtime
+// The view is the frame's `T`, not anything on the receiver: both calls pass the
+// SAME object, so no runtime test of the receiver can tell the two links apart.
+// Only carrying the requested view to the resolver discriminates them.
+function sgif_read<T>(g: SgifSlot<T>) -> T {
+    g.value
+}
+function sgif_symbolic_main() -> bool {
+    let p = SgifPair { int_value: 7, string_value: "seven" }
+    return sgif_read<int>(p) == 7 && sgif_read<string>(p) == "seven"
+}
+test "symbolic_interface_view_selects_per_instantiation_link_runtime" {
+    assert.is_true(sgif_symbolic_main())
+}
+
+// interface_field_write_through_existential_runtime
+interface IfwCounter {
+    count: int
+}
+class IfwBox {
+    label: string
+    count: int
+    implements IfwCounter {}
+}
+function ifw_main() -> bool {
+    let b = IfwBox { label: "b", count: 1 }
+    let c: IfwCounter = b
+    c.count = 10
+    let after_assign = b.count == 10
+    c.count += 5
+    return after_assign && b.count == 15
+}
+test "interface_field_write_through_existential_runtime" {
+    assert.is_true(ifw_main())
+}
+
+// interface_field_write_through_bounded_type_var_runtime
+function ifw_bump<T extends IfwCounter>(t: T) -> void {
+    t.count += 100
+}
+function ifw_typevar_main() -> bool {
+    let b = IfwBox { label: "b", count: 1 }
+    ifw_bump<IfwBox>(b)
+    return b.count == 101
+}
+test "interface_field_write_through_bounded_type_var_runtime" {
+    assert.is_true(ifw_typevar_main())
+}
+
+// generic_implementor_field_resolves_from_receiver_runtime
+// Nothing at the access site names the implementor: `gif_read` sees only the
+// existential. The slot comes from the receiver's own impl at run time, so a
+// generic class works at every instantiation without any of them being
+// enumerable at the access site.
+interface GifHolder {
+    held: string
+}
+class GifBox<T> {
+    payload: T
+    held: string
+    implements GifHolder {}
+}
+function gif_read(h: GifHolder) -> string {
+    h.held
+}
+function gif_main() -> bool {
+    let a = GifBox<int> { payload: 1, held: "one" }
+    let b = GifBox<string> { payload: "x", held: "ex" }
+    return gif_read(a) == "one" && gif_read(b) == "ex"
+}
+test "generic_implementor_field_resolves_from_receiver_runtime" {
+    assert.is_true(gif_main())
+}
+
 // interface_field_via_requires_chain_runtime
 interface IfvrNamed { name: string }
 interface IfvrAged { age: int }
@@ -1919,4 +1993,32 @@ function rcpm_main() -> bool {
 }
 test "requires_closure_preserves_multiple_parent_instantiations_runtime" {
     assert.is_true(rcpm_main())
+}
+
+// interface_type_args_match_positionally_runtime
+// Replaces a compile-time unit test that pinned the same rule on the deleted
+// block-selection path: interface type arguments match *by position*, so
+// `Conv<int, string>` and `Conv<string, int>` are different instantiations. One
+// class implements both, so the receiver cannot discriminate them — only the
+// requested view's argument order can. Order-insensitive matching would resolve
+// both views to whichever rule the registry happens to hold first.
+interface ItampConv<A, B> {
+    function tag(self) -> string throws never
+}
+class ItampBoth {
+    implements ItampConv<int, string> {
+        function tag(self) -> string throws never { "int->string" }
+    }
+    implements ItampConv<string, int> {
+        function tag(self) -> string throws never { "string->int" }
+    }
+}
+function itamp_main() -> bool {
+    let p = ItampBoth {}
+    let forward: ItampConv<int, string> = p
+    let reverse: ItampConv<string, int> = p
+    return forward.tag() == "int->string" && reverse.tag() == "string->int"
+}
+test "interface_type_args_match_positionally_runtime" {
+    assert.is_true(itamp_main())
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/array_rest_binding.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/array_rest_binding.snap
@@ -720,14 +720,14 @@ function array_rest_binding.arb_rest_only_binding_in_for_loop() -> int {
     alloc_array 0
     load_type int[]
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int[], Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int[]>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
 
   L0:
     load_var _8
-    load_type baml.iter.Iterator<Item = int[], Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int[]>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _9

--- a/baml_language/crates/baml_tests/snapshots/baml_src/comparable_sort.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/comparable_sort.snap
@@ -180,11 +180,8 @@ function comparable_sort.FirstNamed$for$T[].first_name(self: #0[]) -> string {
     load_var self
     load_const 0
     load_array_element
-    store_var_load_var _4
-    is_type comparable_sort.Person
-    pop_jump_if_false L3
-    load_var _4
-    load_field .0
+    load_type comparable_sort.Named
+    virtual_load_field .name
     jump L2
 
   L1:
@@ -192,9 +189,6 @@ function comparable_sort.FirstNamed$for$T[].first_name(self: #0[]) -> string {
 
   L2:
     return
-
-  L3:
-    unreachable
 }
 
 function comparable_sort.Num.Cmp.compare(self: comparable_sort.Num, other: comparable_sort.Num) -> int {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/csv.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/csv.snap
@@ -2167,26 +2167,26 @@ function csv.csv_iterator_adapters() -> int {
     load_type never
     load_var _4
     make_closure .<lambda(csv_iterator_adapters, 0)>, 0
-    load_type baml.iter.Iterator<Item = csv.IntRow, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = csv.IntRow>
     load_const "map"
     virtual_call nargs=2 ntypeargs=2
     store_var _3
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var doubled
     load_const 0
     store_var total
     load_var doubled
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _11
 
   L0:
     load_var _11
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _12
@@ -2730,14 +2730,14 @@ function csv.csv_on_skip_observer() -> string {
     call baml.csv.reader
     load_const 0
     store_var count
-    load_type baml.iter.Iterable<Item = baml.csv.CsvRecord, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterable<Error = baml.csv.CsvError | baml.errors.Io, Item = baml.csv.CsvRecord>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
 
   L0:
     load_var _7
-    load_type baml.iter.Iterator<Item = baml.csv.CsvRecord, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = baml.csv.CsvRecord>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
@@ -2793,14 +2793,14 @@ function csv.csv_open_streams_file() -> string {
     load_type csv.IntRow
     load_var r
     call baml.csv.CsvReader.rows
-    load_type baml.iter.Iterable<Item = csv.IntRow, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterable<Error = baml.csv.CsvError | baml.errors.Io, Item = csv.IntRow>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _12
 
   L0:
     load_var _12
-    load_type baml.iter.Iterator<Item = csv.IntRow, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = csv.IntRow>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
@@ -4044,14 +4044,14 @@ function csv.csv_record_snapshot_outlives_reader() -> string {
     alloc_array 0
     store_var kept
     load_var r
-    load_type baml.iter.Iterable<Item = baml.csv.CsvRecord, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterable<Error = baml.csv.CsvError | baml.errors.Io, Item = baml.csv.CsvRecord>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = baml.csv.CsvRecord, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = baml.csv.CsvRecord>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -4071,14 +4071,14 @@ function csv.csv_record_snapshot_outlives_reader() -> string {
     alloc_array 0
     store_var parts
     load_var kept
-    load_type baml.iter.Iterable<Item = baml.csv.CsvRecord, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = baml.csv.CsvRecord>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
 
   L3:
     load_var _13
-    load_type baml.iter.Iterator<Item = baml.csv.CsvRecord, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = baml.csv.CsvRecord>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _14
@@ -4221,14 +4221,14 @@ function csv.csv_skip_mode_diagnostics() -> string {
     load_const 0
     store_var count
     load_var r
-    load_type baml.iter.Iterable<Item = baml.csv.CsvRecord, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterable<Error = baml.csv.CsvError | baml.errors.Io, Item = baml.csv.CsvRecord>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
 
   L0:
     load_var _5
-    load_type baml.iter.Iterator<Item = baml.csv.CsvRecord, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = baml.csv.CsvRecord>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
@@ -4332,14 +4332,14 @@ function csv.csv_skip_mode_typed_decode() -> string {
     load_type csv.IntRow
     load_var r
     call baml.csv.CsvReader.rows
-    load_type baml.iter.Iterable<Item = csv.IntRow, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterable<Error = baml.csv.CsvError | baml.errors.Io, Item = csv.IntRow>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
 
   L0:
     load_var _6
-    load_type baml.iter.Iterator<Item = csv.IntRow, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = csv.IntRow>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
@@ -4444,14 +4444,14 @@ function csv.csv_smoke_decode_user_enum_rows() -> string {
     call baml.csv.decode
     load_const ""
     store_var out
-    load_type baml.iter.Iterable<Item = csv.CsvSmokeEnumRow, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = csv.CsvSmokeEnumRow>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
 
   L0:
     load_var _5
-    load_type baml.iter.Iterator<Item = csv.CsvSmokeEnumRow, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = csv.CsvSmokeEnumRow>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
@@ -4537,14 +4537,14 @@ function csv.csv_smoke_on_error_skip() -> string {
     load_const 0
     store_var count
     load_var r
-    load_type baml.iter.Iterable<Item = baml.csv.CsvRecord, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterable<Error = baml.csv.CsvError | baml.errors.Io, Item = baml.csv.CsvRecord>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
 
   L0:
     load_var _5
-    load_type baml.iter.Iterator<Item = baml.csv.CsvRecord, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = baml.csv.CsvRecord>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
@@ -4605,14 +4605,14 @@ function csv.csv_smoke_reader_streaming_get() -> int {
     call baml.csv.reader
     load_const 0
     store_var total
-    load_type baml.iter.Iterable<Item = baml.csv.CsvRecord, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterable<Error = baml.csv.CsvError | baml.errors.Io, Item = baml.csv.CsvRecord>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = baml.csv.CsvRecord, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = baml.csv.CsvRecord>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -4857,14 +4857,14 @@ function csv.csv_smoke_typed_returns_probe() -> string {
     load_type csv.CsvSmokeIntRow
     load_var r
     call baml.csv.CsvReader.rows
-    load_type baml.iter.Iterable<Item = csv.CsvSmokeIntRow, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterable<Error = baml.csv.CsvError | baml.errors.Io, Item = csv.CsvSmokeIntRow>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _12
 
   L3:
     load_var _12
-    load_type baml.iter.Iterator<Item = csv.CsvSmokeIntRow, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = csv.CsvSmokeIntRow>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
@@ -6058,14 +6058,14 @@ function csv.grid(rows: string[][]) -> string {
     alloc_array 0
     store_var out
     load_var rows
-    load_type baml.iter.Iterable<Item = string[], Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string[]>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = string[], Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string[]>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -6116,14 +6116,14 @@ function csv.join(parts: string[], sep: string) -> string {
     load_const true
     store_var first
     load_var parts
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
 
   L0:
     load_var _5
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _6

--- a/baml_language/crates/baml_tests/snapshots/baml_src/defer.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/defer.snap
@@ -395,14 +395,14 @@ function defer.defer_on_break_main() -> string[] {
     load_const 3
     load_type int
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -457,14 +457,14 @@ function defer.defer_on_continue_main() -> string[] {
     load_const 2
     load_type int
     alloc_array 2
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -520,14 +520,14 @@ function defer.defer_per_loop_iteration_main() -> string {
     load_const 3
     load_type int
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4

--- a/baml_language/crates/baml_tests/snapshots/baml_src/for_loops.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/for_loops.snap
@@ -106,14 +106,14 @@ function for_loops.for_loops_c_for_sum_to_ten() -> int {
 
 function for_loops.for_loops_first_even(xs: int[]) -> int {
     load_var xs
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _2
 
   L0:
     load_var _2
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
@@ -145,14 +145,14 @@ function for_loops.for_loops_for_with_break(xs: int[]) -> int {
     load_const 0
     store_var result
     load_var xs
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -184,14 +184,14 @@ function for_loops.for_loops_for_with_continue(xs: int[]) -> int {
     load_const 0
     store_var result
     load_var xs
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -221,14 +221,14 @@ function for_loops.for_loops_for_with_continue(xs: int[]) -> int {
 
 function for_loops.for_loops_has_empty_cell(grid: string[][]) -> bool {
     load_var grid
-    load_type baml.iter.Iterable<Item = string[], Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string[]>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _2
 
   L0:
     load_var _2
-    load_type baml.iter.Iterator<Item = string[], Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string[]>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
@@ -239,14 +239,14 @@ function for_loops.for_loops_has_empty_cell(grid: string[][]) -> bool {
 
   L1:
     load_var _3
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
 
   L2:
     load_var _8
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
@@ -274,14 +274,14 @@ function for_loops.for_loops_nested_for(arr_a: int[], arr_b: int[]) -> int {
     load_const 0
     store_var result
     load_var arr_a
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -292,14 +292,14 @@ function for_loops.for_loops_nested_for(arr_a: int[], arr_b: int[]) -> int {
 
   L1:
     load_var arr_b
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
 
   L2:
     load_var _9
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _10
@@ -325,14 +325,14 @@ function for_loops.for_loops_render(xs: string[]) -> string {
     load_const ""
     store_var result
     load_var xs
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -371,14 +371,14 @@ function for_loops.for_loops_sum(xs: int[]) -> int {
     load_const 0
     store_var result
     load_var xs
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -406,14 +406,14 @@ function for_loops.for_loops_sum_let_var() -> int {
     load_const 3
     load_type int
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -441,14 +441,14 @@ function for_loops.for_loops_sum_let_var_no_parens() -> int {
     load_const 30
     load_type int
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5

--- a/baml_language/crates/baml_tests/snapshots/baml_src/interfaces.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/interfaces.snap
@@ -1220,26 +1220,16 @@ function interfaces.BsmvAcc.BsmvAdder.addOne(self: interfaces.BsmvAcc, other: in
 
 function interfaces.BtviPrintable$for$T.display(self: #0) -> string {
     load_var self
-    is_type interfaces.BtviPerson
-    pop_jump_if_false L0
-    load_var self
-    load_field .0
+    load_type interfaces.BtviNamed
+    virtual_load_field .name
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.BtvsPrintable$for$T.display(self: #0) -> string {
     load_var self
-    is_type interfaces.BtvsPerson
-    pop_jump_if_false L0
-    load_var self
-    load_field .0
+    load_type interfaces.BtvsNamed
+    virtual_load_field .name
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.CimdGreeter.greet(self: interfaces.CimdGreeter) -> string {
@@ -1492,19 +1482,12 @@ function interfaces.DkslLogger.log(self: interfaces.DkslLogger, msg: string) -> 
 }
 
 function interfaces.DmdtAnimal.describe(self: interfaces.DmdtAnimal) -> string {
-    load_var self
-    is_type interfaces.DmdtDog
-    pop_jump_if_false L0
-    load_var self
-    load_field .0
-    store_var _2
     load_const "animal: "
-    load_var _2
+    load_var self
+    load_type interfaces.DmdtAnimal
+    virtual_load_field .name
     bin_op +
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.DmdtDog.DmdtAnimal.speak(self: interfaces.DmdtDog) -> string {
@@ -1609,15 +1592,9 @@ function interfaces.DwoaTip.name(self: interfaces.DwoaTip) -> string {
 function interfaces.F1bgPrintable$for$F1bgWrapper<T>.display(self: interfaces.F1bgWrapper<#0>) -> string {
     load_var self
     load_field .inner
-    store_var_load_var _2
-    is_type interfaces.F1bgPerson
-    pop_jump_if_false L0
-    load_var _2
-    load_field .0
+    load_type interfaces.F1bgNamed
+    virtual_load_field .name
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.F1dPrintable$for$F1dBox<T>.display(self: interfaces.F1dBox<#0>) -> string {
@@ -1644,92 +1621,39 @@ function interfaces.F1saDescribable$for$F1saPair<T>.describe(self: interfaces.F1
 
 function interfaces.F2amPrintable$for$T.display(self: #0) -> string {
     load_var self
-    is_type interfaces.F2amTeam
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var self
-    is_type interfaces.F2amPerson
-    pop_jump_if_false L3
-    load_var self
-    load_field .0
-    jump L2
-
-  L1:
-    load_var self
-    load_field .0
-
-  L2:
+    load_type interfaces.F2amNamed
+    virtual_load_field .name
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces.F2dPrintable$for$T.display(self: #0) -> string {
-    load_var self
-    is_type interfaces.F2dPerson
-    pop_jump_if_false L0
-    load_var self
-    load_field .0
-    store_var _2
     load_const "named:"
-    load_var _2
+    load_var self
+    load_type interfaces.F2dNamed
+    virtual_load_field .name
     bin_op +
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.F2riPrintable$for$T.display(self: #0) -> string {
     load_var self
-    is_type interfaces.F2riPerson
-    pop_jump_if_false L0
-    load_var self
-    load_field .0
+    load_type interfaces.F2riNamed
+    virtual_load_field .name
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.F2rsPrintable$for$T.display(self: #0) -> string {
     load_var self
-    is_type interfaces.F2rsPerson
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var self
-    is_type interfaces.F2rsTeam
-    pop_jump_if_false L3
-    load_var self
-    load_field .0
-    jump L2
-
-  L1:
-    load_var self
-    load_field .0
-
-  L2:
+    load_type interfaces.F2rsNamed
+    virtual_load_field .name
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces.F2saLabeled$for$T.label(self: #0) -> string {
     load_var self
-    is_type interfaces.F2saProject
-    pop_jump_if_false L0
-    load_var self
-    load_field .0
+    load_type interfaces.F2saNamed
+    virtual_load_field .name
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.Fz03Dog.Fz03Animal.speak(self: interfaces.Fz03Dog) -> string {
@@ -2145,19 +2069,12 @@ function interfaces.MsmaBox.MsmaEquatable.same(self: interfaces.MsmaBox, other: 
 }
 
 function interfaces.OdndAnimal.describe(self: interfaces.OdndAnimal) -> string {
-    load_var self
-    is_type interfaces.OdndCat
-    pop_jump_if_false L0
-    load_var self
-    load_field .0
-    store_var _2
     load_const "default:"
-    load_var _2
+    load_var self
+    load_type interfaces.OdndAnimal
+    virtual_load_field .name
     bin_op +
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.OdndCat.OdndAnimal.describe(self: interfaces.OdndCat) -> string {
@@ -2193,38 +2110,15 @@ function interfaces.RcflLeaf.RcflA.tag(self: interfaces.RcflLeaf) -> string {
 
 function interfaces.RcpfPerson.introduce(self: interfaces.RcpfPerson) -> string {
     load_var self
-    is_type interfaces.RcpfEmployee
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var self
-    is_type interfaces.RcpfEmployee
-    pop_jump_if_false L3
-    load_var self
-    load_field .0
-    jump L2
-
-  L1:
-    load_var self
-    load_field .0
-
-  L2:
+    load_type interfaces.RcpfNamed
+    virtual_load_field .name
     load_const " the "
     bin_op +
-    store_var _2
     load_var self
-    is_type interfaces.RcpfEmployee
-    pop_jump_if_false L3
-    load_var self
-    load_field .1
-    store_var _6
-    load_var2 2 3
+    load_type interfaces.RcpfPerson
+    virtual_load_field .occupation
     bin_op +
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces.RcpmBox.RcpmParent<int>.describe(self: interfaces.RcpmBox) -> string {
@@ -2441,14 +2335,9 @@ function interfaces.W302Loud$for$T.shout(self: #0) -> string {
 
 function interfaces.W302Printable$for$T.display(self: #0) -> string {
     load_var self
-    is_type interfaces.W302Person
-    pop_jump_if_false L0
-    load_var self
-    load_field .0
+    load_type interfaces.W302Named
+    virtual_load_field .name
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.W304Named.describe(self: interfaces.W304Named) -> string {
@@ -2457,20 +2346,10 @@ function interfaces.W304Named.describe(self: interfaces.W304Named) -> string {
 }
 
 function interfaces.W304P.W304Named.describe(self: interfaces.W304P) -> string {
-    load_var self
-    is_type interfaces.W304P
-    pop_jump_if_false L0
-    load_var self
-    load_field .name
-    store_var _7
-    load_var self
-    is_type interfaces.W304P
-    pop_jump_if_false L0
-    load_var self
-    load_field .0
-    store_var _10
     load_const "default.name=["
-    load_var _7
+    load_var self
+    load_type interfaces.W304Named
+    virtual_load_field .name
     bin_op +
     load_const "] self.name=["
     bin_op +
@@ -2479,14 +2358,13 @@ function interfaces.W304P.W304Named.describe(self: interfaces.W304P) -> string {
     bin_op +
     load_const "] as=["
     bin_op +
-    load_var _10
+    load_var self
+    load_type interfaces.W304Named
+    virtual_load_field .name
     bin_op +
     load_const "]"
     bin_op +
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.W307IntBox.W307Box<int>.get(self: interfaces.W307IntBox) -> int {
@@ -2545,19 +2423,12 @@ function interfaces.W3ooDebuggable$for$int.debugW3oo(self: int) -> string {
 }
 
 function interfaces.W3spPerson.W3spNamed.greet(self: interfaces.W3spPerson) -> string {
-    load_var self
-    is_type interfaces.W3spPerson
-    pop_jump_if_false L0
-    load_var self
-    load_field .0
-    store_var _2
     load_const "Hi "
-    load_var _2
+    load_var self
+    load_type interfaces.W3spNamed
+    virtual_load_field .name
     bin_op +
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.W3umCat.W3umAnimal.speak(self: interfaces.W3umCat) -> string {
@@ -2594,35 +2465,21 @@ function interfaces.ausi_main() -> bool {
     load_const "widget"
     load_const "WIDGET-001"
     init_instance user.interfaces.AusiItem .named_name, .labeled_name
-    store_var i
-    load_var i
-    store_var_load_var _4
-    is_type interfaces.AusiItem
-    pop_jump_if_false L1
-    load_var _4
-    load_field .0
-    store_var _3
-    load_var _3
+    store_var_load_var i
+    load_type interfaces.AusiNamed
+    virtual_load_field .name
     load_const "widget"
     cmp_op ==
     jump_if_false L0
     pop 1
     load_var i
-    store_var_load_var _7
-    is_type interfaces.AusiItem
-    pop_jump_if_false L1
-    load_var _7
-    load_field .1
-    store_var _6
-    load_var _6
+    load_type interfaces.AusiLabeled
+    virtual_load_field .name
     load_const "WIDGET-001"
     cmp_op ==
 
   L0:
     return
-
-  L1:
-    unreachable
 }
 
 function interfaces.bgfb_forward(x: #0) -> bool {
@@ -2770,30 +2627,20 @@ function interfaces.cofs_main() -> bool {
     load_const 0
     load_const "localhost"
     init_instance user.interfaces.CofsServer .host, .config_host
-    store_var s
-    load_var s
-    store_var c
-    load_var s
+    store_var_load_var s
     load_field .host
     load_const 0
     cmp_int_op ==
     jump_if_false L0
     pop 1
-    load_var c
-    is_type interfaces.CofsServer
-    pop_jump_if_false L1
-    load_var c
-    load_field .1
-    store_var _5
-    load_var _5
+    load_var s
+    load_type interfaces.CofsConfig
+    virtual_load_field .host
     load_const "localhost"
     cmp_op ==
 
   L0:
     return
-
-  L1:
-    unreachable
 }
 
 function interfaces.comc_main() -> string {
@@ -2823,28 +2670,9 @@ function interfaces.crid_main() -> bool {
 function interfaces.ctpi_main() -> string {
     load_const "Alice"
     init_instance user.interfaces.CtpiEmployee .name
-    store_var_load_var n
-    is_type interfaces.CtpiEmployee
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var n
-    is_type interfaces.CtpiEmployee
-    pop_jump_if_false L3
-    load_var n
-    load_field .0
-    jump L2
-
-  L1:
-    load_var n
-    load_field .0
-
-  L2:
+    load_type interfaces.CtpiNamed
+    virtual_load_field .name
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces.dapc_main() -> string {
@@ -3156,15 +2984,9 @@ function interfaces.dtai_main() -> string {
     alloc_array 1
     load_const 0
     load_array_element
-    store_var_load_var _3
-    is_type interfaces.DtaiCat
-    pop_jump_if_false L0
-    load_var _3
-    load_field .0
+    load_type interfaces.DtaiAnimal
+    virtual_load_field .name
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.dtba_main() -> string {
@@ -3652,79 +3474,29 @@ function interfaces.fz20_main() -> string {
     init_instance user.interfaces.Fz20D .a_label, .b_label
     store_var d
     load_var d
-    store_var_load_var _3
-    is_type interfaces.Fz20D
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var _3
-    is_type interfaces.Fz20D
-    pop_jump_if_false L3
-    load_var _3
-    load_field .1
-    store_var a_val
-    jump L2
-
-  L1:
-    load_var _3
-    load_field .0
-    store_var a_val
-
-  L2:
-    load_var d
-    store_var_load_var _7
-    is_type interfaces.Fz20D
-    pop_jump_if_false L3
-    load_var _7
-    load_field .1
-    store_var b_val
-    load_var a_val
+    load_type interfaces.Fz20A
+    virtual_load_field .label
     load_const "|"
     bin_op +
-    load_var b_val
+    load_var d
+    load_type interfaces.Fz20B
+    virtual_load_field .label
     bin_op +
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces.fz21_get_from_a(a: interfaces.Fz21A) -> string {
     load_var a
-    is_type interfaces.Fz21D
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var a
-    is_type interfaces.Fz21D
-    pop_jump_if_false L3
-    load_var a
-    load_field .1
-    jump L2
-
-  L1:
-    load_var a
-    load_field .0
-
-  L2:
+    load_type interfaces.Fz21A
+    virtual_load_field .label
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces.fz21_get_from_b(b: interfaces.Fz21B) -> string {
     load_var b
-    is_type interfaces.Fz21D
-    pop_jump_if_false L0
-    load_var b
-    load_field .1
+    load_type interfaces.Fz21B
+    virtual_load_field .label
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.fz21_main() -> string {
@@ -4130,15 +3902,9 @@ function interfaces.gben_first_name(items: #0[]) -> string {
     load_var items
     load_const 0
     load_array_element
-    store_var_load_var _2
-    is_type interfaces.GbenDog
-    pop_jump_if_false L0
-    load_var _2
-    load_field .0
+    load_type interfaces.GbenNamed
+    virtual_load_field .name
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.gben_main() -> string {
@@ -4157,15 +3923,9 @@ function interfaces.gbr_first_name(items: #0[]) -> string {
     load_var items
     load_const 0
     load_array_element
-    store_var_load_var _2
-    is_type interfaces.GbrDog
-    pop_jump_if_false L0
-    load_var _2
-    load_field .0
+    load_type interfaces.GbrNamed
+    virtual_load_field .name
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.gbr_main() -> string {
@@ -4204,44 +3964,18 @@ function interfaces.gbsp_same(x: #0, y: #0) -> bool {
 }
 
 function interfaces.gbte_greet(p: #0) -> string {
-    load_var p
-    is_type interfaces.GbteEmployee
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var p
-    is_type interfaces.GbteEmployee
-    pop_jump_if_false L3
-    load_var p
-    load_field .0
-    store_var _4
-    jump L2
-
-  L1:
-    load_var p
-    load_field .0
-    store_var _4
-
-  L2:
     load_const "Hi, "
-    load_var _4
+    load_var p
+    load_type interfaces.GbteNamed
+    virtual_load_field .name
     bin_op +
     load_const " the "
     bin_op +
-    store_var _2
     load_var p
-    is_type interfaces.GbteEmployee
-    pop_jump_if_false L3
-    load_var p
-    load_field .1
-    store_var _7
-    load_var2 2 4
+    load_type interfaces.GbtePerson
+    virtual_load_field .occupation
     bin_op +
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces.gbte_main() -> string {
@@ -4346,42 +4080,17 @@ function interfaces.grpa_main() -> string {
 function interfaces.grpf_main() -> int {
     load_const 42
     init_instance user.interfaces.GrpfBox .value
-    store_var_load_var child
-    is_type interfaces.GrpfBox
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var child
-    is_type interfaces.GrpfBox
-    pop_jump_if_false L3
-    load_var child
-    load_field .0
-    jump L2
-
-  L1:
-    load_var child
-    load_field .0
-
-  L2:
+    load_type interfaces.GrpfParent<int>
+    virtual_load_field .value
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces.grpl_main() -> int {
     load_const 42
     init_instance user.interfaces.GrplBox .stored
-    store_var_load_var child
-    is_type interfaces.GrplBox
-    pop_jump_if_false L0
-    load_var child
-    load_field .0
+    load_type interfaces.GrplParent<int>
+    virtual_load_field .value
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.grpt_main() -> string {
@@ -4452,23 +4161,15 @@ function interfaces.ifcc_main() -> bool {
     store_var s
     load_var s
     store_var_load_var c
-    is_type interfaces.IfccServer
-    pop_jump_if_false L3
-    load_var c
-    load_field .0
-    store_var _6
-    load_var _6
+    load_type interfaces.IfccConfig
+    virtual_load_field .host
     load_const "localhost"
     cmp_op ==
     jump_if_false L0
     pop 1
     load_var c
-    is_type interfaces.IfccServer
-    pop_jump_if_false L3
-    load_var c
-    load_field .1
-    store_var _8
-    load_var _8
+    load_type interfaces.IfccConfig
+    virtual_load_field .port
     load_const 8080
     cmp_int_op ==
 
@@ -4490,9 +4191,6 @@ function interfaces.ifcc_main() -> bool {
 
   L2:
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces.ifvr_main() -> int {
@@ -4501,28 +4199,9 @@ function interfaces.ifvr_main() -> int {
     load_const "PM"
     load_const 1.0
     init_instance user.interfaces.IfvrEmployee .name, .age, .occupation, .salary
-    store_var_load_var a
-    is_type interfaces.IfvrEmployee
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var a
-    is_type interfaces.IfvrEmployee
-    pop_jump_if_false L3
-    load_var a
-    load_field .1
-    jump L2
-
-  L1:
-    load_var a
-    load_field .1
-
-  L2:
+    load_type interfaces.IfvrAged
+    virtual_load_field .age
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces.itic_main() -> string {
@@ -4605,33 +4284,12 @@ function interfaces.mdci_main() -> string {
 }
 
 function interfaces.mdid_describe(a: interfaces.MdidAnimal) -> string {
-    load_var a
-    is_type interfaces.MdidCat
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var a
-    is_type interfaces.MdidDog
-    pop_jump_if_false L3
-    load_var a
-    load_field .0
-    store_var _2
-    jump L2
-
-  L1:
-    load_var a
-    load_field .0
-    store_var _2
-
-  L2:
     load_const "animal: "
-    load_var _2
+    load_var a
+    load_type interfaces.MdidAnimal
+    virtual_load_field .name
     bin_op +
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces.mdid_main() -> string {
@@ -4677,35 +4335,22 @@ function interfaces.midr_describe(s: interfaces.MidrSwitch) -> string {
     is_type interfaces.MidrSwitch
     pop_jump_if_false L0
     load_var s
-    is_type interfaces.MidrLamp
-    pop_jump_if_false L3
-    load_var s
-    load_field .0
-    store_var _3
-    load_var _3
+    load_type interfaces.MidrSwitch
+    virtual_load_field .active
     load_const true
     cmp_op ==
     pop_jump_if_false L0
     jump L1
 
   L0:
-    load_var s
-    is_type interfaces.MidrLamp
-    pop_jump_if_false L3
     load_const "off"
     jump L2
 
   L1:
-    load_var s
-    is_type interfaces.MidrLamp
-    pop_jump_if_false L3
     load_const "on"
 
   L2:
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces.midr_main() -> string {
@@ -4846,28 +4491,9 @@ function interfaces.rcep_main() -> string {
     load_const "Alice"
     load_const "PM"
     init_instance user.interfaces.RcepEmployee .name, .occupation
-    store_var_load_var p
-    is_type interfaces.RcepEmployee
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var p
-    is_type interfaces.RcepEmployee
-    pop_jump_if_false L3
-    load_var p
-    load_field .0
-    jump L2
-
-  L1:
-    load_var p
-    load_field .0
-
-  L2:
+    load_type interfaces.RcepNamed
+    virtual_load_field .name
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces.rcfl_main() -> string {
@@ -5050,37 +4676,21 @@ function interfaces.sfnd_main() -> bool {
     load_const "abc"
     load_const 42
     init_instance user.interfaces.SfndThing .text_id, .numeric_id
-    store_var t
-    load_var t
-    store_var text
-    load_var t
-    store_var numeric
-    load_var text
-    is_type interfaces.SfndThing
-    pop_jump_if_false L1
-    load_var text
-    load_field .0
-    store_var _5
-    load_var _5
+    store_var_load_var t
+    load_type interfaces.SfndHasId
+    virtual_load_field .id
     load_const "abc"
     cmp_op ==
     jump_if_false L0
     pop 1
-    load_var numeric
-    is_type interfaces.SfndThing
-    pop_jump_if_false L1
-    load_var numeric
-    load_field .1
-    store_var _7
-    load_var _7
+    load_var t
+    load_type interfaces.SfndHasNumId
+    virtual_load_field .id
     load_const 42
     cmp_int_op ==
 
   L0:
     return
-
-  L1:
-    unreachable
 }
 
 function interfaces.sgid_main() -> bool {
@@ -5128,37 +4738,21 @@ function interfaces.sgif_main() -> bool {
     load_const 7
     load_const "seven"
     init_instance user.interfaces.SgifPair .int_value, .string_value
-    store_var p
-    load_var p
-    store_var i
-    load_var p
-    store_var s
-    load_var i
-    is_type interfaces.SgifPair
-    pop_jump_if_false L1
-    load_var i
-    load_field .0
-    store_var _5
-    load_var _5
+    store_var_load_var p
+    load_type interfaces.SgifSlot<int>
+    virtual_load_field .value
     load_const 7
     cmp_int_op ==
     jump_if_false L0
     pop 1
-    load_var s
-    is_type interfaces.SgifPair
-    pop_jump_if_false L1
-    load_var s
-    load_field .1
-    store_var _7
-    load_var _7
+    load_var p
+    load_type interfaces.SgifSlot<string>
+    virtual_load_field .value
     load_const "seven"
     cmp_op ==
 
   L0:
     return
-
-  L1:
-    unreachable
 }
 
 function interfaces.spma_combine(x: #0, ys: #0[]) -> int {
@@ -5191,14 +4785,9 @@ function interfaces.srit_main() -> int {
     virtual_call nargs=1 ntypeargs=0
     store_var cloned
     load_var cloned
-    is_type interfaces.SritBox
-    pop_jump_if_false L0
-    load_var cloned
-    load_field .0
+    load_type interfaces.SritCloneable
+    virtual_load_field .value
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.srtc_main() -> int {
@@ -5245,37 +4834,21 @@ function interfaces.tisf_main() -> bool {
     load_const "widget"
     load_const "WIDGET-001"
     init_instance user.interfaces.TisfItem .named_name, .labeled_name
-    store_var i
-    load_var i
-    store_var n
-    load_var i
-    store_var l
-    load_var n
-    is_type interfaces.TisfItem
-    pop_jump_if_false L1
-    load_var n
-    load_field .0
-    store_var _5
-    load_var _5
+    store_var_load_var i
+    load_type interfaces.TisfNamed
+    virtual_load_field .name
     load_const "widget"
     cmp_op ==
     jump_if_false L0
     pop 1
-    load_var l
-    is_type interfaces.TisfItem
-    pop_jump_if_false L1
-    load_var l
-    load_field .1
-    store_var _7
-    load_var _7
+    load_var i
+    load_type interfaces.TisfLabeled
+    virtual_load_field .name
     load_const "WIDGET-001"
     cmp_op ==
 
   L0:
     return
-
-  L1:
-    unreachable
 }
 
 function interfaces.uf01_main() -> string {
@@ -5287,14 +4860,9 @@ function interfaces.uf01_main() -> string {
 
 function interfaces.uf01_readName(x: interfaces.Uf01Dog | interfaces.Uf01Named) -> string {
     load_var x
-    is_type interfaces.Uf01Dog
-    pop_jump_if_false L0
-    load_var x
-    load_field .0
+    load_type interfaces.Uf01Named
+    virtual_load_field .name
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.uf02_addOne(x: interfaces.Uf02Slot<int> | interfaces.Uf02Slot<string>) -> int {
@@ -5311,21 +4879,13 @@ function interfaces.uf02_addOne(x: interfaces.Uf02Slot<int> | interfaces.Uf02Slo
 
   L1:
     load_var _2
-    store_var_load_var a
-    is_type interfaces.Uf02IntSlot
-    pop_jump_if_false L3
-    load_var a
-    load_field .0
-    store_var _4
-    load_var _4
+    load_type interfaces.Uf02Slot<int>
+    virtual_load_field .value
     load_const 1
     add_int
 
   L2:
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces.uf02_main() -> int {
@@ -5592,14 +5152,9 @@ function interfaces.ufp2_main() -> int {
 
 function interfaces.ufp3_getHandler(x: interfaces.Ufp3HasHandler | interfaces.Ufp3A) -> (int) -> string throws never {
     load_var x
-    is_type interfaces.Ufp3A
-    pop_jump_if_false L0
-    load_var x
-    load_field .0
+    load_type interfaces.Ufp3HasHandler
+    virtual_load_field .handler
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces.ufp3_main() -> string {
@@ -5630,10 +5185,8 @@ function interfaces.ufp4_readName(x: interfaces.Ufp4Dog | interfaces.Ufp4Named |
 
   L0:
     load_var x
-    is_type interfaces.Ufp4Dog
-    pop_jump_if_false L3
-    load_var x
-    load_field .0
+    load_type interfaces.Ufp4Named
+    virtual_load_field .name
     jump L2
 
   L1:
@@ -5641,9 +5194,6 @@ function interfaces.ufp4_readName(x: interfaces.Ufp4Dog | interfaces.Ufp4Named |
 
   L2:
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces.ufp5_main() -> int {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/interfaces.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/interfaces.snap
@@ -39,575 +39,610 @@ function interfaces.$init_test_ns_interfaces_interfaces(registry: testing.TestCo
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "interface_field_via_requires_chain_runtime"
+    load_const "symbolic_interface_view_selects_per_instantiation_link_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 5)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "default_call_from_override_returns_string"
+    load_const "interface_field_write_through_existential_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 6)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "default_resolves_to_current_block"
+    load_const "interface_field_write_through_bounded_type_var_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 7)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "as_projection_same_signature_runtime"
+    load_const "generic_implementor_field_resolves_from_receiver_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 8)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "as_projection_works_when_unambiguous_runtime"
+    load_const "interface_field_via_requires_chain_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 9)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "self_as_projection_call_inside_unrelated_block"
+    load_const "default_call_from_override_returns_string"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 10)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "diamond_as_projection_call_runtime"
+    load_const "default_resolves_to_current_block"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 11)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "interface_typed_var_dispatches_to_concrete"
+    load_const "as_projection_same_signature_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 12)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "heterogeneous_interface_array_dispatches"
+    load_const "as_projection_works_when_unambiguous_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 13)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "cast_to_parent_interface_via_requires_runtime"
+    load_const "self_as_projection_call_inside_unrelated_block"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 14)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "default_method_dispatch_through_interface_var"
+    load_const "diamond_as_projection_call_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 15)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "interface_default_method_calls_self_param_method"
+    load_const "interface_typed_var_dispatches_to_concrete"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 16)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "generic_bound_self_param_method_call"
+    load_const "heterogeneous_interface_array_dispatches"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 17)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "self_param_method_accepts_matching_nested_self"
+    load_const "cast_to_parent_interface_via_requires_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 18)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "bound_self_method_value_accepts_matching_arg"
+    load_const "default_method_dispatch_through_interface_var"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 19)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "interface_default_method_reference_accepts_explicit_receiver"
+    load_const "interface_default_method_calls_self_param_method"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 20)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "throwing_interface_dispatch_uses_active_catch"
+    load_const "generic_bound_self_param_method_call"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 21)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "override_dispatched_not_default"
+    load_const "self_param_method_accepts_matching_nested_self"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 22)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "match_narrows_to_concrete_field_access"
+    load_const "bound_self_method_value_accepts_matching_arg"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 23)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "match_destructures_interface_fields"
+    load_const "interface_default_method_reference_accepts_explicit_receiver"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 24)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "match_destructures_interface_fields_directly"
+    load_const "throwing_interface_dispatch_uses_active_catch"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 25)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "match_interface_destructure_respects_field_subpatterns"
+    load_const "override_dispatched_not_default"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 26)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "match_destructures_concrete_implementor_fields"
+    load_const "match_narrows_to_concrete_field_access"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 27)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "match_open_interface_with_wildcard_works"
+    load_const "match_destructures_interface_fields"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 28)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "generic_interface_concrete_type_param_runtime"
+    load_const "match_destructures_interface_fields_directly"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 29)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "same_generic_interface_different_type_params_disambiguated_with_as_projection"
+    load_const "match_interface_destructure_respects_field_subpatterns"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 30)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "generic_bound_runtime"
+    load_const "match_destructures_concrete_implementor_fields"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 31)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "reflect_type_of_interface_to_string"
+    load_const "match_open_interface_with_wildcard_works"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 32)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "reflect_implements_true_for_implementor"
+    load_const "generic_interface_concrete_type_param_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 33)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "reflect_implements_false_for_non_implementor"
+    load_const "same_generic_interface_different_type_params_disambiguated_with_as_projection"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 34)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "reflect_implemented_by_inverse_runtime"
+    load_const "generic_bound_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 35)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "reflect_implements_transitive_via_requires"
+    load_const "reflect_type_of_interface_to_string"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 36)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "reflect_implementors_lists_lexicographic_order_and_identity"
+    load_const "reflect_implements_true_for_implementor"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 37)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "reflect_implementors_empty_for_concrete_class"
+    load_const "reflect_implements_false_for_non_implementor"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 38)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "reflect_implementors_empty_for_primitive"
+    load_const "reflect_implemented_by_inverse_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 39)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "reflect_implements_inside_generic_function"
+    load_const "reflect_implements_transitive_via_requires"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 40)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "reflect_interface_does_not_implement_itself"
+    load_const "reflect_implementors_lists_lexicographic_order_and_identity"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 41)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "class_own_method_callable_from_implements_block"
+    load_const "reflect_implementors_empty_for_concrete_class"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 42)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "class_inherent_method_does_not_override_interface_default_through_existential"
+    load_const "reflect_implementors_empty_for_primitive"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 43)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "generic_bound_extends_named_runtime"
+    load_const "reflect_implements_inside_generic_function"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 44)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "generic_bound_as_projection_selects_generic_interface_instantiation"
+    load_const "reflect_interface_does_not_implement_itself"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 45)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "generic_bound_direct_method_call_dispatches_through_interface"
+    load_const "class_own_method_callable_from_implements_block"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 46)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "generic_interface_method_preserves_method_type_param"
+    load_const "class_inherent_method_does_not_override_interface_default_through_existential"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 47)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "generic_bound_through_extends_chain"
+    load_const "generic_bound_extends_named_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 48)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "self_return_type_carries_concrete_class"
+    load_const "generic_bound_as_projection_selects_generic_interface_instantiation"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 49)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "self_return_on_interface_typed_receiver_collapses_to_interface"
+    load_const "generic_bound_direct_method_call_dispatches_through_interface"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 50)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "multi_self_method_accepts_concrete_receiver"
+    load_const "generic_interface_method_preserves_method_type_param"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 51)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "concrete_receiver_inherited_default_self_param_method"
+    load_const "generic_bound_through_extends_chain"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 52)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "bounded_generic_forwarded_to_bounded_call_is_accepted"
+    load_const "self_return_type_carries_concrete_class"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 53)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "interface_to_interface_conversion_via_unknown_match_narrowing"
+    load_const "self_return_on_interface_typed_receiver_collapses_to_interface"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 54)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "as_upcast_selects_interface_field_link_runtime"
+    load_const "multi_self_method_accepts_concrete_receiver"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 55)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "dispatch_through_function_call_result"
+    load_const "concrete_receiver_inherited_default_self_param_method"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 56)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "dispatch_through_array_index_with_field_access"
+    load_const "bounded_generic_forwarded_to_bounded_call_is_accepted"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 57)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "dispatch_through_field_access_chain"
+    load_const "interface_to_interface_conversion_via_unknown_match_narrowing"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 58)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "requires_chain_four_levels_deep"
+    load_const "as_upcast_selects_interface_field_link_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 59)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "diamond_call_through_interface_typed_var"
+    load_const "dispatch_through_function_call_result"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 60)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "dispatch_chained_three_function_calls_returning_interfaces"
+    load_const "dispatch_through_array_index_with_field_access"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 61)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "dispatch_chained_methods_returning_interface_each_level"
+    load_const "dispatch_through_field_access_chain"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 62)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "dispatch_through_nested_array_of_arrays"
+    load_const "requires_chain_four_levels_deep"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 63)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "dispatch_through_field_of_array_of_interface"
+    load_const "diamond_call_through_interface_typed_var"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 64)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "dispatch_through_five_level_field_chain"
+    load_const "dispatch_chained_three_function_calls_returning_interfaces"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 65)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "dispatch_through_map_value_field_then_method"
+    load_const "dispatch_chained_methods_returning_interface_each_level"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 66)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "dispatch_through_branch_assigned_interface"
+    load_const "dispatch_through_nested_array_of_arrays"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 67)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "dispatch_for_loop_over_interface_array_collects_results"
+    load_const "dispatch_through_field_of_array_of_interface"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 68)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "diamond_six_level_requires_chain"
+    load_const "dispatch_through_five_level_field_chain"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 69)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "diamond_with_overrides_at_each_level"
+    load_const "dispatch_through_map_value_field_then_method"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 70)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "double_diamond_two_independent_inheritance_paths"
+    load_const "dispatch_through_branch_assigned_interface"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 71)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "default_called_twice_in_one_override_body"
+    load_const "dispatch_for_loop_over_interface_array_collects_results"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 72)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "default_call_with_computed_argument_expression"
+    load_const "diamond_six_level_requires_chain"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 73)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "default_keyword_shadowed_by_local_variable_resolves_to_local"
+    load_const "diamond_with_overrides_at_each_level"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 74)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "requires_chain_exposes_parent_fields"
+    load_const "double_diamond_two_independent_inheritance_paths"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 75)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "requires_chain_parent_field_in_default_method"
+    load_const "default_called_twice_in_one_override_body"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 76)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "out_of_body_implements_is_visible_to_reflection_registry"
+    load_const "default_call_with_computed_argument_expression"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 77)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "out_of_body_implements_for_primitive_as_projection_runtime"
+    load_const "default_keyword_shadowed_by_local_variable_resolves_to_local"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 78)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "default_call_from_out_of_body_override_runtime"
+    load_const "requires_chain_exposes_parent_fields"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 79)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "default_call_from_generic_out_of_body_override_runtime"
+    load_const "requires_chain_parent_field_in_default_method"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 80)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "generic_out_of_body_override_preserves_method_type_args_runtime"
+    load_const "out_of_body_implements_is_visible_to_reflection_registry"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 81)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "generic_requires_parent_args_dispatch_on_class_implementor"
+    load_const "out_of_body_implements_for_primitive_as_projection_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 82)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "generic_requires_parent_field_args_runtime"
+    load_const "default_call_from_out_of_body_override_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 83)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "generic_requires_parent_field_alias_runtime"
+    load_const "default_call_from_generic_out_of_body_override_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 84)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "generic_requires_parent_args_dispatch_on_type_implementor"
+    load_const "generic_out_of_body_override_preserves_method_type_args_runtime"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 85)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.interfaces"
-    load_const "requires_closure_preserves_multiple_parent_instantiations_runtime"
+    load_const "generic_requires_parent_args_dispatch_on_class_implementor"
     make_closure .<lambda($init_test_ns_interfaces_interfaces, 86)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.interfaces"
+    load_const "generic_requires_parent_field_args_runtime"
+    make_closure .<lambda($init_test_ns_interfaces_interfaces, 87)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.interfaces"
+    load_const "generic_requires_parent_field_alias_runtime"
+    make_closure .<lambda($init_test_ns_interfaces_interfaces, 88)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.interfaces"
+    load_const "generic_requires_parent_args_dispatch_on_type_implementor"
+    make_closure .<lambda($init_test_ns_interfaces_interfaces, 89)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.interfaces"
+    load_const "requires_closure_preserves_multiple_parent_instantiations_runtime"
+    make_closure .<lambda($init_test_ns_interfaces_interfaces, 90)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.interfaces"
+    load_const "interface_type_args_match_positionally_runtime"
+    make_closure .<lambda($init_test_ns_interfaces_interfaces, 91)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
@@ -2001,6 +2036,16 @@ function interfaces.IdmcPair.IdmcEquatable.eq(self: interfaces.IdmcPair, other: 
 
 function interfaces.IdmrDescribable.describe(self: interfaces.IdmrDescribable) -> string {
     load_const "default"
+    return
+}
+
+function interfaces.ItampBoth.ItampConv<int, string>.tag(self: interfaces.ItampBoth) -> string {
+    load_const "int->string"
+    return
+}
+
+function interfaces.ItampBoth.ItampConv<string, int>.tag(self: interfaces.ItampBoth) -> string {
+    load_const "string->int"
     return
 }
 
@@ -4013,6 +4058,35 @@ function interfaces.gict_main() -> int {
     return
 }
 
+function interfaces.gif_main() -> bool {
+    load_const 1
+    load_const "one"
+    load_type int
+    init_instance<1> user.interfaces.GifBox .payload, .held
+    call user.interfaces.gif_read
+    load_const "one"
+    cmp_op ==
+    jump_if_false L0
+    pop 1
+    load_const "x"
+    load_const "ex"
+    load_type string
+    init_instance<1> user.interfaces.GifBox .payload, .held
+    call user.interfaces.gif_read
+    load_const "ex"
+    cmp_op ==
+
+  L0:
+    return
+}
+
+function interfaces.gif_read(h: interfaces.GifHolder) -> string {
+    load_var h
+    load_type interfaces.GifHolder
+    virtual_load_field .held
+    return
+}
+
 function interfaces.gimp_main() -> string {
     load_type string
     alloc_instance user.interfaces.GimpEchoer
@@ -4201,6 +4275,102 @@ function interfaces.ifvr_main() -> int {
     init_instance user.interfaces.IfvrEmployee .name, .age, .occupation, .salary
     load_type interfaces.IfvrAged
     virtual_load_field .age
+    return
+}
+
+function interfaces.ifw_bump(t: #0) -> void {
+    load_var t
+    load_type interfaces.IfwCounter
+    virtual_load_field .count
+    store_var _2
+    load_var _2
+    load_const 100
+    add_int
+    store_var _2
+    load_var2 1 2
+    load_type interfaces.IfwCounter
+    virtual_store_field .count
+    load_const null
+    return
+}
+
+function interfaces.ifw_main() -> bool {
+    load_const "b"
+    load_const 1
+    init_instance user.interfaces.IfwBox .label, .count
+    store_var b
+    load_var b
+    store_var c
+    load_var c
+    load_const 10
+    load_type interfaces.IfwCounter
+    virtual_store_field .count
+    load_var b
+    load_field .count
+    load_const 10
+    cmp_int_op ==
+    store_var after_assign
+    load_var c
+    load_type interfaces.IfwCounter
+    virtual_load_field .count
+    store_var _5
+    load_var _5
+    load_const 5
+    add_int
+    store_var _5
+    load_var2 2 4
+    load_type interfaces.IfwCounter
+    virtual_store_field .count
+    load_var after_assign
+    jump_if_false L0
+    pop 1
+    load_var b
+    load_field .count
+    load_const 15
+    cmp_int_op ==
+
+  L0:
+    return
+}
+
+function interfaces.ifw_typevar_main() -> bool {
+    load_const "b"
+    load_const 1
+    init_instance user.interfaces.IfwBox .label, .count
+    store_var b
+    load_type interfaces.IfwBox
+    load_var b
+    call user.interfaces.ifw_bump
+    pop 1
+    load_var b
+    load_field .count
+    load_const 101
+    cmp_int_op ==
+    return
+}
+
+function interfaces.itamp_main() -> bool {
+    alloc_instance user.interfaces.ItampBoth
+    store_var_load_var p
+    load_type interfaces.ItampConv<int, string>
+    load_const "tag"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _5
+    load_var _5
+    load_const "int->string"
+    cmp_op ==
+    jump_if_false L0
+    pop 1
+    load_var p
+    load_type interfaces.ItampConv<string, int>
+    load_const "tag"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _6
+    load_var _6
+    load_const "string->int"
+    cmp_op ==
+
+  L0:
     return
 }
 
@@ -4748,6 +4918,35 @@ function interfaces.sgif_main() -> bool {
     load_var p
     load_type interfaces.SgifSlot<string>
     virtual_load_field .value
+    load_const "seven"
+    cmp_op ==
+
+  L0:
+    return
+}
+
+function interfaces.sgif_read(g: interfaces.SgifSlot<#0>) -> #0 {
+    load_var g
+    load_type interfaces.SgifSlot<#0>
+    virtual_load_field .value
+    return
+}
+
+function interfaces.sgif_symbolic_main() -> bool {
+    load_const 7
+    load_const "seven"
+    init_instance user.interfaces.SgifPair .int_value, .string_value
+    store_var p
+    load_type int
+    load_var p
+    call user.interfaces.sgif_read
+    load_const 7
+    cmp_int_op ==
+    jump_if_false L0
+    pop 1
+    load_type string
+    load_var p
+    call user.interfaces.sgif_read
     load_const "seven"
     cmp_op ==
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/interfaces.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/interfaces.snap
@@ -3037,14 +3037,14 @@ function interfaces.dflo_main() -> string {
     alloc_instance user.interfaces.DfloDog
     load_type interfaces.DfloAnimal
     alloc_array 5
-    load_type baml.iter.Iterable<Item = interfaces.DfloAnimal, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = interfaces.DfloAnimal>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
 
   L0:
     load_var _9
-    load_type baml.iter.Iterator<Item = interfaces.DfloAnimal, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = interfaces.DfloAnimal>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _10

--- a/baml_language/crates/baml_tests/snapshots/baml_src/interfaces_associated_types.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/interfaces_associated_types.snap
@@ -320,52 +320,26 @@ function interfaces_associated_types.Ticket.Describable.value(self: interfaces_a
 function interfaces_associated_types.UpcSummarizes$for$UpcEntityBox<T>.key(self: interfaces_associated_types.UpcEntityBox<#0>) -> string {
     load_var self
     load_field .value
-    store_var_load_var _2
-    is_type interfaces_associated_types.UpcUser
-    pop_jump_if_false L0
-    load_var _2
-    load_field .0
+    load_type interfaces_associated_types.UpcHasKey<Key = string>
+    virtual_load_field .key
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces_associated_types.UpcSummarizes$for$UpcEntityBox<T>.summary(self: interfaces_associated_types.UpcEntityBox<#0>) -> string {
     load_var self
-    load_field .value
-    store_var_load_var _4
-    is_type interfaces_associated_types.UpcUser
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var _4
-    is_type interfaces_associated_types.UpcUser
-    pop_jump_if_false L3
-    load_var _4
-    load_field .1
-    jump L2
-
-  L1:
-    load_var _4
-    load_field .1
-
-  L2:
-    load_const ":"
-    bin_op +
-    store_var _2
-    load_var self
     load_type interfaces_associated_types.UpcSummarizes<Key = string>
     load_const "key"
     virtual_call nargs=1 ntypeargs=0
-    store_var _7
-    load_var2 2 4
+    store_var _5
+    load_var self
+    load_field .value
+    load_type interfaces_associated_types.UpcNamed
+    virtual_load_field .name
+    load_const ":"
+    bin_op +
+    load_var _5
     bin_op +
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces_associated_types.adb_main() -> string {
@@ -658,21 +632,11 @@ function interfaces_associated_types.rdf_score(source: interfaces_associated_typ
 
   L1:
     load_var source
-    is_type interfaces_associated_types.RdfIntSource
-    pop_jump_if_false L3
-    load_var source
-    is_type interfaces_associated_types.RdfIntSource
-    pop_jump_if_false L3
-    load_var source
-    load_field .0
-    store_var _4
-    load_var _4
+    load_type interfaces_associated_types.RdfSource<Item = int>
+    virtual_load_field .value
 
   L2:
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces_associated_types.rdn_main() -> int {
@@ -1046,14 +1010,9 @@ function interfaces_associated_types.rpa_main() -> int {
 
 function interfaces_associated_types.upc_entity_key(value: #0) -> string {
     load_var value
-    is_type interfaces_associated_types.UpcUser
-    pop_jump_if_false L0
-    load_var value
-    load_field .0
+    load_type interfaces_associated_types.UpcHasKey<Key = string>
+    virtual_load_field .key
     return
-
-  L0:
-    unreachable
 }
 
 function interfaces_associated_types.upc_main() -> string {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/interfaces_associated_types.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/interfaces_associated_types.snap
@@ -235,7 +235,7 @@ function interfaces_associated_types.CaeIntDriver.CaeDriver<CaeTask<int>>.drive(
 
 function interfaces_associated_types.CaeTask.drive(self: interfaces_associated_types.CaeTask<#0>, driver: #3) -> #1 {
     load_var2 2 1
-    load_type interfaces_associated_types.CaeDriver<interfaces_associated_types.CaeTask<#0>, Output = #1, Error = #2>
+    load_type interfaces_associated_types.CaeDriver<interfaces_associated_types.CaeTask<#0>, Error = #2, Output = #1>
     load_const "drive"
     virtual_call nargs=2 ntypeargs=0
     store_var _0

--- a/baml_language/crates/baml_tests/snapshots/baml_src/interfaces_class_generics.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/interfaces_class_generics.snap
@@ -53,28 +53,9 @@ function interfaces_class_generics.AemValue.AemEq<T>.get(self: interfaces_class_
 function interfaces_class_generics.Box.label(self: interfaces_class_generics.Box<#0>) -> string {
     load_var self
     load_field .value
-    store_var_load_var _2
-    is_type interfaces_class_generics.Person
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var _2
-    is_type interfaces_class_generics.Dog
-    pop_jump_if_false L3
-    load_var _2
-    load_field .0
-    jump L2
-
-  L1:
-    load_var _2
-    load_field .0
-
-  L2:
+    load_type interfaces_class_generics.Named
+    virtual_load_field .name
     return
-
-  L3:
-    unreachable
 }
 
 function interfaces_class_generics.McapIntDriver.McapDriver<McapTask<int>>.drive(self: interfaces_class_generics.McapIntDriver, input: interfaces_class_generics.McapTask<int>) -> string {
@@ -141,25 +122,7 @@ function interfaces_class_generics.function_class_generic_bound_member_access_fn
 
 function interfaces_class_generics.get_name(value: #0) -> string {
     load_var value
-    is_type interfaces_class_generics.Person
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var value
-    is_type interfaces_class_generics.Dog
-    pop_jump_if_false L3
-    load_var value
-    load_field .0
-    jump L2
-
-  L1:
-    load_var value
-    load_field .0
-
-  L2:
+    load_type interfaces_class_generics.Named
+    virtual_load_field .name
     return
-
-  L3:
-    unreachable
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/iter.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/iter.snap
@@ -331,12 +331,12 @@ function iter.iter_array_as_iterable_param() -> int[] {
 
 function iter.iter_array_as_iterable_param_inner(xs: baml.iter.Iterable<Item = int, Error = never>) -> int[] {
     load_var xs
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _2
     load_var _2
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -359,12 +359,12 @@ function iter.iter_array_chain_fluent() -> int[] {
     load_const 4
     load_type int
     alloc_array 2
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "chain"
     virtual_call nargs=2 ntypeargs=1
     store_var _1
     load_var _1
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -385,7 +385,7 @@ function iter.iter_array_collect_count() -> bool {
     virtual_call nargs=1 ntypeargs=0
     store_var _4
     load_var _4
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
@@ -405,7 +405,7 @@ function iter.iter_array_collect_count() -> bool {
     virtual_call nargs=1 ntypeargs=0
     store_var _8
     load_var _8
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "count"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
@@ -468,12 +468,12 @@ function iter.iter_array_filter_map_fluent() -> int[] {
     load_type never
     load_var _2
     make_closure .<lambda(iter_array_filter_map_fluent, 0)>, 0
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "filter_map"
     virtual_call nargs=2 ntypeargs=2
     store_var _1
     load_var _1
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -502,12 +502,12 @@ function iter.iter_array_filter_step_by() -> int[] {
     store_var _2
     load_var _2
     load_const 2
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "step_by"
     virtual_call nargs=2 ntypeargs=0
     store_var _1
     load_var _1
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -539,12 +539,12 @@ function iter.iter_array_first_adapter_defaults() -> bool {
     load_type never
     load_var _3
     make_closure .<lambda(iter_array_first_adapter_defaults, 1)>, 0
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "map"
     virtual_call nargs=2 ntypeargs=2
     store_var _2
     load_var _2
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var mapped
@@ -568,12 +568,12 @@ function iter.iter_array_first_adapter_defaults() -> bool {
     load_type never
     load_var _14
     make_closure .<lambda(iter_array_first_adapter_defaults, 3)>, 0
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "flat_map"
     virtual_call nargs=2 ntypeargs=3
     store_var _13
     load_var _13
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var flattened
@@ -598,7 +598,7 @@ function iter.iter_array_first_adapter_defaults() -> bool {
     load_var _25
     make_closure .<lambda(iter_array_first_adapter_defaults, 5)>, 0
     load_const 0
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "reduce"
     virtual_call nargs=3 ntypeargs=2
     store_var reduced
@@ -623,7 +623,7 @@ function iter.iter_array_first_adapter_defaults() -> bool {
     load_type never
     load_var2 13 12
     make_closure .<lambda(iter_array_first_adapter_defaults, 7)>, 1
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "for_each"
     virtual_call nargs=2 ntypeargs=1
     pop 1
@@ -767,7 +767,7 @@ function iter.iter_array_iter() -> int[] {
     virtual_call nargs=1 ntypeargs=0
     store_var _1
     load_var _1
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -794,7 +794,7 @@ function iter.iter_array_iter_lazy_over_source_details() -> int[] {
     load_type never
     load_var2 4 2
     make_closure .<lambda(iter_array_iter_lazy_over_source_details, 0)>, 1
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "filter"
     virtual_call nargs=2 ntypeargs=1
     store_var it
@@ -803,7 +803,7 @@ function iter.iter_array_iter_lazy_over_source_details() -> int[] {
     call baml.Array.push
     pop 1
     load_var it
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var out
@@ -816,14 +816,14 @@ function iter.iter_array_iter_lazy_over_source_details() -> int[] {
     alloc_array 2
     store_var details
     load_var out
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
 
   L0:
     load_var _13
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _14
@@ -857,7 +857,7 @@ function iter.iter_array_lazy_filter_map_collect() -> int[] {
     load_type never
     load_var _3
     make_closure .<lambda(iter_array_lazy_filter_map_collect, 0)>, 0
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "filter"
     virtual_call nargs=2 ntypeargs=1
     store_var _2
@@ -865,12 +865,12 @@ function iter.iter_array_lazy_filter_map_collect() -> int[] {
     load_type never
     load_var _2
     make_closure .<lambda(iter_array_lazy_filter_map_collect, 1)>, 0
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "map"
     virtual_call nargs=2 ntypeargs=2
     store_var _1
     load_var _1
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -892,14 +892,14 @@ function iter.iter_array_nullable_elements_details() -> int[] {
     load_const 0
     store_var sum
     load_var xs
-    load_type baml.iter.Iterable<Item = int | null, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int | null>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
 
   L0:
     load_var _6
-    load_type baml.iter.Iterator<Item = int | null, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int | null>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
@@ -947,7 +947,7 @@ function iter.iter_array_nullable_elements_details() -> int[] {
     virtual_call nargs=1 ntypeargs=0
     store_var _18
     load_var _18
-    load_type baml.iter.Iterator<Item = int | null, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int | null>
     load_const "count"
     virtual_call nargs=1 ntypeargs=0
     store_var _17
@@ -968,7 +968,7 @@ function iter.iter_array_peekable_fluent() -> int[] {
     virtual_call nargs=1 ntypeargs=0
     store_var _2
     load_var _2
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "peekable"
     virtual_call nargs=1 ntypeargs=0
     store_var p
@@ -1044,12 +1044,12 @@ function iter.iter_chain() -> int[] {
     store_var b
     load_type never
     load_var2 2 3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "chain"
     virtual_call nargs=2 ntypeargs=1
     store_var _7
     load_var _7
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -1065,7 +1065,7 @@ function iter.iter_collect() -> int[] {
     load_type int
     alloc_array 3
     call baml.iter.ArrayIterator.new
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -1081,7 +1081,7 @@ function iter.iter_count() -> int {
     load_type int
     alloc_array 3
     call baml.iter.ArrayIterator.new
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "count"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -1105,7 +1105,7 @@ function iter.iter_explicit_map_coerces_to_iterator() -> int[] {
     load_type never
     load_type never
     init_instance<4> baml.iter.Map .source, .func
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -1126,12 +1126,12 @@ function iter.iter_filter() -> int[] {
     load_type never
     load_var it
     make_closure .<lambda(iter_filter, 0)>, 0
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "filter"
     virtual_call nargs=2 ntypeargs=1
     store_var _4
     load_var _4
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -1157,7 +1157,7 @@ function iter.iter_filter_implicit_source() -> int[] {
     virtual_call nargs=2 ntypeargs=1
     store_var _1
     load_var _1
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -1179,12 +1179,12 @@ function iter.iter_filter_map() -> int[] {
     load_type never
     load_var it
     make_closure .<lambda(iter_filter_map, 0)>, 0
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "filter_map"
     virtual_call nargs=2 ntypeargs=2
     store_var _4
     load_var _4
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -1211,7 +1211,7 @@ function iter.iter_filter_map_implicit_source() -> int[] {
     virtual_call nargs=2 ntypeargs=2
     store_var _1
     load_var _1
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -1232,12 +1232,12 @@ function iter.iter_flat_map() -> int[] {
     load_type never
     load_var it
     make_closure .<lambda(iter_flat_map, 0)>, 0
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "flat_map"
     virtual_call nargs=2 ntypeargs=3
     store_var _4
     load_var _4
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -1263,7 +1263,7 @@ function iter.iter_flat_map_implicit_source() -> int[] {
     virtual_call nargs=2 ntypeargs=3
     store_var _1
     load_var _1
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -1298,7 +1298,7 @@ function iter.iter_flatten() -> int[] {
     load_type baml.iter.ArrayIterator<int>
     load_var outer
     call baml.iter.flatten
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -1317,14 +1317,14 @@ function iter.iter_for_in_array_iterator() -> int[] {
     load_type int
     alloc_array 3
     call baml.iter.ArrayIterator.new
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
 
   L0:
     load_var _5
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
@@ -1352,14 +1352,14 @@ function iter.iter_for_in_array_literal() -> int[] {
     load_const 12
     load_type int
     alloc_array 2
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -1388,14 +1388,14 @@ function iter.iter_for_in_array_of_classes() -> int {
     init_instance user.iter.IterLoopBox .value
     load_type iter.IterLoopBox
     alloc_array 2
-    load_type baml.iter.Iterable<Item = iter.IterLoopBox, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = iter.IterLoopBox>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
 
   L0:
     load_var _5
-    load_type baml.iter.Iterator<Item = iter.IterLoopBox, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = iter.IterLoopBox>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
@@ -1424,14 +1424,14 @@ function iter.iter_for_in_array_of_unions() -> int {
     load_const 3
     load_type int | string
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int | string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int | string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = int | string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int | string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -1480,14 +1480,14 @@ function iter.iter_for_in_range() -> int[] {
     load_const 4
     load_const <omitted>
     call baml.iter.Range.new
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -1515,14 +1515,14 @@ function iter.iter_for_in_repeat() -> int[] {
     load_const 2
     load_type int
     init_instance<1> baml.iter.Repeat .value, .count
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -1554,14 +1554,14 @@ function iter.iter_for_loop_pop_during_iteration() -> int[] {
     alloc_array 0
     store_var visited
     load_var xs
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -1595,14 +1595,14 @@ function iter.iter_for_loop_sees_push_during_iteration() -> int[] {
     alloc_array 0
     store_var visited
     load_var xs
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -1645,12 +1645,12 @@ function iter.iter_map() -> int[] {
     load_type never
     load_var it
     make_closure .<lambda(iter_map, 0)>, 0
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "map"
     virtual_call nargs=2 ntypeargs=2
     store_var _4
     load_var _4
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -1676,7 +1676,7 @@ function iter.iter_map_implicit_source() -> int[] {
     virtual_call nargs=2 ntypeargs=2
     store_var _1
     load_var _1
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -1801,7 +1801,7 @@ function iter.iter_reduce() -> int {
     load_var it
     make_closure .<lambda(iter_reduce, 0)>, 0
     load_const 0
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "reduce"
     virtual_call nargs=3 ntypeargs=2
     store_var _0
@@ -1830,14 +1830,14 @@ function iter.iter_shadowed_param_for_in(source: baml.iter.Iterable<Item = int, 
     load_const "b"
     load_type string
     alloc_array 2
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
 
   L0:
     load_var _5
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
@@ -1937,7 +1937,7 @@ function iter.iter_step_by() -> int[] {
     virtual_call nargs=2 ntypeargs=0
     store_var _1
     load_var _1
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var _0

--- a/baml_language/crates/baml_tests/snapshots/baml_src/iter_closure_elements.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/iter_closure_elements.snap
@@ -38,14 +38,14 @@ function iter_closure_elements.closure_loop_sum() -> int {
     load_const 4
     load_type int
     alloc_array 4
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -69,14 +69,14 @@ function iter_closure_elements.closure_loop_sum() -> int {
 
   L2:
     load_var total
-    load_type baml.iter.Iterable<Item = () -> void throws never, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = () -> void throws never>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _12
 
   L3:
     load_var _12
-    load_type baml.iter.Iterator<Item = () -> void throws never, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = () -> void throws never>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
@@ -104,14 +104,14 @@ function iter_closure_elements.nullable_elements_sum() -> int {
     load_const 3
     load_type int | null
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int | null, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int | null>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int | null, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int | null>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
@@ -341,14 +341,14 @@ function lambdas.lambdas_captures_loop_variable_accumulation() -> int {
     load_const 3
     load_type int
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
 
   L0:
     load_var _5
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _6

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
@@ -284,14 +284,14 @@ function lexical_scoping.closure_parameter_in_for_iterable() -> int {
     alloc_array 4
     make_closure .<lambda(closure_parameter_in_for_iterable, 0)>, 0
     call baml.Array.filter
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
 
   L0:
     load_var _7
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
@@ -349,14 +349,14 @@ function lexical_scoping.for_loop_restores_outer() -> int {
     load_const 3
     load_type int
     alloc_array 2
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -545,14 +545,14 @@ function lexical_scoping.rule2_for_outer_mutation_escapes() -> int {
     load_const 1
     load_type int
     alloc_array 1
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4

--- a/baml_language/crates/baml_tests/snapshots/baml_src/null_handling.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/null_handling.snap
@@ -280,30 +280,18 @@ function null_handling.nh_multi_union_optional_access(animal: null_handling.NhCa
     load_const null
     cmp_op ==
     pop_jump_if_false L0
-    jump L3
+    jump L1
 
   L0:
     load_var animal
-    type_tag
-    load_const NhCat
-    cmp_int_op ==
-    pop_jump_if_false L1
+    load_type null_handling.NhHasSound
+    virtual_load_field .sound
     jump L2
 
   L1:
-    load_var animal
-    load_field .0
-    jump L4
-
-  L2:
-    load_var animal
-    load_field .0
-    jump L4
-
-  L3:
     load_const null
 
-  L4:
+  L2:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
@@ -953,14 +953,14 @@ function patterns_new_runtime.from_array_boxes(boxes: patterns_new_runtime.BoxT<
     load_const 0
     store_var total
     load_var boxes
-    load_type baml.iter.Iterable<Item = patterns_new_runtime.BoxT<int>, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = patterns_new_runtime.BoxT<int>>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = patterns_new_runtime.BoxT<int>, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = patterns_new_runtime.BoxT<int>>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -3382,14 +3382,14 @@ function patterns_new_runtime.test_for_class_binds_inner_zip() -> int {
     init_instance user.patterns_new_runtime.UserCoord .address
     load_type patterns_new_runtime.UserCoord
     alloc_array 3
-    load_type baml.iter.Iterable<Item = patterns_new_runtime.UserCoord, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = patterns_new_runtime.UserCoord>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
 
   L0:
     load_var _13
-    load_type baml.iter.Iterator<Item = patterns_new_runtime.UserCoord, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = patterns_new_runtime.UserCoord>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _14
@@ -3433,14 +3433,14 @@ function patterns_new_runtime.test_for_deep_class_capture_fresh() -> int {
     init_instance user.patterns_new_runtime.UserCoord .address
     load_type patterns_new_runtime.UserCoord
     alloc_array 3
-    load_type baml.iter.Iterable<Item = patterns_new_runtime.UserCoord, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = patterns_new_runtime.UserCoord>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
 
   L0:
     load_var _13
-    load_type baml.iter.Iterator<Item = patterns_new_runtime.UserCoord, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = patterns_new_runtime.UserCoord>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _14
@@ -3509,14 +3509,14 @@ function patterns_new_runtime.test_for_deep_class_sums() -> int {
     init_instance user.patterns_new_runtime.UserCoord .address
     load_type patterns_new_runtime.UserCoord
     alloc_array 3
-    load_type baml.iter.Iterable<Item = patterns_new_runtime.UserCoord, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = patterns_new_runtime.UserCoord>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
 
   L0:
     load_var _13
-    load_type baml.iter.Iterator<Item = patterns_new_runtime.UserCoord, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = patterns_new_runtime.UserCoord>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _14
@@ -3556,14 +3556,14 @@ function patterns_new_runtime.test_for_inside_class_destruct() -> int {
     init_instance user.patterns_new_runtime.Team1 .scores
     load_type patterns_new_runtime.Team1
     alloc_array 3
-    load_type baml.iter.Iterable<Item = patterns_new_runtime.Team1, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = patterns_new_runtime.Team1>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _10
 
   L0:
     load_var _10
-    load_type baml.iter.Iterator<Item = patterns_new_runtime.Team1, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = patterns_new_runtime.Team1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _11
@@ -3599,14 +3599,14 @@ function patterns_new_runtime.test_for_let_chain_alias_capture() -> int {
     load_const 3
     load_type int
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -3667,14 +3667,14 @@ function patterns_new_runtime.test_for_let_chain_of_bindings() -> int {
     load_const 3
     load_type int
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -3712,14 +3712,14 @@ function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
     alloc_array 3
     load_type int[]
     alloc_array 2
-    load_type baml.iter.Iterable<Item = int[], Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int[]>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
 
   L0:
     load_var _5
-    load_type baml.iter.Iterator<Item = int[], Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int[]>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
@@ -3766,14 +3766,14 @@ function patterns_new_runtime.test_for_let_or_same_binding() -> int {
     load_const 4
     load_type int
     alloc_array 4
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -3801,14 +3801,14 @@ function patterns_new_runtime.test_for_let_or_six_bindings() -> int {
     load_const 3
     load_type int
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -3842,14 +3842,14 @@ function patterns_new_runtime.test_for_nested_rest_irrefutable() -> int {
     alloc_array 0
     load_type int[] | never[]
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int[] | never[], Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int[] | never[]>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
 
   L0:
     load_var _6
-    load_type baml.iter.Iterator<Item = int[] | never[], Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int[] | never[]>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
@@ -3891,14 +3891,14 @@ function patterns_new_runtime.test_for_rest_capture_fresh_cell() -> int {
     alloc_array 3
     load_type int[]
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int[], Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int[]>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
 
   L0:
     load_var _7
-    load_type baml.iter.Iterator<Item = int[], Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int[]>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
@@ -3962,14 +3962,14 @@ function patterns_new_runtime.test_for_rest_sums_rows() -> int {
     alloc_array 1
     load_type int[]
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int[], Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int[]>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
 
   L0:
     load_var _7
-    load_type baml.iter.Iterator<Item = int[], Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int[]>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
@@ -4006,14 +4006,14 @@ function patterns_new_runtime.test_for_rest_wildcard_irrefutable() -> int {
     alloc_array 2
     load_type int[]
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int[], Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int[]>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
 
   L0:
     load_var _7
-    load_type baml.iter.Iterator<Item = int[], Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int[]>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _8

--- a/baml_language/crates/baml_tests/snapshots/baml_src/promptast_accessors.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/promptast_accessors.snap
@@ -39,14 +39,14 @@ function promptast_accessors.paa_fold_messages_fn() -> string {
     store_var out
     call user.promptast_accessors.paa_render_ast
     sys_op baml.llm.PromptAst.messages
-    load_type baml.iter.Iterable<Item = baml.llm.PromptMessage, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = baml.llm.PromptMessage>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = baml.llm.PromptMessage, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = baml.llm.PromptMessage>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5

--- a/baml_language/crates/baml_tests/snapshots/baml_src/streaming_parsing.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/streaming_parsing.snap
@@ -333,14 +333,14 @@ function streaming_parsing.openai_sse_body(chunks: string[], finish_reason: stri
     load_const ""
     store_var body
     load_var chunks
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5

--- a/baml_language/crates/baml_tests/snapshots/baml_src/string_regressions.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/string_regressions.snap
@@ -64,14 +64,14 @@ function string_regressions.strregr_iterate_by_character() -> string {
     load_const ""
     store_var out
     load_const "aé😀"
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _2
 
   L0:
     load_var _2
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _3

--- a/baml_language/crates/baml_tests/snapshots/baml_src/typed_inputs.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/typed_inputs.snap
@@ -156,14 +156,14 @@ function typed_inputs.sum(arr: int[]) -> int {
     load_const 0
     store_var total
     load_var arr
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -304,11 +304,11 @@ fn baml.Array.for_each(self: baml.Array, fn: (T) -> void throws E) -> void {
     }
 
     bb2: {
-        _6 = virtual_call iter as baml.iter.Iterable<Item = #0, Error = never>(copy _3) -> [bb3];
+        _6 = virtual_call iter as baml.iter.Iterable<Error = never, Item = #0>(copy _3) -> [bb3];
     }
 
     bb3: {
-        _7 = virtual_call next as baml.iter.Iterator<Item = #0, Error = never>(copy _6) -> [bb4];
+        _7 = virtual_call next as baml.iter.Iterator<Error = never, Item = #0>(copy _6) -> [bb4];
     }
 
     bb4: {
@@ -369,11 +369,11 @@ fn baml.Array.filter_map(self: baml.Array, fn: (T) -> null | U throws E) -> U[] 
     }
 
     bb2: {
-        _7 = virtual_call iter as baml.iter.Iterable<Item = #0, Error = never>(copy _4) -> [bb3];
+        _7 = virtual_call iter as baml.iter.Iterable<Error = never, Item = #0>(copy _4) -> [bb3];
     }
 
     bb3: {
-        _8 = virtual_call next as baml.iter.Iterator<Item = #0, Error = never>(copy _7) -> [bb4];
+        _8 = virtual_call next as baml.iter.Iterator<Error = never, Item = #0>(copy _7) -> [bb4];
     }
 
     bb4: {
@@ -491,11 +491,11 @@ fn baml.Array.sort_by_key(self: baml.Array, key: (T) -> U throws E) -> T[] {
     bb3: {
         _9 = []: #1[];
         _10 = copy _6;
-        _11 = virtual_call iter as baml.iter.Iterable<Item = #0, Error = never>(copy _10) -> [bb4];
+        _11 = virtual_call iter as baml.iter.Iterable<Error = never, Item = #0>(copy _10) -> [bb4];
     }
 
     bb4: {
-        _12 = virtual_call next as baml.iter.Iterator<Item = #0, Error = never>(copy _11) -> [bb5];
+        _12 = virtual_call next as baml.iter.Iterator<Error = never, Item = #0>(copy _11) -> [bb5];
     }
 
     bb5: {
@@ -538,11 +538,11 @@ fn baml.Array.sort_by_key(self: baml.Array, key: (T) -> U throws E) -> T[] {
     bb11: {
         _30 = []: #0[];
         _31 = copy _19;
-        _32 = virtual_call iter as baml.iter.Iterable<Item = int, Error = never>(copy _31) -> [bb12];
+        _32 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int>(copy _31) -> [bb12];
     }
 
     bb12: {
-        _33 = virtual_call next as baml.iter.Iterator<Item = int, Error = never>(copy _32) -> [bb13];
+        _33 = virtual_call next as baml.iter.Iterator<Error = never, Item = int>(copy _32) -> [bb13];
     }
 
     bb13: {
@@ -577,11 +577,11 @@ fn baml.Array.sort_by_key(self: baml.Array, key: (T) -> U throws E) -> T[] {
 
     bb18: {
         _46 = copy _30;
-        _47 = virtual_call iter as baml.iter.Iterable<Item = #0, Error = never>(copy _46) -> [bb19];
+        _47 = virtual_call iter as baml.iter.Iterable<Error = never, Item = #0>(copy _46) -> [bb19];
     }
 
     bb19: {
-        _48 = virtual_call next as baml.iter.Iterator<Item = #0, Error = never>(copy _47) -> [bb20];
+        _48 = virtual_call next as baml.iter.Iterator<Error = never, Item = #0>(copy _47) -> [bb20];
     }
 
     bb20: {
@@ -1951,7 +1951,7 @@ fn baml.csv.read(path: string, options: null | baml.csv.ReaderOptions) -> T[] {
     }
 
     bb4: {
-        _5 = virtual_call collect as baml.iter.Iterator<Item = #0, Error = baml.csv.CsvError | baml.errors.Io>(copy _6) -> [bb5];
+        _5 = virtual_call collect as baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = #0>(copy _6) -> [bb5];
     }
 
     bb5: {
@@ -2092,7 +2092,7 @@ fn baml.csv.decode(source: string | uint8array, options: null | baml.csv.ReaderO
     }
 
     bb4: {
-        _0 = virtual_call collect as baml.iter.Iterator<Item = #0, Error = baml.csv.CsvError | baml.errors.Io>(copy _5) -> [bb8, unwind: bb5];
+        _0 = virtual_call collect as baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = #0>(copy _5) -> [bb8, unwind: bb5];
     }
 
     bb5: {
@@ -2542,11 +2542,11 @@ fn baml.csv.stringify_records(records: (int | bigint | float | string | bool | n
     }
 
     bb3: {
-        _6 = virtual_call iter as baml.iter.Iterable<Item = (null | bool | int | bigint | float | string)[], Error = never>(copy _1) -> [bb4, unwind: bb8];
+        _6 = virtual_call iter as baml.iter.Iterable<Error = never, Item = (null | bool | int | bigint | float | string)[]>(copy _1) -> [bb4, unwind: bb8];
     }
 
     bb4: {
-        _7 = virtual_call next as baml.iter.Iterator<Item = (null | bool | int | bigint | float | string)[], Error = never>(copy _6) -> [bb5, unwind: bb8];
+        _7 = virtual_call next as baml.iter.Iterator<Error = never, Item = (null | bool | int | bigint | float | string)[]>(copy _6) -> [bb5, unwind: bb8];
     }
 
     bb5: {
@@ -3844,7 +3844,7 @@ fn baml.iter.Iterator.chain(self: baml.iter.Iterator, other: baml.iter.Iterable<
     let _3: baml.iter.Iterator<Error = E2, Item = Item>
 
     bb0: {
-        _3 = virtual_call iter as baml.iter.Iterable<Item = #1, Error = #3>(copy _2) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = #3, Item = #1>(copy _2) -> [bb1];
     }
 
     bb1: {
@@ -3895,7 +3895,7 @@ fn baml.iter.Iterator.collect(self: baml.iter.Iterator) -> Item[] {
     }
 
     bb2: {
-        _4 = virtual_call next as baml.iter.Iterator<Item = #1, Error = #2>(copy _1) -> [bb3];
+        _4 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #1>(copy _1) -> [bb3];
     }
 
     bb3: {
@@ -3942,7 +3942,7 @@ fn baml.iter.Iterator.reduce(self: baml.iter.Iterator, fn: (A, Item) -> A throws
     }
 
     bb2: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = #1, Error = #2>(copy _1) -> [bb3];
+        _5 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #1>(copy _1) -> [bb3];
     }
 
     bb3: {
@@ -3985,7 +3985,7 @@ fn baml.iter.Iterator.count(self: baml.iter.Iterator) -> int {
     }
 
     bb2: {
-        _3 = virtual_call next as baml.iter.Iterator<Item = #1, Error = #2>(copy _1) -> [bb3];
+        _3 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #1>(copy _1) -> [bb3];
     }
 
     bb3: {
@@ -4028,7 +4028,7 @@ fn baml.iter.Iterator.for_each(self: baml.iter.Iterator, fn: (Item) -> void thro
     }
 
     bb2: {
-        _3 = virtual_call next as baml.iter.Iterator<Item = #1, Error = #2>(copy _1) -> [bb3];
+        _3 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #1>(copy _1) -> [bb3];
     }
 
     bb3: {
@@ -4072,7 +4072,7 @@ fn baml.iter.Iterator.some(self: baml.iter.Iterator, predicate: (Item) -> bool t
     }
 
     bb2: {
-        _3 = virtual_call next as baml.iter.Iterator<Item = #1, Error = #2>(copy _1) -> [bb3];
+        _3 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #1>(copy _1) -> [bb3];
     }
 
     bb3: {
@@ -4126,7 +4126,7 @@ fn baml.iter.Iterator.every(self: baml.iter.Iterator, predicate: (Item) -> bool 
     }
 
     bb2: {
-        _3 = virtual_call next as baml.iter.Iterator<Item = #1, Error = #2>(copy _1) -> [bb3];
+        _3 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #1>(copy _1) -> [bb3];
     }
 
     bb3: {
@@ -4180,7 +4180,7 @@ fn baml.iter.Iterator.find(self: baml.iter.Iterator, predicate: (Item) -> bool t
     }
 
     bb2: {
-        _3 = virtual_call next as baml.iter.Iterator<Item = #1, Error = #2>(copy _1) -> [bb3];
+        _3 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #1>(copy _1) -> [bb3];
     }
 
     bb3: {
@@ -4493,7 +4493,7 @@ fn baml.iter.Map.Iterator.next(self: baml.iter.Map) -> baml.iter.Done | R {
 
     bb0: {
         _3 = copy _1.0;
-        _2 = virtual_call next as baml.iter.Iterator<Item = #0, Error = #2>(copy _3) -> [bb1];
+        _2 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #0>(copy _3) -> [bb1];
     }
 
     bb1: {
@@ -4560,7 +4560,7 @@ fn baml.iter.Filter.Iterator.next(self: baml.iter.Filter) -> baml.iter.Done | T 
 
     bb3: {
         _3 = copy _1.0;
-        _2 = virtual_call next as baml.iter.Iterator<Item = #0, Error = #1>(copy _3) -> [bb4];
+        _2 = virtual_call next as baml.iter.Iterator<Error = #1, Item = #0>(copy _3) -> [bb4];
     }
 
     bb4: {
@@ -4638,7 +4638,7 @@ fn baml.iter.FilterMap.Iterator.next(self: baml.iter.FilterMap) -> baml.iter.Don
 
     bb3: {
         _3 = copy _1.0;
-        _2 = virtual_call next as baml.iter.Iterator<Item = #0, Error = #2>(copy _3) -> [bb4];
+        _2 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #0>(copy _3) -> [bb4];
     }
 
     bb4: {
@@ -4739,7 +4739,7 @@ fn baml.iter.FlatMap.Iterator.next(self: baml.iter.FlatMap) -> baml.iter.Done | 
 
     bb6: {
         _10 = copy _1.0;
-        _9 = virtual_call next as baml.iter.Iterator<Item = #0, Error = #2>(copy _10) -> [bb7];
+        _9 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #0>(copy _10) -> [bb7];
     }
 
     bb7: {
@@ -4755,7 +4755,7 @@ fn baml.iter.FlatMap.Iterator.next(self: baml.iter.FlatMap) -> baml.iter.Done | 
     }
 
     bb9: {
-        _13 = virtual_call iter as baml.iter.Iterable<Item = #1, Error = #4>(copy _14) -> [bb10];
+        _13 = virtual_call iter as baml.iter.Iterable<Error = #4, Item = #1>(copy _14) -> [bb10];
     }
 
     bb10: {
@@ -4856,7 +4856,7 @@ fn baml.iter.Flatten.Iterator.next(self: baml.iter.Flatten) -> baml.iter.Done | 
 
     bb6: {
         _10 = copy _1.0;
-        _9 = virtual_call next as baml.iter.Iterator<Item = #0, Error = #2>(copy _10) -> [bb7];
+        _9 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #0>(copy _10) -> [bb7];
     }
 
     bb7: {
@@ -4866,7 +4866,7 @@ fn baml.iter.Flatten.Iterator.next(self: baml.iter.Flatten) -> baml.iter.Done | 
 
     bb8: {
         _12 = copy _9;
-        _13 = virtual_call iter as baml.iter.Iterable<Item = #1, Error = #3>(copy _12) -> [bb9];
+        _13 = virtual_call iter as baml.iter.Iterable<Error = #3, Item = #1>(copy _12) -> [bb9];
     }
 
     bb9: {
@@ -4920,7 +4920,7 @@ fn baml.iter.Peekable.peek(self: baml.iter.Peekable) -> baml.iter.Done | T {
 
     bb1: {
         _4 = copy _1.0;
-        _3 = virtual_call next as baml.iter.Iterator<Item = #0, Error = #1>(copy _4) -> [bb2];
+        _3 = virtual_call next as baml.iter.Iterator<Error = #1, Item = #0>(copy _4) -> [bb2];
     }
 
     bb2: {
@@ -4970,7 +4970,7 @@ fn baml.iter.Peekable.Iterator.next(self: baml.iter.Peekable) -> baml.iter.Done 
 
     bb1: {
         _4 = copy _1.0;
-        _0 = virtual_call next as baml.iter.Iterator<Item = #0, Error = #1>(copy _4) -> [bb3];
+        _0 = virtual_call next as baml.iter.Iterator<Error = #1, Item = #0>(copy _4) -> [bb3];
     }
 
     bb2: {
@@ -5037,12 +5037,12 @@ fn baml.iter.StepBy.Iterator.next(self: baml.iter.StepBy) -> baml.iter.Done | T 
 
     bb3: {
         _12 = copy _1.0;
-        _0 = virtual_call next as baml.iter.Iterator<Item = #0, Error = #1>(copy _12) -> [bb9];
+        _0 = virtual_call next as baml.iter.Iterator<Error = #1, Item = #0>(copy _12) -> [bb9];
     }
 
     bb4: {
         _10 = copy _1.0;
-        _9 = virtual_call next as baml.iter.Iterator<Item = #0, Error = #1>(copy _10) -> [bb5];
+        _9 = virtual_call next as baml.iter.Iterator<Error = #1, Item = #0>(copy _10) -> [bb5];
     }
 
     bb5: {
@@ -5063,7 +5063,7 @@ fn baml.iter.StepBy.Iterator.next(self: baml.iter.StepBy) -> baml.iter.Done | T 
     bb8: {
         _1.2 = const false;
         _3 = copy _1.0;
-        _0 = virtual_call next as baml.iter.Iterator<Item = #0, Error = #1>(copy _3) -> [bb9];
+        _0 = virtual_call next as baml.iter.Iterator<Error = #1, Item = #0>(copy _3) -> [bb9];
     }
 
     bb9: {
@@ -5106,7 +5106,7 @@ fn baml.iter.Chain.Iterator.next(self: baml.iter.Chain) -> baml.iter.Done | T {
 
     bb1: {
         _5 = copy _1.0;
-        _4 = virtual_call next as baml.iter.Iterator<Item = #0, Error = #1>(copy _5) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = #1, Item = #0>(copy _5) -> [bb2];
     }
 
     bb2: {
@@ -5127,7 +5127,7 @@ fn baml.iter.Chain.Iterator.next(self: baml.iter.Chain) -> baml.iter.Done | T {
 
     bb5: {
         _8 = copy _1.1;
-        _0 = virtual_call next as baml.iter.Iterator<Item = #0, Error = #2>(copy _8) -> [bb6];
+        _0 = virtual_call next as baml.iter.Iterator<Error = #2, Item = #0>(copy _8) -> [bb6];
     }
 
     bb6: {
@@ -6030,11 +6030,11 @@ fn baml.llm.PlannerState.rr_local_offset(self: baml.llm.PlannerState, client_nam
     bb0: {
         _3 = const 0_i64;
         _4 = copy _1.0;
-        _5 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _4) -> [bb1];
+        _5 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _4) -> [bb1];
     }
 
     bb1: {
-        _6 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _5) -> [bb2];
+        _6 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _5) -> [bb2];
     }
 
     bb2: {
@@ -6755,11 +6755,11 @@ fn baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner_state
     bb8: {
         _8 = []: baml.llm.OrchestrationStep[];
         _9 = copy _1.2;
-        _10 = virtual_call iter as baml.iter.Iterable<Item = baml.llm.Client, Error = never>(copy _9) -> [bb9];
+        _10 = virtual_call iter as baml.iter.Iterable<Error = never, Item = baml.llm.Client>(copy _9) -> [bb9];
     }
 
     bb9: {
-        _11 = virtual_call next as baml.iter.Iterator<Item = baml.llm.Client, Error = never>(copy _10) -> [bb10];
+        _11 = virtual_call next as baml.iter.Iterator<Error = never, Item = baml.llm.Client>(copy _10) -> [bb10];
     }
 
     bb10: {
@@ -6775,11 +6775,11 @@ fn baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner_state
     }
 
     bb12: {
-        _16 = virtual_call iter as baml.iter.Iterable<Item = baml.llm.OrchestrationStep, Error = never>(copy _15) -> [bb13];
+        _16 = virtual_call iter as baml.iter.Iterable<Error = never, Item = baml.llm.OrchestrationStep>(copy _15) -> [bb13];
     }
 
     bb13: {
-        _17 = virtual_call next as baml.iter.Iterator<Item = baml.llm.OrchestrationStep, Error = never>(copy _16) -> [bb14];
+        _17 = virtual_call next as baml.iter.Iterator<Error = never, Item = baml.llm.OrchestrationStep>(copy _16) -> [bb14];
     }
 
     bb14: {
@@ -6952,11 +6952,11 @@ fn baml.llm.Client.build_plan_with_state(self: baml.llm.Client, planner_state: b
 
     bb15: {
         _23 = copy _22;
-        _24 = virtual_call iter as baml.iter.Iterable<Item = baml.llm.OrchestrationStep, Error = never>(copy _23) -> [bb16];
+        _24 = virtual_call iter as baml.iter.Iterable<Error = never, Item = baml.llm.OrchestrationStep>(copy _23) -> [bb16];
     }
 
     bb16: {
-        _25 = virtual_call next as baml.iter.Iterator<Item = baml.llm.OrchestrationStep, Error = never>(copy _24) -> [bb17];
+        _25 = virtual_call next as baml.iter.Iterator<Error = never, Item = baml.llm.OrchestrationStep>(copy _24) -> [bb17];
     }
 
     bb17: {
@@ -7233,7 +7233,7 @@ fn baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: baml.llm.
 
     bb8: {
         _23 = copy _1.2;
-        _24 = virtual_call iter as baml.iter.Iterable<Item = baml.llm.Client, Error = never>(copy _23) -> [bb17];
+        _24 = virtual_call iter as baml.iter.Iterable<Error = never, Item = baml.llm.Client>(copy _23) -> [bb17];
     }
 
     bb9: {
@@ -7281,7 +7281,7 @@ fn baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: baml.llm.
     }
 
     bb17: {
-        _25 = virtual_call next as baml.iter.Iterator<Item = baml.llm.Client, Error = never>(copy _24) -> [bb18];
+        _25 = virtual_call next as baml.iter.Iterator<Error = never, Item = baml.llm.Client>(copy _24) -> [bb18];
     }
 
     bb18: {
@@ -7622,7 +7622,7 @@ fn baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: baml.llm
 
     bb8: {
         _37 = copy _1.2;
-        _38 = virtual_call iter as baml.iter.Iterable<Item = baml.llm.Client, Error = never>(copy _37) -> [bb34];
+        _38 = virtual_call iter as baml.iter.Iterable<Error = never, Item = baml.llm.Client>(copy _37) -> [bb34];
     }
 
     bb9: {
@@ -7747,7 +7747,7 @@ fn baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: baml.llm
     }
 
     bb34: {
-        _39 = virtual_call next as baml.iter.Iterator<Item = baml.llm.Client, Error = never>(copy _38) -> [bb35];
+        _39 = virtual_call next as baml.iter.Iterator<Error = never, Item = baml.llm.Client>(copy _38) -> [bb35];
     }
 
     bb35: {
@@ -8113,11 +8113,11 @@ fn baml.llm.render_prompt_values(values: unknown[]) -> unknown[] {
 
     bb0: {
         _2 = []: unknown[];
-        _3 = virtual_call iter as baml.iter.Iterable<Item = unknown, Error = never>(copy _1) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = unknown>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Item = unknown, Error = never>(copy _3) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = unknown>(copy _3) -> [bb2];
     }
 
     bb2: {
@@ -12048,11 +12048,11 @@ fn baml.toml.table_from_json(j: int | float | string | bool | null | baml.json.j
     }
 
     bb3: {
-        _7 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _4) -> [bb4];
+        _7 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _4) -> [bb4];
     }
 
     bb4: {
-        _8 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _7) -> [bb5];
+        _8 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _7) -> [bb5];
     }
 
     bb5: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -31,14 +31,14 @@ function baml.Array.filter_map(self: baml.Array<#0>, fn: (#0) -> #1 | null throw
     load_const 0
     load_var _5
     call baml.Array.slice
-    load_type baml.iter.Iterable<Item = #0, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = #0>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
 
   L0:
     load_var _7
-    load_type baml.iter.Iterator<Item = #0, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
@@ -92,14 +92,14 @@ function baml.Array.for_each(self: baml.Array<#0>, fn: (#0) -> void throws #1) -
     load_const 0
     load_var _4
     call baml.Array.slice
-    load_type baml.iter.Iterable<Item = #0, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = #0>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
 
   L0:
     load_var _6
-    load_type baml.iter.Iterator<Item = #0, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
@@ -222,14 +222,14 @@ function baml.Array.sort_by_key(self: baml.Array<#0>, key: (#0) -> #1 throws #2)
     alloc_array 0
     store_deref ?5
     load_var items
-    load_type baml.iter.Iterable<Item = #0, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = #0>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _11
 
   L1:
     load_var _11
-    load_type baml.iter.Iterator<Item = #0, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _12
@@ -276,14 +276,14 @@ function baml.Array.sort_by_key(self: baml.Array<#0>, key: (#0) -> #1 throws #2)
     alloc_array 0
     store_var sorted
     load_var order
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _32
 
   L6:
     load_var _32
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _33
@@ -315,14 +315,14 @@ function baml.Array.sort_by_key(self: baml.Array<#0>, key: (#0) -> #1 throws #2)
     call baml.Array.clear
     pop 1
     load_var sorted
-    load_type baml.iter.Iterable<Item = #0, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = #0>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _47
 
   L10:
     load_var _47
-    load_type baml.iter.Iterator<Item = #0, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _48
@@ -1677,7 +1677,7 @@ function baml.csv.decode(source: string | uint8array, options: baml.csv.ReaderOp
     load_type #0
     load_var _6
     call baml.csv.CsvReader.rows
-    load_type baml.iter.Iterator<Item = #0, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = #0>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     jump L3
@@ -1935,7 +1935,7 @@ function baml.csv.read(path: string, options: baml.csv.ReaderOptions | null) -> 
     load_type #0
     load_var r
     call baml.csv.CsvReader.rows
-    load_type baml.iter.Iterator<Item = #0, Error = baml.csv.CsvError | baml.errors.Io>
+    load_type baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = #0>
     load_const "collect"
     virtual_call nargs=1 ntypeargs=0
     store_var result
@@ -2013,14 +2013,14 @@ function baml.csv.stringify_records(records: (null | bool | int | bigint | float
     call baml.csv.buffer
     store_var w
     load_var records
-    load_type baml.iter.Iterable<Item = (null | bool | int | bigint | float | string)[], Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = (null | bool | int | bigint | float | string)[]>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
 
   L1:
     load_var _6
-    load_type baml.iter.Iterator<Item = (null | bool | int | bigint | float | string)[], Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = (null | bool | int | bigint | float | string)[]>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
@@ -2673,7 +2673,7 @@ function baml.iter.Chain.Iterator.next(self: baml.iter.Chain<#0, #1, #2>) -> #0 
     pop_jump_if_false L2
     load_var self
     load_field .first
-    load_type baml.iter.Iterator<Item = #0, Error = #1>
+    load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -2695,7 +2695,7 @@ function baml.iter.Chain.Iterator.next(self: baml.iter.Chain<#0, #1, #2>) -> #0 
   L2:
     load_var self
     load_field .other
-    load_type baml.iter.Iterator<Item = #0, Error = #2>
+    load_type baml.iter.Iterator<Error = #2, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -2723,7 +2723,7 @@ function baml.iter.Filter.Iterator.next(self: baml.iter.Filter<#0, #1, #2>) -> #
   L2:
     load_var self
     load_field .source
-    load_type baml.iter.Iterator<Item = #0, Error = #1>
+    load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _2
@@ -2767,7 +2767,7 @@ function baml.iter.FilterMap.Iterator.next(self: baml.iter.FilterMap<#0, #1, #2,
   L2:
     load_var self
     load_field .source
-    load_type baml.iter.Iterator<Item = #0, Error = #2>
+    load_type baml.iter.Iterator<Error = #2, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _2
@@ -2830,7 +2830,7 @@ function baml.iter.FlatMap.Iterator.next(self: baml.iter.FlatMap<#0, #1, #2, #3,
     pop_jump_if_false L10
     load_var self
     load_field .source
-    load_type baml.iter.Iterator<Item = #0, Error = #2>
+    load_type baml.iter.Iterator<Error = #2, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
@@ -2843,7 +2843,7 @@ function baml.iter.FlatMap.Iterator.next(self: baml.iter.FlatMap<#0, #1, #2, #3,
     load_var2 5 1
     load_field .func
     call_indirect
-    load_type baml.iter.Iterable<Item = #1, Error = #4>
+    load_type baml.iter.Iterable<Error = #4, Item = #1>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var it
@@ -2914,7 +2914,7 @@ function baml.iter.Flatten.Iterator.next(self: baml.iter.Flatten<#0, #1, #2, #3>
     pop_jump_if_false L10
     load_var self
     load_field .source
-    load_type baml.iter.Iterator<Item = #0, Error = #2>
+    load_type baml.iter.Iterator<Error = #2, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
@@ -2925,7 +2925,7 @@ function baml.iter.Flatten.Iterator.next(self: baml.iter.Flatten<#0, #1, #2, #3>
 
   L4:
     load_var _9
-    load_type baml.iter.Iterable<Item = #1, Error = #3>
+    load_type baml.iter.Iterable<Error = #3, Item = #1>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var it
@@ -2984,7 +2984,7 @@ function baml.iter.Iterable$for$string.iter(self: string) -> baml.iter.Iterator<
 
 function baml.iter.Iterator.chain(self: baml.iter.Iterator, other: baml.iter.Iterable<Item = #1, Error = #3>) -> baml.iter.Iterator<Item = #1, Error = #2 | #3> {
     load_var other
-    load_type baml.iter.Iterable<Item = #1, Error = #3>
+    load_type baml.iter.Iterable<Error = #3, Item = #1>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
@@ -3006,7 +3006,7 @@ function baml.iter.Iterator.collect(self: baml.iter.Iterator) -> #1[] {
     load_const true
     pop_jump_if_false L2
     load_var self
-    load_type baml.iter.Iterator<Item = #1, Error = #2>
+    load_type baml.iter.Iterator<Error = #2, Item = #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -3034,7 +3034,7 @@ function baml.iter.Iterator.count(self: baml.iter.Iterator) -> int {
     load_const true
     pop_jump_if_false L2
     load_var self
-    load_type baml.iter.Iterator<Item = #1, Error = #2>
+    load_type baml.iter.Iterator<Error = #2, Item = #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
@@ -3060,7 +3060,7 @@ function baml.iter.Iterator.every(self: baml.iter.Iterator, predicate: (#1) -> b
     load_const true
     pop_jump_if_false L2
     load_var self
-    load_type baml.iter.Iterator<Item = #1, Error = #2>
+    load_type baml.iter.Iterator<Error = #2, Item = #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
@@ -3108,7 +3108,7 @@ function baml.iter.Iterator.find(self: baml.iter.Iterator, predicate: (#1) -> bo
     load_const true
     pop_jump_if_false L2
     load_var self
-    load_type baml.iter.Iterator<Item = #1, Error = #2>
+    load_type baml.iter.Iterator<Error = #2, Item = #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
@@ -3150,7 +3150,7 @@ function baml.iter.Iterator.for_each(self: baml.iter.Iterator, fn: (#1) -> void 
     load_const true
     pop_jump_if_false L2
     load_var self
-    load_type baml.iter.Iterator<Item = #1, Error = #2>
+    load_type baml.iter.Iterator<Error = #2, Item = #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
@@ -3198,7 +3198,7 @@ function baml.iter.Iterator.reduce(self: baml.iter.Iterator, fn: (#3, #1) -> #3 
     load_const true
     pop_jump_if_false L2
     load_var self
-    load_type baml.iter.Iterator<Item = #1, Error = #2>
+    load_type baml.iter.Iterator<Error = #2, Item = #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -3224,7 +3224,7 @@ function baml.iter.Iterator.some(self: baml.iter.Iterator, predicate: (#1) -> bo
     load_const true
     pop_jump_if_false L2
     load_var self
-    load_type baml.iter.Iterator<Item = #1, Error = #2>
+    load_type baml.iter.Iterator<Error = #2, Item = #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
@@ -3264,7 +3264,7 @@ function baml.iter.Map.Iterable.iter(self: baml.iter.Map<#0, #1, #2, #3>) -> bam
 function baml.iter.Map.Iterator.next(self: baml.iter.Map<#0, #1, #2, #3>) -> #1 | baml.iter.Done {
     load_var self
     load_field .source
-    load_type baml.iter.Iterator<Item = #0, Error = #2>
+    load_type baml.iter.Iterator<Error = #2, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _2
@@ -3300,7 +3300,7 @@ function baml.iter.Peekable.Iterator.next(self: baml.iter.Peekable<#0, #1>) -> #
   L0:
     load_var self
     load_field .source
-    load_type baml.iter.Iterator<Item = #0, Error = #1>
+    load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -3333,7 +3333,7 @@ function baml.iter.Peekable.peek(self: baml.iter.Peekable<#0, #1>) -> #0 | baml.
   L0:
     load_var self
     load_field .source
-    load_type baml.iter.Iterator<Item = #0, Error = #1>
+    load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var v
@@ -3489,7 +3489,7 @@ function baml.iter.StepBy.Iterator.next(self: baml.iter.StepBy<#0, #1>) -> #0 | 
   L2:
     load_var self
     load_field .source
-    load_type baml.iter.Iterator<Item = #0, Error = #1>
+    load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -3498,7 +3498,7 @@ function baml.iter.StepBy.Iterator.next(self: baml.iter.StepBy<#0, #1>) -> #0 | 
   L3:
     load_var self
     load_field .source
-    load_type baml.iter.Iterator<Item = #0, Error = #1>
+    load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
@@ -3525,7 +3525,7 @@ function baml.iter.StepBy.Iterator.next(self: baml.iter.StepBy<#0, #1>) -> #0 | 
     store_field .first
     load_var self
     load_field .source
-    load_type baml.iter.Iterator<Item = #0, Error = #1>
+    load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _0
@@ -4280,14 +4280,14 @@ function baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner
     store_var steps
     load_var self
     load_field .sub_clients
-    load_type baml.iter.Iterable<Item = baml.llm.Client, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = baml.llm.Client>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _10
 
   L5:
     load_var _10
-    load_type baml.iter.Iterator<Item = baml.llm.Client, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = baml.llm.Client>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _11
@@ -4299,14 +4299,14 @@ function baml.llm.Client.build_attempt_with_state(self: baml.llm.Client, planner
   L6:
     load_var2 6 2
     call baml.llm.Client.build_plan_with_state
-    load_type baml.iter.Iterable<Item = baml.llm.OrchestrationStep, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = baml.llm.OrchestrationStep>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _16
 
   L7:
     load_var _16
-    load_type baml.iter.Iterator<Item = baml.llm.OrchestrationStep, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = baml.llm.OrchestrationStep>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _17
@@ -4426,14 +4426,14 @@ function baml.llm.Client.build_plan_with_state(self: baml.llm.Client, planner_st
   L8:
     load_var2 1 2
     call baml.llm.Client.build_attempt_with_state
-    load_type baml.iter.Iterable<Item = baml.llm.OrchestrationStep, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = baml.llm.OrchestrationStep>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _24
 
   L9:
     load_var _24
-    load_type baml.iter.Iterator<Item = baml.llm.OrchestrationStep, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = baml.llm.OrchestrationStep>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _25
@@ -4520,14 +4520,14 @@ function baml.llm.Client.execute_once_oneshot(self: baml.llm.Client, context: ba
   L4:
     load_var self
     load_field .sub_clients
-    load_type baml.iter.Iterable<Item = baml.llm.Client, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = baml.llm.Client>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _38
 
   L5:
     load_var _38
-    load_type baml.iter.Iterator<Item = baml.llm.Client, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = baml.llm.Client>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _39
@@ -4700,14 +4700,14 @@ function baml.llm.Client.execute_once_stream(self: baml.llm.Client, context: bam
   L4:
     load_var self
     load_field .sub_clients
-    load_type baml.iter.Iterable<Item = baml.llm.Client, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = baml.llm.Client>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _24
 
   L5:
     load_var _24
-    load_type baml.iter.Iterator<Item = baml.llm.Client, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = baml.llm.Client>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _25
@@ -5008,14 +5008,14 @@ function baml.llm.PlannerState.rr_local_offset(self: baml.llm.PlannerState, clie
     store_var offset
     load_var self
     load_field .rr_client_names
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
 
   L0:
     load_var _5
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
@@ -5610,14 +5610,14 @@ function baml.llm.render_prompt_values(values: unknown[]) -> unknown[] {
     alloc_array 0
     store_var rendered
     load_var values
-    load_type baml.iter.Iterable<Item = unknown, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = unknown>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = unknown, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = unknown>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -8332,14 +8332,14 @@ function baml.toml.table_from_json(j: baml.json.json) -> baml.toml.Table {
     load_type baml.json.json
     load_var j
     call baml.Map.keys
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
 
   L2:
     load_var _7
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _8

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____04_5_mir.snap
@@ -99,11 +99,11 @@ fn testing.TestCollector.register_test(self: testing.TestCollector, name: string
         _15 = copy _8;
         _14 = copy _15 + const "#";
         _16 = copy _1.1;
-        _17 = virtual_call iter as baml.iter.Iterable<Item = testing.TestRegistration, Error = never>(copy _16) -> [bb6];
+        _17 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestRegistration>(copy _16) -> [bb6];
     }
 
     bb6: {
-        _18 = virtual_call next as baml.iter.Iterator<Item = testing.TestRegistration, Error = never>(copy _17) -> [bb7];
+        _18 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestRegistration>(copy _17) -> [bb7];
     }
 
     bb7: {
@@ -261,11 +261,11 @@ fn testing.TestCollector.register_test_set(self: testing.TestCollector, name: st
         _15 = copy _8;
         _14 = copy _15 + const "#";
         _16 = copy _1.2;
-        _17 = virtual_call iter as baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>(copy _16) -> [bb6];
+        _17 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>(copy _16) -> [bb6];
     }
 
     bb6: {
-        _18 = virtual_call next as baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>(copy _17) -> [bb7];
+        _18 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>(copy _17) -> [bb7];
     }
 
     bb7: {
@@ -412,11 +412,11 @@ fn testing.TestCollector.find_testset(self: testing.TestCollector, name: string)
 
     bb0: {
         _3 = copy _1.2;
-        _4 = virtual_call iter as baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>(copy _3) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>(copy _3) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>(copy _4) -> [bb2];
     }
 
     bb2: {
@@ -465,11 +465,11 @@ fn testing.TestCollector.find_test(self: testing.TestCollector, name: string) ->
 
     bb0: {
         _3 = copy _1.1;
-        _4 = virtual_call iter as baml.iter.Iterable<Item = testing.TestRegistration, Error = never>(copy _3) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestRegistration>(copy _3) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = testing.TestRegistration, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestRegistration>(copy _4) -> [bb2];
     }
 
     bb2: {
@@ -571,11 +571,11 @@ fn testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.Serial
     bb0: {
         _2 = []: testing.SerializedTest | testing.SerializedTestSet[];
         _3 = copy _1.0.1;
-        _4 = virtual_call iter as baml.iter.Iterable<Item = testing.TestRegistration, Error = never>(copy _3) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestRegistration>(copy _3) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = testing.TestRegistration, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestRegistration>(copy _4) -> [bb2];
     }
 
     bb2: {
@@ -594,11 +594,11 @@ fn testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.Serial
 
     bb4: {
         _12 = copy _1.0.2;
-        _13 = virtual_call iter as baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>(copy _12) -> [bb5];
+        _13 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>(copy _12) -> [bb5];
     }
 
     bb5: {
-        _14 = virtual_call next as baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>(copy _13) -> [bb6];
+        _14 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>(copy _13) -> [bb6];
     }
 
     bb6: {
@@ -684,11 +684,11 @@ fn testing.TestRegistry.run_test(self: testing.TestRegistry, name: string) -> te
 
     bb0: {
         _3 = copy _1.0.1;
-        _4 = virtual_call iter as baml.iter.Iterable<Item = testing.TestRegistration, Error = never>(copy _3) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestRegistration>(copy _3) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = testing.TestRegistration, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestRegistration>(copy _4) -> [bb2];
     }
 
     bb2: {
@@ -719,11 +719,11 @@ fn testing.TestRegistry.run_test(self: testing.TestRegistry, name: string) -> te
     }
 
     bb6: {
-        _17 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _13) -> [bb7];
+        _17 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _13) -> [bb7];
     }
 
     bb7: {
-        _18 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _17) -> [bb8];
+        _18 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _17) -> [bb8];
     }
 
     bb8: {
@@ -797,11 +797,11 @@ fn testing.TestRegistry.run_testset(self: testing.TestRegistry, name: string) ->
 
     bb0: {
         _3 = copy _1.0.2;
-        _4 = virtual_call iter as baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>(copy _3) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>(copy _3) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>(copy _4) -> [bb2];
     }
 
     bb2: {
@@ -840,11 +840,11 @@ fn testing.TestRegistry.run_testset(self: testing.TestRegistry, name: string) ->
     }
 
     bb8: {
-        _19 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _15) -> [bb9];
+        _19 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _15) -> [bb9];
     }
 
     bb9: {
-        _20 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _19) -> [bb10];
+        _20 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _19) -> [bb10];
     }
 
     bb10: {
@@ -1071,11 +1071,11 @@ fn testing.TestRegistry.expand_set(self: testing.TestRegistry, name: string) -> 
 
     bb0: {
         _3 = copy _1.0.2;
-        _4 = virtual_call iter as baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>(copy _3) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>(copy _3) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>(copy _4) -> [bb2];
     }
 
     bb2: {
@@ -1109,11 +1109,11 @@ fn testing.TestRegistry.expand_set(self: testing.TestRegistry, name: string) -> 
     }
 
     bb7: {
-        _17 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _13) -> [bb8];
+        _17 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _13) -> [bb8];
     }
 
     bb8: {
-        _18 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _17) -> [bb9];
+        _18 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _17) -> [bb9];
     }
 
     bb9: {
@@ -1276,11 +1276,11 @@ fn testing.testset_children(registry: testing.TestRegistry) -> testing.TestSetCh
     bb0: {
         _2 = []: testing.TestSetChild[];
         _3 = copy _1.0.1;
-        _4 = virtual_call iter as baml.iter.Iterable<Item = testing.TestRegistration, Error = never>(copy _3) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestRegistration>(copy _3) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = testing.TestRegistration, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestRegistration>(copy _4) -> [bb2];
     }
 
     bb2: {
@@ -1304,11 +1304,11 @@ fn testing.testset_children(registry: testing.TestRegistry) -> testing.TestSetCh
 
     bb5: {
         _14 = copy _1.0.2;
-        _15 = virtual_call iter as baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>(copy _14) -> [bb6];
+        _15 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>(copy _14) -> [bb6];
     }
 
     bb6: {
-        _16 = virtual_call next as baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>(copy _15) -> [bb7];
+        _16 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>(copy _15) -> [bb7];
     }
 
     bb7: {
@@ -1372,11 +1372,11 @@ fn testing.testset_children_selected(registry: testing.TestRegistry, names: stri
     bb0: {
         _3 = []: testing.TestSetChild[];
         _4 = copy _1.0.1;
-        _5 = virtual_call iter as baml.iter.Iterable<Item = testing.TestRegistration, Error = never>(copy _4) -> [bb1];
+        _5 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestRegistration>(copy _4) -> [bb1];
     }
 
     bb1: {
-        _6 = virtual_call next as baml.iter.Iterator<Item = testing.TestRegistration, Error = never>(copy _5) -> [bb2];
+        _6 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestRegistration>(copy _5) -> [bb2];
     }
 
     bb2: {
@@ -1414,11 +1414,11 @@ fn testing.testset_children_selected(registry: testing.TestRegistry, names: stri
 
     bb8: {
         _17 = copy _1.0.2;
-        _18 = virtual_call iter as baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>(copy _17) -> [bb9];
+        _18 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>(copy _17) -> [bb9];
     }
 
     bb9: {
-        _19 = virtual_call next as baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>(copy _18) -> [bb10];
+        _19 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>(copy _18) -> [bb10];
     }
 
     bb10: {
@@ -1658,11 +1658,11 @@ fn testing._name_selected(name: string, names: string[]) -> bool {
     let _9: string
 
     bb0: {
-        _3 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _2) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _2) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _3) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _3) -> [bb2];
     }
 
     bb2: {
@@ -1710,11 +1710,11 @@ fn testing._has_selected_descendant(prefix: string, names: string[]) -> bool {
 
     bb0: {
         _3 = copy _1 + const "::";
-        _4 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _2) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _2) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _4) -> [bb2];
     }
 
     bb2: {
@@ -1812,11 +1812,11 @@ fn testing.aggregate_reports(named_results: testing.NamedChildReport[]) -> testi
         _5 = []: string[];
         _6 = []: testing.TestReport | testing.TestSetReport[];
         _7 = []: string[];
-        _8 = virtual_call iter as baml.iter.Iterable<Item = testing.NamedChildReport, Error = never>(copy _1) -> [bb1];
+        _8 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.NamedChildReport>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _9 = virtual_call next as baml.iter.Iterator<Item = testing.NamedChildReport, Error = never>(copy _8) -> [bb2];
+        _9 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.NamedChildReport>(copy _8) -> [bb2];
     }
 
     bb2: {
@@ -1901,11 +1901,11 @@ fn testing.aggregate_reports(named_results: testing.NamedChildReport[]) -> testi
 
     bb16: {
         _32 = copy _24;
-        _33 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _32) -> [bb17];
+        _33 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _32) -> [bb17];
     }
 
     bb17: {
-        _34 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _33) -> [bb18];
+        _34 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _33) -> [bb18];
     }
 
     bb18: {
@@ -2010,11 +2010,11 @@ fn testing.run_children_parallel(children: testing.TestSetChild[]) -> testing.Te
 
     bb0: {
         _2 = []: future<testing.NamedChildReport, never>[];
-        _3 = virtual_call iter as baml.iter.Iterable<Item = testing.TestSetChild, Error = never>(copy _1) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestSetChild>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Item = testing.TestSetChild, Error = never>(copy _3) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestSetChild>(copy _3) -> [bb2];
     }
 
     bb2: {
@@ -2597,11 +2597,11 @@ fn testing.any_pattern_matches(pats: string[], canonical_id: string) -> bool {
     let _9: string
 
     bb0: {
-        _3 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _1) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _3) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _3) -> [bb2];
     }
 
     bb2: {
@@ -2734,11 +2734,11 @@ fn testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
 
     bb0: {
         _3 = copy _1 + const "::";
-        _4 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _2) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _2) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _4) -> [bb2];
     }
 
     bb2: {
@@ -2908,11 +2908,11 @@ fn testing.subtree_may_be_selected(prefix: string, include: string[], exclude: s
     }
 
     bb4: {
-        _7 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _2) -> [bb5];
+        _7 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _2) -> [bb5];
     }
 
     bb5: {
-        _8 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _7) -> [bb6];
+        _8 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _7) -> [bb6];
     }
 
     bb6: {
@@ -3000,11 +3000,11 @@ fn testing.select_names_layered(registry: testing.TestRegistry, profile_include:
     bb0: {
         _6 = []: string[];
         _7 = copy _1.0.1;
-        _8 = virtual_call iter as baml.iter.Iterable<Item = testing.TestRegistration, Error = never>(copy _7) -> [bb1];
+        _8 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestRegistration>(copy _7) -> [bb1];
     }
 
     bb1: {
-        _9 = virtual_call next as baml.iter.Iterator<Item = testing.TestRegistration, Error = never>(copy _8) -> [bb2];
+        _9 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestRegistration>(copy _8) -> [bb2];
     }
 
     bb2: {
@@ -3036,11 +3036,11 @@ fn testing.select_names_layered(registry: testing.TestRegistry, profile_include:
 
     bb7: {
         _17 = copy _1.0.2;
-        _18 = virtual_call iter as baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>(copy _17) -> [bb8];
+        _18 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>(copy _17) -> [bb8];
     }
 
     bb8: {
-        _19 = virtual_call next as baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>(copy _18) -> [bb9];
+        _19 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>(copy _18) -> [bb9];
     }
 
     bb9: {
@@ -3076,11 +3076,11 @@ fn testing.select_names_layered(registry: testing.TestRegistry, profile_include:
 
     bb15: {
         _29 = copy _27;
-        _30 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _29) -> [bb16];
+        _30 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _29) -> [bb16];
     }
 
     bb16: {
-        _31 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _30) -> [bb17];
+        _31 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _30) -> [bb17];
     }
 
     bb17: {
@@ -3158,11 +3158,11 @@ fn testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] {
     bb0: {
         _2 = []: string[];
         _3 = copy _1.0.1;
-        _4 = virtual_call iter as baml.iter.Iterable<Item = testing.TestRegistration, Error = never>(copy _3) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestRegistration>(copy _3) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = testing.TestRegistration, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestRegistration>(copy _4) -> [bb2];
     }
 
     bb2: {
@@ -3180,11 +3180,11 @@ fn testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] {
 
     bb4: {
         _11 = copy _1.0.2;
-        _12 = virtual_call iter as baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>(copy _11) -> [bb5];
+        _12 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>(copy _11) -> [bb5];
     }
 
     bb5: {
-        _13 = virtual_call next as baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>(copy _12) -> [bb6];
+        _13 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>(copy _12) -> [bb6];
     }
 
     bb6: {
@@ -3201,11 +3201,11 @@ fn testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] {
     }
 
     bb8: {
-        _19 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _17) -> [bb9];
+        _19 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _17) -> [bb9];
     }
 
     bb9: {
-        _20 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _19) -> [bb10];
+        _20 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _19) -> [bb10];
     }
 
     bb10: {
@@ -3621,11 +3621,11 @@ fn testing.count_leaves(results: (testing.TestReport | testing.TestSetReport)[],
         _4 = const 0_i64;
         _5 = const 0_i64;
         _6 = const 0_i64;
-        _7 = virtual_call iter as baml.iter.Iterable<Item = testing.TestReport | testing.TestSetReport, Error = never>(copy _1) -> [bb1];
+        _7 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestReport | testing.TestSetReport>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _8 = virtual_call next as baml.iter.Iterator<Item = testing.TestReport | testing.TestSetReport, Error = never>(copy _7) -> [bb2];
+        _8 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestReport | testing.TestSetReport>(copy _7) -> [bb2];
     }
 
     bb2: {
@@ -4003,11 +4003,11 @@ fn testing.classify_selected_names(selected_names: string[], hard_failed_names: 
         _6 = []: string[];
         _7 = []: string[];
         _4 = testing.LeafIdentities { copy _5, copy _6, copy _7 };
-        _8 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _1) -> [bb1];
+        _8 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _9 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _8) -> [bb2];
+        _9 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _8) -> [bb2];
     }
 
     bb2: {
@@ -4081,11 +4081,11 @@ fn testing.name_in(name: string, names: string[]) -> bool {
     let _9: string
 
     bb0: {
-        _3 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _2) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _2) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _3) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _3) -> [bb2];
     }
 
     bb2: {
@@ -4172,11 +4172,11 @@ fn testing.failure_matches_selected(selected: string, failed_names: string[]) ->
 
     bb7: {
         _7 = copy _8 + const "::";
-        _12 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _2) -> [bb8];
+        _12 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _2) -> [bb8];
     }
 
     bb8: {
-        _13 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _12) -> [bb9];
+        _13 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _12) -> [bb9];
     }
 
     bb9: {
@@ -4523,11 +4523,11 @@ fn testing.collect_all_failed_names(report: testing.TestSetReport, out: string[]
 
     bb0: {
         _3 = copy _1.4;
-        _4 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _3) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _3) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _4) -> [bb2];
     }
 
     bb2: {
@@ -4560,11 +4560,11 @@ fn testing.collect_all_failed_names(report: testing.TestSetReport, out: string[]
 
     bb7: {
         _14 = copy _1.5;
-        _15 = virtual_call iter as baml.iter.Iterable<Item = testing.TestReport | testing.TestSetReport, Error = never>(copy _14) -> [bb8];
+        _15 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestReport | testing.TestSetReport>(copy _14) -> [bb8];
     }
 
     bb8: {
-        _16 = virtual_call next as baml.iter.Iterator<Item = testing.TestReport | testing.TestSetReport, Error = never>(copy _15) -> [bb9];
+        _16 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestReport | testing.TestSetReport>(copy _15) -> [bb9];
     }
 
     bb9: {
@@ -4632,11 +4632,11 @@ fn testing.collect_leaf_messages(results: (testing.TestReport | testing.TestSetR
     let _26: (testing.TestReport | testing.TestSetReport)[]
 
     bb0: {
-        _3 = virtual_call iter as baml.iter.Iterable<Item = testing.TestReport | testing.TestSetReport, Error = never>(copy _1) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestReport | testing.TestSetReport>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Item = testing.TestReport | testing.TestSetReport, Error = never>(copy _3) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestReport | testing.TestSetReport>(copy _3) -> [bb2];
     }
 
     bb2: {
@@ -4661,11 +4661,11 @@ fn testing.collect_leaf_messages(results: (testing.TestReport | testing.TestSetR
     bb5: {
         _9 = copy _8;
         _10 = copy _9.1;
-        _11 = virtual_call iter as baml.iter.Iterable<Item = testing.RunReport, Error = never>(copy _10) -> [bb6];
+        _11 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.RunReport>(copy _10) -> [bb6];
     }
 
     bb6: {
-        _12 = virtual_call next as baml.iter.Iterator<Item = testing.RunReport, Error = never>(copy _11) -> [bb7];
+        _12 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.RunReport>(copy _11) -> [bb7];
     }
 
     bb7: {
@@ -4854,11 +4854,11 @@ fn .<lambda(<lambda(Quorum, 0)>, 1)>() -> testing.TestReport {
 
     bb8: {
         _9 = copy _7.1;
-        _10 = virtual_call iter as baml.iter.Iterable<Item = testing.RunReport, Error = never>(copy _9) -> [bb9];
+        _10 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.RunReport>(copy _9) -> [bb9];
     }
 
     bb9: {
-        _11 = virtual_call next as baml.iter.Iterator<Item = testing.RunReport, Error = never>(copy _10) -> [bb10];
+        _11 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.RunReport>(copy _10) -> [bb10];
     }
 
     bb10: {
@@ -5028,11 +5028,11 @@ fn .<lambda(<lambda(Retry, 0)>, 1)>() -> testing.TestReport {
     bb10: {
         _3 = copy _3 + const 1_i64;
         _11 = copy _9.1;
-        _12 = virtual_call iter as baml.iter.Iterable<Item = testing.RunReport, Error = never>(copy _11) -> [bb11];
+        _12 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.RunReport>(copy _11) -> [bb11];
     }
 
     bb11: {
-        _13 = virtual_call next as baml.iter.Iterator<Item = testing.RunReport, Error = never>(copy _12) -> [bb12];
+        _13 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.RunReport>(copy _12) -> [bb12];
     }
 
     bb12: {
@@ -5274,11 +5274,11 @@ fn testing.run_children_sequential(children: testing.TestSetChild[], fail_fast: 
 
     bb0: {
         _3 = []: testing.NamedChildReport[];
-        _4 = virtual_call iter as baml.iter.Iterable<Item = testing.TestSetChild, Error = never>(copy _1) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = testing.TestSetChild>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = testing.TestSetChild, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = testing.TestSetChild>(copy _4) -> [bb2];
     }
 
     bb2: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__testing_std__/baml_tests__compiles____testing_std____06_codegen.snap
@@ -110,14 +110,14 @@ function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetRepo
 function testing.TestCollector.find_test(self: testing.TestCollector, name: string) -> testing.TestRegistration {
     load_var self
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -146,14 +146,14 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
 function testing.TestCollector.find_testset(self: testing.TestCollector, name: string) -> testing.TestSetRegistration {
     load_var self
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -227,14 +227,14 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     store_var hash_prefix
     load_var self
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _17
 
   L4:
     load_var _17
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _18
@@ -364,14 +364,14 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     store_var hash_prefix
     load_var self
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _17
 
   L4:
     load_var _17
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _18
@@ -467,14 +467,14 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     load_var self
     load_field .collector
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -503,14 +503,14 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     load_var self
     load_field .expansions
     call baml.Map.keys
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _17
 
   L3:
     load_var _17
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _18
@@ -701,14 +701,14 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     load_var self
     load_field .collector
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -737,14 +737,14 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     load_var self
     load_field .expansions
     call baml.Map.keys
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _17
 
   L3:
     load_var _17
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _18
@@ -783,14 +783,14 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
     load_var self
     load_field .collector
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -820,14 +820,14 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
     load_var self
     load_field .expansions
     call baml.Map.keys
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _19
 
   L3:
     load_var _19
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _20
@@ -869,14 +869,14 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     load_var self
     load_field .collector
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -899,14 +899,14 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     load_var self
     load_field .collector
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
 
   L3:
     load_var _13
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _14
@@ -965,14 +965,14 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
 
 function testing._has_selected_descendant(prefix: string, names: string[]) -> bool {
     load_var names
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -1014,14 +1014,14 @@ function testing._int_to_float(value: int) -> float {
 
 function testing._name_selected(name: string, names: string[]) -> bool {
     load_var names
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -1061,14 +1061,14 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
     alloc_array 0
     store_var result_names
     load_var named_results
-    load_type baml.iter.Iterable<Item = testing.NamedChildReport, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.NamedChildReport>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
 
   L0:
     load_var _8
-    load_type baml.iter.Iterator<Item = testing.NamedChildReport, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.NamedChildReport>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
@@ -1158,14 +1158,14 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
     alloc_array 1
 
   L10:
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _33
 
   L11:
     load_var _33
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _34
@@ -1238,14 +1238,14 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
 function testing.any_pattern_matches(pats: string[], canonical_id: string) -> bool {
     load_var pats
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -1278,14 +1278,14 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
     init_instance testing.LeafIdentities .passed, .failed, .tolerated
     store_var out
     load_var selected_names
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
 
   L0:
     load_var _8
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
@@ -1343,14 +1343,14 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
 function testing.collect_all_failed_names(report: testing.TestSetReport, out: string[]) -> void {
     load_var report
     load_field .failed_names
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -1374,14 +1374,14 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
   L2:
     load_var report
     load_field .results
-    load_type baml.iter.Iterable<Item = testing.TestReport | testing.TestSetReport, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestReport | testing.TestSetReport>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _15
 
   L3:
     load_var _15
-    load_type baml.iter.Iterator<Item = testing.TestReport | testing.TestSetReport, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestReport | testing.TestSetReport>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _16
@@ -1631,14 +1631,14 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
 
 function testing.collect_leaf_messages(results: (testing.TestReport | testing.TestSetReport)[], out: string[]) -> void {
     load_var results
-    load_type baml.iter.Iterable<Item = testing.TestReport | testing.TestSetReport, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestReport | testing.TestSetReport>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = testing.TestReport | testing.TestSetReport, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestReport | testing.TestSetReport>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -1668,14 +1668,14 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
   L3:
     load_var _8
     load_field .runs
-    load_type baml.iter.Iterable<Item = testing.RunReport, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.RunReport>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _11
 
   L4:
     load_var _11
-    load_type baml.iter.Iterator<Item = testing.RunReport, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.RunReport>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _12
@@ -1715,14 +1715,14 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
     load_var registry
     load_field .collector
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -1742,14 +1742,14 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
     load_var registry
     load_field .collector
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _12
 
   L3:
     load_var _12
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
@@ -1761,14 +1761,14 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
   L4:
     load_var2 1 6
     call testing.collect_subtree_names
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _19
 
   L5:
     load_var _19
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _20
@@ -2100,14 +2100,14 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
     load_const 0
     store_var total
     load_var results
-    load_type baml.iter.Iterable<Item = testing.TestReport | testing.TestSetReport, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestReport | testing.TestSetReport>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
 
   L0:
     load_var _7
-    load_type baml.iter.Iterator<Item = testing.TestReport | testing.TestSetReport, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestReport | testing.TestSetReport>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
@@ -2297,14 +2297,14 @@ function testing.failure_matches_selected(selected: string, failed_names: string
     call baml.String.substring
     store_var _8
     load_var failed_names
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _12
 
   L1:
     load_var _12
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
@@ -2682,14 +2682,14 @@ function testing.leaf_selected_layered(name: string, profile_include: string[], 
 
 function testing.name_in(name: string, names: string[]) -> bool {
     load_var names
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -2759,14 +2759,14 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
     alloc_array 0
     store_var futures
     load_var children
-    load_type baml.iter.Iterable<Item = testing.TestSetChild, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetChild>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = testing.TestSetChild, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetChild>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -2809,14 +2809,14 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
     alloc_array 0
     store_var named_results
     load_var children
-    load_type baml.iter.Iterable<Item = testing.TestSetChild, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetChild>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestSetChild, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetChild>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -2943,14 +2943,14 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
     load_var registry
     load_field .collector
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
 
   L0:
     load_var _8
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
@@ -2977,14 +2977,14 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
     load_var registry
     load_field .collector
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _18
 
   L3:
     load_var _18
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _19
@@ -3012,14 +3012,14 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
     load_var2 2 3
     load_var2 4 5
     call testing.collect_subtree_names_layered
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _30
 
   L6:
     load_var _30
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _31
@@ -3045,14 +3045,14 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
     bin_op +
     store_var descendant_prefix
     load_var excludes
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -3124,14 +3124,14 @@ function testing.subtree_may_be_selected(prefix: string, include: string[], excl
 
   L1:
     load_var include
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
 
   L2:
     load_var _7
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
@@ -3217,14 +3217,14 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
     load_var registry
     load_field .collector
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -3252,14 +3252,14 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
     load_var registry
     load_field .collector
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _15
 
   L3:
     load_var _15
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _16
@@ -3289,14 +3289,14 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
     load_var registry
     load_field .collector
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
 
   L0:
     load_var _5
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
@@ -3329,14 +3329,14 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
     load_var registry
     load_field .collector
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _18
 
   L3:
     load_var _18
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _19

--- a/baml_language/crates/baml_tests/snapshots/compiles/anyfunction_reflect/baml_tests__compiles__anyfunction_reflect__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/anyfunction_reflect/baml_tests__compiles__anyfunction_reflect__04_5_mir.snap
@@ -153,11 +153,11 @@ fn user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = unknown
     bb5: {
         _3 = copy _4 + copy _9;
         _13 = copy _2.1;
-        _14 = virtual_call iter as baml.iter.Iterable<Item = reflect.Arg, Error = never>(copy _13) -> [bb6];
+        _14 = virtual_call iter as baml.iter.Iterable<Error = never, Item = reflect.Arg>(copy _13) -> [bb6];
     }
 
     bb6: {
-        _15 = virtual_call next as baml.iter.Iterator<Item = reflect.Arg, Error = never>(copy _14) -> [bb7];
+        _15 = virtual_call next as baml.iter.Iterator<Error = never, Item = reflect.Arg>(copy _14) -> [bb7];
     }
 
     bb7: {
@@ -189,11 +189,11 @@ fn user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = unknown
     }
 
     bb11: {
-        _28 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _24) -> [bb12];
+        _28 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _24) -> [bb12];
     }
 
     bb12: {
-        _29 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _28) -> [bb13];
+        _29 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _28) -> [bb13];
     }
 
     bb13: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/anyfunction_reflect/baml_tests__compiles__anyfunction_reflect__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/anyfunction_reflect/baml_tests__compiles__anyfunction_reflect__06_codegen.snap
@@ -66,14 +66,14 @@ function user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = u
     store_var parts
     load_var sig
     load_field .args
-    load_type baml.iter.Iterable<Item = reflect.Arg, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = reflect.Arg>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _14
 
   L0:
     load_var _14
-    load_type baml.iter.Iterator<Item = reflect.Arg, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = reflect.Arg>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _15
@@ -104,14 +104,14 @@ function user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = u
     load_var sig
     load_field .opts
     call baml.Map.keys
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _28
 
   L3:
     load_var _28
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _29

--- a/baml_language/crates/baml_tests/snapshots/compiles/backtick_dedent/baml_tests__compiles__backtick_dedent__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/backtick_dedent/baml_tests__compiles__backtick_dedent__04_5_mir.snap
@@ -111,11 +111,11 @@ fn user.ForLoopVerbatim(xs: string[]) -> string {
 
     bb0: {
         _2 = const "";
-        _3 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _1) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _3) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _3) -> [bb2];
     }
 
     bb2: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/backtick_dedent/baml_tests__compiles__backtick_dedent__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/backtick_dedent/baml_tests__compiles__backtick_dedent__06_codegen.snap
@@ -30,14 +30,14 @@ function user.ForLoopVerbatim(xs: string[]) -> string {
     load_const ""
     store_var  __m3_for
     load_var xs
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4

--- a/baml_language/crates/baml_tests/snapshots/compiles/backtick_strings/baml_tests__compiles__backtick_strings__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/backtick_strings/baml_tests__compiles__backtick_strings__04_5_mir.snap
@@ -464,11 +464,11 @@ fn user.BacktickM3ForLoop(xs: string[]) -> string {
 
     bb0: {
         _2 = const "";
-        _3 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _1) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _3) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _3) -> [bb2];
     }
 
     bb2: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/backtick_strings/baml_tests__compiles__backtick_strings__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/backtick_strings/baml_tests__compiles__backtick_strings__06_codegen.snap
@@ -174,14 +174,14 @@ function user.BacktickM3ForLoop(xs: string[]) -> string {
     load_const ""
     store_var  __m3_for
     load_var xs
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4

--- a/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__04_5_mir.snap
@@ -27,11 +27,11 @@ fn user.sum_array(arr: int[]) -> int {
     bb0: {
         _2 = const 0_i64;
         _3 = []: never[];
-        _4 = virtual_call iter as baml.iter.Iterable<Item = int, Error = never>(copy _1) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = int, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = int>(copy _4) -> [bb2];
     }
 
     bb2: {
@@ -49,11 +49,11 @@ fn user.sum_array(arr: int[]) -> int {
 
     bb4: {
         _11 = copy _3;
-        _12 = virtual_call iter as baml.iter.Iterable<Item = () -> void throws never, Error = never>(copy _11) -> [bb5];
+        _12 = virtual_call iter as baml.iter.Iterable<Error = never, Item = () -> void throws never>(copy _11) -> [bb5];
     }
 
     bb5: {
-        _13 = virtual_call next as baml.iter.Iterator<Item = () -> void throws never, Error = never>(copy _12) -> [bb6];
+        _13 = virtual_call next as baml.iter.Iterator<Error = never, Item = () -> void throws never>(copy _12) -> [bb6];
     }
 
     bb6: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__06_codegen.snap
@@ -29,14 +29,14 @@ function user.sum_array(arr: int[]) -> int {
     alloc_array 0
     store_var total
     load_var arr
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -60,14 +60,14 @@ function user.sum_array(arr: int[]) -> int {
 
   L2:
     load_var total
-    load_type baml.iter.Iterable<Item = () -> void throws never, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = () -> void throws never>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _12
 
   L3:
     load_var _12
-    load_type baml.iter.Iterator<Item = () -> void throws never, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = () -> void throws never>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _13

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__04_5_mir.snap
@@ -618,11 +618,11 @@ fn user.test_shadowing() -> string {
 
     bb1: {
         _8 = copy _3;
-        _9 = virtual_call iter as baml.iter.Iterable<Item = int, Error = never>(copy _8) -> [bb2];
+        _9 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int>(copy _8) -> [bb2];
     }
 
     bb2: {
-        _10 = virtual_call next as baml.iter.Iterator<Item = int, Error = never>(copy _9) -> [bb3];
+        _10 = virtual_call next as baml.iter.Iterator<Error = never, Item = int>(copy _9) -> [bb3];
     }
 
     bb3: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__06_codegen.snap
@@ -374,14 +374,14 @@ function user.test_shadowing() -> string {
     alloc_array 3
     make_closure .<lambda(test_shadowing, 0)>, 0
     call baml.Array.map
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
 
   L0:
     load_var _9
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _10

--- a/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__04_5_mir.snap
@@ -129,11 +129,11 @@ fn user.for_loop_restores_outer() -> int {
     bb0: {
         _1 = const 1_i64;
         _2 = [const 2_i64, const 3_i64]: int[];
-        _3 = virtual_call iter as baml.iter.Iterable<Item = int, Error = never>(copy _2) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int>(copy _2) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Item = int, Error = never>(copy _3) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = int>(copy _3) -> [bb2];
     }
 
     bb2: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__06_codegen.snap
@@ -69,14 +69,14 @@ function user.for_loop_restores_outer() -> int {
     load_const 3
     load_type int
     alloc_array 2
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4

--- a/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__04_5_mir.snap
@@ -561,11 +561,11 @@ fn user.iterator_style_for_loop() -> int {
     bb0: {
         _1 = const 0_i64;
         _2 = [const 1_i64, const 2_i64, const 3_i64]: int[];
-        _3 = virtual_call iter as baml.iter.Iterable<Item = int, Error = never>(copy _2) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int>(copy _2) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Item = int, Error = never>(copy _3) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = int>(copy _3) -> [bb2];
     }
 
     bb2: {
@@ -615,11 +615,11 @@ fn user.nested_for_loop() -> int {
     bb0: {
         _1 = const 0_i64;
         _2 = [const 1_i64, const 2_i64, const 3_i64]: int[];
-        _3 = virtual_call iter as baml.iter.Iterable<Item = int, Error = never>(copy _2) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int>(copy _2) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Item = int, Error = never>(copy _3) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = int>(copy _3) -> [bb2];
     }
 
     bb2: {
@@ -632,11 +632,11 @@ fn user.nested_for_loop() -> int {
         fresh_cell(_7);
         _7 = copy _6;
         _8 = [const 4_i64, const 5_i64, const 6_i64]: int[];
-        _9 = virtual_call iter as baml.iter.Iterable<Item = int, Error = never>(copy _8) -> [bb4];
+        _9 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int>(copy _8) -> [bb4];
     }
 
     bb4: {
-        _10 = virtual_call next as baml.iter.Iterator<Item = int, Error = never>(copy _9) -> [bb5];
+        _10 = virtual_call next as baml.iter.Iterator<Error = never, Item = int>(copy _9) -> [bb5];
     }
 
     bb5: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__06_codegen.snap
@@ -232,14 +232,14 @@ function user.iterator_style_for_loop() -> int {
     load_const 3
     load_type int
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -334,14 +334,14 @@ function user.nested_for_loop() -> int {
     load_const 3
     load_type int
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -356,14 +356,14 @@ function user.nested_for_loop() -> int {
     load_const 6
     load_type int
     alloc_array 3
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
 
   L2:
     load_var _9
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _10

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__04_5_mir.snap
@@ -276,11 +276,11 @@ fn user.for_let_with_narrow(items: int[]) -> int {
 
     bb0: {
         _2 = const 0_i64;
-        _3 = virtual_call iter as baml.iter.Iterable<Item = int, Error = never>(copy _1) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Item = int, Error = never>(copy _3) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = int>(copy _3) -> [bb2];
     }
 
     bb2: {
@@ -320,11 +320,11 @@ fn user.for_let_ascription(items: int[]) -> int {
 
     bb0: {
         _2 = const 0_i64;
-        _3 = virtual_call iter as baml.iter.Iterable<Item = int, Error = never>(copy _1) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Item = int, Error = never>(copy _3) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = int>(copy _3) -> [bb2];
     }
 
     bb2: {
@@ -365,11 +365,11 @@ fn user.for_let_fn_narrow(items: ((int) -> int throws never)[]) -> int {
 
     bb0: {
         _2 = const 0_i64;
-        _3 = virtual_call iter as baml.iter.Iterable<Item = (int) -> int throws never, Error = never>(copy _1) -> [bb1];
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = (int) -> int throws never>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _4 = virtual_call next as baml.iter.Iterator<Item = (int) -> int throws never, Error = never>(copy _3) -> [bb2];
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = (int) -> int throws never>(copy _3) -> [bb2];
     }
 
     bb2: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__06_codegen.snap
@@ -181,14 +181,14 @@ function user.for_let_ascription(items: int[]) -> int {
     load_const 0
     store_var sum
     load_var items
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -215,14 +215,14 @@ function user.for_let_fn_narrow(items: ((int) -> int throws never)[]) -> int {
     load_const 0
     store_var total
     load_var items
-    load_type baml.iter.Iterable<Item = (int) -> int throws never, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = (int) -> int throws never>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = (int) -> int throws never, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = (int) -> int throws never>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -249,14 +249,14 @@ function user.for_let_with_narrow(items: int[]) -> int {
     load_const 0
     store_var sum
     load_var items
-    load_type baml.iter.Iterable<Item = int, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = int, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = int>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_dynamic/baml_tests__compiles__testset_dynamic__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_dynamic/baml_tests__compiles__testset_dynamic__04_5_mir.snap
@@ -49,11 +49,11 @@ fn .<lambda($init_test_main, 0)>(testset: testing.TestCollector) -> void {
     bb0: {
         _2 = [const "hello", const "world", const "foo"]: string[];
         _3 = copy _2;
-        _4 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _3) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _3) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _4) -> [bb2];
     }
 
     bb2: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__04_5_mir.snap
@@ -45,11 +45,11 @@ fn .<lambda($init_test_main, 0)>(testset: testing.TestCollector) -> void {
     bb0: {
         _2 = [const "happy", const "sad"]: string[];
         _3 = copy _2;
-        _4 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _3) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _3) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _4) -> [bb2];
     }
 
     bb2: {
@@ -119,11 +119,11 @@ fn .<lambda(<lambda($init_test_main, 0)>, 1)>(testset: testing.TestCollector) ->
 
     bb3: {
         _8 = copy _6;
-        _9 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _8) -> [bb4];
+        _9 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _8) -> [bb4];
     }
 
     bb4: {
-        _10 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _9) -> [bb5];
+        _10 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _9) -> [bb5];
     }
 
     bb5: {
@@ -196,11 +196,11 @@ fn .<lambda(<lambda($init_test_main, 0)>, 3)>(testset: testing.TestCollector) ->
     bb0: {
         _2 = [const "happy", const "sad"]: string[];
         _3 = copy _2;
-        _4 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _3) -> [bb1];
+        _4 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _3) -> [bb1];
     }
 
     bb1: {
-        _5 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _4) -> [bb2];
     }
 
     bb2: {
@@ -251,11 +251,11 @@ fn .<lambda(<lambda(<lambda($init_test_main, 0)>, 3)>, 4)>(testset: testing.Test
 
     bb1: {
         _4 = copy _2;
-        _5 = virtual_call iter as baml.iter.Iterable<Item = string, Error = never>(copy _4) -> [bb2];
+        _5 = virtual_call iter as baml.iter.Iterable<Error = never, Item = string>(copy _4) -> [bb2];
     }
 
     bb2: {
-        _6 = virtual_call next as baml.iter.Iterator<Item = string, Error = never>(copy _5) -> [bb3];
+        _6 = virtual_call next as baml.iter.Iterator<Error = never, Item = string>(copy _5) -> [bb3];
     }
 
     bb3: {

--- a/baml_language/crates/baml_tests/src/compiler2_emit/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_emit/mod.rs
@@ -494,3 +494,72 @@ fn multiple_let_bindings_with_valid_dependencies() {
         "expected '$init' in function_indices"
     );
 }
+
+/// `InterfaceDef::fields` is the interface's field *index space*: every
+/// implementation's `RuntimeImplRule::field_links` is baked parallel to it, and a
+/// virtual field access carries a position into it. So the list must hold every
+/// declared field, in declaration order, with nothing dropped.
+///
+/// The regression this pins: a field whose type mentions `Self` or an associated
+/// type (`key: Self.Key`) used to fail runtime lowering and be silently filtered
+/// out, shifting every later field's index.
+#[test]
+fn interface_field_index_space_keeps_every_declared_field() {
+    let mut db = make_db();
+    db.add_file(
+        "test.baml",
+        r#"
+interface Shelf {
+  type Key
+
+  label: string
+  key: Self.Key
+  count: int
+}
+
+class Book {
+  label: string
+  key: string
+  count: int
+
+  implements Shelf {
+    type Key = string
+  }
+}
+
+function main() -> int { 0 }
+"#,
+    );
+    let program = compile(&db);
+
+    let iface = (*program.objects)
+        .iter()
+        .find_map(|obj| match obj {
+            bex_vm_types::Object::Interface(i) if i.name.name().as_str() == "Shelf" => Some(i),
+            _ => None,
+        })
+        .expect("Shelf interface object should be emitted");
+
+    let names: Vec<&str> = iface.fields.iter().map(|f| f.name.as_str()).collect();
+    assert_eq!(
+        names,
+        ["label", "key", "count"],
+        "every declared field must keep its declared position",
+    );
+
+    // The `Self.Key` field stays symbolic — a declaration has no implementor, so it
+    // is resolved against the receiver's impl at run time rather than erased here.
+    assert!(
+        matches!(
+            iface.fields[1].ty,
+            baml_type::RuntimeTy::AssociatedTypeProjection { .. }
+        ),
+        "`key: Self.Key` should stay an associated-type projection, got {:?}",
+        iface.fields[1].ty,
+    );
+    assert!(
+        matches!(iface.fields[2].ty, baml_type::RuntimeTy::Int { .. }),
+        "field after the projection must keep its own type, got {:?}",
+        iface.fields[2].ty,
+    );
+}

--- a/baml_language/crates/baml_tests/src/compiler2_emit/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_emit/mod.rs
@@ -563,3 +563,108 @@ function main() -> int { 0 }
         iface.fields[2].ty,
     );
 }
+
+/// `RuntimeImplRule::field_links` is the interface-field-index → class-slot table a
+/// virtual field access indexes. It must be ordered by the *interface's* field
+/// declarations — not by the class's field order, and not by the order the
+/// `field as class_field` links happen to be written.
+#[test]
+fn impl_rule_field_links_are_ordered_by_the_interface() {
+    let mut db = make_db();
+    db.add_file(
+        "test.baml",
+        r#"
+interface Shelf {
+  label: string
+  count: int
+}
+
+class Book {
+  // Deliberately declared in a different order than `Shelf` lists them, and
+  // with an unrelated field first, so a table built from the class's layout or
+  // from the link order would disagree with one built from the interface's.
+  isbn: string
+  count: int
+  title: string
+
+  implements Shelf {
+    count as count
+    label as title
+  }
+}
+
+function main() -> int { 0 }
+"#,
+    );
+    let program = compile(&db);
+
+    let class = (*program.objects)
+        .iter()
+        .find_map(|obj| match obj {
+            bex_vm_types::Object::Class(c) if c.name.name().as_str() == "Book" => Some(c),
+            _ => None,
+        })
+        .expect("Book class object should be emitted");
+    let slot = |name: &str| {
+        class
+            .fields
+            .iter()
+            .position(|f| f.name == name)
+            .unwrap_or_else(|| panic!("Book should have a `{name}` field"))
+    };
+
+    let rules: Vec<_> = program
+        .packages
+        .values()
+        .flat_map(|pkg| pkg.impl_rules.values().flatten())
+        .filter(|rule| !rule.field_links.is_empty())
+        .collect();
+    assert_eq!(
+        rules.len(),
+        1,
+        "expected exactly one field-bearing impl rule"
+    );
+
+    // Positional over `Shelf`'s declarations: index 0 is `label` (linked to
+    // `title`), index 1 is `count` (same-named).
+    assert_eq!(
+        rules[0].field_links.as_ref(),
+        [slot("title") as u32, slot("count") as u32],
+        "field_links must be indexed by the interface's field order",
+    );
+}
+
+/// The same-name default is applied at bake time, so an `implements` block that
+/// writes no links at all still produces a complete table.
+#[test]
+fn impl_rule_field_links_fill_the_same_name_default() {
+    let mut db = make_db();
+    db.add_file(
+        "test.baml",
+        r#"
+interface Named {
+  name: string
+}
+
+class Person {
+  age: int
+  name: string
+
+  implements Named {}
+}
+
+function main() -> int { 0 }
+"#,
+    );
+    let program = compile(&db);
+
+    let rule = program
+        .packages
+        .values()
+        .flat_map(|pkg| pkg.impl_rules.values().flatten())
+        .find(|rule| !rule.field_links.is_empty())
+        .expect("expected a field-bearing impl rule");
+    // `name` is `Person`'s second field, so an unlinked interface field must still
+    // resolve to slot 1 rather than defaulting to 0.
+    assert_eq!(rule.field_links.as_ref(), [1]);
+}

--- a/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
@@ -2145,10 +2145,12 @@ pub(crate) mod support {
             let class = class_data(db, loc);
             writeln!(output, "class {prefix}{} {{", class.name).ok();
             for field in &class.fields {
-                let ty = field
-                    .type_ref
-                    .map(|id| type_ref_to_string(&class.type_refs, id, &prefix, &local_type_names))
-                    .unwrap_or_else(|| "?".into());
+                let ty = type_ref_to_string(
+                    &class.type_refs,
+                    field.type_ref,
+                    &prefix,
+                    &local_type_names,
+                );
                 writeln!(output, "  {}: {}", field.name, ty).ok();
             }
             writeln!(output, "}}").ok();

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -297,14 +297,14 @@ function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetRepo
 function testing.TestCollector.find_test(self: testing.TestCollector, name: string) -> testing.TestRegistration {
     load_var self
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -333,14 +333,14 @@ function testing.TestCollector.find_test(self: testing.TestCollector, name: stri
 function testing.TestCollector.find_testset(self: testing.TestCollector, name: string) -> testing.TestSetRegistration {
     load_var self
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -414,14 +414,14 @@ function testing.TestCollector.register_test(self: testing.TestCollector, name: 
     store_var hash_prefix
     load_var self
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _17
 
   L4:
     load_var _17
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _18
@@ -551,14 +551,14 @@ function testing.TestCollector.register_test_set(self: testing.TestCollector, na
     store_var hash_prefix
     load_var self
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _17
 
   L4:
     load_var _17
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _18
@@ -654,14 +654,14 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     load_var self
     load_field .collector
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -690,14 +690,14 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
     load_var self
     load_field .expansions
     call baml.Map.keys
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _17
 
   L3:
     load_var _17
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _18
@@ -888,14 +888,14 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     load_var self
     load_field .collector
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -924,14 +924,14 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
     load_var self
     load_field .expansions
     call baml.Map.keys
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _17
 
   L3:
     load_var _17
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _18
@@ -970,14 +970,14 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
     load_var self
     load_field .collector
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -1007,14 +1007,14 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
     load_var self
     load_field .expansions
     call baml.Map.keys
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _19
 
   L3:
     load_var _19
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _20
@@ -1056,14 +1056,14 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     load_var self
     load_field .collector
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -1086,14 +1086,14 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
     load_var self
     load_field .collector
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
 
   L3:
     load_var _13
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _14
@@ -1152,14 +1152,14 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
 
 function testing._has_selected_descendant(prefix: string, names: string[]) -> bool {
     load_var names
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -1201,14 +1201,14 @@ function testing._int_to_float(value: int) -> float {
 
 function testing._name_selected(name: string, names: string[]) -> bool {
     load_var names
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -1248,14 +1248,14 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
     alloc_array 0
     store_var result_names
     load_var named_results
-    load_type baml.iter.Iterable<Item = testing.NamedChildReport, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.NamedChildReport>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
 
   L0:
     load_var _8
-    load_type baml.iter.Iterator<Item = testing.NamedChildReport, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.NamedChildReport>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
@@ -1345,14 +1345,14 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
     alloc_array 1
 
   L10:
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _33
 
   L11:
     load_var _33
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _34
@@ -1425,14 +1425,14 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
 function testing.any_pattern_matches(pats: string[], canonical_id: string) -> bool {
     load_var pats
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -1465,14 +1465,14 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
     init_instance testing.LeafIdentities .passed, .failed, .tolerated
     store_var out
     load_var selected_names
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
 
   L0:
     load_var _8
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
@@ -1530,14 +1530,14 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
 function testing.collect_all_failed_names(report: testing.TestSetReport, out: string[]) -> void {
     load_var report
     load_field .failed_names
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -1561,14 +1561,14 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
   L2:
     load_var report
     load_field .results
-    load_type baml.iter.Iterable<Item = testing.TestReport | testing.TestSetReport, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestReport | testing.TestSetReport>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _15
 
   L3:
     load_var _15
-    load_type baml.iter.Iterator<Item = testing.TestReport | testing.TestSetReport, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestReport | testing.TestSetReport>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _16
@@ -1818,14 +1818,14 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
 
 function testing.collect_leaf_messages(results: (testing.TestReport | testing.TestSetReport)[], out: string[]) -> void {
     load_var results
-    load_type baml.iter.Iterable<Item = testing.TestReport | testing.TestSetReport, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestReport | testing.TestSetReport>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = testing.TestReport | testing.TestSetReport, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestReport | testing.TestSetReport>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -1855,14 +1855,14 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
   L3:
     load_var _8
     load_field .runs
-    load_type baml.iter.Iterable<Item = testing.RunReport, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.RunReport>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _11
 
   L4:
     load_var _11
-    load_type baml.iter.Iterator<Item = testing.RunReport, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.RunReport>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _12
@@ -1902,14 +1902,14 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
     load_var registry
     load_field .collector
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -1929,14 +1929,14 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
     load_var registry
     load_field .collector
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _12
 
   L3:
     load_var _12
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
@@ -1948,14 +1948,14 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
   L4:
     load_var2 1 6
     call testing.collect_subtree_names
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _19
 
   L5:
     load_var _19
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _20
@@ -2287,14 +2287,14 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
     load_const 0
     store_var total
     load_var results
-    load_type baml.iter.Iterable<Item = testing.TestReport | testing.TestSetReport, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestReport | testing.TestSetReport>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
 
   L0:
     load_var _7
-    load_type baml.iter.Iterator<Item = testing.TestReport | testing.TestSetReport, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestReport | testing.TestSetReport>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
@@ -2484,14 +2484,14 @@ function testing.failure_matches_selected(selected: string, failed_names: string
     call baml.String.substring
     store_var _8
     load_var failed_names
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _12
 
   L1:
     load_var _12
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _13
@@ -2869,14 +2869,14 @@ function testing.leaf_selected_layered(name: string, profile_include: string[], 
 
 function testing.name_in(name: string, names: string[]) -> bool {
     load_var names
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -2946,14 +2946,14 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
     alloc_array 0
     store_var futures
     load_var children
-    load_type baml.iter.Iterable<Item = testing.TestSetChild, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetChild>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _3
 
   L0:
     load_var _3
-    load_type baml.iter.Iterator<Item = testing.TestSetChild, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetChild>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
@@ -2996,14 +2996,14 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
     alloc_array 0
     store_var named_results
     load_var children
-    load_type baml.iter.Iterable<Item = testing.TestSetChild, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetChild>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestSetChild, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetChild>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -3130,14 +3130,14 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
     load_var registry
     load_field .collector
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
 
   L0:
     load_var _8
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _9
@@ -3164,14 +3164,14 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
     load_var registry
     load_field .collector
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _18
 
   L3:
     load_var _18
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _19
@@ -3199,14 +3199,14 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
     load_var2 2 3
     load_var2 4 5
     call testing.collect_subtree_names_layered
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _30
 
   L6:
     load_var _30
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _31
@@ -3232,14 +3232,14 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
     bin_op +
     store_var descendant_prefix
     load_var excludes
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -3311,14 +3311,14 @@ function testing.subtree_may_be_selected(prefix: string, include: string[], excl
 
   L1:
     load_var include
-    load_type baml.iter.Iterable<Item = string, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = string>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _7
 
   L2:
     load_var _7
-    load_type baml.iter.Iterator<Item = string, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = string>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _8
@@ -3404,14 +3404,14 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
     load_var registry
     load_field .collector
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _4
 
   L0:
     load_var _4
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
@@ -3439,14 +3439,14 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
     load_var registry
     load_field .collector
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _15
 
   L3:
     load_var _15
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _16
@@ -3476,14 +3476,14 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
     load_var registry
     load_field .collector
     load_field .tests
-    load_type baml.iter.Iterable<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _5
 
   L0:
     load_var _5
-    load_type baml.iter.Iterator<Item = testing.TestRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _6
@@ -3516,14 +3516,14 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
     load_var registry
     load_field .collector
     load_field .testsets
-    load_type baml.iter.Iterable<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterable<Error = never, Item = testing.TestSetRegistration>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _18
 
   L3:
     load_var _18
-    load_type baml.iter.Iterator<Item = testing.TestSetRegistration, Error = never>
+    load_type baml.iter.Iterator<Error = never, Item = testing.TestSetRegistration>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _19

--- a/baml_language/crates/baml_type/src/template.rs
+++ b/baml_language/crates/baml_type/src/template.rs
@@ -413,7 +413,31 @@ impl TyTemplate {
     }
 }
 
+impl std::fmt::Display for TyTemplateInterface {
+    /// Renders as the existential template it denotes, so an interface constraint
+    /// and the type it lifts to print identically in diagnostics and MIR dumps.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_template())
+    }
+}
+
 impl TyTemplateInterface {
+    /// The interface *existential* template ([`TyTemplate::Interface`]) denoted by
+    /// this constraint, with default attributes — the template-level counterpart of
+    /// [`Interface::to_ty`].
+    ///
+    /// Needed only at boundaries that carry a *type* rather than a constraint (the
+    /// bytecode constant pool a `LoadType` reads from). Prefer holding the
+    /// constraint itself wherever an interface is meant: a `TyTemplate` slot admits
+    /// non-interface types, which an interface position can never legitimately hold.
+    pub fn to_template(&self) -> TyTemplate {
+        TyTemplate::interface(
+            self.name.clone(),
+            self.generics.clone(),
+            self.associated_types.clone(),
+        )
+    }
+
     /// Substitute frame type args through the interface's generic and
     /// associated-binding positions, producing the realized [`Interface`]
     /// constraint used to reduce the enclosing projection (see

--- a/baml_language/crates/bex_vm/src/debug.rs
+++ b/baml_language/crates/bex_vm/src/debug.rs
@@ -159,6 +159,8 @@ pub(crate) fn display_instruction(
             None => "(?)".to_string(),
         },
         Instruction::LoadField(_)
+        | Instruction::VirtualLoadField(_)
+        | Instruction::VirtualStoreField(_)
         | Instruction::StoreField(_)
         | Instruction::InitField(_)
         | Instruction::InitSpread(_)
@@ -367,6 +369,7 @@ fn instruction_style(instruction: &Instruction) -> Style {
         | Instruction::LoadVar2(..)
         | Instruction::LoadGlobal(_)
         | Instruction::LoadField(_)
+        | Instruction::VirtualLoadField(_)
         | Instruction::LoadArrayElement
         | Instruction::LoadMapElement => Style::new().blue(),
         Instruction::StoreVar(_)
@@ -374,6 +377,7 @@ fn instruction_style(instruction: &Instruction) -> Style {
         | Instruction::StoreVar2(..)
         | Instruction::StoreGlobal(_)
         | Instruction::StoreField(_)
+        | Instruction::VirtualStoreField(_)
         | Instruction::InitField(_)
         | Instruction::InitSpread(_)
         | Instruction::StoreArrayElement
@@ -754,6 +758,16 @@ fn display_instruction_textual(
             let name = meta_str(idx);
             format!("store_field .{name}")
         }
+        // The operand indexes the *interface's* field list, not the receiver's
+        // layout, so show the name and mark it virtual.
+        Instruction::VirtualLoadField(idx) => {
+            let name = meta_str(idx);
+            format!("virtual_load_field .{name}")
+        }
+        Instruction::VirtualStoreField(idx) => {
+            let name = meta_str(idx);
+            format!("virtual_store_field .{name}")
+        }
         Instruction::InitField(idx) => {
             let name = meta_str(idx);
             format!("init_field .{name}")
@@ -1133,6 +1147,8 @@ fn display_expanded_metadata(ip: usize, instruction: &Instruction, function: &Fu
         | Instruction::LoadGlobal(_)
         | Instruction::StoreGlobal(_)
         | Instruction::LoadField(_)
+        | Instruction::VirtualLoadField(_)
+        | Instruction::VirtualStoreField(_)
         | Instruction::StoreField(_)
         | Instruction::InitField(_)
         | Instruction::InitSpread(_)
@@ -1319,6 +1335,8 @@ pub fn display_compact_bytecode(
             | OpCode::LoadGlobal
             | OpCode::StoreGlobal
             | OpCode::LoadField
+            | OpCode::VirtualLoadField
+            | OpCode::VirtualStoreField
             | OpCode::StoreField
             | OpCode::InitField
             | OpCode::InitSpread

--- a/baml_language/crates/bex_vm/src/package_load.rs
+++ b/baml_language/crates/bex_vm/src/package_load.rs
@@ -43,6 +43,7 @@ fn placeholder() -> Object {
         interface_args: Vec::new(),
         interface_assoc: Vec::new(),
         methods: IndexMap::new(),
+        field_links: Box::default(),
     }))
 }
 
@@ -170,6 +171,7 @@ fn resolve_impl_rule(heap: &BexHeap, rule: &ProgramImplRule) -> RuntimeImplRule 
                 )
             })
             .collect(),
+        field_links: rule.field_links.clone(),
     }
 }
 

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -3409,6 +3409,64 @@ impl BexVm {
         }))
     }
 
+    /// Destructure a virtual-dispatch interface operand into the `(name, input args)`
+    /// pair the impl resolver selects on. Associated types are *outputs* of an impl,
+    /// so they are deliberately not part of the key.
+    fn pop_interface_operand(
+        &mut self,
+        iface_value: Value,
+    ) -> Result<(baml_type::TypeName, Vec<baml_type::RealizedTy>), VmError> {
+        let iface_ptr = self.as_object_ptr(iface_value, ObjectType::Type)?;
+        match self.get_object(iface_ptr) {
+            Object::Type(ty) => match ty.as_ref() {
+                baml_type::RealizedTy::Interface(qtn, args, _assoc, _attr) => {
+                    Ok((qtn.clone(), args.clone()))
+                }
+                other => unreachable!(
+                    "virtual field access interface operand must be an Interface type, \
+                     found {other:?}"
+                ),
+            },
+            other => unreachable!(
+                "as_object_ptr(Type) guarantees a Type object, found {:?}",
+                ObjectType::of(other)
+            ),
+        }
+    }
+
+    /// The receiver's physical field slot for interface field `field_index`: read
+    /// `Self` off the receiver's runtime concrete type, resolve its single
+    /// `implements` rule for the interface (coherence guarantees at most one), then
+    /// index the rule's baked `field_links`.
+    ///
+    /// Both failures are compiler/VM inconsistencies rather than user-reachable
+    /// conditions — the type checker proved the receiver implements the interface
+    /// before emitting the access, and `field_links` is total over the interface's
+    /// declared fields (E0124) — so they surface as internal errors.
+    fn resolve_virtual_field_slot(
+        &mut self,
+        receiver: Value,
+        iface_qtn: &baml_type::TypeName,
+        iface_args: &[baml_type::RealizedTy],
+        field_index: usize,
+    ) -> Result<usize, VmError> {
+        let self_ty =
+            baml_type::RealizedTy::from(self.value_concrete_ty(receiver).unwrap_or_else(|| {
+                unreachable!(
+                    "value of kind {:?} cannot be a virtual field-access receiver",
+                    self.type_of(&receiver)
+                )
+            }));
+        let slot = crate::package_baml::ImplResolver::new(self)
+            .resolve_implements_rule(&self_ty, iface_qtn, iface_args)
+            .and_then(|(rule, _bound_args)| rule.field_links.get(field_index).copied());
+        let slot = slot.ok_or_else(|| VmInternalError::UnresolvedVirtualFieldAccess {
+            interface: iface_qtn.to_string(),
+            field_index,
+        })?;
+        Ok(slot as usize)
+    }
+
     /// Encode an i64 arithmetic result into the i63 range, or throw
     /// `IntegerOverflow`.
     ///
@@ -5899,6 +5957,76 @@ impl BexVm {
                         unreachable!("already type-checked above");
                     };
                     instance.store_field(idx, new_value);
+                }
+
+                // ── VirtualLoadField / VirtualStoreField ──────────────────────
+                // The field analogue of `VirtualCall`: the operand indexes the
+                // *interface's* declared fields, and the receiver's resolved impl
+                // maps that to a physical slot. Open-world by construction — nothing
+                // here enumerates implementors, so a class from a later-loaded
+                // package resolves exactly like a local one.
+                OpCode::VirtualLoadField => {
+                    let field_index = { read_u32_unchecked(code, pc) as usize };
+                    let iface_value = self.stack.ensure_pop();
+                    let (iface_qtn, iface_args) = self.pop_interface_operand(iface_value)?;
+                    let receiver = self.stack.ensure_pop();
+                    let slot = self.resolve_virtual_field_slot(
+                        receiver,
+                        &iface_qtn,
+                        &iface_args,
+                        field_index,
+                    )?;
+                    let obj_ptr = self.as_object_ptr(receiver, ObjectType::Instance)?;
+                    let load_result = {
+                        let Object::Instance(instance) = self.get_object(obj_ptr) else {
+                            return Err(VmInternalError::TypeError {
+                                expected: ObjectType::Instance.into(),
+                                got: ObjectType::of(self.get_object(obj_ptr)).into(),
+                            }
+                            .into());
+                        };
+                        instance
+                            .try_load_field(slot)
+                            .ok_or_else(|| instance.field_len())
+                    };
+                    let value = match load_result {
+                        Ok(value) => value,
+                        Err(length) => return Err(self.invalid_field_access_error(slot, length)),
+                    };
+                    self.stack.push(value);
+                }
+
+                OpCode::VirtualStoreField => {
+                    let field_index = { read_u32_unchecked(code, pc) as usize };
+                    let iface_value = self.stack.ensure_pop();
+                    let (iface_qtn, iface_args) = self.pop_interface_operand(iface_value)?;
+                    let new_value = self.stack.ensure_pop();
+                    let receiver = self.stack.ensure_pop();
+                    let slot = self.resolve_virtual_field_slot(
+                        receiver,
+                        &iface_qtn,
+                        &iface_args,
+                        field_index,
+                    )?;
+                    let obj_ptr = self.as_object_ptr(receiver, ObjectType::Instance)?;
+                    let store_error = {
+                        let Object::Instance(instance) = self.get_object(obj_ptr) else {
+                            return Err(VmInternalError::TypeError {
+                                expected: ObjectType::Instance.into(),
+                                got: ObjectType::of(self.get_object(obj_ptr)).into(),
+                            }
+                            .into());
+                        };
+                        (slot >= instance.field_len()).then_some(instance.field_len())
+                    };
+                    if let Some(length) = store_error {
+                        return Err(self.invalid_field_access_error(slot, length));
+                    }
+                    self.heap.write_barrier(obj_ptr, new_value);
+                    let Object::Instance(instance) = self.get_object(obj_ptr) else {
+                        unreachable!("already type-checked above");
+                    };
+                    instance.store_field(slot, new_value);
                 }
 
                 OpCode::InitField => {

--- a/baml_language/crates/bex_vm_types/src/bytecode.rs
+++ b/baml_language/crates/bex_vm_types/src/bytecode.rs
@@ -235,6 +235,37 @@ pub enum Instruction {
     /// object's fields array.
     StoreField(usize),
 
+    /// Read an *interface* field from a receiver whose concrete type is not known
+    /// statically — the field analogue of [`Self::VirtualCall`].
+    ///
+    /// `LoadField` cannot serve here: its operand is a physical slot in the
+    /// receiver's own layout, and two classes implementing the same interface link
+    /// the same interface field to different slots. So the operand is instead the
+    /// field's index in the *interface's* declaration order, and the VM maps it to a
+    /// slot through the resolved impl's
+    /// [`field_links`](crate::types::RuntimeImplRule::field_links).
+    ///
+    /// Stack: `[receiver, iface_type]` -> `[value]`
+    ///
+    /// Pops `iface_type` (an `Object::Type` holding the — possibly parameterized —
+    /// interface) and the receiver, reads `Self` from the receiver's runtime concrete
+    /// type, resolves `<Self as iface_type>` to its single `implements` rule
+    /// (coherence), and pushes `receiver.fields[rule.field_links[i]]`.
+    ///
+    /// The interface arrives via `LoadType`, which substitutes the *caller's* frame
+    /// type args — so a symbolic view (`Slot<T>` inside a generic function) reaches
+    /// the resolver realized, selecting the right block when one class implements the
+    /// same interface family at several instantiations with different links. That is
+    /// the discrimination a receiver-only type test cannot make.
+    VirtualLoadField(usize),
+
+    /// Write an *interface* field on a statically-unknown receiver — the store
+    /// counterpart of [`Self::VirtualLoadField`], with the same operand meaning and
+    /// the same resolution.
+    ///
+    /// Stack: `[receiver, value, iface_type]` -> `[]`
+    VirtualStoreField(usize),
+
     /// Initialize a field during construction: pops the value, stores it in the field,
     /// and keeps the instance on the stack (unlike `StoreField` which pops both).
     ///
@@ -1007,6 +1038,11 @@ pub enum OpCode {
 
     // Atomic type test plus local binding: u32 type constant + u32 destination.
     NarrowBind,
+
+    // Virtual interface-*field* access (the field analogue of `VirtualCall`):
+    // u32 interface-field index; receiver and interface type come off the stack.
+    VirtualLoadField,
+    VirtualStoreField,
 }
 
 impl OpCode {
@@ -1127,6 +1163,8 @@ impl OpCode {
             | Self::PopJumpIfFalse
             | Self::JumpIfFalse
             | Self::VirtualCall
+            | Self::VirtualLoadField
+            | Self::VirtualStoreField
             | Self::VirtualCallWithRuntimeId => 5,
 
             // 3-byte: opcode + u16
@@ -1274,6 +1312,8 @@ impl TryFrom<u8> for OpCode {
             }
             x if x == Self::LoadVar2 as u8 => Ok(Self::LoadVar2),
             x if x == Self::StoreVar2 as u8 => Ok(Self::StoreVar2),
+            x if x == Self::VirtualLoadField as u8 => Ok(Self::VirtualLoadField),
+            x if x == Self::VirtualStoreField as u8 => Ok(Self::VirtualStoreField),
             x if x == Self::VirtualCall as u8 => Ok(Self::VirtualCall),
             x if x == Self::CallWithRuntimeId as u8 => Ok(Self::CallWithRuntimeId),
             x if x == Self::VirtualCallWithRuntimeId as u8 => Ok(Self::VirtualCallWithRuntimeId),
@@ -1289,6 +1329,8 @@ impl std::fmt::Display for OpCode {
             Self::Return => "RETURN",
             Self::Await => "AWAIT",
             Self::AwaitAny => "AWAIT_ANY",
+            Self::VirtualLoadField => "VIRTUAL_LOAD_FIELD",
+            Self::VirtualStoreField => "VIRTUAL_STORE_FIELD",
             Self::VirtualCall => "VIRTUAL_CALL",
             Self::VirtualCallWithRuntimeId => "VIRTUAL_CALL_WITH_RUNTIME_ID",
             Self::Throw => "THROW",
@@ -1524,6 +1566,8 @@ impl std::fmt::Display for Instruction {
             Instruction::LoadGlobal(i) => write!(f, "LOAD_GLOBAL {i}"),
             Instruction::StoreGlobal(i) => write!(f, "STORE_GLOBAL {i}"),
             Instruction::LoadField(i) => write!(f, "LOAD_FIELD {i}"),
+            Instruction::VirtualLoadField(i) => write!(f, "VIRTUAL_LOAD_FIELD {i}"),
+            Instruction::VirtualStoreField(i) => write!(f, "VIRTUAL_STORE_FIELD {i}"),
             Instruction::StoreField(i) => write!(f, "STORE_FIELD {i}"),
             Instruction::InitField(i) => write!(f, "INIT_FIELD {i}"),
             Instruction::InitSpread(i) => write!(f, "INIT_SPREAD {i}"),
@@ -2126,6 +2170,8 @@ impl Bytecode {
                 | Instruction::StoreVar(v)
                 | Instruction::StoreVarLoadVar(v)
                 | Instruction::LoadField(v)
+                | Instruction::VirtualLoadField(v)
+                | Instruction::VirtualStoreField(v)
                 | Instruction::StoreField(v)
                 | Instruction::InitField(v)
                 | Instruction::InitSpread(v)
@@ -2471,6 +2517,8 @@ impl Bytecode {
             Instruction::LoadGlobal(_) => OpCode::LoadGlobal,
             Instruction::StoreGlobal(_) => OpCode::StoreGlobal,
             Instruction::LoadField(_) => OpCode::LoadField,
+            Instruction::VirtualLoadField(_) => OpCode::VirtualLoadField,
+            Instruction::VirtualStoreField(_) => OpCode::VirtualStoreField,
             Instruction::StoreField(_) => OpCode::StoreField,
             Instruction::InitField(_) => OpCode::InitField,
             Instruction::InitSpread(_) => OpCode::InitSpread,
@@ -2606,6 +2654,60 @@ mod compact_tests {
         assert_eq!(compact.code[0], OpCode::LoadIntSmall as u8);
         assert_eq!(compact.code[1], 42u8);
         assert_eq!(compact.code[2], OpCode::Return as u8);
+    }
+
+    #[test]
+    fn encode_virtual_field_ops() {
+        let bc = make_bytecode(
+            vec![
+                Instruction::VirtualLoadField(3),
+                Instruction::VirtualStoreField(258),
+                Instruction::Return,
+            ],
+            Vec::new(),
+        );
+        let compact = bc.lower_to_compact();
+        // Both are opcode + u32, like `LoadField`.
+        assert_eq!(compact.code.len(), 5 + 5 + 1);
+        assert_eq!(compact.code[0], OpCode::VirtualLoadField as u8);
+        assert_eq!(
+            u32::from_le_bytes(compact.code[1..5].try_into().unwrap()),
+            3
+        );
+        assert_eq!(compact.code[5], OpCode::VirtualStoreField as u8);
+        assert_eq!(
+            u32::from_le_bytes(compact.code[6..10].try_into().unwrap()),
+            258,
+        );
+        assert_eq!(compact.code[10], OpCode::Return as u8);
+    }
+
+    /// A wrong `encoded_size` silently desynchronizes the instruction stream: the
+    /// decoder reads the next opcode from the middle of an operand. The offset
+    /// table is built from `encoded_size` while the bytes are written by
+    /// `lower_to_compact`, so the two must agree for every opcode.
+    #[test]
+    fn encoded_size_matches_emitted_bytes_for_every_opcode() {
+        for (instruction, expected) in [
+            (Instruction::VirtualLoadField(1), OpCode::VirtualLoadField),
+            (Instruction::VirtualStoreField(1), OpCode::VirtualStoreField),
+            (Instruction::LoadField(1), OpCode::LoadField),
+            (Instruction::StoreField(1), OpCode::StoreField),
+        ] {
+            let bc = make_bytecode(vec![instruction], Vec::new());
+            let op = bc.instruction_to_opcode(&instruction);
+            assert_eq!(op, expected, "opcode mapping for {instruction:?}");
+            assert_eq!(
+                bc.lower_to_compact().code.len(),
+                op.encoded_size(),
+                "encoded_size disagrees with emitted bytes for {instruction:?}",
+            );
+            assert_eq!(
+                OpCode::try_from(op as u8).expect("opcode round-trips"),
+                op,
+                "opcode byte round-trip for {instruction:?}",
+            );
+        }
     }
 
     #[test]

--- a/baml_language/crates/bex_vm_types/src/errors.rs
+++ b/baml_language/crates/bex_vm_types/src/errors.rs
@@ -264,6 +264,19 @@ pub enum VmInternalError {
     #[error("virtual call could not resolve interface method `{method}`")]
     UnresolvedVirtualCall { method: String },
 
+    /// A `VirtualLoadField`/`VirtualStoreField` could not resolve interface field
+    /// `field_index` of `interface` for the receiver's runtime concrete type — either
+    /// the impl registry has no rule for the pair, or the rule's `field_links` table
+    /// is shorter than the interface's declared field list. The type checker proves
+    /// the receiver implements the interface before emitting the access, and E0124
+    /// makes the table total, so either is a compiler/VM inconsistency rather than a
+    /// user-reachable condition.
+    #[error("virtual field access could not resolve field #{field_index} of `{interface}`")]
+    UnresolvedVirtualFieldAccess {
+        interface: String,
+        field_index: usize,
+    },
+
     /// A `LoadType` (or other materialization) could not fully realize a
     /// `TyTemplate` against the frame's realized type arguments — a frame
     /// reference out of range, or an associated-type projection that did not

--- a/baml_language/crates/bex_vm_types/src/link.rs
+++ b/baml_language/crates/bex_vm_types/src/link.rs
@@ -778,6 +778,7 @@ fn merge_package_fragment(
                 interface_args: rule.interface_args.clone(),
                 interface_assoc: rule.interface_assoc.clone(),
                 methods,
+                field_links: rule.field_links.clone(),
             });
         }
         pkg.impl_rules

--- a/baml_language/crates/bex_vm_types/src/relink.rs
+++ b/baml_language/crates/bex_vm_types/src/relink.rs
@@ -74,6 +74,8 @@ macro_rules! visit_bytecode_index_operands {
             // uses this bit to add its conservative layout dependency.
             I::LoadField(..)
             | I::StoreField(..)
+            | I::VirtualLoadField(..)
+            | I::VirtualStoreField(..)
             | I::InitField(..)
             | I::InitSpread(..)
             | I::InitInstance(..)

--- a/baml_language/crates/bex_vm_types/src/types/interface.rs
+++ b/baml_language/crates/bex_vm_types/src/types/interface.rs
@@ -115,4 +115,20 @@ pub struct RuntimeImplRule {
     /// merges them in, an override winning over the default), so a lookup resolves
     /// any interface method.
     pub methods: IndexMap<baml_type::Name, MethodImpl>,
+    /// Interface field index → the implementor's physical slot in
+    /// [`Instance::fields`](super::Instance::fields). Indexed by position in the
+    /// implemented [`InterfaceDef::fields`], so a virtual field access carries only
+    /// that index — no name on the operand stack, no lookup at dispatch.
+    ///
+    /// **Positional and total**: exactly one entry per field the interface declares,
+    /// with the explicit `field as class_field` link applied and the same-name
+    /// default filled in. E0124 (every interface field covered) is what makes
+    /// totality a fact about well-formed programs rather than a runtime check, so
+    /// resolution is an in-bounds index and never fails.
+    ///
+    /// A class slot index is well-defined here because E0126 confines every
+    /// field-bearing impl to an in-body `implements` block: `for_ty_pattern`'s head
+    /// is then exactly one class, whose layout is fixed and lives in the same
+    /// package as this rule. Empty for an impl of a field-less interface.
+    pub field_links: Box<[u32]>,
 }

--- a/baml_language/crates/bex_vm_types/src/types/interface.rs
+++ b/baml_language/crates/bex_vm_types/src/types/interface.rs
@@ -12,8 +12,26 @@ pub struct InterfaceDef {
 
     // Member Types
     pub assoc: Vec<(baml_type::Name, baml_type::RuntimeInterface)>,
-    pub fields: Vec<(baml_type::Name, baml_type::RuntimeTy)>,
+    /// The interface's declared fields, in declaration order. **Position is
+    /// identity**: a field's index here is the index every implementation's
+    /// [`RuntimeImplRule::field_links`] is baked against, and the index a
+    /// `VirtualLoadField` / `VirtualStoreField` carries. Entries are therefore never
+    /// dropped, reordered, or deduplicated.
+    pub fields: Vec<InterfaceFieldDef>,
     pub methods: Vec<InterfaceMethodDef>,
+}
+
+/// One field an interface declares, at its dispatch index (its position in
+/// [`InterfaceDef::fields`]).
+#[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
+pub struct InterfaceFieldDef {
+    pub name: baml_type::Name,
+    /// The field's declared type, exactly as written. An interface field's type may
+    /// depend on the implementor (`key: Self.Key`); such a type stays a structural
+    /// `TypeVar`/`AssociatedTypeProjection` here — the `RuntimeTy` family carries
+    /// both — and is resolved dynamically against the receiver's impl, never
+    /// pre-collapsed to a frame slot (an interface *declaration* has no frame).
+    pub ty: baml_type::RuntimeTy,
 }
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]

--- a/baml_language/crates/bex_vm_types/src/types/package.rs
+++ b/baml_language/crates/bex_vm_types/src/types/package.rs
@@ -89,6 +89,10 @@ pub struct ProgramImplRule {
     pub interface_args: Vec<TyTemplate>,
     pub interface_assoc: Vec<(Name, TyTemplate)>,
     pub methods: IndexMap<Name, ProgramMethodImpl>,
+    /// See [`RuntimeImplRule::field_links`](super::RuntimeImplRule::field_links).
+    /// Positional, so — unlike the name-keyed maps — it needs no canonical ordering
+    /// pass in [`ProgramPackage::sort_maps`].
+    pub field_links: Box<[u32]>,
 }
 
 /// The global-index-keyed twin of [`MethodImpl`](super::MethodImpl); `fqn` is the

--- a/baml_language/crates/bex_vm_types/src/unit.rs
+++ b/baml_language/crates/bex_vm_types/src/unit.rs
@@ -152,6 +152,9 @@ pub struct ProgramImplRuleFrag {
     pub interface_assoc: Vec<(Name, TyTemplate)>,
     /// Method name to its symbolic implementation.
     pub methods: Vec<(Name, ProgramMethodImplFrag)>,
+    /// See [`RuntimeImplRule::field_links`](crate::types::RuntimeImplRule::field_links).
+    /// Slot indices are layout, not symbols, so they survive relinking unchanged.
+    pub field_links: Box<[u32]>,
 }
 
 /// Symbolic twin of `ProgramMethodImpl`: `fqn` is the callee function's

--- a/baml_language/tools/speedtest/workloads/interfaces/field-access-100k.md
+++ b/baml_language/tools/speedtest/workloads/interfaces/field-access-100k.md
@@ -1,0 +1,42 @@
+# interfaces::field access 100k
+
+Interface **field** reads through an existential receiver. The three sibling
+workloads all measure interface *method* dispatch, which was already open-world;
+this is the path that changed when the compile-time implementor switch was
+replaced by `virtual_load_field`, so it is the one whose cost moved.
+
+Two implementors with the field at *different* slots, so the read genuinely
+depends on the receiver's impl rather than a shared layout.
+
+## BAML
+```baml
+interface Named {
+  name: string
+}
+class Dog {
+  name: string
+  age: int
+  implements Named {}
+}
+class Robot {
+  serial: int
+  model: string
+  implements Named {
+    name as model
+  }
+}
+function pick(i: int) -> Named {
+  if i % 2 == 0 { return Dog { name: "rex", age: i }; };
+  return Robot { serial: i, model: "r2" };
+}
+function name_len(n: Named) -> int {
+  return n.name.length()
+}
+function main() -> int {
+  let acc = 0;
+  for (let i = 0; i < 100000; i += 1) {
+    acc += name_len(pick(i));
+  };
+  return acc
+}
+```


### PR DESCRIPTION
Previously we emitted a type tag-based switch when accessing interface fields on a non-concrete type. This was unsound and produced unnecessary overhead, so similar to the already-implemented virtual function calls, this PR adds virtual field load/stores.

Additionally:
- Field declarations that are missing a type will get `TypeExprKind::Error` and emit a diagnostic in the AST, instead of being optional (since downstream consumers handled the `None` in different ways)
- Virtual calls now use `TyTemplateInterface` where possible as the representation for the interface position (this still doesn't work on the stack but it does everywhere else)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interface-typed values now support runtime field reads and writes, including through generic and existential values.
  * Interface field dispatch now uses declaration-order indexing and correctly links interface fields to concrete class slots.

* **Bug Fixes**
  * Missing or invalid field types are now recovered consistently, producing stable diagnostics (instead of falling back to “unknown”).
  * Virtual field access resolution is safer, with clearer handling when a receiver’s interface field cannot be resolved.

* **Tests**
  * Added new compiler/runtime integration coverage for interface field index and virtual-field link-table behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->