### PR TITLE
Update Cargo.lock for engine rust sdk

### DIFF
--- a/languages/rust/Cargo.lock
+++ b/languages/rust/Cargo.lock
@@ -31,7 +31,7 @@ dependencies = [
 
 [[package]]
 name = "baml"
-version = "0.221.0"
+version = "0.225.0"
 dependencies = [
  "async-channel",
  "baml-macros",
@@ -48,14 +48,14 @@ dependencies = [
 
 [[package]]
 name = "baml-cli"
-version = "0.221.0"
+version = "0.225.0"
 dependencies = [
  "baml",
 ]
 
 [[package]]
 name = "baml-macros"
-version = "0.221.0"
+version = "0.225.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -64,7 +64,7 @@ dependencies = [
 
 [[package]]
 name = "baml-sys"
-version = "0.221.0"
+version = "0.225.0"
 dependencies = [
  "hex",
  "libc",


### PR DESCRIPTION
The CI crates.io publish was failing due to it