### PR TITLE
Nightly channel should release nightly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -90,6 +90,7 @@ jobs:
             ':scripts/baml-release-platforms' \
             ':scripts/baml_release_platforms.py' \
             ':scripts/baml-bridge-cffi-hygiene' \
+            ':scripts/tests/**' \
             ':release/platforms.json' \
             ':scripts/install.sh' \
             ':scripts/install.ps1' \
@@ -97,6 +98,7 @@ jobs:
             ':tools/pkg_boundaryml_com/**' \
             ':.github/workflows/ci.yaml' \
             ':.github/workflows/release-baml-language.yml' \
+            ':.github/workflows/nightly-release.yml' \
             ':.github/workflows/build2-bridge-cffi.reusable.yaml' \
             ':.github/workflows/build2-python-sdk.reusable.yaml' \
             ':.github/workflows/build2-nodejs-sdk.reusable.yaml' \
@@ -304,6 +306,7 @@ jobs:
             ':.github/workflows/build2-bridge-cffi.reusable.yaml' \
             ':.github/actions/setup-rust/**' \
             ':scripts/baml-bridge-cffi-hygiene' \
+            ':scripts/tests/**' \
             ':release/platforms.json' \
             ':baml_language/Cargo.toml' \
             ':baml_language/Cargo.lock' \
@@ -1268,15 +1271,26 @@ jobs:
           echo "::error::One or more CI jobs failed!"
           exit 1
 
-  # Entry point for the release: a green push to canary hands off to
-  # release-baml-language.yml. The release deliberately has no `workflow_run`
-  # trigger -- crates.io refuses to mint a Trusted Publishing token for
-  # `workflow_run` (and `pull_request_target`) runs, so a `workflow_run` release
-  # can never publish baml_bridge.
+  # Release entry point for pushes to canary. Two things happen here:
+  #
+  #   1. Every green canary commit gets its immutable `baml-language-source-<sha>`
+  #      tag. That tag is the ref every production release run is dispatched at,
+  #      and the release re-checks it before publishing, so it must exist for any
+  #      commit a release could later be cut from -- including commits the
+  #      scheduled nightly picks up hours or days later.
+  #   2. A CANARY release is dispatched, but only when this push bumps
+  #      [release].canary_version in baml_language/release.toml. Everything else
+  #      ships through nightly-release.yml, which cuts one nightly a night at
+  #      midnight Seattle time instead of one per merge.
+  #
+  # The release deliberately has no `workflow_run` trigger -- crates.io refuses
+  # to mint a Trusted Publishing token for `workflow_run` (and
+  # `pull_request_target`) runs, so a `workflow_run` release can never publish
+  # baml_bridge.
   #
   # Same required-gate set as ci-failure-alert above; keep the two lists in sync.
   dispatch-release:
-    name: "Dispatch BAML Language Release"
+    name: "Tag Release Source & Dispatch Canary Cut"
     runs-on: ubuntu-latest
     needs:
       - prek
@@ -1302,6 +1316,8 @@ jobs:
       actions: write
       contents: write
     steps:
+      # Tagging comes first, and needs no checkout: it is what makes a commit
+      # releasable days later, so a clone flake must not be able to stop it.
       - name: Create immutable release workflow ref
         id: release-workflow-ref
         env:
@@ -1335,7 +1351,77 @@ jobs:
           echo "ref=$release_ref" >> "$GITHUB_OUTPUT"
           echo "Release workflow ref: $release_ref ($ref_sha)"
 
-      - name: Dispatch release for this commit
+      - uses: useblacksmith/checkout@v1
+        with:
+          # HEAD^ is all the canary-cut check below needs. canary is
+          # squash-merge-only with linear history required, so every push is a
+          # single commit and HEAD^ is the whole push.
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Decide whether this push cuts a canary release
+        id: canary-cut
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # A canary cut is *requested* by bumping [release].canary_version in
+          # baml_language/release.toml, and is skipped when that version is
+          # already released so a re-run cannot cut it twice. This is the only
+          # push-triggered release; nightly-release.yml owns everything else.
+          if ! git rev-parse HEAD^ >/dev/null 2>&1; then
+            echo "cut=false" >> "$GITHUB_OUTPUT"
+            echo "No parent commit to diff against; leaving this commit to the nightly."
+            exit 0
+          fi
+          if git diff --quiet HEAD^ HEAD -- baml_language/release.toml; then
+            echo "cut=false" >> "$GITHUB_OUTPUT"
+            echo "release.toml unchanged; the nightly schedule owns this commit."
+            exit 0
+          fi
+          canary_version="$(scripts/baml-language-version compute --channel canary)"
+          # The file changing is only a necessary condition -- compare the parsed
+          # value, since an edit to anything else in release.toml is not a
+          # release request. Point the tool's own parser at a tree holding the
+          # parent's file rather than re-implementing TOML parsing in shell.
+          previous_root="$(mktemp -d)"
+          trap 'rm -rf "$previous_root"' EXIT
+          mkdir -p "$previous_root/baml_language"
+          previous_version=""
+          if git show "HEAD^:baml_language/release.toml" \
+            > "$previous_root/baml_language/release.toml" 2>/dev/null; then
+            previous_version="$(BAML_LANGUAGE_VERSION_ROOT="$previous_root" \
+              scripts/baml-language-version show)"
+          fi
+          if [[ "$canary_version" == "$previous_version" ]]; then
+            echo "cut=false" >> "$GITHUB_OUTPUT"
+            echo "[release].canary_version is unchanged at $canary_version; the nightly schedule owns this commit."
+            exit 0
+          fi
+          # Ask for the release by name and read the STATUS: `gh release view`
+          # exits non-zero for a network or auth error just as it does for "not
+          # found", and treating those alike would re-cut a published version.
+          status="$(gh api -i "repos/$GH_REPO/releases/tags/baml-language-$canary_version" \
+            --silent 2>/dev/null | head -1 | awk '{print $2}' || true)"
+          case "$status" in
+            200)
+              echo "cut=false" >> "$GITHUB_OUTPUT"
+              echo "baml-language-$canary_version is already released; not cutting it again."
+              exit 0
+              ;;
+            404)
+              ;;
+            *)
+              echo "::error::could not determine whether baml-language-$canary_version is released (HTTP ${status:-none})"
+              exit 1
+              ;;
+          esac
+          echo "cut=true" >> "$GITHUB_OUTPUT"
+          echo "release.toml bumped to an unreleased version; cutting canary $canary_version."
+
+      - name: Dispatch canary release for this commit
+        if: ${{ steps.canary-cut.outputs.cut == 'true' }}
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_WORKFLOW_REF: ${{ steps.release-workflow-ref.outputs.ref }}
@@ -1346,7 +1432,7 @@ jobs:
           gh workflow run release-baml-language.yml \
             --repo "$GITHUB_REPOSITORY" \
             --ref "$RELEASE_WORKFLOW_REF" \
