### PR TITLE
Fix for equirecursive equivalence algebra

### DIFF
--- a/baml_language/TYPE_SYSTEM.md
+++ b/baml_language/TYPE_SYSTEM.md
@@ -117,6 +117,43 @@ Other subtypes:
 
 In nearly all contexts, we can thus simplify types and maintain equivalence: `1 | int == int | 1 == int`, `anything | unknown == unknown`, `true | false == bool`, `Side.Left | Side.Right == Side` (enum), etc. The only exceptions are places like LLM function return types where the order affects the parsing. However, this should only matter in this one location based on explicit declaration for the SAP parser, and can still be treated the same for in-language type algebra.
 
+## Type Aliases and Recursive Types
+
+Type aliases are transparent (structural, not nominal): `type X = T` makes `X` the very same type as `T` in every context. The alias name is a spelling device, never an identity. Non-recursive aliases are expanded during lowering; only recursive aliases survive as named references, and the name still carries no identity of its own.
+
+### Equirecursive identity
+
+Recursive aliases are equirecursive μ-types over regular trees: a recursive alias denotes the unique regular tree obtained by unfolding its definition, and two types are the same type if and only if their trees are equal under the type algebra. Alias names, unfolding depth, and spelling never contribute identity:
+
+```baml
+type A = int | A[]
+type B = int | B[]
+// A and B are the same type: mutual subtypes, interchangeable everywhere.
+// So are `A`, `int | A[]`, and `int | (int | A[])[]` (partial unfoldings),
+// and mutually recursive definitions that unfold to the same tree.
+```
+
+### Values and membership
+
+BAML values are finite object graphs and may be self-referential (`let a: A = []; a.push(a);` is valid for `type A = A[]`). Membership checking never recurses over a value: every value carries (can trivially reconstruct) its concrete run-time type — for example, a list holds its element type as metadata, and writes into it are statically checked against that element type — so a value `v` is a member of type `T` if and only if `v`'s concrete type is a subtype of `T`. All recursion in the system lives in the type-level subtyping relation, which is decided coinductively over regular trees.
+
+### Productivity
+
+Because values can be self-referential, membership is not a well-founded judgment and subtyping over recursive types is coinductive. Coinductive derivations must be productive: every cycle in a derivation must pass through a type constructor. A self-supporting cycle ("`t <: A` because `t <: A`", reachable through an unguarded recursive union member) proves nothing. Consequently, an unguarded recursive union member contributes nothing to its type, and a fully unguarded cycle is uninhabited:
+
+```baml
+type A = A | A[]   // the same type as `type L = L[]`: the unguarded `A` member is vacuous
+type B = B         // denotes `never` (and is a compile error, E0068)
+```
+
+(The E0068 cycle check is per-SCC — a cycle group needs at least one list/map edge — so types like `A` above are legal; the algebra gives them the productive semantics.)
+
+### Equivalence and canonical forms
+
+Two types are **equivalent** if and only if they are mutual subtypes — they denote the same set of values. The canonical type algebra decides equivalence by structural equality of canonical forms, and for the algebra's rules these provably coincide with mutual subtyping (canonical forms are unique representatives of the equirecursive equivalence class).
+
+`normalize` renders the canonical form back as surface syntax, with the following contract: the output is idempotent (`normalize(normalize(t)) == normalize(t)`), always equivalent to its input, and head-exposed (the root of a recursive alias is unfolded once; nested recursion stays folded as an alias name). Because surface syntax spells recursion via alias names, the rendering is canonical only up to the naming of recursion back-references: `normalize(A)` and `normalize(B)` above are equivalent but each spells back-references with its own name. Canonical *identity* is the equivalence judgment, not syntactic equality of rendered output.
+
 ## Pattern Matching
 
 Pattern matching ([BEP-015](https://beps.boundaryml.com/beps/15)) on types falls naturally out of BAML's subset-based subtyping system. For any given value, BAML can determine whether a value is a member of a given type. A `match` expression with type-pattern arms can be thought of as checking each arm in order to see if the value is a member of the type-set (though various optimizations allow us to implement this more efficiently in many cases).

--- a/baml_language/TYPE_SYSTEM.md
+++ b/baml_language/TYPE_SYSTEM.md
@@ -152,6 +152,8 @@ type B = B         // denotes `never` (and is a compile error, E0068)
 
 Two types are **equivalent** if and only if they are mutual subtypes — they denote the same set of values. The canonical type algebra decides equivalence by structural equality of canonical forms, and for the algebra's rules these provably coincide with mutual subtyping (canonical forms are unique representatives of the equirecursive equivalence class).
 
+Two deliberate carve-outs qualify the "if and only if" (both are compiler devices, not value-set semantics): the error-recovery sentinel types are bidirectionally *compatible* with everything to suppress diagnostic cascades but equivalent only to themselves, and a fact set containing a mutual `requires` cycle between distinct interfaces would make them mutual subtypes while remaining nominally distinct — such cycles are rejected at declaration (E0118), so the case arises only for artificially constructed fact sets.
+
 `normalize` renders the canonical form back as surface syntax, with the following contract: the output is idempotent (`normalize(normalize(t)) == normalize(t)`), always equivalent to its input, and head-exposed (the root of a recursive alias is unfolded once; nested recursion stays folded as an alias name). Because surface syntax spells recursion via alias names, the rendering is canonical only up to the naming of recursion back-references: `normalize(A)` and `normalize(B)` above are equivalent but each spells back-references with its own name. Canonical *identity* is the equivalence judgment, not syntactic equality of rendered output.
 
 ## Pattern Matching

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
@@ -13,7 +13,7 @@ use crate::{
     interfaces::{ImplData, impl_data, impl_data_source_map, interface_loc_qtn, package_impl_locs},
     unify::{
         EnumVariants, Overlap, TypeBindings, chase_var, contains_bound_typevar, enum_variant_names,
-        expand_alias_head, nf, normalized_alias_map, unify_into, var_under_union,
+        nf, normalized_alias_map, unify_into, var_under_union,
     },
 };
 
@@ -158,14 +158,26 @@ pub fn impls_conflict<'db>(
     // An impl whose for-target is not a valid implementor (rejected by the E0138
     // concreteness gate — union, interface, literal, enum variant, or an error
     // type) must not contribute a coherence overlap, or it would stack a spurious
-    // E0132 on top of that rejection. The gate is applied to the *alias-expanded*
-    // for-type: a bare `type AliasC = C` for-type lowers to `Ty::TypeAlias` (not itself
-    // a valid subject), but E0138 expands it and accepts it, so coherence must expand it
-    // too — otherwise `impl I for C` + `impl I for AliasC` would slip past both gates,
-    // leaving two impls for the same concrete type. (Aliases *under* a constructor are
-    // resolved later by `is_same_normalized_type`; only the head matters here.)
-    if !expand_alias_head(&a.for_ty_pattern, aliases).is_valid_impl_subject()
-        || !expand_alias_head(&b.for_ty_pattern, aliases).is_valid_impl_subject()
+    // E0132 on top of that rejection. The gate MUST judge the same spelling
+    // E0138 judges — the fully *normalized* for-type under the same fact
+    // context — or the two gates disagree and an overlap escapes both: E0138
+    // accepts `implements I for true | false` (it normalizes to the valid
+    // subject `bool`) and `implements I for E.A | E.B` (a complete variant set
+    // normalizes to `E`), so coherence rejecting those spellings on their raw
+    // union heads would wave the pair `impl for bool` + `impl for true | false`
+    // through with no E0132 — and at runtime both fully-realized patterns match
+    // every `bool` receiver: ambiguous dispatch with no diagnostic. (Aliases and
+    // collapses *under* a constructor are resolved later by
+    // `is_same_normalized_type`; only the head matters here.)
+    let bounds = crate::lower_type_expr::TypeVarBoundsMap::default();
+    let ctx = crate::type_context::GlobalTypeContext {
+        db,
+        res_ctx: crate::package_interface::package_resolution_context(db, pkg_id),
+        aliases,
+        bounds: &bounds,
+    };
+    if !baml_type::normalize::normalize(&a.for_ty_pattern, &ctx).is_valid_impl_subject()
+        || !baml_type::normalize::normalize(&b.for_ty_pattern, &ctx).is_valid_impl_subject()
     {
         return Overlap::No;
     }

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
@@ -5,12 +5,15 @@
 //! and interface args must unify position-wise, and a bound a pinned param provably
 //! violates makes the pair disjoint.
 
+use std::cell::OnceCell;
+
 use baml_base::{Name, Span, TyAttr};
 use baml_compiler2_hir::package::PackageId;
 use baml_type::{ParamTy, Ty, TypeName};
 
 use crate::{
     interfaces::{ImplData, impl_data, impl_data_source_map, interface_loc_qtn, package_impl_locs},
+    type_context::GlobalTypeContext,
     unify::{
         EnumVariants, Overlap, TypeBindings, chase_var, contains_bound_typevar, enum_variant_names,
         nf, normalized_alias_map, unify_into, var_under_union,
@@ -68,11 +71,11 @@ pub fn package_coherence_diagnostics<'db>(
     // added. Key on `(file_id, start, end)`: a package spans multiple files, and keying
     // on the start offset alone makes two impls at the same offset in *different* files
     // tie and fall back to a nondeterministic order.
-    own.sort_by_key(|(_, s)| {
+    own.sort_by_key(|p| {
         (
-            s.file_id.as_u32(),
-            u32::from(s.range.start()),
-            u32::from(s.range.end()),
+            p.span.file_id.as_u32(),
+            u32::from(p.span.range.start()),
+            u32::from(p.span.range.end()),
         )
     });
     let deps = baml_compiler2_hir::package::package_dependency_closure(db, pkg_id);
@@ -81,34 +84,38 @@ pub fn package_coherence_diagnostics<'db>(
     // alias-referencing for-types and interface args are compared by the same
     // union laws as their spelled-out forms.
     let aliases = normalized_alias_map(db, pkg_id);
+    // The shared facts of every subject-validity gate below; the per-impl piece
+    // (the impl's declared bounds) lives on [`PreparedImpl`], and the gate
+    // itself is memoized per impl — see [`PreparedImpl::valid_subject`].
+    let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
 
-    let dep_impls: Vec<(&ImplData, Span)> = deps
+    let dep_impls: Vec<PreparedImpl> = deps
         .iter()
         .flat_map(|dep| package_impls_with_spans(db, *dep))
         .collect();
 
     let mut violations = Vec::new();
-    for (i, &(own_data, own_span)) in own.iter().enumerate() {
+    for (i, own_impl) in own.iter().enumerate() {
         // own × own — each unordered pair once; the later impl carries the error.
-        for &(other_data, other_span) in &own[i + 1..] {
-            if let Some(indeterminate) =
-                overlap_violation(impls_conflict(db, pkg_id, own_data, other_data, &aliases))
-            {
+        for other in &own[i + 1..] {
+            if let Some(indeterminate) = overlap_violation(impls_conflict(
+                db, pkg_id, own_impl, other, res_ctx, &aliases,
+            )) {
                 violations.push(CoherenceViolation {
-                    primary: other_span,
-                    secondary: own_span,
+                    primary: other.span,
+                    secondary: own_impl.span,
                     indeterminate,
                 });
             }
         }
         // own × dependency — the owning package's impl carries the error.
-        for &(dep_data, dep_span) in &dep_impls {
+        for dep in &dep_impls {
             if let Some(indeterminate) =
-                overlap_violation(impls_conflict(db, pkg_id, own_data, dep_data, &aliases))
+                overlap_violation(impls_conflict(db, pkg_id, own_impl, dep, res_ctx, &aliases))
             {
                 violations.push(CoherenceViolation {
-                    primary: own_span,
-                    secondary: dep_span,
+                    primary: own_impl.span,
+                    secondary: dep.span,
                     indeterminate,
                 });
             }
@@ -117,68 +124,108 @@ pub fn package_coherence_diagnostics<'db>(
     violations
 }
 
-/// The impls of `pkg` the overlap check compares: each resolved [`ImplData`] paired
-/// with its source span, drawn from the canonical `impl_data` substrate. Span-less
-/// (synthesized) impls and unresolved interface targets are dropped — neither can
-/// carry a coherence diagnostic.
+/// The impls of `pkg` the overlap check compares, each prepared once, drawn from
+/// the canonical `impl_data` substrate. Span-less (synthesized) impls and
+/// unresolved interface targets are dropped — neither can carry a coherence
+/// diagnostic.
 fn package_impls_with_spans<'db>(
     db: &'db dyn crate::Db,
     pkg_id: PackageId<'db>,
-) -> Vec<(&'db ImplData<'db>, Span)> {
+) -> Vec<PreparedImpl<'db>> {
     package_impl_locs(db, pkg_id)
         .iter()
         .filter_map(|&loc| {
             let data = impl_data(db, loc).as_ref().ok()?;
             let span = impl_data_source_map(db, loc).impl_span;
-            Some((data, span))
+            Some(PreparedImpl {
+                data,
+                span,
+                interface: interface_loc_qtn(db, data.interface),
+                bounds: data.generic_params.iter().cloned().collect(),
+                valid_subject: OnceCell::new(),
+            })
         })
         .collect()
+}
+
+/// An impl prepared for the pairwise overlap loops: the pair-invariant facts —
+/// the resolved interface and the subject-validity gate — are computed (or
+/// lazily memoized) once per impl instead of recomputed for every pair the
+/// impl participates in.
+struct PreparedImpl<'db> {
+    data: &'db ImplData<'db>,
+    span: Span,
+    /// The implemented interface, or `None` when it did not resolve (such an
+    /// impl conflicts with nothing).
+    interface: Option<TypeName>,
+    /// The impl's declared generic bounds — the exact map the E0138 gate
+    /// normalizes under (`validate_impl_signatures`), so the two gates judge
+    /// one spelling: a bound can change it (`T | Shape` with `T: Shape`
+    /// absorbs to the valid subject `Shape`).
+    bounds: crate::lower_type_expr::TypeVarBoundsMap,
+    /// Memoized [`Self::valid_subject`]. Lazy because the gate costs a
+    /// normalization and is only ever consulted for impls that meet a
+    /// same-interface partner.
+    valid_subject: OnceCell<bool>,
+}
+
+impl<'db> PreparedImpl<'db> {
+    /// Whether this impl's for-target is a valid implementor, judged on its
+    /// normalized spelling.
+    ///
+    /// An impl whose for-target is not a valid implementor (rejected by the E0138
+    /// concreteness gate — union, interface, literal, enum variant, or an error
+    /// type) must not contribute a coherence overlap, or it would stack a spurious
+    /// E0132 on top of that rejection. The gate MUST judge the same spelling
+    /// E0138 judges — the fully *normalized* for-type under the same fact
+    /// context — or the two gates disagree and an overlap escapes both: E0138
+    /// accepts `implements I for true | false` (it normalizes to the valid
+    /// subject `bool`) and `implements I for E.A | E.B` (a complete variant set
+    /// normalizes to `E`), so coherence rejecting those spellings on their raw
+    /// union heads would wave the pair `impl for bool` + `impl for true | false`
+    /// through with no E0132 — and at runtime both fully-realized patterns match
+    /// every `bool` receiver: ambiguous dispatch with no diagnostic. (Aliases and
+    /// collapses *under* a constructor are resolved later by
+    /// `is_same_normalized_type`; only the head matters here.)
+    fn valid_subject(
+        &self,
+        db: &'db dyn crate::Db,
+        res_ctx: &'db crate::package_interface::PackageResolutionContext<'db>,
+        aliases: &std::collections::HashMap<TypeName, Ty>,
+    ) -> bool {
+        *self.valid_subject.get_or_init(|| {
+            let ctx = GlobalTypeContext {
+                db,
+                res_ctx,
+                aliases,
+                bounds: &self.bounds,
+            };
+            baml_type::normalize::normalize(&self.data.for_ty_pattern, &ctx).is_valid_impl_subject()
+        })
+    }
 }
 
 /// True iff two impls of the *same* interface conflict (overlap with no
 /// specialization to rescue them). Distinct interfaces never conflict, and two
 /// in-body blocks of the same class for the same interface are a duplicate
 /// (reported separately), not an overlap.
-pub fn impls_conflict<'db>(
+fn impls_conflict<'db>(
     db: &'db dyn crate::Db,
     pkg_id: PackageId<'db>,
-    a: &ImplData<'db>,
-    b: &ImplData<'db>,
+    a: &PreparedImpl<'db>,
+    b: &PreparedImpl<'db>,
+    res_ctx: &'db crate::package_interface::PackageResolutionContext<'db>,
     aliases: &std::collections::HashMap<TypeName, Ty>,
 ) -> Overlap {
-    let (Some(a_qtn), Some(b_qtn)) = (
-        interface_loc_qtn(db, a.interface),
-        interface_loc_qtn(db, b.interface),
-    ) else {
+    let (Some(a_qtn), Some(b_qtn)) = (&a.interface, &b.interface) else {
         return Overlap::No;
     };
     if a_qtn != b_qtn {
         return Overlap::No;
     }
-    // An impl whose for-target is not a valid implementor (rejected by the E0138
-    // concreteness gate — union, interface, literal, enum variant, or an error
-    // type) must not contribute a coherence overlap, or it would stack a spurious
-    // E0132 on top of that rejection. The gate MUST judge the same spelling
-    // E0138 judges — the fully *normalized* for-type under the same fact
-    // context — or the two gates disagree and an overlap escapes both: E0138
-    // accepts `implements I for true | false` (it normalizes to the valid
-    // subject `bool`) and `implements I for E.A | E.B` (a complete variant set
-    // normalizes to `E`), so coherence rejecting those spellings on their raw
-    // union heads would wave the pair `impl for bool` + `impl for true | false`
-    // through with no E0132 — and at runtime both fully-realized patterns match
-    // every `bool` receiver: ambiguous dispatch with no diagnostic. (Aliases and
-    // collapses *under* a constructor are resolved later by
-    // `is_same_normalized_type`; only the head matters here.)
-    let bounds = crate::lower_type_expr::TypeVarBoundsMap::default();
-    let ctx = crate::type_context::GlobalTypeContext {
-        db,
-        res_ctx: crate::package_interface::package_resolution_context(db, pkg_id),
-        aliases,
-        bounds: &bounds,
-    };
-    if !baml_type::normalize::normalize(&a.for_ty_pattern, &ctx).is_valid_impl_subject()
-        || !baml_type::normalize::normalize(&b.for_ty_pattern, &ctx).is_valid_impl_subject()
-    {
+    // The E0138-mirror gate — see [`PreparedImpl::valid_subject`] for why it
+    // must judge the normalized spelling under each impl's own bounds.
+    if !a.valid_subject(db, res_ctx, aliases) || !b.valid_subject(db, res_ctx, aliases) {
         return Overlap::No;
     }
     // NOTE: same-class in-body duplicates are NOT excluded here. Their exclusion
@@ -188,7 +235,7 @@ pub fn impls_conflict<'db>(
     // letting such duplicates escape both checks. Reporting them here as an overlap
     // (E0132) is correct: a duplicate is a degenerate overlap, matching Rust's
     // conflicting-implementations error for exact duplicates.
-    impls_overlap(db, pkg_id, a, b, aliases)
+    impls_overlap(db, pkg_id, a.data, b.data, aliases)
 }
 
 /// Conservative symmetric overlap test over two impls of the same interface.

--- a/baml_language/crates/baml_compiler2_tir/src/normalize.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/normalize.rs
@@ -82,6 +82,15 @@ fn ty_has_cycle(
         Ty::Class(_, type_args, _) => type_args
             .iter()
             .any(|t| ty_has_cycle(t, aliases, visited, stack)),
+        // A `Future`'s value/error positions carry recursion like a nominal
+        // generic's args do — invisible here before this arm existed, which let
+        // a `type F = Future<F, never>[]` alias slip past both the E0068 guard
+        // and the recursive-alias set, sending runtime lowering into unbounded
+        // inline expansion.
+        Ty::Future(value, error, _) => {
+            ty_has_cycle(value, aliases, visited, stack)
+                || ty_has_cycle(error, aliases, visited, stack)
+        }
         Ty::Interface(_, type_args, associated_bindings, _) => {
             type_args
                 .iter()
@@ -244,6 +253,13 @@ fn extract_type_alias_deps(
                 for t in type_args {
                     visit(t, aliases, non_structural, structural, in_structural);
                 }
+            }
+            Ty::Future(value, error, _) => {
+                // Pass-through, like a nominal generic: a future has no empty
+                // base case (constructing one requires the recursive value), so
+                // it is not a structural guard.
+                visit(value, aliases, non_structural, structural, in_structural);
+                visit(error, aliases, non_structural, structural, in_structural);
             }
             Ty::Interface(_, type_args, associated_bindings, _) => {
                 for t in type_args {
@@ -640,6 +656,47 @@ mod tests {
         );
 
         assert!(find_recursive_aliases(&aliases).contains(&qn("List")));
+    }
+
+    #[test]
+    fn recursion_through_future_is_detected() {
+        // `type F = Future<F, never>[]` — recursion flows through the Future's
+        // value position. Before the Future arms existed, this alias evaded
+        // both the recursive set (so runtime lowering inlined it forever) and
+        // the E0068 guard.
+        let mut aliases = HashMap::new();
+        aliases.insert(
+            qn("F"),
+            Ty::List(
+                Box::new(Ty::Future(
+                    Box::new(type_alias("F")),
+                    Box::new(Ty::Never {
+                        attr: TyAttr::default(),
+                    }),
+                    TyAttr::default(),
+                )),
+                TyAttr::default(),
+            ),
+        );
+        assert!(find_recursive_aliases(&aliases).contains(&qn("F")));
+        // List-guarded: the cycle is valid.
+        assert!(!find_invalid_alias_cycles(&aliases).contains(&qn("F")));
+
+        // A pure-Future cycle has no empty base case — invalid (E0068), like a
+        // required class-field cycle.
+        let mut pure = HashMap::new();
+        pure.insert(
+            qn("G"),
+            Ty::Future(
+                Box::new(type_alias("G")),
+                Box::new(Ty::Never {
+                    attr: TyAttr::default(),
+                }),
+                TyAttr::default(),
+            ),
+        );
+        assert!(find_recursive_aliases(&pure).contains(&qn("G")));
+        assert!(find_invalid_alias_cycles(&pure).contains(&qn("G")));
     }
 
     #[test]

--- a/baml_language/crates/baml_compiler2_tir/src/type_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/type_context.rs
@@ -197,9 +197,12 @@ impl baml_type::normalize::TypeContext for GlobalTypeContext<'_, '_> {
 ///
 /// Alias expansion *is* supplied, because two spellings that differ only by an alias
 /// (`type BI = Box<int>` vs `Box<int>`) genuinely denote the same type. Recursive
-/// aliases are handled by the canonicalizer's own μ-folding (an alias re-encountered
-/// mid-expansion becomes a recursion variable), so no precomputed recursive-alias set
-/// is needed here.
+/// aliases are handled by the canonicalizer's own μ-canonicalization (an alias
+/// re-encountered mid-expansion becomes a recursion variable; α-invariant de Bruijn
+/// binders plus automaton minimization make the canonical form equirecursively
+/// unique — `type A = int | A[]` ≡ `type B = int | B[]` at any unfolding depth, per
+/// `TYPE_SYSTEM.md` §Type Aliases and Recursive Types), so no precomputed
+/// recursive-alias set is needed here.
 ///
 /// The result is *canonical structural* equivalence: it applies the set-theoretic
 /// simplifications that hold regardless of nominal facts (`never` removal,

--- a/baml_language/crates/baml_compiler2_tir/src/unify.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/unify.rs
@@ -1438,6 +1438,67 @@ mod tests {
     }
 
     #[test]
+    fn complete_bool_literal_union_subject_overlaps_bool() {
+        // `implements I for true | false` and `implements I for bool` name the
+        // same subject: `nf` folds the complete literal pair, so unification
+        // reports the overlap that the (normalize-aligned) coherence gate now
+        // forwards here instead of dropping on the raw union head.
+        let aliases = std::collections::HashMap::default();
+        let mut bindings = TypeBindings::default();
+        assert_eq!(
+            unify_into(
+                &Ty::bool(),
+                &Ty::Union(
+                    vec![bool_literal(true), bool_literal(false)],
+                    TyAttr::default(),
+                ),
+                &[],
+                &aliases,
+                &mut bindings,
+            ),
+            Overlap::Yes,
+        );
+    }
+
+    #[test]
+    fn distinct_recursive_alias_subjects_are_disjoint() {
+        // Genuinely different recursive trees (`type R = Box<R>` vs
+        // `type S = Box<Pair<S, int>>`) differ at a finite depth, so the
+        // structural descent expands through the aliases and proves
+        // disjointness without needing the depth backstop — the α-equivalent
+        // same-tree case is answered by `equivalent` before any descent (see
+        // `distinct_recursive_alias_subjects_overlap`).
+        let r = TypeName::local(Name::new("R"));
+        let s = TypeName::local(Name::new("S"));
+        let mut aliases = std::collections::HashMap::default();
+        aliases.insert(
+            r.clone(),
+            Ty::user_class_with_args("Box", vec![Ty::TypeAlias(r.clone(), TyAttr::default())]),
+        );
+        aliases.insert(
+            s.clone(),
+            Ty::user_class_with_args(
+                "Box",
+                vec![Ty::user_class_with_args(
+                    "Pair",
+                    vec![Ty::TypeAlias(s.clone(), TyAttr::default()), Ty::int()],
+                )],
+            ),
+        );
+        let mut bindings = TypeBindings::default();
+        assert_eq!(
+            unify_into(
+                &Ty::TypeAlias(r, TyAttr::default()),
+                &Ty::TypeAlias(s, TyAttr::default()),
+                &[],
+                &aliases,
+                &mut bindings,
+            ),
+            Overlap::No,
+        );
+    }
+
+    #[test]
     fn cover_distinct_interface_binding_is_not_conservative() {
         // Same-name interfaces are decided precisely by `unify_into`, so `cover` does not
         // fall back to the conservative `Yes` — `I<Item=int>` does not cover `I<Item=string>`.

--- a/baml_language/crates/baml_compiler2_tir/src/unify.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/unify.rs
@@ -1404,14 +1404,15 @@ mod tests {
     }
 
     #[test]
-    fn distinct_recursive_alias_subjects_terminate_not_overflow() {
+    fn distinct_recursive_alias_subjects_overlap() {
         // Two *distinct* recursive aliases as impl subjects — `type R = Box<R>` and
-        // `type S = Box<S>` — expand head-first forever: `Box<R>` and `Box<S>` never
-        // normalize equal (their Mu binders carry the distinct alias names), so the
-        // structural `Class` arm keeps descending on the args. The depth backstop must
-        // catch this and fail closed to `Overlap::Unknown` ("too complex to prove
-        // disjoint"), rather than overflowing the stack — which is sound: the pair is
-        // rejected, and these aliases in fact denote the same type.
+        // `type S = Box<S>` — denote the same type: recursive aliases are
+        // equirecursive, and the canonical algebra's de Bruijn μ-binders make
+        // `equivalent` α-invariant, so the alias-equality check inside `unify_into`
+        // answers before the structural `Class` arm would descend head-first into
+        // the expansions. Coherence therefore reports the overlap precisely
+        // (`Overlap::Yes`) instead of failing closed on a depth backstop — the same
+        // rejection, now for the right reason.
         let r = TypeName::local(Name::new("R"));
         let s = TypeName::local(Name::new("S"));
         let mut aliases = std::collections::HashMap::default();
@@ -1432,7 +1433,7 @@ mod tests {
                 &aliases,
                 &mut bindings,
             ),
-            Overlap::Unknown,
+            Overlap::Yes,
         );
     }
 

--- a/baml_language/crates/baml_tests/baml_src/ns_json_alias/json_alias.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_json_alias/json_alias.baml
@@ -90,3 +90,34 @@ function match_json(j: json) -> string {
 test "match_json_arms_exhaustive" {
     assert.is_true(baml.deep_equals(match_json(null), "null"))
 }
+
+// ─── 1.8 Impl dispatch with `json` as a generic argument (B-1078) ────────────
+
+// The impl head below carries the recursive alias as a generic argument. The
+// value's recorded type args cross the normalizer on their way into bytecode,
+// so runtime dispatch compares the impl head's spelling of `JsonWrap<json>`
+// against the normalized one — before equirecursive canonicalization these
+// could disagree (alias vs unfolding) and the resolver declined an impl the
+// compiler had selected.
+
+interface JsonTagged {
+    function tag(self) -> string throws never
+}
+
+class JsonWrap<T> {
+    data T
+}
+
+implements JsonTagged for JsonWrap<json> {
+    function tag(self) -> string { return "json-wrap" }
+}
+
+function json_wrap_tag() -> string {
+    let w = JsonWrap<json> { data: null }
+    let t: JsonTagged = w
+    return t.tag()
+}
+
+test "impl_on_recursive_alias_generic_arg_dispatches" {
+    assert.equal(json_wrap_tag(), "json-wrap")
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/json_alias.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/json_alias.snap
@@ -51,7 +51,19 @@ function json_alias.$init_test_ns_json_alias_json_alias(registry: testing.TestCo
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
+    load_var registry
+    load_const "root.json_alias"
+    load_const "impl_on_recursive_alias_generic_arg_dispatches"
+    make_closure .<lambda($init_test_ns_json_alias_json_alias, 7)>, 0
     load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_const null
+    return
+}
+
+function json_alias.JsonTagged$for$JsonWrap<baml.json.json>.tag(self: json_alias.JsonWrap<baml.json.json>) -> string {
+    load_const "json-wrap"
     return
 }
 
@@ -70,7 +82,7 @@ function json_alias.json_array_len() -> int {
     alloc_array 3
     store_var _2
     load_var _2
-    narrow_bind (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[], slot=1
+    narrow_bind baml.json.json[], slot=1
     pop_jump_if_false L0
     jump L1
 
@@ -95,7 +107,7 @@ function json_alias.json_map_has_key() -> bool {
     alloc_map 1
     store_var _2
     load_var _2
-    narrow_bind map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>, slot=1
+    narrow_bind map<string, baml.json.json>, slot=1
     pop_jump_if_false L0
     jump L1
 
@@ -112,6 +124,18 @@ function json_alias.json_map_has_key() -> bool {
     cmp_int_op ==
 
   L2:
+    return
+}
+
+function json_alias.json_wrap_tag() -> string {
+    load_const null
+    load_type baml.json.json
+    init_instance<1> user.json_alias.JsonWrap .data
+    load_type json_alias.JsonTagged
+    load_const "tag"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/json_parse_stringify.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/json_parse_stringify.snap
@@ -67,7 +67,7 @@ function json_parse_stringify.parse_array_len() -> int {
     call baml.json.parse
     store_var _2
     load_var _2
-    narrow_bind (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[], slot=1
+    narrow_bind baml.json.json[], slot=1
     pop_jump_if_false L0
     jump L1
 
@@ -129,7 +129,7 @@ function json_parse_stringify.parse_then_match_array_len() -> int {
     call baml.json.parse
     store_var _2
     load_var _2
-    narrow_bind (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[], slot=1
+    narrow_bind baml.json.json[], slot=1
     pop_jump_if_false L0
     jump L1
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/json_to_from_string.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/json_to_from_string.snap
@@ -356,7 +356,7 @@ function json_to_from_string.from_string_json_passthrough_object_len() -> int {
     call baml.json.from_string
     store_var _3
     load_var _3
-    narrow_bind map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>, slot=1
+    narrow_bind map<string, baml.json.json>, slot=1
     pop_jump_if_false L0
     jump L1
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -5391,7 +5391,7 @@ fn baml.json.path(j: int | float | string | bool | null | baml.json.json[] | map
     let _6: baml.json.JsonPathError
     let _7: string
     let _8: string
-    let _9: int | float | string | bool | null | (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[] | map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>> // current
+    let _9: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // current
     let _10: int // i
     let _11: bool
     let _12: int
@@ -5419,7 +5419,7 @@ fn baml.json.path(j: int | float | string | bool | null | baml.json.json[] | map
     let _34: bool
     let _35: int
     let _36: int
-    let _37: int | float | string | bool | null | (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[] | map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>
+    let _37: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
     let _38: string
     let _39: int
     let _40: int
@@ -11907,7 +11907,7 @@ fn baml.toml.Table.baml.ToJson.to_json(self: baml.toml.Table) -> int | float | s
     // Locals:
     let _0: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // _0 // return
     let _1: baml.toml.Table // self // param
-    let _2: map<string, int | float | string | bool | baml.time.PlainDate | baml.time.PlainDateTime | baml.time.PlainTime | baml.time.ZonedDateTime | baml.toml.Table | baml.toml.Item[]>
+    let _2: map<string, baml.toml.Item>
     let _3: type
 
     bb0: {
@@ -11942,7 +11942,7 @@ fn baml.toml.table_from_json(j: int | float | string | bool | null | baml.json.j
     let _0: baml.toml.Table // _0 // return
     let _1: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // j // param
     let _2: bool
-    let _3: map<string, int | float | string | bool | baml.time.PlainDate | baml.time.PlainDateTime | baml.time.PlainTime | baml.time.ZonedDateTime | baml.toml.Table | baml.toml.Item[]> // items
+    let _3: map<string, baml.toml.Item> // items
     let _4: string[]
     let _5: type
     let _6: type
@@ -11953,13 +11953,13 @@ fn baml.toml.table_from_json(j: int | float | string | bool | null | baml.json.j
     let _11: string // key
     let _12: string
     let _13: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
-    let _14: map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>
+    let _14: map<string, baml.json.json>
     let _15: string
     let _16: bool
     let _17: baml.json.json // item
     let _18: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
     let _19: int | float | string | bool | baml.time.PlainDate | baml.time.PlainDateTime | baml.time.PlainTime | baml.time.ZonedDateTime | baml.toml.Table | baml.toml.Item[]
-    let _20: map<string, int | float | string | bool | baml.time.PlainDate | baml.time.PlainDateTime | baml.time.PlainTime | baml.time.ZonedDateTime | baml.toml.Table | baml.toml.Item[]>
+    let _20: map<string, baml.toml.Item>
     let _21: baml.json.JsonDecodeError
 
     bb0: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__04_5_mir.snap
@@ -138,9 +138,9 @@ fn user.ExtractAny$parse(json: string, client: baml.llm.Client) -> int | float |
     }
 }
 
-fn user.ExtractAny$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<int | float | string | bool | null | baml.json.json$stream[] | map<string, baml.json.json$stream>, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>> {
+fn user.ExtractAny$parse_stream(sse: baml.http.SseStream, client: baml.llm.Client) -> baml.llm.Stream<baml.json.json, baml.json.json> {
     // Locals:
-    let _0: baml.llm.Stream<int | float | string | bool | null | baml.json.json$stream[] | map<string, baml.json.json$stream>, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>> // _0 // return
+    let _0: baml.llm.Stream<baml.json.json, baml.json.json> // _0 // return
     let _1: baml.http.SseStream // sse // param
     let _2: baml.llm.Client // client // param
     let _3: bool
@@ -195,9 +195,9 @@ fn user.ExtractAny$render_prompt(client: baml.llm.Client) -> baml.llm.PromptAst 
     }
 }
 
-fn user.ExtractAny$stream(client: baml.llm.Client) -> baml.llm.Stream<int | float | string | bool | null | baml.json.json$stream[] | map<string, baml.json.json$stream>, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>> {
+fn user.ExtractAny$stream(client: baml.llm.Client) -> baml.llm.Stream<baml.json.json, baml.json.json> {
     // Locals:
-    let _0: baml.llm.Stream<int | float | string | bool | null | baml.json.json$stream[] | map<string, baml.json.json$stream>, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>> // _0 // return
+    let _0: baml.llm.Stream<baml.json.json, baml.json.json> // _0 // return
     let _1: baml.llm.Client // client // param
     let _2: bool
     let _3: map<string, unknown>

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_map_literal/baml_tests__compiles__json_map_literal__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_map_literal/baml_tests__compiles__json_map_literal__04_5_mir.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 14723
 ---
 === MIR2 ===
 fn user.NestedMapLiteral() -> int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> {
     // Locals:
     let _0: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // _0 // return
-    let _1: (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[]
-    let _2: map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>
+    let _1: baml.json.json[]
+    let _2: map<string, baml.json.json>
 
     bb0: {
         _1 = [const 2_i64, const 3_i64]: baml.json.json[];

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_parse_stringify_intrinsics/baml_tests__compiles__json_parse_stringify_intrinsics__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_parse_stringify_intrinsics/baml_tests__compiles__json_parse_stringify_intrinsics__04_5_mir.snap
@@ -6,8 +6,8 @@ fn user.parse_and_roundtrip(s: string) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // s // param
-    let _2: int | float | string | bool | null | (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[] | map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>> // j
-    let _3: int | float | string | bool | null | (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[] | map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>
+    let _2: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // j
+    let _3: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
 
     bb0: {
         _2 = call const fn baml.json.parse(copy _1) -> [bb1];
@@ -27,8 +27,8 @@ fn user.parse_and_roundtrip_pretty(s: string) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // s // param
-    let _2: int | float | string | bool | null | (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[] | map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>> // j
-    let _3: int | float | string | bool | null | (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[] | map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>
+    let _2: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // j
+    let _3: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
 
     bb0: {
         _2 = call const fn baml.json.parse(copy _1) -> [bb1];
@@ -48,17 +48,17 @@ fn user.match_parsed(s: string) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // s // param
-    let _2: int | float | string | bool | null | (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[] | map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>> // j
-    let _3: int | float | string | bool | null | (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[] | map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>
+    let _2: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // j
+    let _3: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
     let _4: baml.json.json[] // arr
-    let _5: (int | float | string | bool | null | (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[] | map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>)[]
-    let _6: int | float | string | bool | null | (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[] | map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>
+    let _5: baml.json.json[]
+    let _6: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
     let _7: map<string, baml.json.json> // m
-    let _8: map<string, int | float | string | bool | null | (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[] | map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>>
-    let _9: int | float | string | bool | null | (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[] | map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>
-    let _10: int | float | string | bool | null | (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[] | map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>
-    let _11: int | float | string | bool | null | (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[] | map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>
-    let _12: int | float | string | bool | null | (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[] | map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>
+    let _8: map<string, baml.json.json>
+    let _9: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
+    let _10: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
+    let _11: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
+    let _12: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
     let _13: string // st
 
     bb0: {
@@ -67,12 +67,12 @@ fn user.match_parsed(s: string) -> string {
 
     bb1: {
         _3 = copy _2;
-        _3 = narrow_bind copy _3 as List(Union([Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, Float { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, Bool { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, Null { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, List(TypeAlias(QualifiedTypeName { pkg: Dep("baml"), namespace: ["json"], name: "json" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Map { key: String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, value: TypeAlias(QualifiedTypeName { pkg: Dep("baml"), namespace: ["json"], name: "json" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb13, bb2];
+        _3 = narrow_bind copy _3 as List(TypeAlias(QualifiedTypeName { pkg: Dep("baml"), namespace: ["json"], name: "json" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb13, bb2];
     }
 
     bb2: {
         _6 = copy _2;
-        _6 = narrow_bind copy _6 as Map { key: String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, value: Union([Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, Float { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, Bool { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, Null { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, List(TypeAlias(QualifiedTypeName { pkg: Dep("baml"), namespace: ["json"], name: "json" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), Map { key: String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, value: TypeAlias(QualifiedTypeName { pkg: Dep("baml"), namespace: ["json"], name: "json" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb12, bb3];
+        _6 = narrow_bind copy _6 as Map { key: String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } }, value: TypeAlias(QualifiedTypeName { pkg: Dep("baml"), namespace: ["json"], name: "json" }, TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }), attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb12, bb3];
     }
 
     bb3: {

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_parse_stringify_intrinsics/baml_tests__compiles__json_parse_stringify_intrinsics__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_parse_stringify_intrinsics/baml_tests__compiles__json_parse_stringify_intrinsics__06_codegen.snap
@@ -23,7 +23,7 @@ function user.match_parsed(s: string) -> string {
     load_var j
     store_var _3
     load_var _3
-    narrow_bind (int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>)[], slot=3
+    narrow_bind baml.json.json[], slot=3
     pop_jump_if_false L0
     jump L11
 
@@ -31,7 +31,7 @@ function user.match_parsed(s: string) -> string {
     load_var j
     store_var _6
     load_var _6
-    narrow_bind map<string, int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>>, slot=4
+    narrow_bind map<string, baml.json.json>, slot=4
     pop_jump_if_false L1
     jump L10
 

--- a/baml_language/crates/baml_type/src/normalize.rs
+++ b/baml_language/crates/baml_type/src/normalize.rs
@@ -486,9 +486,14 @@ pub fn definitely_equal<C: TypeContext>(a: &Ty, b: &Ty, ctx: &C) -> bool {
 }
 
 impl NormalTy {
-    /// Normalize and canonicalize a [`Ty`] in one step (the shared entry point).
+    /// Normalize and canonicalize a [`Ty`] in one step (the shared entry point):
+    /// build the named intermediate, strictly resolve its binders to the
+    /// canonical de Bruijn phase, then run the set-theoretic algebra.
     fn canonical<C: TypeContext>(ty: &Ty, ctx: &C) -> NormalTy {
-        NormalTy::from_ty(ty, ctx, &mut HashSet::new(), PROJECTION_REDUCTION_FUEL).canonicalize(ctx)
+        let named = NormalTy::from_ty(ty, ctx, &mut HashSet::new(), PROJECTION_REDUCTION_FUEL);
+        let mut saw_mu = false;
+        let resolved = named.resolve_binders(&mut Vec::new(), &mut saw_mu);
+        resolved.canonicalize(ctx, saw_mu)
     }
 }
 
@@ -548,11 +553,17 @@ impl NormalTy {
             NormalTy::Enum(_) | NormalTy::EnumVariant(..) => Category::Enum,
             NormalTy::Function { .. } => Category::Function,
             NormalTy::Future(..) => Category::Future,
-            // Not a ground concrete head — nothing provable.
+            // A μ is transparent to its head: the head of `μX.T` is the head of
+            // its unfolding, and the walk into the body terminates (no unfold
+            // happens here). A non-constructor body head (e.g. a still-unguarded
+            // union, pending the ε-closure step) answers `None` through the arms
+            // below — conservative.
+            NormalTy::Mu { body, .. } => return body.head_category(),
+            // Not a ground concrete head — nothing provable. (A free `RecVar`
+            // only occurs under its binder, which the μ arm above looks through.)
             NormalTy::Interface(..)
             | NormalTy::Union(_)
             | NormalTy::AssociatedTypeProjection { .. }
-            | NormalTy::Mu { .. }
             | NormalTy::RecVar(_)
             | NormalTy::TypeVar(_)
             | NormalTy::OpaqueAlias(_)
@@ -629,6 +640,12 @@ impl NormalTy {
 
     /// Whether no value of `self` can ever be `==`-equal to a value of `other`
     /// (the structural core of [`definitely_disjoint`]).
+    ///
+    /// A μ head is handled by [`Self::head_category`]'s μ-transparency in the
+    /// category fallback below; there is deliberately no unfolding arm here —
+    /// `is_disjoint_from` carries no co-inductive assumption set, so unfolding a
+    /// not-yet-ε-closed unguarded μ (`type A = A | A[]`, legal today) would not
+    /// terminate. Same-category μ pairs conservatively answer `false`.
     fn is_disjoint_from(&self, other: &NormalTy) -> bool {
         match (self, other) {
             // A union is disjoint from `rhs` iff every member is.
@@ -718,13 +735,58 @@ impl Category {
 // NORMALIZED TYPE (private)
 // ═══════════════════════════════════════════════════════════════════════════
 
+/// Phase parameter of [`NormalTy`]: selects the μ-binder representation, so a
+/// cross-phase term is *unrepresentable* — a named binder cannot occur inside a
+/// canonical form, nor a de Bruijn index inside the `from_ty` intermediate, and
+/// the only way from one phase to the other is the strict, total conversion
+/// [`NormalTy::resolve_binders`].
+trait MuPhase {
+    /// Payload carried by a μ-binder ([`NormalTy::Mu`]).
+    type Binder: Clone + std::fmt::Debug + PartialEq + Eq + PartialOrd + Ord + std::hash::Hash;
+    /// Payload carried by a recursion variable ([`NormalTy::RecVar`]).
+    type Var: Clone + std::fmt::Debug + PartialEq + Eq + PartialOrd + Ord + std::hash::Hash;
+}
+
+/// The `from_ty` intermediate phase: binders and back-references carry the alias
+/// name whose expansion introduced them. This phase exists only between
+/// `from_ty` and [`NormalTy::resolve_binders`]; nothing compares it for
+/// identity, subtypes it, or renders it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum Named {}
+
+impl MuPhase for Named {
+    type Binder = QualifiedTypeName;
+    type Var = QualifiedTypeName;
+}
+
+/// The canonical phase: back-references are de Bruijn indices — so the derived
+/// equality on canonical forms *is* α-equivalence (`type A = int | A[]` and
+/// `type B = int | B[]` share one canonical form) — and binders carry only the
+/// equality-transparent [`MuDisplay`] payload for rendering.
+///
+/// INVARIANT (closed-term): a canonical form at a public boundary is closed —
+/// every `RecVar(i)` has more than `i` enclosing `Mu`s. Unfolding
+/// ([`NormalTy::unfold`]) therefore substitutes a *closed* term for the
+/// outermost binder, which needs no index shifting and keeps derived-`==`
+/// assumption probes exact.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+enum Canonical {}
+
+impl MuPhase for Canonical {
+    type Binder = MuDisplay;
+    type Var = u32;
+}
+
 /// Normalized structural type: aliases resolved, attributes and literal
-/// freshness erased, recursion made explicit with μ-binders.
+/// freshness erased, recursion made explicit with μ-binders (representation per
+/// phase `P` — see [`MuPhase`]). The default phase is [`Canonical`]: bare
+/// `NormalTy` throughout the algebra means the canonical form, and only the
+/// short-lived `from_ty` intermediate spells its phase (`NormalTy<Named>`).
 ///
 /// Ordering (`PartialOrd`/`Ord`) is the canonical sort key for union members; it
 /// has no semantic meaning beyond producing a deterministic canonical form.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-enum NormalTy {
+enum NormalTy<P: MuPhase = Canonical> {
     // Primitive leaves
     Int,
     Bigint,
@@ -743,39 +805,46 @@ enum NormalTy {
     // Literal — a single value as a type. Freshness is erased.
     Literal(Literal),
     // Nominal references
-    Class(QualifiedTypeName, Vec<NormalTy>),
-    Interface(QualifiedTypeName, Vec<NormalTy>, Vec<(Name, NormalTy)>),
+    Class(QualifiedTypeName, Vec<NormalTy<P>>),
+    Interface(
+        QualifiedTypeName,
+        Vec<NormalTy<P>>,
+        Vec<(Name, NormalTy<P>)>,
+    ),
     Enum(QualifiedTypeName),
     EnumVariant(QualifiedTypeName, Name),
     // Constructors
-    List(Box<NormalTy>),
+    List(Box<NormalTy<P>>),
     Map {
-        key: Box<NormalTy>,
-        value: Box<NormalTy>,
+        key: Box<NormalTy<P>>,
+        value: Box<NormalTy<P>>,
     },
-    Union(Vec<NormalTy>),
+    Union(Vec<NormalTy<P>>),
     Function {
-        params: Vec<NormalParam>,
-        ret: Box<NormalTy>,
-        throws: Box<NormalTy>,
+        params: Vec<NormalParam<P>>,
+        ret: Box<NormalTy<P>>,
+        throws: Box<NormalTy<P>>,
     },
-    Future(Box<NormalTy>, Box<NormalTy>),
+    Future(Box<NormalTy<P>>, Box<NormalTy<P>>),
     AssociatedTypeProjection {
-        base: Box<NormalTy>,
+        base: Box<NormalTy<P>>,
         /// The declaring interface (a normalized `NormalTy::Interface`), always
         /// present — mirrors the non-optional `Ty::AssociatedTypeProjection`
         /// qualifier it is built from, and is what makes a realized-base
         /// projection reducible via [`TypeContext::project`].
-        interface: Box<NormalTy>,
+        interface: Box<NormalTy<P>>,
         member: Name,
     },
-    // Recursion
+    // Recursion. `Named`: binder/variable carry the alias name whose expansion
+    // introduced them. `Canonical`: the binder carries its equality-transparent
+    // display payload and the variable a de Bruijn index (0 = innermost
+    // enclosing binder) — see [`Canonical`] for the closed-term invariant.
     Mu {
-        var: QualifiedTypeName,
-        body: Box<NormalTy>,
+        binder: P::Binder,
+        body: Box<NormalTy<P>>,
     },
     /// μ-bound recursion variable (a back-reference to an enclosing [`NormalTy::Mu`]).
-    RecVar(QualifiedTypeName),
+    RecVar(P::Var),
     /// A generic type parameter — opaque, compatible only with itself, its
     /// bound's supertypes, and the top type.
     TypeVar(ParamTy),
@@ -794,14 +863,53 @@ enum NormalTy {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
-struct NormalParam {
+struct NormalParam<P: MuPhase = Canonical> {
     name: Option<Name>,
-    ty: NormalTy,
+    ty: NormalTy<P>,
     mode: FunctionParamMode,
 }
 
-impl NormalTy {
-    // ── conversion in: Ty → NormalTy ───────────────────────────────────────
+/// Display payload of a canonical μ-binder ([`NormalTy::Mu`] at
+/// [`Canonical`]): the alias name whose expansion introduced the binder, used by
+/// [`NormalTy::into_ty`] to spell back-references (surface syntax has no binder,
+/// so recursion renders via alias names). The μ-canonicalization automaton will
+/// replace this with the precomputed named-cut rendering of the whole μ-subterm.
+///
+/// **Equality-transparent by design**: all values compare equal, order equal, and
+/// hash identically, so the derived `PartialEq`/`Ord`/`Hash` on [`NormalTy`] see
+/// only the de Bruijn structure — canonical equality *is* α-equivalence, and the
+/// rendering (which necessarily picks concrete alias names) can never split it.
+/// This is the same discipline as spans ignored by AST equality: a description of
+/// the value, not part of it.
+#[derive(Debug, Clone)]
+struct MuDisplay(QualifiedTypeName);
+
+impl PartialEq for MuDisplay {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for MuDisplay {}
+
+impl PartialOrd for MuDisplay {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for MuDisplay {
+    fn cmp(&self, _other: &Self) -> std::cmp::Ordering {
+        std::cmp::Ordering::Equal
+    }
+}
+
+impl std::hash::Hash for MuDisplay {
+    fn hash<H: std::hash::Hasher>(&self, _state: &mut H) {}
+}
+
+impl NormalTy<Named> {
+    // ── conversion in: Ty → NormalTy<Named> ────────────────────────────────
 
     fn from_ty<C: TypeContext>(
         ty: &Ty,
@@ -813,7 +921,7 @@ impl NormalTy {
         // `type B = (C as J).A`; each reduction spends one unit, and on exhaustion
         // the projection stays opaque (conservative — never over-equates).
         fuel: u32,
-    ) -> NormalTy {
+    ) -> NormalTy<Named> {
         match ty {
             Ty::Int { .. } => NormalTy::Int,
             Ty::Bigint { .. } => NormalTy::Bigint,
@@ -941,7 +1049,7 @@ impl NormalTy {
                 expanding.remove(qn);
                 if body.mentions_rec_var(qn) {
                     NormalTy::Mu {
-                        var: qn.clone(),
+                        binder: qn.clone(),
                         body: Box::new(body),
                     }
                 } else {
@@ -956,7 +1064,7 @@ impl NormalTy {
         ctx: &C,
         expanding: &mut HashSet<QualifiedTypeName>,
         fuel: u32,
-    ) -> Vec<NormalTy> {
+    ) -> Vec<NormalTy<Named>> {
         tys.iter()
             .map(|t| Self::from_ty(t, ctx, expanding, fuel))
             .collect()
@@ -967,7 +1075,7 @@ impl NormalTy {
         match self {
             NormalTy::RecVar(v) => v == var,
             // A nested μ shadowing the same name rebinds it; stop descending.
-            NormalTy::Mu { var: v, body } => v != var && body.mentions_rec_var(var),
+            NormalTy::Mu { binder: v, body } => v != var && body.mentions_rec_var(var),
             NormalTy::Class(_, args) => args.iter().any(|a| a.mentions_rec_var(var)),
             NormalTy::Interface(_, args, bindings) => {
                 args.iter().any(|a| a.mentions_rec_var(var))
@@ -1018,43 +1126,183 @@ impl NormalTy {
         }
     }
 
-    // ── canonicalization ───────────────────────────────────────────────────
+    // ── phase conversion: NormalTy<Named> → NormalTy ────────────
 
-    /// Rewrite to a unique canonical form: children canonicalized bottom-up,
-    /// unions reduced by the full set algebra.
-    fn canonicalize<C: TypeContext>(self, ctx: &C) -> NormalTy {
+    /// Strictly convert the `from_ty` intermediate to the canonical de Bruijn
+    /// phase (the only path between the phases): each back-reference becomes the
+    /// distance to its binder, each binder keeps its alias name as the
+    /// equality-transparent display payload, and `saw_mu` reports whether any
+    /// binder was emitted (the recursive-type slow-path flag).
+    ///
+    /// This runs on the *completed* named term, where binder-hood is already
+    /// decided — computing indices during `from_ty` itself would be off by one
+    /// whenever an intervening alias expansion turns out not to bind (mutual
+    /// recursion), because `from_ty` only wraps a binder after seeing the whole
+    /// body.
+    fn resolve_binders(
+        self,
+        stack: &mut Vec<QualifiedTypeName>,
+        saw_mu: &mut bool,
+    ) -> NormalTy<Canonical> {
         match self {
-            NormalTy::Class(qn, args) => {
-                NormalTy::Class(qn, args.into_iter().map(|a| a.canonicalize(ctx)).collect())
+            NormalTy::Mu { binder, body } => {
+                // `from_ty` wraps a binder only when the body mentions it, and
+                // nothing between `from_ty` and this conversion can remove a
+                // back-reference — so a vacuous binder is a bug, not a case.
+                debug_assert!(
+                    body.mentions_rec_var(&binder),
+                    "from_ty emitted a vacuous μ-binder"
+                );
+                *saw_mu = true;
+                let display = MuDisplay(binder.clone());
+                stack.push(binder);
+                let body = body.resolve_binders(stack, saw_mu);
+                stack.pop();
+                NormalTy::Mu {
+                    binder: display,
+                    body: Box::new(body),
+                }
             }
-            NormalTy::Interface(qn, args, bindings) => {
-                let mut bindings: Vec<_> = bindings
+            NormalTy::RecVar(qn) => {
+                let index = stack
+                    .iter()
+                    .rev()
+                    .position(|v| *v == qn)
+                    .unwrap_or_else(|| {
+                        unreachable!(
+                            "from_ty emits a RecVar only while its alias is on the \
+                             expanding path, so its binder is on the stack"
+                        )
+                    });
+                NormalTy::RecVar(index as u32)
+            }
+            NormalTy::Class(qn, args) => NormalTy::Class(
+                qn,
+                args.into_iter()
+                    .map(|a| a.resolve_binders(stack, saw_mu))
+                    .collect(),
+            ),
+            NormalTy::Interface(qn, args, bindings) => NormalTy::Interface(
+                qn,
+                args.into_iter()
+                    .map(|a| a.resolve_binders(stack, saw_mu))
+                    .collect(),
+                bindings
                     .into_iter()
-                    .map(|(name, ty)| (name, ty.canonicalize(ctx)))
-                    .collect();
-                bindings.sort_by(|(a, _), (b, _)| a.cmp(b));
-                NormalTy::Interface(
-                    qn,
-                    args.into_iter().map(|a| a.canonicalize(ctx)).collect(),
-                    bindings,
-                )
-            }
-            NormalTy::List(inner) => NormalTy::List(Box::new(inner.canonicalize(ctx))),
+                    .map(|(n, t)| (n, t.resolve_binders(stack, saw_mu)))
+                    .collect(),
+            ),
+            NormalTy::List(inner) => NormalTy::List(Box::new(inner.resolve_binders(stack, saw_mu))),
             NormalTy::Map { key, value } => NormalTy::Map {
-                key: Box::new(key.canonicalize(ctx)),
-                value: Box::new(value.canonicalize(ctx)),
+                key: Box::new(key.resolve_binders(stack, saw_mu)),
+                value: Box::new(value.resolve_binders(stack, saw_mu)),
+            },
+            NormalTy::Union(members) => NormalTy::Union(
+                members
+                    .into_iter()
+                    .map(|m| m.resolve_binders(stack, saw_mu))
+                    .collect(),
+            ),
+            NormalTy::Function {
+                params,
+                ret,
+                throws,
+            } => NormalTy::Function {
+                params: params
+                    .into_iter()
+                    .map(|p| NormalParam {
+                        name: p.name,
+                        ty: p.ty.resolve_binders(stack, saw_mu),
+                        mode: p.mode,
+                    })
+                    .collect(),
+                ret: Box::new(ret.resolve_binders(stack, saw_mu)),
+                throws: Box::new(throws.resolve_binders(stack, saw_mu)),
             },
             NormalTy::Future(value, error) => NormalTy::Future(
-                Box::new(value.canonicalize(ctx)),
-                Box::new(error.canonicalize(ctx)),
+                Box::new(value.resolve_binders(stack, saw_mu)),
+                Box::new(error.resolve_binders(stack, saw_mu)),
             ),
             NormalTy::AssociatedTypeProjection {
                 base,
                 interface,
                 member,
             } => NormalTy::AssociatedTypeProjection {
-                base: Box::new(base.canonicalize(ctx)),
-                interface: Box::new(interface.canonicalize(ctx)),
+                base: Box::new(base.resolve_binders(stack, saw_mu)),
+                interface: Box::new(interface.resolve_binders(stack, saw_mu)),
+                member,
+            },
+            NormalTy::Int => NormalTy::Int,
+            NormalTy::Bigint => NormalTy::Bigint,
+            NormalTy::Float => NormalTy::Float,
+            NormalTy::String => NormalTy::String,
+            NormalTy::Bool => NormalTy::Bool,
+            NormalTy::Null => NormalTy::Null,
+            NormalTy::Uint8Array => NormalTy::Uint8Array,
+            NormalTy::Media(kind) => NormalTy::Media(kind),
+            NormalTy::Void => NormalTy::Void,
+            NormalTy::RustType => NormalTy::RustType,
+            NormalTy::Type => NormalTy::Type,
+            NormalTy::Resource => NormalTy::Resource,
+            NormalTy::PromptAst => NormalTy::PromptAst,
+            NormalTy::Literal(lit) => NormalTy::Literal(lit),
+            NormalTy::Enum(qn) => NormalTy::Enum(qn),
+            NormalTy::EnumVariant(qn, v) => NormalTy::EnumVariant(qn, v),
+            NormalTy::TypeVar(name) => NormalTy::TypeVar(name),
+            NormalTy::OpaqueAlias(qn) => NormalTy::OpaqueAlias(qn),
+            NormalTy::Never => NormalTy::Never,
+            NormalTy::BuiltinUnknown => NormalTy::BuiltinUnknown,
+            NormalTy::Unknown => NormalTy::Unknown,
+            NormalTy::Error => NormalTy::Error,
+        }
+    }
+}
+
+impl NormalTy {
+    // ── canonicalization ───────────────────────────────────────────────────
+
+    /// Rewrite to a unique canonical form: children canonicalized bottom-up,
+    /// unions reduced by the full set algebra. `saw_mu` is the recursive-type
+    /// flag from [`NormalTy::resolve_binders`]; when clear, the μ-related guards
+    /// below vanish from the hot path.
+    fn canonicalize<C: TypeContext>(self, ctx: &C, saw_mu: bool) -> NormalTy {
+        match self {
+            NormalTy::Class(qn, args) => NormalTy::Class(
+                qn,
+                args.into_iter()
+                    .map(|a| a.canonicalize(ctx, saw_mu))
+                    .collect(),
+            ),
+            NormalTy::Interface(qn, args, bindings) => {
+                let mut bindings: Vec<_> = bindings
+                    .into_iter()
+                    .map(|(name, ty)| (name, ty.canonicalize(ctx, saw_mu)))
+                    .collect();
+                bindings.sort_by(|(a, _), (b, _)| a.cmp(b));
+                NormalTy::Interface(
+                    qn,
+                    args.into_iter()
+                        .map(|a| a.canonicalize(ctx, saw_mu))
+                        .collect(),
+                    bindings,
+                )
+            }
+            NormalTy::List(inner) => NormalTy::List(Box::new(inner.canonicalize(ctx, saw_mu))),
+            NormalTy::Map { key, value } => NormalTy::Map {
+                key: Box::new(key.canonicalize(ctx, saw_mu)),
+                value: Box::new(value.canonicalize(ctx, saw_mu)),
+            },
+            NormalTy::Future(value, error) => NormalTy::Future(
+                Box::new(value.canonicalize(ctx, saw_mu)),
+                Box::new(error.canonicalize(ctx, saw_mu)),
+            ),
+            NormalTy::AssociatedTypeProjection {
+                base,
+                interface,
+                member,
+            } => NormalTy::AssociatedTypeProjection {
+                base: Box::new(base.canonicalize(ctx, saw_mu)),
+                interface: Box::new(interface.canonicalize(ctx, saw_mu)),
                 member,
             },
             NormalTy::Function {
@@ -1067,7 +1315,7 @@ impl NormalTy {
                 let mut required = Vec::new();
                 let mut optional = Vec::new();
                 for p in params {
-                    let ty = p.ty.canonicalize(ctx);
+                    let ty = p.ty.canonicalize(ctx, saw_mu);
                     match p.mode {
                         FunctionParamMode::Required => required.push(NormalParam {
                             name: None,
@@ -1085,26 +1333,23 @@ impl NormalTy {
                 required.extend(optional);
                 NormalTy::Function {
                     params: required,
-                    ret: Box::new(ret.canonicalize(ctx)),
-                    throws: Box::new(throws.canonicalize(ctx)),
+                    ret: Box::new(ret.canonicalize(ctx, saw_mu)),
+                    throws: Box::new(throws.canonicalize(ctx, saw_mu)),
                 }
             }
-            NormalTy::Mu { var, body } => {
-                let body = body.canonicalize(ctx);
-                // A μ whose body no longer mentions its variable is not actually
-                // recursive (an absorption may have removed the back-edge).
-                if body.mentions_rec_var(&var) {
-                    NormalTy::Mu {
-                        var,
-                        body: Box::new(body),
-                    }
-                } else {
-                    body
-                }
-            }
+            // A binder stays put: `resolve_binders` guarantees it is genuinely
+            // recursive, and the μ-guard in `absorb_subtypes` means no algebra
+            // step below can remove its back-references.
+            NormalTy::Mu { binder, body } => NormalTy::Mu {
+                binder,
+                body: Box::new(body.canonicalize(ctx, saw_mu)),
+            },
             NormalTy::Union(members) => {
-                let members = members.into_iter().map(|m| m.canonicalize(ctx)).collect();
-                Self::canonicalize_union(members, ctx)
+                let members = members
+                    .into_iter()
+                    .map(|m| m.canonicalize(ctx, saw_mu))
+                    .collect();
+                Self::canonicalize_union(members, ctx, saw_mu)
             }
             leaf => leaf,
         }
@@ -1205,8 +1450,8 @@ impl NormalTy {
         // The co-inductive assumption set exists *only* to terminate cycles,
         // and a cycle can only arise through an arm that *expands* (regenerates)
         // a type rather than descending into a strictly-smaller subterm:
-        //   * μ-unfolding — `body.substitute(var, self)` can reproduce the same
-        //     pair (`(_, Mu)` on the right, `(Mu, _)` on the left);
+        //   * μ-unfolding — `unfold` can reproduce the same pair (`(_, Mu)` on
+        //     the right, `(Mu, _)` on the left);
         //   * a `TypeVar` / `AssociatedTypeProjection` on the left — its bound is
         //     looked up through the context and may mention the variable itself.
         // Every *structural* arm (unions, invariant containers, functions,
@@ -1252,14 +1497,11 @@ impl NormalTy {
         assumptions: &mut HashSet<(NormalTy, NormalTy)>,
     ) -> bool {
         match (self, sup) {
-            // μ-unfolding (equirecursive).
-            (NormalTy::Mu { var, body }, _) => {
-                body.substitute(var, self)
-                    .is_subtype_of(sup, ctx, assumptions)
-            }
-            (_, NormalTy::Mu { var, body }) => {
-                self.is_subtype_of(&body.substitute(var, sup), ctx, assumptions)
-            }
+            // μ-unfolding (equirecursive). The closed-term substitution needs no
+            // index shifting, and the outer `is_subtype_of` recorded this pair on
+            // the expanding-arm assumption set.
+            (NormalTy::Mu { .. }, _) => self.unfold().is_subtype_of(sup, ctx, assumptions),
+            (_, NormalTy::Mu { .. }) => self.is_subtype_of(&sup.unfold(), ctx, assumptions),
 
             // Union decomposition. `Union <: T` must precede `T <: Union` so a
             // union on the left is not mistaken for a single member of the right.
@@ -1453,9 +1695,17 @@ impl NormalTy {
         }
     }
 
-    // ── conversion out: NormalTy → Ty ──────────────────────────────────────
+    // ── conversion out: NormalTy → Ty ───────────────────────────
 
+    /// Render a **closed** canonical form back as a [`Ty`]. Surface syntax has
+    /// no μ-binder, so recursion is spelled via alias names: each binder's
+    /// [`MuDisplay`] name is pushed while rendering its body, and a
+    /// back-reference renders as `Ty::TypeAlias` of its binder's name.
     fn into_ty(self) -> Ty {
+        self.into_ty_with(&mut Vec::new())
+    }
+
+    fn into_ty_with(self, binders: &mut Vec<QualifiedTypeName>) -> Ty {
         let attr = TyAttr::default();
         match self {
             NormalTy::Int => Ty::Int { attr },
@@ -1476,25 +1726,25 @@ impl NormalTy {
             NormalTy::Unknown => Ty::Unknown { attr },
             NormalTy::Error => Ty::Error { attr },
             NormalTy::Literal(lit) => Ty::Literal(lit, crate::Freshness::Regular, attr),
-            NormalTy::Class(qn, args) => Ty::Class(qn, Self::into_tys(args), attr),
+            NormalTy::Class(qn, args) => Ty::Class(qn, Self::into_tys_with(args, binders), attr),
             NormalTy::Interface(qn, args, bindings) => Ty::Interface(
                 qn,
-                Self::into_tys(args),
+                Self::into_tys_with(args, binders),
                 bindings
                     .into_iter()
-                    .map(|(name, ty)| (name, ty.into_ty()))
+                    .map(|(name, ty)| (name, ty.into_ty_with(binders)))
                     .collect(),
                 attr,
             ),
             NormalTy::Enum(qn) => Ty::Enum(qn, attr),
             NormalTy::EnumVariant(qn, v) => Ty::EnumVariant(qn, v, attr),
-            NormalTy::List(inner) => Ty::List(Box::new(inner.into_ty()), attr),
+            NormalTy::List(inner) => Ty::List(Box::new(inner.into_ty_with(binders)), attr),
             NormalTy::Map { key, value } => Ty::Map {
-                key: Box::new(key.into_ty()),
-                value: Box::new(value.into_ty()),
+                key: Box::new(key.into_ty_with(binders)),
+                value: Box::new(value.into_ty_with(binders)),
                 attr,
             },
-            NormalTy::Union(members) => Ty::Union(Self::into_tys(members), attr),
+            NormalTy::Union(members) => Ty::Union(Self::into_tys_with(members, binders), attr),
             NormalTy::Function {
                 params,
                 ret,
@@ -1504,44 +1754,67 @@ impl NormalTy {
                     .into_iter()
                     .map(|p| FunctionParamTy {
                         name: p.name,
-                        ty: p.ty.into_ty(),
+                        ty: p.ty.into_ty_with(binders),
                         mode: p.mode,
                     })
                     .collect(),
-                ret: Box::new(ret.into_ty()),
-                throws: Box::new(throws.into_ty()),
+                ret: Box::new(ret.into_ty_with(binders)),
+                throws: Box::new(throws.into_ty_with(binders)),
                 attr,
             },
-            NormalTy::Future(value, error) => {
-                Ty::Future(Box::new(value.into_ty()), Box::new(error.into_ty()), attr)
-            }
+            NormalTy::Future(value, error) => Ty::Future(
+                Box::new(value.into_ty_with(binders)),
+                Box::new(error.into_ty_with(binders)),
+                attr,
+            ),
             NormalTy::AssociatedTypeProjection {
                 base,
                 interface,
                 member,
             } => Ty::AssociatedTypeProjection {
-                base: Box::new(base.into_ty()),
+                base: Box::new(base.into_ty_with(binders)),
                 // The projection's qualifier is always a normalized interface, so
-                // it round-trips back to an `Interface` here.
+                // it round-trips back to an `Interface` here. The binder stack
+                // threads through: a qualifier argument may legally capture an
+                // enclosing recursion variable (`type A = (C as I<A>).X | A[]`
+                // passes the per-SCC cycle check).
                 interface: Box::new(
                     interface
-                        .into_interface()
+                        .into_interface_with(binders)
                         .unwrap_or_else(|| unreachable!("projection qualifier is an interface")),
                 ),
                 member,
                 attr,
             },
             NormalTy::TypeVar(name) => Ty::TypeVar(name, attr),
-            // μ-binders and recursion variables round-trip through the alias name.
-            NormalTy::Mu { body, .. } => body.into_ty(),
-            NormalTy::RecVar(qn) | NormalTy::OpaqueAlias(qn) => Ty::TypeAlias(qn, attr),
+            // μ-binders and recursion variables round-trip through the alias
+            // name: the binder itself has no surface syntax (its body renders in
+            // place), and each back-reference renders as the alias name of the
+            // binder it refers to.
+            NormalTy::Mu { binder, body } => {
+                binders.push(binder.0);
+                let rendered = body.into_ty_with(binders);
+                binders.pop();
+                rendered
+            }
+            NormalTy::RecVar(index) => {
+                let Some(qn) = binders.iter().rev().nth(index as usize) else {
+                    unreachable!(
+                        "into_ty on a free RecVar; canonical forms at public \
+                         boundaries are closed, so every back-reference has its \
+                         binder on the render stack"
+                    )
+                };
+                Ty::TypeAlias(qn.clone(), attr)
+            }
+            NormalTy::OpaqueAlias(qn) => Ty::TypeAlias(qn, attr),
         }
     }
 }
 
 impl NormalTy {
-    fn into_tys(tys: Vec<NormalTy>) -> Vec<Ty> {
-        tys.into_iter().map(NormalTy::into_ty).collect()
+    fn into_tys_with(tys: Vec<NormalTy>, binders: &mut Vec<QualifiedTypeName>) -> Vec<Ty> {
+        tys.into_iter().map(|t| t.into_ty_with(binders)).collect()
     }
 
     /// The [`Interface`] constraint denoted by a `NormalTy::Interface`'s parts —
@@ -1549,7 +1822,8 @@ impl NormalTy {
     /// back to `Ty`. This is the precise interface shape handed to the
     /// [`TypeContext`] membership (`implements_interface`) and requires
     /// (`interface_requires`) oracles, so they never have to re-destructure a
-    /// loose `Ty` to recover it.
+    /// loose `Ty` to recover it. The parts are always closed here: the subtype
+    /// arms that build a constraint fire only after μ-unfolding the operand.
     fn interface_constraint(
         name: &QualifiedTypeName,
         generics: &[NormalTy],
@@ -1569,13 +1843,20 @@ impl NormalTy {
     /// [`Interface`] constraint; `None` for any other variant. Used to put the
     /// `as I` annotation of an associated-type projection back into a `Ty`.
     fn into_interface(self) -> Option<Interface> {
+        self.into_interface_with(&mut Vec::new())
+    }
+
+    /// [`Self::into_interface`] with the enclosing render binder stack, for the
+    /// projection arm of [`Self::into_ty_with`] (a qualifier argument may capture
+    /// an enclosing recursion variable).
+    fn into_interface_with(self, binders: &mut Vec<QualifiedTypeName>) -> Option<Interface> {
         match self {
             NormalTy::Interface(name, generics, bindings) => Some(Interface {
                 name,
-                generics: Self::into_tys(generics),
+                generics: Self::into_tys_with(generics, binders),
                 associated_types: bindings
                     .into_iter()
-                    .map(|(name, ty)| (name, ty.into_ty()))
+                    .map(|(name, ty)| (name, ty.into_ty_with(binders)))
                     .collect(),
             }),
             _ => None,
@@ -1598,7 +1879,11 @@ impl NormalTy {
     /// Reduce a union of already-canonical members to canonical form: flatten,
     /// remove `never`, absorb under `unknown`, collapse complete enums, absorb
     /// subtype-members, then sort/dedup and unwrap singletons.
-    fn canonicalize_union<C: TypeContext>(members: Vec<NormalTy>, ctx: &C) -> NormalTy {
+    fn canonicalize_union<C: TypeContext>(
+        members: Vec<NormalTy>,
+        ctx: &C,
+        saw_mu: bool,
+    ) -> NormalTy {
         // Flatten one level (members are canonical, but a μ-unfold or alias could
         // surface a nested union) and drop `never`.
         let mut flat: Vec<NormalTy> = Vec::new();
@@ -1619,7 +1904,7 @@ impl NormalTy {
         flat.dedup();
 
         Self::collapse_complete_enums(&mut flat, ctx);
-        let mut flat = Self::absorb_subtypes(&flat, ctx);
+        let mut flat = Self::absorb_subtypes(&flat, ctx, saw_mu);
 
         flat.sort();
         flat.dedup();
@@ -1667,15 +1952,35 @@ impl NormalTy {
     /// Remove any member subsumed by another (`X | Y == Y` when `X <: Y`). Covers
     /// literal-into-base, variant-into-enum, `C | I == I`, `A | B == B`, and
     /// `T | I == I`. Error-recovery sentinels never absorb or are absorbed.
-    fn absorb_subtypes<C: TypeContext>(members: &[NormalTy], ctx: &C) -> Vec<NormalTy> {
+    ///
+    /// Pairs involving an **open** member — one with a free `RecVar`, which this
+    /// bottom-up pass encounters when running *inside* a μ-body — are skipped: an
+    /// open term must never reach the subtype checker or a [`TypeContext`]
+    /// callback (its recursion variables are bound by a binder we cannot see
+    /// here). Closed members, μ-containing or not, participate normally.
+    /// Deferring is conservative (a union keeps a member another semantically
+    /// covers) — the μ-canonicalization automaton re-runs absorption over closed
+    /// per-state read-backs and completes it.
+    fn absorb_subtypes<C: TypeContext>(
+        members: &[NormalTy],
+        ctx: &C,
+        saw_mu: bool,
+    ) -> Vec<NormalTy> {
         let n = members.len();
+        // Only computed when a μ exists somewhere in the term (rare) — the hot
+        // path pays one branch.
+        let open: Vec<bool> = if saw_mu {
+            members.iter().map(|m| m.has_free_rec_var(0)).collect()
+        } else {
+            vec![false; n]
+        };
         let mut keep = vec![true; n];
         for i in 0..n {
-            if members[i].is_sentinel() {
+            if members[i].is_sentinel() || open[i] {
                 continue;
             }
             for j in 0..n {
-                if i == j || !keep[j] || members[j].is_sentinel() {
+                if i == j || !keep[j] || members[j].is_sentinel() || open[j] {
                     continue;
                 }
                 if !members[i].is_subtype_of(&members[j], ctx, &mut HashSet::new()) {
@@ -1699,39 +2004,124 @@ impl NormalTy {
 }
 
 // ═══════════════════════════════════════════════════════════════════════════
-// SUBSTITUTION (μ-unfolding) & FUNCTION PARAMETERS
+// μ-UNFOLDING & FUNCTION PARAMETERS
 // ═══════════════════════════════════════════════════════════════════════════
 
 impl NormalTy {
-    /// Substitute recursion variable `var` with `replacement` (one μ-unfold step).
-    fn substitute(&self, var: &QualifiedTypeName, replacement: &NormalTy) -> NormalTy {
+    /// One unfold step of a closed canonical μ: `μX.body ↦ body[μX.body/X]`,
+    /// i.e. every `RecVar` bound by *this* binder is replaced with the whole μ-term.
+    ///
+    /// Because `self` is closed (the public canonical-form invariant), the
+    /// replacement is closed too, so grafting it under deeper binders can neither
+    /// capture nor be captured — no de Bruijn shifting is needed, and the result
+    /// is again closed with a unique (α-canonical) representation, keeping the
+    /// derived-`==` probes of the co-inductive assumption set exact.
+    fn unfold(&self) -> NormalTy {
+        let NormalTy::Mu { body, .. } = self else {
+            unreachable!("unfold on a non-μ canonical form");
+        };
+        debug_assert!(
+            self.is_closed(),
+            "unfold on an open term violates the closed-term invariant"
+        );
+        body.replace_rec_var(0, self)
+    }
+
+    /// Whether every `RecVar` is bound by an enclosing μ-binder (debug-assert
+    /// support for the closed-term invariant).
+    fn is_closed(&self) -> bool {
+        !self.has_free_rec_var(0)
+    }
+
+    /// Whether a `RecVar` with index ≥ `depth` (i.e. free relative to `depth`
+    /// enclosing binders) occurs in this term.
+    fn has_free_rec_var(&self, depth: u32) -> bool {
         match self {
-            NormalTy::RecVar(v) if v == var => replacement.clone(),
+            NormalTy::RecVar(i) => *i >= depth,
+            NormalTy::Mu { body, .. } => body.has_free_rec_var(depth + 1),
+            NormalTy::List(inner) => inner.has_free_rec_var(depth),
+            NormalTy::Map { key, value } | NormalTy::Future(key, value) => {
+                key.has_free_rec_var(depth) || value.has_free_rec_var(depth)
+            }
+            NormalTy::Union(members) => members.iter().any(|m| m.has_free_rec_var(depth)),
+            NormalTy::Class(_, args) => args.iter().any(|a| a.has_free_rec_var(depth)),
+            NormalTy::Interface(_, args, bindings) => {
+                args.iter().any(|a| a.has_free_rec_var(depth))
+                    || bindings.iter().any(|(_, t)| t.has_free_rec_var(depth))
+            }
+            NormalTy::Function {
+                params,
+                ret,
+                throws,
+            } => {
+                params.iter().any(|p| p.ty.has_free_rec_var(depth))
+                    || ret.has_free_rec_var(depth)
+                    || throws.has_free_rec_var(depth)
+            }
+            NormalTy::AssociatedTypeProjection {
+                base, interface, ..
+            } => base.has_free_rec_var(depth) || interface.has_free_rec_var(depth),
+            NormalTy::Int
+            | NormalTy::Bigint
+            | NormalTy::Float
+            | NormalTy::String
+            | NormalTy::Bool
+            | NormalTy::Null
+            | NormalTy::Uint8Array
+            | NormalTy::Media(_)
+            | NormalTy::Void
+            | NormalTy::RustType
+            | NormalTy::Type
+            | NormalTy::Resource
+            | NormalTy::PromptAst
+            | NormalTy::Literal(_)
+            | NormalTy::Enum(_)
+            | NormalTy::EnumVariant(_, _)
+            | NormalTy::TypeVar(_)
+            | NormalTy::OpaqueAlias(_)
+            | NormalTy::Never
+            | NormalTy::BuiltinUnknown
+            | NormalTy::Unknown
+            | NormalTy::Error => false,
+        }
+    }
+
+    /// Replace every `RecVar` bound by the binder `depth` levels out with
+    /// `replacement` (which must be closed — see [`Self::unfold`]).
+    fn replace_rec_var(&self, depth: u32, replacement: &NormalTy) -> NormalTy {
+        match self {
+            NormalTy::RecVar(i) if *i == depth => replacement.clone(),
+            NormalTy::Mu { binder, body } => NormalTy::Mu {
+                binder: binder.clone(),
+                body: Box::new(body.replace_rec_var(depth + 1, replacement)),
+            },
             NormalTy::Class(qn, args) => NormalTy::Class(
                 qn.clone(),
                 args.iter()
-                    .map(|a| a.substitute(var, replacement))
+                    .map(|a| a.replace_rec_var(depth, replacement))
                     .collect(),
             ),
             NormalTy::Interface(qn, args, bindings) => NormalTy::Interface(
                 qn.clone(),
                 args.iter()
-                    .map(|a| a.substitute(var, replacement))
+                    .map(|a| a.replace_rec_var(depth, replacement))
                     .collect(),
                 bindings
                     .iter()
-                    .map(|(n, t)| (n.clone(), t.substitute(var, replacement)))
+                    .map(|(n, t)| (n.clone(), t.replace_rec_var(depth, replacement)))
                     .collect(),
             ),
-            NormalTy::List(inner) => NormalTy::List(Box::new(inner.substitute(var, replacement))),
+            NormalTy::List(inner) => {
+                NormalTy::List(Box::new(inner.replace_rec_var(depth, replacement)))
+            }
             NormalTy::Map { key, value } => NormalTy::Map {
-                key: Box::new(key.substitute(var, replacement)),
-                value: Box::new(value.substitute(var, replacement)),
+                key: Box::new(key.replace_rec_var(depth, replacement)),
+                value: Box::new(value.replace_rec_var(depth, replacement)),
             },
             NormalTy::Union(members) => NormalTy::Union(
                 members
                     .iter()
-                    .map(|m| m.substitute(var, replacement))
+                    .map(|m| m.replace_rec_var(depth, replacement))
                     .collect(),
             ),
             NormalTy::Function {
@@ -1743,41 +2133,39 @@ impl NormalTy {
                     .iter()
                     .map(|p| NormalParam {
                         name: p.name.clone(),
-                        ty: p.ty.substitute(var, replacement),
+                        ty: p.ty.replace_rec_var(depth, replacement),
                         mode: p.mode,
                     })
                     .collect(),
-                ret: Box::new(ret.substitute(var, replacement)),
-                throws: Box::new(throws.substitute(var, replacement)),
+                ret: Box::new(ret.replace_rec_var(depth, replacement)),
+                throws: Box::new(throws.replace_rec_var(depth, replacement)),
             },
             NormalTy::Future(value, error) => NormalTy::Future(
-                Box::new(value.substitute(var, replacement)),
-                Box::new(error.substitute(var, replacement)),
+                Box::new(value.replace_rec_var(depth, replacement)),
+                Box::new(error.replace_rec_var(depth, replacement)),
             ),
             NormalTy::AssociatedTypeProjection {
                 base,
                 interface,
                 member,
             } => NormalTy::AssociatedTypeProjection {
-                base: Box::new(base.substitute(var, replacement)),
-                interface: Box::new(interface.substitute(var, replacement)),
+                base: Box::new(base.replace_rec_var(depth, replacement)),
+                interface: Box::new(interface.replace_rec_var(depth, replacement)),
                 member: member.clone(),
             },
-            // A nested μ binding the same name shadows it; do not substitute inside.
-            NormalTy::Mu { var: v, body } if v != var => NormalTy::Mu {
-                var: v.clone(),
-                body: Box::new(body.substitute(var, replacement)),
-            },
+            // Leaves and non-matching indices are untouched.
             _ => self.clone(),
         }
     }
 }
 
-impl NormalParam {
+impl<P: MuPhase> NormalParam<P> {
     fn is_required(&self) -> bool {
         matches!(self.mode, FunctionParamMode::Required)
     }
+}
 
+impl NormalParam {
     /// Function parameter-list subtyping (contravariant): required params
     /// positional and matched in order, optional params matched by name.
     fn list_subtype<C: TypeContext>(

--- a/baml_language/crates/baml_type/src/normalize.rs
+++ b/baml_language/crates/baml_type/src/normalize.rs
@@ -777,6 +777,17 @@ impl NormalTy {
             // compared by equality) except union decomposition into
             // constructor-headed, non-union members — so the recursion is
             // bounded by two unfolds plus one member decomposition per side.
+            //
+            // The read-back bail (`canonicalize_mu` falling back to the
+            // pre-automaton term) is the one path that hands this method a μ
+            // with an unguarded spine; unfolding such a μ re-injects it into
+            // its own union spine without ever crossing a constructor. Nothing
+            // is provable about it here — answer "not provably disjoint".
+            (NormalTy::Mu { .. }, _) | (_, NormalTy::Mu { .. })
+                if self.has_unguarded_mu() || other.has_unguarded_mu() =>
+            {
+                false
+            }
             (NormalTy::Mu { .. }, _) => self.unfold().is_disjoint_from(other),
             (_, NormalTy::Mu { .. }) => self.is_disjoint_from(&other.unfold()),
 

--- a/baml_language/crates/baml_type/src/normalize.rs
+++ b/baml_language/crates/baml_type/src/normalize.rs
@@ -101,7 +101,7 @@ pub trait TypeContext {
     fn implements_interface(&self, concrete: &Ty, interface: &Interface) -> bool;
 
     /// The declared bound of type variable `name` (an interface or a union of
-    /// interfaces), or `None` if it is unbounded or unknown.
+    /// interfaces); empty if it is unbounded or unknown.
     ///
     /// Powers `T <: I` (and the `T | I == I` absorption) when `T`'s bound
     /// is — or transitively requires — `I`.
@@ -190,8 +190,26 @@ pub trait TypeContext {
     /// Two types are [`Self::equivalent`] iff their canonical forms are structurally
     /// equal. The canonical form applies the full set-theoretic algebra (union
     /// flatten/sort/dedup, `never` removal, `unknown` absorption, literal-into-base
-    /// and enum-completeness collapse, interface absorption, alias expansion) so
-    /// that distinct spellings of the same type converge.
+    /// and enum-completeness collapse, interface absorption, alias expansion, and
+    /// μ-canonicalization of recursive aliases) so that distinct spellings of the
+    /// same type converge.
+    ///
+    /// # Recursion renders via alias names
+    ///
+    /// Surface syntax has no μ-binder, so recursion is spelled with alias names:
+    /// a recursive alias at the *root* is unfolded once (exposing its head
+    /// constructor — impl-subject classification, dispatch-target resolution,
+    /// and pattern-matrix specialization rely on it), while *nested* recursion
+    /// stays folded as an alias name (`json[]` renders as `baml.json.json[]`,
+    /// not the unfolding). The output is idempotent
+    /// (`normalize(normalize(t)) == normalize(t)`) and always
+    /// [`Self::equivalent`] to the input, but it is canonical only **up to the
+    /// naming of recursion back-references**: names are recorded per run, so two
+    /// equivalent spellings may render with different alias names
+    /// (`normalize(A) = int | A[]` vs `normalize(B) = int | B[]` for
+    /// α-equivalent `A`/`B`). Canonical *identity* is the
+    /// [`Self::equivalent`] judgment, never syntactic equality of rendered
+    /// output.
     ///
     /// # Attributes are erased
     ///
@@ -208,14 +226,27 @@ pub trait TypeContext {
     where
         Self: Sized,
     {
-        NormalTy::canonical(ty, self).into_ty()
+        NormalTy::canonical_render(ty, self)
     }
 
-    /// Whether `a` and `b` denote the same type under the current context.
+    /// Whether `a` and `b` denote the same type under the current context —
+    /// mutual subtyping, decided as structural equality of canonical forms
+    /// (which coincide: canonical forms are unique representatives of the
+    /// equirecursive equivalence class).
     ///
     /// This is invariant equality, not assignability: use it where two spellings
     /// must denote *the same* type (e.g. exact-type operator operands, interface
     /// field implementations), not merely compatible ones.
+    ///
+    /// Recursive aliases are **equirecursive** (TYPE_SYSTEM.md §Type Aliases and
+    /// Recursive Types): equality holds across alias renaming
+    /// (`type A = int | A[]` ≡ `type B = int | B[]`), finite unfolding depth,
+    /// and mutually recursive definitions. The residual divergences from mutual
+    /// subtyping are deliberate: the error-recovery sentinels (`Unknown`/`Error`
+    /// are bidirectionally *compatible* with everything but equivalent only to
+    /// themselves), and fact sets with a mutual `requires` cycle (mutual
+    /// subtypes as existentials, nominally distinct — rejected in well-formed
+    /// programs by the interface `requires`-cycle check).
     fn equivalent(&self, a: &Ty, b: &Ty) -> bool
     where
         Self: Sized,
@@ -488,12 +519,96 @@ pub fn definitely_equal<C: TypeContext>(a: &Ty, b: &Ty, ctx: &C) -> bool {
 impl NormalTy {
     /// Normalize and canonicalize a [`Ty`] in one step (the shared entry point):
     /// build the named intermediate, strictly resolve its binders to the
-    /// canonical de Bruijn phase, then run the set-theoretic algebra.
+    /// canonical de Bruijn phase, run the bottom-up set-theoretic algebra, and —
+    /// only when recursion is present — the μ-canonicalization automaton
+    /// ([`mu`]), which makes the result a unique representative of the
+    /// equirecursive equivalence class.
     fn canonical<C: TypeContext>(ty: &Ty, ctx: &C) -> NormalTy {
+        let (t, saw_mu) = Self::canonical_bottom_up(ty, ctx);
+        if saw_mu && t.contains_mu() {
+            mu::canonicalize_mu(t, ctx)
+        } else {
+            t
+        }
+    }
+
+    /// [`Self::canonical`] rendered back as a [`Ty`] — the body of
+    /// [`TypeContext::normalize`]. On the μ path the automaton renders the root
+    /// directly (root-unfold-once: a recursive alias exposes its head
+    /// constructor; nested recursion stays folded as alias names), so `normalize`
+    /// never calls [`Self::into_ty`] on a μ root.
+    fn canonical_render<C: TypeContext>(ty: &Ty, ctx: &C) -> Ty {
+        let (t, saw_mu) = Self::canonical_bottom_up(ty, ctx);
+        if saw_mu && t.contains_mu() {
+            mu::canonicalize_mu_with_render(t, ctx).1
+        } else {
+            t.into_ty()
+        }
+    }
+
+    /// The shared pre-automaton pipeline: named intermediate → strict binder
+    /// resolution → bottom-up algebra (with open-member absorption deferred).
+    fn canonical_bottom_up<C: TypeContext>(ty: &Ty, ctx: &C) -> (NormalTy, bool) {
         let named = NormalTy::from_ty(ty, ctx, &mut HashSet::new(), PROJECTION_REDUCTION_FUEL);
         let mut saw_mu = false;
         let resolved = named.resolve_binders(&mut Vec::new(), &mut saw_mu);
-        resolved.canonicalize(ctx, saw_mu)
+        (resolved.canonicalize(ctx, saw_mu), saw_mu)
+    }
+
+    /// Whether a μ-binder survives in this term — the automaton trigger. Checked
+    /// only when [`Self::resolve_binders`] saw one (bottom-up absorption can
+    /// still eliminate a closed μ member, e.g. under `unknown`), so the
+    /// recursion-free hot path never runs this walk.
+    fn contains_mu(&self) -> bool {
+        match self {
+            NormalTy::Mu { .. } => true,
+            // A free `RecVar` cannot occur without its binder in a closed term.
+            NormalTy::RecVar(_) => false,
+            NormalTy::List(inner) => inner.contains_mu(),
+            NormalTy::Map { key, value } | NormalTy::Future(key, value) => {
+                key.contains_mu() || value.contains_mu()
+            }
+            NormalTy::Union(members) => members.iter().any(NormalTy::contains_mu),
+            NormalTy::Class(_, args) => args.iter().any(NormalTy::contains_mu),
+            NormalTy::Interface(_, args, bindings) => {
+                args.iter().any(NormalTy::contains_mu)
+                    || bindings.iter().any(|(_, t)| t.contains_mu())
+            }
+            NormalTy::Function {
+                params,
+                ret,
+                throws,
+            } => {
+                params.iter().any(|p| p.ty.contains_mu())
+                    || ret.contains_mu()
+                    || throws.contains_mu()
+            }
+            NormalTy::AssociatedTypeProjection {
+                base, interface, ..
+            } => base.contains_mu() || interface.contains_mu(),
+            NormalTy::Int
+            | NormalTy::Bigint
+            | NormalTy::Float
+            | NormalTy::String
+            | NormalTy::Bool
+            | NormalTy::Null
+            | NormalTy::Uint8Array
+            | NormalTy::Media(_)
+            | NormalTy::Void
+            | NormalTy::RustType
+            | NormalTy::Type
+            | NormalTy::Resource
+            | NormalTy::PromptAst
+            | NormalTy::Literal(_)
+            | NormalTy::Enum(_)
+            | NormalTy::EnumVariant(_, _)
+            | NormalTy::TypeVar(_)
+            | NormalTy::OpaqueAlias(_)
+            | NormalTy::Never
+            | NormalTy::BuiltinUnknown
+            | NormalTy::Unknown
+            | NormalTy::Error => false,
+        }
     }
 }
 
@@ -634,20 +749,37 @@ impl NormalTy {
     /// Whether `self` and `other`, used as invariant generic arguments, make
     /// their instantiations disjoint: both are fully ground and not the same
     /// realized type. A hole leaves it unprovable (it could realize to match).
+    ///
+    /// Structural `!=` proves distinctness only on **canonical** forms, and the
+    /// μ-unfolding arms of [`Self::is_disjoint_from`] hand this method
+    /// *unfolded* (non-canonical) spellings — `μX.(int | X[])` next to
+    /// `int | (μX.(int | X[]))[]` are one type — so a μ anywhere in either
+    /// argument leaves disjointness unprovable here. (Same-category μ pairs
+    /// still resolve through the nominal-head and category arms, which
+    /// unfolding preserves.)
     fn arg_forces_disjoint(&self, other: &NormalTy) -> bool {
-        self.is_ground() && other.is_ground() && self != other
+        self.is_ground()
+            && other.is_ground()
+            && self != other
+            && !self.contains_mu()
+            && !other.contains_mu()
     }
 
     /// Whether no value of `self` can ever be `==`-equal to a value of `other`
     /// (the structural core of [`definitely_disjoint`]).
-    ///
-    /// A μ head is handled by [`Self::head_category`]'s μ-transparency in the
-    /// category fallback below; there is deliberately no unfolding arm here —
-    /// `is_disjoint_from` carries no co-inductive assumption set, so unfolding a
-    /// not-yet-ε-closed unguarded μ (`type A = A | A[]`, legal today) would not
-    /// terminate. Same-category μ pairs conservatively answer `false`.
     fn is_disjoint_from(&self, other: &NormalTy) -> bool {
         match (self, other) {
+            // A μ is its unfolding — expose the constructor head before the
+            // structural arms. Terminates without an assumption set because
+            // canonical μ bodies are constructor-headed (the automaton's
+            // ε-closure eliminated unguarded spines): after both sides are
+            // unfolded, every arm below is terminal (categories; invariant args
+            // compared by equality) except union decomposition into
+            // constructor-headed, non-union members — so the recursion is
+            // bounded by two unfolds plus one member decomposition per side.
+            (NormalTy::Mu { .. }, _) => self.unfold().is_disjoint_from(other),
+            (_, NormalTy::Mu { .. }) => self.is_disjoint_from(&other.unfold()),
+
             // A union is disjoint from `rhs` iff every member is.
             (NormalTy::Union(members), rhs) => members.iter().all(|m| m.is_disjoint_from(rhs)),
             (lhs, NormalTy::Union(members)) => members.iter().all(|m| lhs.is_disjoint_from(m)),
@@ -869,11 +1001,24 @@ struct NormalParam<P: MuPhase = Canonical> {
     mode: FunctionParamMode,
 }
 
-/// Display payload of a canonical μ-binder ([`NormalTy::Mu`] at
-/// [`Canonical`]): the alias name whose expansion introduced the binder, used by
-/// [`NormalTy::into_ty`] to spell back-references (surface syntax has no binder,
-/// so recursion renders via alias names). The μ-canonicalization automaton will
-/// replace this with the precomputed named-cut rendering of the whole μ-subterm.
+/// Display payload of a canonical μ-binder ([`NormalTy::Mu`] at [`Canonical`]).
+///
+/// `rendered` is the whole μ-subterm as a [`Ty`] — surface syntax has no binder,
+/// so recursion is spelled via alias names — and is what [`NormalTy::into_ty`]
+/// emits for the binder (it never descends into the body). Two producers:
+///
+/// - [`NormalTy::resolve_binders`] fills the **legacy** rendering (the body with
+///   back-references spelled as alias names — the historical `normalize` output),
+///   which pre-μ-canonicalization fact-oracle calls observe during bottom-up
+///   absorption of closed μ members.
+/// - The μ-canonicalization automaton ([`super::normalize::mu`]) replaces it with
+///   the **named-cut** rendering (recursion folded to alias names at every named
+///   cycle state), the canonical output form.
+///
+/// `name` is the alias whose expansion introduced the binder — `None` only for
+/// automaton read-back binders that land on a cycle state no alias denotes (e.g.
+/// the list state of `A[]` for `type A = int | A[]`); such a binder is exactly
+/// why `rendered` must be precomputed (no single alias name can spell it).
 ///
 /// **Equality-transparent by design**: all values compare equal, order equal, and
 /// hash identically, so the derived `PartialEq`/`Ord`/`Hash` on [`NormalTy`] see
@@ -882,7 +1027,10 @@ struct NormalParam<P: MuPhase = Canonical> {
 /// This is the same discipline as spans ignored by AST equality: a description of
 /// the value, not part of it.
 #[derive(Debug, Clone)]
-struct MuDisplay(QualifiedTypeName);
+struct MuDisplay {
+    name: Option<QualifiedTypeName>,
+    rendered: Box<Ty>,
+}
 
 impl PartialEq for MuDisplay {
     fn eq(&self, _other: &Self) -> bool {
@@ -1126,6 +1274,111 @@ impl NormalTy<Named> {
         }
     }
 
+    /// Render a named-phase term as a [`Ty`], with every binder dropped and every
+    /// back-reference spelled as its alias name — the historical `normalize`
+    /// output shape. This fills the *interim* [`MuDisplay::rendered`] payload in
+    /// [`Self::resolve_binders`]: it is what fact-oracle calls
+    /// (`implements_interface`, `interface_requires`) observe when bottom-up
+    /// absorption compares a closed μ member, keeping their view identical to the
+    /// pre-μ-canonicalization behavior. The automaton replaces it with the
+    /// canonical named-cut rendering.
+    fn legacy_render(&self) -> Ty {
+        let attr = TyAttr::default();
+        match self {
+            NormalTy::Int => Ty::Int { attr },
+            NormalTy::Bigint => Ty::Bigint { attr },
+            NormalTy::Float => Ty::Float { attr },
+            NormalTy::String => Ty::String { attr },
+            NormalTy::Bool => Ty::Bool { attr },
+            NormalTy::Null => Ty::Null { attr },
+            NormalTy::Uint8Array => Ty::Uint8Array { attr },
+            NormalTy::Media(kind) => Ty::Media(*kind, attr),
+            NormalTy::Void => Ty::Void { attr },
+            NormalTy::RustType => Ty::RustType { attr },
+            NormalTy::Type => Ty::Type { attr },
+            NormalTy::Resource => Ty::Resource { attr },
+            NormalTy::PromptAst => Ty::PromptAst { attr },
+            NormalTy::BuiltinUnknown => Ty::BuiltinUnknown { attr },
+            NormalTy::Never => Ty::Never { attr },
+            NormalTy::Unknown => Ty::Unknown { attr },
+            NormalTy::Error => Ty::Error { attr },
+            NormalTy::Literal(lit) => Ty::Literal(lit.clone(), crate::Freshness::Regular, attr),
+            NormalTy::Class(qn, args) => Ty::Class(
+                qn.clone(),
+                args.iter().map(NormalTy::legacy_render).collect(),
+                attr,
+            ),
+            NormalTy::Interface(qn, args, bindings) => Ty::Interface(
+                qn.clone(),
+                args.iter().map(NormalTy::legacy_render).collect(),
+                bindings
+                    .iter()
+                    .map(|(name, ty)| (name.clone(), ty.legacy_render()))
+                    .collect(),
+                attr,
+            ),
+            NormalTy::Enum(qn) => Ty::Enum(qn.clone(), attr),
+            NormalTy::EnumVariant(qn, v) => Ty::EnumVariant(qn.clone(), v.clone(), attr),
+            NormalTy::List(inner) => Ty::List(Box::new(inner.legacy_render()), attr),
+            NormalTy::Map { key, value } => Ty::Map {
+                key: Box::new(key.legacy_render()),
+                value: Box::new(value.legacy_render()),
+                attr,
+            },
+            NormalTy::Union(members) => {
+                Ty::Union(members.iter().map(NormalTy::legacy_render).collect(), attr)
+            }
+            NormalTy::Function {
+                params,
+                ret,
+                throws,
+            } => Ty::Function {
+                params: params
+                    .iter()
+                    .map(|p| FunctionParamTy {
+                        name: p.name.clone(),
+                        ty: p.ty.legacy_render(),
+                        mode: p.mode,
+                    })
+                    .collect(),
+                ret: Box::new(ret.legacy_render()),
+                throws: Box::new(throws.legacy_render()),
+                attr,
+            },
+            NormalTy::Future(value, error) => Ty::Future(
+                Box::new(value.legacy_render()),
+                Box::new(error.legacy_render()),
+                attr,
+            ),
+            NormalTy::AssociatedTypeProjection {
+                base,
+                interface,
+                member,
+            } => Ty::AssociatedTypeProjection {
+                base: Box::new(base.legacy_render()),
+                interface: Box::new(match &**interface {
+                    NormalTy::Interface(name, generics, bindings) => Interface {
+                        name: name.clone(),
+                        generics: generics.iter().map(NormalTy::legacy_render).collect(),
+                        associated_types: bindings
+                            .iter()
+                            .map(|(name, ty)| (name.clone(), ty.legacy_render()))
+                            .collect(),
+                    },
+                    _ => unreachable!("projection qualifier is an interface"),
+                }),
+                member: member.clone(),
+                attr,
+            },
+            NormalTy::TypeVar(name) => Ty::TypeVar(name.clone(), attr),
+            // The binder has no surface syntax (its body renders in place); a
+            // back-reference is spelled as its alias name — which in the named
+            // phase the variable itself carries.
+            NormalTy::Mu { body, .. } => body.legacy_render(),
+            NormalTy::RecVar(qn) | NormalTy::OpaqueAlias(qn) => Ty::TypeAlias(qn.clone(), attr),
+        }
+    }
+
     // ── phase conversion: NormalTy<Named> → NormalTy ────────────
 
     /// Strictly convert the `from_ty` intermediate to the canonical de Bruijn
@@ -1154,7 +1407,10 @@ impl NormalTy<Named> {
                     "from_ty emitted a vacuous μ-binder"
                 );
                 *saw_mu = true;
-                let display = MuDisplay(binder.clone());
+                let display = MuDisplay {
+                    name: Some(binder.clone()),
+                    rendered: Box::new(body.legacy_render()),
+                };
                 stack.push(binder);
                 let body = body.resolve_binders(stack, saw_mu);
                 stack.pop();
@@ -1337,9 +1593,12 @@ impl NormalTy {
                     throws: Box::new(throws.canonicalize(ctx, saw_mu)),
                 }
             }
-            // A binder stays put: `resolve_binders` guarantees it is genuinely
-            // recursive, and the μ-guard in `absorb_subtypes` means no algebra
-            // step below can remove its back-references.
+            // A binder stays put here even if an algebra step strands it —
+            // `unknown`-absorption can swallow a whole union including its
+            // back-references, leaving a μ over a body that no longer mentions
+            // it. That is harmless: the automaton's read-back emits binders only
+            // for states that are actually back-referenced, so a vacuous binder
+            // self-heals downstream.
             NormalTy::Mu { binder, body } => NormalTy::Mu {
                 binder,
                 body: Box::new(body.canonicalize(ctx, saw_mu)),
@@ -1697,15 +1956,12 @@ impl NormalTy {
 
     // ── conversion out: NormalTy → Ty ───────────────────────────
 
-    /// Render a **closed** canonical form back as a [`Ty`]. Surface syntax has
-    /// no μ-binder, so recursion is spelled via alias names: each binder's
-    /// [`MuDisplay`] name is pushed while rendering its body, and a
-    /// back-reference renders as `Ty::TypeAlias` of its binder's name.
+    /// Render a **closed** canonical form back as a [`Ty`]. Surface syntax has no
+    /// μ-binder, so a μ-subterm renders as its precomputed [`MuDisplay`] payload
+    /// (recursion spelled via alias names) — this never descends into a μ body,
+    /// which is why a `RecVar` (always under its binder in a closed term) is
+    /// unreachable here.
     fn into_ty(self) -> Ty {
-        self.into_ty_with(&mut Vec::new())
-    }
-
-    fn into_ty_with(self, binders: &mut Vec<QualifiedTypeName>) -> Ty {
         let attr = TyAttr::default();
         match self {
             NormalTy::Int => Ty::Int { attr },
@@ -1726,25 +1982,25 @@ impl NormalTy {
             NormalTy::Unknown => Ty::Unknown { attr },
             NormalTy::Error => Ty::Error { attr },
             NormalTy::Literal(lit) => Ty::Literal(lit, crate::Freshness::Regular, attr),
-            NormalTy::Class(qn, args) => Ty::Class(qn, Self::into_tys_with(args, binders), attr),
+            NormalTy::Class(qn, args) => Ty::Class(qn, Self::into_tys(args), attr),
             NormalTy::Interface(qn, args, bindings) => Ty::Interface(
                 qn,
-                Self::into_tys_with(args, binders),
+                Self::into_tys(args),
                 bindings
                     .into_iter()
-                    .map(|(name, ty)| (name, ty.into_ty_with(binders)))
+                    .map(|(name, ty)| (name, ty.into_ty()))
                     .collect(),
                 attr,
             ),
             NormalTy::Enum(qn) => Ty::Enum(qn, attr),
             NormalTy::EnumVariant(qn, v) => Ty::EnumVariant(qn, v, attr),
-            NormalTy::List(inner) => Ty::List(Box::new(inner.into_ty_with(binders)), attr),
+            NormalTy::List(inner) => Ty::List(Box::new(inner.into_ty()), attr),
             NormalTy::Map { key, value } => Ty::Map {
-                key: Box::new(key.into_ty_with(binders)),
-                value: Box::new(value.into_ty_with(binders)),
+                key: Box::new(key.into_ty()),
+                value: Box::new(value.into_ty()),
                 attr,
             },
-            NormalTy::Union(members) => Ty::Union(Self::into_tys_with(members, binders), attr),
+            NormalTy::Union(members) => Ty::Union(Self::into_tys(members), attr),
             NormalTy::Function {
                 params,
                 ret,
@@ -1754,67 +2010,55 @@ impl NormalTy {
                     .into_iter()
                     .map(|p| FunctionParamTy {
                         name: p.name,
-                        ty: p.ty.into_ty_with(binders),
+                        ty: p.ty.into_ty(),
                         mode: p.mode,
                     })
                     .collect(),
-                ret: Box::new(ret.into_ty_with(binders)),
-                throws: Box::new(throws.into_ty_with(binders)),
+                ret: Box::new(ret.into_ty()),
+                throws: Box::new(throws.into_ty()),
                 attr,
             },
-            NormalTy::Future(value, error) => Ty::Future(
-                Box::new(value.into_ty_with(binders)),
-                Box::new(error.into_ty_with(binders)),
-                attr,
-            ),
+            NormalTy::Future(value, error) => {
+                Ty::Future(Box::new(value.into_ty()), Box::new(error.into_ty()), attr)
+            }
             NormalTy::AssociatedTypeProjection {
                 base,
                 interface,
                 member,
             } => Ty::AssociatedTypeProjection {
-                base: Box::new(base.into_ty_with(binders)),
+                base: Box::new(base.into_ty()),
                 // The projection's qualifier is always a normalized interface, so
-                // it round-trips back to an `Interface` here. The binder stack
-                // threads through: a qualifier argument may legally capture an
-                // enclosing recursion variable (`type A = (C as I<A>).X | A[]`
-                // passes the per-SCC cycle check).
+                // it round-trips back to an `Interface` here. (A qualifier
+                // argument capturing an enclosing recursion variable is fine: the
+                // enclosing μ renders as its display, so this arm only ever sees
+                // qualifiers whose free variables were closed off above.)
                 interface: Box::new(
                     interface
-                        .into_interface_with(binders)
+                        .into_interface()
                         .unwrap_or_else(|| unreachable!("projection qualifier is an interface")),
                 ),
                 member,
                 attr,
             },
             NormalTy::TypeVar(name) => Ty::TypeVar(name, attr),
-            // μ-binders and recursion variables round-trip through the alias
-            // name: the binder itself has no surface syntax (its body renders in
-            // place), and each back-reference renders as the alias name of the
-            // binder it refers to.
-            NormalTy::Mu { binder, body } => {
-                binders.push(binder.0);
-                let rendered = body.into_ty_with(binders);
-                binders.pop();
-                rendered
-            }
-            NormalTy::RecVar(index) => {
-                let Some(qn) = binders.iter().rev().nth(index as usize) else {
-                    unreachable!(
-                        "into_ty on a free RecVar; canonical forms at public \
-                         boundaries are closed, so every back-reference has its \
-                         binder on the render stack"
-                    )
-                };
-                Ty::TypeAlias(qn.clone(), attr)
-            }
+            // A μ-subterm renders as its precomputed display — the named-cut
+            // rendering from the canonicalization automaton (or the legacy
+            // rendering on the short-lived pre-automaton intermediate).
+            NormalTy::Mu { binder, .. } => *binder.rendered,
+            // Unreachable for closed terms: the μ arm above never descends into
+            // its body, so every `RecVar` stays behind its binder's display.
+            NormalTy::RecVar(_) => unreachable!(
+                "into_ty on a free RecVar; canonical forms at public boundaries \
+                 are closed and render recursion via their binder's display"
+            ),
             NormalTy::OpaqueAlias(qn) => Ty::TypeAlias(qn, attr),
         }
     }
 }
 
 impl NormalTy {
-    fn into_tys_with(tys: Vec<NormalTy>, binders: &mut Vec<QualifiedTypeName>) -> Vec<Ty> {
-        tys.into_iter().map(|t| t.into_ty_with(binders)).collect()
+    fn into_tys(tys: Vec<NormalTy>) -> Vec<Ty> {
+        tys.into_iter().map(NormalTy::into_ty).collect()
     }
 
     /// The [`Interface`] constraint denoted by a `NormalTy::Interface`'s parts —
@@ -1842,23 +2086,35 @@ impl NormalTy {
     /// Consume a normalized interface (`NormalTy::Interface`) and rebuild the
     /// [`Interface`] constraint; `None` for any other variant. Used to put the
     /// `as I` annotation of an associated-type projection back into a `Ty`.
+    ///
+    /// A μ-wrapped interface recovers the constraint from its **display**: when
+    /// a projection's qualifier mentions the enclosing recursive alias
+    /// (`type A = I<A> | (C as I<A>).M`), minimization merges the qualifier
+    /// state with the standalone `I<A>` member's, so the canonical qualifier is
+    /// `μX.I<…X…>`. Unfolding here would loop — each unfold re-injects the μ
+    /// into the argument that contains the projection, whose qualifier unfolds
+    /// again — but the display is a finite alias-based spelling of the whole
+    /// qualifier (`I<A>`), computed by the renderer, so its parts are read off
+    /// directly. A display that is not interface-shaped (an exotic cover
+    /// rendering) degrades to `None`, conservative.
     fn into_interface(self) -> Option<Interface> {
-        self.into_interface_with(&mut Vec::new())
-    }
-
-    /// [`Self::into_interface`] with the enclosing render binder stack, for the
-    /// projection arm of [`Self::into_ty_with`] (a qualifier argument may capture
-    /// an enclosing recursion variable).
-    fn into_interface_with(self, binders: &mut Vec<QualifiedTypeName>) -> Option<Interface> {
         match self {
             NormalTy::Interface(name, generics, bindings) => Some(Interface {
                 name,
-                generics: Self::into_tys_with(generics, binders),
+                generics: Self::into_tys(generics),
                 associated_types: bindings
                     .into_iter()
-                    .map(|(name, ty)| (name, ty.into_ty_with(binders)))
+                    .map(|(name, ty)| (name, ty.into_ty()))
                     .collect(),
             }),
+            NormalTy::Mu { binder, .. } => match *binder.rendered {
+                Ty::Interface(name, generics, associated_types, _) => Some(Interface {
+                    name,
+                    generics,
+                    associated_types,
+                }),
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -1904,6 +2160,7 @@ impl NormalTy {
         flat.dedup();
 
         Self::collapse_complete_enums(&mut flat, ctx);
+        Self::collapse_complete_bools(&mut flat);
         let mut flat = Self::absorb_subtypes(&flat, ctx, saw_mu);
 
         flat.sort();
@@ -1942,10 +2199,97 @@ impl NormalTy {
                     _ => None,
                 })
                 .collect();
-            if !all.is_empty() && all.iter().all(|v| present.contains(v)) {
+            // Requires at least two variants: collapsing a single-variant enum
+            // would split one value set into two canonical spellings (`E.A | E.A`
+            // as a union collapses while a bare `E.A` cannot), breaking
+            // idempotence. `E.A` ≡ `E` for a one-variant enum stays an
+            // (acknowledged) incompleteness instead.
+            if all.len() >= 2 && all.iter().all(|v| present.contains(v)) {
                 members.retain(|m| !matches!(m, NormalTy::EnumVariant(en, _) if *en == e));
                 members.push(NormalTy::Enum(e));
             }
+        }
+    }
+
+    /// Whether any μ-binder in this term is **non-contractive**: its body
+    /// reaches a back-reference to that same binder through union spines alone
+    /// (an unguarded member, e.g. the μ of `type A = A | A[]`). The coinductive
+    /// subtype checker is sound only on contractive operands — on an unguarded μ
+    /// the assumption probe can close a derivation without ever crossing a
+    /// constructor and prove `T <: μ` for arbitrary `T` — so such members must
+    /// not reach it until the automaton's ε-closure has resolved the spine.
+    fn has_unguarded_mu(&self) -> bool {
+        fn spine_has_rec(t: &NormalTy, depth: u32) -> bool {
+            match t {
+                NormalTy::RecVar(i) => *i == depth,
+                NormalTy::Union(members) => members.iter().any(|m| spine_has_rec(m, depth)),
+                NormalTy::Mu { body, .. } => spine_has_rec(body, depth + 1),
+                _ => false,
+            }
+        }
+        match self {
+            NormalTy::Mu { body, .. } => spine_has_rec(body, 0) || body.has_unguarded_mu(),
+            NormalTy::RecVar(_) => false,
+            NormalTy::List(inner) => inner.has_unguarded_mu(),
+            NormalTy::Map { key, value } | NormalTy::Future(key, value) => {
+                key.has_unguarded_mu() || value.has_unguarded_mu()
+            }
+            NormalTy::Union(members) => members.iter().any(NormalTy::has_unguarded_mu),
+            NormalTy::Class(_, args) => args.iter().any(NormalTy::has_unguarded_mu),
+            NormalTy::Interface(_, args, bindings) => {
+                args.iter().any(NormalTy::has_unguarded_mu)
+                    || bindings.iter().any(|(_, t)| t.has_unguarded_mu())
+            }
+            NormalTy::Function {
+                params,
+                ret,
+                throws,
+            } => {
+                params.iter().any(|p| p.ty.has_unguarded_mu())
+                    || ret.has_unguarded_mu()
+                    || throws.has_unguarded_mu()
+            }
+            NormalTy::AssociatedTypeProjection {
+                base, interface, ..
+            } => base.has_unguarded_mu() || interface.has_unguarded_mu(),
+            NormalTy::Int
+            | NormalTy::Bigint
+            | NormalTy::Float
+            | NormalTy::String
+            | NormalTy::Bool
+            | NormalTy::Null
+            | NormalTy::Uint8Array
+            | NormalTy::Media(_)
+            | NormalTy::Void
+            | NormalTy::RustType
+            | NormalTy::Type
+            | NormalTy::Resource
+            | NormalTy::PromptAst
+            | NormalTy::Literal(_)
+            | NormalTy::Enum(_)
+            | NormalTy::EnumVariant(_, _)
+            | NormalTy::TypeVar(_)
+            | NormalTy::OpaqueAlias(_)
+            | NormalTy::Never
+            | NormalTy::BuiltinUnknown
+            | NormalTy::Unknown
+            | NormalTy::Error => false,
+        }
+    }
+
+    /// Replace the complete pair of bool literals with `bool`
+    /// (`true | false == bool`, TYPE_SYSTEM.md §Subtyping Cases) — the bool
+    /// analogue of enum completeness, context-free because the variant family is
+    /// closed and its equality unoverridable.
+    fn collapse_complete_bools(members: &mut Vec<NormalTy>) {
+        let has = |members: &[NormalTy], b: bool| {
+            members
+                .iter()
+                .any(|m| matches!(m, NormalTy::Literal(Literal::Bool(x)) if *x == b))
+        };
+        if has(members, true) && has(members, false) {
+            members.retain(|m| !matches!(m, NormalTy::Literal(Literal::Bool(_))));
+            members.push(NormalTy::Bool);
         }
     }
 
@@ -1953,13 +2297,19 @@ impl NormalTy {
     /// literal-into-base, variant-into-enum, `C | I == I`, `A | B == B`, and
     /// `T | I == I`. Error-recovery sentinels never absorb or are absorbed.
     ///
-    /// Pairs involving an **open** member — one with a free `RecVar`, which this
-    /// bottom-up pass encounters when running *inside* a μ-body — are skipped: an
-    /// open term must never reach the subtype checker or a [`TypeContext`]
-    /// callback (its recursion variables are bound by a binder we cannot see
-    /// here). Closed members, μ-containing or not, participate normally.
-    /// Deferring is conservative (a union keeps a member another semantically
-    /// covers) — the μ-canonicalization automaton re-runs absorption over closed
+    /// Pairs involving a **deferred** member are skipped, for two reasons that
+    /// share one guard:
+    /// - an *open* member (a free `RecVar` — this bottom-up pass runs inside
+    ///   μ-bodies) must never reach the subtype checker or a [`TypeContext`]
+    ///   callback: its recursion variables are bound by a binder we cannot see;
+    /// - a member containing a *non-contractive* μ (an unguarded spine, e.g.
+    ///   `type A = A | A[]` before ε-closure) would let the coinductive
+    ///   assumption probe prove `T <: μ` for arbitrary `T` without crossing a
+    ///   constructor, silently absorbing real siblings.
+    ///
+    /// Closed, contractive members participate normally. Deferring is
+    /// conservative (a union keeps a member another semantically covers) — the
+    /// μ-canonicalization automaton re-runs absorption over closed, ε-closed
     /// per-state read-backs and completes it.
     fn absorb_subtypes<C: TypeContext>(
         members: &[NormalTy],
@@ -1970,7 +2320,10 @@ impl NormalTy {
         // Only computed when a μ exists somewhere in the term (rare) — the hot
         // path pays one branch.
         let open: Vec<bool> = if saw_mu {
-            members.iter().map(|m| m.has_free_rec_var(0)).collect()
+            members
+                .iter()
+                .map(|m| m.has_free_rec_var(0) || m.has_unguarded_mu())
+                .collect()
         } else {
             vec![false; n]
         };
@@ -2201,6 +2554,8 @@ impl NormalParam {
         true
     }
 }
+
+mod mu;
 
 #[cfg(test)]
 mod tests;

--- a/baml_language/crates/baml_type/src/normalize/mu.rs
+++ b/baml_language/crates/baml_type/src/normalize/mu.rs
@@ -830,6 +830,11 @@ fn local_key(auto: &Automaton<'_>, s: StateId) -> LocalKey {
 fn algebra_pass<C: TypeContext>(auto: &mut Automaton<'_>, root: StateId, ctx: &C) -> bool {
     let cyclic = cyclic_states(auto, root);
     let mut changed = false;
+    // Member read-backs are pure in the automaton and members recur across
+    // union states (a shared leaf sits in many unions), so memoize them while
+    // the automaton is unmutated: any node rewrite or redirect below clears
+    // the memo (a stale read-back would change absorption decisions).
+    let mut read_backs: BTreeMap<StateId, Option<NormalTy>> = BTreeMap::new();
     for s in auto.reachable(root) {
         let Node::Union(raw) = auto.node(s) else {
             continue;
@@ -846,7 +851,13 @@ fn algebra_pass<C: TypeContext>(auto: &mut Automaton<'_>, root: StateId, ctx: &C
         let materialized: Option<Vec<(NormalTy, StateId)>> = if absorb {
             members
                 .iter()
-                .map(|&m| read_back(auto, m).map(|t| (t, m)))
+                .map(|&m| {
+                    read_backs
+                        .entry(m)
+                        .or_insert_with(|| read_back(auto, m))
+                        .clone()
+                        .map(|t| (t, m))
+                })
                 .collect()
         } else {
             None
@@ -890,9 +901,13 @@ fn algebra_pass<C: TypeContext>(auto: &mut Automaton<'_>, root: StateId, ctx: &C
             members
         };
 
-        changed |= members != before;
+        let state_changed = members != before;
+        changed |= state_changed;
         match members.len() {
-            0 => auto.states[s].node = Node::Leaf(auto.never),
+            0 => {
+                auto.states[s].node = Node::Leaf(auto.never);
+                read_backs.clear();
+            }
             1 => {
                 let m = *members
                     .first()
@@ -902,9 +917,19 @@ fn algebra_pass<C: TypeContext>(auto: &mut Automaton<'_>, root: StateId, ctx: &C
                     // The redirect may point other unions' members at a union —
                     // force another closure/refinement round.
                     changed = true;
+                    read_backs.clear();
                 }
             }
-            _ => auto.states[s].node = Node::Union(members.into_iter().collect()),
+            _ => {
+                // The write normalizes the stored member Vec (resolved, sorted,
+                // deduped); with the member set unchanged that is
+                // read-back-invariant (read-back resolves and sorts members
+                // itself), so cached read-backs stay valid.
+                auto.states[s].node = Node::Union(members.into_iter().collect());
+                if state_changed {
+                    read_backs.clear();
+                }
+            }
         }
     }
     changed

--- a/baml_language/crates/baml_type/src/normalize/mu.rs
+++ b/baml_language/crates/baml_type/src/normalize/mu.rs
@@ -1,0 +1,1720 @@
+//! μ-canonicalization: the automaton stage that makes canonical forms unique
+//! representatives of the **equirecursive** equivalence class.
+//!
+//! A recursive type is a regular tree; a canonical `NormalTy` with μ-binders is
+//! one finite spelling of it, and different spellings of the same tree (alias
+//! renamings, partial unfoldings, mutually recursive definitions) differ
+//! structurally. This module quotients those differences away, as a typestate
+//! pipeline — each stage's invariant is carried by its type:
+//!
+//! [`Builder`] → [`Built`] → [`Closed`] → [`Minimal`] → read-back / render
+//!
+//! 1. **Build** ([`Builder::build`]) — intern the term as a term-graph
+//!    automaton: one state per node, a μ-binder is the knot (its state *is* its
+//!    body's state, carrying the alias name), a recursion variable is a
+//!    back-edge.
+//! 2. **ε-closure** ([`Built::epsilon_close`]) — a union member that is itself a
+//!    union state is an ε-edge; per ε-SCC, members become the
+//!    constructor-successors of the component. This is union flattening
+//!    generalized through recursion, and it implements the productivity ruling
+//!    for unguarded self-references: a member reachable only through ε-cycles
+//!    contributes nothing (`type A = A | A[]` ≡ `μX.X[]`), and a
+//!    constructor-free ε-component is uninhabited (`μX.X` ≡ `never`). After
+//!    this step every μ body is constructor-headed (contractive) — the
+//!    precondition of the assumption-set subtype algorithm.
+//! 3. **Minimization + per-state algebra** ([`Closed::minimize_and_absorb`]) —
+//!    Moore-style partition refinement merges bisimilar states (equal unravelled
+//!    trees — every spelling of one tree at any unfolding depth), interleaved to
+//!    a fixpoint with the union algebra per state: members *materialized as
+//!    closed read-backs* feed the real subtype checker (full context), so the
+//!    absorptions the bottom-up pass deferred for open members complete here,
+//!    and completeness collapses apply across merged members.
+//! 4. **Read-back / render** ([`Minimal::read_back`], [`Minimal::render_root`])
+//!    — a deterministic DFS emits the canonical μ-term: a back edge to an
+//!    on-path state becomes a de Bruijn `RecVar`, the revisited state is wrapped
+//!    in `Mu`, off-path revisits re-expand, union members sort by the canonical
+//!    `Ord`. Each emitted binder's [`MuDisplay`] carries the **named-cut**
+//!    rendering of its subterm (recursion folded to alias names at named cycle
+//!    states), computed here while the automaton — which knows the names — is
+//!    in scope.
+//!
+//! # Representation: borrow the input, compare by id
+//!
+//! The automaton borrows from the input term (lifetime `'a`) and interns every
+//! heavy payload — qualified type names, member names, leaf terms — into dense
+//! ids at build time ([`Interner`]). All downstream phases (ε-closure,
+//! refinement, absorption bookkeeping) are pure integer work; a string is
+//! compared only at its single intern probe, and owned values are cloned only at
+//! output emission. The id seam is also where a future runtime identity handle
+//! (a heap pointer standing for a class/interface/enum) slots in: only the
+//! intern boundary knows what a [`NameId`] refers to.
+//!
+//! # Determinism
+//!
+//! The result must be a function of the input term alone. Every collection whose
+//! iteration order can reach the output is a `Vec`, `BTreeSet`, or `BTreeMap` —
+//! never a hash map — state ids follow the input walk, and intern ids follow
+//! first encounter. Any hash-iteration order feeding the output is a bug.
+//!
+//! # Termination
+//!
+//! ε-closure and refinement are fixpoint passes over finitely many states. The
+//! canonicalization loop only merges states, removes union members, redirects to
+//! existing states, or rewrites a complete variant set to its enum (which
+//! nothing can reintroduce) — all monotone — so it reaches a fixpoint.
+//!
+//! # Names, covers, and the bail
+//!
+//! At build time every cycle passes through a named state: the only back-edges
+//! the named intermediate contains are alias re-encounters, so every
+//! cycle-closing edge targets a binder state carrying its alias name; redirects
+//! transfer names and merges union them. ε-splicing, however, can *bypass* the
+//! named state — splicing named `u_A` (`type A = int | (A | null)[]`) into the
+//! inner union leaves the surviving cycle nameless. The renderer therefore cuts
+//! cycles two ways: at named cyclic states (`Ty::TypeAlias`), and at **subset
+//! covers** — an unnamed cyclic union containing everything a named cyclic
+//! union holds renders as `name | extras`, which is exact by union semantics.
+//! Absorption is withheld from unnamed cyclic unions so covers survive
+//! ([`algebra_pass`]). A cycle neither names nor covers can cut has no finite
+//! alias-based `Ty` spelling at all; rather than hand a wrong display to a fact
+//! oracle, the renderer **bails** and the pipeline degrades to the sound
+//! pre-automaton form (see [`canonicalize_mu`]).
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+
+use super::{MuDisplay, NormalParam, NormalTy, TypeContext};
+use crate::{FunctionParamMode, Name, QualifiedTypeName, Ty, TyAttr};
+
+/// Canonicalize a term containing at least one μ-binder.
+///
+/// Falls back to the (already sound, bottom-up-canonicalized) input when the
+/// automaton's rendering bails — see [`Renderer`]: an exotic cycle that no
+/// alias name or subset cover can cut has no exact `Ty` spelling, and a wrong
+/// display must never reach a fact oracle. The fallback degrades only
+/// *completeness* (two such spellings may miss an equivalence), never
+/// soundness.
+pub(super) fn canonicalize_mu<C: TypeContext>(term: NormalTy, ctx: &C) -> NormalTy {
+    let out = Builder::default()
+        .build(&term)
+        .epsilon_close()
+        .minimize_and_absorb(ctx)
+        .read_back();
+    out.unwrap_or(term)
+}
+
+/// [`canonicalize_mu`] plus the root rendering for `normalize`: root-unfold-once
+/// (a recursive alias exposes its head constructor; nested recursion folds to
+/// alias names). The bail fallback renders the input term via its interim
+/// (legacy) displays — a correct, merely less-canonical spelling.
+pub(super) fn canonicalize_mu_with_render<C: TypeContext>(
+    term: NormalTy,
+    ctx: &C,
+) -> (NormalTy, Ty) {
+    let minimal = Builder::default()
+        .build(&term)
+        .epsilon_close()
+        .minimize_and_absorb(ctx);
+    if let (Some(t), Some(r)) = (minimal.read_back(), minimal.render_root()) {
+        return (t, r);
+    }
+    drop(minimal);
+    let rendered = term.clone().into_ty();
+    (term, rendered)
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// INTERNING
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// A qualified type name, interned. Downstream phases compare and store these
+/// as integers; the value is recovered only at output emission. (The seam for a
+/// future runtime identity handle: only the interner knows the referent.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct NameId(u32);
+
+/// A member/parameter/variant name, interned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct StrId(u32);
+
+/// A childless canonical leaf term, interned.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+struct LeafId(u32);
+
+/// First-encounter interning of borrowed values: one ordered probe per
+/// occurrence at build time buys integer comparison everywhere after.
+struct Interner<'a, T: ?Sized + Ord> {
+    ids: BTreeMap<&'a T, u32>,
+    values: Vec<&'a T>,
+}
+
+impl<'a, T: ?Sized + Ord> Default for Interner<'a, T> {
+    fn default() -> Self {
+        Self {
+            ids: BTreeMap::new(),
+            values: Vec::new(),
+        }
+    }
+}
+
+impl<'a, T: ?Sized + Ord> Interner<'a, T> {
+    fn intern(&mut self, value: &'a T) -> u32 {
+        if let Some(&id) = self.ids.get(value) {
+            return id;
+        }
+        let id = self.values.len() as u32;
+        self.ids.insert(value, id);
+        self.values.push(value);
+        id
+    }
+
+    fn get(&self, id: u32) -> &'a T {
+        self.values[id as usize]
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// AUTOMATON CORE
+// ═══════════════════════════════════════════════════════════════════════════
+
+type StateId = usize;
+
+/// One term-graph node. Children are state ids (resolve through
+/// [`Automaton::resolve`] before use); payloads are interned ids. `Leaf` holds
+/// the childless canonical variants *except* enums, which get their own
+/// id-based kinds so the enum-completeness collapse can synthesize an enum
+/// state without owning a term.
+enum Node {
+    Leaf(LeafId),
+    Enum(NameId),
+    EnumVariant(NameId, StrId),
+    Class(NameId, Vec<StateId>),
+    Interface(NameId, Vec<StateId>, Vec<(StrId, StateId)>),
+    List(StateId),
+    Map(StateId, StateId),
+    Future(StateId, StateId),
+    Union(Vec<StateId>),
+    Function {
+        params: Vec<(Option<StrId>, FunctionParamMode, StateId)>,
+        ret: StateId,
+        throws: StateId,
+    },
+    Projection {
+        base: StateId,
+        interface: StateId,
+        member: StrId,
+    },
+}
+
+struct State {
+    node: Node,
+    /// Alias names denoting this state (μ-binder origins; unioned on merge,
+    /// transferred on redirect). Ordered by id — ties in rendering are broken by
+    /// the *name* ordering below, not id order.
+    names: BTreeSet<NameId>,
+}
+
+const NEVER: NormalTy = NormalTy::Never;
+const UNKNOWN_TOP: NormalTy = NormalTy::BuiltinUnknown;
+const BOOL: NormalTy = NormalTy::Bool;
+const LIT_TRUE: NormalTy = NormalTy::Literal(crate::Literal::Bool(true));
+const LIT_FALSE: NormalTy = NormalTy::Literal(crate::Literal::Bool(false));
+
+struct Automaton<'a> {
+    states: Vec<State>,
+    /// Redirect chains from ε singleton collapses, minimization merges, and
+    /// binder knot-tying; [`Self::resolve`] follows them to the live state.
+    redirect: Vec<StateId>,
+    names: Interner<'a, QualifiedTypeName>,
+    strs: Interner<'a, Name>,
+    leaves: Interner<'a, NormalTy>,
+    /// Pre-interned specials, so the hot special-case probes are id compares.
+    never: LeafId,
+    unknown_top: LeafId,
+    bool_leaf: LeafId,
+    lit_true: LeafId,
+    lit_false: LeafId,
+}
+
+impl<'a> Automaton<'a> {
+    fn new() -> Self {
+        let mut leaves = Interner::default();
+        let never = LeafId(leaves.intern(&NEVER));
+        let unknown_top = LeafId(leaves.intern(&UNKNOWN_TOP));
+        let bool_leaf = LeafId(leaves.intern(&BOOL));
+        let lit_true = LeafId(leaves.intern(&LIT_TRUE));
+        let lit_false = LeafId(leaves.intern(&LIT_FALSE));
+        Self {
+            states: Vec::new(),
+            redirect: Vec::new(),
+            names: Interner::default(),
+            strs: Interner::default(),
+            leaves,
+            never,
+            unknown_top,
+            bool_leaf,
+            lit_true,
+            lit_false,
+        }
+    }
+
+    fn alloc(&mut self, node: Node) -> StateId {
+        let id = self.states.len();
+        self.states.push(State {
+            node,
+            names: BTreeSet::new(),
+        });
+        self.redirect.push(id);
+        id
+    }
+
+    fn resolve(&self, mut s: StateId) -> StateId {
+        while self.redirect[s] != s {
+            s = self.redirect[s];
+        }
+        s
+    }
+
+    /// Redirect `from` to `to`, transferring names.
+    fn redirect_to(&mut self, from: StateId, to: StateId) {
+        debug_assert_ne!(self.resolve(from), self.resolve(to));
+        let names = std::mem::take(&mut self.states[from].names);
+        let to = self.resolve(to);
+        self.states[to].names.extend(names);
+        self.redirect[from] = to;
+    }
+
+    fn node(&self, s: StateId) -> &Node {
+        &self.states[self.resolve(s)].node
+    }
+
+    fn is_never(&self, s: StateId) -> bool {
+        matches!(self.node(s), Node::Leaf(l) if *l == self.never)
+    }
+
+    fn is_unknown_top(&self, s: StateId) -> bool {
+        matches!(self.node(s), Node::Leaf(l) if *l == self.unknown_top)
+    }
+
+    /// The lexicographically least alias name of `s`, if any — the
+    /// deterministic representative for rendering. (State name sets are keyed
+    /// by id; representative selection orders by the *names*.)
+    fn representative_name(&self, s: StateId) -> Option<&'a QualifiedTypeName> {
+        self.states[self.resolve(s)]
+            .names
+            .iter()
+            .map(|&id| self.names.get(id.0))
+            .min()
+    }
+
+    /// All states reachable from `root` (resolved ids, ascending — the
+    /// deterministic processing order).
+    fn reachable(&self, root: StateId) -> Vec<StateId> {
+        let mut seen = BTreeSet::new();
+        let mut stack = vec![self.resolve(root)];
+        while let Some(s) = stack.pop() {
+            if !seen.insert(s) {
+                continue;
+            }
+            for c in children(self.node(s)) {
+                stack.push(self.resolve(c));
+            }
+        }
+        seen.into_iter().collect()
+    }
+}
+
+/// The child state ids of a node, in canonical child order.
+fn children(node: &Node) -> Vec<StateId> {
+    match node {
+        Node::Leaf(_) | Node::Enum(_) | Node::EnumVariant(..) => Vec::new(),
+        Node::Class(_, args) => args.clone(),
+        Node::Interface(_, args, bindings) => args
+            .iter()
+            .chain(bindings.iter().map(|(_, s)| s))
+            .copied()
+            .collect(),
+        Node::List(inner) => vec![*inner],
+        Node::Map(k, v) | Node::Future(k, v) => vec![*k, *v],
+        Node::Union(members) => members.clone(),
+        Node::Function {
+            params,
+            ret,
+            throws,
+        } => params
+            .iter()
+            .map(|(_, _, s)| *s)
+            .chain([*ret, *throws])
+            .collect(),
+        Node::Projection {
+            base, interface, ..
+        } => vec![*base, *interface],
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// STAGE 1: BUILD
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Interns a canonical term into a fresh automaton. Owns the binder stack the
+/// walk needs; consumed by [`Builder::build`].
+#[derive(Default)]
+struct Builder {
+    binders: Vec<StateId>,
+}
+
+impl Builder {
+    fn build<'a>(mut self, term: &'a NormalTy) -> Built<'a> {
+        let mut auto = Automaton::new();
+        let root = self.intern_term(&mut auto, term);
+        debug_assert!(self.binders.is_empty());
+        Built { auto, root }
+    }
+
+    /// A μ-binder ties the knot: its reserved state either receives the body's
+    /// node (when the body is a direct self-reference this is the ε-self-loop
+    /// `Union([s])`, resolved to `never` by closure) or redirects to the body's
+    /// state, carrying the alias name either way. A recursion variable is an
+    /// edge to the binder state `index` levels up the stack.
+    fn intern_term<'a>(&mut self, auto: &mut Automaton<'a>, term: &'a NormalTy) -> StateId {
+        match term {
+            NormalTy::Mu { binder, body } => {
+                let s = auto.alloc(Node::Union(Vec::new()));
+                if let Some(name) = &binder.name {
+                    let id = NameId(auto.names.intern(name));
+                    auto.states[s].names.insert(id);
+                }
+                self.binders.push(s);
+                let b = self.intern_term(auto, body);
+                self.binders.pop();
+                if auto.resolve(b) == s {
+                    // `μX.X`: the body is the back-reference itself — an
+                    // ε-self-loop (constructor-free, hence `never` after closure).
+                    auto.states[s].node = Node::Union(vec![s]);
+                    s
+                } else {
+                    auto.redirect_to(s, b);
+                    auto.resolve(b)
+                }
+            }
+            NormalTy::RecVar(index) => {
+                let i = *index as usize;
+                debug_assert!(i < self.binders.len(), "free RecVar reached the automaton");
+                self.binders[self.binders.len() - 1 - i]
+            }
+            NormalTy::Enum(qn) => {
+                let qn = NameId(auto.names.intern(qn));
+                auto.alloc(Node::Enum(qn))
+            }
+            NormalTy::EnumVariant(qn, v) => {
+                let qn = NameId(auto.names.intern(qn));
+                let v = StrId(auto.strs.intern(v));
+                auto.alloc(Node::EnumVariant(qn, v))
+            }
+            NormalTy::Class(qn, args) => {
+                let qn = NameId(auto.names.intern(qn));
+                let args = args.iter().map(|a| self.intern_term(auto, a)).collect();
+                auto.alloc(Node::Class(qn, args))
+            }
+            NormalTy::Interface(qn, args, bindings) => {
+                let qn = NameId(auto.names.intern(qn));
+                let args = args.iter().map(|a| self.intern_term(auto, a)).collect();
+                let bindings = bindings
+                    .iter()
+                    .map(|(n, t)| (StrId(auto.strs.intern(n)), self.intern_term(auto, t)))
+                    .collect();
+                auto.alloc(Node::Interface(qn, args, bindings))
+            }
+            NormalTy::List(inner) => {
+                let inner = self.intern_term(auto, inner);
+                auto.alloc(Node::List(inner))
+            }
+            NormalTy::Map { key, value } => {
+                let key = self.intern_term(auto, key);
+                let value = self.intern_term(auto, value);
+                auto.alloc(Node::Map(key, value))
+            }
+            NormalTy::Future(value, error) => {
+                let value = self.intern_term(auto, value);
+                let error = self.intern_term(auto, error);
+                auto.alloc(Node::Future(value, error))
+            }
+            NormalTy::Union(members) => {
+                let members = members.iter().map(|m| self.intern_term(auto, m)).collect();
+                auto.alloc(Node::Union(members))
+            }
+            NormalTy::Function {
+                params,
+                ret,
+                throws,
+            } => {
+                let params = params
+                    .iter()
+                    .map(|p| {
+                        (
+                            p.name.as_ref().map(|n| StrId(auto.strs.intern(n))),
+                            p.mode,
+                            self.intern_term(auto, &p.ty),
+                        )
+                    })
+                    .collect();
+                let ret = self.intern_term(auto, ret);
+                let throws = self.intern_term(auto, throws);
+                auto.alloc(Node::Function {
+                    params,
+                    ret,
+                    throws,
+                })
+            }
+            NormalTy::AssociatedTypeProjection {
+                base,
+                interface,
+                member,
+            } => {
+                let base = self.intern_term(auto, base);
+                let interface = self.intern_term(auto, interface);
+                let member = StrId(auto.strs.intern(member));
+                auto.alloc(Node::Projection {
+                    base,
+                    interface,
+                    member,
+                })
+            }
+            leaf => {
+                let id = LeafId(auto.leaves.intern(leaf));
+                auto.alloc(Node::Leaf(id))
+            }
+        }
+    }
+}
+
+/// Stage invariant: a faithful term-graph of the input — knots tied (every
+/// back-edge targets its binder's state, which carries the alias name), no
+/// transformation applied yet.
+struct Built<'a> {
+    auto: Automaton<'a>,
+    root: StateId,
+}
+
+impl<'a> Built<'a> {
+    fn epsilon_close(mut self) -> Closed<'a> {
+        epsilon_close(&mut self.auto, self.root);
+        Closed {
+            auto: self.auto,
+            root: self.root,
+        }
+    }
+}
+
+/// Stage invariant: ε-closed — no union has a union member, a `never` member,
+/// or an unguarded spine; every μ body is constructor-headed (contractive), so
+/// the assumption-set subtype algorithm's precondition holds for anything read
+/// back from here.
+struct Closed<'a> {
+    auto: Automaton<'a>,
+    root: StateId,
+}
+
+impl<'a> Closed<'a> {
+    /// Interleave partition refinement with the per-state union algebra to a
+    /// fixpoint (an absorption redirect can resurface ε-edges, hence the
+    /// re-closure inside the loop).
+    fn minimize_and_absorb<C: TypeContext>(mut self, ctx: &C) -> Minimal<'a> {
+        loop {
+            minimize(&mut self.auto, self.root);
+            if !algebra_pass(&mut self.auto, self.root, ctx) {
+                break;
+            }
+            epsilon_close(&mut self.auto, self.root);
+        }
+        Minimal {
+            auto: self.auto,
+            root: self.root,
+        }
+    }
+}
+
+/// Stage invariant: the canonical automaton — coarsest bisimulation, union
+/// algebra at fixpoint. Its read-back is the unique canonical μ-term of the
+/// input's equivalence class; its renders are the canonical spellings.
+struct Minimal<'a> {
+    auto: Automaton<'a>,
+    root: StateId,
+}
+
+impl Minimal<'_> {
+    fn read_back(&self) -> Option<NormalTy> {
+        read_back(&self.auto, self.root)
+    }
+
+    /// The `normalize` rendering of the whole type: a *named* recursive root is
+    /// unfolded once (callers rely on `normalize` exposing the head
+    /// constructor — impl-subject classification, dispatch-target resolution,
+    /// pattern-matrix specialization), with nested recursion folded to alias
+    /// names; every other root renders by named-cut directly. `None` when the
+    /// renderer bails (see [`Renderer`]).
+    fn render_root(&self) -> Option<Ty> {
+        let auto = &self.auto;
+        let cyclic = cyclic_states(auto, self.root);
+        let orders = union_orders(auto, self.root)?;
+        let mut renderer = Renderer::new(auto, &cyclic, &orders);
+        let r = auto.resolve(self.root);
+        let mut path = Vec::new();
+        if cyclic.contains(&r) && auto.representative_name(r).is_some() {
+            path.push(r);
+            let rendered = renderer.structural(r, &mut path);
+            path.pop();
+            return rendered;
+        }
+        renderer.render(r, &mut path)
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// STAGE 2: ε-CLOSURE
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Close every union state over its ε-edges (members that are themselves union
+/// states). Tarjan yields ε-SCCs successors-first, so by the time a component is
+/// processed every union it can still reach through ε is already closed; the
+/// component's final members are the constructor-successors gathered across it.
+fn epsilon_close(auto: &mut Automaton<'_>, root: StateId) {
+    let sccs = epsilon_sccs(auto, root);
+    for scc in sccs {
+        let in_scc: BTreeSet<StateId> = scc.iter().copied().collect();
+        let mut members: BTreeSet<StateId> = BTreeSet::new();
+        for &u in &scc {
+            let Node::Union(ms) = auto.node(u) else {
+                // A prior component's processing may have redirected this state
+                // (nested singleton collapse); nothing left to close.
+                continue;
+            };
+            for m in ms.clone() {
+                let r = auto.resolve(m);
+                if in_scc.contains(&r) {
+                    continue;
+                }
+                match auto.node(r) {
+                    // An already-closed union: splice its (constructor) members.
+                    Node::Union(inner) => {
+                        let inner = inner.clone();
+                        members.extend(inner.into_iter().map(|x| auto.resolve(x)));
+                    }
+                    _ => {
+                        members.insert(r);
+                    }
+                }
+            }
+        }
+        // `never` contributes nothing; `unknown` absorbs everything.
+        members.retain(|&m| !auto.is_never(m));
+        let has_top = members.iter().any(|&m| auto.is_unknown_top(m));
+        for &u in &scc {
+            if auto.resolve(u) != u {
+                continue;
+            }
+            if has_top {
+                auto.states[u].node = Node::Leaf(auto.unknown_top);
+            } else if members.is_empty() {
+                // A constructor-free ε-component: only non-productive circular
+                // derivations exist, so nothing inhabits it (`μX.X` ≡ `never`).
+                auto.states[u].node = Node::Leaf(auto.never);
+            } else if members.len() == 1 {
+                let m = *members
+                    .first()
+                    .unwrap_or_else(|| unreachable!("len checked"));
+                if auto.resolve(m) != u {
+                    auto.redirect_to(u, m);
+                }
+            } else {
+                auto.states[u].node = Node::Union(members.iter().copied().collect());
+            }
+        }
+    }
+}
+
+/// ε-SCCs over union states, in Tarjan completion order (successors first).
+fn epsilon_sccs(auto: &Automaton<'_>, root: StateId) -> Vec<Vec<StateId>> {
+    struct Tarjan<'x, 'a> {
+        auto: &'x Automaton<'a>,
+        index: BTreeMap<StateId, usize>,
+        low: BTreeMap<StateId, usize>,
+        on_stack: BTreeSet<StateId>,
+        stack: Vec<StateId>,
+        next: usize,
+        sccs: Vec<Vec<StateId>>,
+    }
+    impl Tarjan<'_, '_> {
+        fn visit(&mut self, s: StateId) {
+            self.index.insert(s, self.next);
+            self.low.insert(s, self.next);
+            self.next += 1;
+            self.stack.push(s);
+            self.on_stack.insert(s);
+            let Node::Union(members) = self.auto.node(s) else {
+                unreachable!("ε-SCCs are computed over union states only")
+            };
+            let eps: Vec<StateId> = members
+                .iter()
+                .map(|&m| self.auto.resolve(m))
+                .filter(|&r| r != s && matches!(self.auto.node(r), Node::Union(_)))
+                .collect();
+            for t in eps {
+                if !self.index.contains_key(&t) {
+                    self.visit(t);
+                    let l = self.low[&t].min(self.low[&s]);
+                    self.low.insert(s, l);
+                } else if self.on_stack.contains(&t) {
+                    let l = self.index[&t].min(self.low[&s]);
+                    self.low.insert(s, l);
+                }
+            }
+            if self.low[&s] == self.index[&s] {
+                let mut scc = Vec::new();
+                loop {
+                    let t = self
+                        .stack
+                        .pop()
+                        .unwrap_or_else(|| unreachable!("Tarjan stack underflow"));
+                    self.on_stack.remove(&t);
+                    scc.push(t);
+                    if t == s {
+                        break;
+                    }
+                }
+                scc.sort_unstable();
+                self.sccs.push(scc);
+            }
+        }
+    }
+    let mut t = Tarjan {
+        auto,
+        index: BTreeMap::new(),
+        low: BTreeMap::new(),
+        on_stack: BTreeSet::new(),
+        stack: Vec::new(),
+        next: 0,
+        sccs: Vec::new(),
+    };
+    for s in auto.reachable(root) {
+        if matches!(auto.node(s), Node::Union(_)) && !t.index.contains_key(&s) {
+            t.visit(s);
+        }
+    }
+    t.sccs
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// STAGE 3: MINIMIZATION + PER-STATE ALGEBRA
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Moore-style partition refinement to the coarsest bisimulation, then merge
+/// each block into its smallest member. Union members refine as a *set* of
+/// blocks (duplicates within a block are one member of the tree).
+fn minimize(auto: &mut Automaton<'_>, root: StateId) {
+    let reach = auto.reachable(root);
+
+    // Initial partition by local shape — pure id comparisons.
+    let mut block: BTreeMap<StateId, usize> = BTreeMap::new();
+    {
+        let mut groups: BTreeMap<LocalKey, Vec<StateId>> = BTreeMap::new();
+        for &s in &reach {
+            groups.entry(local_key(auto, s)).or_default().push(s);
+        }
+        for (i, states) in groups.into_values().enumerate() {
+            for s in states {
+                block.insert(s, i);
+            }
+        }
+    }
+
+    // Refine by child blocks until stable.
+    loop {
+        let mut groups: BTreeMap<(usize, Vec<usize>), Vec<StateId>> = BTreeMap::new();
+        for &s in &reach {
+            let sig = match auto.node(s) {
+                Node::Union(members) => {
+                    let mut bs: Vec<usize> =
+                        members.iter().map(|&m| block[&auto.resolve(m)]).collect();
+                    bs.sort_unstable();
+                    bs.dedup();
+                    bs
+                }
+                other => children(other)
+                    .into_iter()
+                    .map(|c| block[&auto.resolve(c)])
+                    .collect(),
+            };
+            groups.entry((block[&s], sig)).or_default().push(s);
+        }
+        let stable = groups.len() == block.values().collect::<BTreeSet<_>>().len();
+        let mut next: BTreeMap<StateId, usize> = BTreeMap::new();
+        for (i, states) in groups.into_values().enumerate() {
+            for s in states {
+                next.insert(s, i);
+            }
+        }
+        block = next;
+        if stable {
+            break;
+        }
+    }
+
+    // Merge each block into its smallest state id.
+    let mut rep: BTreeMap<usize, StateId> = BTreeMap::new();
+    for &s in &reach {
+        rep.entry(block[&s]).or_insert(s); // reach is ascending
+    }
+    for &s in &reach {
+        let r = rep[&block[&s]];
+        if s != r {
+            auto.redirect_to(s, r);
+        }
+    }
+}
+
+/// The local (childless) shape of a state — everything about a node except its
+/// children, as interned ids. Two states can only ever merge if their local
+/// keys are equal.
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+enum LocalKey {
+    Leaf(LeafId),
+    Enum(NameId),
+    EnumVariant(NameId, StrId),
+    Class(NameId, usize),
+    Interface(NameId, usize, Vec<StrId>),
+    List,
+    Map,
+    Future,
+    Union,
+    Function(Vec<(Option<StrId>, FunctionParamMode)>),
+    Projection(StrId),
+}
+
+fn local_key(auto: &Automaton<'_>, s: StateId) -> LocalKey {
+    match auto.node(s) {
+        Node::Leaf(l) => LocalKey::Leaf(*l),
+        Node::Enum(qn) => LocalKey::Enum(*qn),
+        Node::EnumVariant(qn, v) => LocalKey::EnumVariant(*qn, *v),
+        Node::Class(qn, args) => LocalKey::Class(*qn, args.len()),
+        Node::Interface(qn, args, bindings) => {
+            LocalKey::Interface(*qn, args.len(), bindings.iter().map(|(n, _)| *n).collect())
+        }
+        Node::List(_) => LocalKey::List,
+        Node::Map(..) => LocalKey::Map,
+        Node::Future(..) => LocalKey::Future,
+        Node::Union(_) => LocalKey::Union,
+        Node::Function { params, .. } => LocalKey::Function(
+            params
+                .iter()
+                .map(|(name, mode, _)| (*name, *mode))
+                .collect(),
+        ),
+        Node::Projection { member, .. } => LocalKey::Projection(*member),
+    }
+}
+
+/// Re-run the union algebra per state over the merged automaton: dedup members
+/// that became one state, collapse complete enums, and absorb subtype members —
+/// with each member materialized as its **closed** read-back so the real subtype
+/// checker (full context) decides, completing the absorptions the bottom-up pass
+/// deferred for open members. Returns whether anything changed.
+///
+/// Two classes of union state skip the pairwise absorption (collapses and dedup
+/// still apply):
+/// - a **cyclic unnamed** state: its rendering depends on a named subset cover
+///   ([`Renderer`]), and absorbing a covered member would break the only exact
+///   spelling of the cycle — conservative, spelling-invariant (the decision is a
+///   function of the minimal automaton);
+/// - a state with a member whose materialization **bailed**: no sound `Ty`
+///   spelling exists to hand the fact oracles.
+fn algebra_pass<C: TypeContext>(auto: &mut Automaton<'_>, root: StateId, ctx: &C) -> bool {
+    let cyclic = cyclic_states(auto, root);
+    let mut changed = false;
+    for s in auto.reachable(root) {
+        let Node::Union(raw) = auto.node(s) else {
+            continue;
+        };
+        let before: BTreeSet<StateId> = raw.iter().map(|&m| auto.resolve(m)).collect();
+        let mut members: BTreeSet<StateId> = before.clone();
+        members.retain(|&m| !auto.is_never(m));
+
+        collapse_complete_enums(auto, &mut members, ctx);
+        collapse_complete_bools(auto, &mut members);
+
+        let absorb = !(cyclic.contains(&s) && auto.representative_name(s).is_none());
+        // Materialize members as closed terms; canonical order = term order.
+        let materialized: Option<Vec<(NormalTy, StateId)>> = if absorb {
+            members
+                .iter()
+                .map(|&m| read_back(auto, m).map(|t| (t, m)))
+                .collect()
+        } else {
+            None
+        };
+        let members: BTreeSet<StateId> = if let Some(mut items) = materialized {
+            items.sort();
+
+            // The pairwise absorption rule of `absorb_subtypes`, over closed terms.
+            let n = items.len();
+            let mut keep = vec![true; n];
+            for i in 0..n {
+                if items[i].0.is_sentinel() {
+                    continue;
+                }
+                for j in 0..n {
+                    if i == j || !keep[j] || items[j].0.is_sentinel() {
+                        continue;
+                    }
+                    if !items[i]
+                        .0
+                        .is_subtype_of(&items[j].0, ctx, &mut HashSet::new())
+                    {
+                        continue;
+                    }
+                    let mutual = items[j]
+                        .0
+                        .is_subtype_of(&items[i].0, ctx, &mut HashSet::new());
+                    if !mutual || j < i {
+                        keep[i] = false;
+                        break;
+                    }
+                }
+            }
+            items
+                .into_iter()
+                .zip(&keep)
+                .filter(|&(_, &k)| k)
+                .map(|((_, m), _)| m)
+                .collect()
+        } else {
+            members
+        };
+
+        changed |= members != before;
+        match members.len() {
+            0 => auto.states[s].node = Node::Leaf(auto.never),
+            1 => {
+                let m = *members
+                    .first()
+                    .unwrap_or_else(|| unreachable!("len checked"));
+                if auto.resolve(m) != s {
+                    auto.redirect_to(s, m);
+                    // The redirect may point other unions' members at a union —
+                    // force another closure/refinement round.
+                    changed = true;
+                }
+            }
+            _ => auto.states[s].node = Node::Union(members.into_iter().collect()),
+        }
+    }
+    changed
+}
+
+/// Replace a complete set of an enum's variant states with the enum state
+/// (`E.A | E.B | … == E`), finding or allocating it.
+fn collapse_complete_enums<C: TypeContext>(
+    auto: &mut Automaton<'_>,
+    members: &mut BTreeSet<StateId>,
+    ctx: &C,
+) {
+    let mut enums: BTreeSet<NameId> = BTreeSet::new();
+    for &m in members.iter() {
+        if let Node::EnumVariant(e, _) = auto.node(m) {
+            enums.insert(*e);
+        }
+    }
+    for e in enums {
+        let Some(all) = ctx.enum_variants(auto.names.get(e.0)) else {
+            continue; // unknown enum → no collapse (fail-safe)
+        };
+        let present: BTreeSet<&Name> = members
+            .iter()
+            .filter_map(|&m| match auto.node(m) {
+                Node::EnumVariant(en, v) if *en == e => Some(auto.strs.get(v.0)),
+                _ => None,
+            })
+            .collect();
+        // ≥2 variants only — mirrors the bottom-up pass: collapsing a
+        // single-variant enum would split one value set into two canonical
+        // spellings (the union spelling collapses, a bare variant cannot).
+        if all.len() >= 2 && all.iter().all(|v| present.contains(v)) {
+            members.retain(|&m| !matches!(auto.node(m), Node::EnumVariant(en, _) if *en == e));
+            let enum_state = (0..auto.states.len())
+                .find(|&s| {
+                    auto.redirect[s] == s && matches!(auto.node(s), Node::Enum(en) if *en == e)
+                })
+                .unwrap_or_else(|| auto.alloc(Node::Enum(e)));
+            members.insert(enum_state);
+        }
+    }
+}
+
+/// Replace the complete pair of bool literal states with the `bool` state
+/// (`true | false == bool` — the bool analogue of enum completeness,
+/// context-free because the variant family is closed). Mirrors the bottom-up
+/// pass; pre-interned leaf ids make the probes integer compares.
+fn collapse_complete_bools(auto: &mut Automaton<'_>, members: &mut BTreeSet<StateId>) {
+    let is_leaf = |auto: &Automaton<'_>, m: StateId, leaf: LeafId| matches!(auto.node(m), Node::Leaf(l) if *l == leaf);
+    let has_true = members.iter().any(|&m| is_leaf(auto, m, auto.lit_true));
+    let has_false = members.iter().any(|&m| is_leaf(auto, m, auto.lit_false));
+    if has_true && has_false {
+        members.retain(|&m| !is_leaf(auto, m, auto.lit_true) && !is_leaf(auto, m, auto.lit_false));
+        let bool_state = (0..auto.states.len())
+            .find(|&s| {
+                auto.redirect[s] == s
+                    && matches!(auto.node(s), Node::Leaf(l) if *l == auto.bool_leaf)
+            })
+            .unwrap_or_else(|| auto.alloc(Node::Leaf(auto.bool_leaf)));
+        members.insert(bool_state);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// STAGE 4: READ-BACK & RENDERING
+// ═══════════════════════════════════════════════════════════════════════════
+/// An expansion of the automaton into a tree with explicit back-references —
+/// the intermediate between the graph and the μ-term. `needs_binder` marks the
+/// occurrences whose subtree references them (computed on the way back up, which
+/// is what makes single-pass de Bruijn emission impossible directly).
+enum Rb {
+    Ref(StateId),
+    Node {
+        state: StateId,
+        needs_binder: bool,
+        shape: RbShape,
+    },
+}
+
+enum RbShape {
+    Leaf(LeafId),
+    Enum(NameId),
+    EnumVariant(NameId, StrId),
+    Class(NameId, Vec<Rb>),
+    Interface(NameId, Vec<Rb>, Vec<(StrId, Rb)>),
+    List(Box<Rb>),
+    Map(Box<Rb>, Box<Rb>),
+    Future(Box<Rb>, Box<Rb>),
+    Union(Vec<Rb>),
+    Function {
+        params: Vec<(Option<StrId>, FunctionParamMode, Rb)>,
+        ret: Box<Rb>,
+        throws: Box<Rb>,
+    },
+    Projection {
+        base: Box<Rb>,
+        interface: Box<Rb>,
+        member: StrId,
+    },
+}
+
+/// The canonical μ-term rooted at `root`, or `None` when the display renderer
+/// bails (see [`Renderer`]). Three passes: expand the automaton to a tree with
+/// back-references; convert once with placeholder displays to fix the canonical
+/// union member orders; render every binder state's display; convert again with
+/// the real displays. Also used by the algebra pass to materialize union
+/// members as closed terms (every back-reference is wrapped on the way out, so
+/// the result is always closed).
+fn read_back(auto: &Automaton<'_>, root: StateId) -> Option<NormalTy> {
+    let cyclic = cyclic_states(auto, root);
+    let (rb, _) = expand(auto, root, &mut Vec::new());
+
+    // Pass A: canonical member orders (and the binder set). Displays are
+    // placeholders — equality-transparent, so they cannot affect the sort — and
+    // the pass-A term is dropped.
+    let mut rec = Recorder::default();
+    convert(auto, &rb, &mut Vec::new(), None, &mut rec);
+
+    // Render every binder state's display while the automaton (which knows the
+    // names, cycles, and covers) is in scope.
+    let mut renderer = Renderer::new(auto, &cyclic, &rec.union_orders);
+    let mut displays: BTreeMap<StateId, Ty> = BTreeMap::new();
+    for &s in &rec.binder_states {
+        let rendered = renderer.render(s, &mut Vec::new())?;
+        displays.insert(s, rendered);
+    }
+
+    // Pass B: the real term.
+    let mut rec_b = Recorder::default();
+    Some(convert(
+        auto,
+        &rb,
+        &mut Vec::new(),
+        Some(&displays),
+        &mut rec_b,
+    ))
+}
+
+/// The canonical union member orders of every union state in the expansion,
+/// computed by a placeholder-display read-back — the shared prerequisite of
+/// [`Renderer`] for callers that do not otherwise read back (the root render).
+fn union_orders(auto: &Automaton<'_>, root: StateId) -> Option<BTreeMap<StateId, Vec<StateId>>> {
+    let (rb, _) = expand(auto, root, &mut Vec::new());
+    let mut rec = Recorder::default();
+    convert(auto, &rb, &mut Vec::new(), None, &mut rec);
+    Some(rec.union_orders)
+}
+
+/// Expand state `s` into a tree, cutting at on-path revisits. Returns the tree
+/// and the set of states it references freely (used to decide `needs_binder`
+/// bottom-up).
+fn expand(auto: &Automaton<'_>, s: StateId, path: &mut Vec<StateId>) -> (Rb, BTreeSet<StateId>) {
+    let r = auto.resolve(s);
+    if path.contains(&r) {
+        return (Rb::Ref(r), BTreeSet::from([r]));
+    }
+    path.push(r);
+    let mut refs = BTreeSet::new();
+    let child = |auto: &Automaton<'_>,
+                 c: StateId,
+                 path: &mut Vec<StateId>,
+                 refs: &mut BTreeSet<StateId>| {
+        let (rb, r) = expand(auto, c, path);
+        refs.extend(r);
+        rb
+    };
+    let shape = match auto.node(r) {
+        Node::Leaf(l) => RbShape::Leaf(*l),
+        Node::Enum(qn) => RbShape::Enum(*qn),
+        Node::EnumVariant(qn, v) => RbShape::EnumVariant(*qn, *v),
+        Node::Class(qn, args) => {
+            let (qn, args) = (*qn, args.clone());
+            RbShape::Class(
+                qn,
+                args.into_iter()
+                    .map(|a| child(auto, a, path, &mut refs))
+                    .collect(),
+            )
+        }
+        Node::Interface(qn, args, bindings) => {
+            let (qn, args, bindings) = (*qn, args.clone(), bindings.clone());
+            RbShape::Interface(
+                qn,
+                args.into_iter()
+                    .map(|a| child(auto, a, path, &mut refs))
+                    .collect(),
+                bindings
+                    .into_iter()
+                    .map(|(n, t)| (n, child(auto, t, path, &mut refs)))
+                    .collect(),
+            )
+        }
+        Node::List(inner) => {
+            let inner = *inner;
+            RbShape::List(Box::new(child(auto, inner, path, &mut refs)))
+        }
+        Node::Map(k, v) => {
+            let (k, v) = (*k, *v);
+            RbShape::Map(
+                Box::new(child(auto, k, path, &mut refs)),
+                Box::new(child(auto, v, path, &mut refs)),
+            )
+        }
+        Node::Future(v, e) => {
+            let (v, e) = (*v, *e);
+            RbShape::Future(
+                Box::new(child(auto, v, path, &mut refs)),
+                Box::new(child(auto, e, path, &mut refs)),
+            )
+        }
+        Node::Union(members) => RbShape::Union(
+            members
+                .clone()
+                .into_iter()
+                .map(|m| child(auto, m, path, &mut refs))
+                .collect(),
+        ),
+        Node::Function {
+            params,
+            ret,
+            throws,
+        } => {
+            let (params, ret, throws) = (params.clone(), *ret, *throws);
+            RbShape::Function {
+                params: params
+                    .into_iter()
+                    .map(|(n, m, t)| (n, m, child(auto, t, path, &mut refs)))
+                    .collect(),
+                ret: Box::new(child(auto, ret, path, &mut refs)),
+                throws: Box::new(child(auto, throws, path, &mut refs)),
+            }
+        }
+        Node::Projection {
+            base,
+            interface,
+            member,
+        } => {
+            let (base, interface, member) = (*base, *interface, *member);
+            RbShape::Projection {
+                base: Box::new(child(auto, base, path, &mut refs)),
+                interface: Box::new(child(auto, interface, path, &mut refs)),
+                member,
+            }
+        }
+    };
+    path.pop();
+    let needs_binder = refs.remove(&r);
+    (
+        Rb::Node {
+            state: r,
+            needs_binder,
+            shape,
+        },
+        refs,
+    )
+}
+
+/// What a convert pass records for the passes after it: the canonical member
+/// order of every union state (fixed by pass A's term sort, consumed by the
+/// renderer), and the set of states that emit binders (whose displays pass B
+/// needs).
+#[derive(Default)]
+struct Recorder {
+    union_orders: BTreeMap<StateId, Vec<StateId>>,
+    binder_states: BTreeSet<StateId>,
+}
+
+/// Convert the expansion to the canonical μ-term: binder-emitting ancestors form
+/// the de Bruijn context, union members sort by the canonical `Ord`, and each
+/// emitted binder gets its [`MuDisplay`]. With `displays: None` (pass A) the
+/// display payload is a placeholder — [`MuDisplay`] is equality-transparent, so
+/// placeholders cannot affect the member sort — and only the [`Recorder`]
+/// output matters. Owned values are cloned out of the interners here — the
+/// single clone point of the pipeline.
+fn convert(
+    auto: &Automaton<'_>,
+    rb: &Rb,
+    binders: &mut Vec<StateId>,
+    displays: Option<&BTreeMap<StateId, Ty>>,
+    rec: &mut Recorder,
+) -> NormalTy {
+    match rb {
+        Rb::Ref(s) => {
+            let index = binders
+                .iter()
+                .rev()
+                .position(|&b| b == *s)
+                .unwrap_or_else(|| {
+                    unreachable!(
+                        "a back-reference targets an ancestor, and every referenced \
+                         ancestor emits a binder"
+                    )
+                });
+            NormalTy::RecVar(index as u32)
+        }
+        Rb::Node {
+            state,
+            needs_binder,
+            shape,
+        } => {
+            if *needs_binder {
+                binders.push(*state);
+                rec.binder_states.insert(*state);
+            }
+            let body = match shape {
+                RbShape::Leaf(l) => auto.leaves.get(l.0).clone(),
+                RbShape::Enum(qn) => NormalTy::Enum(auto.names.get(qn.0).clone()),
+                RbShape::EnumVariant(qn, v) => {
+                    NormalTy::EnumVariant(auto.names.get(qn.0).clone(), auto.strs.get(v.0).clone())
+                }
+                RbShape::Class(qn, args) => NormalTy::Class(
+                    auto.names.get(qn.0).clone(),
+                    args.iter()
+                        .map(|a| convert(auto, a, binders, displays, rec))
+                        .collect(),
+                ),
+                RbShape::Interface(qn, args, bindings) => NormalTy::Interface(
+                    auto.names.get(qn.0).clone(),
+                    args.iter()
+                        .map(|a| convert(auto, a, binders, displays, rec))
+                        .collect(),
+                    bindings
+                        .iter()
+                        .map(|(n, t)| {
+                            (
+                                auto.strs.get(n.0).clone(),
+                                convert(auto, t, binders, displays, rec),
+                            )
+                        })
+                        .collect(),
+                ),
+                RbShape::List(inner) => {
+                    NormalTy::List(Box::new(convert(auto, inner, binders, displays, rec)))
+                }
+                RbShape::Map(k, v) => NormalTy::Map {
+                    key: Box::new(convert(auto, k, binders, displays, rec)),
+                    value: Box::new(convert(auto, v, binders, displays, rec)),
+                },
+                RbShape::Future(v, e) => NormalTy::Future(
+                    Box::new(convert(auto, v, binders, displays, rec)),
+                    Box::new(convert(auto, e, binders, displays, rec)),
+                ),
+                RbShape::Union(members) => {
+                    let mut converted: Vec<(NormalTy, StateId)> = members
+                        .iter()
+                        .map(|m| {
+                            let state = match m {
+                                Rb::Ref(s) => *s,
+                                Rb::Node { state, .. } => *state,
+                            };
+                            (convert(auto, m, binders, displays, rec), state)
+                        })
+                        .collect();
+                    converted.sort();
+                    converted.dedup_by(|a, b| a.0 == b.0);
+                    rec.union_orders
+                        .entry(*state)
+                        .or_insert_with(|| converted.iter().map(|(_, s)| *s).collect());
+                    let mut members: Vec<NormalTy> =
+                        converted.into_iter().map(|(t, _)| t).collect();
+                    match members.len() {
+                        0 => NormalTy::Never,
+                        1 => members.pop().unwrap_or_else(|| unreachable!("len checked")),
+                        _ => NormalTy::Union(members),
+                    }
+                }
+                RbShape::Function {
+                    params,
+                    ret,
+                    throws,
+                } => NormalTy::Function {
+                    params: params
+                        .iter()
+                        .map(|(name, mode, t)| NormalParam {
+                            name: name.map(|n| auto.strs.get(n.0).clone()),
+                            ty: convert(auto, t, binders, displays, rec),
+                            mode: *mode,
+                        })
+                        .collect(),
+                    ret: Box::new(convert(auto, ret, binders, displays, rec)),
+                    throws: Box::new(convert(auto, throws, binders, displays, rec)),
+                },
+                RbShape::Projection {
+                    base,
+                    interface,
+                    member,
+                } => NormalTy::AssociatedTypeProjection {
+                    base: Box::new(convert(auto, base, binders, displays, rec)),
+                    interface: Box::new(convert(auto, interface, binders, displays, rec)),
+                    member: auto.strs.get(member.0).clone(),
+                },
+            };
+            if *needs_binder {
+                binders.pop();
+                let rendered = match displays {
+                    Some(map) => map
+                        .get(state)
+                        .cloned()
+                        .unwrap_or_else(|| unreachable!("pass A recorded every binder state")),
+                    // Pass A placeholder: never escapes (the pass-A term is
+                    // dropped), and equality-transparency keeps it out of the
+                    // member sort. `Error` is the honest sentinel for "not a
+                    // real rendering".
+                    None => Ty::Error {
+                        attr: TyAttr::default(),
+                    },
+                };
+                NormalTy::Mu {
+                    binder: MuDisplay {
+                        name: auto.representative_name(*state).cloned(),
+                        rendered: Box::new(rendered),
+                    },
+                    body: Box::new(body),
+                }
+            } else {
+                body
+            }
+        }
+    }
+}
+
+/// States on a cycle (in a nontrivial SCC of the full edge graph, or carrying a
+/// self-edge) — the states whose alias names cut recursion in the rendering.
+fn cyclic_states(auto: &Automaton<'_>, root: StateId) -> BTreeSet<StateId> {
+    struct Tarjan<'x, 'a> {
+        auto: &'x Automaton<'a>,
+        index: BTreeMap<StateId, usize>,
+        low: BTreeMap<StateId, usize>,
+        on_stack: BTreeSet<StateId>,
+        stack: Vec<StateId>,
+        next: usize,
+        cyclic: BTreeSet<StateId>,
+    }
+    impl Tarjan<'_, '_> {
+        fn visit(&mut self, s: StateId) {
+            self.index.insert(s, self.next);
+            self.low.insert(s, self.next);
+            self.next += 1;
+            self.stack.push(s);
+            self.on_stack.insert(s);
+            let succs: Vec<StateId> = children(self.auto.node(s))
+                .into_iter()
+                .map(|c| self.auto.resolve(c))
+                .collect();
+            let mut self_edge = false;
+            for t in succs {
+                if t == s {
+                    self_edge = true;
+                    continue;
+                }
+                if !self.index.contains_key(&t) {
+                    self.visit(t);
+                    let l = self.low[&t].min(self.low[&s]);
+                    self.low.insert(s, l);
+                } else if self.on_stack.contains(&t) {
+                    let l = self.index[&t].min(self.low[&s]);
+                    self.low.insert(s, l);
+                }
+            }
+            if self.low[&s] == self.index[&s] {
+                let mut scc = Vec::new();
+                loop {
+                    let t = self
+                        .stack
+                        .pop()
+                        .unwrap_or_else(|| unreachable!("Tarjan stack underflow"));
+                    self.on_stack.remove(&t);
+                    scc.push(t);
+                    if t == s {
+                        break;
+                    }
+                }
+                if scc.len() > 1 {
+                    self.cyclic.extend(scc);
+                } else if self_edge {
+                    self.cyclic.insert(s);
+                }
+            }
+        }
+    }
+    let mut t = Tarjan {
+        auto,
+        index: BTreeMap::new(),
+        low: BTreeMap::new(),
+        on_stack: BTreeSet::new(),
+        stack: Vec::new(),
+        next: 0,
+        cyclic: BTreeSet::new(),
+    };
+    for s in auto.reachable(root) {
+        if !t.index.contains_key(&s) {
+            t.visit(s);
+        }
+    }
+    t.cyclic
+}
+
+/// The named-cut display renderer: recursion folds to an alias name at every
+/// *named cyclic* state, and — when ε-closure has spliced the named union
+/// through, leaving its cycle nameless — to a **subset cover**: an unnamed
+/// cyclic union `v` whose members include everything a named cyclic union `u`
+/// holds renders as `u | (members(v) − members(u))`, which is exact (union
+/// semantics) and cuts every cycle through `v`. Renders are memoized per state
+/// (completed renders are path-independent: every cycle cut is by name or
+/// cover, never by position).
+///
+/// **Bail (`None`)** when an on-path state re-enters with no exact cut — an
+/// exotic cycle (e.g. covers broken by absorption interleavings) whose tree has
+/// no finite alias-based `Ty` spelling. A wrong display must never reach a fact
+/// oracle, so the caller degrades to the pre-automaton form instead
+/// (sound, less canonical).
+struct Renderer<'x, 'a> {
+    auto: &'x Automaton<'a>,
+    cyclic: &'x BTreeSet<StateId>,
+    orders: &'x BTreeMap<StateId, Vec<StateId>>,
+    /// Named union states — the cover candidates — with their resolved member
+    /// sets, in representative-name order (deterministic cover choice). NOT
+    /// restricted to cyclic states: the splice-bypass case leaves the named
+    /// union *off* the surviving cycle, and its name denotes its tree either
+    /// way.
+    candidates: Vec<(StateId, BTreeSet<StateId>)>,
+    memo: BTreeMap<StateId, Ty>,
+}
+
+impl<'x, 'a> Renderer<'x, 'a> {
+    fn new(
+        auto: &'x Automaton<'a>,
+        cyclic: &'x BTreeSet<StateId>,
+        orders: &'x BTreeMap<StateId, Vec<StateId>>,
+    ) -> Self {
+        // The whole automaton, not the reachable cone: an ε-splice bypasses the
+        // named binder union, leaving it *unreachable* from the root — and that
+        // orphaned state is exactly the cover the surviving cycle needs.
+        let mut candidates: Vec<(StateId, BTreeSet<StateId>)> = (0..auto.states.len())
+            .filter(|&s| {
+                auto.redirect[s] == s
+                    && auto.representative_name(s).is_some()
+                    && matches!(auto.node(s), Node::Union(_))
+            })
+            .map(|s| {
+                let Node::Union(members) = auto.node(s) else {
+                    unreachable!("filtered to unions")
+                };
+                (s, members.iter().map(|&m| auto.resolve(m)).collect())
+            })
+            .collect();
+        candidates.sort_by(|(a, _), (b, _)| {
+            auto.representative_name(*a)
+                .cmp(&auto.representative_name(*b))
+        });
+        Self {
+            auto,
+            cyclic,
+            orders,
+            candidates,
+            memo: BTreeMap::new(),
+        }
+    }
+
+    fn render(&mut self, s: StateId, path: &mut Vec<StateId>) -> Option<Ty> {
+        let r = self.auto.resolve(s);
+        if let Some(t) = self.memo.get(&r) {
+            return Some(t.clone());
+        }
+        if self.cyclic.contains(&r)
+            && let Some(name) = self.auto.representative_name(r)
+        {
+            let t = Ty::TypeAlias(name.clone(), TyAttr::default());
+            self.memo.insert(r, t.clone());
+            return Some(t);
+        }
+        if path.contains(&r) {
+            // On-path re-entry with no name: only a union fully covered by
+            // named states can still cut the cycle exactly; anything else has
+            // no finite alias-based spelling — bail.
+            return self.cover_only(r);
+        }
+        path.push(r);
+        let out = self.structural(r, path);
+        path.pop();
+        if let Some(t) = &out {
+            self.memo.insert(r, t.clone());
+        }
+        out
+    }
+
+    /// The named covers of union state `r`: candidates whose member sets are
+    /// subsets of `r`'s, plus the members they leave uncovered.
+    fn covers_of(&self, r: StateId) -> (Vec<StateId>, BTreeSet<StateId>) {
+        let Node::Union(members) = self.auto.node(r) else {
+            return (Vec::new(), BTreeSet::new());
+        };
+        let members: BTreeSet<StateId> = members.iter().map(|&m| self.auto.resolve(m)).collect();
+        let mut covers = Vec::new();
+        let mut covered: BTreeSet<StateId> = BTreeSet::new();
+        for (u, u_members) in &self.candidates {
+            if *u != r && u_members.is_subset(&members) {
+                covers.push(*u);
+                covered.extend(u_members.iter().copied());
+            }
+        }
+        let uncovered = members.difference(&covered).copied().collect();
+        (covers, uncovered)
+    }
+
+    /// Render an on-path unnamed state via covers alone: exact only when the
+    /// covers leave nothing uncovered.
+    fn cover_only(&mut self, r: StateId) -> Option<Ty> {
+        if !matches!(self.auto.node(r), Node::Union(_)) {
+            return None;
+        }
+        let (covers, uncovered) = self.covers_of(r);
+        if covers.is_empty() || !uncovered.is_empty() {
+            return None;
+        }
+        self.cover_union(&covers, &[], &mut Vec::new())
+    }
+
+    /// Assemble a union `Ty` from cover names plus rendered extras.
+    fn cover_union(
+        &mut self,
+        covers: &[StateId],
+        extras: &[StateId],
+        path: &mut Vec<StateId>,
+    ) -> Option<Ty> {
+        let attr = TyAttr::default;
+        let mut parts: Vec<Ty> = Vec::new();
+        for &u in covers {
+            let name = self
+                .auto
+                .representative_name(u)
+                .unwrap_or_else(|| unreachable!("candidates are named"));
+            parts.push(Ty::TypeAlias(name.clone(), attr()));
+        }
+        for &m in extras {
+            parts.push(self.render(m, path)?);
+        }
+        Some(match parts.len() {
+            0 => Ty::Never { attr: attr() },
+            1 => parts.pop().unwrap_or_else(|| unreachable!("len checked")),
+            _ => Ty::Union(parts, attr()),
+        })
+    }
+
+    /// Render `r`'s node one level, children through [`Self::render`]. Public
+    /// to the module so the root render can unfold a *named* root once
+    /// (exposing its head constructor) while nested occurrences fold to the
+    /// name.
+    fn structural(&mut self, r: StateId, path: &mut Vec<StateId>) -> Option<Ty> {
+        let attr = TyAttr::default;
+        let auto = self.auto;
+        Some(match auto.node(r) {
+            Node::Leaf(l) => auto.leaves.get(l.0).clone().into_ty(),
+            Node::Enum(qn) => Ty::Enum(auto.names.get(qn.0).clone(), attr()),
+            Node::EnumVariant(qn, v) => Ty::EnumVariant(
+                auto.names.get(qn.0).clone(),
+                auto.strs.get(v.0).clone(),
+                attr(),
+            ),
+            Node::Class(qn, args) => {
+                let (qn, args) = (*qn, args.clone());
+                let mut out = Vec::with_capacity(args.len());
+                for a in args {
+                    out.push(self.render(a, path)?);
+                }
+                Ty::Class(auto.names.get(qn.0).clone(), out, attr())
+            }
+            Node::Interface(qn, args, bindings) => {
+                let (qn, args, bindings) = (*qn, args.clone(), bindings.clone());
+                let mut out_args = Vec::with_capacity(args.len());
+                for a in args {
+                    out_args.push(self.render(a, path)?);
+                }
+                let mut out_bindings = Vec::with_capacity(bindings.len());
+                for (n, t) in bindings {
+                    out_bindings.push((auto.strs.get(n.0).clone(), self.render(t, path)?));
+                }
+                Ty::Interface(auto.names.get(qn.0).clone(), out_args, out_bindings, attr())
+            }
+            Node::List(inner) => {
+                let inner = *inner;
+                Ty::List(Box::new(self.render(inner, path)?), attr())
+            }
+            Node::Map(k, v) => {
+                let (k, v) = (*k, *v);
+                Ty::Map {
+                    key: Box::new(self.render(k, path)?),
+                    value: Box::new(self.render(v, path)?),
+                    attr: attr(),
+                }
+            }
+            Node::Future(v, e) => {
+                let (v, e) = (*v, *e);
+                Ty::Future(
+                    Box::new(self.render(v, path)?),
+                    Box::new(self.render(e, path)?),
+                    attr(),
+                )
+            }
+            Node::Union(_) => {
+                // Cyclic unnamed unions fold their covered members to alias
+                // names — the splice-bypass case (`type A = int | (A | null)[]`
+                // renders the inner union as `A | null`). Everything else
+                // renders member-wise in the canonical order fixed by pass A.
+                let ordered: Vec<StateId> = match self.orders.get(&r) {
+                    Some(o) => o.clone(),
+                    // Defensive: a union outside the recorded expansion —
+                    // resolved, deduplicated, id-ordered (deterministic).
+                    None => {
+                        let Node::Union(members) = auto.node(r) else {
+                            unreachable!("matched Union above")
+                        };
+                        let set: BTreeSet<StateId> =
+                            members.iter().map(|&m| auto.resolve(m)).collect();
+                        set.into_iter().collect()
+                    }
+                };
+                if self.cyclic.contains(&r) && auto.representative_name(r).is_none() {
+                    let (covers, _) = self.covers_of(r);
+                    let covered: BTreeSet<StateId> = self
+                        .candidates
+                        .iter()
+                        .filter(|(u, _)| covers.contains(u))
+                        .flat_map(|(_, ms)| ms.iter().copied())
+                        .collect();
+                    let extras: Vec<StateId> = ordered
+                        .iter()
+                        .copied()
+                        .filter(|m| !covered.contains(m))
+                        .collect();
+                    if covers.is_empty() {
+                        // No name and no cover: the members render structurally
+                        // only if no cycle re-enters this state (the `render`
+                        // on-path check catches re-entry and bails).
+                        let mut parts = Vec::with_capacity(ordered.len());
+                        for m in ordered {
+                            parts.push(self.render(m, path)?);
+                        }
+                        return Some(match parts.len() {
+                            0 => Ty::Never { attr: attr() },
+                            1 => parts.pop().unwrap_or_else(|| unreachable!("len checked")),
+                            _ => Ty::Union(parts, attr()),
+                        });
+                    }
+                    return self.cover_union(&covers, &extras, path);
+                }
+                let mut parts = Vec::with_capacity(ordered.len());
+                for m in ordered {
+                    parts.push(self.render(m, path)?);
+                }
+                match parts.len() {
+                    0 => Ty::Never { attr: attr() },
+                    1 => parts.pop().unwrap_or_else(|| unreachable!("len checked")),
+                    _ => Ty::Union(parts, attr()),
+                }
+            }
+            Node::Function {
+                params,
+                ret,
+                throws,
+            } => {
+                let (params, ret, throws) = (params.clone(), *ret, *throws);
+                let mut out_params = Vec::with_capacity(params.len());
+                for (name, mode, t) in params {
+                    out_params.push(crate::FunctionParamTy {
+                        name: name.map(|n| auto.strs.get(n.0).clone()),
+                        ty: self.render(t, path)?,
+                        mode,
+                    });
+                }
+                Ty::Function {
+                    params: out_params,
+                    ret: Box::new(self.render(ret, path)?),
+                    throws: Box::new(self.render(throws, path)?),
+                    attr: attr(),
+                }
+            }
+            Node::Projection {
+                base,
+                interface,
+                member,
+            } => {
+                let (base, interface, member) = (*base, *interface, *member);
+                let iface = match auto.node(interface) {
+                    Node::Interface(name, args, bindings) => {
+                        let (name, args, bindings) = (*name, args.clone(), bindings.clone());
+                        let mut out_args = Vec::with_capacity(args.len());
+                        for a in args {
+                            out_args.push(self.render(a, path)?);
+                        }
+                        let mut out_bindings = Vec::with_capacity(bindings.len());
+                        for (n, t) in bindings {
+                            out_bindings.push((auto.strs.get(n.0).clone(), self.render(t, path)?));
+                        }
+                        crate::Interface {
+                            name: auto.names.get(name.0).clone(),
+                            generics: out_args,
+                            associated_types: out_bindings,
+                        }
+                    }
+                    _ => unreachable!("projection qualifier is an interface"),
+                };
+                Ty::AssociatedTypeProjection {
+                    base: Box::new(self.render(base, path)?),
+                    interface: Box::new(iface),
+                    member: auto.strs.get(member.0).clone(),
+                    attr: attr(),
+                }
+            }
+        })
+    }
+}

--- a/baml_language/crates/baml_type/src/normalize/tests.rs
+++ b/baml_language/crates/baml_type/src/normalize/tests.rs
@@ -1576,6 +1576,27 @@ fn overlapping_recursive_types_are_not_disjoint() {
 }
 
 #[test]
+fn unguarded_mu_disjointness_terminates_conservatively() {
+    // The read-back bail keeps the pre-automaton spelling, whose μ spine can be
+    // unguarded (`type A = A | A[]`); unfolding it re-injects the μ into its
+    // own union spine forever, so the guard must answer first.
+    let unguarded = NormalTy::Mu {
+        binder: MuDisplay {
+            name: None,
+            rendered: Box::new(Ty::Never {
+                attr: TyAttr::default(),
+            }),
+        },
+        body: Box::new(NormalTy::Union(vec![
+            NormalTy::RecVar(0),
+            NormalTy::List(Box::new(NormalTy::RecVar(0))),
+        ])),
+    };
+    assert!(!unguarded.is_disjoint_from(&NormalTy::String));
+    assert!(!NormalTy::String.is_disjoint_from(&unguarded));
+}
+
+#[test]
 fn union_nested_recursion_renders_via_subset_cover() {
     // `type A = int | (A | null)[]` — the recursion variable sits inside a
     // nested union under the list, so ε-closure splices the named union through

--- a/baml_language/crates/baml_type/src/normalize/tests.rs
+++ b/baml_language/crates/baml_type/src/normalize/tests.rs
@@ -135,6 +135,12 @@ fn lit_int(n: i64) -> Ty {
 fn union(v: Vec<Ty>) -> Ty {
     Ty::Union(v, TyAttr::default())
 }
+fn list(t: Ty) -> Ty {
+    Ty::List(Box::new(t), TyAttr::default())
+}
+fn alias(s: &str) -> Ty {
+    Ty::TypeAlias(qtn(s), TyAttr::default())
+}
 fn param(index: u32, name: &str) -> ParamTy {
     ParamTy::new(index, Name::new(name))
 }
@@ -819,6 +825,208 @@ fn recursive_alias_terminates() {
     assert!(!equivalent(&alias, &Ty::int(), &ctx));
 }
 
+// ── bool completeness ────────────────────────────────────────────────────--
+
+#[test]
+fn complete_bool_literals_collapse_to_bool() {
+    // `(true | false) == bool` (TYPE_SYSTEM.md §Subtyping Cases) — the bool
+    // analogue of enum completeness, context-free.
+    let ctx = Ctx::default();
+    let both = union(vec![lit_bool(true), lit_bool(false)]);
+    assert!(equivalent(&both, &Ty::bool(), &ctx));
+    assert!(is_subtype(&Ty::bool(), &both, &ctx));
+    assert!(is_subtype(&both, &Ty::bool(), &ctx));
+    assert!(equivalent(
+        &union(vec![lit_bool(true), lit_bool(false), Ty::int()]),
+        &union(vec![Ty::bool(), Ty::int()]),
+        &ctx,
+    ));
+    // A single literal does not collapse (absorption into a present base still
+    // applies).
+    assert!(!equivalent(&lit_bool(true), &Ty::bool(), &ctx));
+    assert!(equivalent(
+        &union(vec![Ty::bool(), lit_bool(true)]),
+        &Ty::bool(),
+        &ctx
+    ));
+    // Through recursion: the collapse applies inside μ-bodies too.
+    let mut ctx = Ctx::default();
+    ctx.aliases.insert(
+        qtn("A"),
+        union(vec![lit_bool(true), lit_bool(false), list(alias("A"))]),
+    );
+    ctx.aliases
+        .insert(qtn("B"), union(vec![Ty::bool(), list(alias("B"))]));
+    assert!(equivalent(&alias("A"), &alias("B"), &ctx));
+}
+
+// ── equirecursive canonical forms ────────────────────────────────────────--
+
+/// `type A = int | A[]` registered under the given name.
+fn int_list_alias(ctx: &mut Ctx, name: &str) {
+    ctx.aliases
+        .insert(qtn(name), union(vec![Ty::int(), list(alias(name))]));
+}
+
+#[test]
+fn alpha_equivalent_recursive_aliases() {
+    // Recursive aliases are equirecursive: the alias name carries no identity,
+    // so two aliases with the same definition denote the same type.
+    let mut ctx = Ctx::default();
+    int_list_alias(&mut ctx, "A");
+    int_list_alias(&mut ctx, "B");
+    assert!(equivalent(&alias("A"), &alias("B"), &ctx));
+    assert!(is_subtype(&alias("A"), &alias("B"), &ctx));
+    assert!(is_subtype(&alias("B"), &alias("A"), &ctx));
+
+    ctx.aliases.insert(qtn("R"), class1("Box", alias("R")));
+    ctx.aliases.insert(qtn("S"), class1("Box", alias("S")));
+    assert!(equivalent(&alias("R"), &alias("S"), &ctx));
+}
+
+#[test]
+fn recursive_alias_spelling_invariance() {
+    // Every finite unfolding of a recursive alias spells the same regular tree.
+    let mut ctx = Ctx::default();
+    int_list_alias(&mut ctx, "A");
+    let body = union(vec![Ty::int(), list(alias("A"))]);
+    let twice = union(vec![Ty::int(), list(body.clone())]);
+    assert!(equivalent(&alias("A"), &body, &ctx));
+    assert!(equivalent(&alias("A"), &twice, &ctx));
+    assert!(equivalent(&list(alias("A")), &list(body.clone()), &ctx));
+    assert!(equivalent(
+        &class1("Box", alias("A")),
+        &class1("Box", body),
+        &ctx
+    ));
+}
+
+#[test]
+fn mutually_recursive_aliases_are_equivalent() {
+    // `type A = int | B[]` and `type B = int | A[]` unfold to one tree.
+    let mut ctx = Ctx::default();
+    ctx.aliases
+        .insert(qtn("A"), union(vec![Ty::int(), list(alias("B"))]));
+    ctx.aliases
+        .insert(qtn("B"), union(vec![Ty::int(), list(alias("A"))]));
+    assert!(equivalent(&alias("A"), &alias("B"), &ctx));
+    assert!(equivalent(
+        &alias("A"),
+        &union(vec![Ty::int(), list(alias("A"))]),
+        &ctx
+    ));
+}
+
+#[test]
+fn unguarded_members_are_vacuous() {
+    // Productivity: an unguarded recursive union member admits only vacuous
+    // circular derivations, so it contributes nothing — `type A = A | A[]` is
+    // `type B = B[]`, and a fully unguarded `type C = C` is uninhabited.
+    let mut ctx = Ctx::default();
+    ctx.aliases
+        .insert(qtn("A"), union(vec![alias("A"), list(alias("A"))]));
+    ctx.aliases.insert(qtn("B"), list(alias("B")));
+    ctx.aliases.insert(qtn("C"), alias("C"));
+    assert!(equivalent(&alias("A"), &alias("B"), &ctx));
+    assert!(equivalent(
+        &alias("C"),
+        &Ty::Never {
+            attr: TyAttr::default()
+        },
+        &ctx
+    ));
+    // The soundness regression: before ε-closure, the assumption-set probe
+    // fired on `string ≤ A` through the unguarded member without crossing a
+    // constructor, wrongly answering `true`.
+    assert!(!is_subtype(&Ty::string(), &alias("A"), &ctx));
+    assert!(!is_subtype(&class("Dog"), &alias("A"), &ctx));
+    // The guarded content is still there.
+    assert!(is_subtype(&list(alias("A")), &alias("A"), &ctx));
+}
+
+#[test]
+fn normalize_is_idempotent_on_recursive_aliases() {
+    let mut ctx = Ctx::default();
+    int_list_alias(&mut ctx, "A");
+    ctx.aliases
+        .insert(qtn("M"), union(vec![Ty::int(), list(alias("B"))]));
+    ctx.aliases
+        .insert(qtn("B"), union(vec![Ty::int(), list(alias("M"))]));
+    ctx.aliases.insert(qtn("R"), class1("Box", alias("R")));
+    let corpus = [
+        alias("A"),
+        list(alias("A")),
+        class1("Box", alias("A")),
+        alias("M"),
+        alias("R"),
+        union(vec![Ty::string(), alias("A")]),
+    ];
+    for t in corpus {
+        let once = ctx.normalize(&t);
+        let twice = ctx.normalize(&once);
+        assert_eq!(once, twice, "normalize must be idempotent for {t:?}");
+        assert!(
+            equivalent(&t, &once, &ctx),
+            "normalize must preserve identity for {t:?}"
+        );
+    }
+}
+
+#[test]
+fn normalize_folds_nested_recursion_and_unfolds_the_root() {
+    let mut ctx = Ctx::default();
+    int_list_alias(&mut ctx, "A");
+    // Root-unfold-once: a recursive alias at the root exposes its head
+    // constructor, with the recursive occurrence folded back to the name.
+    assert_eq!(
+        ctx.normalize(&alias("A")),
+        union(vec![Ty::int(), list(alias("A"))])
+    );
+    // Nested recursion stays folded: `A[]` renders as `A[]`, not the unfolding.
+    assert_eq!(ctx.normalize(&list(alias("A"))), list(alias("A")));
+    assert_eq!(
+        ctx.normalize(&class1("Box", alias("A"))),
+        class1("Box", alias("A"))
+    );
+    // The inline spelling converges to the same rendering as the alias.
+    assert_eq!(
+        ctx.normalize(&union(vec![Ty::int(), list(alias("A"))])),
+        union(vec![Ty::int(), list(alias("A"))])
+    );
+    // An unguarded member vanishes from the rendering too.
+    ctx.aliases
+        .insert(qtn("U"), union(vec![alias("U"), list(alias("U"))]));
+    assert_eq!(ctx.normalize(&alias("U")), list(alias("U")));
+}
+
+#[test]
+fn absorption_completes_across_recursion() {
+    // `type A = I | Box<A>` with `Box implements I`: the recursive member is
+    // absorbed into the interface, and the μ-binder disappears with it.
+    let mut ctx = Ctx::default();
+    ctx.impls.push((qtn("Box"), qtn("I")));
+    ctx.aliases
+        .insert(qtn("A"), union(vec![iface("I"), class1("Box", alias("A"))]));
+    assert!(equivalent(&alias("A"), &iface("I"), &ctx));
+    assert_eq!(ctx.normalize(&alias("A")), iface("I"));
+}
+
+#[test]
+fn recursive_disjointness_is_sound() {
+    let mut ctx = Ctx::default();
+    int_list_alias(&mut ctx, "A");
+    ctx.aliases.insert(qtn("R"), class1("Box", alias("R")));
+    // Two spellings of one recursive type are NOT disjoint invariant arguments
+    // (unsound constant-folding of `==` before canonicalization was complete).
+    let spelled = class1("Box", alias("A"));
+    let unfolded = class1("Box", union(vec![Ty::int(), list(alias("A"))]));
+    assert!(!ctx.definitely_disjoint(&spelled, &unfolded));
+    assert_eq!(ctx.constant_equality(&spelled, &unfolded), None);
+    // Genuinely different types keep their provable disjointness through μ.
+    assert!(ctx.definitely_disjoint(&alias("R"), &class("Dog")));
+    assert!(ctx.definitely_disjoint(&class1("Box", alias("R")), &class("Dog")));
+}
+
 // ── compare-style exact-type use (the motivating case) ───────────────────--
 
 #[test]
@@ -1256,4 +1464,156 @@ fn any_function_existentials_are_covariant_in_their_pins() {
         TyAttr::default(),
     );
     assert!(!is_subtype(&other, &any_function(vec![]), &ctx));
+}
+
+// ── review regressions: renderer totality, unguarded members, qualifiers ──--
+//
+// Reproducers from the pre-merge adversarial review: each hung, panicked, or
+// over-equated before the corresponding fix.
+#[test]
+fn nested_union_member_recursion_renders_totally() {
+    // type A = string | (A | int)[]
+    let mut ctx = Ctx::default();
+    ctx.aliases.insert(
+        qtn("A"),
+        union(vec![Ty::string(), list(union(vec![alias("A"), Ty::int()]))]),
+    );
+    let n = ctx.normalize(&alias("A"));
+    assert!(equivalent(&alias("A"), &n, &ctx));
+    assert_eq!(ctx.normalize(&n), n, "idempotent");
+    assert!(!equivalent(&alias("A"), &Ty::int(), &ctx));
+}
+
+#[test]
+fn unguarded_mu_member_is_not_vacuously_absorbing() {
+    // type A = A | A[]  (== mu X. X[])
+    let mut ctx = Ctx::default();
+    ctx.aliases
+        .insert(qtn("A"), union(vec![alias("A"), list(alias("A"))]));
+    // string | A must NOT be equivalent to A.
+    assert!(
+        !equivalent(&union(vec![Ty::string(), alias("A")]), &alias("A"), &ctx),
+        "string was unsoundly absorbed into the non-contractive mu"
+    );
+}
+
+#[test]
+fn projection_qualifier_on_cycle_terminates() {
+    // type A = I<A> | (int as I<A>).M | J
+    // The standalone `I<A>` member state and the projection's qualifier state
+    // are bisimilar, so minimization merges them; materializing the interface
+    // member then places the recursion cut at the qualifier position.
+    let mut ctx = Ctx::default();
+    let i_of_a = Ty::Interface(qtn("I"), vec![alias("A")], vec![], TyAttr::default());
+    ctx.aliases.insert(
+        qtn("A"),
+        union(vec![
+            i_of_a,
+            Ty::AssociatedTypeProjection {
+                base: Box::new(Ty::int()),
+                interface: Box::new(Interface::new(qtn("I"), vec![alias("A")], vec![])),
+                member: Name::new("M"),
+                attr: TyAttr::default(),
+            },
+            iface("J"),
+        ]),
+    );
+    let n = ctx.normalize(&alias("A"));
+    assert!(equivalent(&alias("A"), &n, &ctx));
+}
+
+#[test]
+fn map_value_union_recursion_renders_totally() {
+    // type J = int | map<string, J | null>
+    let mut ctx = Ctx::default();
+    ctx.aliases.insert(
+        qtn("J"),
+        union(vec![
+            Ty::int(),
+            map_ty(Ty::string(), union(vec![alias("J"), Ty::null()])),
+        ]),
+    );
+    let n = ctx.normalize(&alias("J"));
+    assert!(equivalent(&alias("J"), &n, &ctx));
+    assert_eq!(ctx.normalize(&n), n, "idempotent");
+    assert!(!equivalent(&alias("J"), &Ty::int(), &ctx));
+}
+
+// ── review regressions: unguarded members, disjointness, rendering ───────--
+
+#[test]
+fn unguarded_mu_member_does_not_absorb_siblings() {
+    // `type A = A | A[]` is non-contractive until ε-closure; before the fix the
+    // bottom-up absorption's assumption probe proved `string <: A` vacuously
+    // (a self-supporting derivation that never crosses a constructor) and
+    // silently dropped the sibling.
+    let mut ctx = Ctx::default();
+    ctx.aliases
+        .insert(qtn("A"), union(vec![alias("A"), list(alias("A"))]));
+    let u = union(vec![Ty::string(), alias("A")]);
+    assert!(is_subtype(&Ty::string(), &u, &ctx));
+    assert!(!equivalent(&u, &alias("A"), &ctx));
+    assert!(equivalent(
+        &u,
+        &union(vec![Ty::string(), list(alias("A"))]),
+        &ctx
+    ));
+}
+
+#[test]
+fn overlapping_recursive_types_are_not_disjoint() {
+    // `A[] ⊆ A` for `type A = int | A[]`: claiming disjointness would let `==`
+    // constant-fold to `false` between operands that can hold the same value.
+    // (The μ-unfold arms of `is_disjoint_from` produce non-canonical spellings,
+    // so structural `!=` on invariant args must not fire across a μ.)
+    let mut ctx = Ctx::default();
+    int_list_alias(&mut ctx, "A");
+    assert!(is_subtype(&list(alias("A")), &alias("A"), &ctx));
+    assert!(!ctx.definitely_disjoint(&alias("A"), &list(alias("A"))));
+    let d = union(vec![Ty::bool(), list(alias("A"))]);
+    assert!(!ctx.definitely_disjoint(&alias("A"), &d));
+    assert_eq!(ctx.constant_equality(&alias("A"), &d), None);
+}
+
+#[test]
+fn union_nested_recursion_renders_via_subset_cover() {
+    // `type A = int | (A | null)[]` — the recursion variable sits inside a
+    // nested union under the list, so ε-closure splices the named union through
+    // and the surviving cycle is nameless. The renderer must cut it with the
+    // subset cover (`A | null`), not panic or loop.
+    let mut ctx = Ctx::default();
+    let null = || Ty::Null {
+        attr: TyAttr::default(),
+    };
+    ctx.aliases.insert(
+        qtn("A"),
+        union(vec![Ty::int(), list(union(vec![alias("A"), null()]))]),
+    );
+    let a = alias("A");
+    assert!(equivalent(&a, &a, &ctx));
+    let rendered = ctx.normalize(&a);
+    assert!(equivalent(&a, &rendered, &ctx));
+    assert_eq!(ctx.normalize(&rendered), rendered, "idempotent");
+}
+
+#[test]
+fn single_variant_enum_union_is_idempotent() {
+    // Collapsing a one-variant enum would split one value set into two
+    // canonical spellings (the union spelling collapses, the bare variant
+    // cannot); the collapse now requires at least two variants.
+    let mut ctx = Ctx::default();
+    ctx.enums.insert(qtn("E"), vec![Name::new("A")]);
+    let v = variant("E", "A");
+    let vv = union(vec![v.clone(), v.clone()]);
+    assert!(equivalent(&vv, &v, &ctx));
+    assert!(is_subtype(&vv, &v, &ctx));
+    assert!(is_subtype(&v, &vv, &ctx));
+    // The two-variant collapse is unaffected.
+    ctx.enums
+        .insert(qtn("F"), vec![Name::new("X"), Name::new("Y")]);
+    assert!(equivalent(
+        &union(vec![variant("F", "X"), variant("F", "Y")]),
+        &enum_ty("F"),
+        &ctx
+    ));
 }

--- a/baml_language/crates/bex_vm/src/type_context.rs
+++ b/baml_language/crates/bex_vm/src/type_context.rs
@@ -184,12 +184,15 @@ impl TypeContext for BexVm {
 }
 
 /// A [`TypeContext`] for order-insensitive *structural* equivalence over realized
-/// runtime types: **aliases are expanded** — so recursive aliases fold correctly
-/// (`type A = int | A[]` and `type B = int | B[]` denote the same type, via the
-/// canonicalizer's μ-folding) — while every *re-entrant* nominal fact stays an
-/// opaque leaf. It runs the canonical set-theoretic algebra (union
-/// flatten/sort/dedup, `never` removal, literal-into-base collapse), and interface
-/// bindings compare order-insensitively because the canonicalizer sorts them.
+/// runtime types: **aliases are expanded** — so recursive aliases are
+/// equirecursively correct (`type A = int | A[]` and `type B = int | B[]` denote
+/// the same type at any unfolding depth, via the canonicalizer's
+/// μ-canonicalization: α-invariant de Bruijn binders plus automaton
+/// minimization; `TYPE_SYSTEM.md` §Type Aliases and Recursive Types) — while every
+/// *re-entrant* nominal fact stays an opaque leaf. It runs the canonical
+/// set-theoretic algebra (union flatten/sort/dedup, `never` removal,
+/// literal-into-base collapse), and interface bindings compare
+/// order-insensitively because the canonicalizer sorts them.
 ///
 /// This is the runtime twin of the compiler matcher's `AliasEquivCtx` and shares
 /// its exact fact profile — alias-real, nominal-opaque — which keeps runtime
@@ -205,7 +208,9 @@ impl TypeContext for BexVm {
 /// Two conservative *misses* remain, documented and shared with the compiler
 /// matcher (so the two sides agree): interface-membership absorption
 /// (`Shape | Sq` ≡ `Shape` when `Sq <: Shape`) and enum completeness
-/// (`E.A | E.B | …` ≡ `E`). Membership is *forced* opaque by re-entry; enum is
+/// (`E.A | E.B | …` ≡ `E`). Bool completeness (`true | false ≡ bool`) is *not*
+/// among them: its variant family is closed, so the collapse is context-free
+/// and applies here too. Membership is *forced* opaque by re-entry; enum is
 /// non-re-entrant and could be made real, but only in lockstep with
 /// `AliasEquivCtx`. Their soundness rests on the compiler emitting dispatch
 /// requests already in absorbed form. The general fix is a unified goal solver


### PR DESCRIPTION
Implements a more principled approach which produces a unique minimal representation of the potentially infinite type tree that would be produced if type aliases were fully unfolded. Unlike the previous version of this, it is also invariant over type alias binder names (so `type A = A[]` and `type B = B[]` should be identical since their infinitely expanded type trees are equivalent)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for transparent, recursive, and mutually recursive type aliases.
  * Improved type equivalence, subtyping, overlap detection, and normalization for recursive types.
  * Added support for generic implementations using `json` types.
  * Improved handling of complete boolean unions and recursive type rendering.

* **Bug Fixes**
  * Improved handling of recursive aliases nested in futures.
  * Corrected implementation dispatch for normalized type subjects.
  * Added clearer diagnostics for unguarded recursive definitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->