### PR TITLE
build: reduce macOS release binary size with LLD

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -339,6 +339,9 @@ jobs:
         uses: ./.github/actions/setup-musl-cross
         with:
           target: ${{ matrix.target }}
+      - name: Enable safe ICF
+        if: ${{ !contains(matrix.target, 'windows-msvc') }}
+        run: echo "RUSTFLAGS=$(scripts/baml-release-rustflags)" >> "$GITHUB_ENV"
       - name: Build CLI and pack host
         run: cargo build --manifest-path baml_language/Cargo.toml --release --bin baml-cli --bin baml-pack-host --target "${{ matrix.target }}"
       - name: Archive layout smoke

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -341,7 +341,7 @@ jobs:
           target: ${{ matrix.target }}
       - name: Enable safe ICF
         if: ${{ !contains(matrix.target, 'windows-msvc') }}
-        run: echo "RUSTFLAGS=$(scripts/baml-release-rustflags)" >> "$GITHUB_ENV"
+        run: echo "RUSTFLAGS=$(scripts/baml-release-rustflags '${{ matrix.target }}')" >> "$GITHUB_ENV"
       - name: Build CLI and pack host
         run: cargo build --manifest-path baml_language/Cargo.toml --release --bin baml-cli --bin baml-pack-host --target "${{ matrix.target }}"
       - name: Archive layout smoke

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -341,7 +341,7 @@ jobs:
           target: ${{ matrix.target }}
       - name: Enable safe ICF
         if: ${{ !contains(matrix.target, 'windows-msvc') }}
-        run: echo "RUSTFLAGS=$(scripts/baml-release-rustflags '${{ matrix.target }}')" >> "$GITHUB_ENV"
+        run: echo "RUSTFLAGS=$(scripts/baml-release-rustflags)" >> "$GITHUB_ENV"
       - name: Build CLI and pack host
         run: cargo build --manifest-path baml_language/Cargo.toml --release --bin baml-cli --bin baml-pack-host --target "${{ matrix.target }}"
       - name: Archive layout smoke

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -340,7 +340,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
       - name: Enable safe ICF
-        if: ${{ !contains(matrix.target, 'windows-msvc') }}
+        if: ${{ contains(matrix.target, 'apple-darwin') }}
         run: echo "RUSTFLAGS=$(scripts/baml-release-rustflags)" >> "$GITHUB_ENV"
       - name: Build CLI and pack host
         run: cargo build --manifest-path baml_language/Cargo.toml --release --bin baml-cli --bin baml-pack-host --target "${{ matrix.target }}"

--- a/.github/workflows/size-gate.reusable.yaml
+++ b/.github/workflows/size-gate.reusable.yaml
@@ -88,9 +88,6 @@ jobs:
         run: cargo fetch
         working-directory: baml_language
 
-      - name: "Enable safe ICF"
-        run: echo "RUSTFLAGS=$(scripts/baml-release-rustflags)" >> "$GITHUB_ENV"
-
       - name: "Run size-gate check"
         id: check
         working-directory: baml_language

--- a/.github/workflows/size-gate.reusable.yaml
+++ b/.github/workflows/size-gate.reusable.yaml
@@ -88,6 +88,9 @@ jobs:
         run: cargo fetch
         working-directory: baml_language
 
+      - name: "Enable safe ICF"
+        run: echo "RUSTFLAGS=$(scripts/baml-release-rustflags)" >> "$GITHUB_ENV"
+
       - name: "Run size-gate check"
         id: check
         working-directory: baml_language
@@ -173,6 +176,9 @@ jobs:
       - name: "Fetch cargo dependencies"
         run: cargo fetch
         working-directory: baml_language
+
+      - name: "Enable safe ICF"
+        run: echo "RUSTFLAGS=$(scripts/baml-release-rustflags)" >> "$GITHUB_ENV"
 
       - name: "Run size-gate check"
         id: check

--- a/scripts/baml-release-rustflags
+++ b/scripts/baml-release-rustflags
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+host="$(rustc -vV | sed -n 's/^host: //p')"
+test -n "$host"
+
+lld_dir="$(rustc --print sysroot)/lib/rustlib/$host/bin/gcc-ld"
+case "$(uname -s)" in
+  Darwin) lld="$lld_dir/ld64.lld" ;;
+  Linux) lld="$lld_dir/ld.lld" ;;
+  *) echo "safe ICF release flags are only supported on macOS and Linux" >&2; exit 1 ;;
+esac
+
+test -x "$lld" || { echo "bundled LLD not found at $lld" >&2; exit 1; }
+printf '%s\n' "${RUSTFLAGS:+$RUSTFLAGS }-C link-arg=-B$lld_dir -C link-arg=-fuse-ld=lld -C link-arg=-Wl,--icf=safe"