-            -f channel=auto \
+            -f channel=canary \
             -f dry_run=false \
             -f source_sha="$GITHUB_SHA" \
             -f source_ci_run_id="$GITHUB_RUN_ID"

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,300 @@
+name: Nightly BAML Language Release
+
+# Cuts one nightly per night, at midnight America/Los_Angeles, when canary moved
+# since the last one.
+#
+# `CI - BAML Language` used to dispatch a release for every green push to canary,
+# so "nightly" meant "per merge" -- seven cuts landed on 2026-07-29 alone. CI now
+# dispatches only canary cuts (a baml_language/release.toml version bump), and
+# this workflow is the sole site that cuts the nightly channel. That is what lets
+# "one nightly per night" be true rather than merely intended: with a single cut
+# site there is no second claimant to race.
+#
+# Like every dispatcher of release-baml-language.yml, this one pins the run to
+# the immutable `baml-language-source-<sha>` tag CI created for the commit: the
+# release refuses to publish a production run dispatched at any other ref.
+#
+# Skipping is normal and quiet -- a day with no merges has nothing to release.
+# Everything else is loud: this workflow failing is the signal that the nightly
+# channel has stopped advancing.
+on:
+  schedule:
+    # GitHub cron is UTC-only and does not honor DST, so midnight in Seattle is
+    # 07:00 UTC under PDT and 08:00 UTC under PST. Both entries fire every day
+    # and the local-clock gate below drops whichever one is not local midnight,
+    # so exactly one survives year-round -- including on the DST transition days
+    # themselves, where the surviving entry swaps over. Minute 7 rather than 0
+    # because GitHub delays scheduled runs most at the top of the hour, and a
+    # delay past 01:00 local forfeits the night.
+    - cron: "7 7 * * *"
+    - cron: "7 8 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        # Deliberately does not override the behind/diverged refusal below --
+        # that is the one guard whose whole point is to stop a human overriding
+        # it in a hurry.
+        description: "Cut a nightly even if canary has not moved or a run already exists"
+        type: boolean
+        default: false
+
+permissions:
+  # `actions: write` dispatches the release; the reads below (CI runs, release
+  # runs, commits, tags) need nothing beyond the default scopes.
+  actions: write
+  contents: read
+
+concurrency:
+  group: baml-language-nightly-dispatch
+  cancel-in-progress: false
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  dispatch-nightly:
+    name: Dispatch nightly release
+    # A fork inherits the schedule but must never cut releases for the upstream
+    # registries (and its token could not dispatch this anyway).
+    if: ${{ github.repository == 'BoundaryML/baml' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      source_sha: ${{ steps.select.outputs.sha }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Gate on local midnight in Seattle
+        id: clock
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          local_now="$(TZ=America/Los_Angeles date --iso-8601=seconds)"
+          if [[ "$EVENT_NAME" != "schedule" ]]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "Manual run at $local_now; local-midnight gate does not apply."
+            exit 0
+          fi
+          # Deliberately strict. Accepting the 01:00 hour as well would let a
+          # delayed cron still cut that night, but it would also let BOTH cron
+          # entries through every night under PDT (07:00 UTC = 00:00, 08:00 UTC
+          # = 01:00), and a nightly double-cut every night is far worse than the
+          # rare missed night: the next night ships every commit since anyway.
+          local_hour="$(TZ=America/Los_Angeles date +%H)"
+          if [[ "$local_hour" == "00" ]]; then
+            echo "proceed=true" >> "$GITHUB_OUTPUT"
+            echo "Local time is $local_now; this is tonight's nightly slot."
+          else
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            echo "Local time is $local_now, not the midnight hour; the other cron entry owns tonight."
+          fi
+
+      - name: Select the newest green canary commit
+        id: select
+        if: ${{ steps.clock.outputs.proceed == 'true' }}
+        run: |
+          set -euo pipefail
+          # Off the workspace: this job never checks the repo out.
+          green="$RUNNER_TEMP/green-ci-runs.json"
+          commits="$RUNNER_TEMP/canary-commits.txt"
+          # The release attests its source against a successful `CI - BAML
+          # Language` push run on canary, so only such a commit is releasable.
+          gh run list --workflow ci.yaml --branch canary --event push \
+            --status success --limit 100 \
+            --json headSha,databaseId > "$green"
+          # Walk canary newest-first rather than trusting run order: runs are
+          # ordered by creation, which is not commit ancestry.
+          gh api "repos/$GH_REPO/commits?sha=canary&per_page=100" \
+            --jq '.[].sha' > "$commits"
+          sha=""
+          run_id=""
+          while IFS= read -r commit; do
+            id="$(jq -r --arg commit "$commit" \
+              '[.[] | select(.headSha == $commit) | .databaseId] | max // empty' \
+              "$green")"
+            if [[ -n "$id" ]]; then
+              sha="$commit"
+              run_id="$id"
+              break
+            fi
+          done < "$commits"
+          if [[ -z "$sha" ]]; then
+            echo "::error::no canary commit in the last 100 has a successful CI run, so nothing is releasable tonight"
+            exit 1
+          fi
+          {
+            echo "sha=$sha"
+            echo "run_id=$run_id"
+          } >> "$GITHUB_OUTPUT"
+          echo "Newest green canary commit: $sha (CI run $run_id)"
+
+      - name: Decide whether canary moved since the last nightly
+        id: decide
+        if: ${{ steps.select.outputs.sha != '' }}
+        env:
+          CANDIDATE_SHA: ${{ steps.select.outputs.sha }}
+          FORCE: ${{ inputs.force || false }}
+        run: |
+          set -euo pipefail
+
+          decide() {
+            echo "dispatch=$1" >> "$GITHUB_OUTPUT"
+            echo "$2"
+            echo "$2" >> "$GITHUB_STEP_SUMMARY"
+          }
+
+          # One cut per commit. This observes the EFFECT -- a release run exists
+          # at the candidate's source tag -- rather than whether some earlier run
+          # of this workflow happened to conclude green. That distinction is
+          # load-bearing: the clock gate skips *steps*, not the job, so the cron
+          # entry that loses the midnight gate still concludes `success`, and any
+          # guard keyed on this workflow's own conclusion would read that no-op
+          # as "tonight is handled" and stand the real cut down -- every night,
+          # for the whole PST half of the year. Failed and cancelled runs do not
+          # count; that commit still needs a release.
+          #
+          # A run at this tag may be an unrelated canary release rather than a
+          # nightly. Standing down then costs this night its cut, but not the
+          # commits: the next night's candidate is still ahead of the last
+          # nightly, so they ship then.
+          existing="$(gh run list --workflow release-baml-language.yml --limit 200 \
+            --json headBranch,conclusion |
+            jq --arg branch "baml-language-source-$CANDIDATE_SHA" \
+              '[.[]
+                | select(.headBranch == $branch)
+                | select(.conclusion == null or .conclusion == "" or .conclusion == "success")]
+               | length')"
+          if [[ "$existing" != "0" && "$FORCE" != "true" ]]; then
+            decide false "A release run for $CANDIDATE_SHA is already in flight or done; nothing to do."
+            exit 0
+          fi
+
+          # Newest nightly by PUBLICATION time: `created_at` on a GitHub release
+          # is the tagged commit's date, not the publication time, so sorting on
+          # it misorders cuts that share a source commit.
+          prev_tag="$(gh release list --limit 200 \
+            --json tagName,publishedAt,isDraft |
+            jq -r '[.[]
+                    | select(.isDraft | not)
+                    | select(.tagName | test("^baml-language-[0-9]+\\.[0-9]+\\.[0-9]+-nightly\\."))]
+                   | sort_by(.publishedAt) | last | .tagName // empty')"
+          if [[ -z "$prev_tag" ]]; then
+            decide true "No previous nightly release exists; cutting one from $CANDIDATE_SHA."
+            exit 0
+          fi
+          ref_json="$(gh api "repos/$GH_REPO/git/ref/tags/$prev_tag")"
+          prev_sha="$(jq -r '.object.sha' <<<"$ref_json")"
+          if [[ "$(jq -r '.object.type' <<<"$ref_json")" == "tag" ]]; then
+            prev_sha="$(gh api "repos/$GH_REPO/git/tags/$prev_sha" --jq '.object.sha')"
+          fi
+          echo "Last nightly: $prev_tag (source $prev_sha)"
+
+          comparison="$(gh api "repos/$GH_REPO/compare/$prev_sha...$CANDIDATE_SHA")"
+          status="$(jq -r '.status' <<<"$comparison")"
+          ahead_by="$(jq -r '.ahead_by' <<<"$comparison")"
+          case "$status" in
+            ahead)
+              decide true "$ahead_by new commit(s) on canary since $prev_tag; cutting a nightly from $CANDIDATE_SHA."
+              ;;
+            identical)
+              # The one expected quiet outcome: a day with no merges.
+              if [[ "$FORCE" == "true" ]]; then
+                decide true "Forced: cutting a nightly from $CANDIDATE_SHA though canary has not moved."
+              else
+                decide false "canary has not moved since $prev_tag; nothing to release."
+              fi
+              ;;
+            behind | diverged)
+              # The releasable commit is not a descendant of what shipped last
+              # night, so cutting would publish a content rollback under a higher
+              # version -- and the mutable nightly pointers (the npm dist-tag and
+              # the channel manifest) are last-writer-wins, so consumers would
+              # silently move backwards. `force` deliberately does NOT reach this
+              # branch: re-running with it is the obvious reaction to the red
+              # run, and it must not be the one that ships the rollback.
+              #
+              # Canary is squash-merge-only with force-pushes disabled, so the
+              # reachable cause is a nightly tag published before `--target` was
+              # passed to `gh release create`: those name canary's head at
+              # publish time, which can be ahead of the newest green commit. It
+              # clears once one correctly-targeted nightly publishes.
+              echo "::error::$CANDIDATE_SHA is $status relative to $prev_tag ($prev_sha); refusing to cut a nightly"
+              exit 1
+              ;;
+            *)
+              echo "::error::unexpected compare status '$status' for $prev_sha...$CANDIDATE_SHA"
+              exit 1
+              ;;
+          esac
+
+      - name: Dispatch the nightly release
+        if: ${{ steps.decide.outputs.dispatch == 'true' }}
+        env:
+          SOURCE_SHA: ${{ steps.select.outputs.sha }}
+          SOURCE_CI_RUN_ID: ${{ steps.select.outputs.run_id }}
+        run: |
+          set -euo pipefail
+          # CI tags every green canary push with this ref, and the release
+          # refuses to publish unless it was dispatched at exactly it. Verify
+          # rather than create: a missing or mismatched tag means CI did not tag
+          # the commit whose CI run it attested, which is worth surfacing loudly.
+          release_ref="baml-language-source-$SOURCE_SHA"
+          if ! ref_json="$(gh api "repos/$GH_REPO/git/ref/tags/$release_ref" 2>&1)"; then
+            echo "::error::$release_ref does not resolve: $ref_json"
+            exit 1
+          fi
+          ref_type="$(jq -r '.object.type // ""' <<<"$ref_json")"
+          ref_sha="$(jq -r '.object.sha // ""' <<<"$ref_json")"
+          if [[ "$ref_type" != "commit" || "$ref_sha" != "$SOURCE_SHA" ]]; then
+            echo "::error::$release_ref resolves to $ref_type $ref_sha, expected commit $SOURCE_SHA"
+            exit 1
+          fi
+          # The release names the night itself, from the Seattle date at plan
+          # time. That is stable however long this run queues -- it would take a
+          # 24-hour delay to land on a different local date.
+          gh workflow run release-baml-language.yml \
+            --ref "$release_ref" \
+            -f channel=nightly \
+            -f dry_run=false \
+            -f source_sha="$SOURCE_SHA" \
+            -f source_ci_run_id="$SOURCE_CI_RUN_ID"
+          echo "Dispatched a nightly release for $SOURCE_SHA (CI run $SOURCE_CI_RUN_ID)."
+
+  notify-slack:
+    name: Notify Slack on failure
+    needs: [dispatch-nightly]
+    # Only on failure. The sibling notifier in release-baml-language.yml runs
+    # `always()` because it fans in from forty jobs and one of them can go green
+    # with a failed step; here there is a single upstream job, so a failed step
+    # is a failed job. Gating keeps the ~365 nights a year that the clock gate
+    # legitimately skips from each paying for a checkout and a `uv` install.
+    if: ${{ always() && github.repository == 'BoundaryML/baml' && needs.dispatch-nightly.result == 'failure' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: boundary-tools-dev
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - uses: actions/checkout@v7.0.1
+        with:
+          sparse-checkout: |
+            .github/actions/setup-mise
+            mise.toml
+            tools/notify-release-failure.py
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - uses: ./.github/actions/setup-mise
+        with:
+          install_args: uv
+      - name: Find failures and notify Slack
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SLACK_CHANNEL: "#general"
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOUNDARY_BOT_TOKEN }}
+          CHANNEL: "nightly dispatch"
+          VERSION: ${{ needs.dispatch-nightly.outputs.source_sha || 'no candidate commit' }}
+        run: uv run --script tools/notify-release-failure.py

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -3,21 +3,32 @@ name: BAML Language Release
 # Channel-aware replacement for the legacy BAML language release workflow.
 # Release workflows run packaging smoke tests only; the full suite runs in CI.
 
