### PR TITLE
fix(playground): surface current build failures

### DIFF
--- a/baml_language/crates/bex_project/src/bex_lsp/mod.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/mod.rs
@@ -309,6 +309,10 @@ pub struct PlaygroundSourceFile {
 }
 
 pub trait PlaygroundSender: Send + Sync {
+    /// Serialize and enqueue the notification synchronously without waiting
+    /// for a consumer or performing blocking I/O. Project snapshots keep
+    /// revision-fencing guards through this call, so implementations must
+    /// return after a bounded in-process handoff.
     fn send_playground_notification(&self, notification: PlaygroundNotification);
 }
 

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/mod.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/mod.rs
@@ -145,6 +145,11 @@ struct LiveProject {
     project: BexProject,
     in_memory_changes: Mutex<HashMap<crate::fs::FsPath, OverlayDocument>>,
     diagnostics_fence: Mutex<DiagnosticsFence>,
+    /// The latest build failure that was not represented by source
+    /// diagnostics. Keep it revision-scoped so a later edit immediately stops
+    /// surfacing a stale failure, while `requestState` can still replay the
+    /// failure that made the current build unavailable.
+    build_failure: Mutex<BuildFailureState>,
     /// Debounce tickets (pre-work suppression only — never authorization;
     /// installation is guarded by the revision-conditional commit).
     #[cfg(not(target_arch = "wasm32"))]
@@ -163,6 +168,7 @@ impl LiveProject {
             project,
             in_memory_changes: Mutex::new(HashMap::new()),
             diagnostics_fence: Mutex::new(DiagnosticsFence::default()),
+            build_failure: Mutex::new(BuildFailureState::default()),
             #[cfg(not(target_arch = "wasm32"))]
             diagnostics_epoch: std::sync::atomic::AtomicU64::new(0),
             #[cfg(not(target_arch = "wasm32"))]
@@ -170,6 +176,52 @@ impl LiveProject {
             #[cfg(not(target_arch = "wasm32"))]
             rebuild_gate: tokio::sync::Mutex::new(()),
         }
+    }
+}
+
+#[derive(Default)]
+struct BuildFailureState {
+    latest: Option<(SourceRevision, String)>,
+}
+
+impl BuildFailureState {
+    fn record(&mut self, revision: SourceRevision, message: String) {
+        if self
+            .latest
+            .as_ref()
+            .is_some_and(|(latest_revision, _)| *latest_revision > revision)
+        {
+            return;
+        }
+        self.latest = Some((revision, message));
+    }
+
+    fn clear_through(&mut self, revision: SourceRevision) {
+        if self
+            .latest
+            .as_ref()
+            .is_some_and(|(latest_revision, _)| *latest_revision <= revision)
+        {
+            self.latest = None;
+        }
+    }
+
+    fn message_for(&self, revision: SourceRevision) -> Option<&str> {
+        self.latest
+            .as_ref()
+            .filter(|(failed_revision, _)| *failed_revision == revision)
+            .map(|(_, message)| message.as_str())
+    }
+
+    fn project_diagnostic_for(
+        &self,
+        revision: SourceRevision,
+    ) -> Option<crate::bex_lsp::ProjectDiagnostic> {
+        self.message_for(revision)
+            .map(|message| crate::bex_lsp::ProjectDiagnostic {
+                severity: "error",
+                message: format!("Current build failed: {message}"),
+            })
     }
 }
 
@@ -925,7 +977,7 @@ impl BexMulitProject {
             // The playground project snapshot rides the same debounced tail:
             // emit one owned payload per quiet period, not one per
             // keystroke.
-            this.send_update_project(&project_root, &project);
+            this.send_update_project(project_root.as_str(), &project);
         });
     }
 
