### PR TITLE
fix(python): avoid TypeVar collisions with generated class names

### DIFF
--- a/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
@@ -779,6 +779,19 @@ fn lower_path(
         }
         return ty;
     }
+    // A bare in-scope generic parameter wins over a same-named concrete type:
+    // `class T { … }` must not capture the `T` of `function echo<T>(value: T)`.
+    // Checked ahead of `resolve_type` because that lookup would succeed and
+    // hand back the class. A qualified path (`pkg.T`) still reaches the class
+    // through the namespace below, and a parameterized spelling (`T<int>`)
+    // falls through — a parameter takes no arguments of its own.
+    if segments.len() == 1
+        && generic_args.is_empty()
+        && associated_type_bindings.is_empty()
+        && let Some(param) = ctx.resolve_type_var(&segments[0])
+    {
+        return Ty::TypeVar(param, TyAttr::default());
+    }
     match ctx.resolve_type(segments) {
         Ok(def) => {
             let short = segments.last().expect("non-empty path");
@@ -1003,7 +1016,11 @@ fn lower_path(
         }
         Err(suggestions) => {
             // A single-segment name that is an in-scope type variable
-            // (e.g. T, K, V) lowers to `Ty::TypeVar`, not an error.
+            // (e.g. T, K, V) lowers to `Ty::TypeVar`, not an error. Bare
+            // spellings short-circuit above; a parameterized one (`T<int>`)
+            // reaches here only once `resolve_type` has confirmed no generic
+            // type owns the name, and resolves to the parameter with its
+            // stray arguments dropped.
             if segments.len() == 1
                 && let Some(param) = ctx.resolve_type_var(&segments[0])
             {

--- a/baml_language/crates/baml_project/src/client_codegen.rs
+++ b/baml_language/crates/baml_project/src/client_codegen.rs
@@ -845,6 +845,43 @@ mod tests {
     }
 
     #[test]
+    fn test_bare_generic_param_shadows_same_named_class_in_codegen() {
+        let root = Path::new("/tmp/generic_param_shadows_class");
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(root);
+        db.add_or_update_file(
+            root.join("main.baml").as_path(),
+            "class T { label string }\nfunction echo<T>(value: T) -> T {\n  return value\n}\n",
+        );
+
+        let diagnostics = crate::collect_compiler2_diagnostics(&db);
+        assert!(
+            diagnostics.is_empty(),
+            "expected no diagnostics, got: {diagnostics:#?}"
+        );
+
+        let pool = build_symbol_pool(&db);
+        let key = pool
+            .keys()
+            .find(|k| k.name().as_str() == "echo")
+            .expect("echo function missing from pool");
+        let cg::Symbol::Function(function) = &pool[key] else {
+            panic!("echo must be a Function");
+        };
+        assert_eq!(function.generic_params, vec![Name::new("T")]);
+        assert!(
+            matches!(&function.arguments[0].ty, cg::Ty::TypeVar(param, _) if param.as_str() == "T"),
+            "argument type should be the generic T, got: {:#?}",
+            function.arguments[0].ty,
+        );
+        assert!(
+            matches!(&function.return_type, cg::Ty::TypeVar(param, _) if param.as_str() == "T"),
+            "return type should be the generic T, got: {:#?}",
+            function.return_type,
+        );
+    }
+
+    #[test]
     fn test_llm_functions_and_companions_get_default_client_argument() {
         let root = Path::new("/tmp/llm_default_client_arg");
         let mut db = ProjectDatabase::new();

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/leaf.rs
@@ -22,6 +22,29 @@ use crate::{
     translate_ty::{SelfRef, TranslateCtx, translate_ty},
 };
 
+/// Module globals a leaf binds on its own, independent of its symbols:
+/// the stdlib and third-party modules `stdlib_imports` (and the `.pyi`
+/// header) may `import`, the `_`-aliased `baml_bridge` runtime imports,
+/// and the `baml` builtins re-exports. Reserved by
+/// `LeafBody::allocated_typevars` so a `TypeVar` can never rebind one.
+///
+/// This is the union across both output files. Codegen's own stub-only
+/// `_Baml…` Protocol names are deliberately left out: they exist in
+/// `.pyi` alone, so reserving them would let the two files disagree on
+/// a `TypeVar` spelling.
+const MODULE_BINDINGS: &[&str] = &[
+    "BamlError",
+    "BamlPanic",
+    "UNSET",
+    "_BamlPyHandle",
+    "_define_function",
+    "enum",
+    "importlib",
+    "pydantic",
+    "typing",
+    "typing_extensions",
+];
+
 /// All symbols that land in one leaf's body, in final render order.
 /// Each entry keeps its `SortKey` so the renderer can group function
 /// fan-out siblings tightly (they share their parent's sort key)
@@ -422,6 +445,50 @@ impl LeafBody {
             }
         }
         set.into_iter().collect()
+    }
+
+    /// Allocate the module-level Python binding for each source-level
+    /// `TypeVar`. Keys stay the BAML generic name — that spelling is the
+    /// runtime's `type_params` key and never changes; values are the
+    /// emitted Python identifiers that annotations must reference.
+    ///
+    /// A generic parameter and an ordinary definition can share a name
+    /// (`class T { … }` alongside `function echo<T>(…)`), and so can a
+    /// generic parameter and an import (`typing`, a cross-leaf class).
+    /// Either collision would leave `T = typing.TypeVar("T")` shadowing
+    /// the binding declared above it, so allocation walks
+    /// [`MODULE_BINDINGS`] plus this leaf's own symbols and imports and
+    /// appends `_` until the name is free.
+    ///
+    /// The reserved set is deliberately independent of which file is
+    /// being rendered: `.py` and `.pyi` emit slightly different import
+    /// blocks, and they must still agree on every `TypeVar` spelling.
+    pub(crate) fn allocated_typevars(&self) -> BTreeMap<String, String> {
+        let sources = self.generic_typevars();
+        if sources.is_empty() {
+            return BTreeMap::new();
+        }
+
+        let mut reserved: BTreeSet<String> =
+            MODULE_BINDINGS.iter().map(|n| (*n).to_string()).collect();
+        reserved.extend(
+            self.symbols
+                .iter()
+                .map(|(sym, _)| sym.py_name().to_string()),
+        );
+        reserved.extend(self.all_rel_imports_py().into_iter().map(|r| r.anchor));
+
+        let mut out = BTreeMap::new();
+        for source in sources {
+            let mut emitted = source.clone();
+            while reserved.contains(&emitted) {
+                emitted.push('_');
+            }
+            reserved.insert(emitted.clone());
+            out.insert(source, emitted);
+        }
+
+        out
     }
 }
 
@@ -847,10 +914,22 @@ fn collect_alias_dependencies(
 
 /// Non-generic: `pydantic.BaseModel`.
 /// Generic: `pydantic.BaseModel, typing.Generic[T, …]`.
-fn render_class_bases(generic_params: &[String]) -> String {
+fn render_class_bases(
+    generic_params: &[String],
+    typevars: Option<&BTreeMap<String, String>>,
+) -> String {
     if generic_params.is_empty() {
         "pydantic.BaseModel".to_string()
     } else {
+        let generic_params = generic_params
+            .iter()
+            .map(|name| {
+                typevars
+                    .and_then(|map| map.get(name))
+                    .map(String::as_str)
+                    .unwrap_or(name.as_str())
+            })
+            .collect::<Vec<_>>();
         format!(
             "pydantic.BaseModel, typing.Generic[{}]",
             generic_params.join(", ")
@@ -1034,7 +1113,11 @@ fn build_method_line_views(
 }
 
 /// Render one symbol into its `.py` source block, including trailing `\n`.
-fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
+fn render_symbol(
+    s: &EmittedSymbol,
+    leaf: &LeafPath,
+    typevars: Option<&std::rc::Rc<BTreeMap<String, String>>>,
+) -> String {
     use askama::Template;
     let ctx = TranslateCtx {
         current_leaf: leaf.clone(),
@@ -1043,6 +1126,7 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
         // Runtime `.py`: callback Protocols are stub-only, so optional-arg
         // callables widen to `typing.Callable[..., R]` here.
         callback_protocols: None,
+        typevars: typevars.cloned(),
     };
 
     match s {
@@ -1078,7 +1162,7 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
             );
             let mut out = ClassBodyPy {
                 py_name: c.py_name.clone(),
-                bases: render_class_bases(&c.generic_params),
+                bases: render_class_bases(&c.generic_params, typevars.map(std::rc::Rc::as_ref)),
                 docstring,
                 properties,
                 static_methods: build_method_line_views(&c.static_methods, &c.generic_params),
@@ -1120,7 +1204,7 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
             out
         }
         EmittedSymbol::TypeAlias(a) => {
-            let mut out = render_type_alias(a, leaf);
+            let mut out = render_type_alias(a, leaf, typevars);
             out.push('\n');
             out
         }
@@ -1157,7 +1241,11 @@ fn render_symbol(s: &EmittedSymbol, leaf: &LeafPath) -> String {
 /// Recursive aliases (18c) render via `typing_extensions.TypeAliasType`
 /// with inner self-references quoted, so Pydantic resolves them
 /// through its JSON-schema definitions machinery instead of recursing.
-fn render_type_alias(a: &crate::emit::type_alias::PyTypeAlias, leaf: &LeafPath) -> String {
+fn render_type_alias(
+    a: &crate::emit::type_alias::PyTypeAlias,
+    leaf: &LeafPath,
+    typevars: Option<&std::rc::Rc<BTreeMap<String, String>>>,
+) -> String {
     use askama::Template;
 
     // Special-case the stdlib `baml.json.json` alias.  Its expanded form is
@@ -1203,6 +1291,7 @@ fn render_type_alias(a: &crate::emit::type_alias::PyTypeAlias, leaf: &LeafPath) 
         // with optional params widens to `typing.Callable[..., R]` rather than
         // referencing a stub-only Protocol.
         callback_protocols: None,
+        typevars: typevars.cloned(),
     };
     let rhs = translate_ty(&a.resolves_to, &ctx);
     if a.recursive {
@@ -1381,6 +1470,8 @@ pub(crate) fn render_leaf_body(body: &LeafBody, callable_child_names: &BTreeSet<
     }
 
     let mut out = String::new();
+    let typevars = body.allocated_typevars();
+    let typevars_rc = (!typevars.is_empty()).then(|| std::rc::Rc::new(typevars.clone()));
 
     let mut stdlibs = body.stdlib_imports();
     if !callable_child_names.is_empty() && !stdlibs.contains(&"importlib") {
@@ -1398,7 +1489,7 @@ pub(crate) fn render_leaf_body(body: &LeafBody, callable_child_names: &BTreeSet<
     // Generic functions emit `T = typing.TypeVar("T")` lines below; the
     // `Class`/`TypeAlias` rule in `stdlib_imports` doesn't catch the
     // function-only-but-generic case (e.g. stdlib `string.from<T>`).
-    if !body.generic_typevars().is_empty() && !stdlibs.contains(&"typing") {
+    if !typevars.is_empty() && !stdlibs.contains(&"typing") {
         stdlibs.push("typing");
     }
     let needs_pydantic = body.needs_pydantic();
@@ -1497,11 +1588,10 @@ pub(crate) fn render_leaf_body(body: &LeafBody, callable_child_names: &BTreeSet<
         );
     }
 
-    let typevars = body.generic_typevars();
     if !typevars.is_empty() {
         out.push_str("\n\n");
-        for tv in &typevars {
-            writeln!(out, "{tv} = typing.TypeVar(\"{tv}\")").unwrap();
+        for (source, emitted) in &typevars {
+            writeln!(out, "{emitted} = typing.TypeVar({})", py_string(source)).unwrap();
         }
     }
 
@@ -1509,7 +1599,7 @@ pub(crate) fn render_leaf_body(body: &LeafBody, callable_child_names: &BTreeSet<
 
     let mut prev: Option<(&SortKey, &EmittedSymbol)> = None;
     for (sym, key) in &body.symbols {
-        let body_text = render_symbol(sym, &body.leaf);
+        let body_text = render_symbol(sym, &body.leaf, typevars_rc.as_ref());
         if body_text.is_empty() {
             continue;
         }
@@ -1703,6 +1793,7 @@ fn render_symbol_pyi(
     s: &EmittedSymbol,
     leaf: &LeafPath,
     callback_protocols: Option<&std::rc::Rc<IndexMap<Ty, String>>>,
+    typevars: Option<&std::rc::Rc<BTreeMap<String, String>>>,
 ) -> String {
     use askama::Template;
     let ctx = TranslateCtx {
@@ -1710,6 +1801,7 @@ fn render_symbol_pyi(
         self_ref: None,
         defer_name_refs: false,
         callback_protocols: callback_protocols.cloned(),
+        typevars: typevars.cloned(),
     };
 
     match s {
@@ -1730,7 +1822,7 @@ fn render_symbol_pyi(
                 .collect();
             let mut out = ClassBodyPyi {
                 py_name: c.py_name.clone(),
-                bases: render_class_bases(&c.generic_params),
+                bases: render_class_bases(&c.generic_params, typevars.map(std::rc::Rc::as_ref)),
                 properties,
                 static_methods: build_method_block_views(&c.static_methods, &ctx),
                 instance_methods: build_method_block_views(&c.instance_methods, &ctx),
@@ -1765,7 +1857,7 @@ fn render_symbol_pyi(
         }
         EmittedSymbol::TypeAlias(a) => {
             // Type alias is identical between `.py` and `.pyi`.
-            let mut out = render_type_alias(a, leaf);
+            let mut out = render_type_alias(a, leaf, typevars);
             out.push('\n');
             out
         }
@@ -1884,18 +1976,24 @@ fn render_callable_child_protocol_pyi(
     child_body: &LeafBody,
     parent_leaf: &LeafPath,
     callback_protocols: Option<&std::rc::Rc<IndexMap<Ty, String>>>,
+    typevars: Option<&std::rc::Rc<BTreeMap<String, String>>>,
 ) -> String {
     let parent_ctx = TranslateCtx {
         current_leaf: parent_leaf.clone(),
         self_ref: None,
         defer_name_refs: false,
         callback_protocols: callback_protocols.cloned(),
+        typevars: typevars.cloned(),
     };
+    // The child's methods render *into the parent's* `.pyi`, so they
+    // resolve against the parent's `TypeVar` bindings — the child leaf's
+    // own allocation belongs to the child file and isn't in scope here.
     let child_ctx = TranslateCtx {
         current_leaf: child_body.leaf.clone(),
         self_ref: None,
         defer_name_refs: false,
         callback_protocols: callback_protocols.cloned(),
+        typevars: typevars.cloned(),
     };
     let protocol_name = callable_child_protocol_name(name);
     let mut out = format!("class {protocol_name}(typing.Protocol):\n");
@@ -2072,6 +2170,8 @@ pub(crate) fn render_leaf_body_pyi(
     }
 
     let mut out = String::new();
+    let typevars = body.allocated_typevars();
+    let typevars_rc = (!typevars.is_empty()).then(|| std::rc::Rc::new(typevars.clone()));
 
     let needs_enum = body
         .symbols
@@ -2144,11 +2244,10 @@ pub(crate) fn render_leaf_body_pyi(
 
     // The `.pyi` re-declares TypeVars because stubs don't import from
     // sibling `.py` files.
-    let typevars = body.generic_typevars();
     if !typevars.is_empty() {
         out.push_str("\n\n");
-        for tv in &typevars {
-            writeln!(out, "{tv} = typing.TypeVar(\"{tv}\")").unwrap();
+        for (source, emitted) in &typevars {
+            writeln!(out, "{emitted} = typing.TypeVar({})", py_string(source)).unwrap();
         }
     }
 
@@ -2181,6 +2280,7 @@ pub(crate) fn render_leaf_body_pyi(
             self_ref: None,
             defer_name_refs: false,
             callback_protocols: Some(map.clone()),
+            typevars: typevars_rc.clone(),
         };
         for (ty, _base) in &protocol_tys {
             if let Ty::Function { params, ret, .. } = ty {
@@ -2204,6 +2304,7 @@ pub(crate) fn render_leaf_body_pyi(
                 child_body,
                 &body.leaf,
                 callback_protocols.as_ref(),
+                typevars_rc.as_ref(),
             ));
         }
     }
@@ -2218,7 +2319,12 @@ pub(crate) fn render_leaf_body_pyi(
         {
             continue;
         }
-        let body_text = render_symbol_pyi(sym, &body.leaf, callback_protocols.as_ref());
+        let body_text = render_symbol_pyi(
+            sym,
+            &body.leaf,
+            callback_protocols.as_ref(),
+            typevars_rc.as_ref(),
+        );
         if body_text.is_empty() {
             continue;
         }

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
@@ -3644,6 +3644,166 @@ mod tests {
         );
     }
 
+    /// 13a §4.4 — a generic name that collides with an ordinary symbol in
+    /// the same leaf allocates a distinct `TypeVar` binding. The class keeps
+    /// the plain name, annotations follow the allocated one in both `.py`
+    /// and `.pyi`, and the runtime `type_params` key stays the BAML
+    /// spelling.
+    #[test]
+    fn typevar_binding_avoids_same_leaf_symbol_name() {
+        let mut pool: SymbolPool = HashMap::new();
+        let t_name = cg_name("user", &["lorem"], "T");
+        let box_name = cg_name("user", &["lorem"], "Box");
+        let echo_name = cg_name("user", &["lorem"], "echo");
+
+        pool.insert(t_name.clone(), class_at(t_name, "generic.baml", 0));
+        pool.insert(
+            box_name.clone(),
+            Symbol::Class(Class {
+                name: box_name,
+                generic_params: vec![BaseName::new("T")],
+                docstring: None,
+                properties: vec![ClassProperty {
+                    name: BaseName::new("item"),
+                    docstring: None,
+                    ty: type_var(BaseName::new("T")),
+                }],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("generic.baml", 100),
+            }),
+        );
+        pool.insert(
+            echo_name,
+            Symbol::Function(Function {
+                name: BaseName::new("echo"),
+                generic_params: vec![BaseName::new("T")],
+                docstring: None,
+                arguments: vec![FunctionArgument {
+                    name: BaseName::new("value"),
+                    docstring: None,
+                    ty: type_var(BaseName::new("T")),
+                    default: None,
+                }],
+                return_type: type_var(BaseName::new("T")),
+                throws: None,
+                watchers: vec![],
+                origin: origin("generic.baml", 200),
+            }),
+        );
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let py = &out[&PathBuf::from("lorem/__init__.py")];
+        assert!(
+            py.contains("T_ = typing.TypeVar(\"T\")"),
+            "py missing allocated TypeVar binding:\n{py}",
+        );
+        assert!(
+            !py.contains("\nT = typing.TypeVar(\"T\")"),
+            "py TypeVar must not shadow the class T binding:\n{py}",
+        );
+        assert!(
+            py.contains("class T(pydantic.BaseModel):"),
+            "py should preserve the class binding name:\n{py}",
+        );
+        assert!(
+            py.contains("class Box(pydantic.BaseModel, typing.Generic[T_]):"),
+            "py generic base should reference the allocated TypeVar name:\n{py}",
+        );
+        assert!(
+            py.contains("    item: T_\n"),
+            "py field annotation should reference the allocated TypeVar name:\n{py}",
+        );
+        assert!(
+            py.contains("type_params=[\"T\"]"),
+            "runtime TypeVar keys should remain source generic names:\n{py}",
+        );
+
+        let pyi = &out[&PathBuf::from("lorem/__init__.pyi")];
+        assert!(
+            pyi.contains("T_ = typing.TypeVar(\"T\")"),
+            "pyi missing allocated TypeVar binding:\n{pyi}",
+        );
+        assert!(
+            !pyi.contains("\nT = typing.TypeVar(\"T\")"),
+            "pyi TypeVar must not shadow the class T binding:\n{pyi}",
+        );
+        assert!(
+            pyi.contains("class Box(pydantic.BaseModel, typing.Generic[T_]):"),
+            "pyi generic base should reference the allocated TypeVar name:\n{pyi}",
+        );
+        assert!(
+            pyi.contains("    item: T_\n"),
+            "pyi field annotation should reference the allocated TypeVar name:\n{pyi}",
+        );
+        assert!(
+            pyi.contains("def echo(value: T_, *, _types: dict[str, type]) -> T_: ..."),
+            "pyi function signature should reference the allocated TypeVar name:\n{pyi}",
+        );
+    }
+
+    /// 13a §4.4 — allocation keeps appending `_` until the binding is free,
+    /// so a generic name escapes a whole chain of taken symbols (`T`, `T_`)
+    /// and also escapes the leaf's module imports, which bind names no
+    /// symbol owns (`import typing`).
+    #[test]
+    fn typevar_binding_escapes_chained_and_import_collisions() {
+        let mut pool: SymbolPool = HashMap::new();
+        let t_name = cg_name("user", &["lorem"], "T");
+        let t_underscore_name = cg_name("user", &["lorem"], "T_");
+        let box_name = cg_name("user", &["lorem"], "Box");
+
+        pool.insert(t_name.clone(), class_at(t_name, "generic.baml", 0));
+        pool.insert(
+            t_underscore_name.clone(),
+            class_at(t_underscore_name, "generic.baml", 100),
+        );
+        pool.insert(
+            box_name.clone(),
+            Symbol::Class(Class {
+                name: box_name,
+                generic_params: vec![BaseName::new("T"), BaseName::new("typing")],
+                docstring: None,
+                properties: vec![
+                    ClassProperty {
+                        name: BaseName::new("item"),
+                        docstring: None,
+                        ty: type_var(BaseName::new("T")),
+                    },
+                    ClassProperty {
+                        name: BaseName::new("tag"),
+                        docstring: None,
+                        ty: type_var(BaseName::new("typing")),
+                    },
+                ],
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("generic.baml", 200),
+            }),
+        );
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        for suffix in ["py", "pyi"] {
+            let leaf = &out[&PathBuf::from(format!("lorem/__init__.{suffix}"))];
+            assert!(
+                leaf.contains("T__ = typing.TypeVar(\"T\")"),
+                "{suffix}: T should skip past the T and T_ classes:\n{leaf}",
+            );
+            assert!(
+                leaf.contains("typing_ = typing.TypeVar(\"typing\")"),
+                "{suffix}: typing should not rebind the typing import:\n{leaf}",
+            );
+            assert!(
+                leaf.contains("class Box(pydantic.BaseModel, typing.Generic[T__, typing_]):"),
+                "{suffix}: generic bases should use the allocated names:\n{leaf}",
+            );
+            assert!(
+                leaf.contains("    item: T__\n") && leaf.contains("    tag: typing_\n"),
+                "{suffix}: field annotations should use the allocated names:\n{leaf}",
+            );
+        }
+    }
+
     /// 13a §4.4 — a generic free function emits its `TypeVar`s at the leaf
     /// and the .pyi signature uses bare `TypeVar` identifiers.
     #[test]

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/translate_ty.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/translate_ty.rs
@@ -5,6 +5,8 @@
 //! - `.humanlayer/tasks/clientpython/09b-codegen-rules.md` §6, §9
 //! - `.humanlayer/tasks/clientpython/11e-phaseg3-ty-translator.md`
 
+use std::collections::BTreeMap;
+
 use baml_base::{Literal, MediaKind};
 use baml_codegen_types::{Name, Ty};
 use indexmap::IndexMap;
@@ -38,6 +40,13 @@ pub(crate) struct TranslateCtx {
     /// runtime `.py` path, where callable types fall back to
     /// `typing.Callable[..., R]` (Protocol classes are stub-only).
     pub(crate) callback_protocols: Option<std::rc::Rc<IndexMap<Ty, String>>>,
+    /// Leaf-global mapping from BAML generic names to the module-level
+    /// `TypeVar` bindings allocated for them
+    /// (`LeafBody::allocated_typevars`). The two differ whenever the
+    /// generic name would shadow another module global, so annotations
+    /// must reference the allocated identifier rather than the source
+    /// spelling. `None` for leaves that declare no `TypeVar`s.
+    pub(crate) typevars: Option<std::rc::Rc<BTreeMap<String, String>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -82,7 +91,12 @@ pub(crate) fn translate_ty(ty: &Ty, ctx: &TranslateCtx) -> String {
                 head
             }
         }
-        Ty::TypeVar(name, _) => name.as_str().to_string(),
+        Ty::TypeVar(name, _) => ctx
+            .typevars
+            .as_ref()
+            .and_then(|map| map.get(name.as_str()))
+            .cloned()
+            .unwrap_or_else(|| name.as_str().to_string()),
         Ty::List(inner, _) => format!("typing.List[{}]", translate_ty(inner, ctx)),
         Ty::Map { key, value, .. } => {
             format!(
@@ -241,6 +255,7 @@ mod tests {
             self_ref: None,
             defer_name_refs: false,
             callback_protocols: None,
+            typevars: None,
         }
     }
 
@@ -253,6 +268,7 @@ mod tests {
             current_leaf: leaf(current_segments),
             defer_name_refs: false,
             callback_protocols: None,
+            typevars: None,
             self_ref: Some(SelfRef {
                 routed_leaf: leaf(self_segments),
                 bare_name: bare_name.to_string(),
@@ -272,6 +288,7 @@ mod tests {
             current_leaf: leaf(current_segments),
             defer_name_refs: true,
             callback_protocols: None,
+            typevars: None,
             self_ref: Some(SelfRef {
                 routed_leaf: leaf(self_segments),
                 bare_name: bare_name.to_string(),


### PR DESCRIPTION
Closes #4083.

## The bug

A generic parameter and an ordinary definition can share a name. When they do, the generated Python Pydantic v2 leaf declared the `TypeVar` first and then rebound the same identifier as a class, so every generic reference in the file resolved to the class instead of the parameter:

```baml
class T {
  label string
}

class Box<T> {
  item T
}

function echo<T>(value: T) -> T { ... }
```

```python
T = typing.TypeVar("T")


class T(pydantic.BaseModel):          # rebinds T; the TypeVar is unreachable
    label: str


class Box(pydantic.BaseModel, typing.Generic[T]):   # T is the model now
    item: T
```

This is not cosmetic - the generated SDK does not import at all:

```
TypeError: Parameters to Generic[...] must all be type variables
           or parameter specification variables.
```

## Root cause

Two layers had to agree, and neither did.

**1. Name resolution (`baml_compiler2_tir`).** `lower_path` only consulted `resolve_type_var` inside its `Err` fallback - i.e. only once concrete-type resolution had already failed. With a `class T` in the same package that lookup *succeeds*, so the `T` in `function echo<T>(value: T)` lowered to `Ty::Class`, not `Ty::TypeVar`. The generic parameter was being captured by the class before codegen ever ran.

**2. Binding allocation (`sdkgen_python_pydantic2`).** Leaf `TypeVar`s were emitted under their source spelling with nothing checking it against the rest of the module namespace.

## The change

- `lower_path` now resolves a bare, unparameterized in-scope generic parameter *before* `resolve_type`, so the parameter shadows a same-named concrete type. Qualified paths (`pkg.T`) still reach the class through the namespace, and a parameterized spelling (`T<int>`) still falls through to the existing path.
- New `LeafBody::allocated_typevars()` maps each BAML generic name to a collision-free Python identifier, appending `_` until the name is free. The reserved set is the leaf's own symbols, its cross-leaf import anchors, and `MODULE_BINDINGS` — the stdlib / `baml_bridge` / builtins names a leaf can bind on its own, so a parameter named `typing` can't rebind the `typing` import either.
- `TranslateCtx` carries that map so declarations *and* every reference render from the same allocation. `.py` and `.pyi` compute the reserved set identically - it is deliberately independent of which file is being rendered — so the two files can never disagree on a spelling.

Runtime-facing names are untouched: the binding is still `typing.TypeVar("T")` and `type_params=["T"]` still carries the BAML spelling. Only the local Python identifier moves, and only when it would otherwise collide.

```diff
-T = typing.TypeVar("T")
+T_ = typing.TypeVar("T")


 class T(pydantic.BaseModel):
     label: str


-class Box(pydantic.BaseModel, typing.Generic[T]):
-    item: T
+class Box(pydantic.BaseModel, typing.Generic[T_]):
+    item: T_
```

## Tests

- `typevar_binding_avoids_same_leaf_symbol_name` - the issue's scenario end to end; asserts the class keeps the plain name, `.py` and `.pyi` both follow the allocated one, and `type_params` stays the BAML spelling.
- `typevar_binding_escapes_chained_and_import_collisions` - allocation walks a chain (`T` and `T_` both taken, so the parameter lands on `T__`) and escapes an import name no symbol owns (a parameter named `typing` becomes `typing_`).
- `test_bare_generic_param_shadows_same_named_class_in_codegen` - covers the resolution half: with `class T` and `function echo<T>` in one file, the argument and return types lower to `Ty::TypeVar`, with no diagnostics.

Both scenarios were also checked by importing the generated package under real Pydantic v2. The pre-fix output raises `TypeError` on import; the post-fix output imports cleanly and keeps the BAML spelling at runtime:

| scenario | `parameters` after import | instantiation |
| --- | --- | --- |
| `class T` + `Box<T>` | `(~T,)` | `Box[int](item=3)` |
| `T`/`T_` taken, params `T` + `typing` | `(~T, ~typing)` | `Box[int, str](item=1, tag='x')` |

## Note on scope

`lower_type_expr.rs` and `client_codegen.rs` sit outside the issue's stated affected area. They are in scope because renaming alone would not have fixed anything: the type checker was handing codegen a `Ty::Class` where the schema said `Ty::TypeVar`, so the wrong entity was being referenced regardless of what it was called.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generic type parameters being incorrectly shadowed by same-named concrete types.
  * Improved generated Python typing when generic names conflict with imports, symbols, or other type variables.
  * Ensured generic classes, aliases, callbacks, and annotations consistently reference their allocated type-variable names.

* **Tests**
  * Added coverage for generic shadowing and type-variable name collisions in generated `.py` and `.pyi` files.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->