### PR TITLE
chore: brand legacy releases as BAML v0

### DIFF
--- a/.github/workflows/build-cli-release.reusable.yaml
+++ b/.github/workflows/build-cli-release.reusable.yaml
@@ -323,8 +323,7 @@ jobs:
 
           echo "Copying files to staging directory"
           cp "${{ steps.paths.outputs.bin }}" "$staging_dir/"
-          # Use find for robust copy
-          find . -maxdepth 1 -name 'README.md' -exec cp {} "$staging_dir/" \; || echo "README.md not found"
+          cp README.v0.md "$staging_dir/README.md"
           find . -maxdepth 1 -name 'LICENSE*' -exec cp {} "$staging_dir/" \; || echo "LICENSE* files not found"
 
           echo "Creating archive: $archive_file"
@@ -371,8 +370,7 @@ jobs:
 
           echo "Copying files to staging directory"
           cp "${{ steps.paths.outputs.bin }}" "$staging_dir/"
-          # Use find for robust copy
-          find . -maxdepth 1 -name 'README.md' -exec cp {} "$staging_dir/" \; || echo "README.md not found"
+          cp README.v0.md "$staging_dir/README.md"
           find . -maxdepth 1 -name 'LICENSE*' -exec cp {} "$staging_dir/" \; || echo "LICENSE* files not found"
 
           echo "Creating archive: $archive_file"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,7 +371,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: ${{ needs.determine-version.outputs.version_string }}
+          name: BAML v0 ${{ needs.determine-version.outputs.version_string }}
           tag_name: ${{ needs.determine-version.outputs.version_string }}
           body_path: CHANGELOG.txt
           draft: ${{ needs.determine-version.outputs.is_release_tag == 'false' }}