-# Dispatch-only: `CI - BAML Language` calls `gh workflow run` on this file after
-# a green push to canary. That is deliberately not a `workflow_run` trigger --
-# crates.io refuses to mint a Trusted Publishing token for `workflow_run` (and
-# `pull_request_target`) runs, so a `workflow_run` release can never publish
-# baml_bridge. Dispatching from CI keeps the same "CI must be green" gate while
-# tightening the trust chain: `workflow_run` fires for *every* CI run including
-# fork pull requests, whereas a fork's CI has a read-only token and cannot
-# dispatch at all.
+# Dispatch-only, with exactly one production dispatcher per channel:
+#   - `CI - BAML Language` cuts the CANARY channel after a green push to canary
+#     that bumps [release].canary_version in baml_language/release.toml;
+#   - `Nightly BAML Language Release` cuts the NIGHTLY channel once a night, at
+#     midnight America/Los_Angeles, when canary moved since the last nightly.
+# Both pin the run to the immutable `baml-language-source-<sha>` tag CI created
+# for the commit, which the attestation below re-checks.
+#
+# One dispatcher per channel is deliberate: a canary release used to chain a
+# nightly of its own, which meant two sites racing to name the same night with
+# no way to see each other's in-flight claim. The nightly channel now simply
+# advances at the next midnight cut instead.
+#
+# That is deliberately not a `workflow_run` trigger -- crates.io refuses to mint
+# a Trusted Publishing token for `workflow_run` (and `pull_request_target`)
+# runs, so a `workflow_run` release can never publish baml_bridge. Dispatching
+# from CI keeps the same "CI must be green" gate while tightening the trust
+# chain: `workflow_run` fires for *every* CI run including fork pull requests,
+# whereas a fork's CI has a read-only token and cannot dispatch at all.
 on:
   workflow_dispatch:
     inputs:
       channel:
