### PR TITLE
Lower lambdas in surrounding function

### DIFF
--- a/baml_language/ARCHITECTURE.md
+++ b/baml_language/ARCHITECTURE.md
@@ -140,7 +140,7 @@ The parser produces a **CST** (Concrete Syntax Tree), which is a lossless, error
 **What lives here:**
 - **Companion function expansion** — LLM functions are expanded into the base function plus generated companions (`render_prompt`, `build_request`, `parse`).
 - **Client desugaring** — `client<llm>` blocks are desugared into a top-level `Let` binding (the `Client` object) plus an optional `$new` companion function (the `PrimitiveClient` constructor).
-- **Lambda expression body extraction** — Lambda bodies are lifted into their own scope-addressable units for downstream analysis.
+- **Lambda expression bodies** — A lambda's body is lowered into the enclosing function's arena and referenced by `ExprId`; the lambda gets its own scope, not its own arena.
 - **LLM function normalization** — There is no concept of "LLM function" downstream. LLM functions become regular functions with declarative metadata attached.
 - **Type expression lowering** — Source-level type syntax is converted to `TypeExpr` nodes.
 - **Config item lowering** — Config block syntax (used in clients, generators, etc.) is lowered to AST expressions.
@@ -239,7 +239,7 @@ The parser produces a **CST** (Concrete Syntax Tree), which is a lossless, error
 5. This recursively resolves until a leaf type is reached.
 
 **Key Salsa queries:**
-- `infer_scope_types(db, scope_id)` — Per-scope type inference. This is the main query. It returns types for a single scope, NOT a monolithic per-function result. This gives fine-grained incrementality: editing a lambda body only recomputes that lambda's types, not the enclosing function's.
+- `infer_scope_types(db, scope_id)` — Per-scope type inference. This is the main query. It returns types for a single scope, NOT a monolithic per-function result. Note that a lambda body is *not* independently incremental: it lives in the enclosing function's `ExprBody`, so editing it invalidates that function's body query and hence its inference.
 - `resolve_name_at(db, file, offset, name)` — On-demand name resolution with type information.
 
 ---
@@ -433,9 +433,24 @@ A `client<llm>` block desugars into **two AST items**:
 
 ### Lambda Expression Bodies
 
-Lambda bodies are extracted into their own scope-addressable AST units during CST→AST lowering. This is necessary because:
-- Lambdas need their own scope for per-scope incremental inference.
-- Capture analysis (which happens in HIR) needs each lambda to be a distinct scope.
+A lambda's body is lowered into the **enclosing function's** `ExprBody`, and the
+lambda holds an `ExprId` pointing at it — the same shape as rust-analyzer's
+`Expr::Closure { body: ExprId }`. One arena per function (or top-level `let`),
+never one per lambda.
+
+Lambdas still get their own `ScopeKind::Lambda` scope, because both of the
+reasons they need one are about *scopes*, not arenas:
+- per-scope incremental inference,
+- capture analysis in HIR, which needs each lambda to be a distinct scope.
+
+Scopes and arenas are therefore orthogonal. Two consequences worth knowing:
+- An `ExprId` is unambiguous within a function but **not** within a file, so
+  file-level maps key on `ExprMetadataKey` (arena owner + id), which is rustc's
+  `HirId { owner, local_id }`.
+- Analyses that must not attribute a lambda's behaviour to its definer — effect
+  (`throws`) inference, call-graph edges — cannot scan the arena flatly, because
+  a lambda's expressions are siblings of the function's own. They walk
+  structurally via `ExprBody::reachable_excluding_lambdas`.
 
 ---
 

--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -915,7 +915,7 @@ pub enum Expr {
     /// Lambda expression: anonymous function in expression position.
     /// Reuses `FunctionDef` with synthetic name `"<anonymous function>"`.
     /// The lambda's body gets its own `ExprBody` via `FunctionBodyDef::Expr`.
-    Lambda(Box<FunctionDef>),
+    Lambda(Box<LambdaDef>),
     /// Optional index: `obj?.[expr]` — short-circuits to null if base is null.
     OptionalIndex {
         base: ExprId,
@@ -1525,6 +1525,49 @@ pub struct FunctionDef {
     pub is_tagged_template_tag: bool,
     pub span: TextRange,
     pub name_span: TextRange,
+}
+
+/// What produced a [`LambdaDef`], where that changes how TIR types it.
+///
+/// Replaces matching on a synthetic `name` string, which could not distinguish
+/// the cases without agreeing on a magic constant at a distance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LambdaKind {
+    /// Written in source as `(x) -> { … }`, or synthesized to behave exactly
+    /// like one — the wrappers `lower_cst` builds around `test` / `testset`
+    /// bodies so they can be passed to a registration call.
+    Anonymous,
+    /// The body wrapper `lower_spawn_expr` synthesizes for `spawn { … }`.
+    /// Its throws surface is left open rather than defaulting to `never`,
+    /// because the spawned body's errors surface through the `Future`.
+    Spawn,
+}
+
+/// An anonymous function *value*, written inside an expression body.
+///
+/// Distinct from [`FunctionDef`], which describes a declared item. A lambda has
+/// no name, no generic parameters (the parser rejects them), no attributes, no
+/// docstring and no declarative metadata, and its body is always an expression
+/// body — never a `$rust_function` builtin. Carrying only those fields keeps
+/// those states unrepresentable rather than filling them with synthetic values
+/// that every reader then has to know to ignore.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LambdaDef {
+    pub kind: LambdaKind,
+    pub params: Vec<Param>,
+    /// The lambda's parameter-default expressions, in their own arena.
+    pub defaults: FunctionDefaults,
+    pub return_type: Option<TypeExpr>,
+    pub throws: Option<TypeExpr>,
+    /// The body arena, or `None` when the lambda has no `BLOCK_EXPR` child
+    /// (a parse failure).
+    pub body: Option<(ExprBody, AstSourceMap)>,
+    /// The lambda's *declaration* span, which is not always the span its
+    /// enclosing body records for the `Expr::Lambda` node: the synthetic
+    /// lambdas that `lower_cst` builds for top-level `test` / `testset`
+    /// registration carry an empty range here while their expression node
+    /// carries the test block's real range.
+    pub span: TextRange,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -667,27 +667,35 @@ impl AstSourceMap {
         self.property_shorthand_exprs.contains(&id)
     }
 
+    /// Look up a span in an arena that is index-parallel to the arena `id`
+    /// indexes.
+    ///
+    /// Every `alloc_*` in lowering pushes the node and its span together, so the
+    /// two arenas always have matching indices and this is a direct index rather
+    /// than a search. An out-of-range id means `id` came from a *different*
+    /// arena — a parameter-default id used against a body's map, say. That
+    /// yields an empty range rather than a panic: this runs in the LSP, which is
+    /// compiled to wasm, where a panic aborts the whole runtime.
+    fn span_at<U>(spans: &Arena<TextRange>, id: Idx<U>) -> TextRange {
+        let raw = id.into_raw();
+        if (raw.into_u32() as usize) < spans.len() {
+            spans[Idx::from_raw(raw)]
+        } else {
+            TextRange::default()
+        }
+    }
+
     /// Look up the source span of a statement by its `StmtId`.
     ///
     /// The `stmt_spans` arena is parallel to `ExprBody::stmts` — same indices,
     /// different element type. We convert via raw index.
     pub fn stmt_span(&self, id: StmtId) -> TextRange {
-        let raw: u32 = id.into_raw().into_u32();
-        self.stmt_spans
-            .iter()
-            .nth(raw as usize)
-            .map(|(_, &span)| span)
-            .unwrap_or_default()
+        Self::span_at(&self.stmt_spans, id)
     }
 
     /// Look up the source span of an expression by its `ExprId`.
     pub fn expr_span(&self, id: ExprId) -> TextRange {
-        let raw: u32 = id.into_raw().into_u32();
-        self.expr_spans
-            .iter()
-            .nth(raw as usize)
-            .map(|(_, &span)| span)
-            .unwrap_or_default()
+        Self::span_at(&self.expr_spans, id)
     }
 
     /// Look up the member-name span for a `MemberAccess` expression.
@@ -720,42 +728,22 @@ impl AstSourceMap {
 
     /// Look up the source span of a pattern by its `PatId`.
     pub fn pattern_span(&self, id: PatId) -> TextRange {
-        let raw: u32 = id.into_raw().into_u32();
-        self.pattern_spans
-            .iter()
-            .nth(raw as usize)
-            .map(|(_, &span)| span)
-            .unwrap_or_default()
+        Self::span_at(&self.pattern_spans, id)
     }
 
     /// Look up the source span of a match arm by its `MatchArmId`.
     pub fn match_arm_span(&self, id: MatchArmId) -> TextRange {
-        let raw: u32 = id.into_raw().into_u32();
-        self.match_arm_spans
-            .iter()
-            .nth(raw as usize)
-            .map(|(_, &span)| span)
-            .unwrap_or_default()
+        Self::span_at(&self.match_arm_spans, id)
     }
 
     /// Look up the source span of a type annotation by its `TypeAnnotId`.
     pub fn type_annotation_span(&self, id: TypeAnnotId) -> TextRange {
-        let raw: u32 = id.into_raw().into_u32();
-        self.type_annotation_spans
-            .iter()
-            .nth(raw as usize)
-            .map(|(_, &span)| span)
-            .unwrap_or_default()
+        Self::span_at(&self.type_annotation_spans, id)
     }
 
     /// Look up the source span of a catch arm by its `CatchArmId`.
     pub fn catch_arm_span(&self, id: CatchArmId) -> TextRange {
-        let raw: u32 = id.into_raw().into_u32();
-        self.catch_arm_spans
-            .iter()
-            .nth(raw as usize)
-            .map(|(_, &span)| span)
-            .unwrap_or_default()
+        Self::span_at(&self.catch_arm_spans, id)
     }
 }
 
@@ -1559,9 +1547,12 @@ pub struct LambdaDef {
     pub defaults: FunctionDefaults,
     pub return_type: Option<TypeExpr>,
     pub throws: Option<TypeExpr>,
-    /// The body arena, or `None` when the lambda has no `BLOCK_EXPR` child
-    /// (a parse failure).
-    pub body: Option<(ExprBody, AstSourceMap)>,
+    /// The lambda's body, as an expression in the *enclosing* body's arena.
+    ///
+    /// A lambda does not own an arena: its body is lowered into the body that
+    /// contains it, exactly as rust-analyzer's `Expr::Closure { body: ExprId }`
+    /// does. `None` when the lambda has no `BLOCK_EXPR` child (a parse failure).
+    pub body: Option<ExprId>,
     /// The lambda's *declaration* span, which is not always the span its
     /// enclosing body records for the `Expr::Lambda` node: the synthetic
     /// lambdas that `lower_cst` builds for top-level `test` / `testset`

--- a/baml_language/crates/baml_compiler2_ast/src/disambiguate.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/disambiguate.rs
@@ -8,8 +8,8 @@
 //!   type annotations inside expression bodies (let, patterns, lambdas)
 
 use crate::ast::{
-    ClassDef, Expr, ExprBody, FunctionBodyDef, FunctionDef, Item, LetDef, TypeAliasDef, TypeExpr,
-    TypeExprKind,
+    ClassDef, Expr, ExprBody, FunctionBodyDef, FunctionDef, Item, LambdaDef, LetDef, TypeAliasDef,
+    TypeExpr, TypeExprKind,
 };
 
 /// The canonical set of field attribute names.
@@ -97,11 +97,28 @@ fn validate_expr_body(body: &ExprBody, diagnostics: &mut Vec<(String, text_size:
         }
     }
 
-    // Recurse into lambda bodies — they have their own FunctionDef with nested ExprBody.
+    // Recurse into lambda bodies — each has its own nested `ExprBody`.
     for (_, expr) in body.exprs.iter() {
-        if let Expr::Lambda(func_def) = expr {
-            validate_function(func_def, diagnostics);
+        if let Expr::Lambda(lambda) = expr {
+            validate_lambda(lambda, diagnostics);
         }
+    }
+}
+
+fn validate_lambda(lambda: &LambdaDef, diagnostics: &mut Vec<(String, text_size::TextRange)>) {
+    for param in &lambda.params {
+        if let Some(ref spanned) = param.type_expr {
+            validate_type_expr_tree(spanned, diagnostics);
+        }
+    }
+    if let Some(ref spanned) = lambda.return_type {
+        validate_type_expr_tree(spanned, diagnostics);
+    }
+    if let Some(ref spanned) = lambda.throws {
+        validate_type_expr_tree(spanned, diagnostics);
+    }
+    if let Some((ref body, _)) = lambda.body {
+        validate_expr_body(body, diagnostics);
     }
 }
 

--- a/baml_language/crates/baml_compiler2_ast/src/disambiguate.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/disambiguate.rs
@@ -117,9 +117,8 @@ fn validate_lambda(lambda: &LambdaDef, diagnostics: &mut Vec<(String, text_size:
     if let Some(ref spanned) = lambda.throws {
         validate_type_expr_tree(spanned, diagnostics);
     }
-    if let Some((ref body, _)) = lambda.body {
-        validate_expr_body(body, diagnostics);
-    }
+    // The body lives in the arena this walk is already covering, so there is
+    // nothing further to recurse into.
 }
 
 fn validate_type_alias(

--- a/baml_language/crates/baml_compiler2_ast/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lib.rs
@@ -17,6 +17,7 @@ pub(crate) mod lower_cst;
 pub(crate) mod lower_expr_body;
 pub(crate) mod lower_type_expr;
 pub mod lowering_diagnostic;
+pub mod traverse;
 
 pub use ast::*;
 /// Decode common escape sequences in a quoted string literal body.
@@ -36,6 +37,7 @@ pub use lowering_diagnostic::LoweringDiagnostic;
 // Re-exported so callers of `TypeExprKind::at(span)` can name the span type
 // without depending on `text_size` directly.
 pub use text_size::TextRange;
+pub use traverse::BodyNode;
 
 /// The BEP-044 `default` receiver keyword. Inside an `implements` block,
 /// `default.method(...)` invokes the interface's *default* method body,
@@ -432,7 +434,7 @@ mod tests {
     }
 
     /// Parse BAML source and lower to AST items.
-    fn parse_and_lower(source: &str) -> Vec<Item> {
+    pub(super) fn parse_and_lower(source: &str) -> Vec<Item> {
         let root = parse(source);
         let (items, diags, _env_var_refs) = lower_file(&root);
         assert!(diags.is_empty(), "expected no diagnostics, got: {diags:#?}");
@@ -2504,5 +2506,86 @@ function Demo(name: string) -> string {
             &body.exprs[*lhs2],
             Expr::Literal(baml_base::Literal::String(s)) if s == "Hello, "
         ));
+    }
+}
+
+#[cfg(test)]
+mod traverse_coverage_tests {
+    use crate::{
+        ast::{Expr, FunctionBodyDef, Item},
+        traverse::BodyNode,
+    };
+
+    /// Every expression and statement a lambda-free body allocates must be
+    /// reachable from its root. A child this walker forgets would be silently
+    /// dropped by every analysis built on it — an unwalked `throw` simply
+    /// vanishes from the function's effect set.
+    #[test]
+    fn every_allocated_node_is_reachable_from_the_root() {
+        let sources = [
+            r#"function f(a: int, b: int) -> int throws string {
+  let m = { "k": a + b }
+  let arr = [a, b, m["k"]]
+  for (let x in arr) { if (x > 0) { throw "pos" } }
+  let i = 0
+  while (i < 3) { i = i + 1 }
+  match (a) { 1 => { throw "one" }, _ if b > 0 => { b }, _ => { 0 } }
+}"#,
+            r#"function g(o: int?, cb: () -> int) -> int throws never {
+  defer { let z = 1 }
+  let v = o?.to_string()
+  let c = cb() catch (e) { _ => 0 }
+  return c
+}"#,
+            r#"function h(xs: int[]) -> int throws never {
+  let s = spawn { 1 }
+  let t = await s
+  if let [first, ..rest] = xs { return first }
+  return t
+}"#,
+        ];
+        for source in sources {
+            for item in super::tests::parse_and_lower(source) {
+                let Item::Function(f) = item else { continue };
+                let Some(FunctionBodyDef::Expr(body, _)) = &f.body else {
+                    continue;
+                };
+                // Skip bodies containing lambdas: their nodes live in a nested
+                // arena, so arena membership and reachability legitimately differ.
+                if body.exprs.iter().any(|(_, e)| matches!(e, Expr::Lambda(_))) {
+                    continue;
+                }
+                let Some(root) = body.root_expr else { continue };
+                let reached: std::collections::HashSet<BodyNode> =
+                    body.reachable_excluding_lambdas(root).into_iter().collect();
+
+                let missed_exprs: Vec<_> = body
+                    .exprs
+                    .iter()
+                    .map(|(id, _)| id)
+                    .filter(|id| !reached.contains(&BodyNode::Expr(*id)))
+                    .collect();
+                let missed_stmts: Vec<_> = body
+                    .stmts
+                    .iter()
+                    .map(|(id, _)| id)
+                    .filter(|id| !reached.contains(&BodyNode::Stmt(*id)))
+                    .collect();
+
+                assert!(
+                    missed_exprs.is_empty() && missed_stmts.is_empty(),
+                    "unreachable nodes in `{}`:\n  exprs: {:?}\n  stmts: {:?}\nsource:\n{source}",
+                    f.name,
+                    missed_exprs
+                        .iter()
+                        .map(|id| (*id, &body.exprs[*id]))
+                        .collect::<Vec<_>>(),
+                    missed_stmts
+                        .iter()
+                        .map(|id| (*id, &body.stmts[*id]))
+                        .collect::<Vec<_>>(),
+                );
+            }
+        }
     }
 }

--- a/baml_language/crates/baml_compiler2_ast/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lib.rs
@@ -2538,10 +2538,17 @@ mod traverse_coverage_tests {
   return c
 }"#,
             r#"function h(xs: int[]) -> int throws never {
-  let s = spawn { 1 }
-  let t = await s
   if let [first, ..rest] = xs { return first }
