### PR TITLE
Sort playground functions by workflow size

### DIFF
--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -2405,6 +2405,24 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
     }
   }, [functionNames, selectedProject, projectUpdateVersion, port]);
 
+  const workflowNodeCounts = useMemo(() => {
+    void workflowCacheVersion;
+    if (
+      prefetchedCfgRef.current.version !== projectUpdateVersion ||
+      !functionNames.every((name) => workflowCfgResponsesRef.current.has(name))
+    ) {
+      return undefined;
+    }
+
+    return new Map(
+      functionNames.map((name) => [
+        name,
+        Object.keys(workflowCfgResponsesRef.current.get(name)?.nodes ?? {})
+          .length,
+      ]),
+    );
+  }, [functionNames, projectUpdateVersion, workflowCacheVersion]);
+
   // Reverse call map over the cached CFGs: callee -> the functions that
   // call it. calleeName may be bare while function names are qualified
   // (`main.illustrate`), so resolve by exact match or trailing segment.
@@ -3023,6 +3041,7 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
                   testRunResults={testRunResults}
                   testTree={testTree}
                   viewingCollection={viewingCollection}
+                  workflowNodeCounts={workflowNodeCounts}
                 />
               </div>
               <div

--- a/typescript2/pkg-playground/src/FunctionSidebar.test.ts
+++ b/typescript2/pkg-playground/src/FunctionSidebar.test.ts
@@ -64,6 +64,61 @@ describe('function sidebar tree', () => {
 
     expect([...tree.forcedOpenFolderKeys]).toEqual(['demo']);
   });