-        description: "Release channel to plan (auto: pick canary/nightly from release.toml, as CI does)"
+        description: "Release channel to plan"
         type: choice
-        options: [auto, nightly, canary]
+        options: [nightly, canary]
         default: nightly
         required: true
       dry_run:
@@ -83,7 +94,6 @@ jobs:
       dry_run: ${{ steps.plan.outputs.dry_run }}
       wrapper_version: ${{ steps.wrapper.outputs.wrapper_version }}
       wrapper_changed: ${{ steps.wrapper.outputs.wrapper_changed }}
-      dispatch_nightly_after_canary: ${{ steps.plan.outputs.dispatch_nightly_after_canary }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -194,19 +204,7 @@ jobs:
           channel="${INPUT_CHANNEL:-nightly}"
           dry_run="${INPUT_DRY_RUN:-false}"
           source_branch="${ATTESTED_SOURCE_BRANCH:-${GITHUB_REF_NAME:-}}"
-          dispatch_nightly_after_canary="false"
-          if [[ "$channel" == "auto" ]]; then
-            channel="nightly"
-            if git rev-parse HEAD^ >/dev/null 2>&1 && git diff --quiet HEAD^ HEAD -- baml_language/release.toml; then
-              :
-            elif git rev-parse HEAD^ >/dev/null 2>&1; then
-              canary_version="$(scripts/baml-language-version compute --channel canary)"
-              if ! gh release view "baml-language-${canary_version}" >/dev/null 2>&1; then
-                channel="canary"
-                dispatch_nightly_after_canary="true"
-              fi
-            fi
-          fi
+          # `plan` rejects any channel other than canary/nightly.
           scripts/baml-language-version plan --channel "$channel" --out release-plan.json
           source_sha="$(git rev-parse HEAD)"
           version="$(jq -r .canonical_version release-plan.json)"
@@ -237,7 +235,6 @@ jobs:
             echo "source_branch=$source_branch"
             echo "source_ci_run_id=$INPUT_SOURCE_CI_RUN_ID"
             echo "dry_run=$dry_run"
-            echo "dispatch_nightly_after_canary=$dispatch_nightly_after_canary"
           } >> "$GITHUB_OUTPUT"
 
       - name: Check wrapper version
@@ -1207,12 +1204,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.plan.outputs.git_tag }}
           VERSION: ${{ needs.plan.outputs.version }}
+          SOURCE_SHA: ${{ needs.plan.outputs.source_sha }}
         run: |
           set -euo pipefail
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" dist/toolchain/* dist/vsix/* --clobber
           else