@@ -1097,24 +1149,39 @@ impl BexMulitProject {
 
         match report.engine {
             EngineBuildOutcome::Committed(receipt) => {
+                project
+                    .build_failure
+                    .lock()
+                    .unwrap()
+                    .clear_through(receipt.source_revision);
                 log::info!(
                     "engine rebuild: generation {} committed at {}",
                     receipt.generation,
                     receipt.source_revision
                 );
-                self.send_update_project(project_root, project);
+                self.send_update_project(project_root.as_str(), project);
                 self.collect_tests_for_project(project_root.as_str(), project);
             }
             EngineBuildOutcome::BlockedByDiagnostics { source_revision } => {
+                project
+                    .build_failure
+                    .lock()
+                    .unwrap()
+                    .clear_through(source_revision);
                 log::info!("engine rebuild: blocked by diagnostics at {source_revision}");
-                self.send_update_project(project_root, project);
+                self.send_update_project(project_root.as_str(), project);
             }
             EngineBuildOutcome::Failed {
                 source_revision,
                 message,
             } => {
+                project
+                    .build_failure
+                    .lock()
+                    .unwrap()
+                    .record(source_revision, message.clone());
                 log::warn!("engine rebuild failed at {source_revision}: {message}");
-                self.send_update_project(project_root, project);
+                self.send_update_project(project_root.as_str(), project);
             }
             EngineBuildOutcome::Superseded { current_revision } => {
                 log::info!(
@@ -1168,18 +1235,18 @@ impl BexMulitProject {
         out
     }
 
-    /// Build one owned, complete `ProjectUpdate` payload with a bounded
-    /// source read. `None` means the project was busy or broken — the caller
-    /// keeps the last announced state rather than sending a wiped payload.
-    fn build_project_update(&self, project: &LiveProject) -> Option<crate::bex_lsp::ProjectUpdate> {
-        let is_bex_current = project.project.is_bex_current();
-        let generation = project.project.current_generation();
-
-        let guard = project.project.read_source_for_request().ok()?;
-        let candidate = crate::project::collect_diagnostic_candidate(&guard);
+    /// Build one owned, complete `ProjectUpdate` payload from the caller's
+    /// source lease. The caller keeps that lease through notification
+    /// publication so an edit cannot make this snapshot obsolete mid-send.
+    fn build_project_update(
+        &self,
+        guard: &crate::project::SourceGuard<'_>,
+        is_bex_current: bool,
+        generation: u64,
+    ) -> crate::bex_lsp::ProjectUpdate {
+        let candidate = crate::project::collect_diagnostic_candidate(guard);
         let listing = baml_project::list_functions_with_metadata(guard.db());
         let tests_listing = baml_project::list_tests_with_metadata(guard.db());
-        drop(guard);
 
         let documents = candidate_to_publishable(&candidate, self.encoding_for_publication());
         let diagnostics = Self::flatten_diagnostics(&documents);
@@ -1216,14 +1283,14 @@ impl BexMulitProject {
             })
             .collect();
 
-        Some(crate::bex_lsp::ProjectUpdate {
+        crate::bex_lsp::ProjectUpdate {
             is_bex_current,
             generation,
             functions,
             tests,
             types: Some(listing.types),
             diagnostics,
-        })
+        }
     }
 
     fn send_list_projects(&self) {
@@ -1238,20 +1305,33 @@ impl BexMulitProject {
         );
     }
 
-    fn send_update_project(&self, project_root: &vfs::VfsPath, project: &LiveProject) {
-        let Some(update) = self.build_project_update(project) else {
-            log::debug!(
-                "skipping UpdateProject for busy project {}",
-                project_root.as_str()
-            );
+    fn send_update_project(&self, project_root: &str, project: &LiveProject) {
+        let Ok(guard) = project.project.read_source_for_request() else {
+            log::debug!("skipping UpdateProject for busy project {project_root}");
             return;
         };
+        let source_revision = guard.revision();
+        let (is_bex_current, generation) =
+            project.project.runtime_status_for_source(source_revision);
+        let mut update = self.build_project_update(&guard, is_bex_current, generation);
+
+        // Keep the failure read and notification publication in one critical
+        // section. Otherwise a diagnostics-tail snapshot that read "no
+        // failure" could publish after the engine tail recorded and sent a
+        // failure for the same revision, regressing the UI to its transient
+        // preparing state.
+        let build_failure = project.build_failure.lock().unwrap();
+        if let Some(diagnostic) = build_failure.project_diagnostic_for(source_revision) {
+            update.diagnostics.push(diagnostic);
+        }
         self.playground_sender.send_playground_notification(
             crate::bex_lsp::PlaygroundNotification::UpdateProject {
-                project: project_root.as_str().to_string(),
+                project: project_root.to_string(),
                 update,
             },
         );
+        drop(build_failure);
+        drop(guard);
     }
 
     // ── Test collection / runs ───────────────────────────────────────────
@@ -1937,16 +2017,8 @@ impl super::BexLsp for BexMulitProject {
                 .collect()
         };
         for (fs_path, project) in projects {
-            let root_str = fs_path.as_path().to_string_lossy().into_owned();
-            let Some(update) = self.build_project_update(&project) else {
-                continue;
-            };
-            self.playground_sender.send_playground_notification(
-                crate::bex_lsp::PlaygroundNotification::UpdateProject {
-                    project: root_str,
-                    update,
-                },
-            );
+            let root = fs_path.as_path().to_string_lossy();
+            self.send_update_project(&root, &project);
         }
     }
 
@@ -2312,6 +2384,181 @@ mod tests {
         // Steady state: no repeat clears.
         let deleted = fence.record_publication([a].into_iter().collect());
         assert!(deleted.is_empty());
+    }
+
+    #[test]
+    fn build_failures_are_revision_fenced_for_project_update_replay() {
+        let mut failures = BuildFailureState::default();
+
+        failures.record(SourceRevision(4), "failed to emit bytecode".to_string());
+        assert_eq!(
+            failures.message_for(SourceRevision(4)),
+            Some("failed to emit bytecode")
+        );
+        let rendered = failures
+            .project_diagnostic_for(SourceRevision(4))
+            .expect("the current revision's build failure must reach ProjectUpdate");
+        assert_eq!(rendered.severity, "error");
+        assert_eq!(
+            rendered.message,
+            "Current build failed: failed to emit bytecode"
+        );
+        assert_eq!(
+            failures.message_for(SourceRevision(5)),
+            None,
+            "an edit must not replay the previous revision's failure"
+        );
+
+        failures.record(SourceRevision(3), "older failure".to_string());
+        assert_eq!(
+            failures.message_for(SourceRevision(4)),
+            Some("failed to emit bytecode"),
+            "a late stale rebuild must not replace a newer failure"
+        );
+
+        failures.clear_through(SourceRevision(3));
+        assert_eq!(
+            failures.message_for(SourceRevision(4)),
+            Some("failed to emit bytecode")
+        );
+        failures.clear_through(SourceRevision(4));
+        assert_eq!(failures.message_for(SourceRevision(4)), None);
+    }
+
+    struct GatedPlaygroundSender {
+        publication: std::sync::mpsc::SyncSender<Vec<String>>,
+        release: std::sync::Mutex<std::sync::mpsc::Receiver<()>>,
+    }
+
+    impl crate::bex_lsp::PlaygroundSender for GatedPlaygroundSender {
+        fn send_playground_notification(
+            &self,
+            notification: crate::bex_lsp::PlaygroundNotification,
+        ) {
+            let crate::bex_lsp::PlaygroundNotification::UpdateProject { update, .. } = notification
+            else {
+                return;
+            };
+            self.publication
+                .send(
+                    update
+                        .diagnostics
+                        .into_iter()
+                        .map(|diagnostic| diagnostic.message)
+                        .collect(),
+                )
+                .unwrap();
+            self.release.lock().unwrap().recv().unwrap();
+        }
+    }
+
+    #[test]
+    fn source_lease_fences_failure_publication_against_a_racing_edit() {
+        let root = vfs::VfsPath::new(vfs::MemoryFS::new());
+        let bex_project = crate::project::BexProject::new(
+            &root,
+            std::sync::Arc::new(sys_ops::SysOpsBuilder::new().build()),
+        );
+        let source_path = crate::fs::FsPath::from_str("/p/main.baml".to_string());
+        let revision = bex_project
+            .mutate_sources(crate::project::SourceBatch {
+                replace_all: false,
+                sources: [(
+                    source_path.clone(),
+                    "function main() -> int {\n    1\n}\n".to_string(),
+                )]
+                .into_iter()
+                .collect(),
+                versions: Vec::new(),
+            })
+            .unwrap();
+        let project = std::sync::Arc::new(LiveProject::new(bex_project));
+        project
+            .build_failure
+            .lock()
+            .unwrap()
+            .record(revision, "failed to emit bytecode".to_string());
+
+        let (publication_tx, publication_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let lsp = std::sync::Arc::new(BexMulitProject::new(
+            std::sync::Arc::new(|_: &vfs::VfsPath| {
+                std::sync::Arc::new(sys_ops::SysOpsBuilder::new().build())
+            }),
+            std::sync::Arc::new(RecordingSender {
+                notifications: std::sync::Mutex::new(Vec::new()),
+            }),
+            std::sync::Arc::new(GatedPlaygroundSender {
+                publication: publication_tx,
+                release: std::sync::Mutex::new(release_rx),
+            }),
+            crate::fs::BamlVFS::new(std::sync::Arc::new(Box::new(vfs::PhysicalFS::new("/")))),
+            BackgroundSpawner::new(),
+        ));
+
+        let publishing_lsp = lsp;
+        let publishing_project = project.clone();
+        let publisher = std::thread::spawn(move || {
+            publishing_lsp.send_update_project("/p", &publishing_project);
+        });
+        let diagnostics = publication_rx
+            .recv_timeout(std::time::Duration::from_secs(10))
+            .expect("the failure-bearing update must reach the publication boundary");
+        assert!(
+            diagnostics
+                .iter()
+                .any(|message| message == "Current build failed: failed to emit bytecode")
+        );
+
+        let (edit_started_tx, edit_started_rx) = std::sync::mpsc::sync_channel(1);
+        let (edit_done_tx, edit_done_rx) = std::sync::mpsc::sync_channel(1);
+        let editing_project = project.clone();
+        let editor = std::thread::spawn(move || {
+            edit_started_tx.send(()).unwrap();
+            let next_revision = editing_project
+                .project
+                .mutate_sources(crate::project::SourceBatch {
+                    replace_all: false,
+                    sources: [(
+                        source_path,
+                        "function main() -> int {\n    2\n}\n".to_string(),
+                    )]
+                    .into_iter()
+                    .collect(),
+                    versions: Vec::new(),
+                })
+                .unwrap();
+            edit_done_tx.send(next_revision).unwrap();
+        });
+        edit_started_rx.recv().unwrap();
+        assert!(
+            edit_done_rx
+                .recv_timeout(std::time::Duration::from_millis(100))
+                .is_err(),
+            "the edit must remain blocked while the old revision is publishing"
+        );
+
+        release_tx.send(()).unwrap();
+        publisher.join().unwrap();
+        assert_eq!(
+            edit_done_rx
+                .recv_timeout(std::time::Duration::from_secs(2))
+                .unwrap(),
+            SourceRevision(revision.0 + 1)
+        );
+        editor.join().unwrap();
+
+        let current_revision = project.project.current_revision();
+        assert_eq!(current_revision, SourceRevision(revision.0 + 1));
+        assert!(
+            project
+                .build_failure
+                .lock()
+                .unwrap()
+                .project_diagnostic_for(current_revision)
+                .is_none(),
+            "the previous revision's failure must not appear after the edit"
+        );
     }
 
     #[test]

--- a/baml_language/crates/bex_project/src/project.rs
+++ b/baml_language/crates/bex_project/src/project.rs
@@ -1071,6 +1071,22 @@ impl BexProject {
             .unwrap_or(0)
     }
 
+    /// Runtime status for a source revision already captured under a caller's
+    /// source lease. This avoids re-locking the source gate while that lease
+    /// is held.
+    pub(crate) fn runtime_status_for_source(&self, source_revision: SourceRevision) -> (bool, u64) {
+        let Ok(runtime) = self.lock_runtime() else {
+            return (false, 0);
+        };
+        let Some(installed) = runtime.installed.as_ref() else {
+            return (false, 0);
+        };
+        (
+            installed.source_revision == source_revision,
+            installed.generation,
+        )
+    }
+
     /// Latest installed engine regardless of currentness (playground render
     /// paths that tolerate a stale engine; run launch uses
     /// [`Self::prepare_function_run`] instead).


### PR DESCRIPTION
Fixes [B-1003](https://linear.app/boundaryml2/issue/B-1003/compiler-errors-arent-fully-rendered-in-playground).

## User impact

When the compiler cannot prepare a runnable build without producing a normal source diagnostic, the Run tab now shows the failure in its existing compiler-error banner instead of staying indefinitely at “Preparing current build…”. The error is also replayed after a playground reconnect or state request, and disappears as soon as the source revision changes.

## Root cause

The rebuild pipeline preserved source diagnostics but discarded the message from `EngineBuildOutcome::Failed` after logging it. The resulting `ProjectUpdate` had `isBexCurrent: false` and no error-severity diagnostics, which the playground correctly interpreted as a transient build window. Because the failed revision could never become current, that transient state never ended.

## What changed

- Persist the latest non-diagnostic build failure on `LiveProject`, scoped to its exact `SourceRevision`.
- Include that failure as an error-severity project diagnostic in normal updates and `requestState` replays.
- Ignore late failures from older revisions and clear recorded failures after a successful or source-diagnostic-blocked rebuild.
- Serialize failure lookup through notification publication so a concurrent older diagnostics snapshot cannot overwrite the failure-bearing update.
- Hold the source lease through publication so an edit cannot make a failure-bearing snapshot obsolete while it is being sent.
- Document that `PlaygroundSender` implementations must perform a bounded, synchronous in-process handoff because project snapshots retain revision-fencing guards during publication.
- Add regression coverage for rendering, revision fencing, stale rebuild ordering, clearing, and an edit racing failure publication.

## Verification

- `cargo test -p bex_project --lib` (60 passed, 1 ignored)
- `cargo clippy -p bex_project --lib -- -D warnings`
- `cargo check --target wasm32-unknown-unknown -p bridge_wasm`
- `cargo fmt --all -- --check`
- Verified in the real `baml playground` server using current playground assets. A deterministic engine-construction failure was introduced only as temporary, uncommitted test instrumentation, used identically against latest canary and this branch, then removed before committing.
- Confirmed latest canary remains stuck at “Preparing current build…” with `isBexCurrent: false` and no error diagnostics, while this branch renders the failure in the expanded compiler-error banner.
- Also confirmed ordinary independent source diagnostics already render fully (2/2), narrowing the bug to non-diagnostic engine-build failures.

## Screenshots

### Before — latest canary

![Latest canary remains stuck at Preparing current build](https://uploads.linear.app/17f201ee-07c9-4c00-bec2-4d5b8f1f17a7/0a73f42b-4d56-46ed-a3b5-aeafa8e33e33/79736864-990f-45ea-b063-68f1bfe6200b)

### After — this PR

![This PR renders the current build failure in the compiler-error banner](https://uploads.linear.app/17f201ee-07c9-4c00-bec2-4d5b8f1f17a7/dcd20ef0-75be-468b-9b3a-2a9b80a88c5d/845a6865-0740-49c0-8a4e-f07d490a6a8d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project diagnostics to accurately report build failures for the relevant revision.
  * Prevented outdated build errors from appearing after newer project updates.
  * Automatically clears build-failure diagnostics when a build succeeds or is appropriately blocked.
  * Improved handling of build status when project updates are replayed or processed out of order.
  * Ensured diagnostics remain consistent when project changes and build results arrive at different times.
  * Improved runtime status reporting so it reflects the engine installed for the current project revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->