+
+  it('sorts functions by rendered workflow node count while preserving ties', () => {
+    const tree = buildFunctionSidebarTree(
+      [
+        functionInfo('Small'),
+        functionInfo('LargeFirst'),
+        functionInfo('LargeSecond'),
+        functionInfo('Medium'),
+      ],
+      {
+        workflowNodeCounts: new Map([
+          ['Small', 2],
+          ['LargeFirst', 10],
+          ['LargeSecond', 10],
+          ['Medium', 5],
+        ]),
+      },
+    );
+
+    expect(tree.nodes.map(nodeLabel)).toEqual([
+      'function:LargeFirst',
+      'function:LargeSecond',
+      'function:Medium',
+      'function:Small',
+    ]);
+  });
+
+  it('orders namespace folders and their children by their largest workflows', () => {
+    const tree = buildFunctionSidebarTree(
+      [
+        functionInfo('small.One'),
+        functionInfo('large.Helper'),
+        functionInfo('small.Two'),
+        functionInfo('large.Entry'),
+      ],
+      {
+        workflowNodeCounts: new Map([
+          ['small.One', 2],
+          ['large.Helper', 7],
+          ['small.Two', 4],
+          ['large.Entry', 12],
+        ]),
+      },
+    );
+
+    expect(tree.nodes.map(nodeLabel)).toEqual(['folder:large', 'folder:small']);
+    expect(folder(tree.nodes, 'large').children.map(nodeLabel)).toEqual([
+      'function:Entry',
+      'function:Helper',
+    ]);
+    expect(folder(tree.nodes, 'small').children.map(nodeLabel)).toEqual([
+      'function:Two',
+      'function:One',
+    ]);
+  });
 });
 
 function functionInfo(name: string): FunctionInfo {

--- a/typescript2/pkg-playground/src/FunctionSidebar.tsx
+++ b/typescript2/pkg-playground/src/FunctionSidebar.tsx
@@ -78,7 +78,9 @@ function TestTreeNode({
         style={{ paddingLeft: leafIndent }}
       >
         {isFailed ? (
-          <FlaskConical className={cn(SIDEBAR_LEAF_ICON_CLASS, 'text-red-500')} />
+          <FlaskConical
+            className={cn(SIDEBAR_LEAF_ICON_CLASS, 'text-red-500')}
+          />
         ) : (
           <Loader2 className={cn(SIDEBAR_LEAF_ICON_CLASS, 'animate-spin')} />
         )}
@@ -229,6 +231,8 @@ function TestTreeNode({
 
 export interface FunctionSidebarProps {
   functions: FunctionInfo[];
+  /** Rendered workflow graph node count for each function. */
+  workflowNodeCounts?: ReadonlyMap<string, number>;
   /** Whether internal functions are currently shown (toggled from the
    * panel's settings gear menu) — used only for the empty-state message. */
   showInternalFunctions: boolean;
@@ -317,9 +321,7 @@ function FunctionTreeNode({
             )}
           />
           <Folder className="h-3.5 w-3.5 shrink-0 text-vsc-text-faint" />
-          <span className="truncate text-[11px] font-medium">
-            {node.name}
-          </span>
+          <span className="truncate text-[11px] font-medium">{node.name}</span>
           <span className="text-vsc-text-faint ml-1">
             ({node.functionCount})
           </span>
@@ -379,6 +381,7 @@ function FunctionTreeNode({
 
 export const FunctionSidebar: FC<FunctionSidebarProps> = ({
   functions,
+  workflowNodeCounts,
   showInternalFunctions,
   internalFunctionCount,
   isLoadingProject = false,
@@ -403,8 +406,9 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
   const [search, setSearch] = useState('');
   // Accordion state: tests are the primary view; functions start collapsed.
   const [functionsOpen, setFunctionsOpen] = useState(false);
-  const [openFolderKeys, setOpenFolderKeys] =
-    useState<FunctionFolderOpenState>({});
+  const [openFolderKeys, setOpenFolderKeys] = useState<FunctionFolderOpenState>(
+    {},
+  );
   const [testsOpen, setTestsOpen] = useState(true);
 
   const functionTree = useMemo(
@@ -412,8 +416,9 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
       buildFunctionSidebarTree(functions, {
         search,
         selectedFunctionName: selectedFn,
+        workflowNodeCounts,
       }),
-    [functions, search, selectedFn],
+    [functions, search, selectedFn, workflowNodeCounts],
   );
   const hasFunctionSearch = search.trim() !== '';
   const setFunctionFolderOpen = (key: string, open: boolean) => {
@@ -546,15 +551,18 @@ export const FunctionSidebar: FC<FunctionSidebarProps> = ({
                 </div>
               )}
 
-              {testTree && treeItems.length === 0 && previewTests.length === 0 && (
-                <div className="px-4 py-2 text-[10px] text-vsc-text-faint italic">
-                  No tests found
-                </div>
-              )}
+              {testTree &&
+                treeItems.length === 0 &&
+                previewTests.length === 0 && (
+                  <div className="px-4 py-2 text-[10px] text-vsc-text-faint italic">
+                    No tests found
+                  </div>
+                )}
 
               {previewTests.map((test) => {
                 const key = previewTestKey(test);
-                const duplicateName = (previewNameCounts.get(test.name) ?? 0) > 1;
+                const duplicateName =
+                  (previewNameCounts.get(test.name) ?? 0) > 1;
                 return (
                   <button
                     type="button"

--- a/typescript2/pkg-playground/src/function-sidebar-tree.ts
+++ b/typescript2/pkg-playground/src/function-sidebar-tree.ts
@@ -35,6 +35,7 @@ type MutableFolderNode = Omit<FunctionSidebarFolderNode, 'children'> & {
 type BuildFunctionSidebarTreeOptions = {
   search?: string;
   selectedFunctionName?: string | null;
+  workflowNodeCounts?: ReadonlyMap<string, number>;
 };
 
 export function buildFunctionSidebarTree(
@@ -47,7 +48,20 @@ export function buildFunctionSidebarTree(
   const forcedOpenFolderKeys = new Set<string>();
   let functionCount = 0;
 
-  for (const functionInfo of functions) {
+  const workflowNodeCounts = options.workflowNodeCounts;
+  const sortedFunctions = workflowNodeCounts
+    ? functions
+        .map((functionInfo, index) => ({ functionInfo, index }))
+        .sort(
+          (a, b) =>
+            (workflowNodeCounts.get(b.functionInfo.name) ?? 0) -
+              (workflowNodeCounts.get(a.functionInfo.name) ?? 0) ||
+            a.index - b.index,
+        )
+        .map(({ functionInfo }) => functionInfo)
+    : functions;
+
+  for (const functionInfo of sortedFunctions) {
     if (query && !functionInfo.name.toLowerCase().includes(query)) continue;
 
     const parts = functionInfo.name.split('.');


### PR DESCRIPTION
## Summary

- Sort sidebar functions by the node count of their rendered workflow control-flow graph, largest first.
- Preserve source order for equal-size workflows and rank namespace folders by their largest descendant workflow.
- Wait for all CFG prefetch responses for the current build before applying the order, avoiding incremental sidebar reshuffling.

## Validation

- `pnpm --filter @b/pkg-playground test` (152 tests)
- `pnpm --filter @b/pkg-playground typecheck`
- `pnpm --filter app-vscode-webview build`
- Opened `baml playground` and captured before/after sidebar screenshots for every project in `~/work-repos/baml-demos`

## Screenshots

Before is on the left and after is on the right for each demo project.

### `aie`

<img width="840" alt="aie sidebar before and after workflow-size sorting" src="https://github.com/user-attachments/assets/b39dc9a6-1d8c-4aff-8324-d33ec45aad00" />

### `baml-c-compiler`

<img width="840" alt="baml-c-compiler sidebar before and after workflow-size sorting" src="https://github.com/user-attachments/assets/8a43a295-5400-4e08-a0b1-ff93b303824a" />

### `baml-deep-research-demo`

<img width="840" alt="baml-deep-research-demo sidebar before and after workflow-size sorting" src="https://github.com/user-attachments/assets/ab8f058a-704b-4915-acc8-6f21a19bddb7" />

### `baml-email-agent-demo`

<img width="840" alt="baml-email-agent-demo sidebar before and after workflow-size sorting" src="https://github.com/user-attachments/assets/d3ed643f-e8b6-430c-97a1-3c5b44bfc09c" />

### `baml-text-to-sql-demo`

<img width="840" alt="baml-text-to-sql-demo sidebar before and after workflow-size sorting" src="https://github.com/user-attachments/assets/ad4fe055-2144-460b-bad4-31a231deb739" />

### `bamlcode`

<img width="840" alt="bamlcode sidebar before and after workflow-size sorting" src="https://github.com/user-attachments/assets/dd40eb48-897a-4b09-8d68-5cc9a8bf90b5" />

### `claude-session-quality`

<img width="840" alt="claude-session-quality sidebar before and after workflow-size sorting" src="https://github.com/user-attachments/assets/c0353f89-fd03-4f3a-9fc9-314d52aab95e" />

### `google-adk`

<img width="840" alt="google-adk sidebar before and after workflow-size sorting" src="https://github.com/user-attachments/assets/4be9355d-1526-4257-90a3-f1281c803a22" />

### `python-discord-bot`

<img width="840" alt="python-discord-bot sidebar before and after workflow-size sorting" src="https://github.com/user-attachments/assets/8abc4191-afd0-4c57-ad07-b80ec62ecb25" />