### PR TITLE
Intersection bounds

### DIFF
--- a/baml_language/crates/baml_builtins2_codegen/src/extract.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/extract.rs
@@ -213,7 +213,7 @@ fn extract_from_class(
     let class_generics: Vec<String> = class_def
         .generic_params
         .iter()
-        .map(|n| n.as_str().to_string())
+        .map(|param| param.name.as_str().to_string())
         .collect();
 
     // Builtin methods may be declared directly on the class or inside an
@@ -239,7 +239,7 @@ fn extract_from_class(
         let method_generics: Vec<String> = method
             .generic_params
             .iter()
-            .map(|n| n.as_str().to_string())
+            .map(|param| param.name.as_str().to_string())
             .collect();
         let mut all_generics = class_generics.clone();
         for g in &method_generics {
@@ -392,7 +392,7 @@ fn extract_class_fields(
     let generic_params: Vec<String> = class_def
         .generic_params
         .iter()
-        .map(|n| n.as_str().to_string())
+        .map(|param| param.name.as_str().to_string())
         .collect();
 
     let fields: Vec<NativeClassField> = class_def
@@ -434,7 +434,7 @@ fn extract_from_free_function(
     let generics: Vec<String> = func_def
         .generic_params
         .iter()
-        .map(|n| n.as_str().to_string())
+        .map(|param| param.name.as_str().to_string())
         .collect();
 
     let path = format!("{namespace_prefix}.{}", func_def.name.as_str());
@@ -537,7 +537,7 @@ fn extract_from_implements_for(
     let impl_generics: Vec<String> = impl_def
         .generic_params
         .iter()
-        .map(|(n, _)| n.as_str().to_string())
+        .map(|param| param.name.as_str().to_string())
         .collect();
 
     // `Self` inside method signatures resolves to the `for` target.
@@ -561,7 +561,7 @@ fn extract_from_implements_for(
         let method_generics: Vec<String> = method
             .generic_params
             .iter()
-            .map(|n| n.as_str().to_string())
+            .map(|param| param.name.as_str().to_string())
             .collect();
         let mut all_generics = impl_generics.clone();
         for g in &method_generics {

--- a/baml_language/crates/baml_cli/src/bytecode_cache.rs
+++ b/baml_language/crates/baml_cli/src/bytecode_cache.rs
@@ -915,7 +915,7 @@ fn syntactic_type_names(db: &ProjectDatabase, file: SourceFile) -> HashSet<Strin
         if let Some(id) = func.throws {
             add_type_ref_display(&func.type_refs, id, &mut names);
         }
-        for id in func.generic_param_bounds.iter().flatten() {
+        for id in func.generic_params.iter().flat_map(|p| &p.bounds) {
             add_type_ref_display(&func.type_refs, *id, &mut names);
         }
     }
@@ -930,7 +930,7 @@ fn syntactic_type_names(db: &ProjectDatabase, file: SourceFile) -> HashSet<Strin
         for id in class.fields.iter().map(|f| f.type_ref) {
             add_type_ref_display(&class.type_refs, id, &mut names);
         }
-        for id in class.generic_param_bounds.iter().flatten() {
+        for id in class.generic_params.iter().flat_map(|p| &p.bounds) {
             add_type_ref_display(&class.type_refs, *id, &mut names);
         }
         for block in &class.implements {
@@ -945,7 +945,7 @@ fn syntactic_type_names(db: &ProjectDatabase, file: SourceFile) -> HashSet<Strin
         for id in &iface.requires {
             add_type_ref_display(&iface.type_refs, *id, &mut names);
         }
-        for id in iface.generic_param_bounds.iter().flatten() {
+        for id in iface.generic_params.iter().flat_map(|p| &p.bounds) {
             add_type_ref_display(&iface.type_refs, *id, &mut names);
         }
         for method in &iface.required_methods {
@@ -958,7 +958,7 @@ fn syntactic_type_names(db: &ProjectDatabase, file: SourceFile) -> HashSet<Strin
             if let Some(id) = method.throws {
                 add_type_ref_display(&iface.type_refs, id, &mut names);
             }
-            for id in method.generic_param_bounds.iter().flatten() {
+            for id in method.generic_params.iter().flat_map(|p| &p.bounds) {
                 add_type_ref_display(&iface.type_refs, *id, &mut names);
             }
         }

--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -432,6 +432,24 @@ pub struct AssociatedTypeBinding {
     pub ty: Box<TypeExpr>,
 }
 
+/// A generic type parameter declaration, paired with the `&`-separated bounds
+/// it was declared with (`<T>` → `bounds = []`; `<T extends A & B>` → `bounds =
+/// [A, B]`).
+///
+/// The bound set is a **conjunction**: an argument for this parameter must
+/// satisfy every entry. Holding the name and its bounds together makes a length
+/// mismatch between the two unrepresentable.
+///
+/// Bounds are `TypeExpr`s so generic parents like `Container<int>` round-trip;
+/// that each must denote an *interface* — never an interface-existential type,
+/// see `TYPE_SYSTEM.md` "Generics on Functions" — is enforced where they are
+/// lowered to constraints.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenericParam {
+    pub name: Name,
+    pub bounds: Vec<TypeExpr>,
+}
+
 // ── Expression Bodies ───────────────────────────────────────────
 //
 // Full expression/statement arena — modeled after the existing
@@ -1491,11 +1509,7 @@ pub enum DeclarativeMeta {
 pub struct FunctionDef {
     pub name: Name,
     /// Generic type parameters (e.g., `["T", "U"]`). Empty for non-generic functions.
-    pub generic_params: Vec<Name>,
-    /// BEP-044 generic bounds: parallel to `generic_params`. Each entry
-    /// is the `TypeExpr` after `extends` (e.g. `T extends Named` stores
-    /// `Some(Path(["Named"]))`); `None` for unbounded parameters.
-    pub generic_param_bounds: Vec<Option<TypeExpr>>,
+    pub generic_params: Vec<GenericParam>,
     pub params: Vec<Param>,
     pub defaults: FunctionDefaults,
     pub return_type: Option<TypeExpr>,
@@ -1672,11 +1686,7 @@ impl DefaultExprId {
 pub struct ClassDef {
     pub name: Name,
     /// Generic type parameters (e.g., `["T"]` for `Array<T>`). Empty for non-generic classes.
-    pub generic_params: Vec<Name>,
-    /// Generic bounds parallel to `generic_params`. `Some(te)` means the
-    /// parameter at the matching index was declared with `T extends <te>`;
-    /// `None` means unbounded.
-    pub generic_param_bounds: Vec<Option<TypeExpr>>,
+    pub generic_params: Vec<GenericParam>,
     pub fields: Vec<FieldDef>,
     pub methods: Vec<FunctionDef>,
     /// `implements I { ... }` blocks declared inside the class body (BEP-044).
@@ -1696,11 +1706,7 @@ pub struct ClassDef {
 pub struct InterfaceDef {
     pub name: Name,
     /// Generic type parameters (e.g., `["T"]` for `Container<T>`). Empty for non-generic interfaces.
-    pub generic_params: Vec<Name>,
-    /// BEP-044 generic bounds parallel to `generic_params`. `Some(te)`
-    /// means the parameter at the matching index was declared with
-    /// `T extends <te>`; `None` means unbounded.
-    pub generic_param_bounds: Vec<Option<TypeExpr>>,
+    pub generic_params: Vec<GenericParam>,
     /// Required interfaces from `requires I1, I2, ...`. Each is parsed as a
     /// `TypeExpr` so we can accept generic requirements like `Container<int>`.
     pub requires: Vec<TypeExpr>,
@@ -1724,9 +1730,7 @@ pub struct InterfaceDef {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MethodSigDef {
     pub name: Name,
-    pub generic_params: Vec<Name>,
-    /// BEP-044 generic bounds parallel to `generic_params`.
-    pub generic_param_bounds: Vec<Option<TypeExpr>>,
+    pub generic_params: Vec<GenericParam>,
     pub params: Vec<Param>,
     pub defaults: FunctionDefaults,
     pub return_type: Option<TypeExpr>,
@@ -1771,7 +1775,7 @@ pub struct ImplementsForDef {
     /// Generic type parameters on the implements block, each with its set of
     /// `&`-separated interface bounds (`<T>` → `(T, [])`; `<T extends A & B>` →
     /// `(T, [A, B])`). Empty bound list = unbounded.
-    pub generic_params: Vec<(Name, Vec<TypeExpr>)>,
+    pub generic_params: Vec<GenericParam>,
     /// The interface being implemented.
     pub interface_target: TypeExpr,
     /// The type the interface is being implemented for.

--- a/baml_language/crates/baml_compiler2_ast/src/companions.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/companions.rs
@@ -111,7 +111,6 @@ pub fn llm_parse(parent: &FunctionDef, type_args: Vec<TypeExpr>) -> Option<Funct
     Some(FunctionDef {
         name,
         generic_params: parent.generic_params.clone(),
-        generic_param_bounds: parent.generic_param_bounds.clone(),
         params,
         defaults: parent.defaults.clone(),
         return_type,
@@ -173,7 +172,6 @@ fn make_llm_companion(
     FunctionDef {
         name,
         generic_params: parent.generic_params.clone(),
-        generic_param_bounds: parent.generic_param_bounds.clone(),
         params: parent.params.clone(),
         defaults: parent.defaults.clone(),
         return_type: Some(return_type),

--- a/baml_language/crates/baml_compiler2_ast/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lib.rs
@@ -449,6 +449,21 @@ mod tests {
         (items, diags)
     }
 
+    /// Generic parameters rendered back to source form (`T extends A & B`), so
+    /// one assertion covers both the names and the full conjunction of bounds.
+    fn rendered_generic_params(params: &[crate::ast::GenericParam]) -> Vec<String> {
+        params
+            .iter()
+            .map(|param| {
+                if param.bounds.is_empty() {
+                    return param.name.as_str().to_string();
+                }
+                let bounds: Vec<String> = param.bounds.iter().map(ToString::to_string).collect();
+                format!("{} extends {}", param.name.as_str(), bounds.join(" & "))
+            })
+            .collect()
+    }
+
     fn first_function(items: Vec<Item>) -> crate::ast::FunctionDef {
         items
             .into_iter()
@@ -583,7 +598,7 @@ function deep_copy<T>(value: T) -> T {
         let function = first_function(parse_and_lower(source));
 
         assert_eq!(function.generic_params.len(), 1);
-        assert_eq!(function.generic_params[0].as_str(), "T");
+        assert_eq!(function.generic_params[0].name.as_str(), "T");
     }
 
     #[test]
@@ -956,22 +971,55 @@ interface Box<T extends Named, E> {
             .expect("expected Box interface");
 
         assert_eq!(
-            interface
-                .generic_params
-                .iter()
-                .map(smol_str::SmolStr::as_str)
-                .collect::<Vec<_>>(),
-            vec!["T", "E"]
+            rendered_generic_params(&interface.generic_params),
+            vec!["T extends Named", "E"]
         );
-        assert_eq!(interface.generic_param_bounds.len(), 2);
+    }
+
+    /// `T extends A & B` is a conjunction — every bound must survive lowering.
+    #[test]
+    fn ast_preserves_every_bound_in_a_generic_param_intersection() {
+        let source = r#"
+interface Named {
+  name string
+}
+
+interface Sized {
+  size int
+}
+
+interface Box<T extends Named & Sized, E> {
+  value T
+}
+
+function pack<U extends Named & Sized>(value: U) -> U {
+  value
+}
+"#;
+        let items = parse_and_lower(source);
+        let interface = items
+            .iter()
+            .find_map(|item| match item {
+                Item::Interface(interface) if interface.name.as_str() == "Box" => Some(interface),
+                _ => None,
+            })
+            .expect("expected Box interface");
         assert_eq!(
-            interface.generic_param_bounds[0]
-                .as_ref()
-                .map(ToString::to_string)
-                .as_deref(),
-            Some("Named")
+            rendered_generic_params(&interface.generic_params),
+            vec!["T extends Named & Sized", "E"]
         );
-        assert!(interface.generic_param_bounds[1].is_none());
+
+        let function = items
+            .iter()
+            .find_map(|item| match item {
+                Item::Function(function) if function.name.as_str() == "pack" => Some(function),
+                _ => None,
+            })
+            .expect("expected pack function");
+        assert_eq!(
+            rendered_generic_params(&function.generic_params),
+            vec!["U extends Named & Sized"]
+        );
     }
 
     #[test]
@@ -1001,22 +1049,9 @@ interface Mapper {
             .expect("expected required method");
 
         assert_eq!(
-            method
-                .generic_params
-                .iter()
-                .map(smol_str::SmolStr::as_str)
-                .collect::<Vec<_>>(),
-            vec!["T", "E"]
+            rendered_generic_params(&method.generic_params),
+            vec!["T extends Named", "E"]
         );
-        assert_eq!(method.generic_param_bounds.len(), 2);
-        assert_eq!(
-            method.generic_param_bounds[0]
-                .as_ref()
-                .map(ToString::to_string)
-                .as_deref(),
-            Some("Named")
-        );
-        assert!(method.generic_param_bounds[1].is_none());
     }
 
     #[test]
@@ -1350,7 +1385,7 @@ class Array<T> {
             .expect("expected a ClassDef");
 
         assert_eq!(class.generic_params.len(), 1);
-        assert_eq!(class.generic_params[0].as_str(), "T");
+        assert_eq!(class.generic_params[0].name.as_str(), "T");
     }
 
     #[test]
@@ -1375,8 +1410,8 @@ class Map<K, V> {
             .expect("expected a ClassDef");
 
         assert_eq!(class.generic_params.len(), 2);
-        assert_eq!(class.generic_params[0].as_str(), "K");
-        assert_eq!(class.generic_params[1].as_str(), "V");
+        assert_eq!(class.generic_params[0].name.as_str(), "K");
+        assert_eq!(class.generic_params[1].name.as_str(), "V");
     }
 
     #[test]
@@ -1544,7 +1579,7 @@ class Array<T> {
         if let Item::Class(c) = &items[0] {
             assert_eq!(c.name.as_str(), "Array");
             assert_eq!(c.generic_params.len(), 1);
-            assert_eq!(c.generic_params[0].as_str(), "T");
+            assert_eq!(c.generic_params[0].name.as_str(), "T");
             // 4 user-defined stubs + 2 auto-derived (`to_json`, `from_json`).
             let stub_methods: Vec<_> = c
                 .methods

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -281,19 +281,7 @@ fn lower_function(
         diags.push(LoweringDiagnostic::ReservedRuntimeIdBindingName { span: name_span });
     }
 
-    let generic_params_with_bounds = extract_generic_params_with_bounds(node, diags);
-    let generic_params: Vec<Name> = generic_params_with_bounds
-        .iter()
-        .map(|(n, _)| n.clone())
-        .collect();
-    let mut generic_param_bounds: Vec<Option<crate::ast::TypeExpr>> = generic_params_with_bounds
-        .into_iter()
-        .map(|(_, b)| b)
-        .collect();
-    for bound in generic_param_bounds.iter_mut().flatten() {
-        let bspan = bound.span;
-        lower_type_expr::check_wildcard_type(bound, "a generic type bound", bspan, diags);
-    }
+    let generic_params = extract_generic_params_with_bounds(node, diags);
     let parameter_context = format!("function `{}`", name.as_str());
 
     let (mut params, mut defaults) = func
@@ -449,7 +437,6 @@ fn lower_function(
     Some(FunctionDef {
         name,
         generic_params,
-        generic_param_bounds,
         params,
         defaults,
         return_type,
@@ -1069,19 +1056,7 @@ fn lower_class(
         return None;
     };
 
-    let generic_params_with_bounds = extract_generic_params_with_bounds(node, diags);
-    let generic_params: Vec<Name> = generic_params_with_bounds
-        .iter()
-        .map(|(n, _)| n.clone())
-        .collect();
-    let mut generic_param_bounds: Vec<Option<crate::ast::TypeExpr>> = generic_params_with_bounds
-        .into_iter()
-        .map(|(_, b)| b)
-        .collect();
-    for bound in generic_param_bounds.iter_mut().flatten() {
-        let bspan = bound.span;
-        lower_type_expr::check_wildcard_type(bound, "a generic type bound", bspan, diags);
-    }
+    let generic_params = extract_generic_params_with_bounds(node, diags);
     let class_name = name_token.text().to_string();
 
     let fields = class
@@ -1179,7 +1154,6 @@ fn lower_class(
     let mut class_def = crate::ast::ClassDef {
         name: Name::new(name_token.text()),
         generic_params,
-        generic_param_bounds,
         fields,
         methods,
         implements,
@@ -1201,71 +1175,20 @@ fn lower_class(
 }
 
 /// BEP-044 generic bounds: walk `GENERIC_PARAM_LIST` and return each
-/// parameter's `Name` paired with its optional `extends Iface` bound.
-/// The bound is captured as a `TypeExpr` so generic parents like
-/// `Container<int>` round-trip.
+/// parameter's `Name` paired with **every** `&`-separated bound it declares
+/// (`<T>` → `(T, [])`; `<T extends A & B>` → `(T, [A, B])`). The bound list is
+/// a conjunction: an argument for `T` must satisfy all of them.
+///
+/// Bounds are captured as `TypeExpr`s so generic parents like `Container<int>`
+/// round-trip; that they must denote *interfaces* (never interface-existential
+/// types) is enforced when they are lowered to constraints in TIR.
 pub(crate) fn extract_generic_params_with_bounds(
     node: &SyntaxNode,
     diags: &mut Vec<LoweringDiagnostic>,
-) -> Vec<(Name, Option<crate::ast::TypeExpr>)> {
+) -> Vec<crate::ast::GenericParam> {
     use baml_compiler_syntax::SyntaxKind;
 
-    let mut out: Vec<(Name, Option<crate::ast::TypeExpr>)> = Vec::new();
-    for child in node.children() {
-        let child_kind: SyntaxKind = child.kind();
-        if child_kind != SyntaxKind::GENERIC_PARAM_LIST {
-            continue;
-        }
-        for param_node in child.children() {
-            if param_node.kind() != SyntaxKind::GENERIC_PARAM {
-                continue;
-            }
-            let mut name: Option<Name> = None;
-            for elem in param_node.children_with_tokens() {
-                if let Some(token) = elem.as_token() {
-                    if token.kind() == SyntaxKind::WORD && name.is_none() {
-                        name = Some(Name::new(token.text()));
-                    }
-                }
-            }
-            let bound: Option<crate::ast::TypeExpr> = param_node
-                .children()
-                .find(|n| n.kind() == SyntaxKind::GENERIC_PARAM_BOUNDS)
-                .and_then(|bounds_node| {
-                    // BEP-044 only requires single-bound support; the
-                    // intersection form lexes as multiple `TypeExpr`
-                    // children separated by `&`. We surface the first
-                    // bound and let downstream check intersection in a
-                    // future pass.
-                    bounds_node
-                        .children()
-                        .find(|n| baml_compiler_syntax::ast::TypeExpr::cast(n.clone()).is_some())
-                })
-                .and_then(|n| {
-                    let te = baml_compiler_syntax::ast::TypeExpr::cast(n)?;
-                    Some(lower_type_expr::lower_type_expr_node(&te, diags))
-                });
-            if let Some(n) = name {
-                out.push((n, bound));
-            }
-        }
-    }
-    out
-}
-
-/// Like [`extract_generic_params_with_bounds`], but captures **every**
-/// `&`-separated bound on each generic param (`T extends A & B` → `[A, B]`)
-/// instead of just the first. Used for `implement` blocks (BEP-044), whose
-/// generic-param bounds are an interface intersection. The single-bound
-/// extractor remains for function/class/interface generic params, which do not
-/// yet carry multiple bounds.
-pub(crate) fn extract_generic_params_with_all_bounds(
-    node: &SyntaxNode,
-    diags: &mut Vec<LoweringDiagnostic>,
-) -> Vec<(Name, Vec<crate::ast::TypeExpr>)> {
-    use baml_compiler_syntax::SyntaxKind;
-
-    let mut out: Vec<(Name, Vec<crate::ast::TypeExpr>)> = Vec::new();
+    let mut out: Vec<crate::ast::GenericParam> = Vec::new();
     for child in node.children() {
         if child.kind() != SyntaxKind::GENERIC_PARAM_LIST {
             continue;
@@ -1291,13 +1214,21 @@ pub(crate) fn extract_generic_params_with_all_bounds(
                         .children()
                         .filter_map(|n| {
                             let te = baml_compiler_syntax::ast::TypeExpr::cast(n)?;
-                            Some(lower_type_expr::lower_type_expr_node(&te, diags))
+                            let mut bound = lower_type_expr::lower_type_expr_node(&te, diags);
+                            let span = bound.span;
+                            lower_type_expr::check_wildcard_type(
+                                &mut bound,
+                                "a generic type bound",
+                                span,
+                                diags,
+                            );
+                            Some(bound)
                         })
                         .collect()
                 })
                 .unwrap_or_default();
-            if let Some(n) = name {
-                out.push((n, bounds));
+            if let Some(name) = name {
+                out.push(crate::ast::GenericParam { name, bounds });
             }
         }
     }
@@ -1360,19 +1291,7 @@ fn lower_interface(
         return None;
     };
     let iface_name = name_token.text().to_string();
-    let generic_params_with_bounds = extract_generic_params_with_bounds(node, diags);
-    let generic_params: Vec<Name> = generic_params_with_bounds
-        .iter()
-        .map(|(n, _)| n.clone())
-        .collect();
-    let mut generic_param_bounds: Vec<Option<crate::ast::TypeExpr>> = generic_params_with_bounds
-        .into_iter()
-        .map(|(_, b)| b)
-        .collect();
-    for bound in generic_param_bounds.iter_mut().flatten() {
-        let bspan = bound.span;
-        lower_type_expr::check_wildcard_type(bound, "a generic type bound", bspan, diags);
-    }
+    let generic_params = extract_generic_params_with_bounds(node, diags);
 
     let parent_type_nodes: Vec<baml_compiler_syntax::ast::TypeExpr> =
         if let Some(c) = iface.requires_clause() {
@@ -1470,7 +1389,6 @@ fn lower_interface(
     Some(InterfaceDef {
         name: Name::new(&iface_name),
         generic_params,
-        generic_param_bounds,
         requires,
         fields,
         associated_types,
@@ -1570,19 +1488,7 @@ fn lower_method_sig(
     };
     let name = Name::new(name_token.text());
     let name_span = name_token.text_range();
-    let generic_params_with_bounds = extract_generic_params_with_bounds(sig.syntax(), diags);
-    let generic_params: Vec<Name> = generic_params_with_bounds
-        .iter()
-        .map(|(n, _)| n.clone())
-        .collect();
-    let mut generic_param_bounds: Vec<Option<crate::ast::TypeExpr>> = generic_params_with_bounds
-        .into_iter()
-        .map(|(_, b)| b)
-        .collect();
-    for bound in generic_param_bounds.iter_mut().flatten() {
-        let bspan = bound.span;
-        lower_type_expr::check_wildcard_type(bound, "a generic type bound", bspan, diags);
-    }
+    let generic_params = extract_generic_params_with_bounds(sig.syntax(), diags);
     let parameter_context = format!("method signature `{}`", name.as_str());
 
     let (params, defaults) = sig
@@ -1625,7 +1531,6 @@ fn lower_method_sig(
     Some(MethodSigDef {
         name,
         generic_params,
-        generic_param_bounds,
         params,
         defaults,
         return_type,
@@ -1707,7 +1612,7 @@ fn lower_implements_for(
 ) -> Option<ImplementsForDef> {
     let imp = ast::ImplementsFor::cast(node.clone())?;
 
-    let generic_params = extract_generic_params_with_all_bounds(node, diags);
+    let generic_params = extract_generic_params_with_bounds(node, diags);
 
     // Interface target (the `I` in `implements I for T`)
     let target_node = imp.target()?;
@@ -2225,7 +2130,6 @@ fn synthesize_init_test_function(
     FunctionDef {
         name: Name::new(&fn_name),
         generic_params: vec![],
-        generic_param_bounds: vec![],
         params: vec![registry_param],
         defaults: FunctionDefaults::empty(),
         return_type: None,
@@ -3058,7 +2962,6 @@ fn synthesize_client_new_companion(
     FunctionDef {
         name: Name::new(&func_name),
         generic_params: vec![],
-        generic_param_bounds: vec![],
         params: vec![lenient_param],
         defaults: FunctionDefaults::empty(),
         return_type: None,

--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -29,9 +29,9 @@ use baml_compiler2_mir::{
 use baml_compiler2_ppir::{
     function_body,
     item_data::{
-        class_data, enum_data, file_classes, file_enums, file_free_impls, file_functions,
-        file_interfaces, file_lets, file_template_strings, file_tests, function_data,
-        function_llm_meta, function_llm_prompt, impl_block_data, interface_data,
+        GenericParamData, class_data, enum_data, file_classes, file_enums, file_free_impls,
+        file_functions, file_interfaces, file_lets, file_template_strings, file_tests,
+        function_data, function_llm_meta, function_llm_prompt, impl_block_data, interface_data,
         method_interface_target, template_string_data, test_data,
     },
 };
@@ -233,18 +233,18 @@ fn build_interface_def(
         }
     };
 
-    // A generic param carries at most one bound today; lower it (or none).
+    // `T extends A & B` is a conjunction; every conjunct that resolves to an
+    // interface is emitted so the runtime enforces all of them.
     let store = &interface.type_refs;
     let args = generics
         .iter()
-        .enumerate()
-        .map(|(i, param)| {
-            let bound = interface
-                .generic_param_bounds
-                .get(i)
-                .and_then(|o| *o)
-                .and_then(|id| lower_iface(store, id, &interface_frame_params, &decl_bounds));
-            (param.clone(), bound.into_iter().collect())
+        .map(|declared| {
+            let bounds = declared
+                .bounds
+                .iter()
+                .filter_map(|&id| lower_iface(store, id, &interface_frame_params, &decl_bounds))
+                .collect();
+            (declared.name.clone(), bounds)
         })
         .collect();
     let requires = interface
@@ -277,7 +277,8 @@ fn build_interface_def(
         .iter()
         .map(|m| {
             let mut scope = interface_frame_params.clone();
-            ParamTy::extend_frame(&mut scope, &m.generic_params);
+            let own_names: Vec<Name> = m.generic_params.iter().map(|p| p.name.clone()).collect();
+            ParamTy::extend_frame(&mut scope, &own_names);
             build_method(
                 store,
                 &m.name,
@@ -650,34 +651,35 @@ fn build_packages(
                 &mut diags,
             )
         };
-        // Each generic param's interface bound set (`T extends A & B` → {A, B};
-        // a param has at most one bound today). A bound is an interface, possibly
-        // generic or carrying associated bindings — `split_interface` captures its
-        // args/assoc as templates over the impl's params. A non-interface bound,
-        // rejected upstream, has no interface to record, so skip the whole rule
-        // (`None`); dropping a rule only ever loses a dispatch, never adds a wrong
-        // one.
+        // Each generic param's interface bound set (`T extends A & B` → {A, B}).
+        // A bound is an interface, possibly generic or carrying associated
+        // bindings — `split_interface` captures its args/assoc as templates over
+        // the impl's params. A non-interface bound, rejected upstream, has no
+        // interface to record, so skip the whole rule (`None`); dropping a rule
+        // only ever loses a dispatch, never adds a wrong one. Every conjunct is
+        // emitted: a rule narrowed by two bounds must stay narrowed by both.
         let bound_sets = |store: &TypeRefStore,
-                          param_bounds: &[Option<TypeRefId>],
+                          declared: &[GenericParamData],
                           generics: &[ParamTy],
                           bounds: &TypeVarBoundsMap|
          -> Option<Vec<Vec<InterfaceBound>>> {
-            param_bounds
+            declared
                 .iter()
-                .map(|b| match b {
-                    None => Some(Vec::new()),
-                    Some(id) => {
-                        let bound_ty = lower_constraint_head(store, *id, generics, bounds);
-                        split_interface(&bound_ty, resolved, generics).map(
-                            |(interface, args, assoc)| {
-                                vec![InterfaceBound {
+                .map(|param| {
+                    param
+                        .bounds
+                        .iter()
+                        .map(|&id| {
+                            let bound_ty = lower_constraint_head(store, id, generics, bounds);
+                            split_interface(&bound_ty, resolved, generics).map(
+                                |(interface, args, assoc)| InterfaceBound {
                                     interface,
                                     args,
                                     assoc,
-                                }]
-                            },
-                        )
-                    }
+                                },
+                            )
+                        })
+                        .collect()
                 })
                 .collect()
         };
@@ -720,9 +722,6 @@ fn build_packages(
             };
             let store = &block.type_refs;
             let impl_params = baml_compiler2_tir::impl_generic_params(db, impl_loc);
-            // Legacy flat single-bound form (first `&`-bound per param).
-            let impl_param_bounds: Vec<Option<TypeRefId>> =
-                generics.iter().map(|g| g.bounds.first().copied()).collect();
             let impl_bounds =
                 baml_compiler2_tir::lower_type_expr::impl_generic_param_bounds(db, impl_loc);
             // The target is a constraint, not an existential: it carries only
@@ -756,8 +755,7 @@ fn build_packages(
             );
             let for_ty_pattern =
                 baml_compiler2_mir::tir2_to_template(&for_ty, resolved, &impl_params);
-            let Some(generic_param_bounds) =
-                bound_sets(store, &impl_param_bounds, &impl_params, impl_bounds)
+            let Some(generic_param_bounds) = bound_sets(store, generics, &impl_params, impl_bounds)
             else {
                 continue;
             };
@@ -891,7 +889,7 @@ fn build_packages(
                 )
             };
             let Some(generic_param_bounds) =
-                bound_sets(store, &class.generic_param_bounds, &generics, class_bounds)
+                bound_sets(store, &class.generic_params, &generics, class_bounds)
             else {
                 continue;
             };
@@ -1240,7 +1238,11 @@ fn collect_class_fields_with_implements(
             name,
             field.type_ref,
             field.attributes.clone(),
-            class.generic_params.clone(),
+            class
+                .generic_params
+                .iter()
+                .map(|param| param.name.clone())
+                .collect(),
             pkg_ns.to_vec(),
         ));
     }
@@ -3611,13 +3613,20 @@ fn apply_signature_metadata(f: &mut Function, sig: &baml_compiler2_mir::RuntimeS
     f.display_return_type.clone_from(&sig.display_return_type);
 }
 
-fn type_expr_for_name_with_generic_args(name: Name, generic_params: &[Name]) -> TypeExpr {
+/// `Name<P0, P1, …>` — the declaring item applied to its own parameters as type
+/// variables. Only the parameter *names* matter; bounds are irrelevant to the
+/// synthesized path.
+fn type_expr_for_name_with_generic_args(
+    name: Name,
+    generic_params: &[GenericParamData],
+) -> TypeExpr {
     baml_compiler2_ast::TypeExprKind::Path {
         segments: vec![name],
         generic_args: generic_params
             .iter()
-            .cloned()
-            .map(baml_compiler2_tir::lower_type_expr::type_expr_for_name)
+            .map(|param| {
+                baml_compiler2_tir::lower_type_expr::type_expr_for_name(param.name.clone())
+            })
             .collect(),
         associated_type_bindings: Vec::new(),
         attrs: Vec::new(),
@@ -3647,9 +3656,27 @@ fn compute_function_metadata<'db>(
         ty::Ty,
     };
 
-    // A generic param's single optional `extends` bound as `(store, id)` — enclosing
-    // (class/interface/impl) and function bounds live in different arenas.
-    type BoundRef<'a> = Option<(&'a TypeRefStore, TypeRefId)>;
+    /// One in-scope type variable's declared bound conjunction, as `(store, id)`
+    /// refs into whichever arena declared it — enclosing (class/interface/impl)
+    /// and function bounds live in different arenas. Empty when unbounded.
+    type BoundRef<'a> = Vec<(&'a TypeRefStore, TypeRefId)>;
+
+    /// A declaration's parameters split into parallel name and bound-ref lists,
+    /// keeping every `&`-separated conjunct.
+    fn split_declared<'a>(
+        params: &'a [GenericParamData],
+        store: &'a TypeRefStore,
+    ) -> (Vec<Name>, Vec<BoundRef<'a>>) {
+        params
+            .iter()
+            .map(|param| {
+                (
+                    param.name.clone(),
+                    param.bounds.iter().map(|&id| (store, id)).collect(),
+                )
+            })
+            .unzip()
+    }
 
     let file = func_loc.file(db);
     let func = function_data(db, func_loc);
@@ -3689,56 +3716,26 @@ fn compute_function_metadata<'db>(
     // params are in scope inside the method signature. Mirror
     // `MirLowerer::enclosing_generic_params`: enclosing params come first, then
     // function-level params.
-    let func_bounds = || {
-        func.generic_param_bounds
-            .iter()
-            .map(move |o| o.map(|id| (func_store, id)))
-    };
-    let (scoped_generic_param_names, scoped_generic_bound_refs): (Vec<Name>, Vec<BoundRef>) =
-        if let Some(block) = enclosing_free_impl {
-            // The impl block's declared generics as `(names, each's single optional
-            // bound)` — the flat form the removed `implements_for` exposed directly
-            // (mirrors MIR's `free_impl_generics`). Only the first `&`-bound per
-            // param is kept, matching the legacy shape.
-            let (mut names, mut bounds): (Vec<Name>, Vec<BoundRef>) = match &block.subject {
-                ImplSubjectData::Free { generics, .. } => (
-                    generics.iter().map(|g| g.name.clone()).collect(),
-                    generics
-                        .iter()
-                        .map(|g| g.bounds.first().copied().map(|id| (&block.type_refs, id)))
-                        .collect(),
-                ),
+    let (scoped_generic_param_names, scoped_generic_bound_refs): (Vec<Name>, Vec<BoundRef>) = {
+        let (mut names, mut bounds) = if let Some(block) = enclosing_free_impl {
+            match &block.subject {
+                ImplSubjectData::Free { generics, .. } => {
+                    split_declared(generics, &block.type_refs)
+                }
                 ImplSubjectData::InClass { .. } => (Vec::new(), Vec::new()),
-            };
-            names.extend(func.generic_params.iter().cloned());
-            bounds.extend(func_bounds());
-            (names, bounds)
+            }
         } else if let Some(iface) = enclosing_interface {
-            let mut names = iface.generic_params.clone();
-            names.extend(func.generic_params.iter().cloned());
-            let mut bounds: Vec<BoundRef> = iface
-                .generic_param_bounds
-                .iter()
-                .map(|o| o.map(|id| (&iface.type_refs, id)))
-                .collect();
-            bounds.extend(func_bounds());
-            (names, bounds)
+            split_declared(&iface.generic_params, &iface.type_refs)
         } else {
-            let mut names = enclosing_class
-                .map(|c| c.generic_params.clone())
-                .unwrap_or_default();
-            names.extend(func.generic_params.iter().cloned());
-            let mut bounds: Vec<BoundRef> = enclosing_class
-                .map(|c| {
-                    c.generic_param_bounds
-                        .iter()
-                        .map(|o| o.map(|id| (&c.type_refs, id)))
-                        .collect()
-                })
-                .unwrap_or_default();
-            bounds.extend(func_bounds());
-            (names, bounds)
+            enclosing_class
+                .map(|c| split_declared(&c.generic_params, &c.type_refs))
+                .unwrap_or_default()
         };
+        let (own_names, own_bounds) = split_declared(&func.generic_params, func_store);
+        names.extend(own_names);
+        bounds.extend(own_bounds);
+        (names, bounds)
+    };
     let enclosing_generics = baml_compiler2_tir::function_generic_params(db, func_loc);
 
     // Every type variable in scope for this signature, keyed by name, with its
@@ -3778,10 +3775,10 @@ fn compute_function_metadata<'db>(
             let args = iface
                 .generic_params
                 .iter()
-                .map(|name| {
+                .map(|declared| {
                     let param = enclosing_generics
                         .iter()
-                        .find(|param| param.name() == name)
+                        .find(|param| param.name() == &declared.name)
                         .expect("interface generic parameter is in the function environment");
                     Ty::TypeVar(param.clone(), baml_type::TyAttr::default())
                 })
@@ -3958,36 +3955,46 @@ fn compute_function_metadata<'db>(
     // members it writes, so lowering it existentially would mint completeness
     // diagnostics for members the bound legitimately leaves free (and drop the
     // bound from display). Rendered into `display_type_params` below.
-    let generic_param_bounds: HashMap<Name, Ty> = scoped_generic_param_names
+    let generic_param_bounds: HashMap<Name, Vec<Ty>> = scoped_generic_param_names
         .iter()
         .enumerate()
         .filter_map(|(idx, name)| {
-            let (store, id) = scoped_generic_bound_refs.get(idx).copied().flatten()?;
-            let mut diags = Vec::new();
+            let refs = scoped_generic_bound_refs.get(idx)?;
             let generic_params = if enclosing_interface.is_some() {
                 &interface_binding_params
             } else {
                 &enclosing_generics
             };
-            let lowered = baml_compiler2_tir::lower_type_expr::lower_constraint_head_type_ref(
-                store,
-                id,
-                &ScopeCtx {
-                    db,
-                    package_items: pkg_items,
-                    ns_context: &pkg_info.namespace_path,
-                    generic_params,
-                    bounds: &scope_bounds,
-                    self_ty: None,
-                },
-                &mut diags,
-            );
-            let bound_ty = if enclosing_interface.is_some() {
-                substitute_ty(&lowered, &interface_signature_bindings)
-            } else {
-                lowered
-            };
-            diags.is_empty().then(|| (name.clone(), bound_ty))
+            // Each conjunct lowers independently; one that fails to lower is
+            // dropped (its declaration reported the error) without hiding the
+            // rest of the conjunction.
+            let bound_tys: Vec<Ty> = refs
+                .iter()
+                .filter_map(|&(store, id)| {
+                    let mut diags = Vec::new();
+                    let lowered =
+                        baml_compiler2_tir::lower_type_expr::lower_constraint_head_type_ref(
+                            store,
+                            id,
+                            &ScopeCtx {
+                                db,
+                                package_items: pkg_items,
+                                ns_context: &pkg_info.namespace_path,
+                                generic_params,
+                                bounds: &scope_bounds,
+                                self_ty: None,
+                            },
+                            &mut diags,
+                        );
+                    let bound_ty = if enclosing_interface.is_some() {
+                        substitute_ty(&lowered, &interface_signature_bindings)
+                    } else {
+                        lowered
+                    };
+                    diags.is_empty().then_some(bound_ty)
+                })
+                .collect();
+            (!bound_tys.is_empty()).then(|| (name.clone(), bound_tys))
         })
         .collect();
 
@@ -4001,12 +4008,16 @@ fn compute_function_metadata<'db>(
 
     let display_type_params: Vec<String> = scoped_generic_param_names
         .iter()
-        .map(|name| {
-            if let Some(bound) = generic_param_bounds.get(name) {
-                format!("{} extends {}", name.as_str(), bound.render_user_facing())
-            } else {
-                name.to_string()
+        .map(|name| match generic_param_bounds.get(name) {
+            Some(bounds) => {
+                let rendered = bounds
+                    .iter()
+                    .map(Ty::render_user_facing)
+                    .collect::<Vec<_>>()
+                    .join(" & ");
+                format!("{} extends {rendered}", name.as_str())
             }
+            None => name.to_string(),
         })
         .collect();
 

--- a/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/stack_carry.rs
@@ -1245,9 +1245,17 @@ impl PullSink for StackCarryPullSink<'_> {
                     .get(&local)
                     .and_then(|du| du.def.as_ref())
                     .ok_or(())?;
+                // These are materialized only by `emit_rvalue_pull`, which
+                // intercepts them before the shared walker sees them — so
+                // inlining one here would hand `walk_rvalue_pull` an rvalue it
+                // asserts it never receives. Reject instead, which is also the
+                // honest answer: their stack effects are variable-arity and this
+                // simulator does not model them.
                 if matches!(
                     def.rvalue,
-                    Rvalue::MakeBoundMethod { .. } | Rvalue::MakeVirtualBoundMethod { .. }
+                    Rvalue::MakeBoundMethod { .. }
+                        | Rvalue::MakeVirtualBoundMethod { .. }
+                        | Rvalue::VirtualFieldAccess { .. }
                 ) {
                     return Err(());
                 }

--- a/baml_language/crates/baml_compiler2_hir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/builder.rs
@@ -19,7 +19,7 @@ use crate::{
     diagnostic::{Hir2Diagnostic, MemberSite},
     file_package::file_package,
     ids::{FunctionMarker, LocalItemId},
-    item_tree::{GenericParam, ImplBlock, ImplSubject, InterfaceFieldLink},
+    item_tree::{ImplBlock, ImplSubject, InterfaceFieldLink},
     loc::{
         ClassLoc, ClientLoc, EnumLoc, FunctionLoc, InterfaceLoc, LetLoc, RetryPolicyLoc,
         TemplateStringLoc, TestLoc, TypeAliasLoc,
@@ -1450,14 +1450,7 @@ impl<'db> SemanticIndexBuilder<'db> {
         // Record this out-of-body impl under a stable `ImplId` in the unified `impls` store.
         let iface_head = impl_head_name(&imp.interface_target);
         let for_head = impl_head_name(&imp.for_target);
-        let generics = imp
-            .generic_params
-            .iter()
-            .map(|(name, bounds)| GenericParam {
-                name: name.clone(),
-                bounds: bounds.clone(),
-            })
-            .collect();
+        let generics = imp.generic_params.clone();
         let block = ImplBlock {
             subject: ImplSubject::Free {
                 for_target: imp.for_target.clone(),
@@ -1802,9 +1795,14 @@ impl<'db> SemanticIndexBuilder<'db> {
 
             if let Some(throws) = &function.throws {
                 let mut invalid = Vec::new();
+                let generic_param_names: Vec<Name> = function
+                    .generic_params
+                    .iter()
+                    .map(|param| param.name.clone())
+                    .collect();
                 Self::collect_invalid_builtin_throw_types(
                     throws,
-                    &function.generic_params,
+                    &generic_param_names,
                     &mut invalid,
                 );
                 if !invalid.is_empty() {

--- a/baml_language/crates/baml_compiler2_hir/src/item_tree.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/item_tree.rs
@@ -20,7 +20,6 @@ mod type_aliases;
 
 use std::ops::Index;
 
-use baml_base::Name;
 use baml_compiler2_ast as ast;
 pub use classes::*;
 pub use clients::*;
@@ -103,7 +102,10 @@ impl ItemTree {
     /// The single successor of the `classes.values().find(|c|
     /// c.methods.contains(…))` scans that used to be copied (divergently)
     /// across HIR, PPIR and TIR.
-    pub fn enclosing_type_generic_params(&self, method: LocalItemId<FunctionMarker>) -> &[Name] {
+    pub fn enclosing_type_generic_params(
+        &self,
+        method: LocalItemId<FunctionMarker>,
+    ) -> &[GenericParam] {
         match self.method_owners.get(&method) {
             Some(MethodOwner::Class(id)) => &self[*id].generic_params,
             Some(MethodOwner::Interface(id)) => &self[*id].generic_params,

--- a/baml_language/crates/baml_compiler2_hir/src/item_tree/builder.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/item_tree/builder.rs
@@ -74,7 +74,6 @@ impl ItemTreeBuilder {
             Function {
                 name: f.name.clone(),
                 generic_params: f.generic_params.clone(),
-                generic_param_bounds: f.generic_param_bounds.clone(),
                 params,
                 defaults: f.defaults.clone(),
                 return_type: f.return_type.clone(),
@@ -126,7 +125,6 @@ impl ItemTreeBuilder {
             Class {
                 name: c.name.clone(),
                 generic_params: c.generic_params.clone(),
-                generic_param_bounds: c.generic_param_bounds.clone(),
                 fields,
                 methods: Vec::new(),
                 implements,
@@ -274,7 +272,6 @@ impl ItemTreeBuilder {
             .map(|m| InterfaceMethodSig {
                 name: m.name.clone(),
                 generic_params: m.generic_params.clone(),
-                generic_param_bounds: m.generic_param_bounds.clone(),
                 params: m
                     .params
                     .iter()
@@ -297,7 +294,6 @@ impl ItemTreeBuilder {
             Interface {
                 name: i.name.clone(),
                 generic_params: i.generic_params.clone(),
-                generic_param_bounds: i.generic_param_bounds.clone(),
                 requires: i.requires.clone(),
                 fields,
                 associated_types: i.associated_types.clone(),

--- a/baml_language/crates/baml_compiler2_hir/src/item_tree/classes.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/item_tree/classes.rs
@@ -4,7 +4,7 @@ use text_size::TextRange;
 
 use crate::{
     ids::{FunctionMarker, LocalItemId},
-    item_tree::{Attribute, ImplementsBlock},
+    item_tree::{Attribute, GenericParam, ImplementsBlock},
 };
 
 /// A class field stored in the `ItemTree`.
@@ -22,12 +22,9 @@ pub struct ClassField {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Class {
     pub name: Name,
-    /// Generic type parameters (e.g., `["T"]` for `Array<T>`).
-    /// Empty for non-generic classes.
-    pub generic_params: Vec<Name>,
-    /// Generic bounds parallel to `generic_params`. `Some(te)` means
-    /// `T extends <te>`; `None` means unbounded.
-    pub generic_param_bounds: Vec<Option<ast::TypeExpr>>,
+    /// Generic type parameters (e.g., `["T"]` for `Array<T>`), each with its
+    /// bounds. Empty for non-generic classes.
+    pub generic_params: Vec<GenericParam>,
     /// Fields of the class, in declaration order.
     pub fields: Vec<ClassField>,
     /// Methods defined inside this class, referencing their `Function` entries

--- a/baml_language/crates/baml_compiler2_hir/src/item_tree/common.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/item_tree/common.rs
@@ -1,3 +1,7 @@
+/// Re-exported unchanged: a generic parameter carries only a name and its
+/// bounds (themselves `ast::TypeExpr`s, as everywhere else in the `ItemTree`),
+/// so there is nothing for a mirror struct to strip.
+pub use ast::GenericParam;
 use baml_base::Name;
 use baml_compiler2_ast::ast;
 

--- a/baml_language/crates/baml_compiler2_hir/src/item_tree/functions.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/item_tree/functions.rs
@@ -2,7 +2,10 @@ use baml_base::Name;
 use baml_compiler2_ast::ast;
 use text_size::TextRange;
 
-use crate::ids::{FunctionMarker, LocalItemId};
+use crate::{
+    ids::{FunctionMarker, LocalItemId},
+    item_tree::GenericParam,
+};
 
 /// Full function data stored in the `ItemTree`.
 /// Params and return type are stored for signature queries.
@@ -10,13 +13,9 @@ use crate::ids::{FunctionMarker, LocalItemId};
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Function {
     pub name: Name,
-    /// Generic type parameters (e.g., `["T", "U"]`).
+    /// Generic type parameters (e.g., `["T", "U"]`), each with its bounds.
     /// Empty for non-generic functions.
-    pub generic_params: Vec<Name>,
-    /// BEP-044 generic bounds parallel to `generic_params`. `Some(te)`
-    /// means the parameter at the matching index was declared with
-    /// `T extends <te>`; `None` means unbounded.
-    pub generic_param_bounds: Vec<Option<ast::TypeExpr>>,
+    pub generic_params: Vec<GenericParam>,
     /// Function parameters with optional type annotations and spans.
     pub params: Vec<FunctionParam>,
     /// Function parameter default expression arena.

--- a/baml_language/crates/baml_compiler2_hir/src/item_tree/interfaces.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/item_tree/interfaces.rs
@@ -4,7 +4,7 @@ use text_size::TextRange;
 
 use crate::{
     ids::{ClassMarker, FunctionMarker, LocalItemId},
-    item_tree::{Attribute, ClassField, FunctionParam},
+    item_tree::{Attribute, ClassField, FunctionParam, GenericParam},
 };
 
 /// An interface (BEP-044) stored in the `ItemTree`.
@@ -14,10 +14,8 @@ use crate::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Interface {
     pub name: Name,
-    /// Generic type parameters declared on the interface.
-    pub generic_params: Vec<Name>,
-    /// BEP-044 generic bounds parallel to `generic_params`.
-    pub generic_param_bounds: Vec<Option<ast::TypeExpr>>,
+    /// Generic type parameters declared on the interface, each with its bounds.
+    pub generic_params: Vec<GenericParam>,
     /// Required interfaces from `requires I1, I2, …`.
     pub requires: Vec<ast::TypeExpr>,
     /// Field signatures declared on the interface. Interface fields cannot
@@ -38,10 +36,8 @@ pub struct Interface {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InterfaceMethodSig {
     pub name: Name,
-    /// Generic type parameters local to this method.
-    pub generic_params: Vec<Name>,
-    /// BEP-044 generic bounds parallel to `generic_params`.
-    pub generic_param_bounds: Vec<Option<ast::TypeExpr>>,
+    /// Generic type parameters local to this method, each with its bounds.
+    pub generic_params: Vec<GenericParam>,
     pub params: Vec<FunctionParam>,
     pub return_type: Option<ast::TypeExpr>,
     pub throws: Option<ast::TypeExpr>,
@@ -92,17 +88,6 @@ pub struct ImplementsBlock {
     pub associated_type_bindings: Vec<ast::AssociatedTypeBindingDef>,
     pub is_out_of_body: bool,
     pub span: TextRange,
-}
-
-/// A generic parameter on an out-of-body `implements` block, paired with its set
-/// of `&`-separated interface bounds (`<T>` → `bounds = []`; `<T extends A & B>`
-/// → `bounds = [A, B]`). Pairing name and bounds makes a length mismatch between
-/// the two unrepresentable. Bounds are unresolved `TypeExpr`s here; they resolve
-/// to `baml_type::Interface` constraints downstream.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GenericParam {
-    pub name: Name,
-    pub bounds: Vec<ast::TypeExpr>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/baml_language/crates/baml_compiler2_hir/src/signature.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/signature.rs
@@ -248,12 +248,18 @@ fn elaborated_function_signature_with_source_map<'db>(
 
     let return_type = func_data.return_type.clone();
     let throws = func_data.throws.clone();
-    let reserved_effect_param_names = item_tree
+    let reserved_effect_param_names: Vec<Name> = item_tree
         .enclosing_type_generic_params(function.id(db))
-        .to_vec();
+        .iter()
+        .map(|param| param.name.clone())
+        .collect();
     let signature = Arc::new(elaborate_function_signature_parts(
         func_data.name.clone(),
-        func_data.generic_params.clone(),
+        func_data
+            .generic_params
+            .iter()
+            .map(|param| param.name.clone())
+            .collect(),
         &reserved_effect_param_names,
         params,
         return_type,

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1637,8 +1637,9 @@ impl<'db> LoweringContext<'db> {
                 if &resolved != ty {
                     return self.interface_view_for_tir_ty(&resolved, target_tn);
                 }
-                self.resolve_projection_bound(ty)
-                    .and_then(|bound| self.interface_view_for_tir_ty(&bound, target_tn))
+                self.resolve_projection_bounds(ty)
+                    .iter()
+                    .find_map(|bound| self.interface_view_for_tir_ty(bound, target_tn))
             }
             _ => self.realized_interface_view_for(ty, target_tn),
         }
@@ -2046,7 +2047,7 @@ impl<'db> LoweringContext<'db> {
         // BEP-044 Self-as-type-variable: an interface default method's `self` is
         // a `Self` type variable bound by the interface (matching the TIR
         // typing in `inference.rs`). Registering the bound lets member access on
-        // `self` dispatch through the interface — `interface_dispatch_target_for_tir_ty`
+        // `self` dispatch through the interface — `interface_dispatch_target_for_member`
         // already follows type-var bounds — so default methods keep dispatching
         // through the concrete implementor.
         if let Some(baml_compiler2_ppir::item_data::MethodOwner::Interface(iface_loc)) =
@@ -2805,49 +2806,118 @@ impl<'db> LoweringContext<'db> {
         self.convert_tir_ty_for_runtime(&tir_ty)
     }
 
-    /// The interface *view* a receiver of this static type dispatches through — its
-    /// own for an existential, its bound's for a type variable, its resolved bound's
-    /// for a projection. `None` for concrete receivers: their providing interface is
-    /// method-specific, resolved by [`Self::dispatch_target_for_concrete`].
-    fn interface_dispatch_target_for_tir_ty(&self, ty: &Tir2Ty) -> Option<InterfaceTypeView> {
+    /// The interface *view* a receiver of this static type dispatches through, for
+    /// the `member` being accessed — its own for an existential, its bound's for a
+    /// type variable, its resolved bound's for a projection. `None` for concrete
+    /// receivers: their providing interface is resolved by
+    /// [`Self::dispatch_target_for_concrete`].
+    ///
+    /// `member` is not optional: a dispatch view exists only to key a member access,
+    /// and which view is correct depends on the member. A bound list is a
+    /// *conjunction*, so under `T extends A & B` a member may be declared by either
+    /// conjunct while the emitted `virtual_call` names just one interface. Choosing
+    /// without the member — as this did while a bound could only be a single
+    /// interface — keys the call on an interface that need not declare it, which the
+    /// VM then cannot resolve.
+    fn interface_dispatch_target_for_member(
+        &self,
+        ty: &Tir2Ty,
+        member: &Name,
+    ) -> Option<InterfaceTypeView> {
         match ty {
             Tir2Ty::Interface(qtn, type_args, associated_bindings, _) => {
                 Some((qtn.clone(), type_args.clone(), associated_bindings.clone()))
             }
-            Tir2Ty::TypeVar(name, _) => self
-                .generic_param_bounds
-                .get(name)
-                .into_iter()
-                .flatten()
-                .find_map(|bound| self.interface_dispatch_target_for_tir_ty(&bound.to_ty())),
+            // `T extends A & B` — the generic-parameter axis.
+            Tir2Ty::TypeVar(name, _) => {
+                let conjuncts: Vec<Tir2Ty> = self
+                    .generic_param_bounds
+                    .get(name)
+                    .into_iter()
+                    .flatten()
+                    .map(baml_type::Interface::to_ty)
+                    .collect();
+                self.dispatch_view_over_conjunction(&conjuncts, member)
+            }
+            // `type Item extends A & B` — the associated-type axis, same rule.
             Tir2Ty::AssociatedTypeProjection { .. } => {
                 let resolved = self.resolve_ty_projections(ty);
                 if &resolved != ty {
-                    return self.interface_dispatch_target_for_tir_ty(&resolved);
+                    return self.interface_dispatch_target_for_member(&resolved, member);
                 }
-                self.resolve_projection_bound(ty)
-                    .and_then(|bound| self.interface_dispatch_target_for_tir_ty(&bound))
+                self.dispatch_view_over_conjunction(&self.resolve_projection_bounds(ty), member)
             }
             _ => None,
         }
     }
 
-    fn interface_dispatch_target_for_expr(&self, expr_id: AstExprId) -> Option<InterfaceTypeView> {
-        self.source_param_interface_view_for_expr(expr_id)
+    /// Pick which conjunct of a bound list a `member` access dispatches through: the
+    /// first whose `requires` closure declares it.
+    ///
+    /// Falls back to the first conjunct that yields a view at all when none declares
+    /// `member` — an access TIR has already rejected, so the choice only shapes the
+    /// code emitted for a program that will not run.
+    ///
+    /// Shared by both places a bound list is a conjunction — a generic parameter's
+    /// `T extends A & B` and an associated type's `type Item extends A & B` — so the
+    /// two cannot drift.
+    fn dispatch_view_over_conjunction(
+        &self,
+        bounds: &[Tir2Ty],
+        member: &Name,
+    ) -> Option<InterfaceTypeView> {
+        bounds
+            .iter()
+            .find_map(|bound| {
+                let view = self.interface_dispatch_target_for_member(bound, member)?;
+                self.interface_closure_declares_member(&view.0, member)
+                    .then_some(view)
+            })
+            .or_else(|| {
+                bounds
+                    .iter()
+                    .find_map(|bound| self.interface_dispatch_target_for_member(bound, member))
+            })
+    }
+
+    /// Whether `iface_tn`'s `requires` closure declares `member`, as either a method
+    /// or a field. Selects which conjunct of a bound list a member access dispatches
+    /// through.
+    fn interface_closure_declares_member(&self, iface_tn: &TypeName, member: &Name) -> bool {
+        if self.mir_interface_declares_method(iface_tn, member) {
+            return true;
+        }
+        self.interface_closure_type_name_views(iface_tn, &[], &[])
+            .is_some_and(|views| {
+                views
+                    .iter()
+                    .any(|(tn, _, _)| self.interface_field_index_directly(tn, member).is_some())
+            })
+    }
+
+    /// The interface view an *expression* receiver dispatches through for `member`
+    /// — see [`Self::interface_dispatch_target_for_member`].
+    fn interface_dispatch_target_for_expr_member(
+        &self,
+        expr_id: AstExprId,
+        member: &Name,
+    ) -> Option<InterfaceTypeView> {
+        self.source_param_interface_view_for_expr(expr_id, member)
             .or_else(|| {
                 self.tir_expr_type(self.expr_metadata_key(expr_id))
-                    .and_then(|ty| self.interface_dispatch_target_for_tir_ty(ty))
+                    .and_then(|ty| self.interface_dispatch_target_for_member(ty, member))
             })
             .or_else(|| {
                 self.self_typevar_for_expr(expr_id)
-                    .and_then(|ty| self.interface_dispatch_target_for_tir_ty(&ty))
+                    .and_then(|ty| self.interface_dispatch_target_for_member(&ty, member))
             })
-            .or_else(|| self.upcast_target_interface_view(expr_id))
+            .or_else(|| self.upcast_target_interface_view(expr_id, member))
     }
 
     fn source_param_interface_view_for_expr(
         &self,
         expr_id: AstExprId,
+        member: &Name,
     ) -> Option<InterfaceTypeView> {
         let AstExpr::Path(segments) = &self.body.exprs[expr_id] else {
             return None;
@@ -2855,25 +2925,27 @@ impl<'db> LoweringContext<'db> {
         if segments.len() != 1 {
             return None;
         }
-        self.source_param_interface_view_for_name_at(expr_id, &segments[0])
+        self.source_param_interface_view_for_name_at(expr_id, &segments[0], member)
     }
 
     fn source_param_interface_view_for_name_at(
         &self,
         expr_id: AstExprId,
         name: &Name,
+        member: &Name,
     ) -> Option<InterfaceTypeView> {
         let binding_id = self.binding_id_for_path(expr_id, name)?;
-        self.source_param_interface_view_for_binding(name, binding_id)
+        self.source_param_interface_view_for_binding(name, binding_id, member)
     }
 
     fn source_param_interface_view_for_binding(
         &self,
         name: &Name,
         binding_id: BindingId,
+        member: &Name,
     ) -> Option<InterfaceTypeView> {
         let ty = self.source_param_tir_ty_for_binding(name, binding_id)?;
-        self.interface_dispatch_target_for_tir_ty(&ty)
+        self.interface_dispatch_target_for_member(&ty, member)
     }
 
     fn source_param_tir_ty_for_binding(
@@ -2940,7 +3012,11 @@ impl<'db> LoweringContext<'db> {
         }
     }
 
-    fn upcast_target_interface_view(&self, expr_id: AstExprId) -> Option<InterfaceTypeView> {
+    fn upcast_target_interface_view(
+        &self,
+        expr_id: AstExprId,
+        member: &Name,
+    ) -> Option<InterfaceTypeView> {
         let AstExpr::Upcast { target, .. } = &self.body.exprs[expr_id] else {
             return None;
         };
@@ -2962,7 +3038,7 @@ impl<'db> LoweringContext<'db> {
             },
             &mut diags,
         );
-        self.interface_dispatch_target_for_tir_ty(&target_ty)
+        self.interface_dispatch_target_for_member(&target_ty, member)
     }
 
     fn class_dispatch_target_for_tir_ty(&self, ty: &Tir2Ty) -> Option<(TypeName, Vec<RuntimeTy>)> {
@@ -2979,8 +3055,10 @@ impl<'db> LoweringContext<'db> {
                 if &resolved != ty {
                     return self.class_dispatch_target_for_tir_ty(&resolved);
                 }
-                self.resolve_projection_bound(ty)
-                    .and_then(|bound| self.class_dispatch_target_for_tir_ty(&bound))
+                // An unreduced projection's bounds are interface constraints, and
+                // an interface is never a class, so only the reduction above can
+                // name one.
+                None
             }
             // A type variable has no class dispatch target: its bounds are
             // interface constraints, and an interface is never a class.
@@ -5657,7 +5735,7 @@ impl<'db> LoweringContext<'db> {
                     .cloned();
                 if let Some(view) = recv_tir_ty
                     .as_ref()
-                    .and_then(|ty| self.interface_dispatch_target_for_tir_ty(ty))
+                    .and_then(|ty| self.interface_dispatch_target_for_member(ty, &method_name))
                     .or_else(|| {
                         recv_tir_ty
                             .as_ref()
@@ -5842,7 +5920,7 @@ impl<'db> LoweringContext<'db> {
             let seg_idx = offset + 1;
             let is_last = seg_idx + 1 == segments.len();
             let interface_prefix =
-                self.interface_receiver_for_path_prefix(expr_id, seg_idx - 1, &current_ty);
+                self.interface_receiver_for_path_prefix(expr_id, seg_idx - 1, seg, &current_ty);
             if let Some((tn, class_type_args)) =
                 self.class_receiver_for_path_prefix(expr_id, seg_idx - 1, &current_ty)
             {
@@ -7574,16 +7652,16 @@ impl<'db> LoweringContext<'db> {
                         }
                     });
                 let iface_dispatch_opt: Option<InterfaceTypeView> = if segments.len() == 2 {
-                    self.source_param_interface_view_for_name_at(callee, &segments[0])
+                    self.source_param_interface_view_for_name_at(callee, &segments[0], &method_name)
                         .or_else(|| {
-                            recv_tir_ty
-                                .as_ref()
-                                .and_then(|ty| self.interface_dispatch_target_for_tir_ty(ty))
+                            recv_tir_ty.as_ref().and_then(|ty| {
+                                self.interface_dispatch_target_for_member(ty, &method_name)
+                            })
                         })
                 } else {
                     recv_tir_ty
                         .as_ref()
-                        .and_then(|ty| self.interface_dispatch_target_for_tir_ty(ty))
+                        .and_then(|ty| self.interface_dispatch_target_for_member(ty, &method_name))
                 }
                 // Concrete receiver whose method comes from an impl (blanket,
                 // out-of-body, or in-body) — the providing interface, resolved
@@ -9426,10 +9504,13 @@ impl<'db> LoweringContext<'db> {
         // declaring interface is resolved *before* lowering the receiver so a
         // field access (no such method) falls through to the field path below
         // without evaluating the receiver expression twice.
-        if let Some(view) = self.interface_dispatch_target_for_expr(base).or_else(|| {
-            self.tir_expr_type(self.expr_metadata_key(base))
-                .and_then(|ty| self.dispatch_target_for_concrete(ty, field))
-        }) && self.mir_interface_declares_method(&view.0, field)
+        if let Some(view) = self
+            .interface_dispatch_target_for_expr_member(base, field)
+            .or_else(|| {
+                self.tir_expr_type(self.expr_metadata_key(base))
+                    .and_then(|ty| self.dispatch_target_for_concrete(ty, field))
+            })
+            && self.mir_interface_declares_method(&view.0, field)
         {
             let recv_op = self.lower_to_operand(base);
             let recv_local = self.builder.temp(self.expr_ty(base));
@@ -9518,7 +9599,10 @@ impl<'db> LoweringContext<'db> {
             {
                 self.try_lower_interface_field_access(base_local, &tn, &args, &assoc, field, &dest)
             } else {
-                self.interface_receiver_for_field_access(base, &unwrapped_ty)
+                // Fallback for receivers TIR recorded no virtual-field resolution
+                // for. `field` selects among a bounded type variable's bound
+                // conjunction, where the field may come from any conjunct.
+                self.interface_receiver_for_field_access(base, field, &unwrapped_ty)
                     .is_some_and(|(iface_tn, iface_type_args, iface_assoc)| {
                         self.try_lower_interface_field_access(
                             base_local,
@@ -9577,9 +9661,10 @@ impl<'db> LoweringContext<'db> {
     fn interface_receiver_for_field_access(
         &self,
         base: AstExprId,
+        field: &Name,
         unwrapped_ty: &RuntimeTy,
     ) -> Option<InterfaceTypeView> {
-        if let Some(target) = self.interface_dispatch_target_for_expr(base) {
+        if let Some(target) = self.interface_dispatch_target_for_expr_member(base, field) {
             return Some(target);
         }
 
@@ -9598,18 +9683,19 @@ impl<'db> LoweringContext<'db> {
         &self,
         expr_id: AstExprId,
         prefix_idx: usize,
+        member: &Name,
         current_ty: &RuntimeTy,
     ) -> Option<InterfaceTypeView> {
         if let Some(target) = self
             .tir_path_segment_type((self.current_metadata_scope, expr_id, prefix_idx))
-            .and_then(|ty| self.interface_dispatch_target_for_tir_ty(ty))
+            .and_then(|ty| self.interface_dispatch_target_for_member(ty, member))
         {
             return Some(target);
         }
         if prefix_idx == 0
             && let Some(target) = self
                 .tir_path_root_type(self.expr_metadata_key(expr_id))
-                .and_then(|ty| self.interface_dispatch_target_for_tir_ty(ty))
+                .and_then(|ty| self.interface_dispatch_target_for_member(ty, member))
         {
             return Some(target);
         }
@@ -9834,10 +9920,12 @@ impl<'db> LoweringContext<'db> {
         runtime_id: Option<AstExprId>,
         dest: &Place,
     ) -> bool {
-        let dispatch_target = self.interface_dispatch_target_for_expr(base).or_else(|| {
-            self.tir_expr_type(self.expr_metadata_key(base))
-                .and_then(|ty| self.dispatch_target_for_concrete(ty, method))
-        });
+        let dispatch_target = self
+            .interface_dispatch_target_for_expr_member(base, method)
+            .or_else(|| {
+                self.tir_expr_type(self.expr_metadata_key(base))
+                    .and_then(|ty| self.dispatch_target_for_concrete(ty, method))
+            });
         let Some((iface_tn, iface_type_args, iface_assoc)) = dispatch_target else {
             return false;
         };
@@ -10128,7 +10216,7 @@ impl<'db> LoweringContext<'db> {
     ) -> Option<InterfaceTypeView> {
         let first = members.first()?;
         let view = self
-            .interface_dispatch_target_for_tir_ty(first)
+            .interface_dispatch_target_for_member(first, method)
             .or_else(|| self.dispatch_target_for_concrete(first, method))?;
         Some(self.interface_view_declaring_method(&view, method))
     }
@@ -10315,12 +10403,15 @@ impl<'db> LoweringContext<'db> {
         &mut self,
         target: AstExprId,
         base: AstExprId,
+        field: &Name,
     ) -> Option<InterfaceTypeView> {
         if let Some((view, _index)) = self.tir_virtual_field_view(self.expr_metadata_key(target)) {
             return Some(view);
         }
         let base_ty = self.expr_ty(base).strip_null();
-        self.interface_receiver_for_field_access(base, &base_ty)
+        // `field` selects among a bounded type variable's bound conjunction, where
+        // the field may be declared by any conjunct.
+        self.interface_receiver_for_field_access(base, field, &base_ty)
     }
 
     /// The [`VirtualFieldTarget`] an assignment target denotes when it is an
@@ -10337,7 +10428,7 @@ impl<'db> LoweringContext<'db> {
         match &self.body.exprs[target] {
             AstExpr::MemberAccess { base, member } => {
                 let (base, field) = (*base, member.clone());
-                let view = self.virtual_field_assign_view(target, base)?;
+                let view = self.virtual_field_assign_view(target, base, &field)?;
                 let (iface, field_index) = self.virtual_field_wire_target(&view, &field)?;
                 let recv_op = self.lower_to_operand(base);
                 let receiver = self.operand_to_local(recv_op, self.expr_ty(base));
@@ -10356,8 +10447,8 @@ impl<'db> LoweringContext<'db> {
                     .tir_path_segment_type((self.current_metadata_scope, target, prefix_idx))
                     .cloned()
                     .map(|t| self.convert_tir_ty_for_runtime(&t))?;
-                let view =
-                    self.interface_receiver_for_path_prefix(target, prefix_idx, &prefix_ty)?;
+                let view = self
+                    .interface_receiver_for_path_prefix(target, prefix_idx, &field, &prefix_ty)?;
                 let (iface, field_index) = self.virtual_field_wire_target(&view, &field)?;
                 let root_local = self.local_for_path(target, &segments[0])?;
                 let receiver = self.lower_path_receiver_to_local(
@@ -10462,10 +10553,12 @@ impl<'db> LoweringContext<'db> {
         )
     }
 
-    /// The declared bound of an *unreduced* (symbolic-base) projection `(base as I).member` —
-    /// interface `I`'s `type member extends J`, realized. `None` for a non-projection, an
+    /// The declared bounds of an *unreduced* (symbolic-base) projection
+    /// `(base as I).member` — interface `I`'s `type member extends J & K`, realized.
+    ///
+    /// A conjunction, like a generic parameter's: empty for a non-projection, an
     /// unqualified projection, or an unbounded associated type.
-    fn resolve_projection_bound(&self, ty: &Tir2Ty) -> Option<Tir2Ty> {
+    fn resolve_projection_bounds(&self, ty: &Tir2Ty) -> Vec<Tir2Ty> {
         use baml_type::normalize::TypeContext;
         let Tir2Ty::AssociatedTypeProjection {
             interface: iface,
@@ -10473,7 +10566,7 @@ impl<'db> LoweringContext<'db> {
             ..
         } = ty
         else {
-            return None;
+            return Vec::new();
         };
         with_global_ctx(
             self.db,
@@ -10482,9 +10575,9 @@ impl<'db> LoweringContext<'db> {
             &self.generic_param_bounds,
             |ctx| {
                 ctx.associated_type_bound(iface, member.clone())
-                    .into_iter()
-                    .next()
-                    .map(|bound| bound.to_ty())
+                    .iter()
+                    .map(baml_type::Interface::to_ty)
+                    .collect()
             },
         )
     }
@@ -12628,7 +12721,7 @@ impl LoweringContext<'_> {
             .tir_pat_type(self.pat_metadata_key(class_pat_id))?
             .clone();
         let (iface_tn, iface_args, iface_assoc) =
-            self.interface_dispatch_target_for_tir_ty(&tir_ty)?;
+            self.interface_dispatch_target_for_member(&tir_ty, field)?;
         let field_local = self.builder.temp(self.pat_ty(field_pat_id));
         self.try_lower_interface_field_access(
             scrutinee,

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -96,13 +96,10 @@ fn with_global_ctx<R>(
     db: &dyn baml_compiler2_tir::Db,
     pkg_id: baml_compiler2_hir::package::PackageId<'_>,
     aliases: &HashMap<QualifiedTypeName, Tir2Ty>,
-    bounds: &FxHashMap<ParamTy, Tir2Ty>,
+    bounds: &FxHashMap<ParamTy, Vec<baml_type::Interface>>,
     f: impl FnOnce(&baml_compiler2_tir::type_context::GlobalTypeContext<'_, '_>) -> R,
 ) -> R {
-    let bounds_map: baml_compiler2_tir::lower_type_expr::TypeVarBoundsMap = bounds
-        .iter()
-        .filter_map(|(name, ty)| ty.as_interface().map(|iface| (name.clone(), vec![iface])))
-        .collect();
+    let bounds_map: baml_compiler2_tir::lower_type_expr::TypeVarBoundsMap = bounds.clone();
     let res_ctx = baml_compiler2_tir::package_interface::package_resolution_context(db, pkg_id);
     let ctx = baml_compiler2_tir::type_context::GlobalTypeContext {
         db,
@@ -1341,8 +1338,13 @@ struct LoweringContext<'db> {
         FxHashMap<FileScopeId, &'db baml_compiler2_tir::inference::ScopeInference<'db>>,
     // Function generic bounds, lowered in TIR space. MIR uses these to keep
     // bounded type variables ABI-erased while still lowering bound-member
-    // access through the interface dispatch machinery.
-    generic_param_bounds: FxHashMap<ParamTy, Tir2Ty>,
+    // access through the interface dispatch machinery. A bound *is* an interface
+    // constraint, never a type (`TYPE_SYSTEM.md` "Interfaces"), so it is held as
+    // `baml_type::Interface` — a non-interface bound is rejected at its
+    // declaration and never reaches here. One entry per parameter holding its
+    // full `extends A & B` conjunction: a member may be provided by any
+    // conjunct, so dispatch searches them in declaration order.
+    generic_param_bounds: FxHashMap<ParamTy, Vec<baml_type::Interface>>,
 
     // Package-shared memo for interface-dispatch candidate resolution. Shared
     // across every function the emit driver lowers in one package (fresh and
@@ -1627,7 +1629,9 @@ impl<'db> LoweringContext<'db> {
             Tir2Ty::TypeVar(name, _) => self
                 .generic_param_bounds
                 .get(name)
-                .and_then(|bound| self.interface_view_for_tir_ty(bound, target_tn)),
+                .into_iter()
+                .flatten()
+                .find_map(|bound| self.interface_view_for_tir_ty(&bound.to_ty(), target_tn)),
             Tir2Ty::AssociatedTypeProjection { .. } => {
                 let resolved = self.resolve_ty_projections(ty);
                 if &resolved != ty {
@@ -1909,9 +1913,10 @@ impl<'db> LoweringContext<'db> {
         // Each source item owns its own `TypeRef` arena, so bounds are collected as
         // `(store, id)` pairs — index-aligned with `bound_param_names` — and lowered
         // together below once every sibling param name is in scope (a bound may
-        // reference a sibling type var).
+        // reference a sibling type var). One inner `Vec` per parameter: `T extends
+        // A & B` keeps both conjuncts.
         let mut bound_refs: Vec<
-            Option<(
+            Vec<(
                 &baml_compiler2_hir::type_ref::TypeRefStore,
                 baml_compiler2_hir::type_ref::TypeRefId,
             )>,
@@ -1925,7 +1930,7 @@ impl<'db> LoweringContext<'db> {
             {
                 for g in generics {
                     bound_param_names.push(g.name.clone());
-                    bound_refs.push(g.bounds.first().copied().map(|id| (&imp.type_refs, id)));
+                    bound_refs.push(g.bounds.iter().map(|&id| (&imp.type_refs, id)).collect());
                 }
             }
         } else if let Some(parent_idx) = func_scope.parent {
@@ -1941,9 +1946,15 @@ impl<'db> LoweringContext<'db> {
                     })
                 {
                     let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
-                    bound_param_names.extend(class_data.generic_params.iter().cloned());
-                    for bound in &class_data.generic_param_bounds {
-                        bound_refs.push(bound.map(|id| (&class_data.type_refs, id)));
+                    for param in &class_data.generic_params {
+                        bound_param_names.push(param.name.clone());
+                        bound_refs.push(
+                            param
+                                .bounds
+                                .iter()
+                                .map(|&id| (&class_data.type_refs, id))
+                                .collect(),
+                        );
                     }
                 } else if let Some(iface_loc) =
                     baml_compiler2_ppir::item_data::file_interfaces(db, file)
@@ -1955,56 +1966,81 @@ impl<'db> LoweringContext<'db> {
                         })
                 {
                     let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
-                    bound_param_names.extend(iface_data.generic_params.iter().cloned());
-                    for bound in &iface_data.generic_param_bounds {
-                        bound_refs.push(bound.map(|id| (&iface_data.type_refs, id)));
+                    for param in &iface_data.generic_params {
+                        bound_param_names.push(param.name.clone());
+                        bound_refs.push(
+                            param
+                                .bounds
+                                .iter()
+                                .map(|&id| (&iface_data.type_refs, id))
+                                .collect(),
+                        );
                     }
-                    bound_param_names.extend(
-                        iface_data
-                            .associated_types
-                            .iter()
-                            .map(|assoc| assoc.name.clone()),
-                    );
                     for assoc in &iface_data.associated_types {
-                        bound_refs.push(assoc.bound.map(|id| (&iface_data.type_refs, id)));
+                        bound_param_names.push(assoc.name.clone());
+                        bound_refs.push(
+                            assoc
+                                .bound
+                                .map(|id| (&iface_data.type_refs, id))
+                                .into_iter()
+                                .collect(),
+                        );
                     }
                 }
             }
         }
-        bound_param_names.extend(func_data.generic_params.iter().cloned());
-        for bound in &func_data.generic_param_bounds {
-            bound_refs.push(bound.map(|id| (&func_data.type_refs, id)));
+        for param in &func_data.generic_params {
+            bound_param_names.push(param.name.clone());
+            bound_refs.push(
+                param
+                    .bounds
+                    .iter()
+                    .map(|&id| (&func_data.type_refs, id))
+                    .collect(),
+            );
         }
         let all_generic_params = baml_compiler2_tir::function_generic_params(db, func_loc);
-        let mut generic_param_bounds: FxHashMap<ParamTy, Tir2Ty> = FxHashMap::default();
+        let mut generic_param_bounds: FxHashMap<ParamTy, Vec<baml_type::Interface>> =
+            FxHashMap::default();
         for (idx, name) in bound_param_names.iter().enumerate() {
-            let Some(Some((store, id))) = bound_refs.get(idx).copied() else {
+            let Some(refs) = bound_refs.get(idx) else {
                 continue;
             };
-            let mut diags = Vec::new();
-            // A bound pins only what it writes, so a rigid receiver's dispatch
-            // view keeps unpinned members symbolic and realizes them
-            // per-receiver.
-            let bound_ty = baml_compiler2_tir::lower_type_expr::lower_constraint_head_type_ref(
-                store,
-                id,
-                &baml_compiler2_tir::lower_type_expr::ScopeCtx {
-                    db,
-                    package_items: pkg_items_for_bounds,
-                    ns_context: &pkg_info.namespace_path,
-                    generic_params: &all_generic_params,
-                    // Lowering a bound expression itself: the sibling type-var *names* are in
-                    // scope, but their bounds are not needed (a bound is an interface resolved by
-                    // name), matching tir's own `lower_generic_param_bounds`.
-                    bounds: &baml_compiler2_tir::lower_type_expr::TypeVarBoundsMap::default(),
-                    self_ty: None,
-                },
-                &mut diags,
-            );
-            if diags.is_empty()
-                && let Some(param) = all_generic_params.iter().find(|param| param.name() == name)
-            {
-                generic_param_bounds.insert(param.clone(), bound_ty);
+            let Some(param) = all_generic_params.iter().find(|param| param.name() == name) else {
+                continue;
+            };
+            for &(store, id) in refs {
+                let mut diags = Vec::new();
+                // A bound pins only what it writes, so a rigid receiver's dispatch
+                // view keeps unpinned members symbolic and realizes them
+                // per-receiver.
+                let bound_ty = baml_compiler2_tir::lower_type_expr::lower_constraint_head_type_ref(
+                    store,
+                    id,
+                    &baml_compiler2_tir::lower_type_expr::ScopeCtx {
+                        db,
+                        package_items: pkg_items_for_bounds,
+                        ns_context: &pkg_info.namespace_path,
+                        generic_params: &all_generic_params,
+                        // Lowering a bound expression itself: the sibling type-var *names* are in
+                        // scope, but their bounds are not needed (a bound is an interface resolved
+                        // by name), matching tir's own `lower_generic_param_bounds`.
+                        bounds: &baml_compiler2_tir::lower_type_expr::TypeVarBoundsMap::default(),
+                        self_ty: None,
+                    },
+                    &mut diags,
+                );
+                // A bound that failed to lower, or that named something other
+                // than an interface, is a declaration error reported at its own
+                // site; it contributes no constraint here.
+                if diags.is_empty()
+                    && let Some(constraint) = bound_ty.as_interface()
+                {
+                    generic_param_bounds
+                        .entry(param.clone())
+                        .or_default()
+                        .push(constraint);
+                }
             }
         }
         // BEP-044 Self-as-type-variable: an interface default method's `self` is
@@ -2024,10 +2060,10 @@ impl<'db> LoweringContext<'db> {
                 let args = iface
                     .generic_params
                     .iter()
-                    .map(|name| {
+                    .map(|declared| {
                         let param = all_generic_params
                             .iter()
-                            .find(|param| param.name() == name)
+                            .find(|param| param.name() == &declared.name)
                             .expect("interface generic parameter is in the function environment");
                         Tir2Ty::TypeVar(param.clone(), baml_compiler2_tir::ty::TyAttr::default())
                     })
@@ -2055,12 +2091,7 @@ impl<'db> LoweringContext<'db> {
                     .expect("interface method environment contains Self");
                 generic_param_bounds.insert(
                     self_param.clone(),
-                    Tir2Ty::Interface(
-                        qtn,
-                        args,
-                        associated_bindings,
-                        baml_compiler2_tir::ty::TyAttr::default(),
-                    ),
+                    vec![baml_type::Interface::new(qtn, args, associated_bindings)],
                 );
             }
         }
@@ -2786,7 +2817,9 @@ impl<'db> LoweringContext<'db> {
             Tir2Ty::TypeVar(name, _) => self
                 .generic_param_bounds
                 .get(name)
-                .and_then(|bound| self.interface_dispatch_target_for_tir_ty(bound)),
+                .into_iter()
+                .flatten()
+                .find_map(|bound| self.interface_dispatch_target_for_tir_ty(&bound.to_ty())),
             Tir2Ty::AssociatedTypeProjection { .. } => {
                 let resolved = self.resolve_ty_projections(ty);
                 if &resolved != ty {
@@ -2941,10 +2974,6 @@ impl<'db> LoweringContext<'db> {
                     .map(|arg| self.convert_tir_ty_for_runtime(arg))
                     .collect(),
             )),
-            Tir2Ty::TypeVar(name, _) => self
-                .generic_param_bounds
-                .get(name)
-                .and_then(|bound| self.class_dispatch_target_for_tir_ty(bound)),
             Tir2Ty::AssociatedTypeProjection { .. } => {
                 let resolved = self.resolve_ty_projections(ty);
                 if &resolved != ty {
@@ -2953,6 +2982,9 @@ impl<'db> LoweringContext<'db> {
                 self.resolve_projection_bound(ty)
                     .and_then(|bound| self.class_dispatch_target_for_tir_ty(&bound))
             }
+            // A type variable has no class dispatch target: its bounds are
+            // interface constraints, and an interface is never a class.
+            Tir2Ty::TypeVar(..) => None,
             _ => None,
         }
     }

--- a/baml_language/crates/baml_compiler2_ppir/src/item_data/classes.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/item_data/classes.rs
@@ -7,8 +7,8 @@ use baml_compiler2_hir::{
 use text_size::TextRange;
 
 use crate::item_data::common::{
-    AssociatedTypeBindingData, AssociatedTypeBindingSourceMap, FieldData, InterfaceFieldLinkData,
-    InterfaceFieldLinkSourceMap,
+    AssociatedTypeBindingData, AssociatedTypeBindingSourceMap, FieldData, GenericParamData,
+    InterfaceFieldLinkData, InterfaceFieldLinkSourceMap, lower_generic_params,
 };
 
 /// Span-free semantic data for a `class` declaration.
@@ -19,13 +19,12 @@ use crate::item_data::common::{
 #[derive(Debug, Clone, PartialEq, Eq, salsa::Update)]
 pub struct ClassData<'db> {
     pub name: Name,
-    pub generic_params: Vec<Name>,
+    /// Generic type parameters, each with its conjunction of bounds.
+    pub generic_params: Vec<GenericParamData>,
     /// Every type reference in this class's *signature* — bounds, field types,
     /// and `implements` targets. Scoped to the item, so edits to sibling items
     /// cannot renumber these ids.
     pub type_refs: TypeRefStore,
-    /// Parallel to `generic_params`. `Some` means `T extends <bound>`.
-    pub generic_param_bounds: Vec<Option<TypeRefId>>,
     pub fields: Vec<FieldData>,
     pub methods: Vec<FunctionLoc<'db>>,
     pub implements: Vec<ImplementsData>,
@@ -92,11 +91,7 @@ fn lower<'db>(db: &'db dyn crate::Db, class: ClassLoc<'db>) -> (ClassData<'db>, 
 
     let mut type_refs = TypeRefBuilder::new();
 
-    let generic_param_bounds = data
-        .generic_param_bounds
-        .iter()
-        .map(|bound| bound.as_ref().map(|te| type_refs.lower(te)))
-        .collect();
+    let generic_params = lower_generic_params(&data.generic_params, &mut type_refs);
 
     let fields = data
         .fields
@@ -164,9 +159,8 @@ fn lower<'db>(db: &'db dyn crate::Db, class: ClassLoc<'db>) -> (ClassData<'db>, 
     (
         ClassData {
             name: data.name.clone(),
-            generic_params: data.generic_params.clone(),
+            generic_params,
             type_refs: store,
-            generic_param_bounds,
             fields,
             methods: data
                 .methods

--- a/baml_language/crates/baml_compiler2_ppir/src/item_data/common.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/item_data/common.rs
@@ -5,8 +5,46 @@
 //! here rather than in `classes`/`functions`.
 
 use baml_base::Name;
-use baml_compiler2_hir::{item_tree::Attribute, type_ref::TypeRefId};
+use baml_compiler2_hir::{
+    item_tree::{Attribute, GenericParam},
+    type_ref::{TypeRefBuilder, TypeRefId},
+};
 use text_size::TextRange;
+
+/// A generic parameter on a function, class, interface, interface method
+/// signature, or out-of-body `implements` block, paired with its set of
+/// `&`-separated bounds. Mirrors
+/// [`item_tree::GenericParam`](baml_compiler2_hir::item_tree::GenericParam)
+/// with the bounds lowered into the owning item's type-ref arena.
+///
+/// The bound set is a **conjunction**: an argument for this parameter must
+/// satisfy every entry. Pairing the name with its bounds makes a length
+/// mismatch between the two unrepresentable.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GenericParamData {
+    pub name: Name,
+    pub bounds: Vec<TypeRefId>,
+}
+
+/// Lower a declaration's generic parameters into `type_refs`. Bounds are
+/// allocated in declaration order, so ids stay a pure function of the item's
+/// shape.
+pub(crate) fn lower_generic_params(
+    params: &[GenericParam],
+    type_refs: &mut TypeRefBuilder,
+) -> Vec<GenericParamData> {
+    params
+        .iter()
+        .map(|param| GenericParamData {
+            name: param.name.clone(),
+            bounds: param
+                .bounds
+                .iter()
+                .map(|bound| type_refs.lower(bound))
+                .collect(),
+        })
+        .collect()
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunctionParamData {

--- a/baml_language/crates/baml_compiler2_ppir/src/item_data/functions.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/item_data/functions.rs
@@ -7,7 +7,8 @@ use baml_compiler2_hir::{
 use text_size::TextRange;
 
 use crate::item_data::common::{
-    AssociatedTypeBindingData, AssociatedTypeBindingSourceMap, FunctionParamData,
+    AssociatedTypeBindingData, AssociatedTypeBindingSourceMap, FunctionParamData, GenericParamData,
+    lower_generic_params,
 };
 
 /// Span-free semantic data for a function's *signature*.
@@ -22,13 +23,12 @@ use crate::item_data::common::{
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FunctionData {
     pub name: Name,
-    pub generic_params: Vec<Name>,
+    /// Generic type parameters, each with its conjunction of bounds.
+    pub generic_params: Vec<GenericParamData>,
     /// Every type reference in this function's signature — bounds, parameter
     /// types, return type, throws. Scoped to the item, so edits to sibling items
     /// cannot renumber these ids.
     pub type_refs: TypeRefStore,
-    /// Parallel to `generic_params`. `Some` means `T extends <bound>`.
-    pub generic_param_bounds: Vec<Option<TypeRefId>>,
     pub params: Vec<FunctionParamData>,
     pub return_type: Option<TypeRefId>,
     pub throws: Option<TypeRefId>,
@@ -386,11 +386,7 @@ fn lower<'db>(
 
     let mut type_refs = TypeRefBuilder::new();
 
-    let generic_param_bounds = data
-        .generic_param_bounds
-        .iter()
-        .map(|bound| bound.as_ref().map(|te| type_refs.lower(te)))
-        .collect();
+    let generic_params = lower_generic_params(&data.generic_params, &mut type_refs);
 
     let params: Vec<FunctionParamData> = data
         .params
@@ -410,9 +406,8 @@ fn lower<'db>(
     (
         FunctionData {
             name: data.name.clone(),
-            generic_params: data.generic_params.clone(),
+            generic_params,
             type_refs: store,
-            generic_param_bounds,
             params,
             return_type,
             throws,

--- a/baml_language/crates/baml_compiler2_ppir/src/item_data/impls.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/item_data/impls.rs
@@ -1,4 +1,3 @@
-use baml_base::Name;
 use baml_compiler2_hir::{
     loc::{ClassLoc, FunctionLoc, ImplLoc},
     type_ref::{TypeRefBuilder, TypeRefId, TypeRefSourceMap, TypeRefStore},
@@ -6,8 +5,8 @@ use baml_compiler2_hir::{
 use text_size::TextRange;
 
 use crate::item_data::common::{
-    AssociatedTypeBindingData, AssociatedTypeBindingSourceMap, InterfaceFieldLinkData,
-    InterfaceFieldLinkSourceMap,
+    AssociatedTypeBindingData, AssociatedTypeBindingSourceMap, GenericParamData,
+    InterfaceFieldLinkData, InterfaceFieldLinkSourceMap, lower_generic_params,
 };
 
 /// What an `implements` block applies to.
@@ -29,15 +28,6 @@ pub enum ImplSubjectData<'db> {
         for_target: TypeRefId,
         generics: Vec<GenericParamData>,
     },
-}
-
-/// A generic parameter on an out-of-body `implements` block, paired with its
-/// `&`-separated interface bounds. Pairing name and bounds makes a length
-/// mismatch between the two unrepresentable.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct GenericParamData {
-    pub name: Name,
-    pub bounds: Vec<TypeRefId>,
 }
 
 /// Span-free semantic data for one `implements` block (either kind).
@@ -107,17 +97,7 @@ fn lower<'db>(
             generics,
         } => ImplSubjectData::Free {
             for_target: type_refs.lower(for_target),
-            generics: generics
-                .iter()
-                .map(|param| GenericParamData {
-                    name: param.name.clone(),
-                    bounds: param
-                        .bounds
-                        .iter()
-                        .map(|bound| type_refs.lower(bound))
-                        .collect(),
-                })
-                .collect(),
+            generics: lower_generic_params(generics, &mut type_refs),
         },
     };
 

--- a/baml_language/crates/baml_compiler2_ppir/src/item_data/interfaces.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/item_data/interfaces.rs
@@ -6,19 +6,20 @@ use baml_compiler2_hir::{
 };
 use text_size::TextRange;
 
-use crate::item_data::common::{FieldData, FunctionParamData};
+use crate::item_data::common::{
+    FieldData, FunctionParamData, GenericParamData, lower_generic_params,
+};
 
 /// Span-free semantic data for an `interface` declaration.
 #[derive(Debug, Clone, PartialEq, Eq, salsa::Update)]
 pub struct InterfaceData<'db> {
     pub name: Name,
-    pub generic_params: Vec<Name>,
+    /// Generic type parameters, each with its conjunction of bounds.
+    pub generic_params: Vec<GenericParamData>,
     /// Every type reference in this interface's signature — bounds, `requires`
     /// targets, field types, associated-type bounds and defaults, and required
     /// method signatures. Scoped to the item.
     pub type_refs: TypeRefStore,
-    /// Parallel to `generic_params`. `Some` means `T extends <bound>`.
-    pub generic_param_bounds: Vec<Option<TypeRefId>>,
     /// Targets of `requires I1, I2, …`.
     pub requires: Vec<TypeRefId>,
     /// Field signatures. Interface fields cannot have default values.
@@ -43,8 +44,8 @@ pub struct AssociatedTypeData {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InterfaceMethodSigData {
     pub name: Name,
-    pub generic_params: Vec<Name>,
-    pub generic_param_bounds: Vec<Option<TypeRefId>>,
+    /// Generic type parameters local to this method, each with its bounds.
+    pub generic_params: Vec<GenericParamData>,
     pub params: Vec<FunctionParamData>,
     pub return_type: Option<TypeRefId>,
     pub throws: Option<TypeRefId>,
@@ -125,11 +126,7 @@ fn lower<'db>(
 
     let mut type_refs = TypeRefBuilder::new();
 
-    let generic_param_bounds = data
-        .generic_param_bounds
-        .iter()
-        .map(|bound| bound.as_ref().map(|te| type_refs.lower(te)))
-        .collect();
+    let generic_params = lower_generic_params(&data.generic_params, &mut type_refs);
 
     let requires = data
         .requires
@@ -163,12 +160,7 @@ fn lower<'db>(
         .iter()
         .map(|method| InterfaceMethodSigData {
             name: method.name.clone(),
-            generic_params: method.generic_params.clone(),
-            generic_param_bounds: method
-                .generic_param_bounds
-                .iter()
-                .map(|bound| bound.as_ref().map(|te| type_refs.lower(te)))
-                .collect(),
+            generic_params: lower_generic_params(&method.generic_params, &mut type_refs),
             params: method
                 .params
                 .iter()
@@ -190,9 +182,8 @@ fn lower<'db>(
     (
         InterfaceData {
             name: data.name.clone(),
-            generic_params: data.generic_params.clone(),
+            generic_params,
             type_refs: store,
-            generic_param_bounds,
             requires,
             fields,
             associated_types,

--- a/baml_language/crates/baml_compiler2_ppir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/lib.rs
@@ -469,7 +469,6 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
                     let companion = ast::FunctionDef {
                         name: SmolStr::new(format!("{}$stream", func.name)),
                         generic_params: func.generic_params.clone(),
-                        generic_param_bounds: func.generic_param_bounds.clone(),
                         params: func.params.clone(),
                         defaults: func.defaults.clone(),
                         return_type: Some(companion_stream_return_type.clone()),
@@ -532,7 +531,6 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
                     let companion = ast::FunctionDef {
                         name: SmolStr::new(format!("{}$parse_stream", func.name)),
                         generic_params: func.generic_params.clone(),
-                        generic_param_bounds: func.generic_param_bounds.clone(),
                         params,
                         defaults: func.defaults.clone(),
                         return_type: Some(companion_stream_return_type),
@@ -742,14 +740,20 @@ pub fn elaborated_function_signature<'db>(
 
     let return_type = func_data.return_type.clone();
     let throws = func_data.throws.clone();
-    let reserved_effect_param_names = item_tree
+    let reserved_effect_param_names: Vec<Name> = item_tree
         .enclosing_type_generic_params(function.id(db))
-        .to_vec();
+        .iter()
+        .map(|param| param.name.clone())
+        .collect();
 
     Arc::new(
         baml_compiler2_hir::signature::elaborate_function_signature_parts(
             func_data.name.clone(),
-            func_data.generic_params.clone(),
+            func_data
+                .generic_params
+                .iter()
+                .map(|param| param.name.clone())
+                .collect(),
             &reserved_effect_param_names,
             params,
             return_type,

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -11398,22 +11398,27 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // own `self`) call `Self`-param methods, while a bare interface
                 // (existential) receiver still cannot. Each bound of an
                 // intersection (`T: A & B`) is tried in turn.
-                for iface in &bounds {
-                    if let Some(ty) = self.resolve_interface_member(
-                        InterfaceBound {
-                            name: &iface.name,
-                            type_args: &iface.generics,
-                            associated_bindings: &iface.associated_types,
-                        },
-                        SelfReceiver::RigidVar(name),
-                        MemberAccess { member, at, bound },
-                    ) {
-                        return ty;
-                    }
+                if let Some(ty) = self.resolve_interface_member_over_conjunction(
+                    &bounds,
+                    SelfReceiver::RigidVar(name),
+                    MemberAccess { member, at, bound },
+                ) {
+                    return ty;
                 }
-                // No bound declares the member — fall back to general member resolution
-                // on the first bound's existential view (single-bound today).
-                self.resolve_member(&bounds[0].to_ty(), member, at, bound)
+                // No conjunct declares the member. Reporting it here — rather than
+                // re-resolving against one arbitrarily chosen conjunct's existential
+                // view — keeps the answer independent of the order the bounds were
+                // written, and matches the projection arm below.
+                self.context.report_at_member_simple(
+                    TirTypeError::UnresolvedMember {
+                        base_type: base_ty.clone(),
+                        member: member.clone(),
+                    },
+                    at,
+                );
+                Ty::Error {
+                    attr: TyAttr::default(),
+                }
             }
             Ty::TypeVar(name, _) if member.as_str() == "from_json" => {
                 // Type-check: every BAML type has `from_json(j: json) -> Self` after Phase 5b.1.
@@ -11454,18 +11459,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                     projection_iface,
                     assoc,
                 );
-                for bound_iface in &bounds {
-                    if let Some(ty) = self.resolve_interface_member(
-                        InterfaceBound {
-                            name: &bound_iface.name,
-                            type_args: &bound_iface.generics,
-                            associated_bindings: &bound_iface.associated_types,
-                        },
-                        SelfReceiver::ExactTy(base_ty),
-                        MemberAccess { member, at, bound },
-                    ) {
-                        return ty;
-                    }
+                if let Some(ty) = self.resolve_interface_member_over_conjunction(
+                    &bounds,
+                    SelfReceiver::ExactTy(base_ty),
+                    MemberAccess { member, at, bound },
+                ) {
+                    return ty;
                 }
                 // No declared bound resolves the member — an unbounded (or wrongly
                 // bounded) projection has no members, same as any receiver missing it.

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -192,7 +192,9 @@ fn baml_iter_interface_qtn(name: &str) -> crate::ty::QualifiedTypeName {
 pub(crate) struct CalleeGenerics {
     pub(crate) class_params: Vec<crate::ty::ParamTy>,
     pub(crate) user_params: Vec<crate::ty::ParamTy>,
-    pub(crate) user_bounds: Vec<Option<Ty>>,
+    /// Parallel to `user_params`: each param's full `extends A & B` bound
+    /// conjunction, empty when the param is unbounded.
+    pub(crate) user_bounds: Vec<Vec<Ty>>,
     pub(crate) name: Name,
 }
 
@@ -271,7 +273,7 @@ pub(crate) fn callee_generics_for_func<'db>(
     let user_bounds = lower_generic_param_bound_refs(
         db,
         &func_data.type_refs,
-        &func_data.generic_param_bounds,
+        &func_data.generic_params,
         pkg_items,
         &pkg_info.namespace_path,
         &bound_scope,
@@ -287,61 +289,69 @@ pub(crate) fn callee_generics_for_func<'db>(
     }
 }
 
-/// Lower a declaration's generic-param bounds (`TypeRefId`s into `store`, from
-/// firewall data — `function_data` / `class_data` / …) to their `Ty`s, in
-/// declaration order (`None` for unbounded params).
+/// Lower each declared generic parameter's bound *conjunction* (`TypeRefId`s
+/// into `store`, from firewall data — `function_data` / `class_data` / …) to its
+/// `Ty`s, in declaration order.
+///
+/// The result is parallel to `params`; the inner `Vec` holds every
+/// `&`-separated conjunct the parameter declared and is empty when it is
+/// unbounded.
 #[expect(clippy::too_many_arguments)]
 pub(crate) fn lower_generic_param_bound_refs(
     db: &dyn crate::Db,
     store: &baml_compiler2_hir::type_ref::TypeRefStore,
-    bounds: &[Option<baml_compiler2_hir::type_ref::TypeRefId>],
+    params: &[baml_compiler2_ppir::item_data::GenericParamData],
     pkg_items: &PackageItems<'_>,
     ns_context: &[Name],
     generic_params: &[crate::ty::ParamTy],
     bindings: Option<&FxHashMap<crate::ty::ParamTy, Ty>>,
     diagnostics: &mut Vec<TirTypeError>,
-) -> Vec<Option<Ty>> {
+) -> Vec<Vec<Ty>> {
     // The in-scope names under `bindings` are the same for every bound — snapshot once.
     let binding_params: Vec<crate::ty::ParamTy> = bindings
         .map(|bindings| bindings.keys().cloned().collect())
         .unwrap_or_default();
-    bounds
+    params
         .iter()
-        .map(|bound| {
-            bound.map(|bound| {
-                if let Some(bindings) = bindings {
-                    crate::generics::substitute_ty(
-                        &crate::lower_type_expr::lower_constraint_head_type_ref(
+        .map(|param| {
+            param
+                .bounds
+                .iter()
+                .map(|&bound| {
+                    if let Some(bindings) = bindings {
+                        crate::generics::substitute_ty(
+                            &crate::lower_type_expr::lower_constraint_head_type_ref(
+                                store,
+                                bound,
+                                &crate::lower_type_expr::ScopeCtx {
+                                    db,
+                                    package_items: pkg_items,
+                                    ns_context,
+                                    generic_params: &binding_params,
+                                    bounds: &TypeVarBoundsMap::default(),
+                                    self_ty: None,
+                                },
+                                diagnostics,
+                            ),
+                            bindings,
+                        )
+                    } else {
+                        crate::lower_type_expr::lower_constraint_head_type_ref(
                             store,
                             bound,
                             &crate::lower_type_expr::ScopeCtx {
                                 db,
                                 package_items: pkg_items,
                                 ns_context,
-                                generic_params: &binding_params,
-                                bounds: &TypeVarBoundsMap::default(),
+                                generic_params,
+                                bounds: &crate::lower_type_expr::TypeVarBoundsMap::default(),
                                 self_ty: None,
                             },
                             diagnostics,
-                        ),
-                        bindings,
-                    )
-                } else {
-                    crate::lower_type_expr::lower_constraint_head_type_ref(
-                        store,
-                        bound,
-                        &crate::lower_type_expr::ScopeCtx {
-                            db,
-                            package_items: pkg_items,
-                            ns_context,
-                            generic_params,
-                            bounds: &crate::lower_type_expr::TypeVarBoundsMap::default(),
-                            self_ty: None,
-                        },
-                        diagnostics,
-                    )
-                }
-            })
+                        )
+                    }
+                })
+                .collect()
         })
         .collect()
 }
@@ -763,9 +773,10 @@ impl baml_type::normalize::TypeContext for TypeInferenceBuilder<'_> {
 
 /// A declared interface method's generics for call-site checking, keyed by the
 /// callee expression: the method name (for diagnostics), its generic-param names
-/// in declaration order, and their positional interface bounds (`None` for
-/// unbounded params, including the receiver/`Self` generic when it is unbounded).
-type InterfaceMethodGenerics = (Name, Vec<crate::ty::ParamTy>, Vec<Option<Ty>>);
+/// in declaration order, and their positional interface bounds — one entry per
+/// param holding the full `extends A & B` conjunction (empty for an unbounded
+/// param, including the receiver/`Self` generic when it is unbounded).
+type InterfaceMethodGenerics = (Name, Vec<crate::ty::ParamTy>, Vec<Vec<Ty>>);
 
 /// Per-scope inference builder.
 ///
@@ -2214,7 +2225,7 @@ impl<'db> TypeInferenceBuilder<'db> {
     fn callee_declared_generics(
         &self,
         callee_id: ExprId,
-    ) -> Option<(Vec<crate::ty::ParamTy>, Vec<Option<Ty>>, Name)> {
+    ) -> Option<(Vec<crate::ty::ParamTy>, Vec<Vec<Ty>>, Name)> {
         // Method calls on a local receiver (`rec.get<int>(...)`) parse as a
         // multi-segment Path callee, whose member resolution is recorded in
         // `path_member_resolutions` rather than `resolutions`. Only trust a
@@ -2293,7 +2304,7 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let mut declared_params: Vec<crate::ty::ParamTy> = class_params.to_vec();
         declared_params.extend(data.user_params.iter().cloned());
-        let mut declared_bounds: Vec<Option<Ty>> = vec![None; class_params.len()];
+        let mut declared_bounds: Vec<Vec<Ty>> = vec![Vec::new(); class_params.len()];
         declared_bounds.extend(data.user_bounds.iter().cloned());
         // A user bound that references an enclosing class param (`<U extends
         // Eq<C>>` on a method of `class Box<C>`) is lowered with `C` as a type
@@ -2355,10 +2366,10 @@ impl<'db> TypeInferenceBuilder<'db> {
         // generics, so the params to specialize — and their bounds — come from the
         // callee's *declaration* (resolved via the base expr). A non-declared
         // callee (a plain function value) has none.
-        let (generic_params, generic_param_bounds): (Vec<crate::ty::ParamTy>, Vec<Option<Ty>>) =
-            self.callee_declared_generics(base)
-                .map(|(params, bounds, _)| (params, bounds))
-                .unwrap_or_default();
+        let (generic_params, generic_param_bounds): (Vec<crate::ty::ParamTy>, Vec<Vec<Ty>>) = self
+            .callee_declared_generics(base)
+            .map(|(params, bounds, _)| (params, bounds))
+            .unwrap_or_default();
 
         if type_args.len() != generic_params.len() {
             self.context.report_simple(
@@ -2423,13 +2434,16 @@ impl<'db> TypeInferenceBuilder<'db> {
 
         let bindings = crate::generics::bind_type_vars(&generic_params, &resolved);
 
-        // Generic-bound enforcement: each supplied type arg must satisfy its
-        // param's declared bound. Substitute the bindings first so self-referential
-        // bounds (`<T extends Container<T>>`) resolve before the subtype check.
+        // Generic-bound enforcement: each supplied type arg must satisfy *every*
+        // bound its param declared (`T extends A & B` is a conjunction).
+        // Substitute the bindings first so self-referential bounds
+        // (`<T extends Container<T>>`) resolve before the subtype check.
         for (idx, resolved_arg) in resolved.iter().enumerate() {
-            if let Some(Some(bound)) = generic_param_bounds.get(idx)
-                && let Some(bound) = crate::generics::substitute_ty(bound, &bindings).as_interface()
-            {
+            for bound in generic_param_bounds.get(idx).into_iter().flatten() {
+                let Some(bound) = crate::generics::substitute_ty(bound, &bindings).as_interface()
+                else {
+                    continue;
+                };
                 if let Some(error) = self.bounded_type_arg_error(resolved_arg, &bound) {
                     self.context.report_simple(error, expr_id);
                 }
@@ -3803,7 +3817,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // function value (lambda/local) has none.
                 let (generic_params, generic_param_bounds): (
                     Vec<crate::ty::ParamTy>,
-                    Vec<Option<Ty>>,
+                    Vec<Vec<Ty>>,
                 ) = callee_expr
                     .and_then(|id| self.callee_declared_generics(id))
                     .map(|(params, bounds, _)| (params, bounds))
@@ -4050,18 +4064,21 @@ impl<'db> TypeInferenceBuilder<'db> {
                             let Some(actual) = bindings.get(param).cloned() else {
                                 continue;
                             };
-                            let Some(bound) =
-                                generic_param_bounds.get(idx).and_then(Option::as_ref)
-                            else {
-                                continue;
-                            };
-                            let bound = crate::generics::substitute_ty(bound, &bindings);
-                            self.infer_call_bindings_rigid_self(
-                                &bound,
-                                &actual,
-                                &mut bindings,
-                                rigid_self_var.as_ref(),
-                            );
+                            // Every conjunct can contribute bindings, so drive
+                            // inference through each. Cloned up front: the loop
+                            // mutates `bindings`, which `generic_param_bounds`
+                            // does not borrow but `substitute_ty` reads.
+                            let declared: Vec<Ty> =
+                                generic_param_bounds.get(idx).cloned().unwrap_or_default();
+                            for bound in &declared {
+                                let bound = crate::generics::substitute_ty(bound, &bindings);
+                                self.infer_call_bindings_rigid_self(
+                                    &bound,
+                                    &actual,
+                                    &mut bindings,
+                                    rigid_self_var.as_ref(),
+                                );
+                            }
                         }
                         if bindings == before {
                             break;
@@ -12755,9 +12772,11 @@ impl<'db> TypeInferenceBuilder<'db> {
                             ..
                         } = &target.type_refs[target.target].kind
                         {
-                            for (name, &arg) in iface_data.generic_params.iter().zip(generic_args) {
+                            for (declared, &arg) in
+                                iface_data.generic_params.iter().zip(generic_args)
+                            {
                                 let param = iface_env
-                                    .resolve_param(name)
+                                    .resolve_param(&declared.name)
                                     .expect("interface generic parameter is in its environment")
                                     .clone();
                                 let ty = {
@@ -13697,21 +13716,22 @@ impl<'db> TypeInferenceBuilder<'db> {
         &mut self,
         expr_id: ExprId,
         generic_params: &[crate::ty::ParamTy],
-        generic_param_bounds: &[Option<Ty>],
+        generic_param_bounds: &[Vec<Ty>],
         bindings: &FxHashMap<crate::ty::ParamTy, Ty>,
     ) {
         for (idx, param) in generic_params.iter().enumerate() {
-            let Some(bound) = generic_param_bounds.get(idx).and_then(Option::as_ref) else {
-                continue;
-            };
             let Some(actual) = bindings.get(param) else {
                 continue;
             };
-            let Some(bound) = crate::generics::substitute_ty(bound, bindings).as_interface() else {
-                continue;
-            };
-            if let Some(error) = self.bounded_type_arg_error(actual, &bound) {
-                self.context.report(error, expr_id, Vec::new());
+            // Each conjunct is a separate requirement; report every violation.
+            for bound in generic_param_bounds.get(idx).into_iter().flatten() {
+                let Some(bound) = crate::generics::substitute_ty(bound, bindings).as_interface()
+                else {
+                    continue;
+                };
+                if let Some(error) = self.bounded_type_arg_error(actual, &bound) {
+                    self.context.report(error, expr_id, Vec::new());
+                }
             }
         }
     }
@@ -13814,7 +13834,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.collect_named_generic_bound_errors(
             generic_env.params(),
             &class_data.type_refs,
-            &class_data.generic_param_bounds,
+            &class_data.generic_params,
             class_loc.file(db),
             type_args,
             errors,
@@ -13837,7 +13857,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.collect_named_generic_bound_errors(
             generic_params,
             &interface_data.type_refs,
-            &interface_data.generic_param_bounds,
+            &interface_data.generic_params,
             interface_loc.file(db),
             type_args,
             errors,
@@ -13848,7 +13868,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         &mut self,
         generic_params: &[crate::ty::ParamTy],
         type_refs: &baml_compiler2_hir::type_ref::TypeRefStore,
-        generic_param_bounds: &[Option<baml_compiler2_hir::type_ref::TypeRefId>],
+        declared_params: &[baml_compiler2_ppir::item_data::GenericParamData],
         file: SourceFile,
         type_args: &[Ty],
         errors: &mut Vec<TirTypeError>,
@@ -13868,7 +13888,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         let lowered_bounds = lower_generic_param_bound_refs(
             db,
             type_refs,
-            generic_param_bounds,
+            declared_params,
             pkg_items,
             &pkg_info.namespace_path,
             generic_params,
@@ -13881,15 +13901,16 @@ impl<'db> TypeInferenceBuilder<'db> {
             let Some(actual) = type_args.get(idx) else {
                 continue;
             };
-            let Some(bound) = lowered_bounds.get(idx).and_then(Option::as_ref) else {
-                continue;
-            };
-            let Some(bound) = crate::generics::substitute_ty(bound, &bindings).as_interface()
-            else {
-                continue;
-            };
-            if let Some(error) = self.bounded_type_arg_error(actual, &bound) {
-                errors.push(error);
+            // `T extends A & B` is a conjunction — the argument must satisfy
+            // every conjunct, so each is checked and reported independently.
+            for bound in lowered_bounds.get(idx).into_iter().flatten() {
+                let Some(bound) = crate::generics::substitute_ty(bound, &bindings).as_interface()
+                else {
+                    continue;
+                };
+                if let Some(error) = self.bounded_type_arg_error(actual, &bound) {
+                    errors.push(error);
+                }
             }
         }
     }

--- a/baml_language/crates/baml_compiler2_tir/src/builder/associated_projection.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/associated_projection.rs
@@ -604,10 +604,10 @@ fn associated_type_bound_interface(
         realized.generics.len(),
         iface.generic_params.len(),
     );
-    for (i, name) in iface.generic_params.iter().enumerate() {
+    for (i, declared) in iface.generic_params.iter().enumerate() {
         let arg = realized.generics.get(i).cloned().unwrap_or_else(error_ty);
         let param = generic_env
-            .resolve_param(name)
+            .resolve_param(&declared.name)
             .expect("interface generic parameter is in its environment")
             .clone();
         bindings.insert(param, arg);

--- a/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
@@ -340,21 +340,71 @@ impl<'db> TypeInferenceBuilder<'db> {
         recv: SelfReceiver<'_>,
         access: MemberAccess<'_>,
     ) -> Option<Ty> {
-        let pkg_items = self.resolve_class_pkg_items(bound.name.package())?;
-        let def = pkg_items.lookup_type(bound.name.namespace(), bound.name.name())?;
+        let declarers = self.member_declarers_for_bound(bound, access.member);
+        self.arbitrate_member_declarers(&declarers, recv, access)
+    }
+
+    /// Resolve `access.member` on a receiver bounded by a **conjunction** of interfaces
+    /// (`T extends A & B`, `type Assoc extends J & K`).
+    ///
+    /// Unlike a single bound's `requires` closure, the conjuncts are siblings: none
+    /// shadows another, so a member declared by two of them is ambiguous exactly as two
+    /// incomparable interfaces within one closure are. Collecting every conjunct's
+    /// declarers before arbitrating is what makes that visible — resolving conjunct by
+    /// conjunct and taking the first hit silently picks one.
+    ///
+    /// Each conjunct still applies its own root-wins tiering first, and the union is
+    /// deduped by realized identity, so overlaps that denote the *same* interface (`B`
+    /// requiring `A` with the member on `A`) stay unambiguous.
+    pub(super) fn resolve_interface_member_over_conjunction(
+        &mut self,
+        bounds: &[baml_type::Interface],
+        recv: SelfReceiver<'_>,
+        access: MemberAccess<'_>,
+    ) -> Option<Ty> {
+        let mut declarers: Vec<InterfaceView<'db>> = Vec::new();
+        for iface in bounds {
+            for view in self.member_declarers_for_bound(
+                InterfaceBound {
+                    name: &iface.name,
+                    type_args: &iface.generics,
+                    associated_bindings: &iface.associated_types,
+                },
+                access.member,
+            ) {
+                if !declarers.iter().any(|v| v.realized == view.realized) {
+                    declarers.push(view);
+                }
+            }
+        }
+        self.arbitrate_member_declarers(&declarers, recv, access)
+    }
+
+    /// Every interface in `bound`'s `requires` closure that declares `member`.
+    ///
+    /// Existential / type-var receiver: the concrete type is unknown, so a member may
+    /// come from `bound.name` OR any interface it transitively `requires`. Resolution
+    /// is *tiered*, matching the associated-type resolver `resolve_through_roots`: the
+    /// directly-named interface shadows the ones it requires (root-wins), but two
+    /// *incomparable* interfaces declaring the same member are ambiguous and must be
+    /// qualified (`recv.as<I>.member`). So resolve through the root when it declares
+    /// `member`; otherwise collect the closure interfaces that declare it.
+    fn member_declarers_for_bound(
+        &mut self,
+        bound: InterfaceBound<'_>,
+        member: &Name,
+    ) -> Vec<InterfaceView<'db>> {
+        let Some(pkg_items) = self.resolve_class_pkg_items(bound.name.package()) else {
+            return Vec::new();
+        };
+        let Some(def) = pkg_items.lookup_type(bound.name.namespace(), bound.name.name()) else {
+            return Vec::new();
+        };
         let Definition::Interface(root_loc) = def else {
-            return None;
+            return Vec::new();
         };
         let db = self.context.db();
 
-        // Existential / type-var receiver: the concrete type is unknown, so a member may
-        // come from `bound.name` OR any interface it transitively `requires`. Resolution
-        // is *tiered*, matching the associated-type resolver `resolve_through_roots`: the
-        // directly-named interface shadows the ones it requires (root-wins), but two
-        // *incomparable* interfaces declaring the same member are ambiguous and must be
-        // qualified (`recv.as<I>.member`). So resolve through the root when it declares
-        // `member`; otherwise collect the closure interfaces that declare it — one
-        // resolves, ≥2 are ambiguous, none is unresolved.
         // A rigid `Self` receiver resolves associated types symbolically — do NOT fill
         // an unbound associated type with its interface default (the implementor may
         // override it); the default is applied for concrete/existential receivers by
@@ -368,10 +418,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             false,
         );
         let mut declarers: Vec<InterfaceView<'db>> = Vec::new();
-        if self
-            .interface_member_kind(root_loc, access.member)
-            .is_some()
-        {
+        if self.interface_member_kind(root_loc, member).is_some() {
             // Direct tier: the root shadows everything it transitively requires.
             if let Some((loc, args, assoc)) = closure.iter().find(|(loc, _, _)| *loc == root_loc)
                 && let Some(qtn) = crate::interfaces::interface_loc_qtn(db, *loc)
@@ -388,7 +435,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 if *loc == root_loc {
                     continue;
                 }
-                if self.interface_member_kind(*loc, access.member).is_some()
+                if self.interface_member_kind(*loc, member).is_some()
                     && let Some(qtn) = crate::interfaces::interface_loc_qtn(db, *loc)
                 {
                     let realized = baml_type::Interface::new(qtn, args.clone(), assoc.clone());
@@ -401,8 +448,18 @@ impl<'db> TypeInferenceBuilder<'db> {
                 }
             }
         }
+        declarers
+    }
 
-        match declarers.as_slice() {
+    /// One declarer resolves; ≥2 are ambiguous; none is unresolved (`None`, so the
+    /// caller can fall through to its own not-found handling).
+    fn arbitrate_member_declarers(
+        &mut self,
+        declarers: &[InterfaceView<'db>],
+        recv: SelfReceiver<'_>,
+        access: MemberAccess<'_>,
+    ) -> Option<Ty> {
+        match declarers {
             [] => None,
             [one] => self.resolve_member_on_one_interface(one, recv, &access),
             // ≥2 incomparable interfaces declare `member`: resolving it would silently pick

--- a/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
@@ -97,9 +97,8 @@ pub(crate) struct InterfaceMethodSpec<'db> {
     return_type: SigTypeRef,
     throws: SigTypeRef,
     /// Method generic params with their interface-bound *conjunction* (`T extends A & B`),
-    /// unified. Currently at most one element per param — the parser surfaces only the first
-    /// conjunct — but a list so an override's bounds compare correctly once §3.6 lands.
-    generics: Vec<(Name, Vec<baml_compiler2_hir::type_ref::TypeRefId>)>,
+    /// unified — every conjunct is kept, so an override's bounds compare as sets.
+    generics: Vec<baml_compiler2_ppir::item_data::GenericParamData>,
 }
 
 impl<'db> InterfaceMethodSpec<'db> {
@@ -124,17 +123,9 @@ impl<'db> InterfaceMethodSpec<'db> {
                 SigTypeRef::Id(p.type_ref),
             )
         }));
-        let generics = sig
-            .user_generic_params
-            .iter()
-            .cloned()
-            .zip(
-                func_data
-                    .generic_param_bounds
-                    .iter()
-                    .map(|bound| bound.iter().copied().collect()),
-            )
-            .collect();
+        // `user_generic_params` is the elaborated view of the same declaration
+        // list, so the declaration's params carry the bounds in the same order.
+        let generics = func_data.generic_params.clone();
         Self {
             sig_refs: &sig.type_refs,
             bound_refs: &func_data.type_refs,
@@ -155,16 +146,7 @@ impl<'db> InterfaceMethodSpec<'db> {
             let ty = p.type_ref.map_or(SigTypeRef::Missing, SigTypeRef::Id);
             (is_self, p.has_default, p.name.clone(), ty)
         }));
-        let generics = sig
-            .generic_params
-            .iter()
-            .cloned()
-            .zip(
-                sig.generic_param_bounds
-                    .iter()
-                    .map(|bound| bound.iter().copied().collect()),
-            )
-            .collect();
+        let generics = sig.generic_params.clone();
         Self {
             sig_refs: &iface_data.type_refs,
             bound_refs: &iface_data.type_refs,
@@ -179,14 +161,17 @@ impl<'db> InterfaceMethodSpec<'db> {
     /// The method's own generic parameter names — in scope (as free type variables) when
     /// lowering this spec's signature through a context.
     pub(crate) fn generic_param_names(&self) -> Vec<Name> {
-        self.generics.iter().map(|(name, _)| name.clone()).collect()
+        self.generics
+            .iter()
+            .map(|param| param.name.clone())
+            .collect()
     }
 
     /// The method's generic parameters paired with their interface-bound conjunction
     /// (declaration order, ids into [`Self::bound_store`]) — so an override's bounds can be
     /// checked against the interface method's (an implementation may not add a requirement
     /// the interface does not declare).
-    pub(crate) fn generic_bounds(&self) -> &[(Name, Vec<baml_compiler2_hir::type_ref::TypeRefId>)] {
+    pub(crate) fn generic_bounds(&self) -> &[baml_compiler2_ppir::item_data::GenericParamData] {
         &self.generics
     }
 
@@ -1268,7 +1253,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             SelfReceiver::RigidVar(pin) => Some(pin.clone()),
             _ => None,
         };
-        let generic_names: Vec<Name> = spec.generics.iter().map(|(name, _)| name.clone()).collect();
+        let generic_names: Vec<Name> = spec.generic_param_names();
 
         let symbolic_receiver =
             !access.bound && !matches!(recv, SelfReceiver::ExactTy(_) | SelfReceiver::Union(_));
@@ -1365,10 +1350,10 @@ impl<'db> TypeInferenceBuilder<'db> {
         // enforcement works without the function type carrying them: the receiver generic
         // is bounded by the interface, the method's own params by their declared bounds.
         let mut function_generic_params = Vec::new();
-        let mut function_generic_param_bounds: Vec<Option<Ty>> = Vec::new();
+        let mut function_generic_param_bounds: Vec<Vec<Ty>> = Vec::new();
         if let Some(receiver_generic) = &receiver_generic {
             function_generic_params.push(receiver_generic.clone());
-            function_generic_param_bounds.push(Some(iface_ty.clone()));
+            function_generic_param_bounds.push(vec![iface_ty.clone()]);
             // The synthetic receiver bound is an interface; store it as the conjunction.
             self.generic_param_bounds.insert(
                 receiver_generic.clone(),
@@ -1376,19 +1361,10 @@ impl<'db> TypeInferenceBuilder<'db> {
             );
         }
         function_generic_params.extend(method_generic_params);
-        // Call-site bound enforcement (`function_generic_param_bounds: Vec<Option<Ty>>`) is still
-        // single-bound; take the first conjunct until that path is retyped to a conjunction
-        // (currently a no-op — the parser surfaces at most one). Conformance (E0120) reads the
-        // full conjunction via `generic_bounds()`.
-        let bound_ids: Vec<Option<baml_compiler2_hir::type_ref::TypeRefId>> = spec
-            .generics
-            .iter()
-            .map(|(_, bound)| bound.first().copied())
-            .collect();
         function_generic_param_bounds.extend(lower_generic_param_bound_refs(
             db,
             spec.bound_store(),
-            &bound_ids,
+            spec.generic_bounds(),
             pkg_items,
             &ns,
             &all_generic_params,
@@ -1429,8 +1405,8 @@ impl<'db> TypeInferenceBuilder<'db> {
         let owner_type_arg_bindings = data
             .generic_params
             .iter()
-            .filter_map(|name| {
-                let param = interface_env.resolve_param(name)?;
+            .filter_map(|declared| {
+                let param = interface_env.resolve_param(&declared.name)?;
                 bindings.get(param).cloned().map(|ty| (param.clone(), ty))
             })
             .collect::<Vec<_>>();

--- a/baml_language/crates/baml_compiler2_tir/src/generic_env.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/generic_env.rs
@@ -6,8 +6,26 @@ use baml_compiler2_hir::{
     loc::{ClassLoc, FunctionLoc, ImplLoc, InterfaceLoc},
     type_ref::{TypeRefId, TypeRefStore},
 };
+use baml_compiler2_ppir::item_data::GenericParamData;
 
 use crate::ty::{ParamTy, Ty, TyAttr};
+
+/// A declared parameter's name paired with every bound it carries, as
+/// `BoundSource`s into `store`. The bounds are a conjunction — all of them are
+/// kept, so `T extends A & B` constrains `T` by both.
+fn bound_sources<'db>(
+    param: &GenericParamData,
+    store: &'db TypeRefStore,
+) -> (Name, Vec<BoundSource<'db>>) {
+    (
+        param.name.clone(),
+        param
+            .bounds
+            .iter()
+            .map(|&id| BoundSource::Ref(store, id))
+            .collect(),
+    )
+}
 
 /// One declared generic bound before it is lowered in the complete generic scope.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -75,31 +93,17 @@ impl<'db> GenericEnv<'db> {
 
     fn from_refs(
         parent: Option<Self>,
-        params: &[Name],
+        params: &[GenericParamData],
         store: &'db TypeRefStore,
-        bounds: &[Option<TypeRefId>],
     ) -> Self {
         Self::from_sources(
             parent,
-            params.iter().enumerate().map(|(index, name)| {
-                let bounds = bounds
-                    .get(index)
-                    .copied()
-                    .flatten()
-                    .map(|id| BoundSource::Ref(store, id))
-                    .into_iter()
-                    .collect();
-                (name.clone(), bounds)
-            }),
+            params.iter().map(|param| bound_sources(param, store)),
         )
     }
 
-    pub(crate) fn root_refs(
-        params: &[Name],
-        store: &'db TypeRefStore,
-        bounds: &[Option<TypeRefId>],
-    ) -> Self {
-        Self::from_refs(None, params, store, bounds)
+    pub(crate) fn root_refs(params: &[GenericParamData], store: &'db TypeRefStore) -> Self {
+        Self::from_refs(None, params, store)
     }
 
     #[cfg(test)]
@@ -107,43 +111,33 @@ impl<'db> GenericEnv<'db> {
         Self::from_sources(None, params.iter().cloned().map(|name| (name, Vec::new())))
     }
 
-    pub(crate) fn child_refs(
-        &self,
-        params: &[Name],
-        store: &'db TypeRefStore,
-        bounds: &[Option<TypeRefId>],
-    ) -> Self {
-        Self::from_refs(Some(self.clone()), params, store, bounds)
+    pub(crate) fn child_refs(&self, params: &[GenericParamData], store: &'db TypeRefStore) -> Self {
+        Self::from_refs(Some(self.clone()), params, store)
     }
 
     #[expect(
         deprecated,
         reason = "the one sanctioned Ast producer until the body TypeRef migration"
     )]
-    pub(crate) fn child_unique_ast(
-        &self,
-        params: &[Name],
-        bounds: &[Option<ast::TypeExpr>],
-    ) -> Self {
+    pub(crate) fn child_unique_ast(&self, params: &[ast::GenericParam]) -> Self {
         let mut visible: Vec<_> = self
             .source_params()
             .iter()
             .map(|param| param.name().clone())
             .collect();
-        let own = params.iter().enumerate().filter_map(|(index, name)| {
-            if visible.contains(name) {
+        let own = params.iter().filter_map(|param| {
+            if visible.contains(&param.name) {
                 return None;
             }
-            visible.push(name.clone());
+            visible.push(param.name.clone());
             Some((
-                name.clone(),
-                bounds
-                    .get(index)
+                param.name.clone(),
+                param
+                    .bounds
+                    .iter()
                     .cloned()
-                    .flatten()
                     .map(BoundSource::Ast)
-                    .into_iter()
-                    .collect(),
+                    .collect::<Vec<_>>(),
             ))
         });
         Self::from_sources(Some(self.clone()), own)
@@ -256,11 +250,7 @@ pub(crate) fn class_generic_env<'db>(
     class: ClassLoc<'db>,
 ) -> GenericEnv<'db> {
     let data = baml_compiler2_ppir::item_data::class_data(db, class);
-    GenericEnv::root_refs(
-        &data.generic_params,
-        &data.type_refs,
-        &data.generic_param_bounds,
-    )
+    GenericEnv::root_refs(&data.generic_params, &data.type_refs)
 }
 
 pub(crate) fn interface_generic_env<'db>(
@@ -271,17 +261,11 @@ pub(crate) fn interface_generic_env<'db>(
     let self_name = Name::new("Self");
     let mut params = Vec::with_capacity(1 + data.generic_params.len());
     params.push((self_name, Vec::new()));
-    for (index, name) in data.generic_params.iter().enumerate() {
-        let bounds = data
-            .generic_param_bounds
-            .get(index)
-            .copied()
-            .flatten()
-            .map(|id| BoundSource::Ref(&data.type_refs, id))
-            .into_iter()
-            .collect();
-        params.push((name.clone(), bounds));
-    }
+    params.extend(
+        data.generic_params
+            .iter()
+            .map(|param| bound_sources(param, &data.type_refs)),
+    );
     let env = GenericEnv::from_sources(None, params)
         .with_associated_params(data.associated_types.iter().map(|assoc| assoc.name.clone()));
     let qtn = crate::lower_type_expr::qualify_def(
@@ -318,16 +302,9 @@ pub(crate) fn impl_generic_env<'db>(
         baml_compiler2_ppir::item_data::ImplSubjectData::Free { generics, .. } => {
             GenericEnv::from_sources(
                 None,
-                generics.iter().map(|param| {
-                    let bounds = param
-                        .bounds
-                        .first()
-                        .copied()
-                        .map(|id| BoundSource::Ref(&data.type_refs, id))
-                        .into_iter()
-                        .collect();
-                    (param.name.clone(), bounds)
-                }),
+                generics
+                    .iter()
+                    .map(|param| bound_sources(param, &data.type_refs)),
             )
         }
     }
@@ -351,16 +328,8 @@ pub(crate) fn function_generic_env<'db>(
         None => None,
     };
     let env = match parent {
-        Some(parent) => parent.child_refs(
-            &data.generic_params,
-            &data.type_refs,
-            &data.generic_param_bounds,
-        ),
-        None => GenericEnv::root_refs(
-            &data.generic_params,
-            &data.type_refs,
-            &data.generic_param_bounds,
-        ),
+        Some(parent) => parent.child_refs(&data.generic_params, &data.type_refs),
+        None => GenericEnv::root_refs(&data.generic_params, &data.type_refs),
     };
     let sig = baml_compiler2_ppir::item_data::elaborated_function_data(db, function);
     env.with_additional_own_unbounded(&sig.synthetic_effect_params)

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -384,10 +384,12 @@ fn lower_env_interface_bounds(
         let mut diags = Vec::new();
         let bound_ty = lower_bound_source(bound, &scope, &mut diags);
         if let Some(constraint) = bound_ty.as_interface() {
-            // Inner declarations are visited after their parents. Shadowing is
-            // diagnosed separately, and the inner declaration remains the
-            // recovery binding used by the rest of inference.
-            bounds.insert(param.clone(), vec![constraint]);
+            // One predicate per conjunct, so `T extends A & B` visits `T` twice
+            // — accumulate rather than replace. Distinct parameters never
+            // collide here (`ParamTy` keys on index as well as name), so a
+            // shadowing inner declaration gets its own entry; the shadow itself
+            // is diagnosed separately.
+            bounds.entry(param.clone()).or_default().push(constraint);
         }
     });
     if include_concrete && let Some((param, constraint)) = env.self_bound() {
@@ -399,19 +401,22 @@ fn lower_env_interface_bounds(
 /// Report each generic parameter declared more than once in a single declaration
 /// list (`<T, T>`). A name reused across *nested* scopes is not a duplicate but a
 /// shadow, reported as `TypeParamShadowed` at the inner declaration instead.
-fn report_duplicate_generic_params(
+fn report_duplicate_generic_params<'a>(
     builder: &TypeInferenceBuilder<'_>,
-    params: &[Name],
+    params: impl IntoIterator<Item = &'a Name>,
     span: TextRange,
 ) {
-    for (idx, param) in params.iter().enumerate() {
-        if params[..idx].contains(param) {
+    let mut seen: Vec<&Name> = Vec::new();
+    for param in params {
+        if seen.contains(&param) {
             builder.report_at_span(
                 crate::infer_context::TirTypeError::DuplicateGenericParam {
                     name: param.clone(),
                 },
                 span,
             );
+        } else {
+            seen.push(param);
         }
     }
 }
@@ -582,7 +587,12 @@ fn install_generic_param_bounds(
             span,
             param.index() >= env.parent_count(),
         );
-        bounds.insert(param.clone(), constraint.into_vec());
+        // One predicate per conjunct — accumulate so `T extends A & B` enforces
+        // both, rather than only whichever was visited last.
+        bounds
+            .entry(param.clone())
+            .or_default()
+            .extend(constraint.into_vec());
     });
     if let Some((param, constraint)) = env.self_bound() {
         bounds.insert(param.clone(), vec![constraint.clone()]);
@@ -668,7 +678,7 @@ fn validate_type_ref_generic_bounds_at_span(
 /// so collapsing this call would silently change what `Self` resolves to inside
 /// a lambda body.
 fn lambda_body_env<'db>(env: &GenericEnv<'db>) -> GenericEnv<'db> {
-    env.child_unique_ast(&[], &[])
+    env.child_unique_ast(&[])
 }
 
 fn add_lambda_params_to_builder(
@@ -1385,9 +1395,13 @@ pub fn infer_scope_types<'db>(
 
                 let env = crate::generic_env::function_generic_env(db, func_loc).clone();
                 report_duplicate_generic_params(&builder, &sig.user_generic_params, func_span);
-                let report_type_shadowing = |owner, type_name: &Name, parent_params: &[Name]| {
+                let report_type_shadowing = |owner,
+                                             type_name: &Name,
+                                             parent_params: &[
+                    baml_compiler2_ppir::item_data::GenericParamData
+                ]| {
                     for param in &sig.user_generic_params {
-                        if !parent_params.contains(param) {
+                        if !parent_params.iter().any(|parent| &parent.name == param) {
                             continue;
                         }
                         builder.report_at_span(
@@ -1584,11 +1598,11 @@ pub fn infer_scope_types<'db>(
                                 ..
                             } = &target.type_refs[target.target].kind
                             {
-                                for (param, &arg) in
+                                for (declared, &arg) in
                                     iface_data.generic_params.iter().zip(generic_args.iter())
                                 {
                                     let param = iface_env
-                                        .resolve_param(param)
+                                        .resolve_param(&declared.name)
                                         .expect("interface generic parameter is in its environment")
                                         .clone();
                                     let mut arg_diags = Vec::new();
@@ -2169,7 +2183,11 @@ pub fn infer_scope_types<'db>(
                 let class_data = baml_compiler2_ppir::item_data::class_data(db, class_loc);
                 let class_sm = baml_compiler2_ppir::item_data::class_source_map(db, class_loc);
                 let class_span = class_sm.span;
-                report_duplicate_generic_params(&builder, &class_data.generic_params, class_span);
+                report_duplicate_generic_params(
+                    &builder,
+                    class_data.generic_params.iter().map(|param| &param.name),
+                    class_span,
+                );
                 let env = crate::generic_env::class_generic_env(db, class_loc).clone();
                 apply_generic_env(
                     db,
@@ -2195,14 +2213,22 @@ pub fn infer_scope_types<'db>(
                 let (_, iface_generic_params) = iface_env.interface_param_parts();
                 let iface_sm = baml_compiler2_ppir::item_data::interface_source_map(db, iface_loc);
                 let iface_span = iface_sm.span;
-                report_duplicate_generic_params(&builder, &iface_data.generic_params, iface_span);
+                report_duplicate_generic_params(
+                    &builder,
+                    iface_data.generic_params.iter().map(|param| &param.name),
+                    iface_span,
+                );
                 // Associated types share the interface's type-level namespace with its
                 // generic parameters (a bare `Assoc` reference lowers as a type variable),
                 // so a name collision — with a parameter or another associated type —
                 // would silently alias the two. Both are declaration errors.
                 for (idx, assoc) in iface_data.associated_types.iter().enumerate() {
                     let name_span = iface_sm.associated_type_spans[idx].name_span;
-                    if iface_data.generic_params.contains(&assoc.name) {
+                    if iface_data
+                        .generic_params
+                        .iter()
+                        .any(|param| param.name == assoc.name)
+                    {
                         builder.report_at_span(
                             crate::infer_context::TirTypeError::AssociatedTypeConflictsWithGenericParam {
                                 name: assoc.name.clone(),
@@ -2443,9 +2469,15 @@ pub fn infer_scope_types<'db>(
                     // hygiene checks that the function arm runs for default methods
                     // happen here: no `<T, T>`, and no shadowing of the interface's
                     // type-level parameters (generics and associated types alike).
-                    report_duplicate_generic_params(&builder, &sig.generic_params, sig_span);
-                    for mp in &sig.generic_params {
-                        if iface_params.iter().any(|ip| ip == mp) || iface_assoc_names.contains(mp)
+                    report_duplicate_generic_params(
+                        &builder,
+                        sig.generic_params.iter().map(|param| &param.name),
+                        sig_span,
+                    );
+                    for declared in &sig.generic_params {
+                        let mp = &declared.name;
+                        if iface_params.iter().any(|ip| &ip.name == mp)
+                            || iface_assoc_names.contains(mp)
                         {
                             builder.report_at_span(
                                 crate::infer_context::TirTypeError::TypeParamShadowed {
@@ -2457,11 +2489,7 @@ pub fn infer_scope_types<'db>(
                             );
                         }
                     }
-                    let sig_env = iface_env.child_refs(
-                        &sig.generic_params,
-                        &iface_data.type_refs,
-                        &sig.generic_param_bounds,
-                    );
+                    let sig_env = iface_env.child_refs(&sig.generic_params, &iface_data.type_refs);
                     apply_generic_env(
                         db,
                         &mut builder,

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
@@ -934,6 +934,41 @@ pub fn interface_closure_locs<'db>(
     out
 }
 
+/// Every interface reachable from `roots` (each root plus its transitive
+/// `requires` closure) that declares an associated type named `member`.
+///
+/// `roots` is a *conjunction* — the bounds of one type variable (`T extends A &
+/// B`). Deduplication is shared across all of them, so a declarer two conjuncts
+/// both reach through `requires` is counted **once**: that is one declarer, not
+/// an ambiguity. Deduplicating per root and pooling afterwards is the bug this
+/// exists to prevent.
+///
+/// Order is stable — roots in the order given, each root's closure in BFS order
+/// — so a caller rendering these into a diagnostic gets a deterministic list.
+pub fn interfaces_declaring_associated_type<'db>(
+    db: &'db dyn crate::Db,
+    roots: impl IntoIterator<Item = baml_compiler2_hir::loc::InterfaceLoc<'db>>,
+    member: &baml_base::Name,
+) -> Vec<baml_compiler2_hir::loc::InterfaceLoc<'db>> {
+    let mut out = Vec::new();
+    let mut seen: FxHashSet<baml_compiler2_hir::loc::InterfaceLoc<'db>> = FxHashSet::default();
+    for root in roots {
+        for loc in interface_closure_locs(db, root) {
+            if !seen.insert(loc) {
+                continue;
+            }
+            if baml_compiler2_ppir::item_data::interface_data(db, loc)
+                .associated_types
+                .iter()
+                .any(|assoc| assoc.name == *member)
+            {
+                out.push(loc);
+            }
+        }
+    }
+    out
+}
+
 /// Walk the transitive `requires` closure of `root_iface`, carrying the concrete
 /// generic arguments for each interface in the closure. For example,
 /// `Child<int> requires Parent<T>` yields `(Child, [int])` and `(Parent, [int])`.

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
@@ -325,14 +325,12 @@ pub fn impl_data<'db>(
             let mut class_bound_diags = Vec::new();
             let generic_params: Vec<(ParamTy, Vec<baml_type::Interface>)> = generic_param_names
                 .iter()
-                .zip(class_data.generic_param_bounds.iter())
-                .map(|(name, bound)| {
-                    let bounds: Vec<baml_compiler2_hir::type_ref::TypeRefId> =
-                        bound.iter().copied().collect();
+                .zip(class_data.generic_params.iter())
+                .map(|(name, declared)| {
                     let ifaces = lower_generic_param_interface_bounds(
                         db,
                         &class_data.type_refs,
-                        &bounds,
+                        &declared.bounds,
                         pkg_items,
                         ns,
                         &generic_param_names,
@@ -915,8 +913,9 @@ fn method_generic_bound_interfaces(
     let empty = crate::lower_type_expr::TypeVarBoundsMap::default();
     spec.generic_bounds()
         .iter()
-        .map(|(name, bound_ids)| {
-            let conjunction = bound_ids
+        .map(|declared| {
+            let conjunction = declared
+                .bounds
                 .iter()
                 .filter_map(|&id| {
                     let mut d = Vec::new();
@@ -936,7 +935,7 @@ fn method_generic_bound_interfaces(
                     .as_interface()
                 })
                 .collect();
-            (name.clone(), conjunction)
+            (declared.name.clone(), conjunction)
         })
         .collect()
 }

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -715,8 +715,7 @@ fn validate_associated_type_bindings_in_items(
                 );
             }
             baml_compiler2_ast::Item::Class(class) => {
-                let outer_bounds =
-                    generic_bound_expr_map(&class.generic_params, &class.generic_param_bounds);
+                let outer_bounds = generic_bound_expr_map(&class.generic_params);
                 for method in &class.methods {
                     validate_associated_type_bindings_in_function(
                         db,
@@ -744,8 +743,7 @@ fn validate_associated_type_bindings_in_items(
             }
             baml_compiler2_ast::Item::Interface(iface) => {
                 validate_associated_type_declaration_names(file_id, iface, &mut diagnostics);
-                let iface_bounds =
-                    generic_bound_expr_map(&iface.generic_params, &iface.generic_param_bounds);
+                let iface_bounds = generic_bound_expr_map(&iface.generic_params);
                 for method in &iface.required_methods {
                     validate_associated_type_bindings_in_method_sig(
                         db,
@@ -770,19 +768,7 @@ fn validate_associated_type_bindings_in_items(
                 }
             }
             baml_compiler2_ast::Item::ImplementsFor(imp) => {
-                let impl_generics: Vec<Name> = imp
-                    .generic_params
-                    .iter()
-                    .map(|(name, _)| name.clone())
-                    .collect();
-                // Single-bound view (first `&`-bound only) — unchanged behavior;
-                // the full bound set lives on the new HIR `ImplBlock`.
-                let impl_bound_exprs: Vec<Option<baml_compiler2_ast::TypeExpr>> = imp
-                    .generic_params
-                    .iter()
-                    .map(|(_, bounds)| bounds.first().cloned())
-                    .collect();
-                let impl_bounds = generic_bound_expr_map(&impl_generics, &impl_bound_exprs);
+                let impl_bounds = generic_bound_expr_map(&imp.generic_params);
                 for method in &imp.methods {
                     validate_associated_type_bindings_in_function(
                         db,
@@ -811,7 +797,7 @@ fn validate_associated_type_declaration_names(
         if iface
             .generic_params
             .iter()
-            .any(|param| param == &assoc.name)
+            .any(|param| param.name == assoc.name)
         {
             diagnostics.push(
                 Diagnostic::error(
@@ -831,26 +817,25 @@ fn validate_associated_type_declaration_names(
     }
 }
 
-type GenericBoundExprMap = std::collections::HashMap<Name, baml_compiler2_ast::TypeExpr>;
+/// Each in-scope type variable's declared bound *conjunction* — `T extends A & B`
+/// maps `T` to `[A, B]`, so a `T.member` projection is resolved against all of
+/// them (and reports ambiguity when more than one supplies `member`).
+type GenericBoundExprMap = std::collections::HashMap<Name, Vec<baml_compiler2_ast::TypeExpr>>;
 
-fn generic_bound_expr_map(
-    params: &[Name],
-    bounds: &[Option<baml_compiler2_ast::TypeExpr>],
-) -> GenericBoundExprMap {
+fn generic_bound_expr_map(params: &[baml_compiler2_ast::GenericParam]) -> GenericBoundExprMap {
     params
         .iter()
-        .zip(bounds.iter())
-        .filter_map(|(name, bound)| bound.as_ref().map(|bound| (name.clone(), bound.clone())))
+        .filter(|param| !param.bounds.is_empty())
+        .map(|param| (param.name.clone(), param.bounds.clone()))
         .collect()
 }
 
 fn extend_generic_bound_expr_map(
     outer: &GenericBoundExprMap,
-    params: &[Name],
-    bounds: &[Option<baml_compiler2_ast::TypeExpr>],
+    params: &[baml_compiler2_ast::GenericParam],
 ) -> GenericBoundExprMap {
     let mut merged = outer.clone();
-    merged.extend(generic_bound_expr_map(params, bounds));
+    merged.extend(generic_bound_expr_map(params));
     merged
 }
 
@@ -863,11 +848,8 @@ fn validate_associated_type_bindings_in_function(
     namespace_path: &[Name],
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let generic_bounds = extend_generic_bound_expr_map(
-        outer_generic_bounds,
-        &function.generic_params,
-        &function.generic_param_bounds,
-    );
+    let generic_bounds =
+        extend_generic_bound_expr_map(outer_generic_bounds, &function.generic_params);
     for param in &function.params {
         if let Some(te) = &param.type_expr {
             validate_ambiguous_typevar_associated_projection_in_type_expr(
@@ -917,11 +899,8 @@ fn validate_associated_type_bindings_in_method_sig(
     namespace_path: &[Name],
     diagnostics: &mut Vec<Diagnostic>,
 ) {
-    let generic_bounds = extend_generic_bound_expr_map(
-        outer_generic_bounds,
-        &method.generic_params,
-        &method.generic_param_bounds,
-    );
+    let generic_bounds =
+        extend_generic_bound_expr_map(outer_generic_bounds, &method.generic_params);
     for param in &method.params {
         if let Some(te) = &param.type_expr {
             validate_ambiguous_typevar_associated_projection_in_type_expr(
@@ -970,7 +949,7 @@ fn validate_ambiguous_typevar_associated_projection_in_type_expr(
     span: TextRange,
     pkg_items: &baml_compiler2_hir::package::PackageItems<'_>,
     namespace_path: &[Name],
-    generic_bounds: &std::collections::HashMap<Name, baml_compiler2_ast::TypeExpr>,
+    generic_bounds: &GenericBoundExprMap,
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     use baml_compiler2_ast::TypeExprKind;
@@ -986,19 +965,34 @@ fn validate_ambiguous_typevar_associated_projection_in_type_expr(
             {
                 let base = &segments[0];
                 let member = &segments[1];
-                if let Some(bound) = generic_bounds.get(base) {
-                    let sources = associated_type_projection_sources_for_interface_bound(
-                        db,
-                        bound,
-                        member,
-                        pkg_items,
-                        namespace_path,
-                    );
+                if let Some(bounds) = generic_bounds.get(base) {
+                    // `T extends A & B` — the member may come from any conjunct,
+                    // so the sources are pooled: none means unknown, and two or
+                    // more (whether from one bound or across bounds) is ambiguous.
+                    let sources: Vec<_> = bounds
+                        .iter()
+                        .flat_map(|bound| {
+                            associated_type_projection_sources_for_interface_bound(
+                                db,
+                                bound,
+                                member,
+                                pkg_items,
+                                namespace_path,
+                            )
+                        })
+                        .collect();
                     if sources.is_empty() {
+                        let rendered = bounds
+                            .iter()
+                            .map(ToString::to_string)
+                            .collect::<Vec<_>>()
+                            .join(" & ");
                         diagnostics.push(
                             Diagnostic::error(
                                 DiagnosticId::UnknownType,
-                                format!("unknown associated type `{member}` for bound `{bound}`"),
+                                format!(
+                                    "unknown associated type `{member}` for bound `{rendered}`"
+                                ),
                             )
                             .with_primary_span(Span {
                                 file_id,

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -30,7 +30,7 @@ use baml_compiler2_hir::{file_semantic_index, scope::ScopeKind};
 use baml_compiler2_tir::{
     infer_context::{DiagnosticLocation, TirTypeError},
     inference::render_scope_diagnostics,
-    ty::{ParamTy, QualifiedTypeName, Ty, TyAttr},
+    ty::{ParamTy, Ty, TyAttr},
 };
 use indexmap::IndexMap;
 use text_size::{TextRange, TextSize};
@@ -644,51 +644,23 @@ fn impl_diagnostic_spans(
 ///
 /// Returns `None` if the path doesn't name an interface (including: name
 /// doesn't exist, or resolves to a class/enum/etc.).
-#[derive(Debug, Clone)]
-struct ResolvedInterfaceData<'db> {
-    loc: baml_compiler2_hir::loc::InterfaceLoc<'db>,
-    qtn: QualifiedTypeName,
-}
-
+/// The interface an `extends` bound names, or `None` when it does not resolve to
+/// one (diagnosed elsewhere). Only the `loc` is needed: rendering a declarer's
+/// name goes through the compiler's `interface_loc_qtn`, so this does not carry
+/// a second copy of the identity.
 fn resolve_interface_path<'db>(
     db: &'db dyn Db,
     target: &baml_compiler2_ast::TypeExpr,
     pkg_items: &baml_compiler2_hir::package::PackageItems<'db>,
     namespace_path: &[Name],
-) -> Option<ResolvedInterfaceData<'db>> {
-    let resolved = baml_compiler2_tir::interfaces::resolve_path_to_interface_identity(
+) -> Option<baml_compiler2_hir::loc::InterfaceLoc<'db>> {
+    baml_compiler2_tir::interfaces::resolve_path_to_interface_identity(
         db,
         target,
         pkg_items,
         namespace_path,
-    )?;
-    Some(ResolvedInterfaceData {
-        loc: resolved.loc,
-        qtn: resolved.qtn,
-    })
-}
-
-/// The `TypeRef`-arena twin of [`resolve_interface_path`], for walking a
-/// `requires` target held as firewall data (`interface_data(…).type_refs` plus a
-/// `TypeRefId`) rather than an AST node.
-fn resolve_interface_ref<'db>(
-    db: &'db dyn Db,
-    store: &baml_compiler2_hir::type_ref::TypeRefStore,
-    target: baml_compiler2_hir::type_ref::TypeRefId,
-    pkg_items: &baml_compiler2_hir::package::PackageItems<'db>,
-    namespace_path: &[Name],
-) -> Option<ResolvedInterfaceData<'db>> {
-    let resolved = baml_compiler2_tir::interfaces::resolve_ref_to_interface_identity(
-        db,
-        store,
-        target,
-        pkg_items,
-        namespace_path,
-    )?;
-    Some(ResolvedInterfaceData {
-        loc: resolved.loc,
-        qtn: resolved.qtn,
-    })
+    )
+    .map(|resolved| resolved.loc)
 }
 
 fn validate_associated_type_bindings_in_items(
@@ -967,18 +939,22 @@ fn validate_ambiguous_typevar_associated_projection_in_type_expr(
                 let member = &segments[1];
                 if let Some(bounds) = generic_bounds.get(base) {
                     // `T extends A & B` — the member may come from any conjunct,
-                    // so the sources are pooled: none means unknown, and two or
-                    // more (whether from one bound or across bounds) is ambiguous.
-                    let sources: Vec<_> = bounds
-                        .iter()
-                        .flat_map(|bound| {
-                            associated_type_projection_sources_for_interface_bound(
-                                db,
-                                bound,
-                                member,
-                                pkg_items,
-                                namespace_path,
-                            )
+                    // so the declarers are collected across the whole conjunction:
+                    // none means unknown, two or more is ambiguous. The compiler
+                    // owns that walk (and its cross-conjunct deduplication, without
+                    // which two bounds reaching the same declarer through `requires`
+                    // would look like an ambiguity); this only renders the result.
+                    let roots = bounds.iter().filter_map(|bound| {
+                        resolve_interface_path(db, bound, pkg_items, namespace_path)
+                    });
+                    let sources: Vec<String> =
+                        baml_compiler2_tir::interfaces::interfaces_declaring_associated_type(
+                            db, roots, member,
+                        )
+                        .into_iter()
+                        .filter_map(|loc| {
+                            baml_compiler2_tir::interfaces::interface_loc_qtn(db, loc)
+                                .map(|qtn| qtn.render_user_facing())
                         })
                         .collect();
                     if sources.is_empty() {
@@ -1164,53 +1140,6 @@ fn validate_ambiguous_typevar_associated_projection_in_type_expr(
         }
         _ => {}
     }
-}
-
-fn associated_type_projection_sources_for_interface_bound(
-    db: &dyn Db,
-    bound: &baml_compiler2_ast::TypeExpr,
-    member: &Name,
-    pkg_items: &baml_compiler2_hir::package::PackageItems<'_>,
-    namespace_path: &[Name],
-) -> Vec<String> {
-    let Some(root) = resolve_interface_path(db, bound, pkg_items, namespace_path) else {
-        return Vec::new();
-    };
-    let mut out = Vec::new();
-    let mut visited = HashSet::new();
-    let mut stack = vec![root];
-
-    while let Some(current) = stack.pop() {
-        if !visited.insert(current.qtn.clone()) {
-            continue;
-        }
-        let iface = baml_compiler2_ppir::item_data::interface_data(db, current.loc);
-        if iface
-            .associated_types
-            .iter()
-            .any(|assoc| assoc.name == *member)
-        {
-            out.push(current.qtn.render_user_facing());
-        }
-        let current_file = current.loc.file(db);
-        let current_pkg = baml_compiler2_hir::file_package::file_package(db, current_file);
-        let current_pkg_id =
-            baml_compiler2_hir::package::PackageId::new(db, current_pkg.package.clone());
-        let current_pkg_items = baml_compiler2_hir::package::package_items(db, current_pkg_id);
-        for &parent in &iface.requires {
-            if let Some(parent) = resolve_interface_ref(
-                db,
-                &iface.type_refs,
-                parent,
-                current_pkg_items,
-                &current_pkg.namespace_path,
-            ) {
-                stack.push(parent);
-            }
-        }
-    }
-
-    out
 }
 
 fn check_jinja_templates(

--- a/baml_language/crates/baml_lsp2_actions/src/type_info.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/type_info.rs
@@ -528,7 +528,7 @@ fn generic_type_parameter_info_at(
             continue;
         }
         let data = item_data::function_data(db, *func_loc);
-        if let Some(param_idx) = data.generic_params.iter().position(|param| param == name) {
+        if let Some(declared) = data.generic_params.iter().find(|param| &param.name == name) {
             let origin = item_data::file_classes(db, file)
                 .iter()
                 .find_map(|class_loc| {
@@ -549,11 +549,7 @@ fn generic_type_parameter_info_at(
                         })
                 })
                 .unwrap_or_else(|| format!("function {}", data.name.as_str()));
-            let bound = data
-                .generic_param_bounds
-                .get(param_idx)
-                .and_then(|bound| *bound)
-                .map(|id| data.type_refs.display(id).to_string());
+            let bound = render_generic_bounds(declared, &data.type_refs);
             candidates.push((source_map.span.len(), origin, bound));
         }
     }
@@ -564,16 +560,11 @@ fn generic_type_parameter_info_at(
             continue;
         }
         let data = item_data::class_data(db, *class_loc);
-        if let Some(param_idx) = data.generic_params.iter().position(|param| param == name) {
-            let bound = data
-                .generic_param_bounds
-                .get(param_idx)
-                .and_then(|bound| *bound)
-                .map(|id| data.type_refs.display(id).to_string());
+        if let Some(declared) = data.generic_params.iter().find(|param| &param.name == name) {
             candidates.push((
                 source_map.span.len(),
                 format!("class {}", data.name.as_str()),
-                bound,
+                render_generic_bounds(declared, &data.type_refs),
             ));
         }
     }
@@ -591,29 +582,23 @@ fn generic_type_parameter_info_at(
             if !range_contains(method_source_map.span, offset) {
                 continue;
             }
-            if let Some(param_idx) = method.generic_params.iter().position(|param| param == name) {
-                let bound = method
-                    .generic_param_bounds
-                    .get(param_idx)
-                    .and_then(|bound| *bound)
-                    .map(|id| data.type_refs.display(id).to_string());
+            if let Some(declared) = method
+                .generic_params
+                .iter()
+                .find(|param| &param.name == name)
+            {
                 candidates.push((
                     method_source_map.span.len(),
                     format!("method {}.{}", data.name.as_str(), method.name.as_str()),
-                    bound,
+                    render_generic_bounds(declared, &data.type_refs),
                 ));
             }
         }
-        if let Some(param_idx) = data.generic_params.iter().position(|param| param == name) {
-            let bound = data
-                .generic_param_bounds
-                .get(param_idx)
-                .and_then(|bound| *bound)
-                .map(|id| data.type_refs.display(id).to_string());
+        if let Some(declared) = data.generic_params.iter().find(|param| &param.name == name) {
             candidates.push((
                 source_map.span.len(),
                 format!("interface {}", data.name.as_str()),
-                bound,
+                render_generic_bounds(declared, &data.type_refs),
             ));
         }
     }
@@ -629,20 +614,34 @@ fn generic_type_parameter_info_at(
     })
 }
 
+/// A parameter's declared bounds rendered as source (`A & B`), or `None` when it
+/// is unbounded.
+fn render_generic_bounds(
+    param: &baml_compiler2_ppir::item_data::GenericParamData,
+    store: &baml_compiler2_hir::type_ref::TypeRefStore,
+) -> Option<String> {
+    if param.bounds.is_empty() {
+        return None;
+    }
+    Some(
+        param
+            .bounds
+            .iter()
+            .map(|&id| store.display(id).to_string())
+            .collect::<Vec<_>>()
+            .join(" & "),
+    )
+}
+
 fn render_generic_params(
-    names: &[Name],
-    bounds: &[Option<baml_compiler2_hir::type_ref::TypeRefId>],
+    params: &[baml_compiler2_ppir::item_data::GenericParamData],
     store: &baml_compiler2_hir::type_ref::TypeRefStore,
 ) -> Vec<String> {
-    names
+    params
         .iter()
-        .enumerate()
-        .map(|(idx, name)| {
-            bounds
-                .get(idx)
-                .and_then(|bound| *bound)
-                .map(|id| format!("{} extends {}", name.as_str(), store.display(id)))
-                .unwrap_or_else(|| name.as_str().to_string())
+        .map(|param| match render_generic_bounds(param, store) {
+            Some(bounds) => format!("{} extends {bounds}", param.name.as_str()),
+            None => param.name.as_str().to_string(),
         })
         .collect()
 }
@@ -799,11 +798,7 @@ fn declaration_type_info_at(
 fn render_function_data_signature(
     function: &baml_compiler2_ppir::item_data::FunctionData,
 ) -> String {
-    let generic_params = render_generic_params(
-        &function.generic_params,
-        &function.generic_param_bounds,
-        &function.type_refs,
-    );
+    let generic_params = render_generic_params(&function.generic_params, &function.type_refs);
     let generics = if generic_params.is_empty() {
         String::new()
     } else {
@@ -844,11 +839,7 @@ fn render_interface_method_signature(
     iface: &baml_compiler2_ppir::item_data::InterfaceData<'_>,
     method: &baml_compiler2_ppir::item_data::InterfaceMethodSigData,
 ) -> String {
-    let generic_params = render_generic_params(
-        &method.generic_params,
-        &method.generic_param_bounds,
-        &iface.type_refs,
-    );
+    let generic_params = render_generic_params(&method.generic_params, &iface.type_refs);
     let generics = if generic_params.is_empty() {
         String::new()
     } else {
@@ -1196,11 +1187,8 @@ pub fn type_info_for_definition(db: &dyn Db, def: Definition<'_>) -> TypeInfo {
             let canonical_fqn = utils::canonical_fqn_string(&qtn);
             let methods = crate::describe::class_method_sigs(db, class_loc);
 
-            let generic_params = render_generic_params(
-                &class_data.generic_params,
-                &class_data.generic_param_bounds,
-                &class_data.type_refs,
-            );
+            let generic_params =
+                render_generic_params(&class_data.generic_params, &class_data.type_refs);
 
             TypeInfo::Class {
                 name: class_name,
@@ -1228,11 +1216,7 @@ pub fn type_info_for_definition(db: &dyn Db, def: Definition<'_>) -> TypeInfo {
 
         Definition::Interface(iface_loc) => {
             let iface = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
-            let generic_params = render_generic_params(
-                &iface.generic_params,
-                &iface.generic_param_bounds,
-                &iface.type_refs,
-            );
+            let generic_params = render_generic_params(&iface.generic_params, &iface.type_refs);
             let generics = if generic_params.is_empty() {
                 String::new()
             } else {

--- a/baml_language/crates/baml_project/src/client_codegen.rs
+++ b/baml_language/crates/baml_project/src/client_codegen.rs
@@ -306,7 +306,11 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
                 cg_name.clone(),
                 cg::Symbol::Class(cg::Class {
                     name: cg_name,
-                    generic_params: class.generic_params.clone(),
+                    generic_params: class
+                        .generic_params
+                        .iter()
+                        .map(|param| param.name.clone())
+                        .collect(),
                     docstring: class.docstring.clone(),
                     properties,
                     static_methods: Vec::new(),

--- a/baml_language/crates/baml_tests/baml_src/ns_intersection_bounds/intersection_bounds.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_intersection_bounds/intersection_bounds.baml
@@ -1,0 +1,131 @@
+// Intersection bounds (`T extends A & B`) executed end-to-end.
+//
+// A bound list is a conjunction: an argument must satisfy every conjunct, and
+// `T`'s member surface is the union of all of them. CST lowering used to keep
+// only the first conjunct, so every member reached through a later one was
+// invisible and every later bound went unenforced.
+//
+// Rejection cases live in `projects/diagnostic_errors/generic_intersection_bounds`;
+// the accepted declaration shapes are snapshotted through TIR/MIR in
+// `projects/compiles/generic_intersection_bounds`.
+
+interface IbNamed { name: string }
+
+interface IbSized {
+    function size(self) -> int throws never
+}
+
+interface IbTagged {
+    type Label
+    function tag(self) -> Self.Label throws never
+}
+
+class IbBoth {
+    name: string
+
+    implements IbNamed {}
+
+    implements IbSized {
+        function size(self) -> int { return 7 }
+    }
+
+    implements IbTagged {
+        type Label = string
+        function tag(self) -> string { return "t:" + self.name }
+    }
+}
+
+// Both conjuncts contribute members: `name` from `IbNamed`, `size()` from
+// `IbSized`.
+function ib_describe<T extends IbNamed & IbSized>(item: T) -> string {
+    return item.name + ":" + item.size().to_string()
+}
+
+test "intersection_bound_reaches_members_of_every_conjunct" {
+    assert.equal(ib_describe<IbBoth>(IbBoth { name: "b" }), "b:7")
+}
+
+// A member declared by the *last* of three conjuncts is still in scope.
+function ib_label<T extends IbNamed & IbSized & IbTagged<Label = string>>(item: T) -> string {
+    return item.tag() + "/" + item.size().to_string()
+}
+
+test "intersection_bound_reaches_member_of_trailing_conjunct" {
+    assert.equal(ib_label<IbBoth>(IbBoth { name: "b" }), "t:b/7")
+}
+
+// Conjunct order is not significant — the same conjunction either way.
+function ib_describe_reordered<T extends IbSized & IbNamed>(item: T) -> string {
+    return item.name + ":" + item.size().to_string()
+}
+
+test "intersection_bound_is_order_insensitive" {
+    assert.equal(
+        ib_describe_reordered<IbBoth>(IbBoth { name: "b" }),
+        ib_describe<IbBoth>(IbBoth { name: "b" }),
+    )
+}
+
+// A blanket `implements` over an intersection dispatches through the concrete
+// implementor at runtime.
+interface IbPrintable {
+    function display(self) -> string throws never
+}
+
+implements<T extends IbNamed & IbSized> IbPrintable for T {
+    function display(self) -> string {
+        return ib_describe<T>(self)
+    }
+}
+
+class IbOther {
+    name: string
+
+    implements IbNamed {}
+
+    implements IbSized {
+        function size(self) -> int { return 2 }
+    }
+}
+
+test "blanket_impl_over_intersection_dispatches_per_implementor" {
+    let a: IbPrintable = IbBoth { name: "x" }
+    let b: IbPrintable = IbOther { name: "y" }
+    assert.equal(a.display(), "x:7")
+    assert.equal(b.display(), "y:2")
+}
+
+// A type constructor carries the conjunction through to its field's type.
+class IbHolder<T extends IbNamed & IbSized> {
+    item: T
+}
+
+function ib_holder_summary(holder: IbHolder<IbBoth>) -> string {
+    return holder.item.name + "=" + holder.item.size().to_string()
+}
+
+test "intersection_bound_on_type_constructor_keeps_member_surface" {
+    assert.equal(
+        ib_holder_summary(IbHolder<IbBoth> { item: IbBoth { name: "h" } }),
+        "h=7",
+    )
+}
+
+// An interface method signature's own generics carry a conjunction, and an
+// override may spell the conjuncts in a different order.
+interface IbRegistry {
+    function summarize<U extends IbNamed & IbSized>(self, item: U) -> string throws never
+}
+
+class IbRegistered {
+    implements IbRegistry {
+        function summarize<U extends IbSized & IbNamed>(self, item: U) -> string {
+            return ib_describe<U>(item)
+        }
+    }
+}
+
+test "interface_method_generic_intersection_bound_runs" {
+    let r = IbRegistered {}
+    assert.equal(r.summarize<IbBoth>(IbBoth { name: "r" }), "r:7")
+}

--- a/baml_language/crates/baml_tests/projects/compiles/generic_intersection_bounds/generic_intersection_bounds.baml
+++ b/baml_language/crates/baml_tests/projects/compiles/generic_intersection_bounds/generic_intersection_bounds.baml
@@ -1,0 +1,126 @@
+// A generic parameter's bound list is a CONJUNCTION: `T extends A & B` requires
+// an argument for `T` to implement both, and `T`'s member surface is the union
+// of every conjunct. Each conjunct must name an interface — see
+// `diagnostic_errors/generic_intersection_bounds` for the rejection cases.
+//
+// Every declaration site that accepts bounds appears below, so the TIR snapshot
+// pins both conjuncts on each type variable. CST lowering used to keep only the
+// first, silently weakening every bound written with `&`.
+
+interface Named {
+    name: string
+}
+
+interface Sized {
+    function size(self) -> int throws never
+}
+
+interface Tagged {
+    type Label
+
+    function tag(self) -> Self.Label throws never
+}
+
+class Both {
+    name: string
+
+    implements Named {}
+
+    implements Sized {
+        function size(self) -> int { 7 }
+    }
+
+    implements Tagged {
+        type Label = string
+
+        function tag(self) -> string { self.name }
+    }
+}
+
+// Function generics: members reached through either conjunct.
+function describe<T extends Named & Sized>(item: T) -> string {
+    item.name + ":" + item.size().to_string()
+}
+
+// Three conjuncts: a member declared by the *last* one is still in `T`'s
+// surface, which is the case a dropped conjunct silently broke.
+function label_of<T extends Named & Sized & Tagged<Label = string>>(item: T) -> string {
+    item.tag()
+}
+
+// An interface field read on a bounded type variable lowers to a virtual field
+// access, which the stack-carry simulator must decline to inline. Each consumer
+// below reaches that simulator by a different route — a `Return` terminator, a
+// call argument, and a `Switch` discriminant — so all three are pinned, not just
+// the one a tail expression happens to take.
+function shout(text: string) -> string {
+    text + "!"
+}
+
+function field_into_call_arg<T extends Named & Sized>(item: T) -> string {
+    let out = shout(item.name)
+    out
+}
+
+function field_into_switch<T extends Named & Sized>(item: T) -> int {
+    match (item.name) {
+        "a" => 1,
+        _ => 0,
+    }
+}
+
+// Type-constructor generics carry the same conjunction.
+class Holder<T extends Named & Sized> {
+    item: T
+}
+
+// Interface generics, and an interface method signature's own generics.
+interface Registry<T extends Named & Sized> {
+    function put(self, item: T) -> void throws never
+
+    function summarize<U extends Named & Sized>(self, other: U) -> string throws never
+}
+
+// An out-of-body `implements` block applies only to types satisfying every
+// conjunct of its own bound list.
+interface Printable {
+    function display(self) -> string throws never
+}
+
+implements<T extends Named & Sized> Printable for T {
+    function display(self) -> string { describe<T>(self) }
+}
+
+class Registered {
+    items: Both[]
+
+    implements Registry<Both> {
+        function put(self, item: Both) -> void {}
+
+        // Conformance compares full conjunctions, and the order of conjuncts is
+        // not significant, so the override may spell them the other way round.
+        function summarize<U extends Sized & Named>(self, other: U) -> string {
+            describe<U>(other)
+        }
+    }
+}
+
+function main() -> string {
+    let both = Both { name: "b" }
+    let holder = Holder<Both> { item: both }
+    let printable: Printable = both
+    let registry = Registered { items: [both] }
+    describe<Both>(both)
+        + "/"
+        + field_into_call_arg<Both>(both)
+        + "/"
+        + field_into_switch<Both>(both).to_string()
+        + "/"
+        + label_of<Both>(both)
+        + "/"
+        + holder.item.name
+        + "/"
+        + printable.display()
+        + "/"
+        + registry.summarize<Both>(both)
+}

--- a/baml_language/crates/baml_tests/projects/diagnostic_errors/generic_intersection_bounds/generic_intersection_bounds.baml
+++ b/baml_language/crates/baml_tests/projects/diagnostic_errors/generic_intersection_bounds/generic_intersection_bounds.baml
@@ -1,0 +1,88 @@
+// A bound list is a CONJUNCTION: an argument for `T extends A & B` must satisfy
+// EVERY conjunct. CST lowering used to keep only the first, so a type satisfying
+// `A` alone was silently accepted; each case below must now be rejected, and
+// each must name the conjunct that is missing.
+//
+// Every declaration site that accepts bounds is covered, plus the two
+// order-sensitivity cases (leading conjunct missing, trailing conjunct missing)
+// that prove this is a conjunction rather than "the last bound wins".
+// See `compiles/generic_intersection_bounds` for the accepted shapes.
+
+interface Named {
+    name: string
+}
+
+interface Sized {
+    function size(self) -> int throws never
+}
+
+class OnlyNamed {
+    name: string
+
+    implements Named {}
+}
+
+class OnlySized {
+    implements Sized {
+        function size(self) -> int { 1 }
+    }
+}
+
+function describe<T extends Named & Sized>(item: T) -> string {
+    item.name
+}
+
+// The trailing conjunct is unsatisfied — the case a dropped `& Sized` hid.
+function missing_trailing_conjunct() -> string {
+    describe<OnlyNamed>(OnlyNamed { name: "n" })
+}
+
+// The leading conjunct is unsatisfied, so `Named` is enforced too.
+function missing_leading_conjunct() -> string {
+    describe<OnlySized>(OnlySized {})
+}
+
+// Referencing the generic as a *value* enforces the conjunction as well.
+function missing_conjunct_in_instantiation_expr() -> string {
+    let f = describe<OnlyNamed>
+    "ok"
+}
+
+// Declaration-site bounds on a type constructor are checked at every use.
+class Holder<T extends Named & Sized> {
+    item: T
+}
+
+function missing_conjunct_in_class_type_arg() -> string {
+    let h = Holder<OnlyNamed> { item: OnlyNamed { name: "n" } }
+    h.item.name
+}
+
+// An out-of-body `implements` block applies only to types satisfying every
+// conjunct of its bound list, so `OnlyNamed` gains no `Printable`.
+interface Printable {
+    function display(self) -> string throws never
+}
+
+implements<T extends Named & Sized> Printable for T {
+    function display(self) -> string { self.name }
+}
+
+function blanket_impl_needs_every_conjunct() -> string {
+    let p: Printable = OnlyNamed { name: "n" }
+    p.display()
+}
+
+// An implementation may not require more than the interface declares, so
+// widening `Named` to `Named & Sized` on an override is a conformance error.
+interface Reader {
+    function read<T extends Named>(self, value: T) -> string throws never
+}
+
+class WideningReader {
+    implements Reader {
+        function read<T extends Named & Sized>(self, value: T) -> string {
+            value.name
+        }
+    }
+}

--- a/baml_language/crates/baml_tests/projects/diagnostic_errors/generic_intersection_bounds/generic_intersection_bounds.baml
+++ b/baml_language/crates/baml_tests/projects/diagnostic_errors/generic_intersection_bounds/generic_intersection_bounds.baml
@@ -86,3 +86,25 @@ class WideningReader {
         }
     }
 }
+
+// Two conjuncts declaring the same member are siblings — neither shadows the
+// other — so the access is ambiguous and must be qualified with `.as<I>`.
+// Resolving conjunct-by-conjunct and taking the first hit would silently pick
+// `Sized` here, and which one it picked would depend on the order written.
+interface OtherSized {
+    function size(self) -> int throws never
+}
+
+function ambiguous_across_conjuncts<T extends Sized & OtherSized>(item: T) -> int {
+    item.size()
+}
+
+// A conjunct overlapping through `requires` is NOT ambiguous: both reach the
+// same realized interface, so it dedupes to one declarer.
+interface NamedAndSized requires Named {
+    function extra(self) -> int throws never
+}
+
+function overlap_through_requires<T extends Named & NamedAndSized>(item: T) -> string {
+    item.name
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
@@ -345,6 +345,9 @@ function $init_test(registry: unknown) -> null {
     load_var ?1
     call ?
     pop 1
+    load_var ?1
+    call ?
+    pop 1
     load_const ?
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/intersection_bounds.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/intersection_bounds.snap
@@ -1,0 +1,165 @@
+---
+source: crates/baml_tests/tests/baml_src.rs
+---
+function intersection_bounds.$init_test_ns_intersection_bounds_intersection_bounds(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "root.intersection_bounds"
+    load_const "intersection_bound_reaches_members_of_every_conjunct"
+    make_closure .<lambda($init_test_ns_intersection_bounds_intersection_bounds, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.intersection_bounds"
+    load_const "intersection_bound_reaches_member_of_trailing_conjunct"
+    make_closure .<lambda($init_test_ns_intersection_bounds_intersection_bounds, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.intersection_bounds"
+    load_const "intersection_bound_is_order_insensitive"
+    make_closure .<lambda($init_test_ns_intersection_bounds_intersection_bounds, 2)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.intersection_bounds"
+    load_const "blanket_impl_over_intersection_dispatches_per_implementor"
+    make_closure .<lambda($init_test_ns_intersection_bounds_intersection_bounds, 3)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.intersection_bounds"
+    load_const "intersection_bound_on_type_constructor_keeps_member_surface"
+    make_closure .<lambda($init_test_ns_intersection_bounds_intersection_bounds, 4)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.intersection_bounds"
+    load_const "interface_method_generic_intersection_bound_runs"
+    make_closure .<lambda($init_test_ns_intersection_bounds_intersection_bounds, 5)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_const null
+    return
+}
+
+function intersection_bounds.IbBoth.IbSized.size(self: intersection_bounds.IbBoth) -> int {
+    load_const 7
+    return
+}
+
+function intersection_bounds.IbBoth.IbTagged.tag(self: intersection_bounds.IbBoth) -> string {
+    load_const "t:"
+    load_var self
+    load_field .name
+    bin_op +
+    return
+}
+
+function intersection_bounds.IbOther.IbSized.size(self: intersection_bounds.IbOther) -> int {
+    load_const 2
+    return
+}
+
+function intersection_bounds.IbPrintable$for$T.display(self: #0) -> string {
+    load_type #0
+    load_var self
+    call user.intersection_bounds.ib_describe
+    return
+}
+
+function intersection_bounds.IbRegistered.IbRegistry.summarize(self: intersection_bounds.IbRegistered, item: #0) -> string {
+    load_type #0
+    load_var item
+    call user.intersection_bounds.ib_describe
+    return
+}
+
+function intersection_bounds.ib_describe(item: #0) -> string {
+    load_var item
+    load_type intersection_bounds.IbSized
+    load_const "size"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _5
+    load_type int
+    load_var _5
+    call baml.String.from
+    store_var _4
+    load_var item
+    load_type intersection_bounds.IbNamed
+    virtual_load_field .name
+    load_const ":"
+    bin_op +
+    load_var _4
+    bin_op +
+    return
+}
+
+function intersection_bounds.ib_describe_reordered(item: #0) -> string {
+    load_var item
+    load_type intersection_bounds.IbSized
+    load_const "size"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _5
+    load_type int
+    load_var _5
+    call baml.String.from
+    store_var _4
+    load_var item
+    load_type intersection_bounds.IbNamed
+    virtual_load_field .name
+    load_const ":"
+    bin_op +
+    load_var _4
+    bin_op +
+    return
+}
+
+function intersection_bounds.ib_holder_summary(holder: intersection_bounds.IbHolder<intersection_bounds.IbBoth>) -> string {
+    load_var holder
+    load_field .item
+    load_type intersection_bounds.IbSized
+    load_const "size"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _5
+    load_type int
+    load_var _5
+    call baml.String.from
+    store_var _4
+    load_var holder
+    load_field .item
+    load_field .0
+    load_const "="
+    bin_op +
+    load_var _4
+    bin_op +
+    return
+}
+
+function intersection_bounds.ib_label(item: #0) -> string {
+    load_var item
+    load_type intersection_bounds.IbTagged<Label = string>
+    load_const "tag"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _3
+    load_var item
+    load_type intersection_bounds.IbSized
+    load_const "size"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _5
+    load_type int
+    load_var _5
+    call baml.String.from
+    store_var _4
+    load_var _3
+    load_const "/"
+    bin_op +
+    load_var _4
+    bin_op +
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__03_ppir.snap
@@ -1,0 +1,55 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== PPIR ===
+class user.Both {
+  name: string
+}
+class user.Both$stream {
+  name: string | null
+}
+class user.Holder {
+  item: T
+}
+class user.Holder$stream {
+  item: T | null
+}
+class user.Registered {
+  items: user.Both[]
+}
+class user.Registered$stream {
+  items: user.Both$stream[]
+}
+function user.describe(item: T) -> string  [expr] {
+  {  } item.name Add ":" Add item.size().to_string()
+}
+function user.display(self: ?) -> string  [expr] {
+  {  } describe(self)
+}
+function user.field_into_call_arg(item: T) -> string  [expr] {
+  { let out = shout(item.name) } out
+}
+function user.field_into_switch(item: T) -> int  [expr] {
+  {  } match (item.name) { "a" => 1, _ => 0 }
+}
+function user.label_of(item: T) -> string  [expr] {
+  {  } item.tag()
+}
+function user.main() -> string  [expr] {
+  { let both = user.Both { name: "b" }; let holder = user.Holder { item: both }; let printable: Printable = both; let registry = user.Registered { items: [both] } } describe(both) Add "/" Add field_into_call_arg(both) Add "/" Add field_into_switch(both).to_string() Add "/" Add label_of(both) Add "/" Add holder.item.name Add "/" Add printable.display() Add "/" Add registry.summarize(both)
+}
+function user.put(self: ?, item: user.Both) -> void  [expr] {
+  {  }
+}
+function user.shout(text: string) -> string  [expr] {
+  {  } text Add "!"
+}
+function user.size(self: ?) -> int  [expr] {
+  {  } 7
+}
+function user.summarize(self: ?, other: U) -> string  [expr] {
+  {  } describe(other)
+}
+function user.tag(self: ?) -> string  [expr] {
+  {  } self.name
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__04_5_mir.snap
@@ -1,0 +1,301 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== MIR2 ===
+fn user.Both.Sized.size(self: Both) -> int {
+    // Locals:
+    let _0: int // _0 // return
+    let _1: Both // self // param
+
+    bb0: {
+        _0 = const 7_i64;
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.Both.Tagged.tag(self: Both) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: Both // self // param
+
+    bb0: {
+        _0 = copy _1.0;
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.describe(item: T) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: T // item // param
+    let _2: string
+    let _3: string
+    let _4: string
+    let _5: int
+    let _6: type
+
+    bb0: {
+        _3 = copy _1.name#0 as Named;
+        _2 = copy _3 + const ":";
+        _5 = virtual_call size as Sized(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _6 = load_type(int);
+        _4 = call const fn baml.String.from<copy _6>(copy _5) -> [bb2];
+    }
+
+    bb2: {
+        _0 = copy _2 + copy _4;
+        goto -> bb3;
+    }
+
+    bb3: {
+        return;
+    }
+}
+
+fn user.label_of(item: T) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: T // item // param
+
+    bb0: {
+        _0 = virtual_call tag as Tagged<Label = string>(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.shout(text: string) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: string // text // param
+
+    bb0: {
+        _0 = copy _1 + const "!";
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.field_into_call_arg(item: T) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: T // item // param
+    let _2: string // out
+    let _3: string
+
+    bb0: {
+        _3 = copy _1.name#0 as Named;
+        _2 = call const fn user.shout(copy _3) -> [bb1];
+    }
+
+    bb1: {
+        _0 = copy _2;
+        goto -> bb2;
+    }
+
+    bb2: {
+        return;
+    }
+}
+
+fn user.field_into_switch(item: T) -> int {
+    // Locals:
+    let _0: int // _0 // return
+    let _1: T // item // param
+    let _2: string
+    let _3: bool
+
+    bb0: {
+        _2 = copy _1.name#0 as Named;
+        _3 = copy _2 == const "a";
+        branch copy _3 -> [bb2, bb1];
+    }
+
+    bb1: {
+        _0 = const 0_i64;
+        goto -> bb3;
+    }
+
+    bb2: {
+        _0 = const 1_i64;
+        goto -> bb3;
+    }
+
+    bb3: {
+        return;
+    }
+}
+
+fn user.Printable$for$T.display(self: T) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: T // self // param
+    let _2: type
+
+    bb0: {
+        _2 = load_type(#0);
+        _0 = call const fn user.describe<copy _2>(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.Registered.Registry<Both>.put(self: Registered, item: Both) -> void {
+    // Locals:
+    let _0: void // _0 // return
+    let _1: Registered // self // param
+    let _2: Both // item // param
+
+    bb0: {
+        _0 = const null;
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.Registered.Registry<Both>.summarize(self: Registered, other: U) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: Registered // self // param
+    let _2: U // other // param
+    let _3: type
+
+    bb0: {
+        _3 = load_type(#0);
+        _0 = call const fn user.describe<copy _3>(copy _2) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.main() -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: Both // both
+    let _2: Holder<Both> // holder
+    let _3: Both
+    let _4: Printable // printable
+    let _5: Registered // registry
+    let _6: Both[]
+    let _7: Both
+    let _8: string
+    let _9: string
+    let _10: string
+    let _11: string
+    let _12: string
+    let _13: string
+    let _14: string
+    let _15: string
+    let _16: string
+    let _17: string
+    let _18: string
+    let _19: string
+    let _20: Both
+    let _21: type
+    let _22: string
+    let _23: Both
+    let _24: type
+    let _25: string
+    let _26: int
+    let _27: Both
+    let _28: type
+    let _29: type
+    let _30: string
+    let _31: Both
+    let _32: type
+    let _33: string
+    let _34: string
+    let _35: string
+    let _36: Both
+    let _37: type
+
+    bb0: {
+        _1 = user.Both { const "b" };
+        _3 = copy _1;
+        _2 = user.Holder<Both> { copy _3 };
+        _4 = copy _1;
+        _7 = copy _1;
+        _6 = [copy _7]: Both[];
+        _5 = user.Registered { copy _6 };
+        _20 = copy _1;
+        _21 = load_type(Both);
+        _19 = call const fn user.describe<copy _21>(copy _20) -> [bb1];
+    }
+
+    bb1: {
+        _18 = copy _19 + const "/";
+        _23 = copy _1;
+        _24 = load_type(Both);
+        _22 = call const fn user.field_into_call_arg<copy _24>(copy _23) -> [bb2];
+    }
+
+    bb2: {
+        _17 = copy _18 + copy _22;
+        _16 = copy _17 + const "/";
+        _27 = copy _1;
+        _28 = load_type(Both);
+        _26 = call const fn user.field_into_switch<copy _28>(copy _27) -> [bb3];
+    }
+
+    bb3: {
+        _29 = load_type(int);
+        _25 = call const fn baml.String.from<copy _29>(copy _26) -> [bb4];
+    }
+
+    bb4: {
+        _15 = copy _16 + copy _25;
+        _14 = copy _15 + const "/";
+        _31 = copy _1;
+        _32 = load_type(Both);
+        _30 = call const fn user.label_of<copy _32>(copy _31) -> [bb5];
+    }
+
+    bb5: {
+        _13 = copy _14 + copy _30;
+        _12 = copy _13 + const "/";
+        _33 = copy _2.0.0;
+        _11 = copy _12 + copy _33;
+        _10 = copy _11 + const "/";
+        _34 = virtual_call display as Printable(copy _4) -> [bb6];
+    }
+
+    bb6: {
+        _9 = copy _10 + copy _34;
+        _8 = copy _9 + const "/";
+        _36 = copy _1;
+        _37 = load_type(Both);
+        _35 = virtual_call summarize as Registry<Both><copy _37>(copy _5, copy _36) -> [bb7];
+    }
+
+    bb7: {
+        _0 = copy _8 + copy _35;
+        goto -> bb8;
+    }
+
+    bb8: {
+        return;
+    }
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__04_tir.snap
@@ -1,0 +1,85 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== TIR2 ===
+class user.Both {
+  name: string
+}
+function user.Both.size(self: user.Both) -> int throws never {
+  { : 7
+    7 : 7
+  }
+}
+function user.Both.tag(self: user.Both) -> string throws never {
+  { : string
+    self.name : string
+  }
+}
+function user.describe<T>(item: T) -> string throws never {
+  { : string
+    item.name + ":" + item.size().to_string() : string
+  }
+}
+function user.label_of<T>(item: T) -> string throws never {
+  { : string
+    item.tag() : string
+  }
+}
+function user.shout(text: string) -> string throws never {
+  { : string
+    text + "!" : string
+  }
+}
+function user.field_into_call_arg<T>(item: T) -> string throws never {
+  { : string
+    let out = shout(item.name) : string
+    out : string
+  }
+}
+function user.field_into_switch<T>(item: T) -> int throws never {
+  { : 1 | 0
+    match (item.name : string) : 1 | 0
+      "a" =>
+        1 : 1
+      _ =>
+        0 : 0
+  }
+}
+class user.Holder {
+  item: T
+}
+class user.Registered {
+  items: user.Both[]
+}
+function user.Registered.put(self: user.Registered, item: user.Both) -> void throws never {
+  { : void
+  }
+}
+function user.Registered.summarize<U>(self: user.Registered, other: U) -> string throws never {
+  { : string
+    describe<T>(other) : string
+  }
+}
+function user.main() -> string throws never {
+  { : string
+    let both = Both { name: "b" } : user.Both
+    let holder = Holder { item: both } : user.Holder<user.Both>
+    let printable: Printable = both : user.Both -> user.Printable
+    let registry = Registered { items: [both] } : user.Registered
+    describe<Both>(both) + "/" + field_into_call_arg<Both>(both) + "/" + field_into_switch<Both>(both).to_string() + "/" + label_of<Both>(both) + "/" + holder.item.name + "/" + printable.display() + "/" + registry.summarize<Both>(both) : string
+  }
+}
+function user.T.display(self: unknown) -> string throws never {
+  { : string
+    describe<T>(self) : string
+  }
+}
+class user.Both$stream {
+  name: string | null
+}
+class user.Holder$stream {
+  item: T | null
+}
+class user.Registered$stream {
+  items: user.Both$stream[]
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__05_diagnostics.snap
@@ -1,0 +1,5 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== COMPILER2 DIAGNOSTICS ===
+No errors found.

--- a/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__06_codegen.snap
@@ -1,0 +1,183 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
+}
+
+function boundary.id() -> boundary.LocalId {
+}
+
+function boundary.id.current() -> string {
+}
+
+function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
+}
+
+function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
+}
+
+function user.Both.Sized.size(self: Both) -> int {
+    load_const 7
+    return
+}
+
+function user.Both.Tagged.tag(self: Both) -> string {
+    load_var self
+    load_field .name
+    return
+}
+
+function user.Printable$for$T.display(self: #0) -> string {
+    load_type #0
+    load_var self
+    call user.describe
+    return
+}
+
+function user.Registered.Registry<Both>.put(self: Registered, item: Both) -> void {
+    load_const null
+    return
+}
+
+function user.Registered.Registry<Both>.summarize(self: Registered, other: #0) -> string {
+    load_type #0
+    load_var other
+    call user.describe
+    return
+}
+
+function user.describe(item: #0) -> string {
+    load_var item
+    load_type Sized
+    load_const "size"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _5
+    load_type int
+    load_var _5
+    call baml.String.from
+    store_var _4
+    load_var item
+    load_type Named
+    virtual_load_field .name
+    load_const ":"
+    bin_op +
+    load_var _4
+    bin_op +
+    return
+}
+
+function user.field_into_call_arg(item: #0) -> string {
+    load_var item
+    load_type Named
+    virtual_load_field .name
+    call user.shout
+    return
+}
+
+function user.field_into_switch(item: #0) -> int {
+    load_var item
+    load_type Named
+    virtual_load_field .name
+    load_const "a"
+    cmp_op ==
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const 0
+    jump L2
+
+  L1:
+    load_const 1
+
+  L2:
+    return
+}
+
+function user.label_of(item: #0) -> string {
+    load_var item
+    load_type Tagged<Label = string>
+    load_const "tag"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
+    return
+}
+
+function user.main() -> string {
+    load_const "b"
+    init_instance user.Both .name
+    store_var both
+    load_type Both
+    load_var both
+    call user.describe
+    store_var _19
+    load_type Both
+    load_var both
+    call user.field_into_call_arg
+    store_var _22
+    load_type Both
+    load_var both
+    call user.field_into_switch
+    store_var _26
+    load_type int
+    load_var _26
+    call baml.String.from
+    store_var _25
+    load_type Both
+    load_var both
+    call user.label_of
+    store_var _30
+    load_var both
+    load_type Printable
+    load_const "display"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _34
+    load_type Both
+    load_var both
+    load_type Both
+    alloc_array 1
+    init_instance user.Registered .items
+    load_var both
+    load_type Registry<Both>
+    load_const "summarize"
+    virtual_call nargs=2 ntypeargs=1
+    store_var _35
+    load_var _19
+    load_const "/"
+    bin_op +
+    load_var _22
+    bin_op +
+    load_const "/"
+    bin_op +
+    load_var _25
+    bin_op +
+    load_const "/"
+    bin_op +
+    load_var _30
+    bin_op +
+    load_const "/"
+    bin_op +
+    load_var both
+    load_type Both
+    init_instance<1> user.Holder .item
+    load_field .item
+    load_field .0
+    bin_op +
+    load_const "/"
+    bin_op +
+    load_var _34
+    bin_op +
+    load_const "/"
+    bin_op +
+    load_var _35
+    bin_op +
+    return
+}
+
+function user.shout(text: string) -> string {
+    load_var text
+    load_const "!"
+    bin_op +
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__10_formatter__generic_intersection_bounds.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__10_formatter__generic_intersection_bounds.snap
@@ -1,0 +1,133 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+// A generic parameter's bound list is a CONJUNCTION: `T extends A & B` requires
+// an argument for `T` to implement both, and `T`'s member surface is the union
+// of every conjunct. Each conjunct must name an interface — see
+// `diagnostic_errors/generic_intersection_bounds` for the rejection cases.
+//
+// Every declaration site that accepts bounds appears below, so the TIR snapshot
+// pins both conjuncts on each type variable. CST lowering used to keep only the
+// first, silently weakening every bound written with `&`.
+
+interface Named {
+    name: string
+}
+
+interface Sized {
+    function size(self) -> int throws never
+}
+
+interface Tagged {
+    type Label
+
+    function tag(self) -> Self.Label throws never
+}
+
+class Both {
+    name: string,
+
+    implements Named {}
+
+    implements Sized {
+        function size(self) -> int {
+            7
+        }
+    }
+
+    implements Tagged {
+        type Label = string
+
+        function tag(self) -> string {
+            self.name
+        }
+    }
+}
+
+// Function generics: members reached through either conjunct.
+function describe<T extends Named & Sized>(item: T) -> string {
+    item.name + ":" + item.size().to_string()
+}
+
+// Three conjuncts: a member declared by the *last* one is still in `T`'s
+// surface, which is the case a dropped conjunct silently broke.
+function label_of<T extends Named & Sized & Tagged<Label = string>>(item: T) -> string {
+    item.tag()
+}
+
+// An interface field read on a bounded type variable lowers to a virtual field
+// access, which the stack-carry simulator must decline to inline. Each consumer
+// below reaches that simulator by a different route — a `Return` terminator, a
+// call argument, and a `Switch` discriminant — so all three are pinned, not just
+// the one a tail expression happens to take.
+function shout(text: string) -> string {
+    text + "!"
+}
+
+function field_into_call_arg<T extends Named & Sized>(item: T) -> string {
+    let out = shout(item.name);
+    out
+}
+
+function field_into_switch<T extends Named & Sized>(item: T) -> int {
+    match (item.name) {
+        "a" => 1,
+        _ => 0,
+    }
+}
+
+// Type-constructor generics carry the same conjunction.
+class Holder<T extends Named & Sized> {
+    item: T,
+}
+
+// Interface generics, and an interface method signature's own generics.
+interface Registry<T extends Named & Sized> {
+    function put(self, item: T) -> void throws never
+
+    function summarize<U extends Named & Sized>(self, other: U) -> string throws never
+}
+
+// An out-of-body `implements` block applies only to types satisfying every
+// conjunct of its own bound list.
+interface Printable {
+    function display(self) -> string throws never
+}
+
+implements<T extends Named & Sized> Printable for T {
+    function display(self) -> string { describe<T>(self) }
+}
+
+class Registered {
+    items: Both[],
+
+    implements Registry<Both> {
+        function put(self, item: Both) -> void {}
+
+        // Conformance compares full conjunctions, and the order of conjuncts is
+        // not significant, so the override may spell them the other way round.
+        function summarize<U extends Sized & Named>(self, other: U) -> string {
+            describe<U>(other)
+        }
+    }
+}
+
+function main() -> string {
+    let both = Both { name: "b" };
+    let holder = Holder<Both> { item: both };
+    let printable: Printable = both;
+    let registry = Registered { items: [both] };
+    describe<Both>(both)
+        + "/"
+        + field_into_call_arg<Both>(both)
+        + "/"
+        + field_into_switch<Both>(both).to_string()
+        + "/"
+        + label_of<Both>(both)
+        + "/"
+        + holder.item.name
+        + "/"
+        + printable.display()
+        + "/"
+        + registry.summarize<Both>(both)
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__03_ppir.snap
@@ -1,0 +1,51 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== PPIR ===
+class user.Holder {
+  item: T
+}
+class user.Holder$stream {
+  item: T | null
+}
+class user.OnlyNamed {
+  name: string
+}
+class user.OnlyNamed$stream {
+  name: string | null
+}
+class user.OnlySized {
+}
+class user.OnlySized$stream {
+}
+class user.WideningReader {
+}
+class user.WideningReader$stream {
+}
+function user.blanket_impl_needs_every_conjunct() -> string  [expr] {
+  { let p: Printable = user.OnlyNamed { name: "n" } } p.display()
+}
+function user.describe(item: T) -> string  [expr] {
+  {  } item.name
+}
+function user.display(self: ?) -> string  [expr] {
+  {  } self.name
+}
+function user.missing_conjunct_in_class_type_arg() -> string  [expr] {
+  { let h = user.Holder { item: user.OnlyNamed { name: "n" } } } h.item.name
+}
+function user.missing_conjunct_in_instantiation_expr() -> string  [expr] {
+  { let f = describe<...> } "ok"
+}
+function user.missing_leading_conjunct() -> string  [expr] {
+  {  } describe(user.OnlySized {  })
+}
+function user.missing_trailing_conjunct() -> string  [expr] {
+  {  } describe(user.OnlyNamed { name: "n" })
+}
+function user.read(self: ?, value: T) -> string  [expr] {
+  {  } value.name
+}
+function user.size(self: ?) -> int  [expr] {
+  {  } 1
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__03_ppir.snap
@@ -22,6 +22,9 @@ class user.WideningReader {
 }
 class user.WideningReader$stream {
 }
+function user.ambiguous_across_conjuncts(item: T) -> int  [expr] {
+  {  } item.size()
+}
 function user.blanket_impl_needs_every_conjunct() -> string  [expr] {
   { let p: Printable = user.OnlyNamed { name: "n" } } p.display()
 }
@@ -42,6 +45,9 @@ function user.missing_leading_conjunct() -> string  [expr] {
 }
 function user.missing_trailing_conjunct() -> string  [expr] {
   {  } describe(user.OnlyNamed { name: "n" })
+}
+function user.overlap_through_requires(item: T) -> string  [expr] {
+  {  } item.name
 }
 function user.read(self: ?, value: T) -> string  [expr] {
   {  } value.name

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__04_tir.snap
@@ -60,6 +60,17 @@ function user.WideningReader.read<T>(self: user.WideningReader, value: T) -> str
     value.name : string
   }
 }
+function user.ambiguous_across_conjuncts<T>(item: T) -> int throws never {
+  { : unknown
+    item.size() : unknown
+  }
+  !! 3044..3053: method `size` on class `T` is declared by multiple interfaces: `Sized`, `OtherSized`; unqualified calls will be ambiguous — use obj.as<Sized>.size() or obj.as<OtherSized>.size()
+}
+function user.overlap_through_requires<T>(item: T) -> string throws never {
+  { : string
+    item.name : string
+  }
+}
 function user.T.display(self: unknown) -> string throws never {
   { : string
     self.name : string

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__04_tir.snap
@@ -1,0 +1,77 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== TIR2 ===
+class user.OnlyNamed {
+  name: string
+}
+class user.OnlySized {
+}
+function user.OnlySized.size(self: user.OnlySized) -> int throws never {
+  { : 1
+    1 : 1
+  }
+}
+function user.describe<T>(item: T) -> string throws never {
+  { : string
+    item.name : string
+  }
+}
+function user.missing_trailing_conjunct() -> string throws never {
+  { : string
+    describe<T>(OnlyNamed { name: "n" }) : string
+  }
+  !! 1056..1100: type mismatch: expected Sized, got OnlyNamed
+}
+function user.missing_leading_conjunct() -> string throws never {
+  { : string
+    describe<T>(OnlySized {  }) : string
+  }
+  !! 1224..1257: type mismatch: expected Named, got OnlySized
+}
+function user.missing_conjunct_in_instantiation_expr() -> string throws never {
+  { : "ok"
+    let f = describe<...> : (item: user.OnlyNamed) -> string throws never
+    "ok" : "ok"
+  }
+  !! 1409..1428: type mismatch: expected Sized, got OnlyNamed
+}
+class user.Holder {
+  item: T
+}
+function user.missing_conjunct_in_class_type_arg() -> string throws never {
+  { : string
+    let h = Holder { item: OnlyNamed { name: "n" } } : user.Holder<user.OnlyNamed>
+    h.item.name : string
+  }
+  !! 1641..1692: type mismatch: expected Sized, got OnlyNamed
+}
+function user.blanket_impl_needs_every_conjunct() -> string throws never {
+  { : string
+    let p: Printable = OnlyNamed { name: "n" } : user.OnlyNamed -> user.Printable
+    p.display() : string
+  }
+  !! 2119..2142: type `OnlyNamed` does not satisfy the bound `Sized` required by the blanket `implements` rule
+}
+class user.WideningReader {
+}
+function user.WideningReader.read<T>(self: user.WideningReader, value: T) -> string throws never {
+  { : string
+    value.name : string
+  }
+}
+function user.T.display(self: unknown) -> string throws never {
+  { : string
+    self.name : string
+  }
+}
+class user.OnlyNamed$stream {
+  name: string | null
+}
+class user.OnlySized$stream {
+}
+class user.Holder$stream {
+  item: T | null
+}
+class user.WideningReader$stream {
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__05_diagnostics.snap
@@ -1,0 +1,56 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== COMPILER2 DIAGNOSTICS ===
+  [type] E0001
+
+  × mismatched types
+    ╭─[generic_intersection_bounds.baml:37:5]
+ 37 │     describe<OnlyNamed>(OnlyNamed { name: "n" })
+    ·     ──────────────────────┬─────────────────────
+    ·                           ╰── expected `Sized`, found `OnlyNamed`
+    ╰────
+
+  [type] E0001
+
+  × mismatched types
+    ╭─[generic_intersection_bounds.baml:42:5]
+ 42 │     describe<OnlySized>(OnlySized {})
+    ·     ────────────────┬────────────────
+    ·                     ╰── expected `Named`, found `OnlySized`
+    ╰────
+
+  [type] E0001
+
+  × mismatched types
+    ╭─[generic_intersection_bounds.baml:47:13]
+ 47 │     let f = describe<OnlyNamed>
+    ·             ─────────┬─────────
+    ·                      ╰── expected `Sized`, found `OnlyNamed`
+    ╰────
+
+  [type] E0001
+
+  × mismatched types
+    ╭─[generic_intersection_bounds.baml:57:13]
+ 57 │     let h = Holder<OnlyNamed> { item: OnlyNamed { name: "n" } }
+    ·             ─────────────────────────┬─────────────────────────
+    ·                                      ╰── expected `Sized`, found `OnlyNamed`
+    ╰────
+
+  [type] E0001
+
+  × type `OnlyNamed` does not satisfy the bound `Sized` required by the blanket `implements` rule
+    ╭─[generic_intersection_bounds.baml:72:24]
+ 72 │     let p: Printable = OnlyNamed { name: "n" }
+    ·                        ───────────────────────
+    ╰────
+
+  [type] E0120
+
+  × method `read` requires `T: Sized`, but interface `Reader`'s `read` declares no such bound — an implementation may not add requirements the interface does not
+    ╭─[generic_intersection_bounds.baml:84:9]
+ 84 │ ╭─▶         function read<T extends Named & Sized>(self, value: T) -> string {
+ 85 │ │               value.name
+ 86 │ ╰─▶         }
+    ╰────

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__05_diagnostics.snap
@@ -54,3 +54,11 @@ source: crates/baml_tests/src/generated_tests.rs
  85 │ │               value.name
  86 │ ╰─▶         }
     ╰────
+
+  [type] E0121
+
+  × method `size` on class `T` is declared by multiple interfaces: `Sized`, `OtherSized`; unqualified calls will be ambiguous — use obj.as<Sized>.size() or obj.as<OtherSized>.size()
+    ╭─[generic_intersection_bounds.baml:99:5]
+ 99 │     item.size()
+    ·     ─────────
+    ╰────

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__10_formatter__generic_intersection_bounds.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__10_formatter__generic_intersection_bounds.snap
@@ -1,0 +1,93 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+// A bound list is a CONJUNCTION: an argument for `T extends A & B` must satisfy
+// EVERY conjunct. CST lowering used to keep only the first, so a type satisfying
+// `A` alone was silently accepted; each case below must now be rejected, and
+// each must name the conjunct that is missing.
+//
+// Every declaration site that accepts bounds is covered, plus the two
+// order-sensitivity cases (leading conjunct missing, trailing conjunct missing)
+// that prove this is a conjunction rather than "the last bound wins".
+// See `compiles/generic_intersection_bounds` for the accepted shapes.
+
+interface Named {
+    name: string
+}
+
+interface Sized {
+    function size(self) -> int throws never
+}
+
+class OnlyNamed {
+    name: string,
+
+    implements Named {}
+}
+
+class OnlySized {
+    implements Sized {
+        function size(self) -> int {
+            1
+        }
+    }
+}
+
+function describe<T extends Named & Sized>(item: T) -> string {
+    item.name
+}
+
+// The trailing conjunct is unsatisfied — the case a dropped `& Sized` hid.
+function missing_trailing_conjunct() -> string {
+    describe<OnlyNamed>(OnlyNamed { name: "n" })
+}
+
+// The leading conjunct is unsatisfied, so `Named` is enforced too.
+function missing_leading_conjunct() -> string {
+    describe<OnlySized>(OnlySized {  })
+}
+
+// Referencing the generic as a *value* enforces the conjunction as well.
+function missing_conjunct_in_instantiation_expr() -> string {
+    let f = describe<OnlyNamed>;
+    "ok"
+}
+
+// Declaration-site bounds on a type constructor are checked at every use.
+class Holder<T extends Named & Sized> {
+    item: T,
+}
+
+function missing_conjunct_in_class_type_arg() -> string {
+    let h = Holder<OnlyNamed> { item: OnlyNamed { name: "n" } };
+    h.item.name
+}
+
+// An out-of-body `implements` block applies only to types satisfying every
+// conjunct of its bound list, so `OnlyNamed` gains no `Printable`.
+interface Printable {
+    function display(self) -> string throws never
+}
+
+implements<T extends Named & Sized> Printable for T {
+    function display(self) -> string { self.name }
+}
+
+function blanket_impl_needs_every_conjunct() -> string {
+    let p: Printable = OnlyNamed { name: "n" };
+    p.display()
+}
+
+// An implementation may not require more than the interface declares, so
+// widening `Named` to `Named & Sized` on an override is a conformance error.
+interface Reader {
+    function read<T extends Named>(self, value: T) -> string throws never
+}
+
+class WideningReader {
+    implements Reader {
+        function read<T extends Named & Sized>(self, value: T) -> string {
+            value.name
+        }
+    }
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__10_formatter__generic_intersection_bounds.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/generic_intersection_bounds/baml_tests__diagnostic_errors__generic_intersection_bounds__10_formatter__generic_intersection_bounds.snap
@@ -91,3 +91,25 @@ class WideningReader {
         }
     }
 }
+
+// Two conjuncts declaring the same member are siblings — neither shadows the
+// other — so the access is ambiguous and must be qualified with `.as<I>`.
+// Resolving conjunct-by-conjunct and taking the first hit would silently pick
+// `Sized` here, and which one it picked would depend on the order written.
+interface OtherSized {
+    function size(self) -> int throws never
+}
+
+function ambiguous_across_conjuncts<T extends Sized & OtherSized>(item: T) -> int {
+    item.size()
+}
+
+// A conjunct overlapping through `requires` is NOT ambiguous: both reach the
+// same realized interface, so it dedupes to one declarer.
+interface NamedAndSized requires Named {
+    function extra(self) -> int throws never
+}
+
+function overlap_through_requires<T extends Named & NamedAndSized>(item: T) -> string {
+    item.name
+}

--- a/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
@@ -1155,7 +1155,8 @@ pub(crate) mod support {
                     let generics_display = if gp.is_empty() {
                         String::new()
                     } else {
-                        let names: Vec<String> = gp.iter().map(|n| n.to_string()).collect();
+                        let names: Vec<String> =
+                            gp.iter().map(|param| param.name.to_string()).collect();
                         format!("<{}>", names.join(", "))
                     };
 

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase5.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase5.rs
@@ -22,6 +22,12 @@ fn make_db() -> ProjectDatabase {
     db
 }
 
+/// Declared generic parameter names, for assertions that care about the names
+/// rather than the bounds.
+fn generic_param_names(params: &[baml_compiler2_ppir::item_data::GenericParamData]) -> Vec<Name> {
+    params.iter().map(|param| param.name.clone()).collect()
+}
+
 /// Build a sorted, human-readable summary of what `package_items(db, "baml")`
 /// contains, separated by namespace.
 fn render_baml_package_items(db: &ProjectDatabase) -> String {
@@ -67,7 +73,7 @@ fn render_baml_package_items(db: &ProjectDatabase) -> String {
                             class_data
                                 .generic_params
                                 .iter()
-                                .map(|n| n.as_str())
+                                .map(|param| param.name.as_str())
                                 .collect::<Vec<_>>()
                                 .join(", ")
                         )
@@ -113,7 +119,7 @@ fn render_baml_package_items(db: &ProjectDatabase) -> String {
                             func_data
                                 .generic_params
                                 .iter()
-                                .map(|n| n.as_str())
+                                .map(|param| param.name.as_str())
                                 .collect::<Vec<_>>()
                                 .join(", ")
                         )
@@ -264,7 +270,7 @@ fn array_has_generic_param_t() {
     let class_data = baml_compiler2_ppir::item_data::class_data(&db, *class_loc);
 
     assert_eq!(
-        class_data.generic_params,
+        generic_param_names(&class_data.generic_params),
         vec![Name::new("T")],
         "Array should have generic_params [T]"
     );
@@ -285,7 +291,7 @@ fn map_has_generic_params_k_v() {
     let class_data = baml_compiler2_ppir::item_data::class_data(&db, *class_loc);
 
     assert_eq!(
-        class_data.generic_params,
+        generic_param_names(&class_data.generic_params),
         vec![Name::new("K"), Name::new("V")],
         "Map should have generic_params [K, V]"
     );

--- a/baml_language/crates/baml_tests/src/incremental/scenarios.rs
+++ b/baml_language/crates/baml_tests/src/incremental/scenarios.rs
@@ -479,7 +479,7 @@ fn function_loc<'db>(
 /// and carries no spans, so projecting it away loses nothing these tests check.
 type ClassFingerprint = (
     baml_base::Name,
-    Vec<Option<baml_compiler2_hir::type_ref::TypeRefId>>,
+    Vec<baml_compiler2_ppir::item_data::GenericParamData>,
     baml_compiler2_hir::type_ref::TypeRefStore,
     Vec<baml_compiler2_ppir::item_data::FieldData>,
     Vec<baml_compiler2_ppir::item_data::ImplementsData>,
@@ -494,7 +494,7 @@ fn class_fingerprint(
     let data = baml_compiler2_ppir::item_data::class_data(db, class_loc(db, file, name));
     (
         data.name.clone(),
-        data.generic_param_bounds.clone(),
+        data.generic_params.clone(),
         data.type_refs.clone(),
         data.fields.clone(),
         data.implements.clone(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generic type parameters now support multiple intersection bounds (conjunctive bounds), such as `T extends A & B`.
  * Members and dispatch behavior are derived from all declared conjuncts, not just the first.
  * Generic bound rendering is consistent across signatures and hover/type information.

* **Bug Fixes**
  * Corrected enforcement and validation when any required conjunct is missing.
  * Improved handling of ambiguity and associated-type resolution across conjunct bounds.
  * Prevented an incorrect optimization related to virtual field accesses.

* **Tests**
  * Added end-to-end compile and diagnostic coverage for intersection-bound semantics, including member visibility and ordering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->