### PR TITLE
fix: clarify unnecessary throws diagnostic

### DIFF
--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -1214,7 +1214,7 @@ impl fmt::Display for TirTypeError {
             TirTypeError::ExtraneousThrowsDeclaration { extra_types } => {
                 write!(
                     f,
-                    "extraneous throws declaration: {}",
+                    "Unnecessary throws declaration: this function cannot throw {}.",
                     extra_types.join(", ")
                 )
             }

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/semantic_tokens/throws_clause.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/semantic_tokens/throws_clause.baml
@@ -29,7 +29,7 @@ function MayThrowMultiple(x: int) -> string throws string | int {
 //- diagnostics
 // E0097
 //
-//   ⚠ extraneous throws declaration: int
+//   ⚠ Unnecessary throws declaration: this function cannot throw int.
 //     ╭─[throws_clause.baml:21:52]
 //  21 │ function MayThrowMultiple(x: int) -> string throws string | int {
 //     ·                                                    ────────────

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/hover/catch_rethrow.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/hover/catch_rethrow.baml
@@ -27,7 +27,7 @@ function getProfile(req: int) -> bool throws Errors {
 //     ╰────
 // E0097
 //
-//   ⚠ extraneous throws declaration: AuthenticationError, AuthorizationError
+//   ⚠ Unnecessary throws declaration: this function cannot throw AuthenticationError, AuthorizationError.
 //     ╭─[hover_catch_rethrow.baml:15:46]
 //  15 │ function getProfile(req: int) -> bool throws Errors {
 //     ·                                              ──────

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/hover/catch_rethrow_caller.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/hover/catch_rethrow_caller.baml
@@ -35,7 +35,7 @@ function getProfile(req: int) -> bool throws Errors {
 //     ╰────
 // E0097
 //
-//   ⚠ extraneous throws declaration: AuthenticationError, AuthorizationError
+//   ⚠ Unnecessary throws declaration: this function cannot throw AuthenticationError, AuthorizationError.
 //     ╭─[hover_catch_rethrow_caller.baml:23:46]
 //  23 │ function getProfile(req: int) -> bool throws Errors {
 //     ·                                              ──────

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/hover/function_throws.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/hover/function_throws.baml
@@ -18,7 +18,7 @@ function MayFail<[CURSOR](x: int) -> string throws Errors {
 //    ╰────
 // E0097
 //
-//   ⚠ extraneous throws declaration: Errors
+//   ⚠ Unnecessary throws declaration: this function cannot throw Errors.
 //    ╭─[hover_function_throws.baml:6:43]
 //  6 │ function MayFail(x: int) -> string throws Errors {
 //    ·                                           ──────

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_basic_syntax.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_basic_syntax.baml
@@ -29,7 +29,7 @@ function MayThrowMultiple(x: int) -> string throws string | int {
 //- diagnostics
 // E0097
 //
-//   ⚠ extraneous throws declaration: int
+//   ⚠ Unnecessary throws declaration: this function cannot throw int.
 //     ╭─[throw_throws_basic_syntax.baml:21:52]
 //  21 │ function MayThrowMultiple(x: int) -> string throws string | int {
 //     ·                                                    ────────────

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_caller_sees_contract.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_caller_sees_contract.baml
@@ -29,7 +29,7 @@ function Caller(x: int) -> string {
 //    ╰────
 // E0097
 //
-//   ⚠ extraneous throws declaration: Errors
+//   ⚠ Unnecessary throws declaration: this function cannot throw Errors.
 //    ╭─[throw_throws_caller_sees_contract.baml:9:43]
 //  9 │ function MayFail(x: int) -> string throws Errors {
 //    ·                                           ──────

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_caller_variant_contract.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_caller_variant_contract.baml
@@ -32,7 +32,7 @@ function CallerGood(x: int) -> string {
 //     ╰────
 // E0097
 //
-//   ⚠ extraneous throws declaration: Errors
+//   ⚠ Unnecessary throws declaration: this function cannot throw Errors.
 //     ╭─[throw_throws_caller_variant_contract.baml:10:43]
 //  10 │ function MayFail(x: int) -> string throws Errors {
 //     ·                                           ──────

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_enum_exact_match.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_enum_exact_match.baml
@@ -25,7 +25,7 @@ function ThrowsEnumExact(x: int) -> string throws Errors {
 //    ╰────
 // E0097
 //
-//   ⚠ extraneous throws declaration: Errors
+//   ⚠ Unnecessary throws declaration: this function cannot throw Errors.
 //    ╭─[throw_throws_enum_exact_match.baml:9:51]
 //  9 │ function ThrowsEnumExact(x: int) -> string throws Errors {
 //    ·                                                   ──────

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_enum_extraneous.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_enum_extraneous.baml
@@ -21,7 +21,7 @@ function ThrowsEnumExtraneous(x: int) -> string throws Errors {
 //    ╰────
 // E0097
 //
-//   ⚠ extraneous throws declaration: Errors
+//   ⚠ Unnecessary throws declaration: this function cannot throw Errors.
 //    ╭─[throw_throws_enum_extraneous.baml:9:56]
 //  9 │ function ThrowsEnumExtraneous(x: int) -> string throws Errors {
 //    ·                                                        ──────

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_enum_variant_precise.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_enum_variant_precise.baml
@@ -27,7 +27,7 @@ function ThrowsVariantExact(x: int) -> string throws Errors {
 //     ╰────
 // E0097
 //
-//   ⚠ extraneous throws declaration: Errors
+//   ⚠ Unnecessary throws declaration: this function cannot throw Errors.
 //     ╭─[throw_throws_enum_variant_precise.baml:12:54]
 //  12 │ function ThrowsVariantExact(x: int) -> string throws Errors {
 //     ·                                                      ──────

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_enum_variant_violation.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_enum_variant_violation.baml
@@ -25,7 +25,7 @@ function ThrowsVariantViolation(x: int) -> string throws Errors {
 //     ╰────
 // E0097
 //
-//   ⚠ extraneous throws declaration: Errors
+//   ⚠ Unnecessary throws declaration: this function cannot throw Errors.
 //     ╭─[throw_throws_enum_variant_violation.baml:10:58]
 //  10 │ function ThrowsVariantViolation(x: int) -> string throws Errors {
 //     ·                                                          ──────

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_mixed.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_mixed.baml
@@ -24,7 +24,7 @@ function ThrowsMixed(x: int) -> string throws string | Errors {
 //    ╰────
 // E0097
 //
-//   ⚠ extraneous throws declaration: Errors
+//   ⚠ Unnecessary throws declaration: this function cannot throw Errors.
 //    ╭─[throw_throws_mixed.baml:9:47]
 //  9 │ function ThrowsMixed(x: int) -> string throws string | Errors {
 //    ·                                               ───────────────

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_type_alias_repro.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/syntax/throw/throws_type_alias_repro.baml
@@ -39,7 +39,7 @@ function getProfile(req: Request) -> bool throws Errors {
 //     ╰────
 // E0097
 //
-//   ⚠ extraneous throws declaration: AuthenticationError, AuthorizationError, InternalServerError, NotFoundError
+//   ⚠ Unnecessary throws declaration: this function cannot throw AuthenticationError, AuthorizationError, InternalServerError, NotFoundError.
 //     ╭─[throw_throws_type_alias_repro.baml:27:50]
 //  27 │ function getProfile(req: Request) -> bool throws Errors {
 //     ·                                                  ──────

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/catch_return_type_mismatch/baml_tests__diagnostic_errors__catch_return_type_mismatch__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/catch_return_type_mismatch/baml_tests__diagnostic_errors__catch_return_type_mismatch__04_tir.snap
@@ -7,7 +7,7 @@ function user.callee() -> bool throws user.Errors {
   { : never
     return true : true
   }
-  ?? 219..225: extraneous throws declaration: Errors
+  ?? 219..225: Unnecessary throws declaration: this function cannot throw Errors.
 }
 function user.caller() -> bool throws never {
   { : bool

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/catch_return_type_mismatch/baml_tests__diagnostic_errors__catch_return_type_mismatch__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/catch_return_type_mismatch/baml_tests__diagnostic_errors__catch_return_type_mismatch__05_diagnostics.snap
@@ -4,7 +4,7 @@ source: crates/baml_tests/src/generated_tests.rs
 === COMPILER2 DIAGNOSTICS ===
   [type] E0097
 
-  ⚠ extraneous throws declaration: Errors
+  ⚠ Unnecessary throws declaration: this function cannot throw Errors.
     ╭─[catch_return_type_mismatch.baml:10:34]
  10 │ function callee() -> bool throws Errors {
     ·                                  ──────

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/json_static_method_arity/baml_tests__diagnostic_errors__json_static_method_arity__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/json_static_method_arity/baml_tests__diagnostic_errors__json_static_method_arity__04_tir.snap
@@ -9,7 +9,7 @@ function user.Box.from_json(j: baml.json.json) -> user.Box<T> throws baml.json.J
   { : user.Box<T>
     Box { value: baml.json.from_json<T>(baml.json.field(j, "value")) } : user.Box<T>
   }
-  ?? 956..1008: extraneous throws declaration: baml.json.JsonParseError
+  ?? 956..1008: Unnecessary throws declaration: this function cannot throw baml.json.JsonParseError.
 }
 function user.bad_missing(j: baml.json.json) -> user.Box<int> throws baml.json.JsonParseError | baml.json.JsonDecodeError {
   { : user.Box<int>

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/json_static_method_arity/baml_tests__diagnostic_errors__json_static_method_arity__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/json_static_method_arity/baml_tests__diagnostic_errors__json_static_method_arity__05_diagnostics.snap
@@ -13,7 +13,7 @@ source: crates/baml_tests/src/generated_tests.rs
 
   [type] E0097
 
-  ⚠ extraneous throws declaration: baml.json.JsonParseError
+  ⚠ Unnecessary throws declaration: this function cannot throw baml.json.JsonParseError.
     ╭─[json_static_method_arity.baml:23:60]
  23 │     function from_json(j: baml.json.json) -> Box<T> throws baml.json.JsonParseError | baml.json.JsonDecodeError {
     ·                                                            ────────────────────────────────────────────────────

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase8_exceptions.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase8_exceptions.rs
@@ -97,11 +97,11 @@ fn extraneous_throws_declaration_is_warning() {
     let output = render_tir(&db, file);
     assert!(
         output.contains("??"),
-        "expected warning marker for extraneous throws declaration, got:\n{output}"
+        "expected warning marker for unnecessary throws declaration, got:\n{output}"
     );
     assert!(
-        output.contains("extraneous throws declaration"),
-        "expected extraneous throws diagnostic, got:\n{output}"
+        output.contains("Unnecessary throws declaration: this function cannot throw string."),
+        "expected unnecessary throws diagnostic, got:\n{output}"
     );
 }
 


### PR DESCRIPTION
## Summary

- replace the confusing `extraneous throws declaration` warning with `Unnecessary throws declaration: this function cannot throw ErrorType.`
- assert the complete user-facing diagnostic in the focused compiler regression test
- regenerate all affected LSP expectations and compiler snapshots

## Why

Users could not easily tell what `extraneous throws declaration` meant. The new wording explains that the listed type cannot be thrown by the function and therefore does not belong in its `throws` declaration.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p baml_tests compiler2_tir::phase8_exceptions::extraneous_throws_declaration_is_warning -- --exact --nocapture`
- `cargo test -p baml_lsp2_actions_tests` (468 passed, 1 ignored)
- targeted snapshot suites for `catch_return_type_mismatch` and `json_static_method_arity`
- broad `cargo test --lib` reached and passed the affected compiler, LSP, snapshot, and bridge suites; the workspace-wide run later stopped in the unrelated `bridge_python` crate because the local machine does not have `/install/lib/libpython3.13.dylib`

Linear: https://linear.app/boundaryml2/issue/B-1033/change-extraneous-throws-declaration-error-message