--- a/scripts/baml-release-rustflags
+++ b/scripts/baml-release-rustflags
@@ -3,7 +3,6 @@ set -euo pipefail
 
 host="$(rustc -vV | sed -n 's/^host: //p')"
 test -n "$host"
-target="${1:-$host}"
 
 lld_dir="$(rustc --print sysroot)/lib/rustlib/$host/bin/gcc-ld"
 case "$(uname -s)" in
@@ -13,10 +12,7 @@ case "$(uname -s)" in
     ;;
   Linux)
     lld="$lld_dir/ld.lld"
-    case "$target" in
-      *-linux-gnu) linker_flags="--icf=safe,-z,pack-relative-relocs" ;;
-      *) linker_flags="--icf=safe" ;;
-    esac
+    linker_flags="--icf=safe"
     ;;
   *) echo "safe ICF release flags are only supported on macOS and Linux" >&2; exit 1 ;;
 esac

--- a/scripts/baml-release-rustflags
+++ b/scripts/baml-release-rustflags
@@ -3,13 +3,23 @@ set -euo pipefail
 
 host="$(rustc -vV | sed -n 's/^host: //p')"
 test -n "$host"
+target="${1:-$host}"
 
 lld_dir="$(rustc --print sysroot)/lib/rustlib/$host/bin/gcc-ld"
 case "$(uname -s)" in
-  Darwin) lld="$lld_dir/ld64.lld" ;;
-  Linux) lld="$lld_dir/ld.lld" ;;
+  Darwin)
+    lld="$lld_dir/ld64.lld"
+    linker_flags="--icf=safe,-dead_strip_dylibs,-no_function_starts"
+    ;;
+  Linux)
+    lld="$lld_dir/ld.lld"
+    case "$target" in
+      *-linux-gnu) linker_flags="--icf=safe,-z,pack-relative-relocs" ;;
+      *) linker_flags="--icf=safe" ;;
+    esac
+    ;;
   *) echo "safe ICF release flags are only supported on macOS and Linux" >&2; exit 1 ;;
 esac
 
 test -x "$lld" || { echo "bundled LLD not found at $lld" >&2; exit 1; }
-printf '%s\n' "${RUSTFLAGS:+$RUSTFLAGS }-C link-arg=-B$lld_dir -C link-arg=-fuse-ld=lld -C link-arg=-Wl,--icf=safe"
+printf '%s\n' "${RUSTFLAGS:+$RUSTFLAGS }-C link-arg=-B$lld_dir -C link-arg=-fuse-ld=lld -C link-arg=-Wl,$linker_flags"

--- a/scripts/baml-release-rustflags
+++ b/scripts/baml-release-rustflags
@@ -10,11 +10,7 @@ case "$(uname -s)" in
     lld="$lld_dir/ld64.lld"
     linker_flags="--icf=safe,-dead_strip_dylibs,-no_function_starts"
     ;;
-  Linux)
-    lld="$lld_dir/ld.lld"
-    linker_flags="--icf=safe"
-    ;;
-  *) echo "safe ICF release flags are only supported on macOS and Linux" >&2; exit 1 ;;
+  *) echo "release size flags are only supported on macOS" >&2; exit 1 ;;
 esac
 
 test -x "$lld" || { echo "bundled LLD not found at $lld" >&2; exit 1; }

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -653,7 +653,7 @@ def step_inputs(step: str) -> dict[str, str]:
 
 
 class WorkflowGraphTests(unittest.TestCase):
