### PR TITLE
chore: refresh size-gate baselines

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -49,7 +49,7 @@ max_file_bytes = "20.9 MiB"
 max_file_bytes = "26.9 MiB"
 
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = "22.6 MiB"
+max_file_bytes = "22.5 MiB"
 
 [artifacts.packed-program]
 kind = "pack"


### PR DESCRIPTION
Adopted from CI run [`e26ee02447c5cfe9e8b711265c07f71afd511bd7`](https://github.com/BoundaryML/baml/actions/runs/30593929165).

# Binary size checks passed

✅ **7** passed

| | Artifact | Platform | File | Gzip | Gated on | Baseline | Delta | Status |
|---|----------|----------|------|------|----------|----------|-------|--------|
| :white_check_mark: | `baml-cli` | Linux | 🔒 27.4 MB | 11.6 MB | **file** | 27.4 MB | -8.8 KB (-0.0%) | OK |
| :white_check_mark: | `packed-program` | Linux | 🔒 17.7 MB | 7.3 MB | **file** | 17.7 MB | +26.1 KB (+0.1%) | OK |
| :white_check_mark: | `baml-cli` | macOS | 🔒 21.3 MB | 10.2 MB | **file** | 21.3 MB | -35.0 KB (-0.2%) | OK |
| :white_check_mark: | `packed-program` | macOS | 🔒 13.8 MB | 6.4 MB | **file** | 13.8 MB | -4.6 KB (-0.0%) | OK |
| :white_check_mark: | `bridge_wasm` | WASM | 16.8 MB | 🔒 4.6 MB | **gzip** | 4.6 MB | -44.1 KB (-1.0%) | OK |
| :white_check_mark: | `baml-cli` | Windows | 🔒 22.9 MB | 10.4 MB | **file** | 23.0 MB | -51.3 KB (-0.2%) | OK |
| :white_check_mark: | `packed-program` | Windows | 🔒 14.8 MB | 6.5 MB | **file** | 14.8 MB | -7.7 KB (-0.1%) | OK |

> 🔒 = the size this artifact is GATED on (ceiling + delta). Binaries gate on **file** size (installed binary); WASM gates on **gzip** (download size). The other size is shown for information only.

---
*Generated by `cargo size-gate`*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened the maximum allowed size for the Windows x86_64 command-line package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->