--- a/README.v0.md
+++ b/README.v0.md
@@ -1,0 +1,247 @@
+<div align="center">
+<a href="https://boundaryml.com?utm_source=github" target="_blank" rel="noopener noreferrer">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="fern/assets/baml-lamb-white.png">
+    <img src="fern/assets/baml-lamb-white.png" height="64" id="top">
+  </picture>
+</a>
+
+</div>
+
+<div align="center">
+
+[![BAML Version](https://img.shields.io/pypi/v/baml-py?color=006dad&label=BAML%20Version)](https://pypi.org/project/baml-py/)
+
+## BAML v0: Basically a Made-up Language
+<h4>
+
+[Homepage](https://www.boundaryml.com/) | [Docs](https://docs.boundaryml.com) | [BAML AI Chat](https://www.boundaryml.com/chat) | [Discord](https://discord.gg/BTNBeXGuaS)
+
+
+
+</h4>
+
+
+</div>
+
+BAML v0 is a simple prompting language for building reliable **AI workflows and agents**.
+
+BAML makes prompt engineering easy by turning it into _schema engineering_ — where you mostly focus on the models of your prompt — to get more reliable outputs. 
+You don't need to write your whole app in BAML, only the prompts! You can wire-up your LLM Functions in any language of your choice! See our quickstarts for [Python](https://docs.boundaryml.com/guide/installation-language/python), [TypeScript](https://docs.boundaryml.com/guide/installation-language/typescript), [Ruby](https://docs.boundaryml.com/guide/installation-language/ruby) and [Go, and more](https://docs.boundaryml.com/guide/installation-language/rest-api-other-languages).
+
+BAML comes with all batteries included — with full typesafety, streaming, retries, wide model support, even when they don't support native [tool-calling APIs](#enable-reliable-tool-calling-with-any-model)
+
+**Try BAML**: [Prompt Fiddle](https://www.promptfiddle.com) • [Interactive App Examples](https://baml-examples.vercel.app/)
+
+
+## The core BAML principle: LLM Prompts are functions
+
+The fundamental building block in BAML is a function. Every prompt is a function that takes in parameters and returns a type.
+
+```baml
+function ChatAgent(message: Message[], tone: "happy" | "sad") -> string
+```
+
+Every function additionally defines which models it uses and what its prompt is.
+
+```baml
+function ChatAgent(message: Message[], tone: "happy" | "sad") -> StopTool | ReplyTool {
+    client "openai/gpt-4o-mini"
+
+    prompt #"
+        Be a {{ tone }} bot.
+
+        {{ ctx.output_format }}
+
+        {% for m in message %}
+        {{ _.role(m.role) }}
+        {{ m.content }}
+        {% endfor %}
+    "#
+}
+
+class Message {
+    role string
+    content string
+}
+
+class ReplyTool {
+  response string
+}
+
+class StopTool {
+  action "stop" @description(#"
+    when it might be a good time to end the conversation
+  "#)
+}
+```
+
+## BAML Functions can be called from any language
+Below we call the ChatAgent function we defined in BAML through Python. BAML's Rust compiler generates a "baml_client" to access and call them.
+
+```python
+from baml_client import b
+from baml_client.types import Message, StopTool
+
+messages = [Message(role="assistant", content="How can I help?")]
+
+while True:
+  print(messages[-1].content)
+  user_reply = input()
+  messages.append(Message(role="user", content=user_reply))
+  tool = b.ChatAgent(messages, "happy")
+  if isinstance(tool, StopTool):
+    print("Goodbye!")
+    break
+  else:
+    messages.append(Message(role="assistant", content=tool.response))
+```
+You can write any kind of agent or workflow using chained BAML functions. An agent is a while loop that calls a Chat BAML Function with some state.
+
+And if you need to stream, add a couple more lines:
+```python
+stream = b.stream.ChatAgent(messages, "happy")
+# partial is a Partial type with all Optional fields
+for tool in stream:
+    if isinstance(tool, StopTool):
+      ...
+    
+final = stream.get_final_response()
+```
+And get fully type-safe outputs for each chunk in the stream.
+
+## Test prompts 10x faster, right in your IDE
+BAML comes with native tooling for [VS Code](https://docs.boundaryml.com/guide/installation-editors/vs-code-extension) and [JetBrains IDEs](https://docs.boundaryml.com/guide/installation-editors/jetbrains), with support for [other editors](https://docs.boundaryml.com/guide/installation-editors/others) continuing to expand.
+
+**Visualize full prompt (including any multi-modal assets), and the API request**. BAML gives you full transparency and control of the prompt.
+
+![raw-curl](https://github.com/user-attachments/assets/c0b34db9-80cd-45a7-a356-6b5ab4a9c5b7)
+
+**Using AI is all about iteration speed.**
+
+If testing your pipeline takes 2 minutes, you can only test 10 ideas in 20 minutes.
+
+If you reduce it to 5 seconds, you can test 240 ideas in the same amount of time.
+![resume-attempt2-smaller2](https://github.com/user-attachments/assets/6fc6b8a6-ffed-4cfc-80b8-78bc8a3d66a6)
+
+The playground also allows you to run tests in parallel — for even faster iteration speeds 🚀.
+
+No need to login to websites, and no need to manually define json schemas.
+
+## Enable reliable tool-calling with any model
+BAML works even when the models don't support native tool-calling APIs. We created the SAP (schema-aligned parsing) algorithm to support the flexible outputs LLMs can provide, like markdown within a JSON blob or chain-of-thought prior to answering. [Read more about SAP](https://www.boundaryml.com/blog/schema-aligned-parsing)
+
+With BAML, your structured outputs work in Day-1 of a model release. No need to figure out whether a model supports parallel tool calls, or whether it supports recursive schemas, or `anyOf` or `oneOf` etc.
+
+See it in action with: **[Deepseek-R1](https://www.boundaryml.com/blog/deepseek-r1-function-calling)** and [OpenAI O1](https://www.boundaryml.com/blog/openai-o1).
+
+
+
+## Switch from 100s of models in a couple lines
+```diff
+function Extract() -> Resume {
++  client openai/o3-mini
+  prompt #"
+    ....
+  "#
+}
+```
+[Retry policies](https://docs.boundaryml.com/ref/llm-client-strategies/retry-policy) • [fallbacks](https://docs.boundaryml.com/ref/llm-client-strategies/fallback) • [model rotations](https://docs.boundaryml.com/ref/llm-client-strategies/round-robin). All statically defined.
+![Fallback Retry](https://www.boundaryml.com/blog/2025-01-24-ai-agents-need-a-new-syntax/06-fallback-retry.gif)
+Want to do pick models at runtime? Check out the [Client Registry](https://docs.boundaryml.com/guide/baml-advanced/llm-client-registry).
+
+We support: [OpenAI](https://docs.boundaryml.com/ref/llm-client-providers/open-ai) • [Anthropic](https://docs.boundaryml.com/ref/llm-client-providers/anthropic) • [Gemini](https://docs.boundaryml.com/ref/llm-client-providers/google-ai-gemini) • [Vertex](https://docs.boundaryml.com/ref/llm-client-providers/google-vertex) • [Bedrock](https://docs.boundaryml.com/ref/llm-client-providers/aws-bedrock) • [Azure OpenAI](https://docs.boundaryml.com/ref/llm-client-providers/open-ai-from-azure) • [Anything OpenAI Compatible](https://docs.boundaryml.com/ref/llm-client-providers/openai-generic) ([Ollama](https://docs.boundaryml.com/ref/llm-client-providers/openai-generic-ollama), [OpenRouter](https://docs.boundaryml.com/ref/llm-client-providers/openai-generic-open-router), [VLLM](https://docs.boundaryml.com/ref/llm-client-providers/openai-generic-v-llm), [LMStudio](https://docs.boundaryml.com/ref/llm-client-providers/openai-generic-lm-studio), [TogetherAI](https://docs.boundaryml.com/ref/llm-client-providers/openai-generic-together-ai), and more)
+
+## Build beautiful streaming UIs
+BAML generates a ton of utilities for NextJS, Python (and any language) to make streaming UIs easy.
+![recipe-generator](https://github.com/user-attachments/assets/cf82495b-21fc-40bf-ae98-93eef923d620)
+
+BAML's streaming interfaces are fully type-safe. Check out the [Streaming Docs](https://docs.boundaryml.com/guide/baml-basics/streaming), and our [React hooks](https://docs.boundaryml.com/guide/framework-integration/react-next-js/quick-start)
+
+## Fully Open-Source, and offline
+- 100% open-source (Apache 2)
+- 100% private. AGI will not require an internet connection, neither will BAML
+    - No network requests beyond model calls you explicitly set
+    - Not stored or used for any training data
+- BAML files can be saved locally on your machine and checked into Github for easy diffs.
+- Built in Rust. So fast, you can't even tell it's there.
+
+## BAML's Design Philosophy
+
+Everything is fair game when making new syntax. If you can code it, it can be yours. This is our design philosophy to help restrict ideas:
+
+- **1:** Avoid invention when possible
+    - Yes, prompts need versioning — we have a great versioning tool: git
+    - Yes, you need to save prompts — we have a great storage tool: filesystems
+- **2:** Any file editor and any terminal should be enough to use it
+- **3:** Be fast
+- **4:** A first year university student should be able to understand it
+
+## Why a new programming language
+
+We used to write websites like this:
+
+```python
+def home():
+    return "<button onclick=\"() => alert(\\\"hello!\\\")\">Click</button>"
+```
+
+And now we do this:
+
+```jsx
+function Home() {
+  return <button onClick={() => setCount(prev => prev + 1)}>
+          {count} clicks!
+         </button>
+}
+```
+
+New syntax can be incredible at expressing new ideas. Plus the idea of maintaining hundreds of f-strings for prompts kind of disgusts us 🤮. Strings are bad for maintainable codebases. We prefer structured strings.
+
+The goal of BAML is to give you the expressiveness of English, but the structure of code.
+
+Full [blog post](https://www.boundaryml.com/blog/ai-agents-need-new-syntax) by us.
+
+
+## Conclusion
+
+As models get better, we'll continue expecting even more out of them. But what will never change is that we'll want a way to write maintainable code that uses those models. The current way we all just assemble strings is very reminiscent of the early days PHP/HTML soup in web development. We hope some of the ideas we shared today can make a tiny dent in helping us all shape the way we all code tomorrow.
+
+## FAQ
+|   |   |
+| - | - |
+| Do I need to write my whole app in BAML? | Nope, only the prompts! BAML translates definitions into the language of your choice! [Python](https://docs.boundaryml.com/guide/installation-language/python), [TypeScript](https://docs.boundaryml.com/guide/installation-language/typescript), [Ruby](https://docs.boundaryml.com/guide/installation-language/ruby) and [more](https://docs.boundaryml.com/guide/installation-language/rest-api-other-languages). |
+| Is BAML stable? | Yes, many companies use it in production! We ship updates weekly! |
+| Why a new language? | [Jump to section](#why-a-new-programming-language) |
+
+
+## Contributing
+Checkout our [guide on getting started](/CONTRIBUTING.md)
+
+## Citation
+
+You can cite the BAML repo as follows:
+```bibtex
+@software{baml,
+  author = {Boundary ML},
+  title = {BAML},
+  url = {https://github.com/boundaryml/baml},
+  year = {2024}
+}
+```
+
+---
+
+Made with ❤️ by Boundary
+
+HQ in Seattle, WA
+
+P.S. We're hiring for software engineers that love rust. [Email us](mailto:founders@boundaryml.com) or reach out on [discord](https://discord.gg/ENtBB6kkXH)!
+
+<div align="left" style="align-items: left;">
+        <a href="#top">
+            <img src="https://img.shields.io/badge/Back%20to%20Top-000000?style=for-the-badge&logo=github&logoColor=white" alt="Back to Top">
+        </a>
+</div>
+
+<img src="https://imgs.xkcd.com/comics/standards.png" alt_text="hi" />

--- a/engine/cli/src/commands.rs
+++ b/engine/cli/src/commands.rs
@@ -5,7 +5,7 @@ use baml_runtime::{cli::RuntimeCliDefaults, BamlRuntime};
 use clap::{CommandFactory, Parser, Subcommand};
 
 #[derive(Parser, Debug)]
-#[command(author, version, about = "A CLI tool for working with BAML. Learn more at https://docs.boundaryml.com.", long_about = None)]
+#[command(author, version, about = "A CLI tool for working with BAML v0. Learn more at https://docs.boundaryml.com.", long_about = None)]
 #[command(styles = clap_cargo::style::CLAP_STYLING)]
 #[command(propagate_version = true)]
 pub(crate) struct RuntimeCli {

--- a/engine/language_client_python/Cargo.toml
+++ b/engine/language_client_python/Cargo.toml
@@ -3,7 +3,7 @@ name = "baml-python-ffi"
 edition = "2021"
 version.workspace = true
 authors.workspace = true
-description = "BAML python bindings (Cargo.toml)"
+description = "BAML v0 — Python runtime for baml_client"
 license = "Apache-2.0"
 
 [lib]

--- a/engine/language_client_python/README.md
+++ b/engine/language_client_python/README.md
@@ -1,1 +1,1 @@
-BAML python bindings (readme.md)
+# BAML v0 — Python runtime for baml_client

--- a/engine/language_client_python/pyproject.toml
+++ b/engine/language_client_python/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "baml-py"
 version = "0.224.0"
-description = "BAML python bindings (pyproject.toml)"
+description = "BAML v0 — Python runtime for baml_client"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ "name" = "Boundary", "email" = "contact@boundaryml.com" }]

--- a/engine/language_client_typescript/README.md
+++ b/engine/language_client_typescript/README.md
@@ -1,1 +1,1 @@
-BAML typescript bindings (readme.md)
+# BAML v0 — Node.js runtime for baml_client

--- a/engine/language_client_typescript/package.json
+++ b/engine/language_client_typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boundaryml/baml",
   "version": "0.224.0",
-  "description": "BAML typescript bindings (package.json)",
+  "description": "BAML v0 — Node.js runtime for baml_client",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/BoundaryML/baml.git",
@@ -104,7 +104,7 @@
   "bugs": {
     "url": "https://github.com/BoundaryML/baml/issues"
   },
-  "homepage": "https://github.com/BoundaryML/baml#readme",
+  "homepage": "https://github.com/BoundaryML/baml/blob/canary/README.v0.md",
   "author": "",
   "dependencies": {
     "@scarf/scarf": "^1.3.0"

--- a/engine/zed/Cargo.toml
+++ b/engine/zed/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2024"
 # Both Cargo.toml and extension.toml's version strings
 # are consumed by the Zed extension publishing logic
 version = "0.224.0"
-description = "BAML language support for Zed"
+description = "BAML v0 — Zed extension"
 
 [lib]
 crate-type = ["cdylib"]

--- a/engine/zed/README.md
+++ b/engine/zed/README.md
@@ -1,4 +1,4 @@
-# Zed extension for BAML
+# BAML v0 — Zed extension
 
 Development for this happens in the [BAML monorepo](https://github.com/BoundaryML/baml).
 

--- a/engine/zed/extension.toml
+++ b/engine/zed/extension.toml
@@ -1,6 +1,6 @@
 id = "baml"
-name = "Baml"
-description = "Baml support."
+name = "BAML v0"
+description = "BAML v0 — Zed extension"
 # Both Cargo.toml and extension.toml's version strings
 # are consumed by the Zed extension publishing logic
 version = "0.224.0"
@@ -9,7 +9,7 @@ authors = ["Boundary <contact@boundaryml.com>"]
 repository = "https://github.com/BoundaryML/zed-baml"
 
 [language_servers.baml-language-server]
-name = "Baml Language Server"
+name = "BAML v0 Language Server"
 language = "Baml"
 
 [grammars.baml]

--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -65,8 +65,8 @@ intellijPlatform {
         name = providers.gradleProperty("pluginName")
         version = providers.gradleProperty("pluginVersion")
 
-        // Extract the <!-- Plugin description --> section from README.md and provide for the plugin's manifest
-        description = providers.fileContents(layout.projectDirectory.file("../README.md")).asText.map(::markdownToHTML)
+        // Use the BAML v0 README as the plugin's Marketplace description.
+        description = providers.fileContents(layout.projectDirectory.file("../README.v0.md")).asText.map(::markdownToHTML)
 
         val changelog = project.changelog // local variable for configuration cache compatibility
         // Get the latest available change notes from the changelog file

--- a/jetbrains/gradle.properties
+++ b/jetbrains/gradle.properties
@@ -1,7 +1,7 @@
 # IntelliJ Platform Artifacts Repositories -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 
 pluginGroup = org.jetbrains.plugin.template
-pluginName = BAML
+pluginName = BAML v0 Playground
 pluginId = baml
 pluginRepositoryUrl = https://github.com/boundaryml/baml
 # SemVer format -> https://semver.org

--- a/jetbrains/settings.gradle.kts
+++ b/jetbrains/settings.gradle.kts
@@ -1,4 +1,4 @@
-rootProject.name = "BAML Playground"
+rootProject.name = "BAML v0 Playground"
 
 plugins {
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"

--- a/jetbrains/src/main/kotlin/com/boundaryml/jetbrains_ext/BamlLanguageServerFactory.kt
+++ b/jetbrains/src/main/kotlin/com/boundaryml/jetbrains_ext/BamlLanguageServerFactory.kt
@@ -55,7 +55,7 @@ class BamlLanguageServerInstaller : LanguageServerInstallerBase() {
 
     override fun checkServerInstalled(indicator: ProgressIndicator): Boolean {
         log.info("checkServerInstalled")
-        super.progress("Checking if BAML CLI is installed...", indicator)
+        super.progress("Checking if BAML v0 CLI is installed...", indicator)
         val newCliVersion = service<BamlLanguageServerService>().getCurrentCliVersion()
         return cliDownloader.checkDownloadedCliExists(CliVersion.fromVersionString(newCliVersion))
     }
@@ -63,7 +63,7 @@ class BamlLanguageServerInstaller : LanguageServerInstallerBase() {
     override fun install(indicator: ProgressIndicator) {
         log.info("install")
         try {
-            super.progress("Installing BAML CLI...", indicator)
+            super.progress("Installing BAML v0 CLI...", indicator)
 
             val newCliVersion = service<BamlLanguageServerService>().getCurrentCliVersion()
             val download = runBlocking { cliDownloader.resolveCliPath(newCliVersion) }

--- a/jetbrains/src/main/kotlin/com/boundaryml/jetbrains_ext/BamlPlaygroundAction.kt
+++ b/jetbrains/src/main/kotlin/com/boundaryml/jetbrains_ext/BamlPlaygroundAction.kt
@@ -16,7 +16,7 @@ class BamlPlaygroundAction : LSPCommandAction() {
         log.info("baml playground action $command $e")
         val project = e.project ?: return
         val toolWindow = ToolWindowManager.getInstance(project)
-            .getToolWindow("BAML Playground (beta)")
+            .getToolWindow("BAML v0 Playground (beta)")
 
         val args: List<Any> = command.arguments
 

--- a/jetbrains/src/main/kotlin/com/boundaryml/jetbrains_ext/BamlToolWindowFactory.kt
+++ b/jetbrains/src/main/kotlin/com/boundaryml/jetbrains_ext/BamlToolWindowFactory.kt
@@ -20,7 +20,7 @@ private const val PLACEHOLDER_HTML = """
     <html lang="en">
       <head>
         <meta charset="UTF-8" />
-        <title>Loading BAML Playground…</title>
+        <title>Loading BAML v0 Playground…</title>
         <style>
           body {
             margin: 0;
@@ -48,7 +48,7 @@ private const val PLACEHOLDER_HTML = """
       </head>
       <body>
         <div class="spinner"></div>
-        <h1>Starting BAML Playground…</h1>
+        <h1>Starting BAML v0 Playground…</h1>
         <p>You may need to open a BAML file if this does not load.</p>
       </body>
     </html>
@@ -61,7 +61,7 @@ private const val VITE_HOT_RELOAD_HTML = """
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>BAML Playground</title>
+  <title>BAML v0 Playground</title>
   <script type="module">
     import RefreshRuntime from "http://localhost:3030/@react-refresh"
     RefreshRuntime.injectIntoGlobalHook(window)

--- a/jetbrains/src/main/resources/META-INF/baml-lsp4ij.xml
+++ b/jetbrains/src/main/resources/META-INF/baml-lsp4ij.xml
@@ -2,7 +2,7 @@
 
     <extensions defaultExtensionNs="com.redhat.devtools.lsp4ij">
         <server id="baml-language-server"
-                name="BAML Language Server"
+                name="BAML v0 Language Server"
                 icon="com.boundaryml.jetbrains_ext.BamlIcons.FILETYPE"
                 factoryClass="com.boundaryml.jetbrains_ext.BamlLanguageServerFactory">
             <description><![CDATA[

--- a/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -1,7 +1,7 @@
 <!-- Plugin Configuration File. Read more: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
 <idea-plugin>
     <id>com.boundaryml.jetbrains_ext</id>
-    <name>BAML Playground</name>
+    <name>BAML v0 Playground</name>
     <vendor>BoundaryML</vendor>
 
     <depends>com.intellij.modules.platform</depends>
@@ -14,8 +14,8 @@
         <action
                 id="baml.openBamlPanel"
                 class="com.boundaryml.jetbrains_ext.BamlPlaygroundAction"
-                text="Open BAML Playground"
-                description="Opens an interactive playground for running and testing BAML code."
+                text="Open BAML v0 Playground"
+                description="Opens an interactive BAML v0 playground for running and testing BAML code."
                 icon="/icons/baml-lamb-light-mode.svg"
         >
         </action>
@@ -23,7 +23,7 @@
                 id="baml.runBamlTest"
                 class="com.boundaryml.jetbrains_ext.BamlPlaygroundAction"
                 text="Run BAML Test"
-                description="Opens the BAML playground and runs the specified test."
+                description="Opens the BAML v0 playground and runs the specified test."
                 icon="/icons/baml-lamb-light-mode.svg"
                 >
         </action>
@@ -32,7 +32,7 @@
     <extensions defaultExtensionNs="com.intellij">
         <!-- When changing toolWindow.id, also make sure to change BamlPlaygroundAction.kt -->
         <toolWindow
-                id="BAML Playground (beta)"
+                id="BAML v0 Playground (beta)"
                 factoryClass="com.boundaryml.jetbrains_ext.BamlToolWindowFactory"
                 icon="/icons/baml-lamb-light-mode.svg"
         />

--- a/languages/rust/Cargo.toml
+++ b/languages/rust/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 # This is the MSRV (Minimum Supported Rust Version) for the workspace
 rust-version = "1.70"
 authors = ["Boundary <contact@boundaryml.com>"]
-homepage = "https://github.com/BoundaryML/baml"
+homepage = "https://github.com/BoundaryML/baml/blob/canary/README.v0.md"
 documentation = "https://docs.boundaryml.com"
 repository = "https://github.com/BoundaryML/baml"
 license = "Apache-2.0"

--- a/languages/rust/baml-cli/Cargo.toml
+++ b/languages/rust/baml-cli/Cargo.toml
@@ -8,7 +8,7 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
-description = "BAML CLI for Rust"
+description = "BAML v0 — Rust CLI"
 readme = "README.md"
 keywords = ["baml", "boundaryml", "boundary", "llm", "programming-language"]
 categories = ["command-line-utilities", "development-tools"]

--- a/languages/rust/baml-cli/README.md
+++ b/languages/rust/baml-cli/README.md
@@ -1,6 +1,6 @@
-# baml-cli
+# BAML v0 — Rust CLI
 
-BAML CLI for Rust - Command-line interface for the BAML (Boundary AI Markup Language) runtime.
+BAML v0 CLI for Rust — a command-line interface for the BAML v0 runtime.
 
 ## Installation
 
@@ -40,4 +40,3 @@ For more information, see the [BAML documentation](https://docs.boundaryml.com).
 ## License
 
 MIT License - see the [LICENSE](../../LICENSE) file for details.
-

--- a/languages/rust/baml-macros/Cargo.toml
+++ b/languages/rust/baml-macros/Cargo.toml
@@ -8,7 +8,7 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
-description = "Derive macros for BAML types"
+description = "BAML v0 — Rust derive macros"
 readme = "README.md"
 keywords = ["baml", "boundaryml", "boundary", "llm", "programming-language"]
 categories = ["development-tools", "no-std"]

--- a/languages/rust/baml-macros/README.md
+++ b/languages/rust/baml-macros/README.md
@@ -1,6 +1,6 @@
-# baml-macros
+# BAML v0 — Rust derive macros
 
-Derive macros for BAML types.
+Derive macros for BAML v0 types.
 
 This crate provides procedural macros (`BamlEncode` and `BamlDecode`) for automatically implementing serialization and deserialization for Rust types used with BAML.
 
@@ -25,4 +25,3 @@ This crate is a dependency of the `baml` runtime crate. End users typically inte
 ## License
 
 MIT License - see the [LICENSE](../../LICENSE) file for details.
-

--- a/languages/rust/baml-sys/Cargo.toml
+++ b/languages/rust/baml-sys/Cargo.toml
@@ -8,7 +8,7 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
-description = "BAML FFI bindings with runtime dynamic library loading"
+description = "BAML v0 — Rust FFI bindings"
 readme = "README.md"
 keywords = ["baml", "boundaryml", "boundary", "llm", "programming-language"]
 categories = ["external-ffi-bindings"]

--- a/languages/rust/baml-sys/README.md
+++ b/languages/rust/baml-sys/README.md
@@ -1,10 +1,10 @@
-# baml-sys
+# BAML v0 — Rust FFI bindings
 
-Low-level FFI bindings to the BAML runtime library with runtime dynamic loading.
+Low-level FFI bindings to the BAML v0 runtime library with runtime dynamic loading.
 
 ## Overview
 
-This crate provides the FFI bindings to `libbaml_cffi`, the C FFI interface to the BAML runtime.
+This crate provides the FFI bindings to `libbaml_cffi`, the C FFI interface to the BAML v0 runtime.
 Unlike traditional `-sys` crates that link at compile time, `baml-sys` loads the library
 dynamically at runtime using `libloading`.
 

--- a/languages/rust/baml/Cargo.toml
+++ b/languages/rust/baml/Cargo.toml
@@ -8,7 +8,7 @@ homepage = { workspace = true }
 documentation = { workspace = true }
 repository = { workspace = true }
 license = { workspace = true }
-description = "BAML runtime for Rust - type-safe LLM function calls"
+description = "BAML v0 — Rust runtime for baml_client"
 readme = "README.md"
 keywords = ["baml", "boundaryml", "boundary", "llm", "programming-language"]
 categories = ["development-tools", "web-programming"]

--- a/languages/rust/baml/README.md
+++ b/languages/rust/baml/README.md
@@ -1,6 +1,6 @@
-# baml
+# BAML v0 — Rust runtime for baml_client
 
-BAML runtime for Rust - Type-safe LLM function calls.
+BAML v0 runtime for Rust with type-safe LLM function calls.
 
 This crate provides the runtime support for BAML-generated Rust code. Users should not import from this crate directly - instead, use the generated `baml_client` crate which re-exports necessary types.
 

--- a/typescript/apps/vscode-ext/README.md
+++ b/typescript/apps/vscode-ext/README.md
@@ -1,10 +1,10 @@
-# Baml Language VS Code Extension
+# BAML v0 — VS Code and Cursor extension
 
-This VS Code extension provides support for the Baml language used to define LLM functions, test them in the integrated LLM Playground and build agentic workflows.
+This extension provides VS Code and Cursor support for BAML v0, the DSL used to define LLM functions, test them in the integrated LLM Playground, and build agentic workflows.
 
 ### General features
 
-1. **Syntax Highlighting**: Provides enhanced readability and coding experience by highlighting the Baml language syntax for any file with the `.baml` extension.
+1. **Syntax Highlighting**: Provides enhanced readability and coding experience by highlighting the BAML v0 language syntax for any file with the `.baml` extension.
 2. **Dynamic playground**: Run and test your prompts in real-time.
 3. **Build typed clients in several languages**: Command +S a baml file to build a baml client to call your functions in Python or TS.
 

--- a/typescript/apps/vscode-ext/package.json
+++ b/typescript/apps/vscode-ext/package.json
@@ -1,7 +1,7 @@
 {
   "name": "baml-extension",
-  "displayName": "Baml",
-  "description": "BAML is a DSL for AI applications.",
+  "displayName": "BAML v0",
+  "description": "BAML v0 is a DSL for AI applications.",
   "version": "0.224.0",
   "publisher": "Boundary",
   "packageManager": "pnpm@9.12.0",
@@ -32,7 +32,7 @@
     ],
     "configuration": {
       "type": "object",
-      "title": "Baml extension settings",
+      "title": "BAML v0 extension settings",
       "properties": {
         "baml.cliPath": {
           "type": [
@@ -65,13 +65,13 @@
         "baml.enablePlaygroundProxy": {
           "type": "boolean",
           "default": true,
-          "description": "BAML Extension starts a localhost proxy for the playground to send requests to fix any CORS issues with some LLM providers. Disable this if you're having issues communicating with any APIs via the playground"
+          "description": "BAML v0 extension starts a localhost proxy for the playground to send requests to fix any CORS issues with some LLM providers. Disable this if you're having issues communicating with any APIs via the playground"
         },
         "baml.fileWatcher": {
           "scope": "window",
           "type": "boolean",
           "default": false,
-          "description": "Enable, when checked, the File Watcher functionality for Baml Client."
+          "description": "Enable, when checked, the File Watcher functionality for the BAML v0 client."
         },
         "baml.trace.server": {
           "scope": "window",
@@ -87,7 +87,7 @@
         "baml.bamlPanelOpen": {
           "type": "boolean",
           "default": false,
-          "description": "Indicates whether the Baml playground panel is open or closed."
+          "description": "Indicates whether the BAML v0 playground panel is open or closed."
         },
         "baml.envVarFile": {
           "type": "string",
@@ -118,7 +118,7 @@
       {
         "id": "baml",
         "aliases": [
-          "Baml",
+          "BAML v0",
           "baml"
         ],
         "extensions": [
@@ -169,33 +169,33 @@
       {
         "command": "baml.restartLanguageServer",
         "title": "Restart Language Server",
-        "category": "Baml"
+        "category": "BAML v0"
       },
       {
         "command": "baml.openBamlPanel",
         "title": "Open Playground",
-        "category": "Baml"
+        "category": "BAML v0"
       },
       {
         "command": "baml.checkForUpdates",
         "title": "Check Updates",
-        "category": "Baml"
+        "category": "BAML v0"
       },
       {
         "command": "baml.jumpToDefinition",
         "title": "Jump to Definition",
-        "category": "Baml",
+        "category": "BAML v0",
         "enablement": "editorLangId == 'python'"
       },
       {
         "command": "baml.selectTestCase",
         "title": "Select Test Case",
-        "category": "Baml"
+        "category": "BAML v0"
       },
       {
         "command": "baml.setDefaultFormatter",
         "title": "Set Default Formatter",
-        "category": "Baml"
+        "category": "BAML v0"
       }
     ]
   },

--- a/typescript/apps/vscode-ext/src/panels/WebviewPanelHost.ts
+++ b/typescript/apps/vscode-ext/src/panels/WebviewPanelHost.ts
@@ -103,7 +103,7 @@ export class WebviewPanelHost {
         // Panel view type
         'showHelloWorld',
         // Panel title
-        'BAML Playground',
+        'BAML v0 Playground',
         // The editor column the panel should be displayed in
         // process.env.VSCODE_DEBUG_MODE === 'true' ? ViewColumn.Two : ViewColumn.Beside,
         { viewColumn: ViewColumn.Beside, preserveFocus: true },
@@ -339,7 +339,7 @@ export class WebviewPanelHost {
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <link rel="stylesheet" type="text/css" href="${stylesUri}">
-        <title>BAML Playground</title>
+        <title>BAML v0 Playground</title>
         <style>
           /* Match playground loading spinner style */
           .baml-loading-container {
@@ -399,7 +399,7 @@ export class WebviewPanelHost {
           <div class="baml-loading-container">
             <div class="baml-loading-box">
               <div class="baml-spinner"></div>
-              <div class="baml-loading-title">Loading BAML Playground...</div>
+              <div class="baml-loading-title">Loading BAML v0 Playground...</div>
               <div class="baml-loading-desc">Please wait while the playground loads.</div>
             </div>
           </div>

--- a/typescript/apps/vscode-ext/src/plugins/language-server-client/index.ts
+++ b/typescript/apps/vscode-ext/src/plugins/language-server-client/index.ts
@@ -154,7 +154,7 @@ const executeLanguageServerRestart = async (options: {
     bamlOutputChannel?.appendLine(logMessage);
 
     const userMessage = isManualRestart
-      ? 'Failed to manually restart Baml language server.'
+      ? 'Failed to manually restart BAML v0 language server.'
       : `Failed to restart BAML Language Server to version ${version}.`;
 
     window.showErrorMessage(userMessage);
@@ -250,7 +250,7 @@ const getClientOptions = (): LanguageClientOptions => {
       { scheme: 'file', language: 'baml' },
       { language: 'json', pattern: '**/baml_src/**' },
     ],
-    outputChannel: vscode.window.createOutputChannel('Baml Language Server'),
+    outputChannel: vscode.window.createOutputChannel('BAML v0 Language Server'),
     revealOutputChannelOn: RevealOutputChannelOn.Never,
     synchronize: {
       fileEvents: workspace.createFileSystemWatcher('**/baml_src/**/*.baml'),
@@ -918,7 +918,7 @@ const plugin: BamlVSCodePlugin = {
             `ERROR: Error during manual restart: ${manualRestartErrorMessage}`,
           );
           window.showErrorMessage(
-            'Failed to manually restart Baml language server.',
+            'Failed to manually restart BAML v0 language server.',
           );
         }
       }),

--- a/typescript/apps/vscode-ext/src/util.ts
+++ b/typescript/apps/vscode-ext/src/util.ts
@@ -28,10 +28,10 @@ export function checkForOtherPrismaExtension(): void {
   if (files.length !== 0) {
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     window.showInformationMessage(
-      'You have both both versions (Insider and Stable) of the Baml VS Code extension enabled in your workspace. Please uninstall or disable one of them for a better experience.',
+      'You have both both versions (Insider and Stable) of the BAML v0 VS Code extension enabled in your workspace. Please uninstall or disable one of them for a better experience.',
     );
     console.log(
-      'Both versions (Insider and Stable) of the Baml VS Code extension are enabled.',
+      'Both versions (Insider and Stable) of the BAML v0 VS Code extension are enabled.',
     );
   }
 }
@@ -123,7 +123,7 @@ export function createLanguageServer(
 ): LanguageClient {
   return new LanguageClient(
     'baml',
-    'Baml Language Server',
+    'BAML v0 Language Server',
     serverOptions,
     clientOptions,
   );


### PR DESCRIPTION
## Summary

- label the legacy VS Code/Cursor, JetBrains, Zed, PyPI, npm, crates.io, CLI, and GitHub Release surfaces as BAML v0
- add `README.v0.md` from the pre-PR-3890 legacy README and use it for CLI archives and the JetBrains Marketplace description
- point legacy npm and Rust package homepages at `README.v0.md` instead of the repository root README
- preserve compatibility identifiers while standardizing user-visible extension and language-server labels

## Why

The repository root README now describes the new BAML language, while `.github/workflows/release.yml` still publishes the legacy v0 toolchain and integrations. Those release surfaces were generically labeled BAML and, in a few cases, rendered or linked to the root README, making v0 and the new language difficult to distinguish.

## Validation

- `actionlint` on the modified release workflows (ignoring the repository's known custom Blacksmith runner label)
- JSON and TOML parsing for modified package manifests
- `cargo metadata --no-deps` for the legacy engine and Rust SDK workspaces
- `pnpm run typecheck` in `typescript/apps/vscode-ext`
- `pnpm exec vsce ls --no-dependencies` in `typescript/apps/vscode-ext`
- `./gradlew compileKotlin patchPluginXml --console=plain` in `jetbrains`
- verified the generated JetBrains manifest renders `README.v0.md` and uses `BAML v0 Playground`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive BAML v0 documentation covering syntax, runtimes, IDE tooling, structured outputs, and agent workflows.
  * Updated package and extension documentation to describe BAML v0 capabilities and branding.

* **Enhancements**
  * Standardized BAML v0 branding across the CLI, release archives, VS Code, Zed, JetBrains, Rust, Python, and Node.js integrations.
  * Release names now include the BAML v0 product prefix.
  * Release archives now include the BAML v0 README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->