-  return t
+  return 0
+}"#,
+            // Backtick templates carry their expressions twice — once in
+            // `segments`, once in the desugared tag payload — from the same
+            // `ExprId`s. Both must be walked, and neither may be walked twice.
+            r#"function t(a: string, n: int) -> string throws never {
+  let plain = `hi ${a} there`
+  let looped = `${for (let i in [1, 2])}x${a}${endfor}`
+  let branched = `${if (n > 0)}pos${else}neg${endif}`
+  return plain + looped + branched
 }"#,
         ];
         for source in sources {
@@ -2572,6 +2579,19 @@ mod traverse_coverage_tests {
                     .filter(|id| !reached.contains(&BodyNode::Stmt(*id)))
                     .collect();
 
+                // The arena is a DAG (templates share ids between their two
+                // representations), so the walk must also not repeat itself:
+                // callers that push per visit would report duplicates.
+                let walked = body.reachable_excluding_lambdas(root);
+                assert_eq!(
+                    walked.len(),
+                    reached.len(),
+                    "`{}` visited {} nodes for {} unique — the walk must de-duplicate",
+                    f.name,
+                    walked.len(),
+                    reached.len(),
+                );
+
                 assert!(
                     missed_exprs.is_empty() && missed_stmts.is_empty(),
                     "unreachable nodes in `{}`:\n  exprs: {:?}\n  stmts: {:?}\nsource:\n{source}",
@@ -2587,5 +2607,153 @@ mod traverse_coverage_tests {
                 );
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod testset_nesting_tests {
+    use crate::ast::{Expr, FunctionBodyDef, Item, Stmt};
+
+    /// Count `<collector>.register_test` / `register_test_set` calls in a body.
+    ///
+    /// Lambda bodies share this arena, so the flat scan already covers the
+    /// registration lambdas the test/testset wrappers introduce.
+    fn count_registrations(body: &crate::ast::ExprBody) -> usize {
+        let mut n = 0;
+        for (_, expr) in body.exprs.iter() {
+            if let Expr::Call { callee, .. } = expr {
+                if let Expr::MemberAccess { member, .. } = &body.exprs[*callee]
+                    && matches!(member.as_str(), "register_test" | "register_test_set")
+                {
+                    n += 1;
+                }
+                if let Expr::Path(segments) = &body.exprs[*callee]
+                    && segments.last().is_some_and(|s| {
+                        matches!(s.as_str(), "register_test_at" | "register_test_set_at")
+                    })
+                {
+                    n += 1;
+                }
+            }
+        }
+        n
+    }
+
+    fn count_missing_stmts(body: &crate::ast::ExprBody) -> usize {
+        body.stmts
+            .iter()
+            .filter(|(_, s)| matches!(s, Stmt::Missing))
+            .count()
+    }
+
+    /// A `test` nested inside a `testset` registers; a `test` nested inside a
+    /// `test` does not.
+    ///
+    /// The distinction is carried entirely by `LoweringContext::testset_collector_var`:
+    /// a testset body sets it, a test body clears it. Both intents are currently
+    /// expressed by *which constructor* builds the body's context, so anything
+    /// that changes how those bodies are lowered has to reproduce both — set and
+    /// clear. Getting only the "set" half right makes `test` silently nest.
+    #[test]
+    fn a_test_inside_a_test_does_not_register() {
+        let items = super::tests::parse_and_lower(
+            r#"testset "Outer" {
+  test "Middle" {
+    test "Inner" {
+      assert.is_true(true)
+    }
+  }
+}"#,
+        );
+
+        let init = items
+            .iter()
+            .find_map(|item| match item {
+                Item::Function(f) if f.name.as_str().starts_with("$init_test") => Some(f),
+                _ => None,
+            })
+            .expect("expected a synthesized $init_test function");
+        let Some(FunctionBodyDef::Expr(body, _)) = &init.body else {
+            panic!("expected an expression body for $init_test");
+        };
+
+        // Outer testset + Middle test = 2. `Inner` sits in a test body, where
+        // the collector is cleared, so it lowers to `Stmt::Missing` instead.
+        //
+        // This pins the *registration* behaviour, not the diagnostic story:
+        // dropping `Inner` silently is a separate known bug (see the `// BUG:`
+        // note on the `TEST_EXPR_DEF` arm in `lower_expr_body.rs`).
+        assert_eq!(
+            count_registrations(body),
+            2,
+            "expected exactly the testset and the test it contains to register"
+        );
+        assert!(
+            count_missing_stmts(body) >= 1,
+            "expected the doubly-nested `test` to lower to `Stmt::Missing`"
+        );
+    }
+}
+
+#[cfg(test)]
+mod lambda_arena_tests {
+    use crate::ast::{Expr, FunctionBodyDef, Item, Stmt};
+
+    /// A lambda's body is allocated in the enclosing function's arena, and is
+    /// *not* reachable from that function's root.
+    ///
+    /// This is why effect analyses cannot scan the arena flatly: a `throw`
+    /// written inside a lambda is a sibling of the function's own statements,
+    /// indistinguishable from one the function wrote itself.
+    #[test]
+    fn a_lambdas_throw_is_in_the_enclosing_arena_but_not_reachable_from_its_root() {
+        let items = super::tests::parse_and_lower(
+            r#"function defines(value: int) -> int throws never {
+  let risky = (n: int) -> int {
+    throw "boom"
+  }
+  return value
+}"#,
+        );
+        let Some(Item::Function(f)) = items.into_iter().next() else {
+            panic!("expected a function item");
+        };
+        let Some(FunctionBodyDef::Expr(body, _)) = &f.body else {
+            panic!("expected an expression body");
+        };
+
+        let throw_stmts: Vec<_> = body
+            .stmts
+            .iter()
+            .filter(|(_, s)| matches!(s, Stmt::Throw { .. }))
+            .map(|(id, _)| id)
+            .collect();
+        assert_eq!(
+            throw_stmts.len(),
+            1,
+            "the lambda's `throw` must live in the enclosing function's arena"
+        );
+
+        let root = body.root_expr.expect("root");
+        let reached = body.reachable_excluding_lambdas(root);
+        assert!(
+            !reached.contains(&crate::traverse::BodyNode::Stmt(throw_stmts[0])),
+            "a structural walk that stops at lambdas must not reach the lambda's `throw`"
+        );
+
+        // And the lambda really does own it.
+        let lambda_root = body
+            .exprs
+            .iter()
+            .find_map(|(_, e)| match e {
+                Expr::Lambda(l) => l.body,
+                _ => None,
+            })
+            .expect("lambda body");
+        assert!(
+            body.reachable_excluding_lambdas(lambda_root)
+                .contains(&crate::traverse::BodyNode::Stmt(throw_stmts[0])),
+            "walking from the lambda's own root must reach its `throw`"
+        );
     }
 }

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -2187,7 +2187,7 @@ fn synthesize_init_test_function(
     // Build statements: one per registration
     let mut stmt_ids: Vec<crate::ast::StmtId> = Vec::with_capacity(registrations.len());
     for reg in registrations {
-        let stmt_expr = synthesize_register_call(reg, &test_owner, &mut ctx, diags, env_var_refs);
+        let stmt_expr = synthesize_register_call(reg, &test_owner, &mut ctx);
         stmt_ids.push(ctx.alloc_stmt(crate::ast::Stmt::Expr(stmt_expr), span));
     }
 
@@ -2249,8 +2249,6 @@ fn synthesize_register_call(
     reg: &TestRegistrationItem,
     test_owner: &str,
     ctx: &mut lower_expr_body::InitTestContext,
-    diags: &mut Vec<LoweringDiagnostic>,
-    env_var_refs: &mut Vec<crate::EnvVarRef>,
 ) -> ExprId {
     let span = text_size::TextRange::default();
     match reg {
@@ -2259,11 +2257,8 @@ fn synthesize_register_call(
             body_node,
             runner_element,
         } => {
-            // Lower the test block body into a fresh ExprBody (lambda body)
-            let (lambda_body, lambda_source_map, lambda_diags, lambda_env_refs) =
-                lower_expr_body::lower_block_node(body_node);
-            diags.extend(lambda_diags);
-            env_var_refs.extend(lambda_env_refs);
+            // The body lowers into `$init_test`'s own arena.
+            let lambda_body = ctx.lower_test_body(body_node, span);
 
             let lambda_def = LambdaDef {
                 kind: LambdaKind::Anonymous,
@@ -2271,7 +2266,7 @@ fn synthesize_register_call(
                 defaults: FunctionDefaults::empty(),
                 return_type: Some(crate::ast::TypeExprKind::Void { attrs: vec![] }.at(span)),
                 throws: None,
-                body: Some((lambda_body, lambda_source_map)),
+                body: Some(lambda_body),
                 span,
             };
 
@@ -2318,11 +2313,7 @@ fn synthesize_register_call(
             body_node,
             runner_element,
         } => {
-            // Lower the testset body into a collector lambda using the full testset lowering.
-            let (collector_exprs, collector_source_map, collector_diags, collector_env_refs) =
-                lower_expr_body::lower_testset_block_node(body_node, &Name::new("testset"));
-            diags.extend(collector_diags);
-            env_var_refs.extend(collector_env_refs);
+            let collector_exprs = ctx.lower_testset_body(body_node, Name::new("testset"), span);
 
             // Collector lambda parameter: `testset`
             let testset_param = Param {
@@ -2347,7 +2338,7 @@ fn synthesize_register_call(
                 defaults: FunctionDefaults::empty(),
                 return_type: Some(crate::ast::TypeExprKind::Void { attrs: vec![] }.at(span)),
                 throws: None,
-                body: Some((collector_exprs, collector_source_map)),
+                body: Some(collector_exprs),
                 span,
             };
 

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -18,9 +18,9 @@ use crate::{
         AssociatedTypeBindingDef, AssociatedTypeDef, AstSourceMap, BuiltinKind, CallArg, EnumDef,
         Expr, ExprBody, ExprId, FieldDef, FunctionBodyDef, FunctionDef, FunctionDefaults,
         ImplementsBlockDef, ImplementsForDef, InterfaceDef, InterfaceFieldLinkDef, Interpolation,
-        Item, LetDef, LetOrigin, LlmBodyDef, MethodSigDef, Param, RawAttribute, RawAttributeArg,
-        RawPrompt, TemplateStringDef, TestArgValue, TestDef, TypeAliasDef, TypeExpr, TypeExprKind,
-        VariantDef,
+        Item, LambdaDef, LambdaKind, LetDef, LetOrigin, LlmBodyDef, MethodSigDef, Param,
+        RawAttribute, RawAttributeArg, RawPrompt, TemplateStringDef, TestArgValue, TestDef,
+        TypeAliasDef, TypeExpr, TypeExprKind, VariantDef,
     },
     companions::expand_companions,
     lower_expr_body, lower_type_expr,
@@ -2265,24 +2265,14 @@ fn synthesize_register_call(
             diags.extend(lambda_diags);
             env_var_refs.extend(lambda_env_refs);
 
-            let lambda_def = FunctionDef {
-                name: Name::new("<test body>"),
-                generic_params: vec![],
-                generic_param_bounds: vec![],
+            let lambda_def = LambdaDef {
+                kind: LambdaKind::Anonymous,
                 params: vec![],
                 defaults: FunctionDefaults::empty(),
                 return_type: Some(crate::ast::TypeExprKind::Void { attrs: vec![] }.at(span)),
                 throws: None,
-                body: Some(FunctionBodyDef::Expr(lambda_body, lambda_source_map)),
-                declarative_meta: None,
-                metadata: crate::ast::FunctionMetadata::language_internal(
-                    crate::ast::FunctionOrigin::Internal,
-                ),
-                attributes: vec![],
-                docstring: None,
-                is_tagged_template_tag: false,
+                body: Some((lambda_body, lambda_source_map)),
                 span,
-                name_span: span,
             };
 
             // registry.register_test_at(owner, ...)
@@ -2351,24 +2341,14 @@ fn synthesize_register_call(
                 name_span: span,
             };
 
-            let collector_def = FunctionDef {
-                name: Name::new("<testset collector>"),
-                generic_params: vec![],
-                generic_param_bounds: vec![],
+            let collector_def = LambdaDef {
+                kind: LambdaKind::Anonymous,
                 params: vec![testset_param],
                 defaults: FunctionDefaults::empty(),
                 return_type: Some(crate::ast::TypeExprKind::Void { attrs: vec![] }.at(span)),
                 throws: None,
-                body: Some(FunctionBodyDef::Expr(collector_exprs, collector_source_map)),
-                declarative_meta: None,
-                metadata: crate::ast::FunctionMetadata::language_internal(
-                    crate::ast::FunctionOrigin::Internal,
-                ),
-                attributes: vec![],
-                docstring: None,
-                is_tagged_template_tag: false,
+                body: Some((collector_exprs, collector_source_map)),
                 span,
-                name_span: span,
             };
 
             // registry.register_test_set_at(owner, ...)

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -435,9 +435,7 @@ fn lower_function(
         if let Some(builtin_kind) = check_builtin_body(expr.syntax()) {
             (Some(FunctionBodyDef::Builtin(builtin_kind)), None)
         } else {
-            let param_names: Vec<Name> = params.iter().map(|p| p.name.clone()).collect();
-            let (expr_body, source_map) =
-                lower_expr_body::lower(&expr, &param_names, diags, env_var_refs);
+            let (expr_body, source_map) = lower_expr_body::lower(&expr, diags, env_var_refs);
             (Some(FunctionBodyDef::Expr(expr_body, source_map)), None)
         }
     } else {
@@ -560,13 +558,8 @@ pub(crate) fn lower_params_with_defaults(
         }
     }
 
-    let param_names: Vec<Name> = params.iter().map(|p| p.name.clone()).collect();
-    let (defaults, default_ids) = lower_expr_body::lower_default_expr_nodes(
-        &default_nodes,
-        &param_names,
-        diags,
-        env_var_refs,
-    );
+    let (defaults, default_ids) =
+        lower_expr_body::lower_default_expr_nodes(&default_nodes, diags, env_var_refs);
     for (idx, default_id) in default_ids {
         if let Some(param) = params.get_mut(idx) {
             param.default = Some(default_id);
@@ -2268,7 +2261,7 @@ fn synthesize_register_call(
         } => {
             // Lower the test block body into a fresh ExprBody (lambda body)
             let (lambda_body, lambda_source_map, lambda_diags, lambda_env_refs) =
-                lower_expr_body::lower_block_node(body_node, &[Name::new("registry")]);
+                lower_expr_body::lower_block_node(body_node);
             diags.extend(lambda_diags);
             env_var_refs.extend(lambda_env_refs);
 
@@ -2337,11 +2330,7 @@ fn synthesize_register_call(
         } => {
             // Lower the testset body into a collector lambda using the full testset lowering.
             let (collector_exprs, collector_source_map, collector_diags, collector_env_refs) =
-                lower_expr_body::lower_testset_block_node(
-                    body_node,
-                    &Name::new("testset"),
-                    &[Name::new("registry")],
-                );
+                lower_expr_body::lower_testset_block_node(body_node, &Name::new("testset"));
             diags.extend(collector_diags);
             env_var_refs.extend(collector_env_refs);
 

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -119,24 +119,6 @@ pub(crate) fn lower(
     (body, source_map)
 }
 
-/// Lower a `BLOCK_EXPR` node directly to an owned `ExprBody` + parallel `AstSourceMap`.
-///
-/// Used by `lower_cst` when synthesizing lambda bodies from `TEST_EXPR_DEF` / `TESTSET_DEF`
-/// blocks, where there is no wrapping `EXPR_FUNCTION_BODY` node.
-pub(crate) fn lower_block_node(
-    block_node: &SyntaxNode,
-) -> (
-    ExprBody,
-    AstSourceMap,
-    Vec<LoweringDiagnostic>,
-    Vec<EnvVarRef>,
-) {
-    let mut ctx = LoweringContext::new();
-    let root_expr = baml_compiler_syntax::ast::BlockExpr::cast(block_node.clone())
-        .map(|block| ctx.lower_block_expr(&block));
-    ctx.finish(root_expr)
-}
-
 pub(crate) fn lower_default_expr_nodes(
     defaults: &[(usize, baml_compiler_syntax::SyntaxElement)],
     diags: &mut Vec<LoweringDiagnostic>,
@@ -160,35 +142,6 @@ pub(crate) fn lower_default_expr_nodes(
     diags.extend(ctx_diags);
     env_var_refs.extend(ctx_env_refs);
     (FunctionDefaults { exprs, source_map }, lowered)
-}
-
-/// Lower a testset `BLOCK_EXPR` body node to an owned `ExprBody` + `AstSourceMap`.
-///
-/// The body may contain a mix of regular statements (let bindings, for loops, if conditions)
-/// and `TEST_EXPR_DEF` / `TESTSET_DEF` nodes. The latter are converted to
-/// `<collector_var>.register_test(...)` / `<collector_var>.register_test_set(...)` calls
-/// so that the resulting body is a valid expression body for the testset collector lambda.
-///
-/// `collector_var` is the name of the `testing.TestSetCollector` parameter in scope.
-///
-/// The returned body always has a `null` tail expression so the collector lambda satisfies
-/// the type checker's expectation that the body evaluates to `null`.
-pub(crate) fn lower_testset_block_node(
-    block_node: &SyntaxNode,
-    collector_var: &Name,
-) -> (
-    ExprBody,
-    AstSourceMap,
-    Vec<LoweringDiagnostic>,
-    Vec<EnvVarRef>,
-) {
-    let mut ctx = LoweringContext::new_testset_collector(collector_var.clone());
-    let range = block_node.span_range();
-    let root_expr = baml_compiler_syntax::ast::BlockExpr::cast(block_node.clone()).map(|block| {
-        let inner_block_id = ctx.lower_block_expr(&block);
-        ctx.ensure_null_tail(inner_block_id, range)
-    });
-    ctx.finish(root_expr)
 }
 
 /// Lower a runner `SyntaxElement` (node or token) into an `ExprId` within the given context.
@@ -255,6 +208,36 @@ impl InitTestContext {
         span: text_size::TextRange,
     ) -> crate::ast::StmtId {
         self.inner.alloc_stmt(stmt, span)
+    }
+
+    /// Lower a top-level `test`'s body into the `$init_test` arena, as the body
+    /// of the lambda that gets registered.
+    ///
+    /// The nodes carry their real source offsets even though `$init_test`'s own
+    /// synthesized nodes carry empty ranges — both live in one source map, and
+    /// HIR resolves names inside the body by offset.
+    pub(crate) fn lower_test_body(&mut self, block_node: &SyntaxNode, span: TextRange) -> ExprId {
+        match baml_compiler_syntax::ast::BlockExpr::cast(block_node.clone()) {
+            Some(block) => self.inner.lower_lambda_body(&block),
+            None => self.inner.alloc_expr(Expr::Null, span),
+        }
+    }
+
+    /// Lower a top-level `testset`'s body into the `$init_test` arena, as the
+    /// body of the collector lambda that gets registered.
+    pub(crate) fn lower_testset_body(
+        &mut self,
+        block_node: &SyntaxNode,
+        collector: Name,
+        span: TextRange,
+    ) -> ExprId {
+        match baml_compiler_syntax::ast::BlockExpr::cast(block_node.clone()) {
+            Some(block) => {
+                self.inner
+                    .lower_testset_collector_body(&block, collector, block_node.span_range())
+            }
+            None => self.inner.alloc_expr(Expr::Null, span),
+        }
     }
 
     pub(crate) fn finish(
@@ -444,12 +427,6 @@ impl LoweringContext {
         }
     }
 
-    fn new_testset_collector(collector_var: Name) -> Self {
-        let mut ctx = Self::new();
-        ctx.testset_collector_var = Some(collector_var);
-        ctx
-    }
-
     fn warn_const_introducer(&mut self, span: TextRange) {
         self.diags
             .push(LoweringDiagnostic::ConstBindingIntroducer { span });
@@ -565,6 +542,39 @@ impl LoweringContext {
         }
     }
 
+    /// Lower a lambda's `BLOCK_EXPR` into this arena.
+    ///
+    /// Clears `testset_collector_var` for the duration: a `test` / `testset`
+    /// written inside a lambda body is not in a collector's scope, so it must
+    /// lower to `Stmt::Missing` rather than a registration call. Before lambda
+    /// bodies shared this arena that fell out of building them in a fresh
+    /// `LoweringContext`; now it has to be said.
+    fn lower_lambda_body(&mut self, block: &baml_compiler_syntax::ast::BlockExpr) -> ExprId {
+        let saved_collector = self.testset_collector_var.take();
+        let body = self.lower_block_expr(block);
+        self.testset_collector_var = saved_collector;
+        body
+    }
+
+    /// Lower a testset's `BLOCK_EXPR` into this arena as a collector-lambda body.
+    ///
+    /// Sets `testset_collector_var` for the duration — the exact inverse of
+    /// [`Self::lower_lambda_body`] — so a `test` written inside registers
+    /// against `collector`. The body always ends in a `null` tail, which is what
+    /// the collector lambda's `-> void` signature expects.
+    fn lower_testset_collector_body(
+        &mut self,
+        block: &baml_compiler_syntax::ast::BlockExpr,
+        collector: Name,
+        range: TextRange,
+    ) -> ExprId {
+        let saved_collector = self.testset_collector_var.replace(collector);
+        let inner = self.lower_block_expr(block);
+        let body = self.ensure_null_tail(inner, range);
+        self.testset_collector_var = saved_collector;
+        body
+    }
+
     /// Ensure a block expression ends with a `null` tail.
     ///
     /// If `block_id` refers to a `Block` with no tail expression, this adds a `null` tail
@@ -664,12 +674,23 @@ impl LoweringContext {
                             self.alloc_stmt(Stmt::Continue, node.span_range())
                         }
                         SyntaxKind::DEFER_STMT => self.lower_defer_stmt(node),
+                        // A nested `test` / `testset` registers against the
+                        // enclosing `testset`'s collector, so it only means
+                        // something where `testset_collector_var` is set — i.e.
+                        // directly inside a `testset` body. Everywhere else there
+                        // is nothing to register against and the declaration is
+                        // dropped: inside a `test` body (which clears the var, so
+                        // tests don't nest), inside a lambda, or in an ordinary
+                        // function.
+                        //
+                        // BUG: it is dropped *silently* — neither the parser nor
+                        // this lowering reports it. `testset "A" { test "B" { test
+                        // "C" {} } }` compiles clean while `test "C"` never runs.
                         SyntaxKind::TEST_EXPR_DEF => {
                             if self.testset_collector_var.is_some() {
                                 let expr_id = self.lower_test_expr_as_register_call(node);
                                 self.alloc_stmt(Stmt::Expr(expr_id), node.span_range())
                             } else {
-                                // Invalid context — parser already emitted a diagnostic
                                 self.alloc_stmt(Stmt::Missing, node.span_range())
                             }
                         }
@@ -678,7 +699,6 @@ impl LoweringContext {
                                 let expr_id = self.lower_testset_as_register_call(node);
                                 self.alloc_stmt(Stmt::Expr(expr_id), node.span_range())
                             } else {
-                                // Invalid context — parser already emitted a diagnostic
                                 self.alloc_stmt(Stmt::Missing, node.span_range())
                             }
                         }
@@ -913,19 +933,14 @@ impl LoweringContext {
                 // capture / scope / MIR plumbing applies unchanged.
                 let block = cst_ast::BlockExpr::cast(child.clone());
                 let func_def = block.map(|block| {
-                    let mut lambda_ctx = LoweringContext::new();
-                    let root_expr = lambda_ctx.lower_block_expr(&block);
-                    let (lbody, source_map, lambda_diags, lambda_env_refs) =
-                        lambda_ctx.finish(Some(root_expr));
-                    self.diags.extend(lambda_diags);
-                    self.env_var_refs.extend(lambda_env_refs);
+                    let body = self.lower_lambda_body(&block);
                     LambdaDef {
                         kind: LambdaKind::Spawn,
                         params: Vec::new(),
                         defaults: crate::ast::FunctionDefaults::empty(),
                         return_type: None,
                         throws: None,
-                        body: Some((lbody, source_map)),
+                        body: Some(body),
                         span: child.span_range(),
                     }
                 });
@@ -4350,20 +4365,12 @@ impl LoweringContext {
                     .with_span(te.syntax().span_range())
             });
 
-        // Lower body via a FRESH LoweringContext — lambda gets its own ExprBody.
+        // The body lowers into *this* arena — a lambda owns no `ExprBody`.
         let body = node
             .children()
             .find(|n| n.kind() == SyntaxKind::BLOCK_EXPR)
             .and_then(ast::BlockExpr::cast)
-            .map(|block| {
-                let mut lambda_ctx = LoweringContext::new();
-                let root_expr = lambda_ctx.lower_block_expr(&block);
-                let (body, source_map, lambda_diags, lambda_env_refs) =
-                    lambda_ctx.finish(Some(root_expr));
-                self.diags.extend(lambda_diags);
-                self.env_var_refs.extend(lambda_env_refs);
-                (body, source_map)
-            });
+            .map(|block| self.lower_lambda_body(&block));
 
         let lambda_def = LambdaDef {
             kind: LambdaKind::Anonymous,
@@ -4866,18 +4873,11 @@ impl LoweringContext {
         // Find the BLOCK_EXPR child (the test body)
         let body_node_opt = node.children().find(|c| c.kind() == SyntaxKind::BLOCK_EXPR);
 
-        let (lambda_body, lambda_source_map, lambda_diags, lambda_env_refs) =
-            if let Some(body_node) = body_node_opt {
-                // Lower the body using a fresh context (no collector var — test bodies don't nest)
-                crate::lower_expr_body::lower_block_node(&body_node)
-            } else {
-                // Empty body: produce null
-                let mut sub_ctx = LoweringContext::new();
-                let null_expr = sub_ctx.alloc_expr(Expr::Null, span);
-                sub_ctx.finish(Some(null_expr))
-            };
-        self.diags.extend(lambda_diags);
-        self.env_var_refs.extend(lambda_env_refs);
+        // `lower_lambda_body` clears the collector — test bodies don't nest.
+        let lambda_body = match body_node_opt.and_then(baml_compiler_syntax::ast::BlockExpr::cast) {
+            Some(block) => self.lower_lambda_body(&block),
+            None => self.alloc_expr(Expr::Null, span),
+        };
 
         let lambda_def = LambdaDef {
             kind: LambdaKind::Anonymous,
@@ -4885,7 +4885,7 @@ impl LoweringContext {
             defaults: FunctionDefaults::empty(),
             return_type: None,
             throws: None,
-            body: Some((lambda_body, lambda_source_map)),
+            body: Some(lambda_body),
             span,
         };
 
@@ -4939,16 +4939,15 @@ impl LoweringContext {
         // Find the BLOCK_EXPR child (the testset body)
         let body_node_opt = node.children().find(|c| c.kind() == SyntaxKind::BLOCK_EXPR);
 
-        let (sub_body, sub_source_map, sub_diags, sub_env_refs) =
-            if let Some(body_node) = body_node_opt {
-                crate::lower_expr_body::lower_testset_block_node(&body_node, &Name::new("testset"))
-            } else {
-                let mut sub_ctx = LoweringContext::new();
-                let null_expr = sub_ctx.alloc_expr(Expr::Null, span);
-                sub_ctx.finish(Some(null_expr))
-            };
-        self.diags.extend(sub_diags);
-        self.env_var_refs.extend(sub_env_refs);
+        let sub_body = match body_node_opt.as_ref().and_then(|body_node| {
+            baml_compiler_syntax::ast::BlockExpr::cast(body_node.clone())
+                .map(|block| (block, body_node.span_range()))
+        }) {
+            Some((block, range)) => {
+                self.lower_testset_collector_body(&block, Name::new("testset"), range)
+            }
+            None => self.alloc_expr(Expr::Null, span),
+        };
 
         let sub_param = Param {
             name: Name::new("testset"),
@@ -4972,7 +4971,7 @@ impl LoweringContext {
             defaults: FunctionDefaults::empty(),
             return_type: None,
             throws: None,
-            body: Some((sub_body, sub_source_map)),
+            body: Some(sub_body),
             span,
         };
 

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -101,16 +101,10 @@ fn find_callee_generic_args(callee_node: &SyntaxNode) -> Option<SyntaxNode> {
 /// Lower a CST `ExprFunctionBody` to an owned `ExprBody` + parallel `AstSourceMap`.
 pub(crate) fn lower(
     expr_body: &baml_compiler_syntax::ast::ExprFunctionBody,
-    param_names: &[Name],
     diags: &mut Vec<LoweringDiagnostic>,
     env_var_refs: &mut Vec<EnvVarRef>,
 ) -> (ExprBody, AstSourceMap) {
     let mut ctx = LoweringContext::new();
-
-    // Add function parameters to scope tracking (for gensym avoidance)
-    for name in param_names {
-        ctx.names_in_scope.insert(name.to_string());
-    }
 
     // The EXPR_FUNCTION_BODY contains a BLOCK_EXPR as its child
     let root_expr = expr_body
@@ -131,7 +125,6 @@ pub(crate) fn lower(
 /// blocks, where there is no wrapping `EXPR_FUNCTION_BODY` node.
 pub(crate) fn lower_block_node(
     block_node: &SyntaxNode,
-    param_names: &[Name],
 ) -> (
     ExprBody,
     AstSourceMap,
@@ -139,9 +132,6 @@ pub(crate) fn lower_block_node(
     Vec<EnvVarRef>,
 ) {
     let mut ctx = LoweringContext::new();
-    for name in param_names {
-        ctx.names_in_scope.insert(name.to_string());
-    }
     let root_expr = baml_compiler_syntax::ast::BlockExpr::cast(block_node.clone())
         .map(|block| ctx.lower_block_expr(&block));
     ctx.finish(root_expr)
@@ -149,14 +139,10 @@ pub(crate) fn lower_block_node(
 
 pub(crate) fn lower_default_expr_nodes(
     defaults: &[(usize, baml_compiler_syntax::SyntaxElement)],
-    param_names: &[Name],
     diags: &mut Vec<LoweringDiagnostic>,
     env_var_refs: &mut Vec<EnvVarRef>,
 ) -> (FunctionDefaults, Vec<(usize, DefaultExprId)>) {
     let mut ctx = LoweringContext::new();
-    for name in param_names {
-        ctx.names_in_scope.insert(name.to_string());
-    }
 
     let mut lowered = Vec::with_capacity(defaults.len());
     for (idx, element) in defaults {
@@ -184,14 +170,12 @@ pub(crate) fn lower_default_expr_nodes(
 /// so that the resulting body is a valid expression body for the testset collector lambda.
 ///
 /// `collector_var` is the name of the `testing.TestSetCollector` parameter in scope.
-/// `param_names` are additional parameters to seed `names_in_scope` (e.g. the parent scope).
 ///
 /// The returned body always has a `null` tail expression so the collector lambda satisfies
 /// the type checker's expectation that the body evaluates to `null`.
 pub(crate) fn lower_testset_block_node(
     block_node: &SyntaxNode,
     collector_var: &Name,
-    param_names: &[Name],
 ) -> (
     ExprBody,
     AstSourceMap,
@@ -199,10 +183,6 @@ pub(crate) fn lower_testset_block_node(
     Vec<EnvVarRef>,
 ) {
     let mut ctx = LoweringContext::new_testset_collector(collector_var.clone());
-    ctx.names_in_scope.insert(collector_var.to_string());
-    for name in param_names {
-        ctx.names_in_scope.insert(name.to_string());
-    }
     let range = block_node.span_range();
     let root_expr = baml_compiler_syntax::ast::BlockExpr::cast(block_node.clone()).map(|block| {
         let inner_block_id = ctx.lower_block_expr(&block);
@@ -260,9 +240,9 @@ pub(crate) struct InitTestContext {
 
 impl InitTestContext {
     pub(crate) fn new() -> Self {
-        let mut inner = LoweringContext::new();
-        inner.names_in_scope.insert("registry".to_string());
-        Self { inner }
+        Self {
+            inner: LoweringContext::new(),
+        }
     }
 
     pub(crate) fn alloc_expr(&mut self, expr: Expr, span: text_size::TextRange) -> ExprId {
@@ -408,8 +388,6 @@ struct LoweringContext {
     type_annotations: Arena<TypeExpr>,
     /// Parallel span storage
     source_map: AstSourceMap,
-    /// All names used, for generating unique synthetic variable names.
-    names_in_scope: std::collections::HashSet<String>,
     /// When set, `TEST_EXPR_DEF` and `TESTSET_DEF` nodes encountered during block
     /// lowering are converted to `<var>.register_test(...)` / `<var>.register_test_set(...)`
     /// calls using this variable name. This supports dynamic test generation inside
@@ -457,7 +435,6 @@ impl LoweringContext {
             catch_arms: Arena::new(),
             type_annotations: Arena::new(),
             source_map: AstSourceMap::new(),
-            names_in_scope: std::collections::HashSet::new(),
             testset_collector_var: None,
             diags: Vec::new(),
             env_var_refs: Vec::new(),
@@ -4345,8 +4322,6 @@ impl LoweringContext {
             })
             .unwrap_or_else(|| (Vec::new(), FunctionDefaults::empty()));
 
-        let param_names: Vec<Name> = params.iter().map(|p| p.name.clone()).collect();
-
         // Lower optional return type: the TYPE_EXPR that is a direct child of the
         // lambda node, appearing after PARAMETER_LIST but before THROWS_CLAUSE/BLOCK_EXPR.
         // We scan children in order, skipping items until after PARAMETER_LIST.
@@ -4393,9 +4368,6 @@ impl LoweringContext {
             .and_then(ast::BlockExpr::cast)
             .map(|block| {
                 let mut lambda_ctx = LoweringContext::new();
-                for name in &param_names {
-                    lambda_ctx.names_in_scope.insert(name.to_string());
-                }
                 let root_expr = lambda_ctx.lower_block_expr(&block);
                 let (body, source_map, lambda_diags, lambda_env_refs) =
                     lambda_ctx.finish(Some(root_expr));
@@ -4918,10 +4890,7 @@ impl LoweringContext {
         let (lambda_body, lambda_source_map, lambda_diags, lambda_env_refs) =
             if let Some(body_node) = body_node_opt {
                 // Lower the body using a fresh context (no collector var — test bodies don't nest)
-                crate::lower_expr_body::lower_block_node(
-                    &body_node,
-                    std::slice::from_ref(&collector_name),
-                )
+                crate::lower_expr_body::lower_block_node(&body_node)
             } else {
                 // Empty body: produce null
                 let mut sub_ctx = LoweringContext::new();
@@ -5003,11 +4972,7 @@ impl LoweringContext {
 
         let (sub_body, sub_source_map, sub_diags, sub_env_refs) =
             if let Some(body_node) = body_node_opt {
-                crate::lower_expr_body::lower_testset_block_node(
-                    &body_node,
-                    &Name::new("testset"),
-                    std::slice::from_ref(&collector_name),
-                )
+                crate::lower_expr_body::lower_testset_block_node(&body_node, &Name::new("testset"))
             } else {
                 let mut sub_ctx = LoweringContext::new();
                 let null_expr = sub_ctx.alloc_expr(Expr::Null, span);

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -14,9 +14,9 @@ use crate::{
     LoweringDiagnostic,
     ast::{
         ArrayRestPat, AssignOp, AstSourceMap, BinaryOp, CallArg, CatchArm, CatchArmId, CatchClause,
-        CatchClauseKind, DefaultExprId, Expr, ExprBody, ExprId, FieldPat, FunctionBodyDef,
-        FunctionDef, FunctionDefaults, LetOrigin, Literal, LoopOrigin, MatchArm, MatchArmId, Param,
-        PatId, Pattern, SpreadField, Stmt, StmtId, TemplateIfBranch, TemplateSegment, TemplateTag,
+        CatchClauseKind, DefaultExprId, Expr, ExprBody, ExprId, FieldPat, FunctionDefaults,
+        LambdaDef, LambdaKind, LetOrigin, Literal, LoopOrigin, MatchArm, MatchArmId, Param, PatId,
+        Pattern, SpreadField, Stmt, StmtId, TemplateIfBranch, TemplateSegment, TemplateTag,
         TypeAnnotId, TypeExpr, TypeExprKind, UnaryOp,
     },
 };
@@ -919,24 +919,14 @@ impl LoweringContext {
                         lambda_ctx.finish(Some(root_expr));
                     self.diags.extend(lambda_diags);
                     self.env_var_refs.extend(lambda_env_refs);
-                    FunctionDef {
-                        name: Name::new("<spawn>"),
-                        generic_params: Vec::new(),
-                        generic_param_bounds: Vec::new(),
+                    LambdaDef {
+                        kind: LambdaKind::Spawn,
                         params: Vec::new(),
                         defaults: crate::ast::FunctionDefaults::empty(),
                         return_type: None,
                         throws: None,
-                        body: Some(FunctionBodyDef::Expr(lbody, source_map)),
-                        declarative_meta: None,
-                        metadata: crate::ast::FunctionMetadata::language_internal(
-                            crate::ast::FunctionOrigin::Internal,
-                        ),
-                        attributes: Vec::new(),
-                        docstring: None,
-                        is_tagged_template_tag: false,
+                        body: Some((lbody, source_map)),
                         span: child.span_range(),
-                        name_span: child.span_range(),
                     }
                 });
                 if let Some(fd) = func_def {
@@ -4302,8 +4292,7 @@ impl LoweringContext {
 
         // A lambda is a function *value* and cannot declare generic parameters
         // (rejected by the parser). Any leading `<...>` is left in the CST for
-        // recovery and ignored here, so the lambda carries no generics.
-        let generic_params = Vec::new();
+        // recovery and ignored here — `LambdaDef` has nowhere to put them.
 
         // Lower parameter list — gives us Vec<Param>
         let (params, defaults) = node
@@ -4373,30 +4362,20 @@ impl LoweringContext {
                     lambda_ctx.finish(Some(root_expr));
                 self.diags.extend(lambda_diags);
                 self.env_var_refs.extend(lambda_env_refs);
-                FunctionBodyDef::Expr(body, source_map)
+                (body, source_map)
             });
 
-        let func_def = FunctionDef {
-            name: Name::new("<anonymous function>"),
-            generic_params,
-            generic_param_bounds: Vec::new(),
+        let lambda_def = LambdaDef {
+            kind: LambdaKind::Anonymous,
             params,
             defaults,
             return_type,
             throws,
             body,
-            declarative_meta: None,
-            metadata: crate::ast::FunctionMetadata::user_facing(
-                crate::ast::FunctionOrigin::UserDefined,
-            ),
-            attributes: Vec::new(),
-            docstring: None,
-            is_tagged_template_tag: false,
             span: node.span_range(),
-            name_span: node.span_range(), // synthetic: use the lambda span
         };
 
-        self.alloc_expr(Expr::Lambda(Box::new(func_def)), node.span_range())
+        self.alloc_expr(Expr::Lambda(Box::new(lambda_def)), node.span_range())
     }
 
     fn try_lower_paren_token_content(&mut self, node: &SyntaxNode) -> Option<ExprId> {
@@ -4900,24 +4879,14 @@ impl LoweringContext {
         self.diags.extend(lambda_diags);
         self.env_var_refs.extend(lambda_env_refs);
 
-        let lambda_def = FunctionDef {
-            name: Name::new("<test body>"),
-            generic_params: vec![],
-            generic_param_bounds: vec![],
+        let lambda_def = LambdaDef {
+            kind: LambdaKind::Anonymous,
             params: vec![],
             defaults: FunctionDefaults::empty(),
             return_type: None,
             throws: None,
-            body: Some(FunctionBodyDef::Expr(lambda_body, lambda_source_map)),
-            declarative_meta: None,
-            metadata: crate::ast::FunctionMetadata::language_internal(
-                crate::ast::FunctionOrigin::Internal,
-            ),
-            attributes: vec![],
-            docstring: None,
-            is_tagged_template_tag: false,
+            body: Some((lambda_body, lambda_source_map)),
             span,
-            name_span: span,
         };
 
         // <collector>.register_test(name_expr, lambda, runner_or_null)
@@ -4997,24 +4966,14 @@ impl LoweringContext {
             name_span: span,
         };
 
-        let sub_collector_def = FunctionDef {
-            name: Name::new("<testset collector>"),
-            generic_params: vec![],
-            generic_param_bounds: vec![],
+        let sub_collector_def = LambdaDef {
+            kind: LambdaKind::Anonymous,
             params: vec![sub_param],
             defaults: FunctionDefaults::empty(),
             return_type: None,
             throws: None,
-            body: Some(FunctionBodyDef::Expr(sub_body, sub_source_map)),
-            declarative_meta: None,
-            metadata: crate::ast::FunctionMetadata::language_internal(
-                crate::ast::FunctionOrigin::Internal,
-            ),
-            attributes: vec![],
-            docstring: None,
-            is_tagged_template_tag: false,
+            body: Some((sub_body, sub_source_map)),
             span,
-            name_span: span,
         };
 
         // <collector>.register_test_set(name_expr, sub_collector_lambda, runner_or_null)

--- a/baml_language/crates/baml_compiler2_ast/src/traverse.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/traverse.rs
@@ -1,0 +1,253 @@
+//! Structural traversal of an [`ExprBody`] arena.
+//!
+//! An `ExprBody` is a flat arena, but the nodes in it form a tree rooted at
+//! [`ExprBody::root_expr`]. Iterating the arena directly and iterating the tree
+//! are *not* the same thing, and the difference is load-bearing: a lambda's
+//! body hangs off its `Expr::Lambda` node, so a flat scan sees a `throw` written
+//! inside a lambda as though the enclosing function wrote it.
+//!
+//! These helpers enumerate a node's *direct children* and leave descent to the
+//! caller, because whether to enter a lambda body is a per-analysis decision —
+//! scope building enters it, effect analysis must not. A caller that stops at
+//! lambdas checks the node itself before recursing:
+//!
+//! ```ignore
+//! if matches!(body.exprs[id], Expr::Lambda(_)) {
+//!     return; // a lambda's effects belong to the lambda, not to us
+//! }
+//! ```
+
+use crate::ast::{Expr, ExprBody, ExprId, Stmt, StmtId, TemplateSegment};
+
+/// A direct child of an expression or statement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BodyNode {
+    Expr(ExprId),
+    Stmt(StmtId),
+}
+
+impl ExprBody {
+    /// Append the direct children of `id` to `out`, in source order.
+    ///
+    /// A `Expr::Lambda`'s body is *not* a child: it lives in the lambda's own
+    /// arena and is not addressable by an `ExprId` in this one. Callers that
+    /// want to descend into it must reach it through the [`crate::ast::LambdaDef`].
+    pub fn expr_children(&self, id: ExprId, out: &mut Vec<BodyNode>) {
+        match &self.exprs[id] {
+            Expr::Literal(_)
+            | Expr::ByteStringLiteral(_)
+            | Expr::Null
+            | Expr::Path(_)
+            | Expr::Lambda(_)
+            | Expr::Missing => {}
+            Expr::GenericApply { base, .. }
+            | Expr::MemberAccess { base, .. }
+            | Expr::OptionalMemberAccess { base, .. }
+            | Expr::Upcast { base, .. } => out.push(BodyNode::Expr(*base)),
+            Expr::Unary { expr, .. } | Expr::OptionalChain { expr } => {
+                out.push(BodyNode::Expr(*expr));
+            }
+            Expr::Throw { value } => out.push(BodyNode::Expr(*value)),
+            Expr::Await { future } => out.push(BodyNode::Expr(*future)),
+            Expr::Return { value } => out.extend(value.map(BodyNode::Expr)),
+            Expr::If {
+                condition,
+                then_branch,
+                else_branch,
+            } => {
+                out.push(BodyNode::Expr(*condition));
+                out.push(BodyNode::Expr(*then_branch));
+                out.extend(else_branch.map(BodyNode::Expr));
+            }
+            Expr::IfLet {
+                scrutinee,
+                then_branch,
+                else_branch,
+                ..
+            } => {
+                out.push(BodyNode::Expr(*scrutinee));
+                out.push(BodyNode::Expr(*then_branch));
+                out.extend(else_branch.map(BodyNode::Expr));
+            }
+            Expr::Match {
+                scrutinee, arms, ..
+            } => {
+                out.push(BodyNode::Expr(*scrutinee));
+                for arm in arms {
+                    let arm = &self.match_arms[*arm];
+                    out.extend(arm.guard.map(BodyNode::Expr));
+                    out.push(BodyNode::Expr(arm.body));
+                }
+            }
+            Expr::Is { scrutinee, .. } => out.push(BodyNode::Expr(*scrutinee)),
+            Expr::Catch { base, clauses } => {
+                out.push(BodyNode::Expr(*base));
+                for clause in clauses {
+                    for arm in &clause.arms {
+                        out.push(BodyNode::Expr(self.catch_arms[*arm].body));
+                    }
+                }
+            }
+            Expr::Spawn {
+                name,
+                with_exprs,
+                body,
+            } => {
+                out.extend(name.map(BodyNode::Expr));
+                out.extend(with_exprs.iter().copied().map(BodyNode::Expr));
+                out.push(BodyNode::Expr(*body));
+            }
+            Expr::Binary { lhs, rhs, .. } => {
+                out.push(BodyNode::Expr(*lhs));
+                out.push(BodyNode::Expr(*rhs));
+            }
+            Expr::Index { base, index } | Expr::OptionalIndex { base, index } => {
+                out.push(BodyNode::Expr(*base));
+                out.push(BodyNode::Expr(*index));
+            }
+            Expr::Call { callee, args, .. } => {
+                out.push(BodyNode::Expr(*callee));
+                out.extend(args.iter().map(|arg| BodyNode::Expr(arg.expr)));
+            }
+            Expr::OptionalCall { callee, args } => {
+                out.push(BodyNode::Expr(*callee));
+                out.extend(args.iter().map(|arg| BodyNode::Expr(arg.expr)));
+            }
+            Expr::Object {
+                fields, spreads, ..
+            } => {
+                out.extend(fields.iter().map(|(_, expr)| BodyNode::Expr(*expr)));
+                out.extend(spreads.iter().map(|s| BodyNode::Expr(s.expr)));
+            }
+            Expr::Array { elements } => {
+                out.extend(elements.iter().copied().map(BodyNode::Expr));
+            }
+            Expr::Map { entries } => {
+                for (key, value) in entries {
+                    out.push(BodyNode::Expr(*key));
+                    out.push(BodyNode::Expr(*value));
+                }
+            }
+            Expr::Block { stmts, tail_expr } => {
+                out.extend(stmts.iter().copied().map(BodyNode::Stmt));
+                out.extend(tail_expr.map(BodyNode::Expr));
+            }
+            Expr::Template { segments, .. } => {
+                for segment in segments {
+                    template_segment_children(segment, out);
+                }
+            }
+        }
+    }
+
+    /// Append the direct children of `id` to `out`, in source order.
+    pub fn stmt_children(&self, id: StmtId, out: &mut Vec<BodyNode>) {
+        match &self.stmts[id] {
+            Stmt::Break | Stmt::Continue | Stmt::Missing | Stmt::HeaderComment { .. } => {}
+            Stmt::Expr(expr) | Stmt::Throw { value: expr } | Stmt::Defer { body: expr } => {
+                out.push(BodyNode::Expr(*expr));
+            }
+            Stmt::Return(expr) => out.extend(expr.map(BodyNode::Expr)),
+            Stmt::Let {
+                initializer,
+                else_branch,
+                ..
+            } => {
+                out.extend(initializer.map(BodyNode::Expr));
+                out.extend(else_branch.map(BodyNode::Expr));
+            }
+            Stmt::While {
+                condition,
+                body,
+                after,
+                ..
+            } => {
+                out.push(BodyNode::Expr(*condition));
+                out.push(BodyNode::Expr(*body));
+                out.extend(after.map(BodyNode::Stmt));
+            }
+            Stmt::WhileLet {
+                scrutinee, body, ..
+            } => {
+                out.push(BodyNode::Expr(*scrutinee));
+                out.push(BodyNode::Expr(*body));
+            }
+            Stmt::For {
+                collection, body, ..
+            } => {
+                out.push(BodyNode::Expr(*collection));
+                out.push(BodyNode::Expr(*body));
+            }
+            Stmt::Assign { target, value } | Stmt::AssignOp { target, value, .. } => {
+                out.push(BodyNode::Expr(*target));
+                out.push(BodyNode::Expr(*value));
+            }
+        }
+    }
+
+    /// Every node reachable from `root`, in pre-order, without entering nested
+    /// lambda bodies.
+    ///
+    /// This is the traversal an effect analysis wants: a lambda is a *value*, so
+    /// what its body throws or calls belongs to the lambda, not to the code that
+    /// defines it. Only invoking it transfers those effects.
+    pub fn reachable_excluding_lambdas(&self, root: ExprId) -> Vec<BodyNode> {
+        let mut stack = vec![BodyNode::Expr(root)];
+        let mut visited = Vec::new();
+        let mut children = Vec::new();
+        while let Some(node) = stack.pop() {
+            visited.push(node);
+            children.clear();
+            // `expr_children` yields nothing for a lambda, so a lambda node is
+            // visited but its body is not descended into.
+            match node {
+                BodyNode::Expr(id) => self.expr_children(id, &mut children),
+                BodyNode::Stmt(id) => self.stmt_children(id, &mut children),
+            }
+            stack.extend(children.iter().rev().copied());
+        }
+        visited
+    }
+}
+
+fn template_segment_children(segment: &TemplateSegment, out: &mut Vec<BodyNode>) {
+    match segment {
+        TemplateSegment::Text(_) => {}
+        TemplateSegment::Interp(expr) => out.push(BodyNode::Expr(*expr)),
+        TemplateSegment::For {
+            collection, body, ..
+        } => {
+            out.push(BodyNode::Expr(*collection));
+            for inner in body {
+                template_segment_children(inner, out);
+            }
+        }
+        TemplateSegment::CStyleFor {
+            init,
+            cond,
+            step,
+            body,
+        } => {
+            out.push(BodyNode::Stmt(*init));
+            out.push(BodyNode::Expr(*cond));
+            out.extend(step.map(BodyNode::Stmt));
+            for inner in body {
+                template_segment_children(inner, out);
+            }
+        }
+        TemplateSegment::If {
+            branches,
+            else_body,
+        } => {
+            for branch in branches {
+                out.push(BodyNode::Expr(branch.condition));
+                for inner in &branch.body {
+                    template_segment_children(inner, out);
+                }
+            }
+            for inner in else_body.iter().flatten() {
+                template_segment_children(inner, out);
+            }
+        }
+    }
+}

--- a/baml_language/crates/baml_compiler2_ast/src/traverse.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/traverse.rs
@@ -17,7 +17,9 @@
 //! }
 //! ```
 
-use crate::ast::{Expr, ExprBody, ExprId, Stmt, StmtId, TemplateSegment};
+use std::collections::HashSet;
+
+use crate::ast::{Expr, ExprBody, ExprId, Stmt, StmtId, TemplateSegment, TemplateTag};
 
 /// A direct child of an expression or statement.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -29,9 +31,10 @@ pub enum BodyNode {
 impl ExprBody {
     /// Append the direct children of `id` to `out`, in source order.
     ///
-    /// A `Expr::Lambda`'s body is *not* a child: it lives in the lambda's own
-    /// arena and is not addressable by an `ExprId` in this one. Callers that
-    /// want to descend into it must reach it through the [`crate::ast::LambdaDef`].
+    /// A lambda's body is deliberately *not* a child. It is an `ExprId` in this
+    /// same arena, reachable through [`crate::ast::LambdaDef::body`] — but a
+    /// lambda is a value, so what its body does belongs to the lambda. Callers
+    /// that want it ask for it explicitly.
     pub fn expr_children(&self, id: ExprId, out: &mut Vec<BodyNode>) {
         match &self.exprs[id] {
             Expr::Literal(_)
@@ -132,7 +135,22 @@ impl ExprBody {
                 out.extend(stmts.iter().copied().map(BodyNode::Stmt));
                 out.extend(tail_expr.map(BodyNode::Expr));
             }
-            Expr::Template { segments, .. } => {
+            Expr::Template { tag, segments } => {
+                // Both representations, because they carry different things and
+                // HIR/TIR each read only one: `segments` holds the user's
+                // `${…}` expressions (what diagnostics and name resolution
+                // point at), while the tag payload holds the desugared
+                // realization — the concat chain, its `.to_string()` calls, the
+                // `${for}` accumulators. Effect and call-graph analysis need the
+                // latter. The two share `ExprId`s by construction, which is why
+                // `reachable_excluding_lambdas` must de-duplicate.
+                match tag {
+                    TemplateTag::Default { elaborated } => out.push(BodyNode::Expr(*elaborated)),
+                    TemplateTag::Custom { tag, body } => {
+                        out.push(BodyNode::Expr(*tag));
+                        out.push(BodyNode::Expr(*body));
+                    }
+                }
                 for segment in segments {
                     template_segment_children(segment, out);
                 }
@@ -192,10 +210,20 @@ impl ExprBody {
     /// what its body throws or calls belongs to the lambda, not to the code that
     /// defines it. Only invoking it transfers those effects.
     pub fn reachable_excluding_lambdas(&self, root: ExprId) -> Vec<BodyNode> {
+        // The arena is a DAG, not a tree: a template's `segments` and its
+        // desugared tag payload are built from the *same* `ExprId`s, so a
+        // subtree is reachable by more than one path. Without this set the walk
+        // re-visits shared nodes once per path — exponential in template
+        // nesting — and callers that push per visit (find-references,
+        // call-site collection) report duplicates.
+        let mut seen: HashSet<BodyNode> = HashSet::new();
         let mut stack = vec![BodyNode::Expr(root)];
         let mut visited = Vec::new();
         let mut children = Vec::new();
         while let Some(node) = stack.pop() {
+            if !seen.insert(node) {
+                continue;
+            }
             visited.push(node);
             children.clear();
             // `expr_children` yields nothing for a lambda, so a lambda node is

--- a/baml_language/crates/baml_compiler2_hir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/builder.rs
@@ -389,7 +389,7 @@ impl<'db> SemanticIndexBuilder<'db> {
             }
             ast::Expr::Lambda(func_def) => {
                 self.record_expr_scope(expr_id);
-                self.walk_lambda_expr(expr_id, func_def, source_map);
+                self.walk_lambda_expr(expr_id, func_def, body, source_map);
             }
             _ => {
                 self.record_expr_scope(expr_id);
@@ -1111,6 +1111,7 @@ impl<'db> SemanticIndexBuilder<'db> {
         &mut self,
         expr_id: ast::ExprId,
         lambda: &ast::LambdaDef,
+        body: &ast::ExprBody,
         source_map: &ast::AstSourceMap,
     ) {
         self.push_scope(ScopeKind::Lambda, None, source_map.expr_span(expr_id));
@@ -1123,9 +1124,20 @@ impl<'db> SemanticIndexBuilder<'db> {
         self.emit_duplicate_param_diagnostics(&lambda.params);
         self.lambda_stack.push(scope_id);
         self.walk_parameter_defaults(&lambda.params, &lambda.defaults);
-        if let Some((lambda_body, lambda_source_map)) = &lambda.body {
-            self.walk_expr_body(lambda_body, lambda_source_map);
-            self.analyze_lambda_captures(scope_id, lambda_body, lambda_source_map);
+        if let Some(lambda_body) = lambda.body {
+            // The body shares this arena, but it still gets its own metadata
+            // namespace keyed by the lambda's scope. That keeps HIR agreeing
+            // with TIR's `infer_lambda_body` and MIR's `lower_lambda`, both of
+            // which look expression metadata up under the lambda scope. A
+            // mismatch here does not fail loudly: `path_resolution` simply
+            // misses, flow narrowing silently stops inside every lambda, and
+            // reconstructed closure signatures silently degrade to `unknown`.
+            let metadata_scope = ExprMetadataScope::Body(scope_id);
+            self.expr_metadata_scope_stack.push(metadata_scope);
+            self.walk_expr(lambda_body, body, source_map, false);
+            let popped = self.expr_metadata_scope_stack.pop();
+            debug_assert_eq!(popped, Some(metadata_scope));
+            self.analyze_lambda_captures(scope_id, body, source_map);
         }
         self.lambda_stack.pop();
         self.pop_scope();

--- a/baml_language/crates/baml_compiler2_hir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/builder.rs
@@ -348,17 +348,14 @@ impl<'db> SemanticIndexBuilder<'db> {
         debug_assert_eq!(popped, Some(metadata_scope));
     }
 
-    fn walk_parameter_defaults(&mut self, function: &ast::FunctionDef) {
+    /// Takes the parameter list and default arena separately so it serves both
+    /// declared functions and lambdas, which no longer share a type.
+    fn walk_parameter_defaults(&mut self, params: &[ast::Param], defaults: &ast::FunctionDefaults) {
         let metadata_scope = ExprMetadataScope::ParameterDefault(self.current_scope_id());
         self.expr_metadata_scope_stack.push(metadata_scope);
-        for param in &function.params {
+        for param in params {
             if let Some(default) = param.default {
-                self.walk_expr(
-                    default.expr(),
-                    &function.defaults.exprs,
-                    &function.defaults.source_map,
-                    true,
-                );
+                self.walk_expr(default.expr(), &defaults.exprs, &defaults.source_map, true);
             }
         }
         let popped = self.expr_metadata_scope_stack.pop();
@@ -1113,20 +1110,20 @@ impl<'db> SemanticIndexBuilder<'db> {
     fn walk_lambda_expr(
         &mut self,
         expr_id: ast::ExprId,
-        func_def: &ast::FunctionDef,
+        lambda: &ast::LambdaDef,
         source_map: &ast::AstSourceMap,
     ) {
         self.push_scope(ScopeKind::Lambda, None, source_map.expr_span(expr_id));
         let scope_id = self.current_scope_id();
-        for (idx, param) in func_def.params.iter().enumerate() {
+        for (idx, param) in lambda.params.iter().enumerate() {
             self.scope_bindings[scope_id.index() as usize]
                 .params
                 .push((param.name.clone(), idx));
         }
-        self.emit_duplicate_param_diagnostics(&func_def.params);
+        self.emit_duplicate_param_diagnostics(&lambda.params);
         self.lambda_stack.push(scope_id);
-        self.walk_parameter_defaults(func_def);
-        if let Some(ast::FunctionBodyDef::Expr(lambda_body, lambda_source_map)) = &func_def.body {
+        self.walk_parameter_defaults(&lambda.params, &lambda.defaults);
+        if let Some((lambda_body, lambda_source_map)) = &lambda.body {
             self.walk_expr_body(lambda_body, lambda_source_map);
             self.analyze_lambda_captures(scope_id, lambda_body, lambda_source_map);
         }
@@ -1266,7 +1263,7 @@ impl<'db> SemanticIndexBuilder<'db> {
                 .push((param.name.clone(), idx));
         }
         self.emit_duplicate_param_diagnostics(&f.params);
-        self.walk_parameter_defaults(f);
+        self.walk_parameter_defaults(&f.params, &f.defaults);
 
         if let Some(ast::FunctionBodyDef::Expr(ref body, ref source_map)) = f.body {
             self.walk_expr_body(body, source_map);

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -3913,14 +3913,12 @@ impl<'db> LoweringContext<'db> {
             self.current_scope
         };
 
-        // Pull out the lambda's body and source map.
-        let (lambda_body, lambda_source_map) = match func_def.body.as_ref() {
-            Some((body, sm)) => (body.clone(), Some(sm.clone())),
-            _ => {
-                // No body — emit a panic stub and return.
-                self.emit_panic_call("lambda without body", expr_id);
-                return;
-            }
+        // The body is an expression in the arena already installed — a lambda
+        // owns no `ExprBody`, so there is nothing to swap in.
+        let Some(lambda_root) = func_def.body else {
+            // No body — emit a panic stub and return.
+            self.emit_panic_call("lambda without body", expr_id);
+            return;
         };
 
         // Read HIR captures for this lambda scope.
@@ -3946,8 +3944,6 @@ impl<'db> LoweringContext<'db> {
             &mut self.builder,
             MirBuilder::new(Name::new(&lambda_name), 0),
         );
-        let saved_body = std::mem::replace(&mut self.body, lambda_body);
-        let saved_source_map = std::mem::replace(&mut self.source_map, lambda_source_map);
         let saved_locals = std::mem::take(&mut self.locals);
         let saved_binding_locals = std::mem::take(&mut self.binding_locals);
         let saved_exit_block = self.exit_block;
@@ -4163,15 +4159,8 @@ impl<'db> LoweringContext<'db> {
         self.exit_block = exit_blk;
         self.builder.set_current_block(entry);
 
-        // Lower the root expression into the return place.
-        if let Some(root) = self.body.root_expr {
-            self.lower_expr(root, Place::local(ret));
-        } else {
-            self.builder.assign(
-                Place::local(ret),
-                Rvalue::Use(Operand::Constant(Constant::Null)),
-            );
-        }
+        // Lower the body expression into the return place.
+        self.lower_expr(lambda_root, Place::local(ret));
 
         // Terminate: goto exit, then return.
         if !self.builder.is_current_terminated() {
@@ -4231,8 +4220,6 @@ impl<'db> LoweringContext<'db> {
         // Restore parent state.
         self.lambda_param_tir_types = saved_lambda_param_tir_types;
         self.builder = saved_builder;
-        self.body = saved_body;
-        self.source_map = saved_source_map;
         self.locals = saved_locals;
         self.binding_locals = saved_binding_locals;
         self.exit_block = saved_exit_block;

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -3878,7 +3878,7 @@ impl<'db> LoweringContext<'db> {
     #[allow(clippy::cast_possible_truncation)]
     fn lower_lambda(
         &mut self,
-        func_def: &baml_compiler2_ast::FunctionDef,
+        func_def: &baml_compiler2_ast::LambdaDef,
         expr_id: AstExprId,
         dest: Place,
     ) {
@@ -3915,9 +3915,7 @@ impl<'db> LoweringContext<'db> {
 
         // Pull out the lambda's body and source map.
         let (lambda_body, lambda_source_map) = match func_def.body.as_ref() {
-            Some(baml_compiler2_ast::FunctionBodyDef::Expr(body, sm)) => {
-                (body.clone(), Some(sm.clone()))
-            }
+            Some((body, sm)) => (body.clone(), Some(sm.clone())),
             _ => {
                 // No body — emit a panic stub and return.
                 self.emit_panic_call("lambda without body", expr_id);
@@ -3960,17 +3958,10 @@ impl<'db> LoweringContext<'db> {
         let saved_defer_stack = std::mem::take(&mut self.defer_stack);
         let saved_current_scope = self.current_scope;
         let saved_metadata_scope = self.current_metadata_scope;
-        // Extend the enclosing-lambda generic params with this lambda's own
-        // params for the duration of its body, so `reflect.type_of<T>` (and any
-        // type-arg resolution) inside resolves `T` to the right frame slot.
-        // Appended after the enclosing params, matching the runtime layout:
-        // frame.type_args = [captured enclosing params..., this lambda's args...].
+        // A lambda declares no generic parameters of its own, so its frame is
+        // exactly the enclosing one and nothing is appended for the body. The
+        // save/restore stays because the body may itself contain lambdas.
         let saved_lambda_generic_params = self.lambda_generic_params.clone();
-        let mut all_generic_params = self.enclosing_generic_params();
-        let inherited_count = all_generic_params.len();
-        ParamTy::extend_frame(&mut all_generic_params, &func_def.generic_params);
-        self.lambda_generic_params
-            .extend_from_slice(&all_generic_params[inherited_count..]);
         // NOTE: synthetic_name_counts is intentionally NOT saved — its counter
         // keeps incrementing across the whole function for uniqueness.
         //
@@ -4216,12 +4207,9 @@ impl<'db> LoweringContext<'db> {
             // A lambda has no source-level name; its `Function::name` is a
             // synthetic debug identity.
             name: None,
-            docstring: func_def.docstring.clone(),
-            display_type_params: func_def
-                .generic_params
-                .iter()
-                .map(std::string::ToString::to_string)
-                .collect(),
+            // A lambda carries neither a docstring nor generic parameters.
+            docstring: None,
+            display_type_params: Vec::new(),
             display_param_types: sig_display_param_types,
             display_return_type: sig_display_return_type,
             param_names: func_def.params.iter().map(|p| p.name.to_string()).collect(),

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -1667,20 +1667,16 @@ impl<'db> TypeInferenceBuilder<'db> {
         ty
     }
 
-    fn lower_lambda_return_annotation(&mut self, func_def: &ast::FunctionDef) -> Option<Ty> {
-        let te = func_def.return_type.as_ref()?;
-        let all_generic_params =
-            Self::params_with_names(&self.generic_params, &func_def.generic_params);
-        Some(self.lower_lambda_type_expr(te, &all_generic_params, te.span))
-    }
-
-    fn params_with_names(parent: &[crate::ty::ParamTy], names: &[Name]) -> Vec<crate::ty::ParamTy> {
-        crate::generic_env::append_params(parent, names)
+    fn lower_lambda_return_annotation(&mut self, lambda: &ast::LambdaDef) -> Option<Ty> {
+        let te = lambda.return_type.as_ref()?;
+        // A lambda declares no generics of its own, so the enclosing scope's
+        // parameters are the whole environment.
+        Some(self.lower_lambda_type_expr(te, &self.generic_params.clone(), te.span))
     }
 
     fn choose_lambda_throws_surface(
         &mut self,
-        func_def: &baml_compiler2_ast::FunctionDef,
+        func_def: &baml_compiler2_ast::LambdaDef,
         generic_params: &[crate::ty::ParamTy],
         contextual_throws: Option<&Ty>,
     ) -> (Ty, TextRange, bool) {
@@ -1689,7 +1685,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             (ty, throws.span, true)
         } else if let Some(contextual) = contextual_throws {
             (contextual.clone(), func_def.span, false)
-        } else if Self::is_spawn_body_lambda(func_def) {
+        } else if func_def.kind == baml_compiler2_ast::LambdaKind::Spawn {
             // BEP-034: a `spawn { body }` body is wrapped in a synthetic
             // 0-arg lambda whose throws are captured into the resulting
             // `Future<T, E>`'s E parameter, not propagated to the
@@ -1714,14 +1710,6 @@ impl<'db> TypeInferenceBuilder<'db> {
                 false,
             )
         }
-    }
-
-    /// Synthetic lambda produced by `lower_spawn_expr` carries the name
-    /// `<spawn>`. The marker is the only safe way to distinguish a
-    /// user-written `() => { ... }` from spawn's body wrapper at this
-    /// layer (their `FunctionDef`s are otherwise identical).
-    fn is_spawn_body_lambda(func_def: &baml_compiler2_ast::FunctionDef) -> bool {
-        func_def.name.as_str() == "<spawn>"
     }
 
     fn throws_surface_has_open_slot(throws_facts: &BTreeSet<Ty>) -> bool {
@@ -3388,7 +3376,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                         );
                     }
                 }
-                if let Some(ast::FunctionBodyDef::Expr(lambda_body, _)) = &func_def.body
+                if let Some((lambda_body, _)) = &func_def.body
                     && let Some(root_expr) = lambda_body.root_expr
                 {
                     Self::collect_default_expr_forward_references(
@@ -5689,7 +5677,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     #[inline(never)]
-    fn infer_lambda_expr(&mut self, expr_id: ExprId, func_def: &ast::FunctionDef) -> Ty {
+    fn infer_lambda_expr(&mut self, expr_id: ExprId, func_def: &ast::LambdaDef) -> Ty {
         // Synthesis mode: no expected type available.
         // All param types MUST be annotated; unannotated params produce an error.
 
@@ -5736,7 +5724,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         // middleware body wrap `() -> { original() * 2 }` where `original:
         // () -> T throws E` types as `() -> T throws E`, not `throws never`.
         let infer_throws_from_body =
-            func_def.throws.is_none() && !Self::is_spawn_body_lambda(func_def);
+            func_def.throws.is_none() && func_def.kind != baml_compiler2_ast::LambdaKind::Spawn;
         let throws_ty = if infer_throws_from_body {
             Ty::Unknown {
                 attr: TyAttr::default(),
@@ -6740,7 +6728,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         expr_id: ExprId,
         body: &ExprBody,
         expected: &Ty,
-        func_def: &ast::FunctionDef,
+        func_def: &ast::LambdaDef,
     ) -> Ty {
         let expected_function = self.expected_lambda_function_ty(expected);
         match expected_function.as_ref() {
@@ -6764,8 +6752,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                     );
                 }
 
-                let all_generic_params =
-                    Self::params_with_names(&self.generic_params, &func_def.generic_params);
+                // Lambdas cannot declare generic parameters (rejected by the
+                // parser), so they only see the enclosing generic scope.
+                let all_generic_params = self.generic_params.clone();
 
                 // Determine param types: annotation takes precedence, else use expected
                 let mut param_tys: Vec<FunctionParamTy> = Vec::new();
@@ -14867,17 +14856,15 @@ impl<'db> TypeInferenceBuilder<'db> {
     /// Returns `(inferred_return_ty, lambda_file_scope_id, effective_throws)`.
     pub fn infer_lambda_body(
         &mut self,
-        func_def: &baml_compiler2_ast::FunctionDef,
+        func_def: &baml_compiler2_ast::LambdaDef,
         param_tys: &[FunctionParamTy],
         expected_ret: Option<&Ty>,
         chosen_throws: &Ty,
         throws_report_span: TextRange,
         warn_extraneous_throws: bool,
     ) -> (Ty, Option<FileScopeId>, Ty) {
-        use baml_compiler2_ast::FunctionBodyDef;
-
         // Get the lambda's ExprBody
-        let Some(FunctionBodyDef::Expr(lambda_body, lambda_source_map)) = &func_def.body else {
+        let Some((lambda_body, lambda_source_map)) = &func_def.body else {
             return (
                 Ty::Unknown {
                     attr: TyAttr::default(),
@@ -14942,9 +14929,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         // rendered with the enclosing scope's map (see `freeze_diagnostic_spans_from`).
         let lambda_diag_start = self.context.diagnostic_count();
 
-        // Extend generic params with the lambda's own generic params
-        self.generic_params =
-            Self::params_with_names(&self.generic_params, &func_def.generic_params);
+        // A lambda declares no generics of its own, so `self.generic_params`
+        // already holds the whole environment its body sees.
 
         // Seed lambda params (captures remain accessible via parent locals).
         //

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -1937,6 +1937,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     fn check_throws_surface(
         &mut self,
         body: &ExprBody,
+        root: Option<ExprId>,
         throws_ty: &Ty,
         span: TextRange,
         warn_extraneous: bool,
@@ -1949,7 +1950,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         // stays a fact — correctly, since the body genuinely throws it.
         let declared = crate::throw_inference::flatten_ty_to_facts(&self.normalize(throws_ty));
         let effective: BTreeSet<Ty> = self
-            .collect_effective_throws(body)
+            .collect_effective_throws(body, root)
             .iter()
             .flat_map(|fact| crate::throw_inference::flatten_ty_to_facts(&self.normalize(fact)))
             .collect();
@@ -3376,12 +3377,10 @@ impl<'db> TypeInferenceBuilder<'db> {
                         );
                     }
                 }
-                if let Some((lambda_body, _)) = &func_def.body
-                    && let Some(root_expr) = lambda_body.root_expr
-                {
+                if let Some(lambda_root) = func_def.body {
                     Self::collect_default_expr_forward_references(
-                        root_expr,
-                        lambda_body,
+                        lambda_root,
+                        body,
                         later_params,
                         shadowed,
                         refs,
@@ -4923,7 +4922,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 self.in_optional_chain -= 1;
                 ty
             }
-            Expr::Lambda(func_def) => self.infer_lambda_expr(expr_id, func_def),
+            Expr::Lambda(func_def) => self.infer_lambda_expr(expr_id, body, func_def),
             Expr::Spawn {
                 name,
                 with_exprs,
@@ -5677,7 +5676,12 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     #[inline(never)]
-    fn infer_lambda_expr(&mut self, expr_id: ExprId, func_def: &ast::LambdaDef) -> Ty {
+    fn infer_lambda_expr(
+        &mut self,
+        expr_id: ExprId,
+        body: &ExprBody,
+        func_def: &ast::LambdaDef,
+    ) -> Ty {
         // Synthesis mode: no expected type available.
         // All param types MUST be annotated; unannotated params produce an error.
 
@@ -5736,6 +5740,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         // Infer the lambda body using save/restore approach
         let (ret_ty, lambda_fsi, lambda_effective_throws) = self.infer_lambda_body(
             func_def,
+            body,
             &param_tys,
             return_annotation.as_ref(),
             &throws_ty,
@@ -6806,6 +6811,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // Infer/check the lambda body using save/restore approach
                 let (ret_ty, lambda_fsi, lambda_effective_throws) = self.infer_lambda_body(
                     func_def,
+                    body,
                     &param_tys,
                     effective_ret,
                     &throws_ty,
@@ -8662,7 +8668,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             self.context.report_at_span(diag, span);
         }
         self.validate_type_generic_bounds_at_span(span, &declared_ty);
-        self.check_throws_surface(body, &declared_ty, span, warn_extraneous);
+        self.check_throws_surface(body, body.root_expr, &declared_ty, span, warn_extraneous);
     }
 
     // ====================================================================
@@ -9335,10 +9341,11 @@ impl<'db> TypeInferenceBuilder<'db> {
         out
     }
 
-    fn collect_effective_throws(&self, body: &ExprBody) -> BTreeSet<Ty> {
-        crate::throws_analysis::collect_escaping_throws(
+    fn collect_effective_throws(&self, body: &ExprBody, root: Option<ExprId>) -> BTreeSet<Ty> {
+        crate::throws_analysis::collect_escaping_throws_from(
             &BuilderThrowsAnalysis { builder: self },
             body,
+            root,
         )
     }
 
@@ -14854,31 +14861,25 @@ impl<'db> TypeInferenceBuilder<'db> {
     /// body (which also stops its diagnostics from being reported twice).
     ///
     /// Returns `(inferred_return_ty, lambda_file_scope_id, effective_throws)`.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the lambda, the body it was written in, and its inferred signature parts"
+    )]
     pub fn infer_lambda_body(
         &mut self,
         func_def: &baml_compiler2_ast::LambdaDef,
+        lambda_body: &ExprBody,
         param_tys: &[FunctionParamTy],
         expected_ret: Option<&Ty>,
         chosen_throws: &Ty,
         throws_report_span: TextRange,
         warn_extraneous_throws: bool,
     ) -> (Ty, Option<FileScopeId>, Ty) {
-        // Get the lambda's ExprBody
-        let Some((lambda_body, lambda_source_map)) = &func_def.body else {
+        // The body is an expression in the enclosing arena, so `lambda_body` is
+        // the body this lambda was written in — there is no arena to switch to.
+        let Some(root_expr) = func_def.body else {
             return (
                 Ty::Unknown {
-                    attr: TyAttr::default(),
-                },
-                None,
-                Ty::Never {
-                    attr: TyAttr::default(),
-                },
-            );
-        };
-
-        let Some(root_expr) = lambda_body.root_expr else {
-            return (
-                Ty::Void {
                     attr: TyAttr::default(),
                 },
                 None,
@@ -14921,13 +14922,6 @@ impl<'db> TypeInferenceBuilder<'db> {
         // in. Reset the counters for the body and restore them afterwards.
         let saved_loop_depth = std::mem::take(&mut self.loop_depth);
         let saved_defer_loop_floors = std::mem::take(&mut self.defer_loop_floors);
-        let saved_body_source_map = self.body_source_map.clone();
-        self.body_source_map = Some(lambda_source_map.clone());
-        // Diagnostics emitted below carry THIS lambda's arena IDs but are
-        // recorded in the enclosing scope's set; freeze their spans against the
-        // lambda's source map at the end so they don't collapse to `0..0` when
-        // rendered with the enclosing scope's map (see `freeze_diagnostic_spans_from`).
-        let lambda_diag_start = self.context.diagnostic_count();
 
         // A lambda declares no generics of its own, so `self.generic_params`
         // already holds the whole environment its body sees.
@@ -14991,9 +14985,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             // (or reported) twice.
             let key_fsi = index.lambda_scope_for(func_def.span);
             let seed_fsi = key_fsi.or_else(|| {
-                lambda_body
-                    .root_expr
-                    .and_then(|root| index.lambda_scope_for(lambda_source_map.expr_span(root)))
+                self.body_source_map
+                    .as_ref()
+                    .map(|sm| sm.expr_span(root_expr))
+                    .and_then(|span| index.lambda_scope_for(span))
             });
             if let Some(fsi) = seed_fsi {
                 let captures_to_seed: Vec<(Name, baml_compiler2_hir::semantic_index::BindingId)> =
@@ -15021,8 +15016,6 @@ impl<'db> TypeInferenceBuilder<'db> {
             self.declared_return_ty = None;
         }
 
-        let lambda_diagnostics_start = self.context.diagnostic_count();
-
         // Infer or check the lambda body
         let ret_ty = if let Some(expected) = expected_ret {
             if matches!(expected, Ty::Unknown { .. } | Ty::TypeVar(_, _)) {
@@ -15037,14 +15030,13 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         self.check_throws_surface(
             lambda_body,
+            Some(root_expr),
             chosen_throws,
             throws_report_span,
             warn_extraneous_throws,
         );
-        self.context
-            .freeze_diagnostic_spans_from(lambda_diagnostics_start, lambda_source_map);
 
-        let effective_facts = self.collect_effective_throws(lambda_body);
+        let effective_facts = self.collect_effective_throws(lambda_body, Some(root_expr));
         let lambda_effective_throws = Self::ty_from_concrete_facts(&effective_facts)
             .or_else(|| {
                 // A rigid TypeVar fact — an ENCLOSING function's generic param,
@@ -15160,11 +15152,6 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.loop_depth = saved_loop_depth;
         self.defer_loop_floors = saved_defer_loop_floors;
         self.expr_metadata_scope = saved_expr_metadata_scope;
-        // Freeze this lambda's diagnostic spans against its own source map
-        // before restoring the enclosing map (otherwise they render at `0..0`).
-        self.context
-            .freeze_diagnostic_spans_from(lambda_diag_start, lambda_source_map);
-        self.body_source_map = saved_body_source_map;
 
         (ret_ty, lambda_file_scope_id, lambda_effective_throws)
     }

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -17,7 +17,7 @@ use std::{
 
 use baml_base::{Name, SourceFile};
 use baml_compiler2_ast::{
-    self as ast, AstSourceMap, Expr as AstExpr, ExprBody, ExprId, FunctionDef, PatId,
+    self as ast, AstSourceMap, Expr as AstExpr, ExprBody, ExprId, LambdaDef, PatId,
 };
 use baml_compiler2_hir::{
     body::{FunctionBody, LetBody},
@@ -629,11 +629,15 @@ fn validate_type_ref_generic_bounds_at_span(
     builder.validate_type_generic_bounds_at_span(span, &ty);
 }
 
-fn extend_env_with_lambda_generics<'db>(
-    env: &GenericEnv<'db>,
-    func_def: &FunctionDef,
-) -> GenericEnv<'db> {
-    env.child_unique_ast(&func_def.generic_params, &func_def.generic_param_bounds)
+/// The generic environment a lambda body is inferred in.
+///
+/// A lambda declares no generic parameters of its own (the parser rejects
+/// them), so this adds none. The child environment is still created rather than
+/// reusing the parent directly: building a child resets `self_bound` to `None`,
+/// so collapsing this call would silently change what `Self` resolves to inside
+/// a lambda body.
+fn lambda_body_env<'db>(env: &GenericEnv<'db>) -> GenericEnv<'db> {
+    env.child_unique_ast(&[], &[])
 }
 
 fn add_lambda_params_to_builder(
@@ -642,7 +646,7 @@ fn add_lambda_params_to_builder(
     pkg_items: &PackageItems<'_>,
     ns_context: &[Name],
     env: &GenericEnv,
-    func_def: &FunctionDef,
+    func_def: &LambdaDef,
     contextual_param_tys: Option<&[FunctionParamTy]>,
 ) {
     // The lambda's own generic bounds (its env extends the enclosing scope's) let a
@@ -1242,33 +1246,24 @@ fn seed_template_body_params(
 /// Search for a `Lambda` expression whose source span matches `target_span` in
 /// `body`/`source_map`, recursively descending into nested lambda bodies.
 ///
-/// Returns `Some((func_def, lambda_body, lambda_source_map, lambda_expr_id))` when
+/// Returns `Some((lambda, lambda_body, lambda_source_map, lambda_expr_id))` when
 /// found; `None` otherwise.
 fn find_lambda_by_span<'a>(
     body: &'a ExprBody,
     source_map: &AstSourceMap,
     target_span: TextRange,
-) -> Option<(&'a FunctionDef, &'a ExprBody, &'a AstSourceMap, ExprId)> {
+) -> Option<(&'a LambdaDef, &'a ExprBody, &'a AstSourceMap, ExprId)> {
     for (expr_id, expr) in body.exprs.iter() {
-        if let AstExpr::Lambda(ref func_def) = *expr {
-            let span = source_map.expr_span(expr_id);
-            if span == target_span {
-                // Found the matching lambda
-                if let Some(baml_compiler2_ast::FunctionBodyDef::Expr(
-                    ref lambda_body,
-                    ref lambda_sm,
-                )) = func_def.body
-                {
-                    return Some((func_def, lambda_body, lambda_sm, expr_id));
-                }
+        if let AstExpr::Lambda(ref lambda) = *expr {
+            let Some((ref lambda_body, ref lambda_sm)) = lambda.body else {
+                continue;
+            };
+            if source_map.expr_span(expr_id) == target_span {
+                return Some((lambda, lambda_body, lambda_sm, expr_id));
             }
             // Recurse into nested lambda bodies
-            if let Some(baml_compiler2_ast::FunctionBodyDef::Expr(ref nested_body, ref nested_sm)) =
-                func_def.body
-            {
-                if let Some(found) = find_lambda_by_span(nested_body, nested_sm, target_span) {
-                    return Some(found);
-                }
+            if let Some(found) = find_lambda_by_span(lambda_body, lambda_sm, target_span) {
+                return Some(found);
             }
         }
     }
@@ -2040,8 +2035,7 @@ pub fn infer_scope_types<'db>(
 
                                     let parent_env =
                                         crate::generic_env::function_generic_env(db, ancestor_func);
-                                    let env =
-                                        extend_env_with_lambda_generics(&parent_env, func_def);
+                                    let env = lambda_body_env(&parent_env);
                                     apply_generic_env(
                                         db,
                                         &mut builder,
@@ -2107,8 +2101,7 @@ pub fn infer_scope_types<'db>(
                                         ancestor_scope,
                                     )
                                     .unwrap_or_default();
-                                    let env =
-                                        extend_env_with_lambda_generics(&parent_env, func_def);
+                                    let env = lambda_body_env(&parent_env);
                                     apply_generic_env(
                                         db,
                                         &mut builder,

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -83,8 +83,21 @@ pub(crate) fn inference_owner_scope(
 /// scope id to feed `infer_scope_types`.
 #[derive(Clone)]
 pub struct ScopeBody<'db> {
-    /// The inference-owner scope (`Function` / `Let` / `Lambda`).
+    /// The scope owning `scope_id`'s *inference* — a `Function`, `Let`, or
+    /// `Lambda`.
+    ///
+    /// Distinct from the scope owning the arena: since lambda bodies are
+    /// lowered into the enclosing function's `ExprBody`, `expr_body` below is
+    /// that function's whole body while a lambda keeps its own inference
+    /// (`infer_lambda_body` moves its tables into `nested_lambda_inference`).
+    /// Infer with this scope; index into `expr_body` from `root`.
     pub scope: ScopeId<'db>,
+    /// The expression this scope's inference is rooted at: a lambda's body
+    /// expression, or the whole body's root for a function / `let`.
+    ///
+    /// Walking `expr_body` flatly instead would visit the entire enclosing
+    /// function, whose expressions this scope's inference does not cover.
+    pub root: Option<ExprId>,
     pub expr_body: ExprBody,
     pub source_map: AstSourceMap,
 }
@@ -101,10 +114,18 @@ pub struct ScopeBody<'db> {
 pub fn scope_body<'db>(db: &'db dyn crate::Db, scope_id: ScopeId<'db>) -> Option<ScopeBody<'db>> {
     let file = scope_id.file(db);
     let index = baml_compiler2_ppir::file_semantic_index(db, file);
-    let owner = inference_owner_scope(index, scope_id.file_scope_id(db));
-    let (expr_body, source_map) = fetch_scope_body(db, index, owner)?;
+    let inference_owner = inference_owner_scope(index, scope_id.file_scope_id(db));
+    let (expr_body, source_map) = fetch_scope_body(db, index, inference_owner)?;
+    let owner_scope = &index.scopes[inference_owner.index() as usize];
+    let root = if owner_scope.kind == ScopeKind::Lambda {
+        find_lambda_by_span(&expr_body, &source_map, owner_scope.range)
+            .and_then(|(lambda, _)| lambda.body)
+    } else {
+        expr_body.root_expr
+    };
     Some(ScopeBody {
-        scope: index.scope_ids[owner.index() as usize],
+        scope: index.scope_ids[inference_owner.index() as usize],
+        root,
         expr_body,
         source_map,
     })
@@ -120,6 +141,26 @@ pub fn scope_inference_owner<'db>(db: &'db dyn crate::Db, scope_id: ScopeId<'db>
     let index = baml_compiler2_ppir::file_semantic_index(db, scope_id.file(db));
     let owner = inference_owner_scope(index, scope_id.file_scope_id(db));
     index.scope_ids[owner.index() as usize]
+}
+
+/// The scope owning the arena that `scope_id`'s expressions live in.
+///
+/// A lambda has its own scope but no arena of its own, so this walks past it to
+/// the enclosing Function / Let — the body its expressions were lowered into.
+fn body_owner_scope(
+    index: &baml_compiler2_hir::semantic_index::FileSemanticIndex<'_>,
+    mut scope_id: FileScopeId,
+) -> FileScopeId {
+    loop {
+        let scope = &index.scopes[scope_id.index() as usize];
+        if matches!(scope.kind, ScopeKind::Function | ScopeKind::Let) {
+            return scope_id;
+        }
+        let Some(parent) = scope.parent else {
+            return scope_id;
+        };
+        scope_id = parent;
+    }
 }
 
 /// Fetch the `(ExprBody, AstSourceMap)` for an inference-owner scope.
@@ -163,22 +204,12 @@ fn fetch_scope_body<'db>(
             Some((eb.clone(), sm))
         }
         ScopeKind::Lambda => {
-            // The lambda body is nested inside the enclosing Function/Let body;
-            // descend to it by span.
-            let mut parent = scope.parent;
-            let enclosing = loop {
-                let p = parent?;
-                if matches!(
-                    index.scopes[p.index() as usize].kind,
-                    ScopeKind::Function | ScopeKind::Let
-                ) {
-                    break p;
-                }
-                parent = index.scopes[p.index() as usize].parent;
-            };
-            let (eb, sm) = fetch_scope_body(db, index, enclosing)?;
-            let (_, lambda_body, lambda_sm, _) = find_lambda_by_span(&eb, &sm, scope.range)?;
-            Some((lambda_body.clone(), lambda_sm.clone()))
+            // A lambda's body is lowered into the enclosing Function/Let body's
+            // arena, so that body *is* the lambda's body.
+            let enclosing = body_owner_scope(index, owner);
+            (enclosing != owner)
+                .then(|| fetch_scope_body(db, index, enclosing))
+                .flatten()
         }
         _ => None,
     }
@@ -1243,31 +1274,21 @@ fn seed_template_body_params(
     }
 }
 
-/// Search for a `Lambda` expression whose source span matches `target_span` in
-/// `body`/`source_map`, recursively descending into nested lambda bodies.
+/// The `Lambda` expression in `body` whose source span is `target_span`.
 ///
-/// Returns `Some((lambda, lambda_body, lambda_source_map, lambda_expr_id))` when
-/// found; `None` otherwise.
+/// Every lambda in the function — including ones nested inside another lambda —
+/// is an entry in this one arena, so a single scan finds them all.
 fn find_lambda_by_span<'a>(
     body: &'a ExprBody,
     source_map: &AstSourceMap,
     target_span: TextRange,
-) -> Option<(&'a LambdaDef, &'a ExprBody, &'a AstSourceMap, ExprId)> {
-    for (expr_id, expr) in body.exprs.iter() {
-        if let AstExpr::Lambda(ref lambda) = *expr {
-            let Some((ref lambda_body, ref lambda_sm)) = lambda.body else {
-                continue;
-            };
-            if source_map.expr_span(expr_id) == target_span {
-                return Some((lambda, lambda_body, lambda_sm, expr_id));
-            }
-            // Recurse into nested lambda bodies
-            if let Some(found) = find_lambda_by_span(lambda_body, lambda_sm, target_span) {
-                return Some(found);
-            }
+) -> Option<(&'a LambdaDef, ExprId)> {
+    body.exprs.iter().find_map(|(expr_id, expr)| match expr {
+        AstExpr::Lambda(lambda) if source_map.expr_span(expr_id) == target_span => {
+            Some((&**lambda, expr_id))
         }
-    }
-    None
+        _ => None,
+    })
 }
 
 /// Per-scope type inference — the primary Salsa query for type checking.
@@ -2012,7 +2033,7 @@ pub fn infer_scope_types<'db>(
                                     baml_compiler2_ppir::function_body_source_map(db, ancestor_func)
                             {
                                 let func_sm = &func_sm;
-                                if let Some((func_def, lambda_body, _lambda_sm, _lambda_expr_id)) =
+                                if let Some((func_def, _lambda_expr_id)) =
                                     find_lambda_by_span(func_body, func_sm, lambda_span)
                                 {
                                     // Look up contextual param types via the lambda's FileScopeId
@@ -2059,9 +2080,10 @@ pub fn infer_scope_types<'db>(
                                         file_scope,
                                         parent_inference,
                                     );
-                                    // Infer the lambda body
-                                    if let Some(root_expr) = lambda_body.root_expr {
-                                        builder.infer_expr(root_expr, lambda_body);
+                                    // Infer the lambda body — it lives in the
+                                    // enclosing function's arena.
+                                    if let Some(body_expr) = func_def.body {
+                                        builder.infer_expr(body_expr, func_body);
                                     }
                                 }
                             }
@@ -2078,7 +2100,7 @@ pub fn infer_scope_types<'db>(
                             if let (LetBody::Expr(let_body), Some(let_sm)) =
                                 (body.as_ref(), source_map_opt)
                             {
-                                if let Some((func_def, lambda_body, _lambda_sm, _lambda_expr_id)) =
+                                if let Some((func_def, _lambda_expr_id)) =
                                     find_lambda_by_span(let_body, &let_sm, lambda_span)
                                 {
                                     // Look up contextual param types via FileScopeId (same as Function branch).
@@ -2125,8 +2147,10 @@ pub fn infer_scope_types<'db>(
                                         file_scope,
                                         parent_inference,
                                     );
-                                    if let Some(root_expr) = lambda_body.root_expr {
-                                        builder.infer_expr(root_expr, lambda_body);
+                                    // The lambda body lives in the `let`
+                                    // initializer's arena.
+                                    if let Some(body_expr) = func_def.body {
+                                        builder.infer_expr(body_expr, let_body);
                                     }
                                 }
                             }
@@ -3014,64 +3038,17 @@ pub fn render_scope_diagnostics<'db>(
     let file = scope_id.file(db);
     let file_scope = scope_id.file_scope_id(db);
     let index = baml_compiler2_ppir::file_semantic_index(db, file);
-    let scope = &index.scopes[file_scope.index() as usize];
-
-    let source_map = match &scope.kind {
-        ScopeKind::Lambda => {
-            // For lambda scopes, walk ancestors to find the parent Function/Let body,
-            // then use find_lambda_by_span to get the lambda's own source map.
-            let lambda_span = scope.range;
-            let mut found_sm = None;
-            for ancestor_fsi in index.ancestor_scopes(file_scope) {
-                let ancestor_scope = index.scope_ids[ancestor_fsi.index() as usize];
-                let Some(owner) = baml_compiler2_ppir::item_data::scope_owner(db, ancestor_scope)
-                else {
-                    continue;
-                };
-                // The first Function/Let ancestor owns the body the lambda lives in.
-                let body_and_map = match owner {
-                    baml_compiler2_ppir::item_data::ScopeOwner::Function(func_loc) => {
-                        match baml_compiler2_ppir::function_body(db, func_loc).as_ref() {
-                            baml_compiler2_hir::body::FunctionBody::Expr(body) => {
-                                baml_compiler2_ppir::function_body_source_map(db, func_loc)
-                                    .map(|sm| (body.clone(), sm))
-                            }
-                            baml_compiler2_hir::body::FunctionBody::Builtin(_)
-                            | baml_compiler2_hir::body::FunctionBody::Missing => None,
-                        }
-                    }
-                    baml_compiler2_ppir::item_data::ScopeOwner::Let(let_loc) => {
-                        match baml_compiler2_hir::body::let_body(db, let_loc).as_ref() {
-                            baml_compiler2_hir::body::LetBody::Expr(body) => {
-                                baml_compiler2_hir::body::let_body_source_map(db, let_loc)
-                                    .map(|sm| (body.clone(), sm))
-                            }
-                            baml_compiler2_hir::body::LetBody::Missing => None,
-                        }
-                    }
-                    _ => continue,
-                };
-                if let Some((body, sm)) = body_and_map
-                    && let Some((_, _, lambda_sm, _)) = find_lambda_by_span(&body, &sm, lambda_span)
-                {
-                    found_sm = Some(lambda_sm.clone());
-                }
-                break;
-            }
-            found_sm
+    // A lambda shares the enclosing Function/Let body's source map, so resolve
+    // through whichever scope owns the arena.
+    let owner_scope = index.scope_ids[body_owner_scope(index, file_scope).index() as usize];
+    let source_map = match baml_compiler2_ppir::item_data::scope_owner(db, owner_scope) {
+        Some(baml_compiler2_ppir::item_data::ScopeOwner::Function(func_loc)) => {
+            baml_compiler2_ppir::function_body_source_map(db, func_loc)
         }
-        _ => {
-            // Function/Let scopes: the owner is recorded, so no scan is needed.
-            match baml_compiler2_ppir::item_data::scope_owner(db, scope_id) {
-                Some(baml_compiler2_ppir::item_data::ScopeOwner::Function(func_loc)) => {
-                    baml_compiler2_ppir::function_body_source_map(db, func_loc)
-                }
-                Some(baml_compiler2_ppir::item_data::ScopeOwner::Let(let_loc)) => {
-                    baml_compiler2_hir::body::let_body_source_map(db, let_loc)
-                }
-                _ => None,
-            }
+        Some(baml_compiler2_ppir::item_data::ScopeOwner::Let(let_loc)) => {
+            baml_compiler2_hir::body::let_body_source_map(db, let_loc)
         }
+        _ => None,
     };
 
     diags

--- a/baml_language/crates/baml_compiler2_tir/src/throw_inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/throw_inference.rs
@@ -8,7 +8,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use baml_base::Name;
-use baml_compiler2_ast::{AstSourceMap, Expr, ExprBody, Literal};
+use baml_compiler2_ast::{AstSourceMap, BodyNode, Expr, ExprBody, Literal};
 use baml_compiler2_hir::{
     contributions::Definition,
     package::{PackageId, PackageItems, package_dependencies},
@@ -416,30 +416,27 @@ pub fn collect_direct_throws<'db>(
         .then(|| baml_compiler2_ppir::function_body_source_map(db, func_loc))
         .flatten();
 
-    for (_, expr) in body.exprs.iter() {
-        if let Expr::Throw { value } = expr
-            && !is_catch_rethrow(*value, body, source_map.as_ref(), &catch_arm_bodies)
-        {
+    // Walk the body structurally rather than scanning the arena: a `throw`
+    // written inside a lambda belongs to that lambda's throw set, not to this
+    // function's. Only calling the lambda transfers the effect.
+    for node in body_nodes(body) {
+        let value = match node {
+            BodyNode::Expr(id) => match &body.exprs[id] {
+                Expr::Throw { value } => *value,
+                _ => continue,
+            },
+            BodyNode::Stmt(id) => match &body.stmts[id] {
+                baml_compiler2_ast::Stmt::Throw { value } => *value,
+                _ => continue,
+            },
+        };
+        if !is_catch_rethrow(value, body, source_map.as_ref(), &catch_arm_bodies) {
             facts.insert(throw_fact_from_expr(
                 db,
                 pkg_items,
                 ns_context,
                 param_types,
-                *value,
-                body,
-            ));
-        }
-    }
-    for (_, stmt) in body.stmts.iter() {
-        if let baml_compiler2_ast::Stmt::Throw { value } = stmt
-            && !is_catch_rethrow(*value, body, source_map.as_ref(), &catch_arm_bodies)
-        {
-            facts.insert(throw_fact_from_expr(
-                db,
-                pkg_items,
-                ns_context,
-                param_types,
-                *value,
+                value,
                 body,
             ));
         }
@@ -518,12 +515,16 @@ fn is_catch_rethrow(
 
 pub fn collect_call_targets(body: &ExprBody) -> BTreeSet<Name> {
     let mut targets = BTreeSet::new();
-    for (_, expr) in body.exprs.iter() {
-        if let Expr::Call { callee, .. } = expr {
-            if let Some(path) = expr_to_path(*callee, body) {
-                let joined = path.iter().map(Name::as_str).collect::<Vec<_>>().join(".");
-                targets.insert(Name::new(joined));
-            }
+    // Structural, not a flat arena scan: a call made inside a lambda body is an
+    // edge from the *lambda*, so charging it to the enclosing function would
+    // give the function the callee's throws without it ever calling anything.
+    for node in body_nodes(body) {
+        let BodyNode::Expr(id) = node else { continue };
+        if let Expr::Call { callee, .. } = &body.exprs[id]
+            && let Some(path) = expr_to_path(*callee, body)
+        {
+            let joined = path.iter().map(Name::as_str).collect::<Vec<_>>().join(".");
+            targets.insert(Name::new(joined));
         }
     }
     targets
@@ -692,8 +693,10 @@ fn lookup_type_in_scope<'db>(
 /// pairs whose arm-body span scopes the rethrows of that binding.
 fn collect_catch_arm_bodies(body: &ExprBody) -> Vec<(&str, baml_compiler2_ast::ExprId)> {
     let mut arms = Vec::new();
-    for (_, expr) in body.exprs.iter() {
-        if let Expr::Catch { clauses, .. } = expr {
+    // Structural: a `catch` inside a lambda scopes only that lambda's rethrows.
+    for node in body_nodes(body) {
+        let BodyNode::Expr(id) = node else { continue };
+        if let Expr::Catch { clauses, .. } = &body.exprs[id] {
             for clause in clauses {
                 if let Some(name) = body.patterns[clause.binding].binding_name(&body.patterns) {
                     for &arm_id in &clause.arms {
@@ -704,6 +707,16 @@ fn collect_catch_arm_bodies(body: &ExprBody) -> Vec<(&str, baml_compiler2_ast::E
         }
     }
     arms
+}
+
+/// Every node of `body` that belongs to *this* function, in pre-order.
+///
+/// Empty when the body has no root expression (a parse failure), which is the
+/// same set a flat arena scan would have found meaningful.
+fn body_nodes(body: &ExprBody) -> Vec<BodyNode> {
+    body.root_expr
+        .map(|root| body.reachable_excluding_lambdas(root))
+        .unwrap_or_default()
 }
 
 fn expr_to_path(expr_id: baml_compiler2_ast::ExprId, body: &ExprBody) -> Option<Vec<Name>> {

--- a/baml_language/crates/baml_compiler2_tir/src/throws_analysis.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/throws_analysis.rs
@@ -156,8 +156,21 @@ pub(crate) fn collect_escaping_throws<C: ThrowsAnalysisContext>(
     context: &C,
     body: &ExprBody,
 ) -> BTreeSet<Ty> {
+    collect_escaping_throws_from(context, body, body.root_expr)
+}
+
+/// [`collect_escaping_throws`] rooted at an arbitrary expression of `body`.
+///
+/// A lambda's body is an expression inside the enclosing function's arena, so
+/// its throw surface must be collected from *its* root — walking `body.root_expr`
+/// would compute the enclosing function's surface instead.
+pub(crate) fn collect_escaping_throws_from<C: ThrowsAnalysisContext>(
+    context: &C,
+    body: &ExprBody,
+    root: Option<ExprId>,
+) -> BTreeSet<Ty> {
     let mut out = BTreeSet::new();
-    if let Some(root) = body.root_expr {
+    if let Some(root) = root {
         collect_from_expr(context, root, body, &mut out);
     }
     out

--- a/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
+++ b/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
@@ -34,7 +34,18 @@ pub fn build_control_flow_graph_from_ast(
     function_name: &str,
     body: &ast::ExprBody,
 ) -> ControlFlowGraph {
-    let Some(root_expr) = body.root_expr else {
+    build_control_flow_graph_from_expr(function_name, body, body.root_expr)
+}
+
+/// [`build_control_flow_graph_from_ast`] rooted at an arbitrary expression of
+/// `body`, for callables whose body is an expression *inside* another body —
+/// a lambda, which owns no `ExprBody` of its own.
+pub fn build_control_flow_graph_from_expr(
+    function_name: &str,
+    body: &ast::ExprBody,
+    root: Option<ast::ExprId>,
+) -> ControlFlowGraph {
+    let Some(root_expr) = root else {
         // No root expression — return a graph with just the root node.
         let mut graph = GraphAccumulator::default();
         let root_id = graph.allocate_id();
@@ -991,8 +1002,10 @@ fn collect_callee_names_expr(body: &ast::ExprBody, id: ast::ExprId, names: &mut 
             }
         },
 
-        // Leaves (no nested expressions in this body's arena). Lambda bodies
-        // live in their own ExprBody, so they cannot be walked from here.
+        // Leaves for this walk. A lambda's body is an expression in this same
+        // arena, but it is deliberately not followed: a lambda is a separate
+        // callable, so the calls it makes are its own graph's edges, not this
+        // one's.
         ast::Expr::Literal(_)
         | ast::Expr::ByteStringLiteral(_)
         | ast::Expr::Null

--- a/baml_language/crates/baml_compiler2_visualization/src/control_flow/mod.rs
+++ b/baml_language/crates/baml_compiler2_visualization/src/control_flow/mod.rs
@@ -9,7 +9,9 @@ mod from_ast;
 use std::{collections::HashMap, fmt};
 
 pub use flatten::{flatten_control_flow_graph, prepare_control_flow_graph_for_visualization};
-pub use from_ast::{STMT_SOURCE_EXPR_TAG, build_control_flow_graph_from_ast};
+pub use from_ast::{
+    STMT_SOURCE_EXPR_TAG, build_control_flow_graph_from_ast, build_control_flow_graph_from_expr,
+};
 use indexmap::IndexMap;
 
 // ---------------------------------------------------------------------------

--- a/baml_language/crates/baml_lsp2_actions/src/annotations.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/annotations.rs
@@ -55,7 +55,7 @@
 use baml_base::SourceFile;
 use baml_compiler2_ast::{
     Expr, ExprId, Stmt,
-    ast::{AstSourceMap, ExprBody, FunctionBodyDef, FunctionOrigin},
+    ast::{AstSourceMap, ExprBody, FunctionOrigin},
 };
 use baml_compiler2_hir::{body::FunctionBody, scope::FileScopeId};
 use baml_compiler2_tir::{inference::infer_scope_types, ty::Ty};
@@ -309,7 +309,7 @@ fn process_body(
             // Lambdas (including desugared `test` / `testset` bodies) carry their
             // own body + source map — recurse so their lets and calls get hints.
             Expr::Lambda(func_def) => {
-                if let Some(FunctionBodyDef::Expr(lbody, lsmap)) = &func_def.body {
+                if let Some((lbody, lsmap)) = &func_def.body {
                     let lambda_scope = index
                         .lambda_scope_for_within(owner_scope, source_map.expr_span(expr_id))
                         .unwrap_or(owner_scope);

--- a/baml_language/crates/baml_lsp2_actions/src/annotations.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/annotations.rs
@@ -239,84 +239,70 @@ fn process_body(
         });
     }
 
-    // ── Parameter-name hints on calls + recurse into lambdas ──────────────────
+    // ── Parameter-name hints on calls ─────────────────────────────────────────
+    // Lambda bodies share this arena, so this one pass covers them too.
     for (expr_id, expr) in body.exprs.iter() {
-        match expr {
-            Expr::Call { callee, args, .. } => {
-                // Skip synthesized test/testset registration calls — their
-                // `name` / `body` / `collector` / `runner` arguments are codegen,
-                // not user-facing. We still recurse into their lambda arguments
-                // (the actual test bodies) via the `Expr::Lambda` arm below.
-                if is_synthetic_registration(body, *callee) {
-                    continue;
-                }
-                // Skip compiler-synthesized wrapping calls — e.g. the
-                // `string.from(${expr})` that `${…}` interpolation lowers to.
-                // Marked at lowering time (see `AstSourceMap::synthetic_exprs`),
-                // so without this every interpolation would get a spurious
-                // `value:` parameter hint.
-                if source_map.is_synthetic_expr(expr_id) {
-                    continue;
-                }
-                let callee_span = source_map.expr_span(*callee);
-                if callee_span.is_empty() {
-                    continue;
-                }
+        if let Expr::Call { callee, args, .. } = expr {
+            // Skip synthesized test/testset registration calls — their
+            // `name` / `body` / `collector` / `runner` arguments are codegen,
+            // not user-facing. We still recurse into their lambda arguments
+            // (the actual test bodies) via the `Expr::Lambda` arm below.
+            if is_synthetic_registration(body, *callee) {
+                continue;
+            }
+            // Skip compiler-synthesized wrapping calls — e.g. the
+            // `string.from(${expr})` that `${…}` interpolation lowers to.
+            // Marked at lowering time (see `AstSourceMap::synthetic_exprs`),
+            // so without this every interpolation would get a spurious
+            // `value:` parameter hint.
+            if source_map.is_synthetic_expr(expr_id) {
+                continue;
+            }
+            let callee_span = source_map.expr_span(*callee);
+            if callee_span.is_empty() {
+                continue;
+            }
 
-                // Find a scope where the callee resolves to a function type.
-                // ExprIds are arena-local (per body), so restrict lookup to the
-                // callee's source scope chain instead of scanning every scope in
-                // the file for the first matching numeric id.
-                let use_scope =
-                    scope_at_offset_within_body(index, callee_span.start(), owner_scope);
-                for file_scope_id in ancestor_scopes_within_body(index, use_scope, owner_scope) {
-                    let scope_id = index.scope_ids[file_scope_id.index() as usize];
-                    let inference = infer_scope_types(db, scope_id);
-                    let Some(Ty::Function { params, .. }) = inference.expression_type(*callee)
-                    else {
+            // Find a scope where the callee resolves to a function type.
+            // ExprIds are arena-local (per body), so restrict lookup to the
+            // callee's source scope chain instead of scanning every scope in
+            // the file for the first matching numeric id.
+            let use_scope = scope_at_offset_within_body(index, callee_span.start(), owner_scope);
+            for file_scope_id in ancestor_scopes_within_body(index, use_scope, owner_scope) {
+                let scope_id = index.scope_ids[file_scope_id.index() as usize];
+                let inference = infer_scope_types(db, scope_id);
+                let Some(Ty::Function { params, .. }) = inference.expression_type(*callee) else {
+                    continue;
+                };
+                if args.len() != params.len() {
+                    continue;
+                }
+                for (arg, param) in args.iter().zip(params.iter()) {
+                    if arg.label.is_some() {
+                        continue;
+                    }
+                    let Some(name) = &param.name else {
                         continue;
                     };
-                    if args.len() != params.len() {
+                    let name_str = name.as_str();
+                    // `self` is implicit.
+                    if name_str == "self" {
                         continue;
                     }
-                    for (arg, param) in args.iter().zip(params.iter()) {
-                        if arg.label.is_some() {
-                            continue;
-                        }
-                        let Some(name) = &param.name else {
-                            continue;
-                        };
-                        let name_str = name.as_str();
-                        // `self` is implicit.
-                        if name_str == "self" {
-                            continue;
-                        }
-                        let arg_span = source_map.expr_span(arg.expr);
-                        if arg_span.is_empty() {
-                            continue;
-                        }
-                        out.push(InlineAnnotation {
-                            offset: arg_span.start(),
-                            label: format!("{name_str}: "),
-                            kind: AnnotationKind::Parameter,
-                            padding_left: false,
-                            padding_right: false,
-                        });
+                    let arg_span = source_map.expr_span(arg.expr);
+                    if arg_span.is_empty() {
+                        continue;
                     }
-                    break;
+                    out.push(InlineAnnotation {
+                        offset: arg_span.start(),
+                        label: format!("{name_str}: "),
+                        kind: AnnotationKind::Parameter,
+                        padding_left: false,
+                        padding_right: false,
+                    });
                 }
+                break;
             }
-            // Lambdas (including desugared `test` / `testset` bodies) carry their
-            // own body + source map — recurse so their lets and calls get hints.
-            Expr::Lambda(func_def) => {
-                if let Some((lbody, lsmap)) = &func_def.body {
-                    let lambda_scope = index
-                        .lambda_scope_for_within(owner_scope, source_map.expr_span(expr_id))
-                        .unwrap_or(owner_scope);
-                    process_body(db, file, index, lambda_scope, lbody, lsmap, out);
-                }
-            }
-            _ => {}
         }
     }
 }

--- a/baml_language/crates/baml_lsp2_actions/src/completions.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/completions.rs
@@ -1470,11 +1470,7 @@ fn descend_into_lambdas<'a>(
         if let baml_compiler2_ast::Expr::Lambda(func_def) = expr {
             let expr_span = source_map.expr_span(expr_id);
             if expr_span == target_range {
-                if let Some(baml_compiler2_ast::FunctionBodyDef::Expr(
-                    ref nested_body,
-                    ref nested_sm,
-                )) = func_def.body
-                {
+                if let Some((ref nested_body, ref nested_sm)) = func_def.body {
                     return descend_into_lambdas(nested_body, nested_sm, &lambda_ranges[1..]);
                 }
             }

--- a/baml_language/crates/baml_lsp2_actions/src/completions.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/completions.rs
@@ -1337,9 +1337,9 @@ fn local_variable_ty(
             }
         }
         baml_compiler2_hir::semantic_index::DefinitionSite::Statement(_) => {
-            // Search all scopes for the binding type. This handles variables
-            // inside lambdas (test bodies, closures) where the variable's
-            // StmtId is in a nested ExprBody, not the outer function's body.
+            // Handles variables declared inside lambdas (test bodies,
+            // closures) as well as directly in the function body — both index
+            // the same arena.
             find_binding_ty_for_local(db, file, at_offset, site)
         }
         baml_compiler2_hir::semantic_index::DefinitionSite::PatternBinding(_)
@@ -1353,12 +1353,9 @@ fn local_variable_ty(
 /// (which may be a nested lambda body for test/testset code) and looking up the
 /// binding type from TIR inference.
 ///
-/// For `Statement` bindings, we walk the scope tree to build a nesting path from
-/// the cursor's innermost Lambda scope up to the enclosing Function scope, then
-/// descend through the `ExprBody` tree using each body's source map to match
-/// lambda expression spans against scope ranges. This ensures we find the correct
-/// `ExprBody` even for deeply nested testset/test lambdas, where `func_def.span`
-/// may not match the scope range set by the HIR builder.
+/// For `Statement` bindings, the `StmtId` indexes the enclosing function's
+/// `ExprBody`. Lambda bodies are lowered into that same arena, so the statement
+/// resolves against it however deeply the cursor sits inside nested lambdas.
 fn find_binding_ty_for_local(
     db: &dyn Db,
     file: SourceFile,
@@ -1369,23 +1366,17 @@ fn find_binding_ty_for_local(
 
     let pat_id = match site {
         baml_compiler2_hir::semantic_index::DefinitionSite::Statement(stmt_id) => {
-            // 1. Build the scope nesting path from cursor to enclosing Function.
-            //    lambda_ranges: innermost-first Lambda scope ranges.
-            //    func_range: the enclosing Function scope range.
+            // Walk out to the enclosing Function scope, which owns the arena
+            // every statement in it — lambda bodies included — lives in.
             let scope_id = index.scope_at_offset(at_offset, None);
             let ancestors = index.ancestor_scopes(scope_id);
 
-            let mut lambda_ranges_rev: Vec<text_size::TextRange> = Vec::new();
             let mut func_range: Option<text_size::TextRange> = None;
             for ancestor_id in &ancestors {
                 let s = &index.scopes[ancestor_id.index() as usize];
-                match s.kind {
-                    ScopeKind::Lambda => lambda_ranges_rev.push(s.range),
-                    ScopeKind::Function => {
-                        func_range = Some(s.range);
-                        break;
-                    }
-                    _ => {}
+                if s.kind == ScopeKind::Function {
+                    func_range = Some(s.range);
+                    break;
                 }
             }
 
@@ -1397,21 +1388,7 @@ fn find_binding_ty_for_local(
                 return None;
             };
 
-            // 3. If cursor is directly in the Function (no lambda nesting), use it.
-            if lambda_ranges_rev.is_empty() {
-                extract_pat_from_stmt(top_body, stmt_id)
-            } else {
-                // Get the top-level source map and descend through nested lambdas.
-                let top_source_map =
-                    baml_compiler2_hir::body::function_body_source_map(db, func_loc)?;
-
-                // Reverse to get outermost→innermost order for descent.
-                lambda_ranges_rev.reverse();
-
-                let target_body =
-                    descend_into_lambdas(top_body, &top_source_map, &lambda_ranges_rev)?;
-                extract_pat_from_stmt(target_body, stmt_id)
-            }
+            extract_pat_from_stmt(top_body, stmt_id)
         }
         baml_compiler2_hir::semantic_index::DefinitionSite::PatternBinding(pat_id)
         | baml_compiler2_hir::semantic_index::DefinitionSite::CatchBinding(pat_id) => Some(pat_id),
@@ -1448,35 +1425,6 @@ fn extract_pat_from_stmt(
         } => Some(*pattern),
         _ => None,
     }
-}
-
-/// Descend through nested lambda bodies following the given scope ranges.
-///
-/// `lambda_ranges` is ordered outermost→innermost. At each level, finds the
-/// `Expr::Lambda` whose expression span (from the current body's source map)
-/// matches the target range, then recurses into that lambda's body. This uses
-/// the **same** source map the HIR builder used when creating scope ranges,
-/// guaranteeing a match even for deeply nested testset/test lambdas.
-fn descend_into_lambdas<'a>(
-    body: &'a baml_compiler2_ast::ExprBody,
-    source_map: &baml_compiler2_ast::AstSourceMap,
-    lambda_ranges: &[text_size::TextRange],
-) -> Option<&'a baml_compiler2_ast::ExprBody> {
-    if lambda_ranges.is_empty() {
-        return Some(body);
-    }
-    let target_range = lambda_ranges[0];
-    for (expr_id, expr) in body.exprs.iter() {
-        if let baml_compiler2_ast::Expr::Lambda(func_def) = expr {
-            let expr_span = source_map.expr_span(expr_id);
-            if expr_span == target_range {
-                if let Some((ref nested_body, ref nested_sm)) = func_def.body {
-                    return descend_into_lambdas(nested_body, nested_sm, &lambda_ranges[1..]);
-                }
-            }
-        }
-    }
-    None
 }
 
 // ── Value-position completions ────────────────────────────────────────────────

--- a/baml_language/crates/baml_lsp2_actions/src/describe.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/describe.rs
@@ -547,7 +547,7 @@ fn describe_locals(db: &dyn Db, files: &[SourceFile], name: &str) -> Vec<SymbolD
 
                     let type_str = match def_site {
                         baml_compiler2_hir::semantic_index::DefinitionSite::Statement(stmt_id) => {
-                            pattern_from_owner_body(db, func_loc, index, owner_scope, stmt_id)
+                            pattern_from_owner_body(db, func_loc, stmt_id)
                                 .and_then(|pattern| inference.binding_type(pattern))
                                 .map(crate::utils::display_ty)
                                 .unwrap_or_else(|| "unknown".to_string())
@@ -633,43 +633,20 @@ fn body_owner_scope(
     }
 }
 
-/// Extract the binding pattern for a statement from the body that owns it.
+/// The binding pattern for `stmt_id`, resolved against the function's body.
 ///
-/// `StmtId` is arena-local to an `ExprBody`. For ordinary function/block scopes,
-/// that owner is the enclosing function body. For lambda scopes, including block
-/// descendants inside lambdas, the owner is the matched lambda body.
+/// Lambda bodies share that arena, so a `StmtId` resolves against it whatever
+/// scope owns the statement.
 fn pattern_from_owner_body(
     db: &dyn Db,
     func_loc: baml_compiler2_hir::loc::FunctionLoc<'_>,
-    index: &baml_compiler2_hir::semantic_index::FileSemanticIndex<'_>,
-    owner_scope: FileScopeId,
     stmt_id: baml_compiler2_ast::StmtId,
 ) -> Option<baml_compiler2_ast::PatId> {
     let body = baml_compiler2_hir::body::function_body(db, func_loc);
     let baml_compiler2_hir::body::FunctionBody::Expr(top_body) = body.as_ref() else {
         return None;
     };
-
-    match index.scopes[owner_scope.index() as usize].kind {
-        ScopeKind::Lambda => {
-            let source_map = baml_compiler2_hir::body::function_body_source_map(db, func_loc)?;
-            let mut lambda_ranges = Vec::new();
-
-            for ancestor_id in index.ancestor_scopes(owner_scope) {
-                let scope = &index.scopes[ancestor_id.index() as usize];
-                match scope.kind {
-                    ScopeKind::Lambda => lambda_ranges.push(scope.range),
-                    ScopeKind::Function => break,
-                    _ => {}
-                }
-            }
-
-            lambda_ranges.reverse();
-            let owner_body = descend_into_lambdas(top_body, &source_map, &lambda_ranges)?;
-            extract_pat_from_stmt(owner_body, stmt_id)
-        }
-        _ => extract_pat_from_stmt(top_body, stmt_id),
-    }
+    extract_pat_from_stmt(top_body, stmt_id)
 }
 
 /// Extract the binding pattern from a let/for statement in a specific body.
@@ -692,34 +669,6 @@ fn extract_pat_from_stmt(
 }
 
 /// Descend through nested lambda bodies using scope ranges as stable anchors.
-fn descend_into_lambdas<'a>(
-    body: &'a baml_compiler2_ast::ExprBody,
-    source_map: &baml_compiler2_ast::AstSourceMap,
-    lambda_ranges: &[TextRange],
-) -> Option<&'a baml_compiler2_ast::ExprBody> {
-    if lambda_ranges.is_empty() {
-        return Some(body);
-    }
-
-    let target_range = lambda_ranges[0];
-    for (expr_id, expr) in body.exprs.iter() {
-        if let baml_compiler2_ast::Expr::Lambda(func_def) = expr {
-            let expr_span = source_map.expr_span(expr_id);
-            if expr_span == target_range {
-                if let Some((ref nested_body, ref nested_source_map)) = func_def.body {
-                    return descend_into_lambdas(
-                        nested_body,
-                        nested_source_map,
-                        &lambda_ranges[1..],
-                    );
-                }
-            }
-        }
-    }
-
-    None
-}
-
 /// Build a `DepRef` pointing to a function.
 fn make_function_dep(
     db: &dyn crate::Db,

--- a/baml_language/crates/baml_lsp2_actions/src/describe.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/describe.rs
@@ -706,11 +706,7 @@ fn descend_into_lambdas<'a>(
         if let baml_compiler2_ast::Expr::Lambda(func_def) = expr {
             let expr_span = source_map.expr_span(expr_id);
             if expr_span == target_range {
-                if let Some(baml_compiler2_ast::FunctionBodyDef::Expr(
-                    ref nested_body,
-                    ref nested_source_map,
-                )) = func_def.body
-                {
+                if let Some((ref nested_body, ref nested_source_map)) = func_def.body {
                     return descend_into_lambdas(
                         nested_body,
                         nested_source_map,

--- a/baml_language/crates/baml_lsp2_actions/src/tokens/index.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/tokens/index.rs
@@ -87,6 +87,7 @@ pub(super) fn scope_resolution_index(db: &dyn Db, scope_id: ScopeId<'_>) -> Arc<
         index_function(
             db,
             scope_id.file(db),
+            body.root,
             &body.expr_body,
             &body.source_map,
             inference,
@@ -124,12 +125,23 @@ pub(super) fn build(db: &dyn Db, file: SourceFile) -> ResolutionIndex {
 fn index_function(
     db: &dyn Db,
     file: SourceFile,
+    root: Option<baml_compiler2_ast::ExprId>,
     expr_body: &ExprBody,
     source_map: &baml_compiler2_ast::AstSourceMap,
     inference: &ScopeInference<'_>,
     index: &mut ResolutionIndex,
 ) {
-    for (expr_id, expr) in expr_body.exprs.iter() {
+    // Only the expressions this scope's inference actually covers: lambda
+    // bodies share the arena but are typed by their own scope, so indexing them
+    // here would resolve them against the wrong tables.
+    let nodes = root
+        .map(|root| expr_body.reachable_excluding_lambdas(root))
+        .unwrap_or_default();
+    for node in nodes {
+        let baml_compiler2_ast::BodyNode::Expr(expr_id) = node else {
+            continue;
+        };
+        let expr = &expr_body.exprs[expr_id];
         match expr {
             Expr::Path(segments) if !segments.is_empty() => {
                 let seg_span = source_map.path_segment_span(expr_id, 0);

--- a/baml_language/crates/baml_lsp2_actions/src/usages.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/usages.rs
@@ -214,18 +214,25 @@ fn find_local_usages(
     };
     collector.collect(
         enclosing_func_scope,
+        expr_body.root_expr,
         expr_body,
         ExprMetadataScope::Body(enclosing_func_scope),
         &source_map,
     );
 
+    // A defaults arena is a *forest* — one root per defaulted parameter, and
+    // `root_expr` is always `None` for it (`lower_default_expr_nodes` finishes
+    // with `None`). Walk each parameter's default separately.
     let defaults = baml_compiler2_ppir::function_parameter_defaults(db, func_loc);
-    collector.collect(
-        enclosing_func_scope,
-        &defaults.defaults.exprs,
-        ExprMetadataScope::ParameterDefault(enclosing_func_scope),
-        &defaults.defaults.source_map,
-    );
+    for default in defaults.params.iter().flatten() {
+        collector.collect(
+            enclosing_func_scope,
+            Some(default.expr.expr()),
+            &defaults.defaults.exprs,
+            ExprMetadataScope::ParameterDefault(enclosing_func_scope),
+            &defaults.defaults.source_map,
+        );
+    }
 
     collector.results
 }
@@ -239,15 +246,28 @@ struct LocalUsageCollector<'index, 'db> {
 }
 
 impl LocalUsageCollector<'_, '_> {
-    /// Walk one expression arena and recurse into nested lambda arenas.
+    /// Walk the expressions belonging to `owner_scope`, recursing into lambda
+    /// bodies under *their* scope.
+    ///
+    /// Structural rather than a flat arena scan: lambda bodies share this arena
+    /// but are recorded under their own metadata namespace, so visiting them
+    /// here would look them up under the wrong key and silently find nothing.
     fn collect(
         &mut self,
         owner_scope: FileScopeId,
+        root: Option<baml_compiler2_ast::ExprId>,
         expr_body: &ExprBody,
         metadata_scope: ExprMetadataScope,
         source_map: &baml_compiler2_ast::AstSourceMap,
     ) {
-        for (expr_id, expr) in expr_body.exprs.iter() {
+        let nodes = root
+            .map(|root| expr_body.reachable_excluding_lambdas(root))
+            .unwrap_or_default();
+        for node in nodes {
+            let baml_compiler2_ast::BodyNode::Expr(expr_id) = node else {
+                continue;
+            };
+            let expr = &expr_body.exprs[expr_id];
             match expr {
                 Expr::Path(segments) if segments.first() == Some(&self.name) => {
                     let segment_range = source_map.path_segment_span(expr_id, 0);
@@ -274,21 +294,27 @@ impl LocalUsageCollector<'_, '_> {
                         continue;
                     };
 
-                    self.collect(
-                        lambda_scope,
-                        &func_def.defaults.exprs,
-                        ExprMetadataScope::ParameterDefault(lambda_scope),
-                        &func_def.defaults.source_map,
-                    );
-
-                    if let Some((body, body_source_map)) = &func_def.body {
+                    // One root per defaulted parameter — see above.
+                    for param in &func_def.params {
+                        let Some(default) = param.default else {
+                            continue;
+                        };
                         self.collect(
                             lambda_scope,
-                            body,
-                            ExprMetadataScope::Body(lambda_scope),
-                            body_source_map,
+                            Some(default.expr()),
+                            &func_def.defaults.exprs,
+                            ExprMetadataScope::ParameterDefault(lambda_scope),
+                            &func_def.defaults.source_map,
                         );
                     }
+
+                    self.collect(
+                        lambda_scope,
+                        func_def.body,
+                        expr_body,
+                        ExprMetadataScope::Body(lambda_scope),
+                        source_map,
+                    );
                 }
                 _ => {}
             }

--- a/baml_language/crates/baml_lsp2_actions/src/usages.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/usages.rs
@@ -281,9 +281,7 @@ impl LocalUsageCollector<'_, '_> {
                         &func_def.defaults.source_map,
                     );
 
-                    if let Some(baml_compiler2_ast::FunctionBodyDef::Expr(body, body_source_map)) =
-                        &func_def.body
-                    {
+                    if let Some((body, body_source_map)) = &func_def.body {
                         self.collect(
                             lambda_scope,
                             body,

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -749,9 +749,7 @@ impl ProjectDatabase {
                     let Expr::Lambda(test_lambda) = &registration_body.exprs[args[2].expr] else {
                         continue;
                     };
-                    let Some(FunctionBodyDef::Expr(test_body, test_source_map)) =
-                        test_lambda.body.as_ref()
-                    else {
+                    let Some((test_body, test_source_map)) = test_lambda.body.as_ref() else {
                         continue;
                     };
 

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -682,7 +682,7 @@ impl ProjectDatabase {
     ) -> Option<baml_compiler2_visualization::control_flow::ControlFlowGraph> {
         use baml_compiler2_ast::{Expr, FunctionBodyDef, Item};
         use baml_compiler2_visualization::control_flow::{
-            NodeType, build_control_flow_graph_from_ast,
+            NodeType, build_control_flow_graph_from_expr,
         };
         use baml_type::Literal;
 
@@ -749,12 +749,16 @@ impl ProjectDatabase {
                     let Expr::Lambda(test_lambda) = &registration_body.exprs[args[2].expr] else {
                         continue;
                     };
-                    let Some((test_body, test_source_map)) = test_lambda.body.as_ref() else {
-                        continue;
-                    };
-
-                    let mut graph = build_control_flow_graph_from_ast(test_name, test_body);
-                    self.attach_source_spans_to_graph(&mut graph, source_file, test_source_map);
+                    // The test body is an expression in the registration body's
+                    // own arena, so it shares that body's source map.
+                    let test_body = registration_body;
+                    let mut graph =
+                        build_control_flow_graph_from_expr(test_name, test_body, test_lambda.body);
+                    self.attach_source_spans_to_graph(
+                        &mut graph,
+                        source_file,
+                        registration_source_map,
+                    );
 
                     let test_name_span =
                         Self::source_map_expr_range(registration_source_map, args[1].expr)

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/void_return_type/baml_tests__diagnostic_errors__void_return_type__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/void_return_type/baml_tests__diagnostic_errors__void_return_type__05_diagnostics.snap
@@ -11,10 +11,10 @@ source: crates/baml_tests/src/generated_tests.rs
     ·          ─────────────────────────────────────────
     ╰────
   ╰─▶   ☞ this call forwards whatever callback `handler` throws
-         ╭─[function_type_throws.baml:1:1]
-       1 │ // Function types outside immediate callback-parameter position must declare
-         · ▲
-         ╰────
+          ╭─[function_type_throws.baml:31:35]
+       31 │   return (value: int) -> string { handler(value) }
+          ·                                   ──────────────
+          ╰────
 
   [type] E0001
 

--- a/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
@@ -716,20 +716,18 @@ fn lambda_scope_retypes_capture_from_function_parameter() {
     let baml_compiler2_hir::body::FunctionBody::Expr(main_expr_body) = main_body.as_ref() else {
         panic!("main expression body");
     };
-    let lambda_body = main_expr_body
+    // The lambda's body is an expression in `main`'s own arena.
+    let root_expr = main_expr_body
         .exprs
         .iter()
         .find_map(|(_, expr)| {
-            if let baml_compiler2_ast::Expr::Lambda(func_def) = expr
-                && let Some((lambda_body, _)) = &func_def.body
-            {
-                Some(lambda_body)
+            if let baml_compiler2_ast::Expr::Lambda(func_def) = expr {
+                func_def.body
             } else {
                 None
             }
         })
         .expect("lambda body");
-    let root_expr = lambda_body.root_expr.expect("lambda root expr");
 
     assert_eq!(
         lambda_inference

--- a/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
@@ -721,8 +721,7 @@ fn lambda_scope_retypes_capture_from_function_parameter() {
         .iter()
         .find_map(|(_, expr)| {
             if let baml_compiler2_ast::Expr::Lambda(func_def) = expr
-                && let Some(baml_compiler2_ast::FunctionBodyDef::Expr(lambda_body, _)) =
-                    &func_def.body
+                && let Some((lambda_body, _)) = &func_def.body
             {
                 Some(lambda_body)
             } else {

--- a/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
@@ -530,11 +530,9 @@ pub(crate) mod support {
             Expr::Lambda(func_def) => {
                 let desc = expr_desc(expr_id, body);
                 writeln!(output, "{pad}{desc} : {ty}").ok();
-                // Recursively render the lambda's own ExprBody
-                if let Some((lambda_body, _)) = &func_def.body
-                    && let Some(root) = lambda_body.root_expr
-                {
-                    render_expr_body_untyped(lambda_body, root, indent + 2, output);
+                // The body is an expression in this same arena.
+                if let Some(root) = func_def.body {
+                    render_expr_body_untyped(body, root, indent + 2, output);
                 }
             }
             Expr::Call { callee, args, .. } => {
@@ -577,8 +575,10 @@ pub(crate) mod support {
         }
     }
 
-    /// Render a lambda's ExprBody without type information (since lambda bodies
-    /// have their own ExprBody arena and we don't have a ScopeInference for them).
+    /// Render a lambda's body without type information.
+    ///
+    /// The body shares the enclosing function's arena, but its types live in
+    /// the lambda's own `ScopeInference`, which this renderer does not hold.
     fn render_expr_body_untyped(
         body: &ExprBody,
         expr_id: ExprId,
@@ -616,10 +616,8 @@ pub(crate) mod support {
             Expr::Lambda(func_def) => {
                 let desc = expr_desc(expr_id, body);
                 writeln!(output, "{pad}{desc}").ok();
-                if let Some((lb, _)) = &func_def.body
-                    && let Some(root) = lb.root_expr
-                {
-                    render_expr_body_untyped(lb, root, indent + 2, output);
+                if let Some(root) = func_def.body {
+                    render_expr_body_untyped(body, root, indent + 2, output);
                 }
             }
             _ => {
@@ -1940,15 +1938,10 @@ pub(crate) mod support {
                 ),
                 Expr::Lambda(func_def) => {
                     let sig = format_lambda_signature_hir(func_def, prefix, local_type_names);
-                    let body_desc = func_def
-                        .body
-                        .as_ref()
-                        .map(|(lb, _)| {
-                            lb.root_expr
-                                .map(|root| expr_desc_hir(root, lb, prefix, local_type_names))
-                                .unwrap_or_else(|| "<empty>".into())
-                        })
-                        .unwrap_or_else(|| "<no body>".into());
+                    let body_desc = func_def.body.map_or_else(
+                        || "<no body>".into(),
+                        |root| expr_desc_hir(root, body, prefix, local_type_names),
+                    );
                     // Replace "{ ... }" placeholder with actual body
                     sig.replace("{ ... }", &format!("{{ {body_desc} }}"))
                 }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
@@ -334,7 +334,7 @@ pub(crate) mod support {
         }
     }
 
-    fn format_lambda_signature(func_def: &baml_compiler2_ast::FunctionDef) -> String {
+    fn format_lambda_signature(func_def: &baml_compiler2_ast::LambdaDef) -> String {
         let params: Vec<String> = func_def
             .params
             .iter()
@@ -357,28 +357,13 @@ pub(crate) mod support {
             .as_ref()
             .map(|te| format!(" throws {}", te))
             .unwrap_or_default();
-        let generics = if func_def.generic_params.is_empty() {
-            String::new()
-        } else {
-            format!(
-                "<{}>",
-                func_def
-                    .generic_params
-                    .iter()
-                    .map(|n| n.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            )
-        };
-        format!(
-            "{generics}({}) ->{ret}{throws} {{ ... }}",
-            params.join(", ")
-        )
+        // A lambda never declares generics, so the signature has no `<…>`.
+        format!("({}) ->{ret}{throws} {{ ... }}", params.join(", "))
     }
 
     /// HIR-aware version of `format_lambda_signature` that qualifies type names.
     fn format_lambda_signature_hir(
-        func_def: &baml_compiler2_ast::FunctionDef,
+        func_def: &baml_compiler2_ast::LambdaDef,
         prefix: &str,
         local_type_names: &std::collections::HashSet<&str>,
     ) -> String {
@@ -412,23 +397,8 @@ pub(crate) mod support {
             .as_ref()
             .map(|te| format!(" throws {}", qualify(te)))
             .unwrap_or_default();
-        let generics = if func_def.generic_params.is_empty() {
-            String::new()
-        } else {
-            format!(
-                "<{}>",
-                func_def
-                    .generic_params
-                    .iter()
-                    .map(|n| n.as_str())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            )
-        };
-        format!(
-            "{generics}({}) ->{ret}{throws} {{ ... }}",
-            params.join(", ")
-        )
+        // A lambda never declares generics, so the signature has no `<…>`.
+        format!("({}) ->{ret}{throws} {{ ... }}", params.join(", "))
     }
 
     /// Like `expr_desc` but enriches Call expressions with type params from inference.
@@ -561,8 +531,7 @@ pub(crate) mod support {
                 let desc = expr_desc(expr_id, body);
                 writeln!(output, "{pad}{desc} : {ty}").ok();
                 // Recursively render the lambda's own ExprBody
-                if let Some(baml_compiler2_ast::FunctionBodyDef::Expr(lambda_body, _)) =
-                    &func_def.body
+                if let Some((lambda_body, _)) = &func_def.body
                     && let Some(root) = lambda_body.root_expr
                 {
                     render_expr_body_untyped(lambda_body, root, indent + 2, output);
@@ -647,7 +616,7 @@ pub(crate) mod support {
             Expr::Lambda(func_def) => {
                 let desc = expr_desc(expr_id, body);
                 writeln!(output, "{pad}{desc}").ok();
-                if let Some(baml_compiler2_ast::FunctionBodyDef::Expr(lb, _)) = &func_def.body
+                if let Some((lb, _)) = &func_def.body
                     && let Some(root) = lb.root_expr
                 {
                     render_expr_body_untyped(lb, root, indent + 2, output);
@@ -1974,12 +1943,10 @@ pub(crate) mod support {
                     let body_desc = func_def
                         .body
                         .as_ref()
-                        .map(|b| match b {
-                            baml_compiler2_ast::FunctionBodyDef::Expr(lb, _) => lb
-                                .root_expr
+                        .map(|(lb, _)| {
+                            lb.root_expr
                                 .map(|root| expr_desc_hir(root, lb, prefix, local_type_names))
-                                .unwrap_or_else(|| "<empty>".into()),
-                            _ => "<non-expr>".into(),
+                                .unwrap_or_else(|| "<empty>".into())
                         })
                         .unwrap_or_else(|| "<no body>".into());
                     // Replace "{ ... }" placeholder with actual body

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase8_exceptions.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase8_exceptions.rs
@@ -788,6 +788,41 @@ fn stored_lambda_with_omitted_throws_is_inferred_not_violation() {
 }
 
 #[test]
+fn defining_a_throwing_lambda_does_not_charge_the_enclosing_functions_throw_set() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"function defines(value: int) -> int throws never {
+  let risky = (n: int) -> int {
+    throw "boom"
+  }
+  return value
+}
+
+function calls(value: int) -> int throws never {
+  return defines(value)
+}"#,
+    );
+
+    // `defines` never invokes `risky`, so `boom` is the lambda's effect and not
+    // its definer's. The distinction is carried by walking the body structurally
+    // and stopping at `Expr::Lambda`; a flat scan of the expression arena would
+    // see the `throw` as though `defines` wrote it, give `defines` a
+    // package-level throw set of `string`, and propagate that to every caller.
+    let output = render_tir(&db, file);
+    assert!(
+        !output.contains("declared throws"),
+        "neither the definer nor its caller may violate `throws never`, got:\n{output}"
+    );
+    // The effect is not lost, just attributed to the right place: the lambda's
+    // own inferred type carries it.
+    assert!(
+        output.contains("(n: int) -> int throws string"),
+        "the throw must land on the lambda's inferred type, got:\n{output}"
+    );
+}
+
+#[test]
 fn alias_hidden_omitted_lambda_reports_local_violation() {
     let mut db = make_db();
     let file = db.add_file(


### PR DESCRIPTION
Lambdas use their parent function's `TypeExpr`/`TypeRef` arenas, now have a separate `LambdaDef` AST type and generally lower in their surrounding function rather than as a separate system. This improves the internal representation and also is part of the groundwork for a rust-like inference system.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved handling of lambda expressions and nested test bodies for more accurate type inference, diagnostics, and control-flow analysis.
  * Ensured exceptions raised inside unused lambdas do not incorrectly affect the enclosing function.
  * Improved code navigation, local-variable resolution, inlay hints, completions, and usage tracking within lambdas.
  * Added structural expression traversal to improve analysis accuracy and consistency.

* **Documentation**
  * Updated compiler architecture documentation to explain lambda-body representation and incremental inference behavior.

* **Tests**
  * Added coverage for traversal completeness and lambda exception handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->