-    def test_unix_toolchain_releases_and_size_gates_enable_safe_icf(
+    def test_macos_toolchain_releases_and_size_gate_enable_safe_icf(
         self,
     ) -> None:
         release = RELEASE_WORKFLOW.read_text(encoding="utf-8")
@@ -666,9 +666,9 @@ class WorkflowGraphTests(unittest.TestCase):
         self.assertIn("-dead_strip_dylibs", rustflags)
         self.assertIn("-no_function_starts", rustflags)
         self.assertIn("gcc-ld", rustflags)
-        self.assertIn("!contains(matrix.target, 'windows-msvc')", release)
+        self.assertIn("contains(matrix.target, 'apple-darwin')", release)
         self.assertEqual(release.count("scripts/baml-release-rustflags"), 1)
-        self.assertEqual(size_gate.count("scripts/baml-release-rustflags"), 2)
+        self.assertEqual(size_gate.count("scripts/baml-release-rustflags"), 1)
 
     def test_cffi_hygiene_is_enforced_at_production_and_package_boundaries(
         self,

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -661,9 +661,14 @@ class WorkflowGraphTests(unittest.TestCase):
         rustflags = RELEASE_RUSTFLAGS.read_text(encoding="utf-8")
 
         self.assertIn("-fuse-ld=lld", rustflags)
-        self.assertIn("-Wl,--icf=safe", rustflags)
+        self.assertIn("--icf=safe", rustflags)
+        self.assertIn("-Wl,$linker_flags", rustflags)
+        self.assertIn("-dead_strip_dylibs", rustflags)
+        self.assertIn("-no_function_starts", rustflags)
+        self.assertIn("pack-relative-relocs", rustflags)
         self.assertIn("gcc-ld", rustflags)
         self.assertIn("!contains(matrix.target, 'windows-msvc')", release)
+        self.assertIn("baml-release-rustflags '${{ matrix.target }}'", release)
         self.assertEqual(release.count("scripts/baml-release-rustflags"), 1)
         self.assertEqual(size_gate.count("scripts/baml-release-rustflags"), 2)
 

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -16,6 +16,8 @@ VERSION_TOOL = ROOT / "scripts" / "baml-language-version"
 GO_RELEASE_SMOKE = ROOT / "scripts" / "smoke-go-release.py"
 PLATFORMS = ROOT / "release" / "platforms.json"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-baml-language.yml"
+SIZE_GATE_WORKFLOW = ROOT / ".github" / "workflows" / "size-gate.reusable.yaml"
+RELEASE_RUSTFLAGS = ROOT / "scripts" / "baml-release-rustflags"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yaml"
 SIZE_POLICY = ROOT / "release" / "csharp-package-size-policy.json"
 BRIDGE_CFFI_PUBLIC_EXPORTS = (
@@ -651,6 +653,20 @@ def step_inputs(step: str) -> dict[str, str]:
 
 
 class WorkflowGraphTests(unittest.TestCase):
+    def test_unix_toolchain_releases_and_size_gates_enable_safe_icf(
+        self,
+    ) -> None:
+        release = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        size_gate = SIZE_GATE_WORKFLOW.read_text(encoding="utf-8")
+        rustflags = RELEASE_RUSTFLAGS.read_text(encoding="utf-8")
+
+        self.assertIn("-fuse-ld=lld", rustflags)
+        self.assertIn("-Wl,--icf=safe", rustflags)
+        self.assertIn("gcc-ld", rustflags)
+        self.assertIn("!contains(matrix.target, 'windows-msvc')", release)
+        self.assertEqual(release.count("scripts/baml-release-rustflags"), 1)
+        self.assertEqual(size_gate.count("scripts/baml-release-rustflags"), 2)
+
     def test_cffi_hygiene_is_enforced_at_production_and_package_boundaries(
         self,
     ) -> None:

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -665,10 +665,8 @@ class WorkflowGraphTests(unittest.TestCase):
         self.assertIn("-Wl,$linker_flags", rustflags)
         self.assertIn("-dead_strip_dylibs", rustflags)
         self.assertIn("-no_function_starts", rustflags)
-        self.assertIn("pack-relative-relocs", rustflags)
         self.assertIn("gcc-ld", rustflags)
         self.assertIn("!contains(matrix.target, 'windows-msvc')", release)
-        self.assertIn("baml-release-rustflags '${{ matrix.target }}'", release)
         self.assertEqual(release.count("scripts/baml-release-rustflags"), 1)
         self.assertEqual(size_gate.count("scripts/baml-release-rustflags"), 2)
 


### PR DESCRIPTION
## Summary

- link macOS toolchain releases with the Rust 1.93 bundled LLD and safe ICF
- remove unused dylib loads and Mach-O function-start metadata
- apply the same flags to the macOS size gate
- leave Linux and Windows unchanged
- cover the release workflow contract

## Size impact

Measured with the `aarch64-apple-darwin` size gate:

| Artifact | Baseline | Safe ICF | Final | Total reduction |
| --- | ---: | ---: | ---: | ---: |
| `baml-cli` | 21,286,092 B | 20,720,192 B | 20,666,768 B | 619,324 B (2.91%) |
| packed program | 13,841,203 B | 13,620,482 B | 13,586,034 B | 255,169 B (1.84%) |

Removing `LC_FUNCTION_STARTS` accounts for the additional 53,424 B reduction in `baml-cli` and 34,448 B in the packed program. It does not affect runtime performance, but removes function-boundary metadata used by macOS profilers and symbolication tools.

Linux experiments were not retained:

- LLD with safe ICF increased `baml-cli` by 8,832 B versus the default linker in consecutive CI runs.
- `DT_RELR` saved roughly 1 MB, but `baml pack` cannot parse the resulting ELF section with the pinned `object` implementation. It would also require glibc 2.36 or newer.

## Verification

- macOS `baml-cli` and `baml-pack-host` release builds
- valid ad hoc signatures on both executables
- full local size gate, including packed-program creation and launch
- `python3 -m unittest scripts.tests.test_release_pipeline_contract` (23 tests)
- repository pre-commit hooks