+            # `--target` is load-bearing, not cosmetic: without it GitHub tags
+            # the default branch's head at publish time, which is not the commit
+            # these artifacts were built from once canary advances during the
+            # build. The nightly scheduler reads this tag to decide whether
+            # canary moved since the last nightly, so a tag pointing at unbuilt
+            # commits would silently retire them.
             gh release create "$TAG" dist/toolchain/* dist/vsix/* \
+              --target "$SOURCE_SHA" \
               --title "BAML Language $VERSION" \
               --notes "BAML language toolchain $VERSION"
           fi
@@ -1304,6 +1309,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.plan.outputs.git_tag }}
           VERSION: ${{ needs.plan.outputs.version }}
+          SOURCE_SHA: ${{ needs.plan.outputs.source_sha }}
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -1313,9 +1319,11 @@ jobs:
             exit 1
           fi
           # The toolchain publisher created the shared release; create it only if
-          # a cffi-only rerun somehow got here first.
+          # a cffi-only rerun somehow got here first. `--target` for the same
+          # reason it is there: whoever wins the race must tag the source commit.
           if ! gh release view "$TAG" >/dev/null 2>&1; then
-            gh release create "$TAG" --title "BAML Language $VERSION" \
+            gh release create "$TAG" --target "$SOURCE_SHA" \
+              --title "BAML Language $VERSION" \
               --notes "BAML language $VERSION"
           fi
           # Immutable upload: add missing assets, verify identical bytes for any
@@ -2030,41 +2038,6 @@ jobs:
             --content-type application/json \
             --cache-control "public, max-age=60, must-revalidate"
 
-  dispatch-nightly-after-canary:
-    name: Queue nightly after canary publish
-    needs: [plan, publish-pkg-channel]
-    if: >-
-      ${{
-        !cancelled() &&
-        needs.plan.result == 'success' &&
-        needs.publish-pkg-channel.result == 'success' &&
-        needs.plan.outputs.dispatch_nightly_after_canary == 'true' &&
-        needs.plan.outputs.dry_run == 'false' &&
-        needs.plan.outputs.source_branch == 'canary'
-      }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-      contents: read
-    steps:
-      - name: Dispatch nightly release run
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SOURCE_SHA: ${{ needs.plan.outputs.source_sha }}
-          SOURCE_CI_RUN_ID: ${{ needs.plan.outputs.source_ci_run_id }}
-          SOURCE_WORKFLOW_REF: ${{ github.ref_name }}
-        run: |
-          set -euo pipefail
-          # Reuse the immutable workflow ref from this canary release so the
-          # nightly cannot combine a newer workflow with the pinned source.
-          gh workflow run release-baml-language.yml \
-            --repo "$GITHUB_REPOSITORY" \
-            --ref "$SOURCE_WORKFLOW_REF" \
-            -f channel=nightly \
-            -f dry_run=false \
-            -f source_sha="$SOURCE_SHA" \
-            -f source_ci_run_id="$SOURCE_CI_RUN_ID"
-
   publish-homebrew:
     name: Publish Homebrew wrapper formula
     needs: [plan, all-builds, publish-wrapper-release]
@@ -2338,7 +2311,6 @@ jobs:
       - publish-crates-io
       - publish-pkg-boundaryml-com
       - smoke-go-release
-      - dispatch-nightly-after-canary
       - publish-homebrew
       - publish-aur
       - dry-run-artifacts

--- a/baml_language/sdks/agent-docs/bridge-ref/ref-java-packaging.md
+++ b/baml_language/sdks/agent-docs/bridge-ref/ref-java-packaging.md
@@ -54,7 +54,7 @@ homebrew/AUR). npm uses OIDC trusted publishing with channel→dist-tag
   unreasonable download.
 - **Channels:** Maven has no dist-tags; canary = plain version
   (`0.15.0`), nightly = suffixed version
-  (`0.15.0-nightly.YYYYMMDD`). Publish job slots into
+  (`0.15.0-nightly.YYYYMMDD.a`). Publish job slots into
   `release-baml-language.yml` as `build-java-sdk` / `publish-maven`.
 - **CLI:** covered by the wrapper/toolchain tier; nothing to ship via
   Maven. What Java *does* need is a `"java"` `OutputType` variant in

--- a/baml_language/sdks/java/baml_bridge/PUBLISHING.md
+++ b/baml_language/sdks/java/baml_bridge/PUBLISHING.md
@@ -109,7 +109,8 @@ The `build-java-sdk` / `publish-maven` jobs slot into
 
 1. **Version** — `-PbamlVersion`. Maven has no dist-tags, so:
    - canary → plain version, e.g. `0.15.0`;
-   - nightly → suffixed version, e.g. `0.15.0-nightly.YYYYMMDD`.
+   - nightly → suffixed version, e.g. `0.15.0-nightly.YYYYMMDD.a`, where the
+     trailing letter distinguishes repeat cuts for the same night.
 2. **Per-platform native builds** — one publish invocation per target in the
    8-target matrix, each passing that platform's
    `-PbamlNativePlatform=<os>-<arch>` and `-PbamlNativeLib=<built cdylib>`. The

--- a/scripts/baml-language-version
+++ b/scripts/baml-language-version
@@ -10,6 +10,7 @@ import os
 import re
 import subprocess
 import sys
+import zoneinfo
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -273,13 +274,47 @@ def previous_release_toml() -> str | None:
     return None
 
 
-def today_utc() -> str:
-    override = os.environ.get("BAML_LANGUAGE_VERSION_DATE")
+SEATTLE = "America/Los_Angeles"
+
+# Determinism knobs for fixture builds. No release path sets either one.
+NIGHTLY_DATE_ENV = "BAML_LANGUAGE_VERSION_DATE"
+NIGHTLY_LETTER_ENV = "BAML_LANGUAGE_VERSION_NIGHTLY_LETTER"
+
+
+def night_for(moment: dt.datetime) -> str:
+    """The Seattle day a nightly cut made at `moment` is named for.
+
+    A nightly closes out a day, and .github/workflows/nightly-release.yml cuts it
+    in the midnight hour that follows, so the cut is named for the day that just
+    ended. Deriving that from the local *date* rather than the local time keeps
+    the answer stable however late the cut runs: a release that is dispatched at
+    00:05 and only reaches its plan step at 02:30 still names the same night.
+
+    Cuts are ordered by this date and then by letter, so the pair rises
+    monotonically as long as cuts happen in time order.
+    """
+    if moment.tzinfo is None:
+        fail("night_for requires a timezone-aware moment")
+    # ZoneInfo is built lazily: only version computation needs the tz database,
+    # while `stamp` runs on every build runner, including Windows.
+    local_date = moment.astimezone(zoneinfo.ZoneInfo(SEATTLE)).date()
+    return (local_date - dt.timedelta(days=1)).strftime("%Y%m%d")
+
+
+def nightly_date() -> str:
+    override = os.environ.get(NIGHTLY_DATE_ENV)
     if override:
-        if not re.fullmatch(r"\d{8}", override):
-            fail("BAML_LANGUAGE_VERSION_DATE must be YYYYMMDD")
+        # `\d` would accept non-ASCII digits, and an 8-digit string is not
+        # necessarily a date; this value ends up in irreversible registry
+        # publishes, so require a real one.
+        if not re.fullmatch(r"[0-9]{8}", override):
+            fail(f"{NIGHTLY_DATE_ENV} must be YYYYMMDD")
+        try:
+            dt.datetime.strptime(override, "%Y%m%d")
+        except ValueError:
+            fail(f"{NIGHTLY_DATE_ENV} {override!r} is not a real date")
         return override
-    return dt.datetime.now(dt.timezone.utc).strftime("%Y%m%d")
+    return night_for(dt.datetime.now(dt.timezone.utc))
 
 
 def command_output(command: list[str]) -> str | None:
@@ -296,6 +331,15 @@ def command_output(command: list[str]) -> str | None:
 
 
 def release_tags() -> list[str]:
+    """Every release tag, or a hard failure -- never a silent empty list.
+
+    The nightly letter is allocated by looking for the tags a night already has,
+    so "the lookup failed" and "this night has no tags yet" must not collapse
+    into the same answer: doing so restarts lettering at `a` and re-mints an
+    already-published version, whose release assets the toolchain publisher then
+    overwrites. `command_output` returns None on failure and "" on success with
+    no output, which is exactly the distinction needed here.
+    """
     output = command_output(
         [
             "gh",
@@ -311,26 +355,57 @@ def release_tags() -> list[str]:
             ".[].tagName",
         ]
     )
-    if output:
-        return [line.strip() for line in output.splitlines() if line.strip()]
-
-    output = command_output(["git", "ls-remote", "--tags", "https://github.com/BoundaryML/baml.git"])
-    if output:
-        tags: list[str] = []
-        for line in output.splitlines():
-            ref = line.rsplit("/", 1)[-1].removesuffix("^{}")
-            if ref:
-                tags.append(ref)
+    if output is None:
+        output = command_output(
+            ["git", "ls-remote", "--tags", "https://github.com/BoundaryML/baml.git"]
+        )
+        if output is None:
+            fail(
+                "could not list release tags (`gh release list` and `git ls-remote` "
+                "both failed); refusing to compute a version that could collide "
+                "with a published release"
+            )
+        tags = [
+            ref
+            for line in output.splitlines()
+            if (ref := line.rsplit("/", 1)[-1].removesuffix("^{}"))
+        ]
+        if not tags:
+            # Reached only because `gh` already failed. An empty answer from the
+            # fallback is far likelier to be a second symptom than a repository
+            # with no tags, and reading it as "no tags yet" is precisely the
+            # collapse this function exists to prevent.
+            fail(
+                "`git ls-remote --tags` returned no tags; refusing to compute a "
+                "version that could collide with a published release"
+            )
         return tags
 
-    return []
+    return [line.strip() for line in output.splitlines() if line.strip()]
+
+
+def newest_nightly_stamp(base: Version, tags: list[str]) -> tuple[str, str] | None:
+    """The (night, letter) of the newest nightly already published for `base`.
+
+    Nightlies sort by night and then by letter, so this pair is exactly what a
+    newly planned cut has to beat.
+    """
+    prefix = f"baml-language-{base}-nightly."
+    stamps = []
+    for tag in tags:
+        if not tag.startswith(prefix):
+            continue
+        night, _, letter = tag.removeprefix(prefix).partition(".")
+        if re.fullmatch(r"[0-9]{8}", night) and SHA_RE.fullmatch(letter):
+            stamps.append((night, letter))
+    return max(stamps, default=None)
 
 
 def next_nightly_letter(base: Version, date: str, tags: list[str] | None = None) -> str:
-    override = os.environ.get("BAML_LANGUAGE_VERSION_NIGHTLY_LETTER")
+    override = os.environ.get(NIGHTLY_LETTER_ENV)
     if override:
         if SHA_RE.fullmatch(override) is None:
-            fail("BAML_LANGUAGE_VERSION_NIGHTLY_LETTER must be one lowercase letter")
+            fail(f"{NIGHTLY_LETTER_ENV} must be one lowercase letter")
         return override
     prefix = f"baml-language-{base}-nightly.{date}."
     used = sorted(
@@ -344,7 +419,7 @@ def next_nightly_letter(base: Version, date: str, tags: list[str] | None = None)
     max_index = max(ord(letter) - ord("a") for letter in used)
     if max_index >= 25:
         fail(
-            f"26 nightly builds today for base {base}; wait for the next UTC day or cut a new canary release by bumping baml_language/release.toml [release].canary_version.",
+            f"26 nightly builds for base {base} on this night; wait for the next Seattle day or cut a new canary release by bumping baml_language/release.toml [release].canary_version.",
             code=2,
         )
     return chr(ord("a") + max_index + 1)
@@ -356,8 +431,25 @@ def compute_version(channel: str) -> str:
         return str(canary)
     if channel == "nightly":
         base = canary.next_patch()
-        date = today_utc()
-        letter = next_nightly_letter(base, date)
+        date = nightly_date()
+        # The two overrides exist to pin fixture builds to a fixed version.
+        # Those never publish, and a pinned past date is *expected* to sort under
+        # what is live, so they opt out of the ordering check below.
+        if os.environ.get(NIGHTLY_DATE_ENV) or os.environ.get(NIGHTLY_LETTER_ENV):
+            return f"{base}-nightly.{date}.{next_nightly_letter(base, date)}"
+        tags = release_tags()
+        letter = next_nightly_letter(base, date, tags)
+        # The registries mostly resolve by highest version, but the nightly npm
+        # dist-tag and the channel manifest are last-writer-wins: publishing a
+        # version below the live one walks every consumer backwards. Nothing
+        # downstream re-checks this, so refuse here rather than ship it.
+        published = newest_nightly_stamp(base, tags)
+        if published is not None and (date, letter) <= published:
+            fail(
+                f"planned nightly {base}-nightly.{date}.{letter} is not newer than the "
+                f"published {base}-nightly.{published[0]}.{published[1]}; refusing to "
+                "walk the nightly channel backwards"
+            )
         return f"{base}-nightly.{date}.{letter}"
     fail(f"unsupported channel {channel!r}")
 

--- a/scripts/tests/test_baml_language_version.py
+++ b/scripts/tests/test_baml_language_version.py
@@ -1,16 +1,40 @@
 from __future__ import annotations
 
+import datetime as dt
+import functools
+import importlib.machinery
+import importlib.util
 import json
 import os
 import re
 import subprocess
+import sys
 import tempfile
 import unittest
+import unittest.mock
+import zoneinfo
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[2]
 VERSION_TOOL = ROOT / "scripts" / "baml-language-version"
+
+
+@functools.cache
+def version_tool_module():
+    """Import the tool for tests that exercise a pure function directly.
+
+    It has no `.py` suffix, so it needs an explicit source loader, and it must
+    be in `sys.modules` before it executes for its dataclasses to resolve.
+    """
+    loader = importlib.machinery.SourceFileLoader(
+        "baml_language_version", str(VERSION_TOOL)
+    )
+    spec = importlib.util.spec_from_loader(loader.name, loader)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[loader.name] = module
+    loader.exec_module(module)
+    return module
 
 
 class VersionToolTests(unittest.TestCase):
@@ -269,6 +293,163 @@ if "build:debug" in sys.argv:
         result = self.run_tool("check", check=False)
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("C# NuGet project version", result.stderr)
+
+    def test_nightly_letter_advances_past_the_nights_published_tags(self) -> None:
+        # `already_cut` used to sit on top of this; the letter scan is what it
+        # was really made of, and it is the only thing keeping two cuts on one
+        # night from colliding.
+        module = version_tool_module()
+        base = module.Version.parse("1.2.4")
+        env = {key: value for key, value in self.env.items() if "NIGHTLY_LETTER" not in key}
+        with unittest.mock.patch.dict(os.environ, env, clear=True):
+            letter = module.next_nightly_letter
+            self.assertEqual(letter(base, "20260723", []), "a")
+            self.assertEqual(
+                letter(base, "20260723", ["baml-language-1.2.4-nightly.20260723.a"]), "b"
+            )
+            # Gaps do not reset it, and other bases/nights are not this night's.
+            self.assertEqual(
+                letter(
+                    base,
+                    "20260723",
+                    [
+                        "baml-language-1.2.4-nightly.20260723.a",
+                        "baml-language-1.2.4-nightly.20260723.c",
+                        "baml-language-1.2.4-nightly.20260722.z",
+                        "baml-language-9.9.9-nightly.20260723.z",
+                        "baml-language-1.2.4",
+                    ],
+                ),
+                "d",
+            )
+
+    def test_nightly_refuses_to_plan_below_a_published_night(self) -> None:
+        # The registries mostly resolve by highest version, but the nightly npm
+        # dist-tag and the channel manifest are last-writer-wins, so a version
+        # below the live one walks consumers backwards.
+        module = version_tool_module()
+        base = module.Version.parse("1.2.4")
+        newest = module.newest_nightly_stamp
+        self.assertIsNone(newest(base, ["baml-language-1.2.4"]))
+        self.assertEqual(
+            newest(
+                base,
+                [
+                    "baml-language-1.2.4-nightly.20260722.b",
+                    "baml-language-1.2.4-nightly.20260723.a",
+                    "baml-language-9.9.9-nightly.20260830.a",
+                ],
+            ),
+            ("20260723", "a"),
+        )
+        # The comparison the planner makes: night first, then letter.
+        self.assertLess(("20260723", "a"), ("20260723", "b"))
+        self.assertLess(("20260722", "z"), ("20260723", "a"))
+
+    def test_tag_lookup_failure_is_loud_rather_than_an_empty_list(self) -> None:
+        # Failing open here restarts lettering at `a` and re-mints a published
+        # version, whose release assets the toolchain publisher then clobbers.
+        stub = self.write("bin/gh", "#!/bin/sh\nexit 1\n")
+        stub.chmod(0o755)
+        stub = self.write("bin/git", "#!/bin/sh\nexit 1\n")
+        stub.chmod(0o755)
+        env = {
+            key: value
+            for key, value in self.env.items()
+            if "NIGHTLY_LETTER" not in key and "VERSION_DATE" not in key
+        }
+        env["PATH"] = f"{self.bin}:/usr/bin:/bin"
+        result = subprocess.run(
+            [str(VERSION_TOOL), "compute", "--channel", "nightly"],
+            cwd=self.root,
+            env=env,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("could not list release tags", result.stderr)
+
+    def test_nightly_date_override_must_be_a_real_ascii_date(self) -> None:
+        for value in ("20261345", "99999999", "٢٠٢٦٠٧٣٠", "2026073"):
+            env = dict(self.env)
+            env["BAML_LANGUAGE_VERSION_DATE"] = value
+            result = subprocess.run(
+                [str(VERSION_TOOL), "compute", "--channel", "nightly"],
+                cwd=self.root,
+                env=env,
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+            self.assertNotEqual(result.returncode, 0, value)
+            self.assertIn("BAML_LANGUAGE_VERSION_DATE", result.stderr, value)
+
+
+class NightNamingTests(unittest.TestCase):
+    """The rule that decides which day a nightly cut is named for.
+
+    Every nightly is a midnight cut, so it closes out the day that just ended.
+    Deriving that from the local *date* rather than the local time makes the
+    answer independent of how late in the slot the cut actually runs.
+    """
+
+    @staticmethod
+    def night(utc: str) -> str:
+        return version_tool_module().night_for(dt.datetime.fromisoformat(utc))
+
+    def test_midnight_cut_closes_out_the_day_that_just_ended(self) -> None:
+        # 07:00 UTC is midnight in Seattle while PDT, 08:00 UTC while PST; the
+        # cron entry that is not local midnight never reaches this rule.
+        self.assertEqual(self.night("2026-07-30T07:00:00+00:00"), "20260729")
+        self.assertEqual(self.night("2026-01-15T08:00:00+00:00"), "20260114")
+
+    def test_a_late_cut_still_names_the_night_it_was_scheduled_for(self) -> None:
+        # The gate reads the clock in the first step and the release names the
+        # night in a later job, so those two reads can straddle 01:00. Naming by
+        # local date means they cannot disagree: only crossing the *next* local
+        # midnight would change the answer.
+        for utc in (
+            "2026-07-30T07:59:00+00:00",  # 00:59 local, still in the slot
+            "2026-07-30T09:30:00+00:00",  # 02:30 local, well past it
+            "2026-07-30T22:00:00+00:00",  # 15:00 local, a manual repair run
+        ):
+            self.assertEqual(self.night(utc), "20260729", utc)
+
+    def test_dst_transitions_keep_one_night_per_day(self) -> None:
+        # Spring forward: 02:00 PST becomes 03:00 PDT on 2026-03-08, so the
+        # 08:00 UTC entry is that night's local midnight.
+        self.assertEqual(self.night("2026-03-08T08:00:00+00:00"), "20260307")
+        # Fall back: 02:00 PDT becomes 01:00 PST on 2026-11-01, so the 07:00 UTC
+        # entry is local midnight.
+        self.assertEqual(self.night("2026-11-01T07:00:00+00:00"), "20261031")
+
+    def test_a_naive_moment_is_rejected_rather_than_read_as_machine_local(self) -> None:
+        with self.assertRaises(SystemExit):
+            version_tool_module().night_for(dt.datetime(2026, 7, 30, 0, 30))
+
+    def test_every_night_of_the_next_five_years_is_named_exactly_once(self) -> None:
+        seattle = zoneinfo.ZoneInfo("America/Los_Angeles")
+        day = dt.date(2026, 1, 1)
+        named: list[str] = []
+        while day < dt.date(2031, 1, 1):
+            midnight_slots = [
+                dt.datetime(day.year, day.month, day.day, hour, tzinfo=dt.timezone.utc)
+                for hour in (7, 8)
+                if dt.datetime(
+                    day.year, day.month, day.day, hour, tzinfo=dt.timezone.utc
+                )
+                .astimezone(seattle)
+                .hour
+                == 0
+            ]
+            # Exactly one cron entry lands in the midnight hour, every day,
+            # including the two DST transition days.
+            self.assertEqual(len(midnight_slots), 1, day)
+            named.append(self.night(midnight_slots[0].isoformat()))
+            day += dt.timedelta(days=1)
+        self.assertEqual(named, sorted(named))
+        self.assertEqual(len(named), len(set(named)))
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import json
+import re
 import subprocess
 import tempfile
 import unittest
@@ -17,6 +18,7 @@ GO_RELEASE_SMOKE = ROOT / "scripts" / "smoke-go-release.py"
 PLATFORMS = ROOT / "release" / "platforms.json"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-baml-language.yml"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yaml"
+NIGHTLY_WORKFLOW = ROOT / ".github" / "workflows" / "nightly-release.yml"
 SIZE_POLICY = ROOT / "release" / "csharp-package-size-policy.json"
 BRIDGE_CFFI_PUBLIC_EXPORTS = (
     ROOT / "release" / "bridge-cffi-public-exports.txt"
@@ -784,7 +786,7 @@ class WorkflowGraphTests(unittest.TestCase):
         manifest = job_block(release, "publish-pkg-boundaryml-com")
         channel = job_block(release, "publish-pkg-channel")
         dry_run = job_block(release, "dry-run-artifacts")
-        nightly = job_block(release, "dispatch-nightly-after-canary")
+        nightly = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
 
         self.assertIn("source_ci_run_id:", release)
         self.assertIn("Attest production source CI run", plan)
@@ -830,16 +832,18 @@ class WorkflowGraphTests(unittest.TestCase):
             '-f source_ci_run_id="$GITHUB_RUN_ID"',
             job_block(ci, "dispatch-release"),
         )
+        # The nightly scheduler is the other production dispatcher, and is held
+        # to the same trust chain: attested CI run, dispatched at the source tag.
         self.assertIn(
             '-f source_ci_run_id="$SOURCE_CI_RUN_ID"',
             nightly,
         )
         self.assertIn(
-            'SOURCE_WORKFLOW_REF: ${{ github.ref_name }}',
+            'release_ref="baml-language-source-$SOURCE_SHA"',
             nightly,
         )
         self.assertIn(
-            '--ref "$SOURCE_WORKFLOW_REF"',
+            '--ref "$release_ref"',
             nightly,
         )
         self.assertNotIn("--ref canary", nightly)
@@ -859,6 +863,120 @@ class WorkflowGraphTests(unittest.TestCase):
             "`repo:${GITHUB_REPO}:ref:*`",
             pkg_stack,
         )
+
+    def test_nightly_is_scheduled_and_pushes_only_cut_canary(self) -> None:
+        release = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        ci_dispatch = job_block(CI_WORKFLOW.read_text(encoding="utf-8"), "dispatch-release")
+        nightly_workflow = NIGHTLY_WORKFLOW.read_text(encoding="utf-8")
+        dispatch_job = job_block(nightly_workflow, "dispatch-nightly")
+        toolchain = job_block(release, "publish-toolchain-release")
+        cffi = job_block(release, "publish-bridge-cffi-release")
+
+        # A push to canary cuts the canary channel only, and only when
+        # release.toml asks for it. Nothing else releases on merge.
+        self.assertIn("-f channel=canary", ci_dispatch)
+        self.assertNotIn("-f channel=nightly", ci_dispatch)
+        # Bound the slice to the channel input itself rather than a character
+        # count, so it cannot drift into a neighbouring input's description.
+        # `auto` used to let CI defer the channel choice to the release.
+        channel_input = release[
+            release.index("      channel:") : release.index("      dry_run:")
+        ]
+        self.assertIn("options: [nightly, canary]", channel_input)
+        self.assertNotIn("auto", channel_input)
+        self.assertIn(
+            "git diff --quiet HEAD^ HEAD -- baml_language/release.toml",
+            ci_dispatch,
+        )
+        # The file changing is only the fast path; the cut turns on the parsed
+        # [release].canary_version differing, so that an edit to anything else
+        # in release.toml cannot dispatch a release.
+        self.assertIn('git show "HEAD^:baml_language/release.toml"', ci_dispatch)
+        self.assertIn(
+            'if [[ "$canary_version" == "$previous_version" ]]', ci_dispatch
+        )
+        self.assertIn("steps.canary-cut.outputs.cut == 'true'", ci_dispatch)
+        # The source tag is minted for EVERY green canary push, not just the
+        # cuts: the scheduled nightly dispatches at a tag CI may have created
+        # days earlier, and the release refuses any other ref.
+        tag_step = step_block(ci_dispatch, "Create immutable release workflow ref")
+        self.assertIn('release_ref="baml-language-source-$GITHUB_SHA"', tag_step)
+        self.assertNotIn("if:", tag_step)
+
+        # Two crons bracket both DST offsets; the gate keeps whichever one is
+        # local midnight. Both halves matter: dropping the gate double-cuts, and
+        # inverting it cuts at the wrong hour.
+        crons = re.findall(r"- cron: ['\"](\S+) (\S+) [^'\"]*['\"]", nightly_workflow)
+        self.assertEqual(len(crons), 2, nightly_workflow)
+        self.assertEqual({hour for _, hour in crons}, {"7", "8"}, crons)
+        for minute, _ in crons:
+            # Not on the hour: GitHub delays scheduled runs most at :00, and a
+            # delay past 01:00 local forfeits the night.
+            self.assertNotEqual(minute, "0", crons)
+        self.assertIn('local_hour="$(TZ=America/Los_Angeles date +%H)"', nightly_workflow)
+        # Assert the gate's POLARITY, not just that both words appear: the
+        # midnight branch proceeds and the off-hour branch stands down. Swapping
+        # the two would cut at 23:00 or 01:00 and still contain both strings.
+        gate = re.search(
+            r'if \[\[ "\$local_hour" == "00" \]\]; then(.*?)\belse\b(.*?)\bfi\b',
+            step_block(dispatch_job, "Gate on local midnight in Seattle"),
+            flags=re.DOTALL,
+        )
+        self.assertIsNotNone(gate, dispatch_job)
+        at_midnight, off_hour = gate.groups()
+        self.assertIn("proceed=true", at_midnight)
+        self.assertNotIn("proceed=false", at_midnight)
+        self.assertIn("proceed=false", off_hour)
+        self.assertNotIn("proceed=true", off_hour)
+
+        # One cut per commit, and the guard must observe the EFFECT -- a release
+        # run at the candidate's source tag -- rather than this workflow's own
+        # conclusion. The clock gate skips steps, not the job, so the cron entry
+        # that loses the gate concludes `success` too; a self-referential guard
+        # would read that no-op as "tonight is handled" and stand the real cut
+        # down every night for the whole PST half of the year.
+        self.assertIn("gh run list --workflow release-baml-language.yml", dispatch_job)
+        self.assertIn("baml-language-source-$CANDIDATE_SHA", dispatch_job)
+        self.assertIn('if [[ "$existing" != "0"', dispatch_job)
+        self.assertNotIn("--workflow nightly-release.yml", dispatch_job)
+
+        # A fork inherits the schedule and must never cut releases upstream.
+        self.assertIn("github.repository == 'BoundaryML/baml'", dispatch_job)
+
+        # Only a CI-attested canary commit is releasable, dispatched at its own
+        # immutable tag with the run that attests it.
+        self.assertIn(
+            "gh run list --workflow ci.yaml --branch canary --event push",
+            nightly_workflow,
+        )
+        self.assertIn("commits?sha=canary", nightly_workflow)
+        self.assertIn('release_ref="baml-language-source-$SOURCE_SHA"', nightly_workflow)
+        self.assertIn('--ref "$release_ref"', nightly_workflow)
+        self.assertNotIn("--ref canary", nightly_workflow)
+        self.assertIn("-f channel=nightly", nightly_workflow)
+        self.assertIn('-f source_ci_run_id="$SOURCE_CI_RUN_ID"', nightly_workflow)
+        # The dispatch verifies the tag resolves to exactly the attested commit.
+        self.assertIn('"$ref_sha" != "$SOURCE_SHA"', nightly_workflow)
+
+        # The schedule is the ONLY nightly cut site. A canary release used to
+        # chain one, which meant two sites racing to name the same night.
+        self.assertNotIn("dispatch-nightly-after-canary", release)
+        self.assertNotIn("dispatch_nightly_after_canary", release)
+        self.assertNotIn("nightly-slot", release + nightly_workflow)
+        self.assertNotIn("nightly_date", release + nightly_workflow)
+
+        # `force` must not reach the rollback guard: re-running with it is the
+        # obvious reaction to that failure, and would publish the rollback.
+        rollback_arm = re.search(
+            r"behind\s*\|\s*diverged\)(.*?);;", nightly_workflow, flags=re.DOTALL
+        )
+        self.assertIsNotNone(rollback_arm, nightly_workflow)
+        self.assertNotIn("FORCE", rollback_arm.group(1))
+
+        # The release tag must name the commit the artifacts were built from:
+        # the scheduler reads it to decide whether canary moved.
+        self.assertIn('--target "$SOURCE_SHA"', toolchain)
+        self.assertIn('--target "$SOURCE_SHA"', cffi)
 
     def test_release_graph_has_early_preflight_parallel_producers_and_complete_fanin(
         self,
@@ -951,10 +1069,8 @@ class WorkflowGraphTests(unittest.TestCase):
 
         swift_verify = job_block(workflow, "verify-swift-sdk")
         swift_smoke = job_block(workflow, "smoke-swift-release")
-        dispatch = job_block(workflow, "dispatch-nightly-after-canary")
         self.assertIn("BamlRuntime.nativeVersion()", swift_verify)
         self.assertIn("BamlRuntime.nativeVersion()", swift_smoke)
-        self.assertIn("publish-pkg-channel", dispatch)
         self.assertIn(
             '--cfg=getrandom_backend=\\"wasm_js\\"',
             CFFI_BUILDER.read_text(encoding="utf-8"),
@@ -967,7 +1083,6 @@ class WorkflowGraphTests(unittest.TestCase):
         go_publisher = job_block(workflow, "publish-go-sdk")
         go_smoke = job_block(workflow, "smoke-go-release")
         channel = job_block(workflow, "publish-pkg-channel")
-        nightly = job_block(workflow, "dispatch-nightly-after-canary")
 
         self.assertIn(
             'require_skipped Gradle-Plugin-Portal "$GRADLE_PLUGIN"',
@@ -1006,13 +1121,6 @@ class WorkflowGraphTests(unittest.TestCase):
                     "needs.release-complete.result == 'success'",
                     "needs.smoke-go-release.result == 'success'",
                     "needs.smoke-swift-release.result == 'success'",
-                ),
-            ),
-            (
-                nightly,
-                (
-                    "needs.plan.result == 'success'",
-                    "needs.publish-pkg-channel.result == 'success'",
                 ),
             ),
         )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated nightly releases based on the newest validated canary build.
  * Added support for manual nightly release runs.
  * Added immutable source tags and explicit canary/nightly release channels.
  * Added safeguards against duplicate, rolled-back, or invalid releases.

* **Bug Fixes**
  * Improved nightly versioning across local time boundaries and repeated nightly cuts.
  * Ensured release artifacts reference the correct source commit.
  * Added failure notifications for nightly release issues.

* **Documentation**
  * Updated Java Maven nightly versioning guidance to include letter suffixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->