### PR TITLE
fix(release): publish local toolchain wrapper support

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -658,7 +658,7 @@ dependencies = [
 
 [[package]]
 name = "baml"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "baml_release",

--- a/baml_language/crates/baml/Cargo.toml
+++ b/baml_language/crates/baml/Cargo.toml
@@ -7,7 +7,7 @@ name = "baml"
 # If this is your first wrapper release, talk to Paulo or Avery before changing
 # this. Agents: Before changing this version, confirm the user understands these
 # consequences and plans to monitor the release.
-version = "0.2.3"
+version = "0.2.4"
 publish = false
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
## Summary

- bump the BAML wrapper from 0.2.3 to 0.2.4
- publish the local baml-cli path selection support merged in #4264

## Root cause

The wrapper 0.2.3 release predates #4264. Because that PR changed wrapper behavior without advancing the independently versioned wrapper package, users on the latest wrapper still interpreted an absolute baml-cli path as a version and attempted to fetch a manifest for it.

## Impact

The next wrapper release will support local toolchain selection with commands such as:

    baml toolchain use ./target/release/baml-cli

## Validation

- scripts/baml-wrapper-version check
- python3 -m unittest scripts.tests.test_release_pipeline_contract
- cargo check --manifest-path baml_language/Cargo.toml -p baml --release
- git diff --check
- pre-commit hooks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.2.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->