### PR TITLE
feat(tir): mounted-blob packages resolve in type positions (BEP-066 slice 6a, PR 3)

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -497,6 +497,74 @@ fn build_packages(
             }
         }
     }
+    // Mounted interfaces contribute the same declaration-side runtime facts as
+    // source interfaces. Their compiled objects/functions already live in the
+    // linked base image; these loc-free rows let a USER impl inherit a mounted
+    // default method, bake an associated default, and construct field links.
+    // Without this prepass a source `implements app.Named {}` got
+    // `label=app.Named.label`, while the blob path emitted an empty method
+    // table — a check-clean program whose virtual dispatch differed at runtime.
+    for package in baml_compiler2_hir::package::mounted_package_names(db) {
+        let Some(package_interface) =
+            baml_compiler2_tir::package_interface::mounted_interface(db, &package)
+        else {
+            continue;
+        };
+        let mut interfaces: Vec<_> = package_interface
+            .types
+            .values()
+            .flat_map(|namespace| namespace.values())
+            .filter_map(|exported| match exported {
+                baml_compiler2_tir::package_interface::ExportedType::Interface {
+                    qtn,
+                    self_param,
+                    generic_params,
+                    associated_types,
+                    fields,
+                    default_methods,
+                    ..
+                } => Some((
+                    qtn,
+                    self_param,
+                    generic_params,
+                    associated_types,
+                    fields,
+                    default_methods,
+                )),
+                _ => None,
+            })
+            .collect();
+        interfaces.sort_by_key(|(qtn, ..)| qtn.render_dotted(false));
+        for (qtn, self_param, generic_params, associated_types, fields, default_methods) in
+            interfaces
+        {
+            if !fields.is_empty() {
+                iface_field_decls
+                    .entry(qtn.clone())
+                    .or_insert_with(|| fields.iter().map(|(name, ..)| name.clone()).collect());
+            }
+            if !associated_types.is_empty() {
+                iface_assoc_decls.entry(qtn.clone()).or_insert_with(|| {
+                    (
+                        self_param.clone(),
+                        generic_params.clone(),
+                        associated_types
+                            .iter()
+                            .map(|associated| (associated.name.clone(), associated.default.clone()))
+                            .collect(),
+                    )
+                });
+            }
+            if !default_methods.is_empty() {
+                let entry = iface_defaults.entry(qtn.clone()).or_default();
+                for method in default_methods {
+                    entry
+                        .entry(method.name.clone())
+                        .or_insert_with(|| method.callable_fqn.clone());
+                }
+            }
+        }
+    }
     // The frame an inherited default of `iface_tn` is invoked with, for a rule
     // implementing it at `for_ty_pattern` / `interface_args` / `interface_assoc`:
     // the implementor type (`Self`) at slot 0, then the interface's generic args,
@@ -1177,6 +1245,34 @@ impl std::fmt::Display for LoweringError {
 
 impl std::error::Error for LoweringError {}
 
+/// Failure while compiling a consumer against independently emitted mounted
+/// dependency units.
+#[derive(Debug)]
+pub enum MountedPackageLinkError {
+    /// The dependency units did not form a valid, self-contained prefix image.
+    DependencyLink(bex_vm_types::link::LinkError),
+    /// The consumer failed during ordinary MIR lowering or bytecode emission.
+    Consumer(LoweringError),
+}
+
+impl std::fmt::Display for MountedPackageLinkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DependencyLink(error) => write!(f, "link mounted dependency units: {error}"),
+            Self::Consumer(error) => write!(f, "compile mounted-package consumer: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for MountedPackageLinkError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::DependencyLink(error) => Some(error),
+            Self::Consumer(error) => Some(error),
+        }
+    }
+}
+
 /// Extract `@description`, `@alias`, `@skip` from span-free HIR attributes.
 ///
 /// Returns `(description, alias, skip)`. Invalid attribute usage is diagnosed
@@ -1316,6 +1412,54 @@ pub fn generate_project_bytecode_with_stdlib(
     base: &Program,
 ) -> Result<Program, LoweringError> {
     generate_impl(db, options, opt, Some(base), false, None)
+}
+
+/// Compile and link a source consumer against independently emitted mounted
+/// dependency units.
+///
+/// This is the supported slice-6 seam between a package's two artifacts:
+///
+/// - `db` must already contain the dependency's serialized package-interface
+///   blobs through its mounted-packages input; those blobs drive checking and
+///   loc-free call resolution.
+/// - `dependency_units` are the matching runtime artifact, normally returned by
+///   [`emit_units`] in the dependency build. Together they must be one complete,
+///   duplicate-free prefix image in deterministic discovery order, including
+///   the builtin units exactly once, and must use the same compiler build and
+///   optimization level as the consumer.
+///
+/// The units are first linked symbolically. Their resulting image seeds the
+/// ordinary consumer emitter, whose fully-qualified imports resolve against the
+/// dependency definitions. The output is a single runnable [`Program`]. A bad
+/// dependency unit set is reported as
+/// [`MountedPackageLinkError::DependencyLink`]; consumer lowering and project
+/// diagnostics retain the ordinary [`LoweringError`] surface through
+/// [`MountedPackageLinkError::Consumer`].
+///
+/// # Slice 6a residue ledger
+///
+/// - E0158 remains only for mounted compiler/VM builtin-kind callables, which
+///   have no loc-free bytecode link contract.
+/// - Mounted declarations have no source spans, so definition navigation,
+///   rename, and other location-owning LSP handles remain unavailable.
+/// - Mount aliases must equal the package identity encoded in the blob;
+///   transitive re-export and package re-aliasing are not implemented.
+/// - Canonical `$stream` companion types are exported and consumer LLM
+///   expansion checks, but live Package.compile/sys-op loading is slice 6.
+/// - Artifact compatibility/version validation and loading into an already-live
+///   VM are slice 6 concerns; this seam produces a new combined `Program`.
+/// - First-class interface-method values still depend on the compiler's general
+///   synthesized-dispatcher support; direct, UFCS, and virtual calls are linked.
+pub fn generate_project_bytecode_with_mounted_units(
+    db: &dyn crate::Db,
+    options: &CompileOptions,
+    opt: OptLevel,
+    dependency_units: &[CompilationUnit],
+) -> Result<Program, MountedPackageLinkError> {
+    let base = bex_vm_types::link::link(dependency_units)
+        .map_err(MountedPackageLinkError::DependencyLink)?;
+    generate_impl(db, options, opt, Some(&base), false, None)
+        .map_err(MountedPackageLinkError::Consumer)
 }
 
 /// Incremental compile that lowers function bodies only for dirty files, reuses
@@ -2650,6 +2794,31 @@ fn generate_impl(
         &tables.classes,
         &mut tables.program_packages,
     );
+    // A MOUNTED (source-less) package contributes no files to this database,
+    // so `build_packages` cannot rebuild its impl rules or recursive aliases
+    // (`from_stdlib_program` clears both for recomputation). Restore them from
+    // the spliced base image, which carries the library's own compiled rules —
+    // without this, interface dispatch through a mounted impl would find no
+    // registered rule at runtime (BEP-066 slice 6a).
+    if let Some(base) = base {
+        for pkg_name in baml_compiler2_hir::package::mounted_package_names(db) {
+            let Some(base_pkg) = base.packages.get(&pkg_name) else {
+                continue;
+            };
+            match tables.program_packages.get_mut(&pkg_name) {
+                Some(pkg) => {
+                    pkg.impl_rules.clone_from(&base_pkg.impl_rules);
+                    pkg.recursive_type_aliases
+                        .clone_from(&base_pkg.recursive_type_aliases);
+                }
+                None => {
+                    tables
+                        .program_packages
+                        .insert(pkg_name.clone(), base_pkg.clone());
+                }
+            }
+        }
+    }
     tables.program_packages.sort_keys();
     program.packages = tables.program_packages;
 

--- a/baml_language/crates/baml_compiler2_hir/src/package.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/package.rs
@@ -380,7 +380,7 @@ const RESERVED_PACKAGE_NAMES: &[&str] = &[
     "baml", "boundary", "testing", "assert", "log", "reflect", "user", "root", "env",
 ];
 
-/// Whether `name` is reserved against mounting — see [`RESERVED_PACKAGE_NAMES`].
+/// Whether `name` is reserved against mounting — see `RESERVED_PACKAGE_NAMES`.
 pub fn is_reserved_package_name(name: &str) -> bool {
     RESERVED_PACKAGE_NAMES.contains(&name)
 }

--- a/baml_language/crates/baml_compiler2_hir/src/package.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/package.rs
@@ -445,10 +445,12 @@ pub fn package_dependencies<'db>(
         // The "testing" and "assert" packages depend on "baml" only.
         "testing" | "assert" => vec![PackageId::new(db, Name::new("baml"))],
         // User packages depend on public builtin packages — plus every mounted
-        // source-less package (BEP-066 slice 6a). A mounted package itself
-        // keeps the stdlib list only: blobs were compiled against the stdlib,
-        // and mounted packages do not see each other (no mount declares a
-        // dependency on another mount).
+        // source-less package (BEP-066 slice 6a) and every auxiliary source
+        // package installed through `compiler2_extra_files`. The latter makes
+        // the source side of the source-vs-blob contract real: a package such
+        // as `<builtin>/app/…` is the same direct dependency whether its source
+        // or its mounted interface is present. A mounted/auxiliary package
+        // itself keeps the stdlib list only, avoiding dependency cycles.
         name => {
             let mut deps = vec![
                 PackageId::new(db, Name::new("baml")),
@@ -464,6 +466,23 @@ pub fn package_dependencies<'db>(
                     mounted
                         .into_iter()
                         .map(|mounted_name| PackageId::new(db, mounted_name)),
+                );
+            }
+            if name == "user" {
+                let source_packages: std::collections::BTreeSet<Name> =
+                    crate::compiler2_all_files(db)
+                        .into_iter()
+                        .map(|file| crate::file_package::file_package(db, file).package)
+                        .filter(|package| {
+                            package.as_str() != name
+                                && !is_reserved_package_name(package.as_str())
+                                && !is_mounted_package(db, package)
+                        })
+                        .collect();
+                deps.extend(
+                    source_packages
+                        .into_iter()
+                        .map(|package| PackageId::new(db, package)),
                 );
             }
             deps

--- a/baml_language/crates/baml_compiler2_hir/src/package.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/package.rs
@@ -368,6 +368,53 @@ mod tests {
     }
 }
 
+/// Package names a mounted blob may NOT claim (BEP-066 slice 6a): the
+/// hardcoded stdlib arms of [`package_dependencies`] plus the names
+/// `file_package` can assign to real files (`user`, `env`) and the `root`
+/// self-reference keyword. A mounted entry under any of these is ignored
+/// entirely — it never becomes a dependency and `package_interface` never
+/// serves its blob — so a mount can never shadow the stdlib or the user's own
+/// package. Kept in lockstep with the hardcoded arms below (same maintenance
+/// story as those arms themselves).
+const RESERVED_PACKAGE_NAMES: &[&str] = &[
+    "baml", "boundary", "testing", "assert", "log", "reflect", "user", "root", "env",
+];
+
+/// Whether `name` is reserved against mounting — see [`RESERVED_PACKAGE_NAMES`].
+pub fn is_reserved_package_name(name: &str) -> bool {
+    RESERVED_PACKAGE_NAMES.contains(&name)
+}
+
+/// The names of every mounted source-less dependency package (BEP-066 slice
+/// 6a): the keys of the [`baml_workspace::MountedPackages`] input, minus any
+/// reserved name ([`is_reserved_package_name`] — a blob may not shadow the
+/// stdlib, `user`, `root`, or `env`). Deterministically ordered (`BTreeMap`
+/// keys). Empty for databases that mount nothing.
+///
+/// Reading the input inside a tracked query records a dependency on the mount
+/// map, so mounting/unmounting invalidates dependents for free.
+pub fn mounted_package_names(db: &dyn crate::Db) -> Vec<Name> {
+    let Some(mounted) = db.mounted_packages() else {
+        return Vec::new();
+    };
+    mounted
+        .by_package(db)
+        .keys()
+        .filter(|name| !is_reserved_package_name(name))
+        .map(|name| Name::new(name.as_str()))
+        .collect()
+}
+
+/// Whether `name` is a mounted source-less dependency package (a
+/// non-reserved key of the `MountedPackages` input).
+pub fn is_mounted_package(db: &dyn crate::Db, name: &Name) -> bool {
+    if is_reserved_package_name(name.as_str()) {
+        return false;
+    }
+    db.mounted_packages()
+        .is_some_and(|mounted| mounted.by_package(db).contains_key(name.as_str()))
+}
+
 /// The *direct* dependencies of `package_id` (hardcoded for now).
 ///
 /// Note these lists are not uniformly flattened: `testing`/`assert` list `baml`
@@ -397,15 +444,30 @@ pub fn package_dependencies<'db>(
         ],
         // The "testing" and "assert" packages depend on "baml" only.
         "testing" | "assert" => vec![PackageId::new(db, Name::new("baml"))],
-        // User packages depend on public builtin packages.
-        _ => vec![
-            PackageId::new(db, Name::new("baml")),
-            PackageId::new(db, Name::new("boundary")),
-            PackageId::new(db, Name::new("testing")),
-            PackageId::new(db, Name::new("assert")),
-            PackageId::new(db, Name::new("log")),
-            PackageId::new(db, Name::new("reflect")),
-        ],
+        // User packages depend on public builtin packages — plus every mounted
+        // source-less package (BEP-066 slice 6a). A mounted package itself
+        // keeps the stdlib list only: blobs were compiled against the stdlib,
+        // and mounted packages do not see each other (no mount declares a
+        // dependency on another mount).
+        name => {
+            let mut deps = vec![
+                PackageId::new(db, Name::new("baml")),
+                PackageId::new(db, Name::new("boundary")),
+                PackageId::new(db, Name::new("testing")),
+                PackageId::new(db, Name::new("assert")),
+                PackageId::new(db, Name::new("log")),
+                PackageId::new(db, Name::new("reflect")),
+            ];
+            let mounted = mounted_package_names(db);
+            if !mounted.iter().any(|m| m.as_str() == name) {
+                deps.extend(
+                    mounted
+                        .into_iter()
+                        .map(|mounted_name| PackageId::new(db, mounted_name)),
+                );
+            }
+            deps
+        }
     }
 }
 

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -847,14 +847,39 @@ pub fn def_to_item_ref<'db>(db: &'db dyn crate::Db, def: Definition<'db>) -> Ite
             Some(MethodOwner::FreeImpl(impl_loc)) => {
                 let block = impl_block_data(db, impl_loc);
                 if let ImplSubjectData::Free { for_target, .. } = &block.subject {
+                    let raw_owner = Name::new(format!(
+                        "{}$for${}",
+                        block.type_refs.display(block.interface_target),
+                        block.type_refs.display(*for_target)
+                    ));
+                    let owner = baml_compiler2_tir::interfaces::impl_data(db, impl_loc)
+                        .as_ref()
+                        .ok()
+                        .and_then(|data| {
+                            let qtn = data.interface_qtn(db)?;
+                            let interface = baml_type::Interface::new(
+                                qtn,
+                                data.interface_args.clone(),
+                                data.associated_types.clone(),
+                            );
+                            Some(
+                                baml_compiler2_tir::package_interface::impl_method_symbol_owner(
+                                    &interface,
+                                    &data.for_ty_pattern,
+                                    &pkg_info.package,
+                                    &pkg_info.namespace_path,
+                                ),
+                            )
+                        })
+                        .unwrap_or_else(|| raw_owner.clone());
+                    assert_eq!(
+                        owner, raw_owner,
+                        "structural impl symbol must preserve the source-era B-693 spelling"
+                    );
                     return ItemRef::Method {
                         package: pkg_info.package.clone(),
                         namespace: pkg_info.namespace_path,
-                        class: Name::new(format!(
-                            "{}$for${}",
-                            block.type_refs.display(block.interface_target),
-                            block.type_refs.display(*for_target)
-                        )),
+                        class: owner,
                         name,
                     };
                 }
@@ -950,19 +975,53 @@ fn resolution_to_item_ref(
             let data = baml_compiler2_tir::interfaces::impl_data(db, *impl_loc)
                 .as_ref()
                 .ok()?;
-            // A mounted-interface target has no loc; TIR never records an
-            // `InterfaceConcreteMethod` for one (mounted calls are reserved
-            // until the BEP-066 call-lowering PR), so this is unreachable —
-            // fail soft rather than panic if it ever regresses.
-            let iface_loc = data.interface_loc()?;
-            let pkg_info = file_package(db, iface_loc.file(db));
-            let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
+            // The interface's qualified name is total over source-backed and
+            // MOUNTED targets (a user impl of a mounted interface has no
+            // interface loc, but its qtn names the same dispatch slot —
+            // BEP-066 slice 6a).
+            let iface_qtn = data.interface_qtn(db)?;
             let func_data = baml_compiler2_ppir::item_data::function_data(db, *func_loc);
             Some(ItemRef::Method {
-                package: pkg_info.package,
-                namespace: pkg_info.namespace_path,
-                class: iface_data.name.clone(),
+                package: iface_qtn.package().clone(),
+                namespace: iface_qtn.namespace().clone(),
+                class: iface_qtn.name().clone(),
                 name: func_data.name.clone(),
+            })
+        }
+        // A mounted-package callee (BEP-066 slice 6a): the resolution already
+        // carries the exact names of the library's exported symbol.
+        MemberResolution::External(external) => {
+            use baml_compiler2_tir::inference::ExternalCallTarget;
+            Some(match &external.target {
+                ExternalCallTarget::Free {
+                    package,
+                    namespace,
+                    name,
+                } => ItemRef::Free {
+                    package: package.clone(),
+                    namespace: namespace.clone(),
+                    name: name.clone(),
+                },
+                ExternalCallTarget::Method {
+                    package,
+                    namespace,
+                    class,
+                    name,
+                } => ItemRef::Method {
+                    package: package.clone(),
+                    namespace: namespace.clone(),
+                    class: class.clone(),
+                    name: name.clone(),
+                },
+                // Interface-routed: the interface's method slot — the VM
+                // resolves the receiver's registered impl (the same routing as
+                // `InterfaceConcreteMethod` above).
+                ExternalCallTarget::Interface { iface, method } => ItemRef::Method {
+                    package: iface.package().clone(),
+                    namespace: iface.namespace().clone(),
+                    class: iface.name().clone(),
+                    name: method.clone(),
+                },
             })
         }
         MemberResolution::Field { .. }
@@ -984,7 +1043,11 @@ fn resolution_func_loc<'db>(
         | MemberResolution::BoundMethod { func_loc, .. }
         | MemberResolution::UnboundMethod { func_loc, .. }
         | MemberResolution::InterfaceConcreteMethod { func_loc, .. } => Some(*func_loc),
-        MemberResolution::InterfaceVirtualMethod { .. }
+        // A mounted callee has no loc-backed body in this database at all —
+        // and is never a builtin, so every builtin/sys-op probe correctly
+        // answers "no" through this `None` (BEP-066 slice 6a).
+        MemberResolution::External(_)
+        | MemberResolution::InterfaceVirtualMethod { .. }
         | MemberResolution::Field { .. }
         | MemberResolution::Variant { .. }
         | MemberResolution::InterfaceVirtualField { .. } => None,
@@ -1214,6 +1277,27 @@ fn class_type_tags_for_project(
         }
     }
 
+    // MOUNTED (source-less) packages have no files; their classes tag from the
+    // blob rows. Content-addressing is over the fq name alone, so these are
+    // byte-identical to the tags the library's own compile assigned (BEP-066
+    // slice 6a).
+    for pkg_name in baml_compiler2_hir::package::mounted_package_names(db) {
+        let Some(mounted) = baml_compiler2_tir::package_interface::mounted_interface(db, &pkg_name)
+        else {
+            continue;
+        };
+        for types_in_ns in mounted.types.values() {
+            for exported in types_in_ns.values() {
+                if let baml_compiler2_tir::package_interface::ExportedType::Class { qtn, .. } =
+                    exported
+                {
+                    let type_tag = baml_type::typetag::class_type_tag(&qtn.render_dotted(false));
+                    tags.entry(qtn.clone()).or_insert(type_tag);
+                }
+            }
+        }
+    }
+
     ProjectClassTypeTags { tags }
 }
 
@@ -1243,8 +1327,21 @@ fn package_lowering_data<'db>(
         // Dependency packages first (e.g., "baml" builtins); current-package
         // items overwrite on collision.
         for &dep_id in package_dependencies(db, pkg_id) {
-            let dep_items = package_items(db, dep_id);
             let dep_name = dep_id.name(db);
+            // A MOUNTED (source-less) dependency has no items — its class
+            // fields / enum variants come from the interface blob's rows
+            // (BEP-066 slice 6a).
+            if let Some(mounted) =
+                baml_compiler2_tir::package_interface::mounted_interface(db, &dep_name)
+            {
+                LoweringContext::populate_from_mounted_package(
+                    mounted,
+                    &mut population,
+                    &resolved_aliases,
+                );
+                continue;
+            }
+            let dep_items = package_items(db, dep_id);
             LoweringContext::populate_from_package(
                 db,
                 dep_items,
@@ -1279,6 +1376,28 @@ fn package_lowering_data<'db>(
     let mut all_pkgs = vec![pkg_id];
     all_pkgs.extend(package_dependency_closure(db, pkg_id).iter().copied());
     for pkg in all_pkgs {
+        // A MOUNTED (source-less) dependency's interface methods come from its
+        // blob rows — without them the fast pre-filter would hide every
+        // mounted-impl dispatch (BEP-066 slice 6a).
+        if let Some(mounted) =
+            baml_compiler2_tir::package_interface::mounted_interface(db, &pkg.name(db))
+        {
+            for types_in_ns in mounted.types.values() {
+                for exported in types_in_ns.values() {
+                    if let baml_compiler2_tir::package_interface::ExportedType::Interface {
+                        required_methods,
+                        default_methods,
+                        ..
+                    } = exported
+                    {
+                        for m in required_methods.iter().chain(default_methods) {
+                            interface_method_names.insert(m.name.clone());
+                        }
+                    }
+                }
+            }
+            continue;
+        }
         let items = package_items(db, pkg);
         for ns in items.namespaces.values() {
             for def in ns.types.values() {
@@ -1873,6 +1992,42 @@ impl<'db> LoweringContext<'db> {
                         out.enum_variants.insert(enum_qtn, variants);
                     }
                     _ => {}
+                }
+            }
+        }
+    }
+
+    /// The MOUNTED-package twin of [`Self::populate_from_package`] (BEP-066
+    /// slice 6a): class field indices/types and enum variant indices from the
+    /// blob's exported rows. Field types are already-lowered `Ty`s, so
+    /// population is a pure conversion — no per-loc lowering.
+    fn populate_from_mounted_package(
+        mounted: &baml_compiler2_tir::package_interface::PackageInterface,
+        out: &mut PackagePopulation<'_>,
+        resolved_aliases: &ResolvedAliases,
+    ) {
+        use baml_compiler2_tir::package_interface::ExportedType;
+        for types_in_ns in mounted.types.values() {
+            for exported in types_in_ns.values() {
+                match exported {
+                    ExportedType::Class { qtn, fields, .. } => {
+                        let mut field_indices = IndexMap::new();
+                        let mut field_types = IndexMap::new();
+                        for (idx, (name, ty, _attrs)) in fields.iter().enumerate() {
+                            field_indices.insert(name.to_string(), idx);
+                            field_types.insert(name.to_string(), resolved_aliases.convert(ty));
+                        }
+                        out.class_fields.insert(qtn.clone(), field_indices);
+                        out.class_field_types.insert(qtn.clone(), field_types);
+                    }
+                    ExportedType::Enum { qtn, variants } => {
+                        let mut variant_indices = IndexMap::new();
+                        for (idx, variant) in variants.iter().enumerate() {
+                            variant_indices.insert(variant.to_string(), idx);
+                        }
+                        out.enum_variants.insert(qtn.clone(), variant_indices);
+                    }
+                    ExportedType::Interface { .. } | ExportedType::TypeAlias { .. } => {}
                 }
             }
         }
@@ -3171,6 +3326,22 @@ impl<'db> LoweringContext<'db> {
         let Some(baml_compiler2_hir::contributions::Definition::Interface(root_loc)) =
             pkg_items.lookup_type(iface_qtn.namespace(), iface_qtn.name())
         else {
+            // A MOUNTED (source-less) interface answers from its exported row;
+            // its `requires` rows are the pre-flattened transitive closure, so
+            // one recursion level per entry covers inheritance (BEP-066 6a).
+            if let Some(baml_compiler2_tir::package_interface::ExportedType::Interface {
+                required_methods,
+                default_methods,
+                requires,
+                ..
+            }) = baml_compiler2_tir::package_interface::mounted_type_row(self.db, iface_qtn)
+            {
+                return required_methods.iter().any(|m| m.name == *method)
+                    || default_methods.iter().any(|m| m.name == *method)
+                    || requires
+                        .iter()
+                        .any(|req| self.mir_interface_declares_method(&req.name, method));
+            }
             return false;
         };
         baml_compiler2_tir::interfaces::interface_closure_locs(self.db, root_loc)
@@ -3203,6 +3374,10 @@ impl<'db> LoweringContext<'db> {
         matches!(
             pkg_items.lookup_type(tn.namespace(), tn.name()),
             Some(baml_compiler2_hir::contributions::Definition::Interface(_))
+        ) || matches!(
+            // A MOUNTED interface has no Definition — its row answers.
+            baml_compiler2_tir::package_interface::mounted_type_row(self.db, tn),
+            Some(baml_compiler2_tir::package_interface::ExportedType::Interface { .. })
         )
     }
 
@@ -3214,6 +3389,16 @@ impl<'db> LoweringContext<'db> {
         let Some(baml_compiler2_hir::contributions::Definition::Interface(loc)) =
             pkg_items.lookup_type(iface_tn.namespace(), iface_tn.name())
         else {
+            // A MOUNTED interface's direct members come from its exported row.
+            if let Some(baml_compiler2_tir::package_interface::ExportedType::Interface {
+                required_methods,
+                default_methods,
+                ..
+            }) = baml_compiler2_tir::package_interface::mounted_type_row(self.db, iface_tn)
+            {
+                return required_methods.iter().any(|m| m.name == *method)
+                    || default_methods.iter().any(|m| m.name == *method);
+            }
             return false;
         };
         let iface_data = interface_data(self.db, loc);
@@ -3254,9 +3439,21 @@ impl<'db> LoweringContext<'db> {
         let pkg_id =
             baml_compiler2_hir::package::PackageId::new(self.db, iface_tn.package().clone());
         let pkg_items = baml_compiler2_hir::package::package_items(self.db, pkg_id);
-        let baml_compiler2_hir::contributions::Definition::Interface(loc) =
-            pkg_items.lookup_type(iface_tn.namespace(), iface_tn.name())?
-        else {
+        let Some(def) = pkg_items.lookup_type(iface_tn.namespace(), iface_tn.name()) else {
+            // A MOUNTED interface's declared field order comes from its
+            // exported row (declaration order — the same index space its
+            // implementations were baked against at the library's own emit).
+            if let Some(baml_compiler2_tir::package_interface::ExportedType::Interface {
+                fields,
+                ..
+            }) = baml_compiler2_tir::package_interface::mounted_type_row(self.db, iface_tn)
+            {
+                let index = fields.iter().position(|(name, _, _)| name == field)?;
+                return Some(u32::try_from(index).expect("interface field count fits u32"));
+            }
+            return None;
+        };
+        let baml_compiler2_hir::contributions::Definition::Interface(loc) = def else {
             return None;
         };
         let index = interface_data(self.db, loc)
@@ -5612,16 +5809,61 @@ impl<'db> LoweringContext<'db> {
                     // must capture the receiver and bind its impl at runtime — the
                     // virtual-bound path below handles it; a bare function constant
                     // would name an interface-keyed global that (for a required
-                    // method) does not exist.
+                    // method) does not exist. An interface-routed MOUNTED callee
+                    // (BEP-066 slice 6a) rides the same rule.
                     Some(
                         MemberResolution::InterfaceVirtualMethod { .. }
                         | MemberResolution::InterfaceConcreteMethod { .. },
                     ) if self.binding_id_for_path(expr_id, &segments[0]).is_some() => {}
+                    Some(MemberResolution::External(external))
+                        if matches!(
+                            external.target,
+                            baml_compiler2_tir::inference::ExternalCallTarget::Interface { .. }
+                        ) && self.binding_id_for_path(expr_id, &segments[0]).is_some() => {}
+                    // A mounted class's plain method referenced on a value
+                    // receiver: capture the receiver, exactly as `BoundMethod`.
+                    Some(MemberResolution::External(external))
+                        if external.takes_self
+                            && matches!(
+                                external.target,
+                                baml_compiler2_tir::inference::ExternalCallTarget::Method { .. }
+                            )
+                            && self.binding_id_for_path(expr_id, &segments[0]).is_some() =>
+                    {
+                        let resolution = member_resolutions.into_iter().last().unwrap();
+                        if let Some(item) = resolution_to_item_ref(self.db, &resolution) {
+                            let receiver_segments = &segments[..segments.len() - 1];
+                            let receiver_op = if receiver_segments.len() == 1 {
+                                self.place_for_path(expr_id, &segments[0]).map_or_else(
+                                    || Operand::Constant(Constant::Null),
+                                    Operand::Copy,
+                                )
+                            } else {
+                                let recv_ty = self.expr_ty(expr_id);
+                                let recv_local = self.builder.temp(recv_ty);
+                                self.lower_multi_segment_path_as_field_chain(
+                                    expr_id,
+                                    receiver_segments,
+                                    Place::local(recv_local),
+                                );
+                                Operand::Copy(Place::local(recv_local))
+                            };
+                            self.builder.assign(
+                                dest,
+                                Rvalue::MakeBoundMethod {
+                                    item_ref: item,
+                                    receiver: receiver_op,
+                                },
+                            );
+                            return;
+                        }
+                    }
                     Some(
                         MemberResolution::UnboundMethod { .. }
                         | MemberResolution::Free { .. }
                         | MemberResolution::InterfaceVirtualMethod { .. }
-                        | MemberResolution::InterfaceConcreteMethod { .. },
+                        | MemberResolution::InterfaceConcreteMethod { .. }
+                        | MemberResolution::External(_),
                     ) => {
                         // Unbound method or free function reference — emit a plain function constant.
                         let resolution = member_resolutions.into_iter().last().unwrap();
@@ -5689,13 +5931,57 @@ impl<'db> LoweringContext<'db> {
                     // Value-rooted interface-method reference: see the
                     // `member_resolutions` match above — the virtual-bound path
                     // below captures the receiver and binds its impl at runtime.
+                    // Interface-routed mounted callees ride the same rule.
                     MemberResolution::InterfaceVirtualMethod { .. }
                     | MemberResolution::InterfaceConcreteMethod { .. }
                         if self.binding_id_for_path(expr_id, &segments[0]).is_some() => {}
+                    MemberResolution::External(external)
+                        if matches!(
+                            external.target,
+                            baml_compiler2_tir::inference::ExternalCallTarget::Interface { .. }
+                        ) && self.binding_id_for_path(expr_id, &segments[0]).is_some() => {}
+                    // A mounted class's plain method referenced on a value
+                    // receiver: capture the receiver, exactly as `BoundMethod`.
+                    MemberResolution::External(external)
+                        if external.takes_self
+                            && matches!(
+                                external.target,
+                                baml_compiler2_tir::inference::ExternalCallTarget::Method { .. }
+                            )
+                            && self.binding_id_for_path(expr_id, &segments[0]).is_some() =>
+                    {
+                        if let Some(item) = resolution_to_item_ref(self.db, &resolution) {
+                            let receiver_segments = &segments[..segments.len() - 1];
+                            let receiver_op = if receiver_segments.len() == 1 {
+                                self.place_for_path(expr_id, &segments[0]).map_or_else(
+                                    || Operand::Constant(Constant::Null),
+                                    Operand::Copy,
+                                )
+                            } else {
+                                let recv_ty = self.expr_ty(expr_id);
+                                let recv_local = self.builder.temp(recv_ty);
+                                self.lower_multi_segment_path_as_field_chain(
+                                    expr_id,
+                                    receiver_segments,
+                                    Place::local(recv_local),
+                                );
+                                Operand::Copy(Place::local(recv_local))
+                            };
+                            self.builder.assign(
+                                dest,
+                                Rvalue::MakeBoundMethod {
+                                    item_ref: item,
+                                    receiver: receiver_op,
+                                },
+                            );
+                            return;
+                        }
+                    }
                     MemberResolution::UnboundMethod { .. }
                     | MemberResolution::Free { .. }
                     | MemberResolution::InterfaceVirtualMethod { .. }
-                    | MemberResolution::InterfaceConcreteMethod { .. } => {
+                    | MemberResolution::InterfaceConcreteMethod { .. }
+                    | MemberResolution::External(_) => {
                         if let Some(item) = resolution_to_item_ref(self.db, &resolution) {
                             self.builder.assign(
                                 dest,
@@ -7527,6 +7813,8 @@ impl<'db> LoweringContext<'db> {
         runtime_id: Option<AstExprId>,
         dest: Place,
     ) {
+        use baml_compiler2_tir::inference::{ExternalCallTarget, MemberResolution};
+
         let callee_expr = self.body.exprs[callee].clone();
         if let AstExpr::MemberAccess { base, member } = &callee_expr {
             let member_name = member.clone();
@@ -7569,6 +7857,23 @@ impl<'db> LoweringContext<'db> {
             ) {
                 return;
             }
+        }
+        // Mounted UFCS through an interface-provided class method
+        // (`app.Widget.describe(widget)`) has an explicit receiver as its
+        // first argument. The exported callee names the interface slot, so
+        // lower it as the same open-world VirtualCall used by `widget.describe()`
+        // rather than as a direct call to a nonexistent interface body.
+        if matches!(callee_expr, AstExpr::Path(_))
+            && let Some(MemberResolution::External(external)) =
+                self.tir_resolution(self.expr_metadata_key(callee)).cloned()
+            && let ExternalCallTarget::Interface { method, .. } = &external.target
+            && external.takes_self
+            && let Some(&receiver) = args.first()
+            && self.try_lower_interface_ufcs_dispatch(
+                expr_id, receiver, method, args, runtime_id, &dest,
+            )
+        {
+            return;
         }
         // BEP-044: `default.<method>(...)` inside an `implements I { ... }`
         // block emits a static call to `I`'s default function, with the
@@ -7958,6 +8263,7 @@ impl<'db> LoweringContext<'db> {
                             | MemberResolution::Free { .. }
                             | MemberResolution::InterfaceVirtualMethod { .. }
                             | MemberResolution::InterfaceConcreteMethod { .. }
+                            | MemberResolution::External(_)
                     )
                 })
             {
@@ -7993,6 +8299,9 @@ impl<'db> LoweringContext<'db> {
                             // A virtual interface-method call is always on a receiver, so it
                             // takes `self`; there is no static body to inspect.
                             MemberResolution::InterfaceVirtualMethod { .. } => true,
+                            // A mounted callee carries its receiver convention
+                            // on the resolution (BEP-066 slice 6a).
+                            MemberResolution::External(external) => external.takes_self,
                             _ => false,
                         })
                 };
@@ -8057,6 +8366,11 @@ impl<'db> LoweringContext<'db> {
                                 | MemberResolution::UnboundMethod { .. }
                                 | MemberResolution::InterfaceVirtualMethod { .. }
                                 | MemberResolution::InterfaceConcreteMethod { .. }
+                        ) || matches!(
+                            r,
+                            // A mounted method with a `self` receiver (a free
+                            // function stays on the plain-callee path below).
+                            MemberResolution::External(external) if external.takes_self
                         )
                     });
             // Also check flat resolutions (package-path method call, kept for compatibility).
@@ -8072,6 +8386,9 @@ impl<'db> LoweringContext<'db> {
                                 | MemberResolution::UnboundMethod { .. }
                                 | MemberResolution::InterfaceVirtualMethod { .. }
                                 | MemberResolution::InterfaceConcreteMethod { .. }
+                        ) || matches!(
+                            r,
+                            MemberResolution::External(external) if external.takes_self
                         )
                     });
 
@@ -8106,6 +8423,9 @@ impl<'db> LoweringContext<'db> {
                                 .is_some_and(|param| param.name.as_str() == "self")
                         }
                         MemberResolution::InterfaceVirtualMethod { .. } => true,
+                        // A mounted callee carries its receiver convention on
+                        // the resolution (BEP-066 slice 6a).
+                        MemberResolution::External(external) => external.takes_self,
                         _ => false,
                     }
                 });
@@ -9167,6 +9487,7 @@ impl LoweringContext<'_> {
                     | MemberResolution::UnboundMethod { .. }
                     | MemberResolution::InterfaceVirtualMethod { .. }
                     | MemberResolution::InterfaceConcreteMethod { .. }
+                    | MemberResolution::External(_)
             )
         };
         let key = self.expr_metadata_key(base);
@@ -9649,6 +9970,38 @@ impl<'db> LoweringContext<'db> {
                     // the receiver and bind its impl at runtime — the virtual-bound
                     // path below handles it.
                 }
+                // A mounted callee (BEP-066 slice 6a): a plain method on a
+                // value receiver binds like `BoundMethod`; an interface-routed
+                // one falls through to the virtual-bound path below (same rule
+                // as the interface arms above).
+                MemberResolution::External(external) => {
+                    use baml_compiler2_tir::inference::ExternalCallTarget;
+                    match &external.target {
+                        ExternalCallTarget::Method { .. } if external.takes_self => {
+                            if let Some(item) = resolution_to_item_ref(self.db, &resolution) {
+                                let receiver_op = self.lower_to_operand(base);
+                                self.builder.assign(
+                                    dest,
+                                    Rvalue::MakeBoundMethod {
+                                        item_ref: item,
+                                        receiver: receiver_op,
+                                    },
+                                );
+                                return;
+                            }
+                        }
+                        ExternalCallTarget::Interface { .. } => {}
+                        ExternalCallTarget::Free { .. } | ExternalCallTarget::Method { .. } => {
+                            if let Some(item) = resolution_to_item_ref(self.db, &resolution) {
+                                self.builder.assign(
+                                    dest,
+                                    Rvalue::Use(Operand::Constant(Constant::Function(item))),
+                                );
+                                return;
+                            }
+                        }
+                    }
+                }
                 MemberResolution::Field { .. }
                 | MemberResolution::Variant { .. }
                 | MemberResolution::InterfaceVirtualField { .. } => {
@@ -10115,6 +10468,49 @@ impl<'db> LoweringContext<'db> {
         )
     }
 
+    /// UFCS twin of `try_lower_interface_dispatch`. Its call plan is
+    /// self-inclusive, so lower the complete source argument list once, peel
+    /// the first operand off as the virtual receiver, and retain the rest as
+    /// method arguments. This preserves source evaluation order and avoids
+    /// asking `lower_call_arg_operands` to interpret a truncated call.
+    fn try_lower_interface_ufcs_dispatch(
+        &mut self,
+        expr_id: AstExprId,
+        receiver: AstExprId,
+        method: &Name,
+        args: &[AstExprId],
+        runtime_id: Option<AstExprId>,
+        dest: &Place,
+    ) -> bool {
+        let dispatch_target = self
+            .interface_dispatch_target_for_expr_member(receiver, method)
+            .or_else(|| {
+                self.tir_expr_type(self.expr_metadata_key(receiver))
+                    .and_then(|ty| self.dispatch_target_for_concrete(ty, method))
+            });
+        let Some((iface_tn, iface_type_args, iface_assoc)) = dispatch_target else {
+            return false;
+        };
+        let mut arg_ops = self.lower_call_arg_operands(expr_id, args);
+        if arg_ops.is_empty() {
+            return false;
+        }
+        let receiver_op = arg_ops.remove(0);
+        let (decl_tn, decl_args, decl_assoc) =
+            self.interface_view_declaring_method(&(iface_tn, iface_type_args, iface_assoc), method);
+        self.emit_virtual_call_with_value_operands(
+            receiver_op,
+            &decl_tn,
+            &decl_args,
+            &decl_assoc,
+            method,
+            expr_id,
+            arg_ops,
+            runtime_id,
+            dest,
+        )
+    }
+
     /// Emit an open-world [`Terminator::VirtualCall`] dispatching `method` of
     /// interface `iface_tn` on `recv_local`. The receiver is passed as the first
     /// value argument; the VM reads its runtime concrete type as `Self` and
@@ -10143,6 +10539,34 @@ impl<'db> LoweringContext<'db> {
         // call's type args — inference may also surface the owner (interface) args,
         // which lead and are dropped here since the VM supplies them from the impl.
         let arg_ops = self.lower_call_arg_operands(expr_id, args);
+        self.emit_virtual_call_with_value_operands(
+            Operand::Copy(Place::Local(recv_local)),
+            iface_tn,
+            iface_type_args,
+            iface_assoc,
+            method,
+            expr_id,
+            arg_ops,
+            runtime_id,
+            dest,
+        )
+    }
+
+    /// Shared virtual-call frame assembly after the receiver and value
+    /// arguments have been lowered in source order.
+    #[expect(clippy::too_many_arguments)]
+    fn emit_virtual_call_with_value_operands(
+        &mut self,
+        receiver: Operand,
+        iface_tn: &TypeName,
+        iface_type_args: &[Tir2Ty],
+        iface_assoc: &[(Name, Tir2Ty)],
+        method: &Name,
+        expr_id: AstExprId,
+        arg_ops: Vec<Operand>,
+        runtime_id: Option<AstExprId>,
+        dest: &Place,
+    ) -> bool {
         let method_arg_count = self
             .interface_method_generic_count(iface_tn, method)
             .unwrap_or(0);
@@ -10156,7 +10580,7 @@ impl<'db> LoweringContext<'db> {
         let ntypeargs = method_type_arg_ops.len();
         let mut all_args = Vec::with_capacity(ntypeargs + arg_ops.len() + 1);
         all_args.extend(method_type_arg_ops);
-        all_args.push(Operand::Copy(Place::Local(recv_local)));
+        all_args.push(receiver);
         all_args.extend(arg_ops);
         // Non-generic interfaces (`Equals`/`Compare`) carry empty args/assoc; a
         // parameterized interface bakes its arguments into the template. The
@@ -10493,9 +10917,30 @@ impl<'db> LoweringContext<'db> {
         let iface_pkg_name = iface_tn.package();
         let iface_pkg_items = self.resolve_class_pkg_items_by_name(iface_pkg_name);
         let iface_ns: Vec<Name> = iface_tn.namespace().clone();
-        let Definition::Interface(iface_loc) =
-            iface_pkg_items.lookup_type(&iface_ns, iface_tn.name())?
-        else {
+        let Some(def) = iface_pkg_items.lookup_type(&iface_ns, iface_tn.name()) else {
+            // A MOUNTED interface's method generics come from its exported
+            // row (declared params — the same count `function_data` reports
+            // for a source interface method).
+            if let Some(baml_compiler2_tir::package_interface::ExportedType::Interface {
+                required_methods,
+                default_methods,
+                ..
+            }) = baml_compiler2_tir::package_interface::mounted_type_row(self.db, iface_tn)
+            {
+                return required_methods
+                    .iter()
+                    .chain(default_methods)
+                    .find(|m| m.name == *method)
+                    .map(|m| {
+                        m.generic_params
+                            .iter()
+                            .filter(|param| !baml_type::is_synthetic_effect_param(param.name()))
+                            .count()
+                    });
+            }
+            return None;
+        };
+        let Definition::Interface(iface_loc) = def else {
             return None;
         };
         let iface_data = interface_data(self.db, iface_loc);
@@ -10791,9 +11236,38 @@ impl<'db> LoweringContext<'db> {
         let iface_pkg_name = iface_tn.package();
         let iface_pkg_items = self.resolve_class_pkg_items_by_name(iface_pkg_name);
         let iface_ns: Vec<Name> = iface_tn.namespace().clone();
-        let Definition::Interface(requested_root_loc) =
-            iface_pkg_items.lookup_type(&iface_ns, iface_tn.name())?
-        else {
+        let Some(def) = iface_pkg_items.lookup_type(&iface_ns, iface_tn.name()) else {
+            // A MOUNTED interface: the exported `requires` rows are the
+            // pre-flattened transitive closure at identity args, so the view
+            // list is the root plus each row realized at the requested args
+            // (`Self`-rooted projections stay symbolic — they only narrow
+            // dispatch views, where the name is what matters).
+            let baml_compiler2_tir::package_interface::ExportedType::Interface {
+                generic_params,
+                requires,
+                ..
+            } = baml_compiler2_tir::package_interface::mounted_type_row(self.db, iface_tn)?
+            else {
+                return None;
+            };
+            let bindings: FxHashMap<ParamTy, Tir2Ty> = generic_params
+                .iter()
+                .cloned()
+                .zip(iface_type_args.iter().cloned())
+                .collect();
+            let mut views = vec![(
+                iface_tn.clone(),
+                iface_type_args.to_vec(),
+                iface_assoc.to_vec(),
+            )];
+            for required in requires {
+                let realized = required
+                    .map_tys(|ty| baml_compiler2_tir::generics::substitute_ty(ty, &bindings));
+                views.push((realized.name, realized.generics, realized.associated_types));
+            }
+            return Some(views);
+        };
+        let Definition::Interface(requested_root_loc) = def else {
             return None;
         };
         Some(

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -950,7 +950,11 @@ fn resolution_to_item_ref(
             let data = baml_compiler2_tir::interfaces::impl_data(db, *impl_loc)
                 .as_ref()
                 .ok()?;
-            let iface_loc = data.interface;
+            // A mounted-interface target has no loc; TIR never records an
+            // `InterfaceConcreteMethod` for one (mounted calls are reserved
+            // until the BEP-066 call-lowering PR), so this is unreachable —
+            // fail soft rather than panic if it ever regresses.
+            let iface_loc = data.interface_loc()?;
             let pkg_info = file_package(db, iface_loc.file(db));
             let iface_data = baml_compiler2_ppir::item_data::interface_data(db, iface_loc);
             let func_data = baml_compiler2_ppir::item_data::function_data(db, *func_loc);

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -115,6 +115,13 @@ enum ClassMethodLookup<'db> {
         class_loc: ClassLoc<'db>,
         func_loc: FunctionLoc<'db>,
     },
+    /// A method of a MOUNTED (source-less) dependency's class, typed from its
+    /// exported signature (BEP-066 slice 6a). Carries no locs — a reference
+    /// types fine, but a call cannot record a `MemberResolution` for MIR and
+    /// is reported reserved (see `foreign_callable_exprs`).
+    ForeignFound {
+        ty: Ty,
+    },
     DuplicateInherent,
     DeferToInterfaces,
     NotFound,
@@ -935,6 +942,14 @@ pub struct TypeInferenceBuilder<'db> {
     /// reference an owner param (`<U extends Eq<C>>` on `class Box<C>`) that is
     /// otherwise absent from the call-site bindings.
     owner_type_arg_binding_seed: FxHashMap<ExprId, Vec<(crate::ty::ParamTy, Ty)>>,
+    /// Callee-position expressions that resolved to a MOUNTED (source-less)
+    /// package's function or method (BEP-066 slice 6a), keyed by the resolved
+    /// expression with the dotted path for the message. A *reference* types
+    /// fine (the exported signature), but an actual CALL needs a
+    /// `MemberResolution` for MIR — which a blob cannot provide until the
+    /// call-lowering PR — so the call arms report
+    /// [`TirTypeError::MountedPackageCallUnsupported`] for any marked callee.
+    foreign_callable_exprs: FxHashMap<ExprId, Name>,
     /// For a Self-pinned interface method call (resolved through a type-variable
     /// receiver — `self` in a default method, or a generic `T extends I`), the
     /// rigid `Self` type variable, keyed by the callee (member-access) expr.
@@ -1214,6 +1229,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             path_member_resolutions: FxHashMap::default(),
             interface_method_generic_params: FxHashMap::default(),
             owner_type_arg_binding_seed: FxHashMap::default(),
+            foreign_callable_exprs: FxHashMap::default(),
             self_pinned_rigid_var: FxHashMap::default(),
             param_types: Vec::new(),
             call_plans: FxHashMap::default(),
@@ -6366,6 +6382,17 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     #[inline(never)]
+    /// Report the reserved BEP-066 slice 6a diagnostic when a call's callee
+    /// resolved into a MOUNTED package (see `foreign_callable_exprs`): the
+    /// reference typed fine, but the call needs a `MemberResolution` for MIR,
+    /// which a source-less blob cannot provide until the call-lowering PR.
+    fn report_reserved_mounted_call(&mut self, callee: ExprId, at: ExprId) {
+        if let Some(path) = self.foreign_callable_exprs.get(&callee).cloned() {
+            self.context
+                .report_simple(TirTypeError::MountedPackageCallUnsupported { path }, at);
+        }
+    }
+
     fn check_call_expr(
         &mut self,
         expr_id: ExprId,
@@ -7197,9 +7224,15 @@ impl<'db> TypeInferenceBuilder<'db> {
                 callee,
                 type_args,
                 args,
-            } => self.check_call_expr(expr_id, body, expected, *callee, type_args, args),
+            } => {
+                let ty = self.check_call_expr(expr_id, body, expected, *callee, type_args, args);
+                self.report_reserved_mounted_call(*callee, expr_id);
+                ty
+            }
             Expr::OptionalCall { callee, args } => {
-                self.check_optional_call_expr(expr_id, body, expected, *callee, args)
+                let ty = self.check_optional_call_expr(expr_id, body, expected, *callee, args);
+                self.report_reserved_mounted_call(*callee, expr_id);
+                ty
             }
             // Catch: propagate expected type to the base expression
             // `a ?? b` in checking position: the expected type propagates into the
@@ -10409,6 +10442,15 @@ impl<'db> TypeInferenceBuilder<'db> {
             return None;
         }
 
+        // A MOUNTED (source-less) package answers from its interface blob —
+        // its raw items are empty by design (BEP-066 slice 6a).
+        if let Some(mounted) =
+            crate::package_interface::mounted_interface(self.context.db(), &pkg_items.package)
+        {
+            let pkg_name = pkg_items.package.clone();
+            return self.resolve_mounted_package_item(mounted, &pkg_name, path, expr_id);
+        }
+
         // Try as a value (function) in a nested namespace
         let item = path.last().expect("non-empty path");
         let lookup_val = pkg_items.lookup_value(&path[..path.len() - 1], item);
@@ -10514,7 +10556,115 @@ impl<'db> TypeInferenceBuilder<'db> {
                             attr: TyAttr::default(),
                         });
                     }
+                    ClassMethodLookup::ForeignFound { ty } => {
+                        // A mounted class's method: no locs to record — the
+                        // reference types, a call is reported reserved.
+                        self.foreign_callable_exprs.insert(
+                            expr_id,
+                            Name::new(path.iter().map(Name::as_str).collect::<Vec<_>>().join(".")),
+                        );
+                        return Some(ty);
+                    }
                     ClassMethodLookup::DeferToInterfaces | ClassMethodLookup::NotFound => {}
+                }
+            }
+        }
+
+        None
+    }
+
+    /// The MOUNTED-package arm of [`Self::resolve_package_item`] (BEP-066
+    /// slice 6a): answer a `pkg.…` value/type path from the mounted interface
+    /// blob. Mirrors the raw-items arm — functions type from their exported
+    /// signature (but record NO `MemberResolution`, so a CALL of the result is
+    /// reported reserved via `foreign_callable_exprs`); classes/enums/
+    /// interfaces produce the same bare value-position types as
+    /// `resolve_package_item`'s type arm; enum variants verify against the
+    /// exported variant list. UFCS method paths (`app.Widget.describe`) type
+    /// through the exported class methods, also call-reserved.
+    fn resolve_mounted_package_item(
+        &mut self,
+        iface: &'db crate::package_interface::PackageInterface,
+        pkg_name: &Name,
+        path: &[Name],
+        expr_id: ExprId,
+    ) -> Option<Ty> {
+        use crate::package_interface::ExportedType;
+
+        let dotted = |path: &[Name]| {
+            let mut parts = vec![pkg_name.as_str()];
+            parts.extend(path.iter().map(Name::as_str));
+            Name::new(parts.join("."))
+        };
+        let item = path.last().expect("non-empty path");
+        let ns = &path[..path.len() - 1];
+
+        // Free function: the exported signature is the reference type.
+        if let Some(f) = iface.lookup_function(ns, item) {
+            self.foreign_callable_exprs.insert(expr_id, dotted(path));
+            return Some(Ty::Function {
+                params: f.params.clone(),
+                ret: Box::new(f.return_type.clone()),
+                throws: Box::new(f.callable_throws.clone()),
+                attr: TyAttr::default(),
+            });
+        }
+
+        // A type in value position — the same bare shapes as the raw-items arm.
+        if let Some(row) = iface.lookup_type(ns, item) {
+            match row {
+                ExportedType::Class { qtn, .. } => {
+                    return Some(Ty::Class(qtn.clone(), vec![], TyAttr::default()));
+                }
+                ExportedType::Enum { qtn, .. } => {
+                    return Some(Ty::Enum(qtn.clone(), TyAttr::default()));
+                }
+                ExportedType::Interface { qtn, .. } => {
+                    return Some(Ty::Interface(
+                        qtn.clone(),
+                        vec![],
+                        vec![],
+                        TyAttr::default(),
+                    ));
+                }
+                ExportedType::TypeAlias { .. } => {}
+            }
+        }
+
+        // Enum variant (`app.Status.Active`), verified against the exported
+        // variant list.
+        for split in 1..path.len() {
+            let ns = &path[..split - 1];
+            let type_name = &path[split - 1];
+            if let Some(ExportedType::Enum { qtn, variants }) = iface.lookup_type(ns, type_name) {
+                if split + 1 != path.len() {
+                    continue;
+                }
+                let variant_name = &path[split];
+                if variants.contains(variant_name) {
+                    return Some(Ty::EnumVariant(
+                        qtn.clone(),
+                        variant_name.clone(),
+                        TyAttr::default(),
+                    ));
+                }
+            }
+        }
+
+        // UFCS method path (`app.Widget.describe`) through the exported class.
+        for split in 1..path.len() {
+            let ns = &path[..split - 1];
+            let type_name = &path[split - 1];
+            if let Some(ExportedType::Class { qtn, .. }) = iface.lookup_type(ns, type_name) {
+                if split + 1 != path.len() {
+                    continue;
+                }
+                let method_name = &path[split];
+                if let ClassMethodLookup::ForeignFound { ty } =
+                    self.lookup_class_method(qtn, &[], method_name)
+                {
+                    self.foreign_callable_exprs.insert(expr_id, dotted(path));
+                    return Some(ty);
                 }
             }
         }
@@ -10852,6 +11002,32 @@ impl<'db> TypeInferenceBuilder<'db> {
                         class_loc,
                         func_loc,
                     } => Some((ty, class_loc, func_loc)),
+                    ClassMethodLookup::ForeignFound { ty } => {
+                        // A mounted class's method: the reference types from
+                        // the exported signature (self stripped for a bound
+                        // access), but no `MemberResolution` exists — a call
+                        // of the result is reported reserved.
+                        self.foreign_callable_exprs
+                            .insert(at, Name::new(format!("{class_name}.{member}")));
+                        if bound
+                            && let Ty::Function {
+                                params,
+                                ret,
+                                throws,
+                                attr,
+                            } = ty
+                        {
+                            let stripped_params =
+                                crate::generics::skip_self_param(&params).to_vec();
+                            return Ty::Function {
+                                params: stripped_params,
+                                ret,
+                                throws,
+                                attr,
+                            };
+                        }
+                        return ty;
+                    }
                     ClassMethodLookup::DuplicateInherent => {
                         return Ty::Error {
                             attr: TyAttr::default(),
@@ -12246,6 +12422,25 @@ impl<'db> TypeInferenceBuilder<'db> {
         _include_aliases: bool,
     ) -> Vec<(Name, Ty)> {
         let mut out: Vec<(Name, Ty)> = Vec::new();
+        // A MOUNTED (source-less) dependency's class: fields come from its
+        // exported row, generics substituted at this receiver (BEP-066 6a).
+        if let Some(crate::package_interface::ExportedType::Class {
+            generic_params,
+            fields,
+            ..
+        }) = crate::package_interface::mounted_type_row(self.context.db(), class_name)
+        {
+            let bindings = crate::generics::bind_type_vars(generic_params, class_type_args);
+            for (name, ty, _attrs) in fields {
+                let field_ty = if bindings.is_empty() {
+                    ty.clone()
+                } else {
+                    crate::generics::substitute_ty(ty, &bindings)
+                };
+                out.push((name.clone(), field_ty));
+            }
+            return out;
+        }
         let Some(pkg_items_for_class) = self.resolve_class_pkg_items(class_name.package()) else {
             return out;
         };
@@ -12530,6 +12725,43 @@ impl<'db> TypeInferenceBuilder<'db> {
         class_type_args: &[Ty],
         method_name: &Name,
     ) -> ClassMethodLookup<'db> {
+        // A MOUNTED (source-less) dependency's class: type the method from its
+        // exported signature (BEP-066 slice 6a) — declaration-scoped, with the
+        // class generics substituted at this receiver's type args. No locs.
+        if let Some(crate::package_interface::ExportedType::Class {
+            generic_params,
+            methods,
+            ..
+        }) = crate::package_interface::mounted_type_row(self.context.db(), class_name)
+        {
+            let Some(method) = methods.iter().find(|m| &m.name == method_name) else {
+                return ClassMethodLookup::NotFound;
+            };
+            let bindings = crate::generics::bind_type_vars(generic_params, class_type_args);
+            let substitute = |ty: &Ty| {
+                if bindings.is_empty() {
+                    ty.clone()
+                } else {
+                    crate::generics::substitute_ty(ty, &bindings)
+                }
+            };
+            return ClassMethodLookup::ForeignFound {
+                ty: Ty::Function {
+                    params: method
+                        .params
+                        .iter()
+                        .map(|p| crate::ty::FunctionParamTy {
+                            name: p.name.clone(),
+                            ty: substitute(&p.ty),
+                            mode: p.mode,
+                        })
+                        .collect(),
+                    ret: Box::new(substitute(&method.return_type)),
+                    throws: Box::new(substitute(&method.callable_throws)),
+                    attr: TyAttr::default(),
+                },
+            };
+        }
         let Some(pkg_items_for_class) = self.resolve_class_pkg_items(class_name.package()) else {
             return ClassMethodLookup::NotFound;
         };

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -2920,6 +2920,7 @@ impl<'db> TypeInferenceBuilder<'db> {
             std::mem::take(&mut self.interface_method_generic_params);
         let saved_owner_type_arg_binding_seed =
             std::mem::take(&mut self.owner_type_arg_binding_seed);
+        let saved_foreign_callable_exprs = std::mem::take(&mut self.foreign_callable_exprs);
         let saved_self_pinned_rigid_var = std::mem::take(&mut self.self_pinned_rigid_var);
         let saved_call_plans = std::mem::take(&mut self.call_plans);
         let saved_call_type_instantiations = std::mem::take(&mut self.call_type_instantiations);
@@ -3047,6 +3048,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         self.path_member_resolutions = saved_path_member_resolutions;
         self.interface_method_generic_params = saved_interface_method_generic_params;
         self.owner_type_arg_binding_seed = saved_owner_type_arg_binding_seed;
+        self.foreign_callable_exprs = saved_foreign_callable_exprs;
         self.self_pinned_rigid_var = saved_self_pinned_rigid_var;
         self.call_plans = saved_call_plans;
         self.call_type_instantiations = saved_call_type_instantiations;

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -13,7 +13,10 @@
 //! NOT recurse into it — lambda bodies are separate scopes with their own
 //! `infer_scope_types` Salsa query.
 
-use std::collections::{BTreeSet, HashMap};
+use std::{
+    collections::{BTreeSet, HashMap},
+    sync::Arc,
+};
 
 use baml_base::{Name, SourceFile};
 use baml_compiler2_ast::{
@@ -116,11 +119,14 @@ enum ClassMethodLookup<'db> {
         func_loc: FunctionLoc<'db>,
     },
     /// A method of a MOUNTED (source-less) dependency's class, typed from its
-    /// exported signature (BEP-066 slice 6a). Carries no locs — a reference
-    /// types fine, but a call cannot record a `MemberResolution` for MIR and
-    /// is reported reserved (see `foreign_callable_exprs`).
+    /// exported signature (BEP-066 slice 6a). Carries no locs; `callee` is the
+    /// loc-free [`MemberResolution::External`] payload the caller records so
+    /// MIR can lower a call symbolically. `None` marks the residue MIR cannot
+    /// lower yet (a blob-exported builtin-kind body) — the reference still
+    /// types, but a call is reported reserved (see `foreign_callable_exprs`).
     ForeignFound {
         ty: Ty,
+        callee: Option<Arc<crate::inference::ExternalCallable>>,
     },
     DuplicateInherent,
     DeferToInterfaces,
@@ -2208,14 +2214,26 @@ impl<'db> TypeInferenceBuilder<'db> {
     /// are exempt, and a `GenericApply` (`foo<int>`) records no `Free` resolution
     /// on its own node, so it is already realized.
     fn references_unspecialized_generic_function(&self, expr: ExprId) -> bool {
-        if let Some(crate::inference::MemberResolution::Free { func_loc }) =
-            self.resolutions.get(&expr)
-        {
-            !baml_compiler2_ppir::item_data::elaborated_function_data(self.context.db(), *func_loc)
+        match self.resolutions.get(&expr) {
+            Some(crate::inference::MemberResolution::Free { func_loc }) => {
+                !baml_compiler2_ppir::item_data::elaborated_function_data(
+                    self.context.db(),
+                    *func_loc,
+                )
                 .user_generic_params
                 .is_empty()
-        } else {
-            false
+            }
+            // A mounted free function (BEP-066 slice 6a): the exported facts
+            // carry the user-declared params.
+            Some(crate::inference::MemberResolution::External(external))
+                if matches!(
+                    external.target,
+                    crate::inference::ExternalCallTarget::Free { .. }
+                ) =>
+            {
+                external.user_generic_params().next().is_some()
+            }
+            _ => false,
         }
     }
 
@@ -2262,6 +2280,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                             | crate::inference::MemberResolution::BoundMethod { .. }
                             | crate::inference::MemberResolution::InterfaceVirtualMethod { .. }
                             | crate::inference::MemberResolution::InterfaceConcreteMethod { .. }
+                            | crate::inference::MemberResolution::External(_)
                     )
                 })
         });
@@ -2297,6 +2316,22 @@ impl<'db> TypeInferenceBuilder<'db> {
                     .get(&callee_id)
                     .cloned()?;
                 return Some((declared_params, declared_bounds, callee_name));
+            }
+            // A mounted-package callee (BEP-066 slice 6a): the declared list is
+            // the resolution's owned copy of the exported facts — the owner
+            // params this call form supplies (unbounded at call position, like
+            // the loc path's prepended class params), then the user-declared
+            // function params with their bounds. Synthetic effect params are
+            // never call-site suppliable, exactly as on the loc path.
+            crate::inference::MemberResolution::External(external) => {
+                let mut declared_params: Vec<crate::ty::ParamTy> =
+                    external.owner_generic_params.clone();
+                let mut declared_bounds: Vec<Vec<Ty>> = vec![Vec::new(); declared_params.len()];
+                for (param, bounds) in external.user_generic_params() {
+                    declared_params.push(param.clone());
+                    declared_bounds.push(bounds.iter().map(baml_type::Interface::to_ty).collect());
+                }
+                return Some((declared_params, declared_bounds, external.display_name()));
             }
             _ => return None,
         };
@@ -2860,6 +2895,16 @@ impl<'db> TypeInferenceBuilder<'db> {
                     .get(&callee_id)
                     .map(|(_, params, _)| crate::ty::RuntimeGenericLayout::new(params))
                     .unwrap_or_else(|| crate::ty::RuntimeGenericLayout::new(callee_generic_params)),
+                // A mounted-package callee's frame layout comes from the
+                // exported facts the resolution carries: the owner params it
+                // supplies at this call form, then the callee's own (user +
+                // synthetic effect) params — mirroring the loc path's
+                // `function_generic_env` ordering (BEP-066 slice 6a).
+                MemberResolution::External(external) => {
+                    let mut params: Vec<crate::ty::ParamTy> = external.owner_generic_params.clone();
+                    params.extend(external.generic_params.iter().cloned());
+                    crate::ty::RuntimeGenericLayout::new(&params)
+                }
                 MemberResolution::Field { .. }
                 | MemberResolution::Variant { .. }
                 | MemberResolution::InterfaceVirtualField { .. } => {
@@ -6384,12 +6429,10 @@ impl<'db> TypeInferenceBuilder<'db> {
     }
 
     #[inline(never)]
-    /// Report the reserved BEP-066 slice 6a diagnostic when a call's callee
-    /// resolved into a MOUNTED package (see `foreign_callable_exprs`): the
-    /// reference typed fine, but the call needs a `MemberResolution` for MIR,
-    /// which a source-less blob cannot provide until the call-lowering PR.
+    /// Report the reserved BEP-066 slice 6a diagnostic when a mounted callee
+    /// has no loc-free link contract (currently compiler/VM builtin bodies).
     fn report_reserved_mounted_call(&mut self, callee: ExprId, at: ExprId) {
-        if let Some(path) = self.foreign_callable_exprs.get(&callee).cloned() {
+        if let Some(path) = self.foreign_callable_exprs.remove(&callee) {
             self.context
                 .report_simple(TirTypeError::MountedPackageCallUnsupported { path }, at);
         }
@@ -10134,12 +10177,15 @@ impl<'db> TypeInferenceBuilder<'db> {
             if self.locals.contains_key(&segments[0]) {
                 // Root is a local variable — chain resolve_member for segments[1..].
                 // The last segment resolves as a bound method reference.
-                self.infer_local_rooted_path(segments, expr_id, true)
+                let ty = self.infer_local_rooted_path(segments, expr_id, true);
+                self.report_reserved_mounted_call(expr_id, expr_id);
+                ty
             } else {
                 // Root is not a known local. Try full package/namespace resolution:
                 // 1. Package path (e.g. baml.llm.ClientType.Primitive, baml.env.get)
                 let pkg_ty = self.infer_multi_segment_path(segments, expr_id);
                 if !matches!(pkg_ty, Ty::Unknown { .. }) {
+                    self.report_reserved_mounted_call(expr_id, expr_id);
                     return pkg_ty;
                 }
                 // 2. Primitive static access (e.g. image.from_url)
@@ -10171,7 +10217,9 @@ impl<'db> TypeInferenceBuilder<'db> {
                 //    root_is_value = false → last segment is an unbound method reference.
                 let root_ty = self.infer_single_name(&segments[0]);
                 if !matches!(root_ty, Ty::Unknown { .. }) {
-                    return self.infer_local_rooted_path(segments, expr_id, false);
+                    let ty = self.infer_local_rooted_path(segments, expr_id, false);
+                    self.report_reserved_mounted_call(expr_id, expr_id);
+                    return ty;
                 }
                 // 4. Truly unresolved — report error if not a known namespace/package name.
                 let is_dep_package = self
@@ -10558,13 +10606,32 @@ impl<'db> TypeInferenceBuilder<'db> {
                             attr: TyAttr::default(),
                         });
                     }
-                    ClassMethodLookup::ForeignFound { ty } => {
-                        // A mounted class's method: no locs to record — the
-                        // reference types, a call is reported reserved.
-                        self.foreign_callable_exprs.insert(
-                            expr_id,
-                            Name::new(path.iter().map(Name::as_str).collect::<Vec<_>>().join(".")),
-                        );
+                    ClassMethodLookup::ForeignFound { ty, callee } => {
+                        // A mounted class's method reached through a
+                        // source-package path (unreachable in practice — a
+                        // class found in raw items is never mounted): mirror
+                        // the mounted UFCS arm's recording.
+                        match callee {
+                            Some(callee)
+                                if matches!(
+                                    callee.target,
+                                    crate::inference::ExternalCallTarget::Method { .. }
+                                ) =>
+                            {
+                                self.resolutions.insert(
+                                    expr_id,
+                                    crate::inference::MemberResolution::External(callee),
+                                );
+                            }
+                            Some(_) | None => {
+                                self.foreign_callable_exprs.insert(
+                                    expr_id,
+                                    Name::new(
+                                        path.iter().map(Name::as_str).collect::<Vec<_>>().join("."),
+                                    ),
+                                );
+                            }
+                        }
                         return Some(ty);
                     }
                     ClassMethodLookup::DeferToInterfaces | ClassMethodLookup::NotFound => {}
@@ -10578,12 +10645,14 @@ impl<'db> TypeInferenceBuilder<'db> {
     /// The MOUNTED-package arm of [`Self::resolve_package_item`] (BEP-066
     /// slice 6a): answer a `pkg.…` value/type path from the mounted interface
     /// blob. Mirrors the raw-items arm — functions type from their exported
-    /// signature (but record NO `MemberResolution`, so a CALL of the result is
-    /// reported reserved via `foreign_callable_exprs`); classes/enums/
+    /// signature and record a loc-free [`MemberResolution::External`] (so MIR
+    /// lowers the call to the library's exported symbol); classes/enums/
     /// interfaces produce the same bare value-position types as
     /// `resolve_package_item`'s type arm; enum variants verify against the
     /// exported variant list. UFCS method paths (`app.Widget.describe`) type
-    /// through the exported class methods, also call-reserved.
+    /// through the exported class methods; interface-scoped UFCS calls route
+    /// through the interface slot. Blob-exported builtin-kind bodies remain
+    /// call-reserved via `foreign_callable_exprs` (E0158).
     fn resolve_mounted_package_item(
         &mut self,
         iface: &'db crate::package_interface::PackageInterface,
@@ -10601,9 +10670,31 @@ impl<'db> TypeInferenceBuilder<'db> {
         let item = path.last().expect("non-empty path");
         let ns = &path[..path.len() - 1];
 
-        // Free function: the exported signature is the reference type.
+        // Free function: the exported signature is the reference type, and the
+        // call target is the exported `pkg.ns….name` symbol.
         if let Some(f) = iface.lookup_function(ns, item) {
-            self.foreign_callable_exprs.insert(expr_id, dotted(path));
+            if f.builtin_kind.is_some() {
+                // A blob-exported builtin body (`$rust_function` and kin) has
+                // no symbolic call contract for a consumer image — reserved.
+                self.foreign_callable_exprs.insert(expr_id, dotted(path));
+            } else {
+                self.resolutions.insert(
+                    expr_id,
+                    crate::inference::MemberResolution::External(Arc::new(
+                        crate::inference::ExternalCallable {
+                            target: crate::inference::ExternalCallTarget::Free {
+                                package: pkg_name.clone(),
+                                namespace: ns.to_vec(),
+                                name: item.clone(),
+                            },
+                            takes_self: false,
+                            owner_generic_params: Vec::new(),
+                            generic_params: f.generic_params.clone(),
+                            generic_param_bounds: f.generic_param_bounds.clone(),
+                        },
+                    )),
+                );
+            }
             return Some(Ty::Function {
                 params: f.params.clone(),
                 ret: Box::new(f.return_type.clone()),
@@ -10657,15 +10748,39 @@ impl<'db> TypeInferenceBuilder<'db> {
         for split in 1..path.len() {
             let ns = &path[..split - 1];
             let type_name = &path[split - 1];
-            if let Some(ExportedType::Class { qtn, .. }) = iface.lookup_type(ns, type_name) {
+            if let Some(ExportedType::Class {
+                qtn,
+                generic_params,
+                ..
+            }) = iface.lookup_type(ns, type_name)
+            {
                 if split + 1 != path.len() {
                     continue;
                 }
                 let method_name = &path[split];
-                if let ClassMethodLookup::ForeignFound { ty } =
+                if let ClassMethodLookup::ForeignFound { ty, callee } =
                     self.lookup_class_method(qtn, &[], method_name)
                 {
-                    self.foreign_callable_exprs.insert(expr_id, dotted(path));
+                    match callee {
+                        // A plain method in static (UFCS) form: the class's
+                        // own generic params are supplied at the call site, so
+                        // they prepend the declared list (the loc path's
+                        // `treat_as_static_method` shape).
+                        Some(callee) => {
+                            let mut callee = (*callee).clone();
+                            callee.owner_generic_params.clone_from(generic_params);
+                            self.resolutions.insert(
+                                expr_id,
+                                crate::inference::MemberResolution::External(Arc::new(callee)),
+                            );
+                        }
+                        // A blob-exported builtin-kind method has no consumer
+                        // link contract (the implementation lives in the
+                        // compiler/VM, not as an ordinary B-693 unit symbol).
+                        None => {
+                            self.foreign_callable_exprs.insert(expr_id, dotted(path));
+                        }
+                    }
                     return Some(ty);
                 }
             }
@@ -11004,13 +11119,28 @@ impl<'db> TypeInferenceBuilder<'db> {
                         class_loc,
                         func_loc,
                     } => Some((ty, class_loc, func_loc)),
-                    ClassMethodLookup::ForeignFound { ty } => {
+                    ClassMethodLookup::ForeignFound { ty, callee } => {
                         // A mounted class's method: the reference types from
                         // the exported signature (self stripped for a bound
-                        // access), but no `MemberResolution` exists — a call
-                        // of the result is reported reserved.
-                        self.foreign_callable_exprs
-                            .insert(at, Name::new(format!("{class_name}.{member}")));
+                        // access) and records the loc-free `External`
+                        // resolution — a plain method lowers to the exported
+                        // `pkg.Class.name` symbol, an `implements`-block one
+                        // routes through its interface slot. The receiver's
+                        // class args seed the frame at runtime (bound form),
+                        // so `owner_generic_params` stays empty. Builtin-kind
+                        // residue stays call-reserved.
+                        match callee {
+                            Some(callee) => {
+                                self.resolutions.insert(
+                                    at,
+                                    crate::inference::MemberResolution::External(callee),
+                                );
+                            }
+                            None => {
+                                self.foreign_callable_exprs
+                                    .insert(at, Name::new(format!("{class_name}.{member}")));
+                            }
+                        }
                         if bound
                             && let Ty::Function {
                                 params,
@@ -12729,8 +12859,11 @@ impl<'db> TypeInferenceBuilder<'db> {
     ) -> ClassMethodLookup<'db> {
         // A MOUNTED (source-less) dependency's class: type the method from its
         // exported signature (BEP-066 slice 6a) — declaration-scoped, with the
-        // class generics substituted at this receiver's type args. No locs.
+        // class generics substituted at this receiver's type args. No locs;
+        // the `ForeignFound` carries the loc-free `External` callee facts so
+        // the caller can record a MIR-lowerable resolution.
         if let Some(crate::package_interface::ExportedType::Class {
+            qtn,
             generic_params,
             methods,
             ..
@@ -12747,6 +12880,39 @@ impl<'db> TypeInferenceBuilder<'db> {
                     crate::generics::substitute_ty(ty, &bindings)
                 }
             };
+            // The symbol a call lowers to: an `implements`-block method routes
+            // through its interface slot (the VM resolves the receiver's
+            // registered impl — the `InterfaceConcreteMethod` routing); a
+            // plain method is the direct `pkg.ns….Class.name` symbol the
+            // library's own emit exported. A blob-exported builtin-kind body
+            // has no lowerable symbol contract here — reserved (`None`).
+            let callee = if method.builtin_kind.is_some() {
+                None
+            } else {
+                let target = match &method.interface_target {
+                    Some(iface_qtn) => crate::inference::ExternalCallTarget::Interface {
+                        iface: iface_qtn.clone(),
+                        method: method.name.clone(),
+                    },
+                    None => crate::inference::ExternalCallTarget::Method {
+                        package: qtn.package().clone(),
+                        namespace: qtn.namespace().clone(),
+                        class: qtn.name().clone(),
+                        name: method.name.clone(),
+                    },
+                };
+                Some(Arc::new(crate::inference::ExternalCallable {
+                    target,
+                    takes_self: method
+                        .params
+                        .first()
+                        .and_then(|p| p.name.as_ref())
+                        .is_some_and(|n| n.as_str() == "self"),
+                    owner_generic_params: Vec::new(),
+                    generic_params: method.generic_params.clone(),
+                    generic_param_bounds: method.generic_param_bounds.clone(),
+                }))
+            };
             return ClassMethodLookup::ForeignFound {
                 ty: Ty::Function {
                     params: method
@@ -12762,6 +12928,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                     throws: Box::new(substitute(&method.callable_throws)),
                     attr: TyAttr::default(),
                 },
+                callee,
             };
         }
         let Some(pkg_items_for_class) = self.resolve_class_pkg_items(class_name.package()) else {

--- a/baml_language/crates/baml_compiler2_tir/src/builder/associated_projection.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/associated_projection.rs
@@ -685,6 +685,30 @@ pub(crate) fn associated_type_declared_bound(
     interface: &baml_type::Interface,
     member: &Name,
 ) -> Vec<baml_type::Interface> {
+    // A MOUNTED (source-less) interface's bounds live pre-realized (identity
+    // args, symbolic `Self`) on its exported row: realize at the qualifier's
+    // arguments by substitution; `Self` stays symbolic per this oracle's
+    // contract (BEP-066 slice 6a). Sibling pins ride `Self.<name>`
+    // projections and stay symbolic (fail-safe: an unreduced projection only
+    // makes the bound-satisfaction check conservative).
+    if let Some(crate::package_interface::ExportedType::Interface {
+        generic_params,
+        associated_types,
+        ..
+    }) = crate::package_interface::mounted_type_row(db, &interface.name)
+    {
+        if generic_params.len() != interface.generics.len() {
+            return Vec::new();
+        }
+        let Some(assoc) = associated_types.iter().find(|a| &a.name == member) else {
+            return Vec::new();
+        };
+        let Some(bound) = &assoc.bound else {
+            return Vec::new();
+        };
+        let bindings = crate::generics::bind_type_vars(generic_params, &interface.generics);
+        return vec![bound.map_tys(|ty| crate::generics::substitute_ty(ty, &bindings))];
+    }
     let Some(iface_loc) = resolve_interface_loc(db, &interface.name) else {
         return Vec::new();
     };
@@ -913,6 +937,13 @@ pub(crate) fn resolve_concrete_projection(
 
 /// Whether interface `qtn` declares associated type `member` directly.
 fn interface_declares_member(db: &dyn crate::Db, qtn: &QualifiedTypeName, member: &Name) -> bool {
+    // A MOUNTED interface answers from its exported row (BEP-066 slice 6a).
+    if let Some(crate::package_interface::ExportedType::Interface {
+        associated_types, ..
+    }) = crate::package_interface::mounted_type_row(db, qtn)
+    {
+        return associated_types.iter().any(|a| &a.name == member);
+    }
     resolve_interface_loc(db, qtn).is_some_and(|loc| interface_declares_member_at(db, loc, member))
 }
 

--- a/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
@@ -524,17 +524,26 @@ impl<'db> TypeInferenceBuilder<'db> {
         // `Repeat<int>` receiver is `Iterator<int, never>`, never the raw pattern form): those
         // declaring `member` as a method, and (separately) those declaring it as a field.
         // Coherence forbids two impls of the same realized interface, so dedup defensively.
-        let mut method_candidates: Vec<(baml_type::Interface, _, _, _)> = Vec::new();
+        let mut method_candidates: Vec<(baml_type::Interface, _, _, _, _)> = Vec::new();
         for resolved_impl in &impls {
             let Some(resolved_method) = resolved_impl.get_method(db, member) else {
                 continue;
             };
-            let Ok(data) = crate::interfaces::impl_data(db, resolved_impl.impl_loc) else {
+            let Some(data) = resolved_impl.data(db) else {
+                continue;
+            };
+            // A mounted blob impl (or an impl of a mounted interface) has no
+            // locs to record for MIR's concrete dispatch — method calls
+            // through those land with the mounted-call lowering PR, so the
+            // candidate is skipped (the member reports unresolved).
+            let (Some(impl_loc), Some(iface_loc)) =
+                (resolved_impl.impl_loc(), data.interface_loc())
+            else {
                 continue;
             };
             let realized = resolved_impl.implemented_interface(db);
             if !method_candidates.iter().any(|(r, ..)| *r == realized) {
-                method_candidates.push((realized, resolved_impl.impl_loc, data, resolved_method));
+                method_candidates.push((realized, impl_loc, iface_loc, data, resolved_method));
             }
         }
         let field_sources = self.concrete_interface_field_sources(&impls, member);
@@ -593,14 +602,15 @@ impl<'db> TypeInferenceBuilder<'db> {
                 attr: TyAttr::default(),
             });
         }
-        let (realized, impl_loc, data, resolved_method) = method_candidates.into_iter().next()?;
+        let (realized, impl_loc, iface_loc, data, resolved_method) =
+            method_candidates.into_iter().next()?;
 
         // The realized interface declares the member; build its `Ty::Function` with `Self`
         // pinned to the concrete receiver (the impl conforms, so the signature is the
         // interface's). The view lowers the interface's declared types in its own package.
         let access = MemberAccess { member, at, bound };
         let view = InterfaceView {
-            loc: data.interface,
+            loc: iface_loc,
             realized,
         };
         let ty =
@@ -654,10 +664,16 @@ impl<'db> TypeInferenceBuilder<'db> {
         let db = self.context.db();
         let mut sources: Vec<ConcreteFieldSource<'db>> = Vec::new();
         for resolved_impl in impls {
-            let Ok(data) = crate::interfaces::impl_data(db, resolved_impl.impl_loc) else {
+            let Some(data) = resolved_impl.data(db) else {
                 continue;
             };
-            let declares_field = baml_compiler2_ppir::item_data::interface_data(db, data.interface)
+            // Mounted interfaces export no field declarations reachable here;
+            // interface-field views through mounted impls land with the
+            // call-lowering PR.
+            let Some(iface_loc) = data.interface_loc() else {
+                continue;
+            };
+            let declares_field = baml_compiler2_ppir::item_data::interface_data(db, iface_loc)
                 .fields
                 .iter()
                 .any(|f| &f.name == field);
@@ -677,7 +693,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 .map(|(_, class_field)| class_field.clone())
                 .unwrap_or_else(|| field.clone());
             sources.push(ConcreteFieldSource {
-                iface_loc: data.interface,
+                iface_loc,
                 interface,
                 class_field,
             });
@@ -836,11 +852,12 @@ impl<'db> TypeInferenceBuilder<'db> {
                 .type_impls(arm)
                 .iter()
                 .filter_map(|resolved_impl| {
-                    let Ok(data) = crate::interfaces::impl_data(db, resolved_impl.impl_loc) else {
-                        return None;
-                    };
+                    // Mounted rows without a source-backed interface loc are
+                    // skipped: the union-member view reads the interface's
+                    // declared members through its loc (call-lowering PR).
+                    let iface_loc = resolved_impl.data(db)?.interface_loc()?;
                     Some(ArmInterface {
-                        iface_loc: data.interface,
+                        iface_loc,
                         interface: resolved_impl.implemented_interface(db),
                     })
                 })

--- a/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder/interface_resolution.rs
@@ -30,6 +30,23 @@ struct InterfaceView<'db> {
     realized: baml_type::Interface,
 }
 
+/// A member declarer may have a source loc or be represented solely by a
+/// mounted interface row. Keeping both in one candidate set is essential for
+/// conjunction ambiguity: source and mounted bounds are sibling constraints.
+enum MemberDeclarer<'db> {
+    Source(InterfaceView<'db>),
+    Mounted(baml_type::Interface),
+}
+
+impl MemberDeclarer<'_> {
+    fn realized(&self) -> &baml_type::Interface {
+        match self {
+            Self::Source(view) => &view.realized,
+            Self::Mounted(realized) => realized,
+        }
+    }
+}
+
 impl<'db> InterfaceView<'db> {
     /// The namespace the interface is declared in — the scope its member type expressions
     /// resolve unqualified names against.
@@ -340,6 +357,12 @@ impl<'db> TypeInferenceBuilder<'db> {
         recv: SelfReceiver<'_>,
         access: MemberAccess<'_>,
     ) -> Option<Ty> {
+        // A MOUNTED (source-less) interface has no loc: its declaration
+        // surface is the exported row, resolved by pure substitution
+        // (BEP-066 slice 6a).
+        if crate::package_interface::mounted_type_row(self.context.db(), bound.name).is_some() {
+            return self.resolve_member_on_mounted_interface(bound, recv, access);
+        }
         let declarers = self.member_declarers_for_bound(bound, access.member);
         self.arbitrate_member_declarers(&declarers, recv, access)
     }
@@ -362,7 +385,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         recv: SelfReceiver<'_>,
         access: MemberAccess<'_>,
     ) -> Option<Ty> {
-        let mut declarers: Vec<InterfaceView<'db>> = Vec::new();
+        let mut declarers: Vec<MemberDeclarer<'db>> = Vec::new();
         for iface in bounds {
             for view in self.member_declarers_for_bound(
                 InterfaceBound {
@@ -372,12 +395,148 @@ impl<'db> TypeInferenceBuilder<'db> {
                 },
                 access.member,
             ) {
-                if !declarers.iter().any(|v| v.realized == view.realized) {
-                    declarers.push(view);
+                if !declarers.iter().any(|v| v.realized() == &view.realized) {
+                    declarers.push(MemberDeclarer::Source(view));
+                }
+            }
+            for declarer in self.mounted_method_declarers_for_bound(
+                InterfaceBound {
+                    name: &iface.name,
+                    type_args: &iface.generics,
+                    associated_bindings: &iface.associated_types,
+                },
+                access.member,
+            ) {
+                if !declarers
+                    .iter()
+                    .any(|v| v.realized() == declarer.realized())
+                {
+                    declarers.push(declarer);
                 }
             }
         }
-        self.arbitrate_member_declarers(&declarers, recv, access)
+        match declarers.as_slice() {
+            [] => None,
+            [MemberDeclarer::Source(view)] => {
+                self.resolve_member_on_one_interface(view, recv, &access)
+            }
+            [MemberDeclarer::Mounted(realized)] => self.resolve_member_on_mounted_interface(
+                InterfaceBound {
+                    name: &realized.name,
+                    type_args: &realized.generics,
+                    associated_bindings: &realized.associated_types,
+                },
+                recv,
+                access,
+            ),
+            _ => {
+                let is_field = declarers.iter().any(|declarer| match declarer {
+                    MemberDeclarer::Source(view) => {
+                        self.interface_member_kind(view.loc, access.member)
+                            == Some(UnionMemberKind::Field)
+                    }
+                    MemberDeclarer::Mounted(_) => false,
+                });
+                let receiver = match &recv {
+                    SelfReceiver::RigidVar(name) => name.to_string(),
+                    SelfReceiver::ExactTy(ty)
+                    | SelfReceiver::Existential(ty)
+                    | SelfReceiver::Union(ty) => ty.render_user_facing(),
+                };
+                let sources: Vec<String> = declarers
+                    .iter()
+                    .map(|v| self.qualified_interface_display(v.realized()))
+                    .collect();
+                let error = if is_field {
+                    TirTypeError::AmbiguousInterfaceField {
+                        class_name: Name::new(&receiver),
+                        field_name: access.member.clone(),
+                        sources: sources
+                            .into_iter()
+                            .map(|source| Name::new(&source))
+                            .collect(),
+                    }
+                } else {
+                    TirTypeError::AmbiguousInterfaceMethod {
+                        class_name: Name::new(&receiver),
+                        method_name: access.member.clone(),
+                        sources,
+                    }
+                };
+                self.context.report_at_member_simple(error, access.at);
+                Some(Ty::Unknown {
+                    attr: TyAttr::default(),
+                })
+            }
+        }
+    }
+
+    /// Loc-free declarers for one mounted bound, with root-wins tiering and a
+    /// mixed source/mounted `requires` closure. Mounted fields remain outside
+    /// the current slice; this helper intentionally enumerates methods only.
+    fn mounted_method_declarers_for_bound(
+        &self,
+        bound: InterfaceBound<'_>,
+        member: &Name,
+    ) -> Vec<MemberDeclarer<'db>> {
+        use crate::package_interface::ExportedType;
+
+        let db = self.context.db();
+        let Some(ExportedType::Interface {
+            qtn,
+            generic_params,
+            required_methods,
+            default_methods,
+            requires,
+            ..
+        }) = crate::package_interface::mounted_type_row(db, bound.name)
+        else {
+            return Vec::new();
+        };
+        let root = baml_type::Interface::new(
+            qtn.clone(),
+            bound.type_args.to_vec(),
+            bound.associated_bindings.to_vec(),
+        );
+        if required_methods
+            .iter()
+            .chain(default_methods)
+            .any(|method| method.name == *member)
+        {
+            return vec![MemberDeclarer::Mounted(root)];
+        }
+
+        let bindings = crate::generics::bind_type_vars(generic_params, bound.type_args);
+        let mut out = Vec::new();
+        for required in requires {
+            let realized = required.map_tys(|ty| crate::generics::substitute_ty(ty, &bindings));
+            let pkg =
+                baml_compiler2_hir::package::PackageId::new(db, realized.name.package().clone());
+            match baml_compiler2_ppir::package_items(db, pkg)
+                .lookup_type(realized.name.namespace(), realized.name.name())
+            {
+                Some(Definition::Interface(loc))
+                    if self.interface_member_kind(loc, member) == Some(UnionMemberKind::Method) =>
+                {
+                    out.push(MemberDeclarer::Source(InterfaceView { loc, realized }));
+                }
+                _ => {
+                    if let Some(ExportedType::Interface {
+                        required_methods,
+                        default_methods,
+                        ..
+                    }) = crate::package_interface::mounted_type_row(db, &realized.name)
+                        && required_methods
+                            .iter()
+                            .chain(default_methods)
+                            .any(|method| method.name == *member)
+                    {
+                        out.push(MemberDeclarer::Mounted(realized));
+                    }
+                }
+            }
+        }
+        out
     }
 
     /// Every interface in `bound`'s `requires` closure that declares `member`.
@@ -532,18 +691,15 @@ impl<'db> TypeInferenceBuilder<'db> {
             let Some(data) = resolved_impl.data(db) else {
                 continue;
             };
-            // A mounted blob impl (or an impl of a mounted interface) has no
-            // locs to record for MIR's concrete dispatch — method calls
-            // through those land with the mounted-call lowering PR, so the
-            // candidate is skipped (the member reports unresolved).
-            let (Some(impl_loc), Some(iface_loc)) =
-                (resolved_impl.impl_loc(), data.interface_loc())
-            else {
-                continue;
-            };
             let realized = resolved_impl.implemented_interface(db);
             if !method_candidates.iter().any(|(r, ..)| *r == realized) {
-                method_candidates.push((realized, impl_loc, iface_loc, data, resolved_method));
+                method_candidates.push((
+                    realized,
+                    resolved_impl.impl_loc(),
+                    data.interface_loc(),
+                    data,
+                    resolved_method,
+                ));
             }
         }
         let field_sources = self.concrete_interface_field_sources(&impls, member);
@@ -605,6 +761,17 @@ impl<'db> TypeInferenceBuilder<'db> {
         let (realized, impl_loc, iface_loc, data, resolved_method) =
             method_candidates.into_iter().next()?;
 
+        // The fully source-backed case preserves its concrete-resolution locs.
+        // Any mounted side is loc-free and routes through the interface slot;
+        // obtain the same symbolic declaration surface from the package export
+        // and let `build_foreign_interface_method_ty` realize it at `base_ty`.
+        let Some(func_loc) = resolved_method.method_loc() else {
+            return self.resolve_member_from_external_impl(base_ty, member, at, bound, &realized);
+        };
+        let (Some(impl_loc), Some(iface_loc)) = (impl_loc, iface_loc) else {
+            return self.resolve_member_from_external_impl(base_ty, member, at, bound, &realized);
+        };
+
         // The realized interface declares the member; build its `Ty::Function` with `Self`
         // pinned to the concrete receiver (the impl conforms, so the signature is the
         // interface's). The view lowers the interface's declared types in its own package.
@@ -621,10 +788,7 @@ impl<'db> TypeInferenceBuilder<'db> {
         // seed with the impl's frame (the override body is keyed by the impl's own params).
         self.resolutions.insert(
             at,
-            crate::inference::MemberResolution::InterfaceConcreteMethod {
-                impl_loc,
-                func_loc: resolved_method.method,
-            },
+            crate::inference::MemberResolution::InterfaceConcreteMethod { impl_loc, func_loc },
         );
         if !resolved_method.from_interface_default {
             let frame = data
@@ -636,6 +800,59 @@ impl<'db> TypeInferenceBuilder<'db> {
             self.owner_type_arg_binding_seed.insert(at, frame);
         }
         Some(ty)
+    }
+
+    /// Resolve a concrete member supplied by a loc-free impl through the
+    /// implemented interface's exported declaration row. The row may itself
+    /// be mounted or source-backed in this database; cloning it before the
+    /// builder mutation keeps the Salsa borrow boundary explicit.
+    fn resolve_member_from_external_impl(
+        &mut self,
+        base_ty: &Ty,
+        member: &Name,
+        at: ExprId,
+        bound: bool,
+        realized: &baml_type::Interface,
+    ) -> Option<Ty> {
+        use crate::package_interface::ExportedType;
+
+        let db = self.context.db();
+        let exported = crate::package_interface::mounted_type_row(db, &realized.name)
+            .cloned()
+            .or_else(|| {
+                let pkg = baml_compiler2_hir::package::PackageId::new(
+                    db,
+                    realized.name.package().clone(),
+                );
+                crate::package_interface::package_interface(db, pkg)
+                    .lookup_type(realized.name.namespace(), realized.name.name())
+                    .cloned()
+            })?;
+        let ExportedType::Interface {
+            qtn,
+            self_param,
+            generic_params,
+            required_methods,
+            default_methods,
+            ..
+        } = exported
+        else {
+            return None;
+        };
+        let method = required_methods
+            .iter()
+            .chain(&default_methods)
+            .find(|method| method.name == *member)?;
+        self.build_foreign_interface_method_ty(
+            &qtn,
+            &self_param,
+            &generic_params,
+            realized,
+            method,
+            SelfReceiver::ExactTy(base_ty),
+            &MemberAccess { member, at, bound },
+        )
+        .into()
     }
 
     /// All impl blocks the concrete `base_ty` satisfies — `impls_for_type` with the builder's
@@ -1501,4 +1718,372 @@ impl<'db> TypeInferenceBuilder<'db> {
         );
         fn_ty
     }
+
+    /// Resolve `access.member` on a receiver whose bound names a MOUNTED
+    /// (source-less) interface — the loc-free foreign twin of
+    /// [`Self::resolve_interface_member`] (BEP-066 slice 6a). The exported row
+    /// carries pre-lowered symbolic-`Self` signatures and the pre-flattened
+    /// `requires` closure, so root-wins tiering runs over rows and realization
+    /// at this receiver is pure substitution. A `requires` parent that is
+    /// source-backed in THIS database (a mounted interface requiring a stdlib
+    /// one) delegates to the ordinary loc view.
+    ///
+    /// Mounted interface FIELDS deliberately stay unresolved here (fail-closed
+    /// residue: the virtual-field view's loc-free lowering lands in a
+    /// follow-up), and unbound (`I.method`) value accesses never reach this
+    /// path (they stay call-reserved upstream).
+    fn resolve_member_on_mounted_interface(
+        &mut self,
+        bound: InterfaceBound<'_>,
+        recv: SelfReceiver<'_>,
+        access: MemberAccess<'_>,
+    ) -> Option<Ty> {
+        use crate::package_interface::ExportedType;
+        let db = self.context.db();
+        let ExportedType::Interface {
+            qtn,
+            self_param,
+            generic_params,
+            fields,
+            required_methods,
+            default_methods,
+            requires,
+            ..
+        } = crate::package_interface::mounted_type_row(db, bound.name)?
+        else {
+            return None;
+        };
+
+        // Root-wins tier: the mounted root's own declaration surface shadows
+        // everything it transitively requires.
+        if let Some(method) = required_methods
+            .iter()
+            .chain(default_methods)
+            .find(|m| m.name == *access.member)
+        {
+            let realized = baml_type::Interface::new(
+                qtn.clone(),
+                bound.type_args.to_vec(),
+                bound.associated_bindings.to_vec(),
+            );
+            return Some(self.build_foreign_interface_method_ty(
+                qtn,
+                self_param,
+                generic_params,
+                &realized,
+                method,
+                recv,
+                &access,
+            ));
+        }
+        if fields.iter().any(|(name, _, _)| name == access.member) {
+            // Field residue: unresolved (never a fabricated view).
+            return None;
+        }
+
+        // Transitive tier: the pre-flattened `requires` closure realized at
+        // the bound's args, deduped by realized identity; declarers split by
+        // which declaration surface they have HERE.
+        let bindings = crate::generics::bind_type_vars(generic_params, bound.type_args);
+        let mut source_declarers: Vec<InterfaceView<'db>> = Vec::new();
+        let mut foreign_declarers: Vec<baml_type::Interface> = Vec::new();
+        for required in requires {
+            let realized = required.map_tys(|ty| crate::generics::substitute_ty(ty, &bindings));
+            let req_pkg =
+                baml_compiler2_hir::package::PackageId::new(db, realized.name.package().clone());
+            match baml_compiler2_ppir::package_items(db, req_pkg)
+                .lookup_type(realized.name.namespace(), realized.name.name())
+            {
+                Some(Definition::Interface(loc)) => {
+                    if self.interface_member_kind(loc, access.member).is_some()
+                        && !source_declarers.iter().any(|v| v.realized == realized)
+                    {
+                        source_declarers.push(InterfaceView { loc, realized });
+                    }
+                }
+                _ => {
+                    if let Some(ExportedType::Interface {
+                        required_methods,
+                        default_methods,
+                        ..
+                    }) = crate::package_interface::mounted_type_row(db, &realized.name)
+                        && required_methods
+                            .iter()
+                            .chain(default_methods)
+                            .any(|m| m.name == *access.member)
+                        && !foreign_declarers.contains(&realized)
+                    {
+                        foreign_declarers.push(realized);
+                    }
+                }
+            }
+        }
+        match (source_declarers.as_slice(), foreign_declarers.as_slice()) {
+            ([], []) => None,
+            ([one], []) => {
+                let view = one.clone();
+                self.resolve_member_on_one_interface(&view, recv, &access)
+            }
+            ([], [_one]) => {
+                let realized = foreign_declarers.into_iter().next().expect("one declarer");
+                let ExportedType::Interface {
+                    qtn,
+                    self_param,
+                    generic_params,
+                    required_methods,
+                    default_methods,
+                    ..
+                } = crate::package_interface::mounted_type_row(db, &realized.name)?
+                else {
+                    return None;
+                };
+                let method = required_methods
+                    .iter()
+                    .chain(default_methods)
+                    .find(|m| m.name == *access.member)?;
+                Some(self.build_foreign_interface_method_ty(
+                    qtn,
+                    self_param,
+                    generic_params,
+                    &realized,
+                    method,
+                    recv,
+                    &access,
+                ))
+            }
+            // ≥2 incomparable declarers (any mix of surfaces): ambiguous,
+            // exactly as `arbitrate_member_declarers` reports it.
+            _ => {
+                let receiver = match &recv {
+                    SelfReceiver::RigidVar(name) => name.to_string(),
+                    SelfReceiver::ExactTy(ty)
+                    | SelfReceiver::Existential(ty)
+                    | SelfReceiver::Union(ty) => ty.render_user_facing(),
+                };
+                let sources: Vec<String> = source_declarers
+                    .iter()
+                    .map(|v| self.qualified_interface_display(&v.realized))
+                    .chain(
+                        foreign_declarers
+                            .iter()
+                            .map(|r| self.qualified_interface_display(r)),
+                    )
+                    .collect();
+                self.context.report_at_member_simple(
+                    TirTypeError::AmbiguousInterfaceMethod {
+                        class_name: Name::new(&receiver),
+                        method_name: access.member.clone(),
+                        sources,
+                    },
+                    access.at,
+                );
+                Some(Ty::Unknown {
+                    attr: TyAttr::default(),
+                })
+            }
+        }
+    }
+
+    /// Build the `Ty::Function` for a MOUNTED interface's method resolved on a
+    /// receiver — the substitution twin of [`Self::build_interface_method_ty`]
+    /// (BEP-066 slice 6a). The exported signature keeps `Self` symbolic (and
+    /// associated types as `Self.<name>` projections on it), so realization is
+    /// one substitution: interface params to the realized args, `Self` to the
+    /// receiver; residual projections reduce under `normalize` through the
+    /// receiver's pins/impls. Records the loc-free `External` resolution
+    /// (interface-slot routing — the VM resolves the receiver's registered
+    /// impl) plus the same call-site seeds the source path records.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "the exported row's decomposed fields plus the receiver/access pair"
+    )]
+    fn build_foreign_interface_method_ty(
+        &mut self,
+        iface_qtn: &crate::ty::QualifiedTypeName,
+        self_param: &crate::ty::ParamTy,
+        iface_generic_params: &[crate::ty::ParamTy],
+        realized: &baml_type::Interface,
+        method: &crate::package_interface::ExportedFunction,
+        recv: SelfReceiver<'_>,
+        access: &MemberAccess<'_>,
+    ) -> Ty {
+        // `Self` for this receiver. The foreign path serves bound accesses and
+        // rigid receivers; an exact/union/existential receiver pins `Self` to
+        // its own type (the existential's pins travel on the type itself).
+        let (self_ty, rigid_pin) = match recv {
+            SelfReceiver::RigidVar(param) => (
+                Ty::TypeVar(param.clone(), TyAttr::default()),
+                Some(param.clone()),
+            ),
+            SelfReceiver::ExactTy(ty) | SelfReceiver::Union(ty) | SelfReceiver::Existential(ty) => {
+                (ty.clone(), None)
+            }
+        };
+
+        // Object safety on a bare existential/union receiver, on the exported
+        // symbolic-`Self` surface: a non-receiver parameter mentioning bare
+        // `Self` (projections exempt) is uncallable; `Self` nested in an
+        // invariant constructor in return/throws likewise (a bare top-level
+        // `-> Self` collapses covariantly). Mirrors the source arm.
+        if matches!(recv, SelfReceiver::Existential(_) | SelfReceiver::Union(_)) && access.bound {
+            let param_self = method
+                .params
+                .iter()
+                .filter(|p| p.name.as_ref().map(Name::as_str) != Some("self"))
+                .any(|p| mentions_bare_self(&p.ty, self_param));
+            let position = if param_self {
+                Some(SelfCallPosition::Parameter)
+            } else if self_nested_in_invariant_position(&method.return_type, self_param)
+                || self_nested_in_invariant_position(&method.callable_throws, self_param)
+            {
+                Some(SelfCallPosition::NestedInReturn)
+            } else {
+                None
+            };
+            if let Some(position) = position {
+                self.context.report_simple(
+                    TirTypeError::InvalidSelfCallThroughInterface {
+                        interface_name: iface_qtn.name().clone(),
+                        method_name: access.member.clone(),
+                        position,
+                    },
+                    access.at,
+                );
+            }
+        }
+
+        let mut bindings =
+            crate::generics::bind_type_vars(iface_generic_params, &realized.generics);
+        bindings.insert(self_param.clone(), self_ty);
+        for gp in &method.generic_params {
+            bindings
+                .entry(gp.clone())
+                .or_insert_with(|| Ty::TypeVar(gp.clone(), TyAttr::default()));
+        }
+        let substitute = |ty: &Ty| crate::generics::substitute_ty(ty, &bindings);
+
+        let takes_self = method
+            .params
+            .first()
+            .and_then(|p| p.name.as_ref())
+            .is_some_and(|n| n.as_str() == "self");
+        let mut params: Vec<crate::ty::FunctionParamTy> = method
+            .params
+            .iter()
+            .map(|p| crate::ty::FunctionParamTy {
+                name: p.name.clone(),
+                ty: substitute(&p.ty),
+                mode: p.mode,
+            })
+            .collect();
+        if access.bound {
+            params = crate::generics::skip_self_param(&params).to_vec();
+        }
+        let fn_ty = Ty::Function {
+            params,
+            ret: Box::new(substitute(&method.return_type)),
+            throws: Box::new(substitute(&method.callable_throws)),
+            attr: TyAttr::default(),
+        };
+
+        // The call-site facts, realized at this receiver: the loc-free
+        // `External` resolution (the interface's method slot — virtual
+        // dispatch), the interface args seed for bound checks that reference
+        // owner params, and the rigid `Self` pin.
+        let realized_bounds: Vec<Vec<baml_type::Interface>> = method
+            .generic_param_bounds
+            .iter()
+            .map(|conjunction| {
+                conjunction
+                    .iter()
+                    .map(|bound| bound.map_tys(&substitute))
+                    .collect()
+            })
+            .collect();
+        self.resolutions.insert(
+            access.at,
+            crate::inference::MemberResolution::External(std::sync::Arc::new(
+                crate::inference::ExternalCallable {
+                    target: crate::inference::ExternalCallTarget::Interface {
+                        iface: iface_qtn.clone(),
+                        method: method.name.clone(),
+                    },
+                    takes_self,
+                    owner_generic_params: Vec::new(),
+                    generic_params: method.generic_params.clone(),
+                    generic_param_bounds: realized_bounds,
+                },
+            )),
+        );
+        let owner_bindings: Vec<(crate::ty::ParamTy, Ty)> = iface_generic_params
+            .iter()
+            .cloned()
+            .zip(realized.generics.iter().cloned())
+            .collect();
+        if !owner_bindings.is_empty() {
+            self.owner_type_arg_binding_seed
+                .insert(access.at, owner_bindings);
+        }
+        if let Some(pin) = rigid_pin {
+            self.self_pinned_rigid_var.insert(access.at, pin);
+        }
+        fn_ty
+    }
+}
+
+/// Whether `ty` mentions the symbolic `Self` parameter OUTSIDE an
+/// associated-type projection base (`Self` is bare; `Self.Item` is exempt —
+/// the receiver's pins make it one concrete type). The exported-row twin of
+/// `type_ref_contains_bare_self`, walking the already-lowered `Ty`.
+fn mentions_bare_self(ty: &Ty, self_param: &crate::ty::ParamTy) -> bool {
+    match ty {
+        Ty::TypeVar(param, _) => param == self_param,
+        // The projection base is exempt; its qualifying interface's own types
+        // are still walked (a `(Self as I<Self>)`-shaped qualifier is bare use).
+        Ty::AssociatedTypeProjection { interface, .. } => {
+            interface.tys().any(|t| mentions_bare_self(t, self_param))
+        }
+        Ty::List(inner, _) | Ty::EvolvingList(inner, _) => mentions_bare_self(inner, self_param),
+        Ty::Map {
+            key: k, value: v, ..
+        }
+        | Ty::EvolvingMap(k, v, _) => {
+            mentions_bare_self(k, self_param) || mentions_bare_self(v, self_param)
+        }
+        Ty::Union(tys, _) => tys.iter().any(|t| mentions_bare_self(t, self_param)),
+        Ty::Future(value, error, _) => {
+            mentions_bare_self(value, self_param) || mentions_bare_self(error, self_param)
+        }
+        Ty::Function {
+            params,
+            ret,
+            throws,
+            ..
+        } => {
+            params
+                .iter()
+                .any(|param| mentions_bare_self(&param.ty, self_param))
+                || mentions_bare_self(ret, self_param)
+                || mentions_bare_self(throws, self_param)
+        }
+        Ty::Class(_, type_args, _) => type_args.iter().any(|t| mentions_bare_self(t, self_param)),
+        Ty::Interface(_, type_args, associated_bindings, _) => {
+            type_args.iter().any(|t| mentions_bare_self(t, self_param))
+                || associated_bindings
+                    .iter()
+                    .any(|(_, ty)| mentions_bare_self(ty, self_param))
+        }
+        _ => false,
+    }
+}
+
+/// Whether bare `Self` appears NESTED inside `ty` — anywhere except as the
+/// whole type — the invariant-constructor half of the object-safety rule for
+/// return/throws positions (`-> Self` collapses covariantly; `-> Self[]` /
+/// `-> Box<Self>` do not).
+fn self_nested_in_invariant_position(ty: &Ty, self_param: &crate::ty::ParamTy) -> bool {
+    if matches!(ty, Ty::TypeVar(param, _) if param == self_param) {
+        return false;
+    }
+    mentions_bare_self(ty, self_param)
 }

--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -110,12 +110,10 @@ pub enum TirTypeError {
     UnionMemberNoCommonInterface { union: Ty, member: Name },
     /// Name could not be resolved at all.
     UnresolvedName { name: Name },
-    /// A CALL whose callee resolves into a MOUNTED (source-less) dependency
-    /// package (BEP-066 slice 6a). The reference itself types fine from the
-    /// exported signature, but lowering the call needs a loc-backed
-    /// `MemberResolution` for MIR, which a blob cannot provide yet — calls
-    /// into mounted packages land in the next PR. `path` is the dotted
-    /// callee path for the message (`app.add`).
+    /// A CALL whose callee is exported by a MOUNTED dependency but has no
+    /// loc-free link contract. Ordinary bytecode functions and methods carry
+    /// symbolic identities; compiler/VM builtin bodies do not. `path` is the
+    /// dotted callee path for the message (`app.native_value`).
     MountedPackageCallUnsupported { path: Name },
     /// A shorthand property (`{ name }`) could not resolve its implicit value.
     /// Suggestions are in-scope values with similar names; the diagnostic
@@ -831,8 +829,8 @@ impl fmt::Display for TirTypeError {
             TirTypeError::MountedPackageCallUnsupported { path } => {
                 write!(
                     f,
-                    "cannot call `{path}`: calls into mounted packages are not supported yet \
-                     (the mounted package has no compiled body to link against in this build)"
+                    "cannot call mounted callable `{path}`: this callable kind has no \
+                     loc-free bytecode link contract"
                 )
             }
             TirTypeError::UnresolvedPropertyShorthand { name, suggestions } => {

--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -110,6 +110,13 @@ pub enum TirTypeError {
     UnionMemberNoCommonInterface { union: Ty, member: Name },
     /// Name could not be resolved at all.
     UnresolvedName { name: Name },
+    /// A CALL whose callee resolves into a MOUNTED (source-less) dependency
+    /// package (BEP-066 slice 6a). The reference itself types fine from the
+    /// exported signature, but lowering the call needs a loc-backed
+    /// `MemberResolution` for MIR, which a blob cannot provide yet — calls
+    /// into mounted packages land in the next PR. `path` is the dotted
+    /// callee path for the message (`app.add`).
+    MountedPackageCallUnsupported { path: Name },
     /// A shorthand property (`{ name }`) could not resolve its implicit value.
     /// Suggestions are in-scope values with similar names; the diagnostic
     /// renders them as explicit `name: suggestion` mappings.
@@ -820,6 +827,13 @@ impl fmt::Display for TirTypeError {
             }
             TirTypeError::UnresolvedName { name } => {
                 write!(f, "unresolved name: {name}")
+            }
+            TirTypeError::MountedPackageCallUnsupported { path } => {
+                write!(
+                    f,
+                    "cannot call `{path}`: calls into mounted packages are not supported yet \
+                     (the mounted package has no compiled body to link against in this build)"
+                )
             }
             TirTypeError::UnresolvedPropertyShorthand { name, suggestions } => {
                 if suggestions.is_empty() {

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -223,6 +223,21 @@ pub(crate) fn interface_associated_type_names_for_qtn(
     db: &dyn crate::Db,
     qtn: &crate::ty::QualifiedTypeName,
 ) -> FxHashSet<Name> {
+    // A MOUNTED (source-less) interface answers from its exported row; its
+    // `requires` rows are the pre-flattened transitive closure, so one level
+    // of name collection per entry covers inheritance (BEP-066 slice 6a).
+    if let Some(crate::package_interface::ExportedType::Interface {
+        associated_types,
+        requires,
+        ..
+    }) = crate::package_interface::mounted_type_row(db, qtn)
+    {
+        let mut names: FxHashSet<Name> = associated_types.iter().map(|a| a.name.clone()).collect();
+        for required in requires {
+            names.extend(interface_associated_type_names_for_qtn(db, &required.name));
+        }
+        return names;
+    }
     let pkg_id = PackageId::new(db, qtn.package().clone());
     let pkg_items = baml_compiler2_ppir::package_items(db, pkg_id);
     let Some(Definition::Interface(iface_loc)) = pkg_items.lookup_type(qtn.namespace(), qtn.name())
@@ -2716,6 +2731,14 @@ pub fn collect_type_aliases<'db>(
 /// lookup, but resolved on demand and reaching every dependency (not only the aliases a
 /// package happens to re-export).
 pub fn alias_def(db: &dyn crate::Db, qtn: &crate::ty::QualifiedTypeName) -> Option<Ty> {
+    // A mounted (source-less) package's aliases live pre-resolved on its
+    // interface blob (BEP-066 slice 6a).
+    if let Some(row) = crate::package_interface::mounted_type_row(db, qtn) {
+        let crate::package_interface::ExportedType::TypeAlias { resolved, .. } = row else {
+            return None;
+        };
+        return Some(resolved.clone());
+    }
     let pkg_id = PackageId::new(db, qtn.package().clone());
     let items = baml_compiler2_ppir::package_items(db, pkg_id);
     match items.lookup_type(qtn.namespace(), qtn.name())? {
@@ -2737,6 +2760,14 @@ pub fn enum_variants<'db>(
     res_ctx: &'db crate::package_interface::PackageResolutionContext<'db>,
     enum_name: &crate::ty::QualifiedTypeName,
 ) -> Option<Vec<Name>> {
+    // A mounted (source-less) package's enums live on its interface blob
+    // (BEP-066 slice 6a); its raw items are empty by design.
+    if let Some(row) = crate::package_interface::mounted_type_row(db, enum_name) {
+        let crate::package_interface::ExportedType::Enum { variants, .. } = row else {
+            return None;
+        };
+        return Some(variants.clone());
+    }
     let items = res_ctx.items_for_package(db, enum_name.package())?;
     let Some(Definition::Enum(enum_loc)) =
         items.lookup_type(enum_name.namespace(), enum_name.name())

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -825,6 +825,96 @@ pub enum MemberResolution<'db> {
         field_index: u32,
         field: Name,
     },
+    /// A callee that resolved into a MOUNTED (source-less) dependency package
+    /// (BEP-066 slice 6a). Loc-free by construction: the identity is carried as
+    /// plain names — exactly the material MIR's `ItemRef` is built from — and the
+    /// call-site facts TIR/MIR consult (receiver convention, generic params and
+    /// bounds) are copied OUT of the exported signature at resolution time. All
+    /// data is owned (never a borrow into another query's storage — the
+    /// incremental-invalidation rule `PackageResolutionContext` documents);
+    /// `Arc`-wrapped because resolutions are cloned freely during MIR lowering.
+    External(Arc<ExternalCallable>),
+}
+
+/// The loc-free facts of a mounted-package callee — see
+/// [`MemberResolution::External`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalCallable {
+    /// Which linked symbol the call (or value reference) lowers to.
+    pub target: ExternalCallTarget,
+    /// Whether the callee's first declared parameter is the `self` receiver
+    /// (drives MIR's receiver-prepending on method-shaped call sites).
+    pub takes_self: bool,
+    /// The receiver-owner's generic params when they are supplied at the CALL
+    /// site (the static/UFCS form on a generic mounted class); empty for
+    /// bound-receiver accesses (the receiver's own class args seed the frame),
+    /// free functions, and interface targets. Mirrors the source path's
+    /// `treat_as_static_method` distinction in `callee_declared_generics`.
+    pub owner_generic_params: Vec<crate::ty::ParamTy>,
+    /// The callee's exported generic params: user-declared params first, then
+    /// any synthetic effect params. Only user-declared params are call-site
+    /// suppliable ([`Self::user_generic_params`]), and `RuntimeGenericLayout`
+    /// erases effects from every runtime frame.
+    pub generic_params: Vec<crate::ty::ParamTy>,
+    /// Per-param interface-bound conjunctions, parallel to
+    /// [`generic_params`](Self::generic_params) (when synthetic effect params
+    /// are present they are unbounded, so their entries are empty).
+    pub generic_param_bounds: Vec<Vec<baml_type::Interface>>,
+}
+
+impl ExternalCallable {
+    /// The user-declared (call-site suppliable) prefix of
+    /// [`generic_params`](Self::generic_params) with its bounds — synthetic
+    /// effect params are always inferred, never written.
+    pub fn user_generic_params(
+        &self,
+    ) -> impl Iterator<Item = (&crate::ty::ParamTy, &Vec<baml_type::Interface>)> {
+        self.generic_params
+            .iter()
+            .zip(self.generic_param_bounds.iter())
+            .filter(|(param, _)| !baml_type::is_synthetic_effect_param(param.name()))
+    }
+
+    /// The callee's short name, for diagnostics.
+    pub fn display_name(&self) -> Name {
+        match &self.target {
+            ExternalCallTarget::Free { name, .. } | ExternalCallTarget::Method { name, .. } => {
+                name.clone()
+            }
+            ExternalCallTarget::Interface { method, .. } => method.clone(),
+        }
+    }
+}
+
+/// The linked-symbol identity of a mounted-package callee. Names only — the
+/// same fields MIR's `ItemRef::Free`/`ItemRef::Method` carry, so lowering is a
+/// pure repackaging (and matches the symbol the library's own emit exported).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ExternalCallTarget {
+    /// A free function: `pkg.ns….name`.
+    Free {
+        package: Name,
+        namespace: Vec<Name>,
+        name: Name,
+    },
+    /// A plain (non-`implements`) class method: `pkg.ns….Class.name` — the
+    /// exact symbol the library's `def_to_item_ref` exported for it.
+    Method {
+        package: Name,
+        namespace: Vec<Name>,
+        class: Name,
+        name: Name,
+    },
+    /// A method reached through an interface (an `implements`-block method on
+    /// a concrete mounted receiver, or any interface-dispatched member whose
+    /// declaring interface is mounted): the emitted callee is the interface's
+    /// method slot (`ifacepkg.ns….Iface.method`) and the VM resolves the
+    /// receiver's registered impl — the same routing MIR uses for
+    /// [`MemberResolution::InterfaceConcreteMethod`].
+    Interface {
+        iface: crate::ty::QualifiedTypeName,
+        method: Name,
+    },
 }
 
 // ── Per-Scope Inference Result ─────────────────────────────────────────────

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces.rs
@@ -676,6 +676,26 @@ pub(crate) fn existential_associated_default(
     self_ty: &Ty,
     member: &Name,
 ) -> Option<Ty> {
+    // A MOUNTED (source-less) interface's defaults live pre-lowered (symbolic
+    // `Self`) on its exported row — realization is pure substitution
+    // (BEP-066 slice 6a).
+    if let Some(crate::package_interface::ExportedType::Interface {
+        self_param,
+        generic_params,
+        associated_types,
+        ..
+    }) = crate::package_interface::mounted_type_row(db, qtn)
+    {
+        let assoc = associated_types.iter().find(|a| &a.name == member)?;
+        let default = assoc.default.as_ref()?;
+        return Some(realize_associated_default(
+            default,
+            generic_params,
+            args,
+            self_param,
+            self_ty,
+        ));
+    }
     let items = res_ctx.items_for_package(db, qtn.package())?;
     let Definition::Interface(iface_loc) = items.lookup_type(qtn.namespace(), qtn.name())? else {
         return None;
@@ -1465,6 +1485,44 @@ pub fn interface_requires<'db>(
     mut equivalent: impl FnMut(&Ty, &Ty) -> bool,
 ) -> bool {
     if sub.name == sup.name {
+        return false;
+    }
+    // A MOUNTED (source-less) `sub`: its exported `requires` rows are the
+    // pre-flattened transitive closure at identity args with symbolic `Self`
+    // — realize by substituting `sub`'s generic arguments and compare
+    // (BEP-066 slice 6a). Two conservative gaps vs. the source walk, both
+    // fail-closed (`false`, never a wrong `true`): a member pinned at the
+    // walk root stays a symbolic `Self.<member>` projection rather than
+    // collapsing to `sub`'s written witness, and unfilled defaults are left
+    // absent (the export's rigid-`Self` rule) — so a `sup` pinning such a
+    // member won't match.
+    if let Some(crate::package_interface::ExportedType::Interface {
+        generic_params,
+        requires,
+        ..
+    }) = crate::package_interface::mounted_type_row(db, &sub.name)
+    {
+        let bindings = generics::bind_type_vars(generic_params, &sub.generics);
+        for required in requires {
+            let realized = required.map_tys(|ty| generics::substitute_ty(ty, &bindings));
+            if realized.name == sup.name
+                && realized.generics.len() == sup.generics.len()
+                && realized
+                    .generics
+                    .iter()
+                    .zip(sup.generics.iter())
+                    .all(|(a, b)| equivalent(a, b))
+                && sup.associated_types.iter().all(|(sup_name, sup_ty)| {
+                    realized
+                        .associated_types
+                        .iter()
+                        .find(|(name, _)| name == sup_name)
+                        .is_some_and(|(_, ty)| equivalent(ty, sup_ty))
+                })
+            {
+                return true;
+            }
+        }
         return false;
     }
     let Some(pkg_items) = res_ctx.items_for_package(db, sub.name.package()) else {

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/coherence.rs
@@ -12,7 +12,7 @@ use baml_compiler2_hir::package::PackageId;
 use baml_type::{ParamTy, Ty, TypeName};
 
 use crate::{
-    interfaces::{ImplData, impl_data, impl_data_source_map, interface_loc_qtn, package_impl_locs},
+    interfaces::{ImplData, impl_data, impl_data_source_map, package_impl_locs},
     type_context::GlobalTypeContext,
     unify::{
         EnumVariants, Overlap, TypeBindings, chase_var, contains_bound_typevar, enum_variant_names,
@@ -34,13 +34,21 @@ fn overlap_violation(overlap: Overlap) -> Option<bool> {
 /// A coherence violation: two implementations of the same interface that overlap,
 /// or that could not be proven disjoint. With no specialization, either is a hard
 /// error; `indeterminate` lets the caller word the diagnostic correctly.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CoherenceViolation {
     /// The offending impl. Always owned by the package being checked, so the
     /// diagnostic lands on a file the user can edit.
     pub primary: Span,
-    /// The impl it overlaps with. May live in a dependency package.
-    pub secondary: Span,
+    /// The impl it overlaps with. May live in a dependency package; `None`
+    /// when the partner is a MOUNTED (source-less) dependency's blob row
+    /// (BEP-066 slice 6a), which has no span anywhere — the diagnostic is
+    /// attributed primary-only, with the partner rendered structurally in
+    /// [`secondary_desc`](Self::secondary_desc).
+    pub secondary: Option<Span>,
+    /// A structural rendering of a span-less partner (`implement I for T` of
+    /// a mounted dependency); `None` whenever [`secondary`](Self::secondary)
+    /// carries a real span.
+    pub secondary_desc: Option<String>,
     /// `true` when overlap could be neither proven nor disproven (conservatively
     /// rejected) rather than a definite overlap.
     pub indeterminate: bool,
@@ -72,11 +80,15 @@ pub fn package_coherence_diagnostics<'db>(
     // on the start offset alone makes two impls at the same offset in *different* files
     // tie and fall back to a nondeterministic order.
     own.sort_by_key(|p| {
-        (
-            p.span.file_id.as_u32(),
-            u32::from(p.span.range.start()),
-            u32::from(p.span.range.end()),
-        )
+        // Span-less (mounted) rows sort last; they never carry a primary
+        // diagnostic anyway (the own package being checked has source).
+        p.span.map_or((u32::MAX, u32::MAX, u32::MAX), |span| {
+            (
+                span.file_id.as_u32(),
+                u32::from(span.range.start()),
+                u32::from(span.range.end()),
+            )
+        })
     });
     let deps = baml_compiler2_hir::package::package_dependency_closure(db, pkg_id);
 
@@ -96,26 +108,39 @@ pub fn package_coherence_diagnostics<'db>(
 
     let mut violations = Vec::new();
     for (i, own_impl) in own.iter().enumerate() {
+        // A span-less own row cannot carry a diagnostic (only mounted rows
+        // are span-less, and a mounted package is never the one being
+        // checked — it has no files).
+        let Some(own_span) = own_impl.span else {
+            continue;
+        };
         // own × own — each unordered pair once; the later impl carries the error.
         for other in &own[i + 1..] {
+            let Some(other_span) = other.span else {
+                continue;
+            };
             if let Some(indeterminate) = overlap_violation(impls_conflict(
                 db, pkg_id, own_impl, other, res_ctx, &aliases,
             )) {
                 violations.push(CoherenceViolation {
-                    primary: other.span,
-                    secondary: own_impl.span,
+                    primary: other_span,
+                    secondary: Some(own_span),
+                    secondary_desc: None,
                     indeterminate,
                 });
             }
         }
-        // own × dependency — the owning package's impl carries the error.
+        // own × dependency — the owning package's impl carries the error. A
+        // mounted dependency's row has no span: primary-only attribution,
+        // the partner rendered structurally (BEP-066 slice 6a).
         for dep in &dep_impls {
             if let Some(indeterminate) =
                 overlap_violation(impls_conflict(db, pkg_id, own_impl, dep, res_ctx, &aliases))
             {
                 violations.push(CoherenceViolation {
-                    primary: own_impl.span,
+                    primary: own_span,
                     secondary: dep.span,
+                    secondary_desc: dep.span.is_none().then(|| dep.render_structural()),
                     indeterminate,
                 });
             }
@@ -132,20 +157,35 @@ fn package_impls_with_spans<'db>(
     db: &'db dyn crate::Db,
     pkg_id: PackageId<'db>,
 ) -> Vec<PreparedImpl<'db>> {
-    package_impl_locs(db, pkg_id)
+    let mut out: Vec<PreparedImpl<'db>> = package_impl_locs(db, pkg_id)
         .iter()
         .filter_map(|&loc| {
             let data = impl_data(db, loc).as_ref().ok()?;
             let span = impl_data_source_map(db, loc).impl_span;
             Some(PreparedImpl {
                 data,
-                span,
-                interface: interface_loc_qtn(db, data.interface),
+                span: Some(span),
+                interface: data.interface_qtn(db),
                 bounds: data.generic_params.iter().cloned().collect(),
                 valid_subject: OnceCell::new(),
             })
         })
-        .collect()
+        .collect();
+    // A MOUNTED package's blob rows participate span-less (BEP-066 slice 6a):
+    // a user impl overlapping a dependency's exported impl is a real E0132,
+    // attributed primary-only at the user's impl.
+    out.extend(
+        crate::interfaces::mounted_impl_datas(db, pkg_id)
+            .iter()
+            .map(|data| PreparedImpl {
+                data,
+                span: None,
+                interface: data.interface_qtn(db),
+                bounds: data.generic_params.iter().cloned().collect(),
+                valid_subject: OnceCell::new(),
+            }),
+    );
+    out
 }
 
 /// An impl prepared for the pairwise overlap loops: the pair-invariant facts —
@@ -154,7 +194,8 @@ fn package_impls_with_spans<'db>(
 /// impl participates in.
 struct PreparedImpl<'db> {
     data: &'db ImplData<'db>,
-    span: Span,
+    /// The impl's source span; `None` for a mounted (source-less) blob row.
+    span: Option<Span>,
     /// The implemented interface, or `None` when it did not resolve (such an
     /// impl conflicts with nothing).
     interface: Option<TypeName>,
@@ -170,6 +211,20 @@ struct PreparedImpl<'db> {
 }
 
 impl<'db> PreparedImpl<'db> {
+    /// A structural rendering of a span-less impl for diagnostics:
+    /// `implement I for T` in user-facing type syntax.
+    fn render_structural(&self) -> String {
+        let iface = self
+            .interface
+            .as_ref()
+            .map(|qtn| qtn.render_dotted(false))
+            .unwrap_or_else(|| "<unresolved>".to_string());
+        format!(
+            "implement {iface} for {}",
+            self.data.for_ty_pattern.render_user_facing()
+        )
+    }
+
     /// Whether this impl's for-target is a valid implementor, judged on its
     /// normalized spelling.
     ///

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
@@ -61,7 +61,7 @@ impl<'db> ImplData<'db> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ImplData<'db> {
     /// The implemented interface's resolved head identity. Impls whose target
     /// doesn't resolve to an interface are dropped (`impl_data` → `None`).
@@ -84,6 +84,10 @@ pub struct ImplData<'db> {
     /// The impl body's own method overrides, as stable function ids. Inherited
     /// interface defaults are merged by downstream consumers, not here.
     pub methods: Vec<baml_compiler2_hir::loc::FunctionLoc<'db>>,
+    /// The impl body's loc-free method overrides when this data was
+    /// materialized from a mounted package interface. Source-backed impls keep
+    /// this empty and use [`Self::methods`]; mounted impls do the inverse.
+    pub mounted_methods: Vec<crate::package_interface::ExportedImplMethod>,
     /// Interface associated-type bindings supplied by this impl body
     /// (`type Item = int`), resolved.
     pub associated_types: Vec<(Name, Ty)>,
@@ -835,6 +839,7 @@ pub fn impl_data<'db>(
         generic_params,
         diagnostics,
         methods,
+        mounted_methods: Vec::new(),
         associated_types,
         field_links,
         origin,
@@ -1190,6 +1195,7 @@ fn mounted_impl_data<'db>(
         generic_params,
         diagnostics,
         methods: block.methods.clone(),
+        mounted_methods: Vec::new(),
         associated_types,
         field_links: block
             .field_links
@@ -2326,10 +2332,10 @@ pub struct ResolvedImpl<'db> {
 /// over them. Loc-free by construction: the interface target resolves to a
 /// source loc when the implemented interface is itself source-backed in THIS
 /// database (a blob impl of a stdlib interface), else stays a `Mounted`
-/// qualified name; `methods` is empty (blob overrides have no locs — method
-/// dispatch through mounted impls lands with the call-lowering PR) and
-/// `diagnostics` is empty (blob impls are pre-checked at export; they are
-/// never re-validated here). Empty for non-mounted packages.
+/// qualified name. Blob overrides are retained in `mounted_methods` (their
+/// structural owner is the enclosing row); `diagnostics` is empty because
+/// mounted impls were checked before export and are never re-validated here.
+/// Empty for non-mounted packages.
 #[salsa::tracked(returns(ref))]
 pub fn mounted_impl_datas<'db>(
     db: &'db dyn crate::Db,
@@ -2362,6 +2368,7 @@ pub fn mounted_impl_datas<'db>(
                     .collect(),
                 diagnostics: Vec::new(),
                 methods: Vec::new(),
+                mounted_methods: row.methods.clone(),
                 associated_types: row.associated_types.clone(),
                 field_links: row.field_links.clone(),
                 origin: match &row.origin {
@@ -3051,10 +3058,18 @@ pub(crate) fn first_failing_impl_bound<'db>(
 /// An interface method resolved on a [`ResolvedImpl`] — the function backing it
 /// plus the type arguments to instantiate its generic frame. Produced by
 /// [`ResolvedImpl::get_method`].
+pub enum ResolvedMethodProvider<'db> {
+    /// A source-backed function body.
+    Source(baml_compiler2_hir::loc::FunctionLoc<'db>),
+    /// A loc-free mounted body and signature. Its symbol owner is the
+    /// enclosing `ExportedImpl`, never `sig.callable_fqn` alone.
+    Mounted(Box<crate::package_interface::ExportedFunction>),
+}
+
 pub struct ResolvedMethod<'db> {
     /// The function providing the implementation: the impl block's own override,
     /// or — when the impl does not override it — the interface's default method.
-    pub method: baml_compiler2_hir::loc::FunctionLoc<'db>,
+    pub method: ResolvedMethodProvider<'db>,
     /// `true` when `method` is the interface's default body rather than an impl
     /// override. The two are referenced differently downstream: a free function
     /// vs. a method dispatched through the interface on its implementor.
@@ -3063,6 +3078,16 @@ pub struct ResolvedMethod<'db> {
     /// own generic params resolved through the impl bindings for an override, or
     /// the realized interface input args for an inherited default.
     pub frame_type_args: Vec<Ty>,
+}
+
+impl<'db> ResolvedMethod<'db> {
+    /// The backing function loc when the provider is source-backed.
+    pub fn method_loc(&self) -> Option<baml_compiler2_hir::loc::FunctionLoc<'db>> {
+        match self.method {
+            ResolvedMethodProvider::Source(loc) => Some(loc),
+            ResolvedMethodProvider::Mounted(_) => None,
+        }
+    }
 }
 
 impl<'db> ResolvedImpl<'db> {
@@ -3120,34 +3145,107 @@ impl<'db> ResolvedImpl<'db> {
                     })
                     .collect();
                 return Some(ResolvedMethod {
-                    method: func_loc,
+                    method: ResolvedMethodProvider::Source(func_loc),
                     from_interface_default: false,
                     frame_type_args,
                 });
             }
         }
 
-        // The interface's default — framed by the realized interface input args.
-        // A MOUNTED interface's default bodies have no locs; resolving a call
-        // to one lands with the mounted-call lowering PR, so the lookup
-        // reports "no such method" until then.
-        let iface_loc = data.interface_loc()?;
-        let iface_data = interface_data(db, iface_loc);
-        for &fn_loc in &iface_data.default_methods {
-            if function_data(db, fn_loc).name == *method {
+        // A mounted impl's own override — the same generic frame as the source
+        // arm, but with an exported signature instead of a FunctionLoc.
+        for exported in &data.mounted_methods {
+            if exported.name == *method {
                 let frame_type_args = data
-                    .interface_args
+                    .generic_params
                     .iter()
-                    .map(|arg| substitute_ty(arg, &self.bindings))
+                    .map(|(name, _)| {
+                        self.bindings
+                            .get(name)
+                            .cloned()
+                            .unwrap_or(Ty::BuiltinUnknown {
+                                attr: TyAttr::default(),
+                            })
+                    })
                     .collect();
                 return Some(ResolvedMethod {
-                    method: fn_loc,
-                    from_interface_default: true,
+                    method: ResolvedMethodProvider::Mounted(Box::new(exported.sig.clone())),
+                    from_interface_default: false,
                     frame_type_args,
                 });
             }
         }
+
+        // The interface's default — framed by the realized interface input
+        // args, through either the source declaration or its mounted row.
+        match &data.interface {
+            ImplInterfaceTarget::Source(iface_loc) => {
+                let iface_data = interface_data(db, *iface_loc);
+                for &fn_loc in &iface_data.default_methods {
+                    if function_data(db, fn_loc).name == *method {
+                        let frame_type_args = data
+                            .interface_args
+                            .iter()
+                            .map(|arg| substitute_ty(arg, &self.bindings))
+                            .collect();
+                        return Some(ResolvedMethod {
+                            method: ResolvedMethodProvider::Source(fn_loc),
+                            from_interface_default: true,
+                            frame_type_args,
+                        });
+                    }
+                }
+            }
+            ImplInterfaceTarget::Mounted(qtn) => {
+                if let Some(crate::package_interface::ExportedType::Interface {
+                    default_methods,
+                    ..
+                }) = crate::package_interface::mounted_type_row(db, qtn)
+                    && let Some(exported) = default_methods.iter().find(|m| m.name == *method)
+                {
+                    let frame_type_args = data
+                        .interface_args
+                        .iter()
+                        .map(|arg| substitute_ty(arg, &self.bindings))
+                        .collect();
+                    return Some(ResolvedMethod {
+                        method: ResolvedMethodProvider::Mounted(Box::new(exported.clone())),
+                        from_interface_default: true,
+                        frame_type_args,
+                    });
+                }
+            }
+        }
         None
+    }
+
+    /// Whether this impl PROVIDES `method` — an override, an inherited
+    /// interface default, or (for a mounted blob row, whose overrides have no
+    /// locs) an exported method row. Kept as a named predicate for candidate
+    /// callers that do not need the provider payload.
+    pub fn provides_method(&self, db: &'db dyn crate::Db, method: &Name) -> bool {
+        use baml_compiler2_ppir::item_data::{function_data, interface_data};
+        if self.get_method(db, method).is_some() {
+            return true;
+        }
+        let Some(data) = self.data(db) else {
+            return false;
+        };
+        // The implemented interface's own default — through whichever
+        // declaration surface exists (source loc or mounted row).
+        match &data.interface {
+            ImplInterfaceTarget::Source(iface_loc) => interface_data(db, *iface_loc)
+                .default_methods
+                .iter()
+                .any(|&fn_loc| function_data(db, fn_loc).name == *method),
+            ImplInterfaceTarget::Mounted(qtn) => matches!(
+                crate::package_interface::mounted_type_row(db, qtn),
+                Some(crate::package_interface::ExportedType::Interface {
+                    default_methods,
+                    ..
+                }) if default_methods.iter().any(|m| m.name == *method)
+            ),
+        }
     }
 
     /// The interface this impl provides at its resolved instantiation: the declared interface

--- a/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/interfaces/impl_rules.rs
@@ -27,11 +27,45 @@ use crate::{
 /// This is the single point where an impl's interface target, for-type, and
 /// associated bindings are resolved; the registry, MIR, and LSP all read it
 /// instead of re-lowering the raw `TypeExpr` paths.
+/// The resolved identity of the interface an impl implements: a source-backed
+/// declaration (a loc), or a MOUNTED (source-less) dependency's interface row
+/// (BEP-066 slice 6a) — identified by qualified name, its declaration surface
+/// served from the mounted `PackageInterface` blob.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ImplInterfaceTarget<'db> {
+    /// A source-backed interface declaration.
+    Source(baml_compiler2_hir::loc::InterfaceLoc<'db>),
+    /// A mounted dependency's interface, by qualified name — owned, never a
+    /// borrow into another query's storage (the incremental-invalidation rule
+    /// `PackageResolutionContext` documents). The declaration surface is
+    /// recovered through `mounted_type_row`.
+    Mounted(QualifiedTypeName),
+}
+
+impl<'db> ImplData<'db> {
+    /// The source-backed interface loc, when the target is source-backed.
+    pub fn interface_loc(&self) -> Option<baml_compiler2_hir::loc::InterfaceLoc<'db>> {
+        match &self.interface {
+            ImplInterfaceTarget::Source(loc) => Some(*loc),
+            ImplInterfaceTarget::Mounted(_) => None,
+        }
+    }
+
+    /// The implemented interface's qualified name — total over both targets
+    /// (the `Option` mirrors [`interface_loc_qtn`]'s legacy shape).
+    pub fn interface_qtn(&self, db: &'db dyn crate::Db) -> Option<QualifiedTypeName> {
+        match &self.interface {
+            ImplInterfaceTarget::Source(loc) => interface_loc_qtn(db, *loc),
+            ImplInterfaceTarget::Mounted(qtn) => Some(qtn.clone()),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ImplData<'db> {
     /// The implemented interface's resolved head identity. Impls whose target
     /// doesn't resolve to an interface are dropped (`impl_data` → `None`).
-    pub interface: baml_compiler2_hir::loc::InterfaceLoc<'db>,
+    pub interface: ImplInterfaceTarget<'db>,
     /// The interface's generic input args (`<int>` in `Container<int>`).
     pub interface_args: Vec<Ty>,
     /// The resolved implementor pattern (may carry `Ty::TypeVar`s).
@@ -448,10 +482,34 @@ pub fn impl_data<'db>(
     // Resolve the interface head to its loc *after* lowering, so a bad interface
     // target still surfaces its diagnostics (and the for-target / bound ones).
     // Associated bindings are skipped here — they can't be checked without the
-    // interface declaration.
-    let Some(iface_loc) =
-        resolve_ref_to_interface(db, &block.type_refs, block.interface_target, pkg_items, ns)
-    else {
+    // interface declaration. A target naming a MOUNTED (source-less)
+    // dependency's interface has no loc; its declaration surface is the
+    // exported row (BEP-066 slice 6a), handled by the mounted arm below.
+    let resolved_target =
+        resolve_ref_to_interface(db, &block.type_refs, block.interface_target, pkg_items, ns);
+    if resolved_target.is_none()
+        && let Ty::Interface(target_qtn, _, _, _) = &lowered_interface
+        && let Some(crate::package_interface::ExportedType::Interface { .. }) =
+            crate::package_interface::mounted_type_row(db, target_qtn)
+    {
+        return Ok(mounted_impl_data(
+            db,
+            block,
+            pkg_items,
+            ns,
+            target_qtn.clone(),
+            MountedImplParts {
+                interface_args,
+                for_ty_pattern,
+                generic_params,
+                origin,
+                interface_target_diags,
+                for_target_diags,
+                bound_diags,
+            },
+        ));
+    }
+    let Some(iface_loc) = resolved_target else {
         // The head didn't name an interface. If it resolved to a named non-interface type, that
         // is a specialized "not an interface" (E0119); otherwise the head is unknown, so the
         // generic unresolved-type lowering error (E0112-equivalent) rides along. The for-target
@@ -771,7 +829,7 @@ pub fn impl_data<'db>(
         .collect();
 
     Ok(ImplData {
-        interface: iface_loc,
+        interface: ImplInterfaceTarget::Source(iface_loc),
         interface_args,
         for_ty_pattern,
         generic_params,
@@ -781,6 +839,365 @@ pub fn impl_data<'db>(
         field_links,
         origin,
     })
+}
+
+/// The head-resolution outputs `impl_data` computed before discovering the
+/// target is a MOUNTED interface — handed to [`mounted_impl_data`] so the
+/// mounted arm shares the exact same header lowering.
+struct MountedImplParts {
+    interface_args: Vec<Ty>,
+    for_ty_pattern: Ty,
+    generic_params: Vec<(ParamTy, Vec<baml_type::Interface>)>,
+    origin: InterfaceImplOrigin,
+    interface_target_diags: Vec<crate::infer_context::TirTypeError>,
+    for_target_diags: Vec<crate::infer_context::TirTypeError>,
+    bound_diags: Vec<crate::infer_context::TirTypeError>,
+}
+
+/// The MOUNTED-interface arm of [`impl_data`] (BEP-066 slice 6a): a user impl
+/// whose target is a source-less dependency's interface. The declaration
+/// surface — associated types (with pre-lowered symbolic-`Self` defaults),
+/// fields, required/default methods — comes from the exported row instead of
+/// `interface_data`, and the same name/membership conformance rules run
+/// against it (E0113/E0115/E0124/E0126/E0128/E0129/E0130, associated-binding
+/// hygiene). Type-level conformance (signatures, requires, bound
+/// satisfaction) runs downstream in `validate_impl_signatures`' mounted arm.
+fn mounted_impl_data<'db>(
+    db: &'db dyn crate::Db,
+    block: &baml_compiler2_ppir::item_data::ImplBlockData<'db>,
+    pkg_items: &baml_compiler2_hir::package::PackageItems<'db>,
+    ns: &[Name],
+    iface_qtn: QualifiedTypeName,
+    parts: MountedImplParts,
+) -> ImplData<'db> {
+    use baml_compiler2_ppir::item_data::{ImplSubjectData, function_data};
+
+    use crate::package_interface::ExportedType;
+
+    let MountedImplParts {
+        interface_args,
+        for_ty_pattern,
+        generic_params,
+        origin,
+        interface_target_diags,
+        for_target_diags,
+        bound_diags,
+    } = parts;
+    let Some(ExportedType::Interface {
+        self_param,
+        generic_params: iface_params,
+        associated_types: iface_assoc,
+        fields: iface_fields,
+        required_methods,
+        default_methods,
+        ..
+    }) = crate::package_interface::mounted_type_row(db, &iface_qtn)
+    else {
+        unreachable!("mounted_impl_data is called with a verified mounted interface row")
+    };
+
+    // ── Associated bindings: the mounted twin of
+    // `lower_interface_associated_bindings`. Explicit `type X = …` pins lower
+    // in the impl's own scope (`Self` a rigid var bounded by the interface at
+    // the already-resolved pins, so `Self.Earlier` collapses without touching
+    // the impl set); an omitted default is the row's pre-lowered symbolic-Self
+    // value realized at this receiver by pure substitution. ──
+    let mut assoc_diags = Vec::new();
+    let generic_param_names: Vec<ParamTy> = generic_params
+        .iter()
+        .map(|(name, _)| name.clone())
+        .collect();
+    let impl_bounds: crate::lower_type_expr::TypeVarBoundsMap =
+        generic_params.iter().cloned().collect();
+    let mut value_scope = generic_param_names.clone();
+    value_scope.push(self_param.clone());
+    let mut value_bindings: TypeBindings = crate::generics::identity_bindings(&generic_param_names);
+    value_bindings.insert(self_param.clone(), for_ty_pattern.clone());
+    let mut resolved_pins: Vec<(Name, Ty)> = Vec::new();
+    let associated_types: Vec<(Name, Ty)> = iface_assoc
+        .iter()
+        .filter_map(|assoc| {
+            let ty = if let Some(binding) = block
+                .associated_type_bindings
+                .iter()
+                .find(|binding| binding.name == assoc.name)
+                && let Some(type_ref) = binding.type_ref
+            {
+                let mut bounds = impl_bounds.clone();
+                bounds.insert(
+                    self_param.clone(),
+                    vec![baml_type::Interface::new(
+                        iface_qtn.clone(),
+                        interface_args.clone(),
+                        resolved_pins.clone(),
+                    )],
+                );
+                crate::generics::substitute_ty(
+                    &crate::lower_type_expr::lower_type_ref(
+                        &block.type_refs,
+                        type_ref,
+                        &crate::lower_type_expr::ScopeCtx {
+                            db,
+                            package_items: pkg_items,
+                            ns_context: ns,
+                            generic_params: &value_scope,
+                            bounds: &bounds,
+                            self_ty: Some(Ty::TypeVar(self_param.clone(), TyAttr::default())),
+                        },
+                        &mut assoc_diags,
+                    ),
+                    &value_bindings,
+                )
+            } else {
+                // Fill the omitted default at the impl's receiver: the row's
+                // default is pre-lowered with symbolic `Self`, so realization
+                // is pure substitution (sibling references ride `Self.<name>`
+                // projections that become receiver projections here — the
+                // same shape the source twin leaves).
+                let default = assoc.default.as_ref()?;
+                let realized = crate::interfaces::realize_associated_default(
+                    default,
+                    iface_params,
+                    &interface_args,
+                    self_param,
+                    &for_ty_pattern,
+                );
+                substitute_ty(&realized, &value_bindings)
+            };
+            resolved_pins.push((assoc.name.clone(), ty.clone()));
+            Some((assoc.name.clone(), ty))
+        })
+        .collect();
+
+    // ── Name/membership conformance against the row (the mounted twin of the
+    // source arm's conformance block). ──
+    let mut conformance_diags: Vec<(crate::infer_context::TirTypeError, ImplDiagnosticLocation)> =
+        Vec::new();
+    if matches!(origin, InterfaceImplOrigin::OutOfBody) && !iface_fields.is_empty() {
+        conformance_diags.push((
+            crate::infer_context::TirTypeError::OutOfBodyImplementsFieldInterface {
+                interface: iface_qtn.clone(),
+            },
+            ImplDiagnosticLocation::InterfaceTarget,
+        ));
+    }
+    let override_names: Vec<&Name> = block
+        .methods
+        .iter()
+        .map(|loc| &function_data(db, *loc).name)
+        .collect();
+    let default_names: Vec<&Name> = default_methods.iter().map(|m| &m.name).collect();
+    // E0113: a required method with no override and no inherited default.
+    for required in required_methods {
+        let provided = override_names.iter().any(|n| **n == required.name)
+            || default_names.iter().any(|n| **n == required.name);
+        if !provided {
+            conformance_diags.push((
+                crate::infer_context::TirTypeError::MissingInterfaceMethod {
+                    interface: iface_qtn.clone(),
+                    method: required.name.clone(),
+                },
+                ImplDiagnosticLocation::InterfaceTarget,
+            ));
+        }
+    }
+    // E0115: an override matching no required or default method.
+    for (idx, &name) in override_names.iter().enumerate() {
+        if override_names[..idx].contains(&name) {
+            continue;
+        }
+        let is_member = required_methods.iter().any(|m| m.name == *name)
+            || default_names.iter().any(|n| **n == *name);
+        if !is_member {
+            conformance_diags.push((
+                crate::infer_context::TirTypeError::UnknownInterfaceMember {
+                    interface: iface_qtn.clone(),
+                    member: name.clone(),
+                },
+                ImplDiagnosticLocation::Method(name.clone()),
+            ));
+        }
+    }
+    // Field-side conformance, in-body class impls only (mirrors the source
+    // arm; E0128/E0129/E0130 link hygiene + E0124 coverage).
+    if let InterfaceImplOrigin::InBodyClass { class_qtn } = &origin
+        && let ImplSubjectData::InClass { class, .. } = &block.subject
+        && (!block.field_links.is_empty() || !iface_fields.is_empty())
+    {
+        let class_fields = crate::inference::resolve_class_fields(db, *class);
+        let is_iface_field = |name: &Name| iface_fields.iter().any(|(n, _, _)| n == name);
+        let is_class_field = |name: &Name| class_fields.fields.iter().any(|(n, _, _)| n == name);
+
+        for (idx, link) in block.field_links.iter().enumerate() {
+            let iface_field = &link.interface_field;
+            if block.field_links[..idx]
+                .iter()
+                .any(|l| l.interface_field == *iface_field)
+            {
+                continue;
+            }
+            if block.field_links[idx + 1..]
+                .iter()
+                .any(|l| l.interface_field == *iface_field)
+            {
+                conformance_diags.push((
+                    crate::infer_context::TirTypeError::DuplicateInterfaceFieldLink {
+                        interface: iface_qtn.clone(),
+                        field: iface_field.clone(),
+                    },
+                    ImplDiagnosticLocation::InterfaceFieldLink(iface_field.clone()),
+                ));
+            }
+            if !is_iface_field(iface_field) {
+                conformance_diags.push((
+                    crate::infer_context::TirTypeError::UnknownInterfaceFieldLink {
+                        interface: iface_qtn.clone(),
+                        field: iface_field.clone(),
+                    },
+                    ImplDiagnosticLocation::InterfaceFieldLink(iface_field.clone()),
+                ));
+            }
+        }
+        for (idx, link) in block.field_links.iter().enumerate() {
+            if !is_iface_field(&link.interface_field) {
+                continue;
+            }
+            let class_field = &link.class_field;
+            if block.field_links[..idx]
+                .iter()
+                .any(|l| l.class_field == *class_field && is_iface_field(&l.interface_field))
+            {
+                continue;
+            }
+            if !is_class_field(class_field) {
+                conformance_diags.push((
+                    crate::infer_context::TirTypeError::UnknownClassFieldInInterfaceLink {
+                        class: class_qtn.name().clone(),
+                        interface: iface_qtn.clone(),
+                        field: class_field.clone(),
+                    },
+                    ImplDiagnosticLocation::ClassFieldLink(class_field.clone()),
+                ));
+            }
+        }
+        // E0124: every interface field covered by a same-named class field or
+        // an explicit link.
+        for (iface_field, _, _) in iface_fields {
+            let linked = block
+                .field_links
+                .iter()
+                .any(|fl| fl.interface_field == *iface_field);
+            if !linked && !is_class_field(iface_field) {
+                conformance_diags.push((
+                    crate::infer_context::TirTypeError::MissingInterfaceField {
+                        interface: iface_qtn.clone(),
+                        field: iface_field.clone(),
+                    },
+                    ImplDiagnosticLocation::InterfaceTarget,
+                ));
+            }
+        }
+    }
+    // Associated-type binding hygiene (duplicate / unknown / missing).
+    let is_assoc = |name: &Name| iface_assoc.iter().any(|a| &a.name == name);
+    for (idx, binding) in block.associated_type_bindings.iter().enumerate() {
+        if block.associated_type_bindings[..idx]
+            .iter()
+            .any(|b| b.name == binding.name)
+        {
+            continue;
+        }
+        if block.associated_type_bindings[idx + 1..]
+            .iter()
+            .any(|b| b.name == binding.name)
+        {
+            conformance_diags.push((
+                crate::infer_context::TirTypeError::DuplicateAssociatedTypeBinding {
+                    interface: iface_qtn.clone(),
+                    name: binding.name.clone(),
+                },
+                ImplDiagnosticLocation::AssociatedBinding(binding.name.clone()),
+            ));
+        }
+        if !is_assoc(&binding.name) {
+            conformance_diags.push((
+                crate::infer_context::TirTypeError::UnknownAssociatedTypeBinding {
+                    interface: iface_qtn.clone(),
+                    name: binding.name.clone(),
+                },
+                ImplDiagnosticLocation::AssociatedBinding(binding.name.clone()),
+            ));
+        }
+    }
+    for assoc in iface_assoc {
+        if assoc.default.is_none()
+            && !block
+                .associated_type_bindings
+                .iter()
+                .any(|b| b.name == assoc.name)
+        {
+            conformance_diags.push((
+                crate::infer_context::TirTypeError::MissingImplAssociatedTypeBinding {
+                    interface: iface_qtn.clone(),
+                    name: assoc.name.clone(),
+                },
+                ImplDiagnosticLocation::InterfaceTarget,
+            ));
+        }
+    }
+    // Bindings written on the `implements` target are rejected, as on the
+    // source path.
+    if let baml_compiler2_hir::type_ref::TypeRefKind::Path {
+        associated_type_bindings,
+        ..
+    } = &block.type_refs[block.interface_target].kind
+        && !associated_type_bindings.is_empty()
+    {
+        conformance_diags.push((
+            crate::infer_context::TirTypeError::AssociatedTypeBindingsOnImplementsTarget {
+                interface: iface_qtn.clone(),
+            },
+            ImplDiagnosticLocation::InterfaceTarget,
+        ));
+    }
+
+    let diagnostics: Vec<(crate::infer_context::TirTypeError, ImplDiagnosticLocation)> =
+        interface_target_diags
+            .into_iter()
+            .map(|e| (e, ImplDiagnosticLocation::InterfaceTarget))
+            .chain(
+                assoc_diags
+                    .into_iter()
+                    .map(|e| (e, ImplDiagnosticLocation::InterfaceTarget)),
+            )
+            .chain(conformance_diags)
+            .chain(
+                for_target_diags
+                    .into_iter()
+                    .map(|e| (e, ImplDiagnosticLocation::ForTarget)),
+            )
+            .chain(
+                bound_diags
+                    .into_iter()
+                    .map(|e| (e, ImplDiagnosticLocation::Bound)),
+            )
+            .collect();
+
+    ImplData {
+        interface: ImplInterfaceTarget::Mounted(iface_qtn),
+        interface_args,
+        for_ty_pattern,
+        generic_params,
+        diagnostics,
+        methods: block.methods.clone(),
+        associated_types,
+        field_links: block
+            .field_links
+            .iter()
+            .map(|fl| (fl.interface_field.clone(), fl.class_field.clone()))
+            .collect(),
+        origin,
+    }
 }
 
 /// Span sidecar for [`impl_data`] (early-cutoff split).
@@ -1054,7 +1471,16 @@ pub fn validate_impl_signatures<'db>(
         }
         Err(ImplDataError::InterfaceUnresolved { .. } | ImplDataError::Malformed) => return diags,
     };
-    let Some(iface_qtn) = interface_loc_qtn(db, data.interface) else {
+    // A MOUNTED interface target (BEP-066 slice 6a) has no loc; its
+    // declaration surface is the exported row, and type-level conformance runs
+    // through the substitution-based mounted arm.
+    let iface_loc = match &data.interface {
+        ImplInterfaceTarget::Source(loc) => *loc,
+        ImplInterfaceTarget::Mounted(qtn) => {
+            return validate_mounted_impl_signatures(db, impl_loc, data, qtn);
+        }
+    };
+    let Some(iface_qtn) = interface_loc_qtn(db, iface_loc) else {
         return diags;
     };
     let file = impl_loc.file(db);
@@ -1075,12 +1501,11 @@ pub fn validate_impl_signatures<'db>(
         bounds: &bounds,
     };
 
-    let iface_data = interface_data(db, data.interface);
-    let iface_env = crate::generic_env::interface_generic_env(db, data.interface);
+    let iface_data = interface_data(db, iface_loc);
+    let iface_env = crate::generic_env::interface_generic_env(db, iface_loc);
     let (iface_self_param, iface_generic_params) = iface_env.interface_param_parts();
     let iface_self_param = iface_self_param.clone();
-    let iface_pkg_info =
-        baml_compiler2_hir::file_package::file_package(db, data.interface.file(db));
+    let iface_pkg_info = baml_compiler2_hir::file_package::file_package(db, iface_loc.file(db));
     let iface_pkg_items =
         baml_compiler2_ppir::package_items(db, PackageId::new(db, iface_pkg_info.package.clone()));
 
@@ -1091,7 +1516,7 @@ pub fn validate_impl_signatures<'db>(
     {
         let class_fields = crate::inference::resolve_class_fields(db, *class);
         let iface_field_bounds =
-            crate::lower_type_expr::interface_generic_param_bounds(db, data.interface);
+            crate::lower_type_expr::interface_generic_param_bounds(db, iface_loc);
         // Realize the interface's declared field types at the impl's interface args.
         let iface_bindings =
             crate::generics::bind_type_vars(iface_generic_params, &data.interface_args);
@@ -1212,7 +1637,7 @@ pub fn validate_impl_signatures<'db>(
         data.generic_params.iter().map(|(n, _)| n.clone()).collect();
     let iface_bindings =
         crate::generics::bind_type_vars(iface_generic_params, &data.interface_args);
-    let iface_bounds = crate::lower_type_expr::interface_generic_param_bounds(db, data.interface);
+    let iface_bounds = crate::lower_type_expr::interface_generic_param_bounds(db, iface_loc);
     // In the interface's own declared signatures (and `requires` clauses), `Self` is a rigid
     // type variable bound to the interface being implemented, realized at the impl's args. Both
     // conformance sides realize `Self.member` symbolically through this bound, then substitute
@@ -1501,16 +1926,483 @@ pub fn validate_impl_signatures<'db>(
     diags
 }
 
+/// The MOUNTED-interface arm of [`validate_impl_signatures`] (BEP-066 slice
+/// 6a): type-level conformance for a user impl of a source-less dependency's
+/// interface. The interface side of every comparison comes from the exported
+/// row — pre-lowered at the interface's own declaration scope with symbolic
+/// `Self` — so realization at this impl is pure substitution (generic params →
+/// `interface_args`, `Self` → for-type), where the source arm re-lowers
+/// through `realize_with_symbolic_self`. The impl side (the user's overrides)
+/// is source-backed and lowers exactly as on the source arm.
+///
+/// One deliberate divergence: the row's `requires` closure is pre-flattened
+/// (transitive), so E0125 obligations cover the whole closure where the
+/// source arm checks only the direct clauses — strictly more complete, and
+/// consistent because a dependency's own impls were checked before export.
+fn validate_mounted_impl_signatures<'db>(
+    db: &'db dyn crate::Db,
+    impl_loc: baml_compiler2_hir::loc::ImplLoc<'db>,
+    data: &ImplData<'db>,
+    iface_qtn: &QualifiedTypeName,
+) -> Vec<(crate::infer_context::TirTypeError, ImplDiagnosticLocation)> {
+    use baml_compiler2_ppir::item_data::{function_data, impl_block_data};
+
+    use crate::{
+        builder::interface_resolution::InterfaceMethodSpec, package_interface::ExportedType,
+    };
+
+    let mut diags = Vec::new();
+    let Some(ExportedType::Interface {
+        self_param: iface_self_param,
+        generic_params: iface_generic_params,
+        associated_types: _,
+        fields: iface_fields,
+        required_methods,
+        default_methods,
+        requires,
+        ..
+    }) = crate::package_interface::mounted_type_row(db, iface_qtn)
+    else {
+        return diags;
+    };
+    let file = impl_loc.file(db);
+    let block = impl_block_data(db, impl_loc);
+    let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);
+    let current_package = pkg_info.package.clone();
+    let pkg_id = PackageId::new(db, pkg_info.package);
+
+    let res_ctx = crate::package_interface::package_resolution_context(db, pkg_id);
+    let aliases = crate::inference::package_resolved_aliases(db, pkg_id);
+    let bounds: crate::lower_type_expr::TypeVarBoundsMap =
+        data.generic_params.iter().cloned().collect();
+    let ctx = crate::type_context::GlobalTypeContext {
+        db,
+        res_ctx,
+        aliases,
+        bounds: &bounds,
+    };
+
+    let for_ty = data.for_ty_pattern.clone();
+    // Realize an interface-scoped exported type at this impl: generic params
+    // to the impl's interface args, symbolic `Self` to the for-type. The
+    // blob's types were lowered once with `Self` symbolic, so one substitution
+    // does what the source arm's realize-then-substitute does; residual
+    // `(for_ty as I).member` projections reduce under `normalize`.
+    let mut realize_bindings =
+        crate::generics::bind_type_vars(iface_generic_params, &data.interface_args);
+    realize_bindings.insert(iface_self_param.clone(), for_ty.clone());
+    let realize = |ty: &Ty| substitute_ty(ty, &realize_bindings);
+
+    // ── E0116: field-type conformance (in-body impls). ──
+    if !iface_fields.is_empty()
+        && matches!(data.origin, InterfaceImplOrigin::InBodyClass { .. })
+        && let baml_compiler2_ppir::item_data::ImplSubjectData::InClass { class, .. } =
+            &block.subject
+    {
+        let class_fields = crate::inference::resolve_class_fields(db, *class);
+        for (iface_field_name, iface_field_ty, _) in iface_fields {
+            let class_field_name = block
+                .field_links
+                .iter()
+                .find(|fl| fl.interface_field == *iface_field_name)
+                .map_or(iface_field_name, |fl| &fl.class_field);
+            let Some((_, class_field_ty, _)) = class_fields
+                .fields
+                .iter()
+                .find(|(name, _, _)| name == class_field_name)
+            else {
+                continue;
+            };
+            let declared = realize(iface_field_ty);
+            if !baml_type::normalize::equivalent(&declared, class_field_ty, &ctx) {
+                diags.push((
+                    crate::infer_context::TirTypeError::InterfaceFieldTypeMismatch {
+                        interface: iface_qtn.clone(),
+                        field: iface_field_name.clone(),
+                        expected: declared,
+                        got: class_field_ty.clone(),
+                    },
+                    ImplDiagnosticLocation::InterfaceTarget,
+                ));
+            }
+        }
+    }
+
+    // ── Impl-header gates (out-of-body only) — identical to the source arm;
+    // none of these consult the interface declaration. ──
+    if matches!(data.origin, InterfaceImplOrigin::OutOfBody) {
+        if !baml_type::normalize::normalize(&data.for_ty_pattern, &ctx).is_valid_impl_subject() {
+            diags.push((
+                crate::infer_context::TirTypeError::ImplTargetNotConcrete {
+                    target: data.for_ty_pattern.clone(),
+                },
+                ImplDiagnosticLocation::ForTarget,
+            ));
+        }
+        let mut determined = Vec::new();
+        collect_type_var_names(&data.for_ty_pattern, &mut determined);
+        for arg in &data.interface_args {
+            collect_type_var_names(arg, &mut determined);
+        }
+        for (name, _) in &data.generic_params {
+            if !determined.contains(name) {
+                diags.push((
+                    crate::infer_context::TirTypeError::UnconstrainedImplTypeParam {
+                        name: name.name().clone(),
+                    },
+                    ImplDiagnosticLocation::Bound,
+                ));
+            }
+        }
+        match orphan_check(
+            &current_package,
+            iface_qtn,
+            &data.for_ty_pattern,
+            &data.interface_args,
+        ) {
+            OrphanOutcome::Ok => {}
+            OrphanOutcome::UncoveredParam(name) => diags.push((
+                crate::infer_context::TirTypeError::ImplViolatesOrphanRule {
+                    interface: iface_qtn.clone(),
+                    uncovered_param: Some(name),
+                },
+                ImplDiagnosticLocation::InterfaceTarget,
+            )),
+            OrphanOutcome::NoLocalType => diags.push((
+                crate::infer_context::TirTypeError::ImplViolatesOrphanRule {
+                    interface: iface_qtn.clone(),
+                    uncovered_param: None,
+                },
+                ImplDiagnosticLocation::InterfaceTarget,
+            )),
+        }
+    }
+
+    // ── E0120: method-signature conformance against the exported rows. ──
+    let impl_generic_names: Vec<ParamTy> =
+        data.generic_params.iter().map(|(n, _)| n.clone()).collect();
+    let self_bound =
+        baml_type::Interface::new(iface_qtn.clone(), data.interface_args.clone(), vec![]);
+    let no_bindings = TypeBindings::default();
+    for &method_loc in &data.methods {
+        let method_name = function_data(db, method_loc).name.clone();
+        if !function_data(db, method_loc).generic_params.is_empty()
+            && matches!(
+                baml_compiler2_ppir::function_body(db, method_loc).as_ref(),
+                baml_compiler2_hir::body::FunctionBody::Builtin(
+                    baml_compiler2_ast::BuiltinKind::Io
+                )
+            )
+        {
+            diags.push((
+                crate::infer_context::TirTypeError::GenericSysOpMethodInInterfaceImpl {
+                    interface: iface_qtn.clone(),
+                    method: method_name.clone(),
+                },
+                ImplDiagnosticLocation::Method(method_name.clone()),
+            ));
+            continue;
+        }
+        let Some(iface_method) = required_methods
+            .iter()
+            .chain(default_methods)
+            .find(|m| m.name == method_name)
+        else {
+            continue; // unknown member -> E0115 (impl_data's mounted arm)
+        };
+
+        let mut d = Vec::new();
+        // The override's function type: identical to the source arm (the
+        // override is source-backed), with `Self` the row's symbolic param.
+        let impl_spec = InterfaceMethodSpec::from_default(db, method_loc);
+        let impl_scope_generics = crate::generic_env::append_params(
+            &impl_generic_names,
+            &impl_spec.generic_param_names(),
+        );
+        let impl_method_params = &impl_scope_generics[impl_generic_names.len()..];
+        let mut impl_fn = realize_with_symbolic_self(
+            db,
+            &res_ctx.own_items,
+            &pkg_info.namespace_path,
+            &impl_scope_generics,
+            iface_self_param,
+            &bounds,
+            &self_bound,
+            &for_ty,
+            &no_bindings,
+            |scope| impl_spec.to_function_ty(scope, &mut d),
+        );
+        if let Ty::Function { throws, .. } = &mut impl_fn {
+            **throws = crate::callable::callable_throws(db, method_loc).clone();
+        }
+
+        // The interface method's function type: the exported symbolic-`Self`
+        // signature realized by substitution, its method generics mapped
+        // positionally onto the override's.
+        let method_generic_arity_matches =
+            impl_method_params.len() == iface_method.generic_params.len();
+        let mut iface_method_bindings = realize_bindings.clone();
+        if method_generic_arity_matches {
+            iface_method_bindings.extend(
+                iface_method
+                    .generic_params
+                    .iter()
+                    .zip(impl_method_params)
+                    .map(|(iface_param, impl_param)| {
+                        (
+                            iface_param.clone(),
+                            Ty::TypeVar(impl_param.clone(), TyAttr::default()),
+                        )
+                    }),
+            );
+        }
+        // The throws slot mirrors `lower_signature`'s Missing convention: the
+        // declared clause, `unknown` when unwritten (a default method's
+        // body-inferred contract is not the declared surface).
+        let iface_fn = substitute_ty(
+            &Ty::Function {
+                params: iface_method.params.clone(),
+                ret: Box::new(iface_method.return_type.clone()),
+                throws: Box::new(iface_method.declared_throws.clone().unwrap_or(Ty::Unknown {
+                    attr: TyAttr::default(),
+                })),
+                attr: TyAttr::default(),
+            },
+            &iface_method_bindings,
+        );
+
+        if !method_generic_arity_matches
+            || !baml_type::normalize::is_subtype(&impl_fn, &iface_fn, &ctx)
+        {
+            diags.push((
+                crate::infer_context::TirTypeError::InterfaceMethodSignatureMismatch {
+                    interface: iface_qtn.clone(),
+                    method: method_name.clone(),
+                    expected: iface_fn,
+                    got: impl_fn,
+                },
+                ImplDiagnosticLocation::Method(method_name.clone()),
+            ));
+        }
+
+        // An override may not add a generic bound the interface method does
+        // not declare (the exported rows carry the interface-side bounds).
+        let impl_bounds_by_param = method_generic_bound_interfaces(
+            db,
+            &res_ctx.own_items,
+            &pkg_info.namespace_path,
+            &impl_scope_generics,
+            &impl_spec,
+        );
+        let iface_method_bounds: Vec<Vec<baml_type::Interface>> = iface_method
+            .generic_param_bounds
+            .iter()
+            .map(|conjunction| {
+                conjunction
+                    .iter()
+                    .map(|bound| bound.map_tys(|ty| substitute_ty(ty, &iface_method_bindings)))
+                    .collect()
+            })
+            .collect();
+        for (i, (param, impl_conjunction)) in impl_bounds_by_param.iter().enumerate() {
+            let iface_conjunction = iface_method_bounds.get(i).map(Vec::as_slice).unwrap_or(&[]);
+            for impl_bound in impl_conjunction {
+                let entailed = iface_conjunction.iter().any(|iface_bound| {
+                    super::carried_bound_satisfies(&ctx, iface_bound, impl_bound)
+                        || ctx.interface_requires(iface_bound, impl_bound)
+                });
+                if !entailed {
+                    diags.push((
+                        crate::infer_context::TirTypeError::InterfaceMethodAddsGenericBound {
+                            interface: iface_qtn.clone(),
+                            method: method_name.clone(),
+                            param: param.clone(),
+                            bound: impl_bound.clone(),
+                        },
+                        ImplDiagnosticLocation::Method(method_name.clone()),
+                    ));
+                }
+            }
+        }
+    }
+
+    // ── E0125: `requires` obligations from the pre-flattened exported closure. ──
+    for required in requires {
+        let required_ty = substitute_ty(&required.to_ty(), &realize_bindings);
+        let required_ty = baml_type::normalize::normalize(&required_ty, &ctx);
+        let Ty::Interface(qtn, generics, assoc, _) = &required_ty else {
+            continue;
+        };
+        if crate::generics::contains_error_recovery(&required_ty) {
+            continue;
+        }
+        let required_iface = baml_type::Interface {
+            name: qtn.clone(),
+            generics: generics.clone(),
+            associated_types: assoc.clone(),
+        };
+        if !implements_interface(db, &for_ty, &required_iface, aliases, |a, b| {
+            baml_type::normalize::is_subtype(a, b, &ctx)
+        }) {
+            diags.push((
+                crate::infer_context::TirTypeError::MissingRequiredInterface {
+                    interface: iface_qtn.clone(),
+                    required: required_iface,
+                },
+                ImplDiagnosticLocation::InterfaceTarget,
+            ));
+        }
+    }
+
+    // ── Associated-type binding bound satisfaction — identical to the source
+    // arm (`associated_type_declared_bound` reads the mounted row). ──
+    {
+        let target_iface = baml_type::Interface {
+            name: iface_qtn.clone(),
+            generics: data.interface_args.clone(),
+            associated_types: data.associated_types.clone(),
+        };
+        for binding in &block.associated_type_bindings {
+            let Some((_, binding_ty)) = data
+                .associated_types
+                .iter()
+                .find(|(n, _)| *n == binding.name)
+            else {
+                continue;
+            };
+            let normalized = baml_type::normalize::normalize(binding_ty, &ctx);
+            for bound in crate::builder::associated_projection::associated_type_declared_bound(
+                db,
+                &target_iface,
+                &binding.name,
+            ) {
+                if !normalized_arg_implements_bound(&ctx, &normalized, &bound) {
+                    diags.push((
+                        crate::infer_context::TirTypeError::AssociatedTypeBindingViolatesBound {
+                            interface: iface_qtn.clone(),
+                            name: binding.name.clone(),
+                            binding: binding_ty.clone(),
+                            bound,
+                        },
+                        ImplDiagnosticLocation::AssociatedBinding(binding.name.clone()),
+                    ));
+                }
+            }
+        }
+    }
+
+    diags
+}
+
+/// A stable reference to one impl: a source-backed `implements` block (by
+/// loc), or one of a MOUNTED package's blob rows (BEP-066 slice 6a — loc-free,
+/// indexed into [`mounted_impl_datas`]).
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ImplRef<'db> {
+    /// A source-backed `implements` block.
+    Loc(baml_compiler2_hir::loc::ImplLoc<'db>),
+    /// Row `index` of the mounted package `pkg`'s exported impls table.
+    Mounted { pkg: PackageId<'db>, index: u32 },
+}
+
 /// One `implements` block resolved for a specific *realized* `(interface, type)`
 /// pair, returned by [`get_implements_block`].
 pub struct ResolvedImpl<'db> {
-    /// The unique impl block — coherence guarantees at most one per realized
-    /// `(interface, type)`, so this is a single id, never a candidate set.
-    pub impl_loc: baml_compiler2_hir::loc::ImplLoc<'db>,
+    /// The unique impl — coherence guarantees at most one per realized
+    /// `(interface, type)`, so this is a single reference, never a candidate
+    /// set. May be a mounted blob row (loc-free); consumers that need a
+    /// source-backed loc (LSP navigation, MIR call lowering) go through
+    /// [`Self::impl_loc`].
+    pub imp: ImplRef<'db>,
     /// The impl's own generic params bound to the realized type arguments — e.g.
     /// `U := int` for `implement<U> Foo for Box<U>` resolved at `Box<int>`. The
     /// method/frame resolution reads these to instantiate the callee.
     pub bindings: TypeBindings,
+}
+
+/// The impls of a MOUNTED (source-less) package, materialized from its blob's
+/// `ExportedImpl` rows into the checker's native [`ImplData`] currency
+/// (BEP-066 slice 6a) — so matching, membership, and coherence run unchanged
+/// over them. Loc-free by construction: the interface target resolves to a
+/// source loc when the implemented interface is itself source-backed in THIS
+/// database (a blob impl of a stdlib interface), else stays a `Mounted`
+/// qualified name; `methods` is empty (blob overrides have no locs — method
+/// dispatch through mounted impls lands with the call-lowering PR) and
+/// `diagnostics` is empty (blob impls are pre-checked at export; they are
+/// never re-validated here). Empty for non-mounted packages.
+#[salsa::tracked(returns(ref))]
+pub fn mounted_impl_datas<'db>(
+    db: &'db dyn crate::Db,
+    pkg_id: PackageId<'db>,
+) -> Vec<ImplData<'db>> {
+    let Some(iface) = crate::package_interface::mounted_interface(db, &pkg_id.name(db)) else {
+        return Vec::new();
+    };
+    iface
+        .impls
+        .iter()
+        .map(|row| {
+            let target_qtn = &row.interface.name;
+            let target_pkg = PackageId::new(db, target_qtn.package().clone());
+            let interface = match baml_compiler2_ppir::package_items(db, target_pkg)
+                .lookup_type(target_qtn.namespace(), target_qtn.name())
+            {
+                Some(Definition::Interface(loc)) => ImplInterfaceTarget::Source(loc),
+                _ => ImplInterfaceTarget::Mounted(target_qtn.clone()),
+            };
+            ImplData {
+                interface,
+                interface_args: row.interface.generics.clone(),
+                for_ty_pattern: row.for_ty_pattern.clone(),
+                generic_params: row
+                    .generic_params
+                    .iter()
+                    .cloned()
+                    .zip(row.param_bounds.iter().cloned())
+                    .collect(),
+                diagnostics: Vec::new(),
+                methods: Vec::new(),
+                associated_types: row.associated_types.clone(),
+                field_links: row.field_links.clone(),
+                origin: match &row.origin {
+                    crate::package_interface::ExportedImplOrigin::InBodyClass { class_qtn } => {
+                        InterfaceImplOrigin::InBodyClass {
+                            class_qtn: class_qtn.clone(),
+                        }
+                    }
+                    crate::package_interface::ExportedImplOrigin::OutOfBody => {
+                        InterfaceImplOrigin::OutOfBody
+                    }
+                },
+            }
+        })
+        .collect()
+}
+
+/// Every impl visible in `pkg` — source-backed blocks (resolvable `impl_data`)
+/// plus a mounted package's materialized blob rows — with the stable
+/// [`ImplRef`] each match reports. The single enumeration seam of the
+/// membership/dispatch/coherence walkers (the BEP-066 seed-or-source split).
+pub(crate) fn package_impls<'db>(
+    db: &'db dyn crate::Db,
+    pkg: PackageId<'db>,
+) -> Vec<(ImplRef<'db>, &'db ImplData<'db>)> {
+    let mut out = Vec::new();
+    for &impl_loc in package_impl_locs(db, pkg) {
+        if let Ok(data) = impl_data(db, impl_loc).as_ref() {
+            out.push((ImplRef::Loc(impl_loc), data));
+        }
+    }
+    for (index, data) in mounted_impl_datas(db, pkg).iter().enumerate() {
+        out.push((
+            ImplRef::Mounted {
+                pkg,
+                index: u32::try_from(index).expect("mounted impl count fits in u32"),
+            },
+            data,
+        ));
+    }
+    out
 }
 
 /// Every `implements` block id declared in a package, as stable
@@ -1815,10 +2707,7 @@ pub fn type_implements_interface<'db>(
         db, pkg_id,
     ));
     for pkg in packages {
-        for &impl_loc in package_impl_locs(db, pkg) {
-            let Ok(data) = impl_data(db, impl_loc).as_ref() else {
-                continue;
-            };
+        for (_imp, data) in package_impls(db, pkg) {
             let Some(bindings) = match_impl_head(db, data, concrete, interface, aliases) else {
                 continue;
             };
@@ -1853,10 +2742,7 @@ pub(crate) fn get_implements_block_symbolic<'db>(
     ));
     let mut found: Option<ResolvedImpl<'db>> = None;
     for pkg in packages {
-        for &impl_loc in package_impl_locs(db, pkg) {
-            let Ok(data) = impl_data(db, impl_loc).as_ref() else {
-                continue;
-            };
+        for (imp, data) in package_impls(db, pkg) {
             let Some(bindings) = match_impl_head(db, data, concrete, interface, aliases) else {
                 continue;
             };
@@ -1868,7 +2754,7 @@ pub(crate) fn get_implements_block_symbolic<'db>(
                 // structurally matching a symbolic query cannot both realize the pins.
                 return None;
             }
-            found = Some(ResolvedImpl { impl_loc, bindings });
+            found = Some(ResolvedImpl { imp, bindings });
         }
     }
     found
@@ -1908,10 +2794,7 @@ fn get_implements_block_within_depth<'db>(
     ));
 
     for pkg in packages {
-        for &impl_loc in package_impl_locs(db, pkg) {
-            let Ok(data) = impl_data(db, impl_loc).as_ref() else {
-                continue;
-            };
+        for (imp, data) in package_impls(db, pkg) {
             // Structural match: exact interface head, the bare-blanket guard, joint
             // for-type + interface-arg unification, and associated-type pins. Inputs are
             // realized here, so the resulting bindings are ground.
@@ -1958,7 +2841,7 @@ fn get_implements_block_within_depth<'db>(
             }
 
             // Unique by coherence — the first full match is the only match.
-            return Some(ResolvedImpl { impl_loc, bindings });
+            return Some(ResolvedImpl { imp, bindings });
         }
     }
     None
@@ -1980,7 +2863,7 @@ fn match_impl_head<'db>(
     requested_iface: &baml_type::Interface,
     aliases: &HashMap<QualifiedTypeName, Ty>,
 ) -> Option<TypeBindings> {
-    if interface_loc_qtn(db, data.interface).as_ref() != Some(&requested_iface.name)
+    if data.interface_qtn(db).as_ref() != Some(&requested_iface.name)
         || data.interface_args.len() != requested_iface.generics.len()
     {
         return None;
@@ -2070,10 +2953,7 @@ pub fn impls_for_type<'db>(
     ));
     let mut out = Vec::new();
     for pkg in packages {
-        for &impl_loc in package_impl_locs(db, pkg) {
-            let Ok(data) = impl_data(db, impl_loc).as_ref() else {
-                continue;
-            };
+        for (imp, data) in package_impls(db, pkg) {
             let param_names: Vec<ParamTy> = data
                 .generic_params
                 .iter()
@@ -2091,7 +2971,7 @@ pub fn impls_for_type<'db>(
                 continue;
             };
             if impl_bounds_hold_symbolic(data, &bindings, &mut is_subtype) {
-                out.push(ResolvedImpl { impl_loc, bindings });
+                out.push(ResolvedImpl { imp, bindings });
             }
         }
     }
@@ -2123,12 +3003,9 @@ pub(crate) fn first_failing_impl_bound<'db>(
         db, pkg_id,
     ));
     for pkg in packages {
-        for &impl_loc in package_impl_locs(db, pkg) {
-            let Ok(data) = impl_data(db, impl_loc).as_ref() else {
-                continue;
-            };
+        for (_imp, data) in package_impls(db, pkg) {
             // Only an impl of the requested interface can "almost" satisfy it.
-            if interface_loc_qtn(db, data.interface).as_ref() != Some(requested_qtn) {
+            if data.interface_qtn(db).as_ref() != Some(requested_qtn) {
                 continue;
             }
             let param_names: Vec<ParamTy> = data
@@ -2189,6 +3066,24 @@ pub struct ResolvedMethod<'db> {
 }
 
 impl<'db> ResolvedImpl<'db> {
+    /// The resolved impl's facts: `impl_data` for a source-backed block, the
+    /// materialized blob row for a mounted one.
+    pub fn data(&self, db: &'db dyn crate::Db) -> Option<&'db ImplData<'db>> {
+        match self.imp {
+            ImplRef::Loc(impl_loc) => impl_data(db, impl_loc).as_ref().ok(),
+            ImplRef::Mounted { pkg, index } => mounted_impl_datas(db, pkg).get(index as usize),
+        }
+    }
+
+    /// The source-backed block's loc, when this impl is source-backed
+    /// (`None` for a mounted blob row).
+    pub fn impl_loc(&self) -> Option<baml_compiler2_hir::loc::ImplLoc<'db>> {
+        match self.imp {
+            ImplRef::Loc(impl_loc) => Some(impl_loc),
+            ImplRef::Mounted { .. } => None,
+        }
+    }
+
     /// Resolve `method` to its backing function and frame on this impl. Returns
     /// the impl block's override if it defines one, otherwise *this interface's*
     /// own default method, otherwise `None` (this interface neither declares an
@@ -2204,7 +3099,7 @@ impl<'db> ResolvedImpl<'db> {
     pub fn get_method(&self, db: &'db dyn crate::Db, method: &Name) -> Option<ResolvedMethod<'db>> {
         use baml_compiler2_ppir::item_data::{function_data, interface_data};
 
-        let data = impl_data(db, self.impl_loc).as_ref().ok()?;
+        let data = self.data(db)?;
 
         // The impl's own override — a free function, framed by the impl's
         // generic params bound to the realized type arguments. A param that the
@@ -2233,7 +3128,11 @@ impl<'db> ResolvedImpl<'db> {
         }
 
         // The interface's default — framed by the realized interface input args.
-        let iface_data = interface_data(db, data.interface);
+        // A MOUNTED interface's default bodies have no locs; resolving a call
+        // to one lands with the mounted-call lowering PR, so the lookup
+        // reports "no such method" until then.
+        let iface_loc = data.interface_loc()?;
+        let iface_data = interface_data(db, iface_loc);
         for &fn_loc in &iface_data.default_methods {
             if function_data(db, fn_loc).name == *method {
                 let frame_type_args = data
@@ -2262,10 +3161,11 @@ impl<'db> ResolvedImpl<'db> {
         // (`impls_for_type`, `get_implements_block`) filters with `let Ok(data) = ...` — and an
         // Ok impl resolved its interface target (`InterfaceUnresolved` would be the `Err`), so
         // its loc always has a qualified name. Both branches below are therefore unreachable.
-        let data = impl_data(db, self.impl_loc)
-            .as_ref()
-            .unwrap_or_else(|_| unreachable!("a ResolvedImpl carries an impl_data-Ok impl"));
-        let name = interface_loc_qtn(db, data.interface)
+        let data = self
+            .data(db)
+            .unwrap_or_else(|| unreachable!("a ResolvedImpl carries a resolvable impl"));
+        let name = data
+            .interface_qtn(db)
             .unwrap_or_else(|| unreachable!("an impl_data-Ok impl has a named interface target"));
         let generics = data
             .interface_args

--- a/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
@@ -53,7 +53,7 @@ pub trait TypeExprContext<'db> {
     fn resolve_type(
         &self,
         segments: &[baml_base::Name],
-    ) -> Result<Definition<'db>, Box<[baml_base::Name]>>;
+    ) -> Result<ResolvedTypeDefinition<'db>, Box<[baml_base::Name]>>;
 
     /// What `Self` lowers to here, or `None` where `Self` is not in scope
     /// (free functions, type aliases).
@@ -165,7 +165,7 @@ impl<'db> TypeExprContext<'db> for ScopeCtx<'_, 'db> {
     fn resolve_type(
         &self,
         segments: &[baml_base::Name],
-    ) -> Result<Definition<'db>, Box<[baml_base::Name]>> {
+    ) -> Result<ResolvedTypeDefinition<'db>, Box<[baml_base::Name]>> {
         resolve_type_in(self.db, self.package_items, self.ns_context, segments)
             .ok_or_else(|| type_suggestions(self.package_items, segments))
     }
@@ -310,16 +310,32 @@ fn interface_base_without_member_pin(
     }
 }
 
+/// A type-position resolution result: a definition in a source-backed package
+/// (a loc), or an exported row of a MOUNTED source-less dependency (BEP-066
+/// slice 6a) — which has no loc, only its blob-captured typed surface. The two
+/// heads of every declaration-site type path; `lower_path`'s arms build the
+/// corresponding `Ty` from either.
+#[derive(Debug, Clone, Copy)]
+pub enum ResolvedTypeDefinition<'db> {
+    /// A source-backed definition (own package or a source-backed dependency).
+    Own(Definition<'db>),
+    /// A mounted dependency's exported row, served from its interface blob.
+    Foreign(&'db crate::package_interface::ExportedType),
+}
+
 /// Resolve a type name/path to its definition, with `ns_context` as the namespace
 /// prefix. Tries the namespace-qualified own-package lookup, then a cross-package lookup
-/// (`root.ns.Name` or `pkg.ns.Name`), then the `$stream` companion (whose base class/alias
-/// the caller re-qualifies under the `$stream` name). `None` when unresolved.
+/// (`root.ns.Name` or `pkg.ns.Name` — a MOUNTED package resolves through its interface
+/// blob instead of raw items), then the `$stream` companion (whose base class/alias
+/// the caller re-qualifies under the `$stream` name; mounted packages export no
+/// `$stream` rows, so their companions stay unresolved — the ordinary E0002).
+/// `None` when unresolved.
 pub(crate) fn resolve_type_in<'db>(
     db: &'db dyn crate::Db,
     package_items: &PackageItems<'db>,
     ns_context: &[baml_base::Name],
     segments: &[baml_base::Name],
-) -> Option<Definition<'db>> {
+) -> Option<ResolvedTypeDefinition<'db>> {
     let item = segments.last().expect("non-empty path");
     let seg_ns = &segments[..segments.len() - 1];
     let resolved = if !ns_context.is_empty() {
@@ -327,15 +343,27 @@ pub(crate) fn resolve_type_in<'db>(
         package_items.lookup_type(&ns, item)
     } else {
         package_items.lookup_type(seg_ns, item)
-    };
+    }
+    .map(ResolvedTypeDefinition::Own);
     let resolved = resolved.or_else(|| {
         if segments.len() >= 2 {
             if segments[0].as_str() == "root" {
-                package_items.lookup_type(&segments[1..segments.len() - 1], item)
+                package_items
+                    .lookup_type(&segments[1..segments.len() - 1], item)
+                    .map(ResolvedTypeDefinition::Own)
+            } else if let Some(mounted) =
+                crate::package_interface::mounted_interface(db, &segments[0])
+            {
+                // Mounted (source-less) package: the blob's rows are the only
+                // representation — raw `package_items` is empty by design.
+                mounted
+                    .lookup_type(&segments[1..segments.len() - 1], item)
+                    .map(ResolvedTypeDefinition::Foreign)
             } else {
                 let pkg_id = PackageId::new(db, segments[0].clone());
                 let pkg = baml_compiler2_ppir::package_items(db, pkg_id);
                 pkg.lookup_type(&segments[1..segments.len() - 1], item)
+                    .map(ResolvedTypeDefinition::Own)
             }
         } else {
             None
@@ -365,7 +393,8 @@ pub(crate) fn resolve_type_in<'db>(
             }
         })?;
         // Only classes and aliases get a `$stream` companion.
-        matches!(base_def, Definition::Class(_) | Definition::TypeAlias(_)).then_some(base_def)
+        matches!(base_def, Definition::Class(_) | Definition::TypeAlias(_))
+            .then_some(ResolvedTypeDefinition::Own(base_def))
     })
 }
 
@@ -780,7 +809,17 @@ fn lower_path(
         return ty;
     }
     match ctx.resolve_type(segments) {
-        Ok(def) => {
+        Ok(ResolvedTypeDefinition::Foreign(row)) => lower_foreign_path(
+            store,
+            row,
+            segments,
+            generic_args,
+            associated_type_bindings,
+            ctx,
+            diagnostics,
+            position,
+        ),
+        Ok(ResolvedTypeDefinition::Own(def)) => {
             let short = segments.last().expect("non-empty path");
             match def {
                 Definition::Class(class_loc) => {
@@ -1016,19 +1055,36 @@ fn lower_path(
             if segments.len() >= 2 {
                 let (variant, enum_path) = segments.split_last().unwrap();
                 let enum_short = enum_path.last().unwrap();
-                if let Ok(def @ Definition::Enum(enum_loc)) = ctx.resolve_type(enum_path) {
-                    // Verify the variant actually exists on the enum;
-                    // otherwise `Status.Typo` would silently produce a
-                    // bogus `Ty::EnumVariant` and downstream code would
-                    // never see `UnresolvedType`.
-                    let enum_data = baml_compiler2_ppir::item_data::enum_data(db, enum_loc);
-                    if enum_data.variants.iter().any(|v| v.name == *variant) {
-                        return Ty::EnumVariant(
-                            qualify_def(db, def, enum_short),
-                            variant.clone(),
-                            TyAttr::default(),
-                        );
+                match ctx.resolve_type(enum_path) {
+                    Ok(ResolvedTypeDefinition::Own(def @ Definition::Enum(enum_loc))) => {
+                        // Verify the variant actually exists on the enum;
+                        // otherwise `Status.Typo` would silently produce a
+                        // bogus `Ty::EnumVariant` and downstream code would
+                        // never see `UnresolvedType`.
+                        let enum_data = baml_compiler2_ppir::item_data::enum_data(db, enum_loc);
+                        if enum_data.variants.iter().any(|v| v.name == *variant) {
+                            return Ty::EnumVariant(
+                                qualify_def(db, def, enum_short),
+                                variant.clone(),
+                                TyAttr::default(),
+                            );
+                        }
                     }
+                    // A mounted dependency's enum: the exported row carries the
+                    // variant names, so the same verified-variant fallback
+                    // applies (`app.Status.Active` in a type position).
+                    Ok(ResolvedTypeDefinition::Foreign(
+                        crate::package_interface::ExportedType::Enum { qtn, variants },
+                    )) => {
+                        if variants.contains(variant) {
+                            return Ty::EnumVariant(
+                                qtn.clone(),
+                                variant.clone(),
+                                TyAttr::default(),
+                            );
+                        }
+                    }
+                    _ => {}
                 }
             }
             // Associated type projection fallback: after ordinary type
@@ -1112,6 +1168,176 @@ fn lower_path(
             Ty::Error {
                 attr: TyAttr::default(),
             }
+        }
+    }
+}
+
+/// The [`lower_path`] arm for a *foreign* resolution — an exported row of a
+/// mounted source-less dependency (BEP-066 slice 6a). Mirrors the `Own` arms
+/// exactly, drawing every declared fact (qtn, generic arity, associated types
+/// with pre-lowered symbolic-`Self` defaults) from the row instead of per-loc
+/// queries, so a blob-backed and a source-backed dependency lower the same
+/// spelling to the same `Ty`.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "the exact lower_path parameter surface, plus the resolved row"
+)]
+fn lower_foreign_path(
+    store: &baml_compiler2_hir::type_ref::TypeRefStore,
+    row: &crate::package_interface::ExportedType,
+    segments: &[baml_base::Name],
+    generic_args: &[baml_compiler2_hir::type_ref::TypeRefId],
+    associated_type_bindings: &[baml_compiler2_hir::type_ref::AssociatedTypeBindingRef],
+    ctx: &dyn TypeExprContext<'_>,
+    diagnostics: &mut Vec<TirTypeError>,
+    position: TypePosition,
+) -> Ty {
+    use crate::package_interface::ExportedType;
+    let short = segments.last().expect("non-empty path");
+    match row {
+        ExportedType::Class {
+            qtn,
+            generic_params,
+            ..
+        } => {
+            let mut lowered_args: Vec<Ty> = generic_args
+                .iter()
+                .map(|&ga| lower_type_ref(store, ga, ctx, diagnostics))
+                .collect();
+            enforce_generic_arity(
+                &mut lowered_args,
+                generic_params.len(),
+                short,
+                position,
+                diagnostics,
+            );
+            // No `baml.future.Future` special case: `baml` is a reserved name a
+            // mount can never claim, so a foreign class is never that class.
+            Ty::Class(qtn.clone(), lowered_args, TyAttr::default())
+        }
+        ExportedType::Interface {
+            qtn,
+            self_param,
+            generic_params,
+            associated_types,
+            ..
+        } => {
+            let mut lowered_args: Vec<Ty> = generic_args
+                .iter()
+                .map(|&ga| lower_type_ref(store, ga, ctx, diagnostics))
+                .collect();
+            enforce_generic_arity(
+                &mut lowered_args,
+                generic_params.len(),
+                short,
+                position,
+                diagnostics,
+            );
+            let known_associated_types: FxHashSet<baml_base::Name> = associated_types
+                .iter()
+                .map(|assoc| assoc.name.clone())
+                .collect();
+            // Written bindings: unknown or re-bound names are diagnosed and
+            // dropped, exactly as in the `Own` interface arm.
+            let mut seen_associated_bindings = FxHashSet::default();
+            let mut associated_bindings: Vec<(baml_base::Name, Ty)> = associated_type_bindings
+                .iter()
+                .filter_map(|binding| {
+                    let value = lower_type_ref(store, binding.ty, ctx, diagnostics);
+                    if !known_associated_types.contains(&binding.name) {
+                        diagnostics.push(TirTypeError::UnresolvedType {
+                            name: binding.name.clone(),
+                            suggestions: known_associated_types.iter().cloned().collect(),
+                        });
+                        return None;
+                    }
+                    if !seen_associated_bindings.insert(binding.name.clone()) {
+                        diagnostics.push(TirTypeError::DuplicateAssociatedTypeBinding {
+                            interface: qtn.clone(),
+                            name: binding.name.clone(),
+                        });
+                        return None;
+                    }
+                    Some((binding.name.clone(), value))
+                })
+                .collect();
+            // §1.7(a): an existential eagerly fills omitted defaulted members.
+            // The row's defaults are pre-lowered with symbolic `Self` (exactly
+            // what `interface_associated_type_default` produces), so filling is
+            // pure substitution — the same `realize_associated_default` the
+            // `Own` arm runs.
+            if position == TypePosition::Existential {
+                for assoc in associated_types {
+                    if associated_bindings.iter().any(|(n, _)| *n == assoc.name) {
+                        continue;
+                    }
+                    if let Some(default) = &assoc.default {
+                        let self_ty = Ty::Interface(
+                            qtn.clone(),
+                            lowered_args.clone(),
+                            associated_bindings.clone(),
+                            TyAttr::default(),
+                        );
+                        let filled = crate::interfaces::realize_associated_default(
+                            default,
+                            generic_params,
+                            &lowered_args,
+                            self_param,
+                            &self_ty,
+                        );
+                        associated_bindings.push((assoc.name.clone(), filled));
+                    }
+                }
+                let missing: Vec<baml_base::Name> = associated_types
+                    .iter()
+                    .map(|assoc| assoc.name.clone())
+                    .filter(|name| !associated_bindings.iter().any(|(n, _)| n == name))
+                    .collect();
+                if !missing.is_empty() {
+                    for name in &missing {
+                        associated_bindings.push((
+                            name.clone(),
+                            Ty::Error {
+                                attr: TyAttr::default(),
+                            },
+                        ));
+                    }
+                    diagnostics.push(TirTypeError::MissingAssociatedTypeBindings {
+                        interface: qtn.clone(),
+                        missing,
+                    });
+                }
+            }
+            Ty::Interface(
+                qtn.clone(),
+                lowered_args,
+                associated_bindings,
+                TyAttr::default(),
+            )
+        }
+        ExportedType::Enum { qtn, .. } => {
+            for &ga in generic_args {
+                let _ = lower_type_ref(store, ga, ctx, diagnostics);
+            }
+            if !generic_args.is_empty() {
+                diagnostics.push(TirTypeError::TypeIsNotGeneric {
+                    type_name: short.clone(),
+                    kind: "enum",
+                });
+            }
+            Ty::Enum(qtn.clone(), TyAttr::default())
+        }
+        ExportedType::TypeAlias { qtn, .. } => {
+            for &ga in generic_args {
+                let _ = lower_type_ref(store, ga, ctx, diagnostics);
+            }
+            if !generic_args.is_empty() {
+                diagnostics.push(TirTypeError::TypeIsNotGeneric {
+                    type_name: short.clone(),
+                    kind: "type alias",
+                });
+            }
+            Ty::TypeAlias(qtn.clone(), TyAttr::default())
         }
     }
 }

--- a/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
@@ -326,9 +326,11 @@ pub enum ResolvedTypeDefinition<'db> {
 /// Resolve a type name/path to its definition, with `ns_context` as the namespace
 /// prefix. Tries the namespace-qualified own-package lookup, then a cross-package lookup
 /// (`root.ns.Name` or `pkg.ns.Name` — a MOUNTED package resolves through its interface
-/// blob instead of raw items), then the `$stream` companion (whose base class/alias
-/// the caller re-qualifies under the `$stream` name; mounted packages export no
-/// `$stream` rows, so their companions stay unresolved — the ordinary E0002).
+/// blob instead of raw items), then the legacy `$stream` companion fallback
+/// (whose base class/alias the caller re-qualifies under the `$stream` name).
+/// Canonical PPIR `$stream` items are exported as ordinary rows, so mounted
+/// companions resolve in the first step; the fallback remains for source
+/// shapes that predate or bypass canonical expansion.
 /// `None` when unresolved.
 pub(crate) fn resolve_type_in<'db>(
     db: &'db dyn crate::Db,

--- a/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
@@ -1075,14 +1075,8 @@ fn lower_path(
                     // applies (`app.Status.Active` in a type position).
                     Ok(ResolvedTypeDefinition::Foreign(
                         crate::package_interface::ExportedType::Enum { qtn, variants },
-                    )) => {
-                        if variants.contains(variant) {
-                            return Ty::EnumVariant(
-                                qtn.clone(),
-                                variant.clone(),
-                                TyAttr::default(),
-                            );
-                        }
+                    )) if variants.contains(variant) => {
+                        return Ty::EnumVariant(qtn.clone(), variant.clone(), TyAttr::default());
                     }
                     _ => {}
                 }

--- a/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
@@ -2,10 +2,9 @@
 //!
 //! `PackageInterface` is a fully-resolved typed summary of everything a package
 //! exports — classes, enums, type aliases, interfaces, functions, throw sets,
-//! and the namespace set. Dependent packages consume this instead of reaching
-//! into raw `ItemTree` / `TypeExpr` data. (Interface rows and the other slice
-//! 6a enrichments are derived but not yet consumed — resolution still walks
-//! dependency source items; the consumption rewires land in follow-up PRs.)
+//! and the namespace set. Mounted, source-less dependencies consume this
+//! instead of reaching into raw `ItemTree` / `TypeExpr` data; source-backed
+//! dependencies retain their loc path where navigation/body access needs it.
 //!
 //! `PackageResolutionContext` bundles a package's own `PackageItems` with its
 //! dependencies' `PackageInterface`s, providing unified lookup methods.
@@ -67,14 +66,12 @@ pub struct PackageInterface {
     /// resolves, whether or not it exports a type or function (the root
     /// namespace is `[]`). A source-less consumer needs this to distinguish "a
     /// namespace with nothing visible" from "no such namespace" (BEP-066 slice
-    /// 6a; nothing reads it yet).
+    /// 6a; mounted namespace traversal can consume it without source items).
     pub namespaces: BTreeSet<Vec<Name>>,
     /// Every `implements` block the package declares, exported loc-free (BEP-066
     /// slice 6a) — the blob-side twin of the `impl_data` substrate, so a
     /// source-less dependency still contributes its impls to matching,
-    /// membership, and coherence (the R2 "fails-open" hole). Derived but not yet
-    /// consumed: the impl enumerators still walk `ImplLoc`s until the
-    /// seed-or-source `package_impls` reroute lands in a follow-up PR.
+    /// membership, coherence, and dispatch (closing the R2 "fails-open" hole).
     ///
     /// Sorted by each row's borsh encoding — a canonical total order over the
     /// row's full content, independent of file enumeration order (ties are
@@ -188,12 +185,13 @@ pub struct ExportedFunction {
     pub return_type: Ty,
     pub declared_throws: Option<Ty>,
     pub callable_throws: Ty,
-    /// Function-level generic parameters, including any synthetic callback
-    /// effect parameters introduced by bounded signature elaboration.
+    /// Function-level generic parameters: user-declared parameters followed by
+    /// synthetic callback-effect parameters introduced by signature
+    /// elaboration. Runtime layout erases the synthetic effects.
     pub generic_params: Vec<ParamTy>,
     /// Per-parameter interface-bound conjunctions, parallel to
-    /// `generic_params` (synthetic effect parameters are unbounded, so their
-    /// entries are empty).
+    /// `generic_params` (when synthetic effect parameters are present they are
+    /// unbounded, so their entries are empty).
     pub generic_param_bounds: Vec<Vec<baml_type::Interface>>,
     pub builtin_kind: Option<BuiltinKind>,
     /// For a class method written in an `implements I { … }` block: `I`'s
@@ -207,16 +205,15 @@ pub struct ExportedFunction {
     /// rendering as MIR's `ItemRef` `Display` for `Free`/`Method`. Two
     /// same-named methods (a plain method plus an `implements`-block one)
     /// share this string and are disambiguated by `interface_target`; MIR's
-    /// implements-scoped symbol naming is reconstructed from the pair by the
-    /// consumer (impls-table PR).
+    /// implements-scoped symbol naming is reconstructed from the pair and its
+    /// exported impl head by the consumer.
     pub callable_fqn: String,
 }
 
 /// One `implements` block exported loc-free (BEP-066 slice 6a) — the blob-side
 /// mirror of [`crate::interfaces::ImplData`], carrying everything a source-less
 /// consumer needs to run impl matching (`match_impl_head`-shaped unification),
-/// bound discharge, membership, and coherence without `ImplLoc`s. Derived but
-/// not yet consumed; the enumerator reroutes land in follow-up PRs.
+/// bound discharge, membership, coherence, and dispatch without `ImplLoc`s.
 ///
 /// Like `ImplData`, every impl — in-body or out-of-body — is normalized to the
 /// same *free* shape: an in-body `implements I {…}` inside `class C<T>` exports
@@ -277,7 +274,7 @@ pub enum ExportedImplOrigin {
 /// One impl-body method override, exported with a *structural* identity: the
 /// owner is the enclosing [`ExportedImpl`] itself (interface head + for-type),
 /// and `name` picks the interface member it overrides. Deliberately NOT MIR's
-/// `{iface-display}$for${target-display}` source-text naming — the consumer PR
+/// `{iface-display}$for${target-display}` source-text naming — the consumer
 /// reconstructs MIR's symbol from this structural pair. `sig.callable_fqn`
 /// alone is NOT unique for a free-impl method (it renders owner-less,
 /// `pkg.ns….name`); identity is `(enclosing impl, name)`.
@@ -294,6 +291,61 @@ pub struct ExportedImplMethod {
     /// (`validate_impl_signatures`) lowers the override through.
     /// `interface_target` is always the implemented interface's qtn.
     pub sig: ExportedFunction,
+}
+
+/// Reconstruct the MIR owner segment for an out-of-body impl method from the
+/// resolved impl head. This is the loc-free counterpart of the historical
+/// source spelling `{interface-ref}$for${for-ref}`: qualified leaves are
+/// rendered as they are addressable from the impl's package/namespace, while
+/// all generic/container structure comes from [`Ty::render_with`]. Source and
+/// mounted callers MUST use this same function so independently compiled
+/// units agree on the B-693 symbol.
+pub fn impl_method_symbol_owner(
+    interface: &baml_type::Interface,
+    for_ty: &Ty,
+    package: &Name,
+    namespace: &[Name],
+) -> Name {
+    struct ImplSymbolRender<'a> {
+        package: &'a Name,
+        namespace: &'a [Name],
+    }
+
+    impl baml_type::TyRenderStrategy for ImplSymbolRender<'_> {
+        fn qtn(&self, qtn: &QualifiedTypeName) -> String {
+            if qtn.package() != self.package {
+                return qtn.render_dotted(false);
+            }
+            if qtn.namespace() == self.namespace {
+                return qtn.name().to_string();
+            }
+            std::iter::once("root".to_string())
+                .chain(qtn.namespace().iter().map(ToString::to_string))
+                .chain(std::iter::once(qtn.name().to_string()))
+                .collect::<Vec<_>>()
+                .join(".")
+        }
+
+        fn type_var(&self, name: &Name) -> String {
+            name.to_string()
+        }
+    }
+
+    let renderer = ImplSymbolRender { package, namespace };
+    // Associated-type values are consequences of the impl and may include
+    // declaration defaults that were never written in the source-era symbol.
+    // Coherence keys an impl on the interface head + for-type, so they are not
+    // part of the B-693 owner segment.
+    let interface_head = baml_type::Interface::new(
+        interface.name.clone(),
+        interface.generics.clone(),
+        Vec::new(),
+    );
+    Name::new(format!(
+        "{}$for${}",
+        interface_head.to_ty().render_with(&renderer),
+        for_ty.render_with(&renderer)
+    ))
 }
 
 /// The typed export surface a single file contributes to its package.
@@ -439,7 +491,7 @@ impl PackageInterface {
 /// point for foreign (blob-backed) lookups: callers holding a package-prefixed
 /// path or a foreign `QualifiedTypeName` consult the blob's rows through this
 /// instead of raw `package_items` (which is empty for a mounted package).
-pub(crate) fn mounted_interface<'db>(
+pub fn mounted_interface<'db>(
     db: &'db dyn crate::Db,
     pkg_name: &Name,
 ) -> Option<&'db PackageInterface> {
@@ -451,7 +503,7 @@ pub(crate) fn mounted_interface<'db>(
 
 /// Look up an exported type row in a mounted package by qualified name.
 /// `None` when `qtn`'s package is not mounted or the row does not exist.
-pub(crate) fn mounted_type_row<'db>(
+pub fn mounted_type_row<'db>(
     db: &'db dyn crate::Db,
     qtn: &QualifiedTypeName,
 ) -> Option<&'db ExportedType> {
@@ -479,9 +531,7 @@ impl ExportedType {
             ExportedType::Enum { qtn, .. } => Ty::Enum(qtn.clone(), TyAttr::default()),
             ExportedType::TypeAlias { qtn, .. } => Ty::TypeAlias(qtn.clone(), TyAttr::default()),
             // Mirrors `def_to_ty`'s Interface arm (empty args/assoc — the
-            // own-package resolution shape). Unreachable through today's
-            // resolution paths, which skip dep-interface rows until the
-            // dualized resolution context lands (BEP-066 slice 6a follow-up).
+            // unspecialized declaration shape).
             ExportedType::Interface { qtn, .. } => {
                 Ty::Interface(qtn.clone(), vec![], vec![], TyAttr::default())
             }
@@ -1151,9 +1201,19 @@ fn exported_impl_method<'db>(
         .iter()
         .map(|(param, _)| param.clone())
         .collect();
-    let scope_generics =
-        crate::generic_env::append_params(&impl_param_names, &spec.generic_param_names());
-    let own_params = &scope_generics[impl_param_names.len()..];
+    // Unlike `InterfaceMethodSpec`, whose generic list is the user-written
+    // declaration, the function environment also contains signature
+    // elaboration's synthetic callback-effect params. They must cross the blob
+    // boundary too: source and mounted call inference consult the same free
+    // type variables even though runtime layout later erases them.
+    let impl_param_count = impl_param_names.len();
+    let scope_generics = crate::function_generic_params(db, method_loc);
+    debug_assert_eq!(
+        &scope_generics[..impl_param_count],
+        impl_param_names.as_slice(),
+        "an impl method's function environment must begin with the impl parameters"
+    );
+    let own_params = &scope_generics[impl_param_count..];
     let mut bounds: crate::lower_type_expr::TypeVarBoundsMap =
         data.generic_params.iter().cloned().collect();
     // Lowering diagnostics are dropped, matching every export path: the
@@ -1162,7 +1222,11 @@ fn exported_impl_method<'db>(
     let mut diags = Vec::new();
     let mut generic_params = Vec::new();
     let mut generic_param_bounds = Vec::new();
-    for (param, declared) in own_params.iter().zip(spec.generic_bounds()) {
+    let declared_count = spec.generic_bounds().len();
+    for (param, declared) in own_params[..declared_count]
+        .iter()
+        .zip(spec.generic_bounds())
+    {
         let ifaces = crate::interfaces::lower_generic_param_interface_bounds(
             db,
             spec.bound_store(),
@@ -1175,6 +1239,11 @@ fn exported_impl_method<'db>(
         bounds.insert(param.clone(), ifaces.clone());
         generic_params.push(param.clone());
         generic_param_bounds.push(ifaces);
+    }
+    for param in &own_params[declared_count..] {
+        bounds.insert(param.clone(), Vec::new());
+        generic_params.push(param.clone());
+        generic_param_bounds.push(Vec::new());
     }
 
     // The interface's symbolic `Self` parameter: from its generic env when the

--- a/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
@@ -106,9 +106,10 @@ pub enum ExportedType {
         resolved: Ty,
     },
     /// An interface declaration's full loc-free surface (BEP-066 slice 6a).
-    /// Derived but not yet consumed: today's resolution paths deliberately
-    /// treat these rows as absent (see `resolve_type_in_own_then_deps`) until
-    /// the dualized resolution context lands in a follow-up PR.
+    /// Resolution consumes these rows for mounted (source-less) dependencies,
+    /// where the exported blob is the sole representation. They remain
+    /// invisible for source-backed dependencies, whose interfaces resolve
+    /// through source items instead.
     ///
     /// Every type below is lowered at the interface's *own declaration scope*:
     /// the declared generic parameters are rigid `TypeVar`s and `Self` is the

--- a/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
@@ -139,14 +139,19 @@ pub enum ExportedType {
         /// scope (the same data [`crate::interfaces::resolve_interface_fields`]
         /// carries), plus schema attributes.
         fields: Vec<(Name, Ty, ExportedFieldAttrs)>,
-        /// Required methods first (declaration order), then default methods
-        /// (declaration order) — `InterfaceData` splits them, so the original
-        /// interleaving is not recoverable here. Signatures keep `Self`
-        /// symbolic; a default method's `callable_throws` is the body-inferred
-        /// contract from [`crate::callable::callable_throws`], a required
-        /// method's is its declared clause (`unknown` when unwritten, matching
-        /// `signature::lower_signature`'s `Missing` slot convention).
-        methods: Vec<ExportedFunction>,
+        /// Required methods in declaration order (no body — an implementor must
+        /// provide each). Signatures keep `Self` symbolic; `callable_throws` is
+        /// the declared clause (`unknown` when unwritten, matching
+        /// `signature::lower_signature`'s `Missing` slot convention). Split
+        /// from [`default_methods`](Self::Interface::default_methods) exactly
+        /// as `InterfaceData` splits them — a source-less consumer needs the
+        /// distinction for conformance (E0113 required-method coverage) and
+        /// method-default fallback.
+        required_methods: Vec<ExportedFunction>,
+        /// Default methods in declaration order (the interface provides a
+        /// body). `callable_throws` is the body-inferred contract from
+        /// [`crate::callable::callable_throws`].
+        default_methods: Vec<ExportedFunction>,
     },
 }
 
@@ -426,6 +431,30 @@ impl PackageInterface {
     pub fn lookup_function(&self, namespace: &[Name], item: &Name) -> Option<&ExportedFunction> {
         self.functions.get(namespace)?.get(item)
     }
+}
+
+/// The mounted (source-less) package interface for `pkg_name`, or `None` when
+/// `pkg_name` is not a mounted package (BEP-066 slice 6a). The single entry
+/// point for foreign (blob-backed) lookups: callers holding a package-prefixed
+/// path or a foreign `QualifiedTypeName` consult the blob's rows through this
+/// instead of raw `package_items` (which is empty for a mounted package).
+pub(crate) fn mounted_interface<'db>(
+    db: &'db dyn crate::Db,
+    pkg_name: &Name,
+) -> Option<&'db PackageInterface> {
+    if !baml_compiler2_hir::package::is_mounted_package(db, pkg_name) {
+        return None;
+    }
+    Some(package_interface(db, PackageId::new(db, pkg_name.clone())))
+}
+
+/// Look up an exported type row in a mounted package by qualified name.
+/// `None` when `qtn`'s package is not mounted or the row does not exist.
+pub(crate) fn mounted_type_row<'db>(
+    db: &'db dyn crate::Db,
+    qtn: &QualifiedTypeName,
+) -> Option<&'db ExportedType> {
+    mounted_interface(db, qtn.package())?.lookup_type(qtn.namespace(), qtn.name())
 }
 
 impl ExportedType {
@@ -779,9 +808,10 @@ fn lower_interface_export<'db>(
         })
         .collect();
 
-    // Required methods first, then default methods — each list in declaration
-    // order (`InterfaceData` splits them; the original interleaving is lost).
-    let mut methods = Vec::new();
+    // Required and default methods, each list in declaration order — exported
+    // split (as `InterfaceData` splits them) so a source-less consumer can run
+    // conformance (E0113) and default fallback.
+    let mut required_methods = Vec::new();
     let resolved_required = crate::interfaces::resolve_interface_required_methods(db, iface_loc);
     for (sig, resolved) in iface.required_methods.iter().zip(resolved_required) {
         // A required method has no body: its effective throws contract is its
@@ -790,9 +820,10 @@ fn lower_interface_export<'db>(
         if let Some(exported) =
             exported_interface_method(&qtn, resolved, sig.throws.is_some(), None, None)
         {
-            methods.push(exported);
+            required_methods.push(exported);
         }
     }
+    let mut default_methods = Vec::new();
     let resolved_default = crate::interfaces::resolve_interface_default_methods(db, iface_loc);
     for (&func_loc, resolved) in iface.default_methods.iter().zip(resolved_default) {
         let declared_throws_written =
@@ -810,7 +841,7 @@ fn lower_interface_export<'db>(
             Some(callable_throws),
             builtin_kind,
         ) {
-            methods.push(exported);
+            default_methods.push(exported);
         }
     }
 
@@ -822,7 +853,8 @@ fn lower_interface_export<'db>(
         requires,
         associated_types,
         fields,
-        methods,
+        required_methods,
+        default_methods,
     }
 }
 
@@ -977,6 +1009,26 @@ pub fn package_interface<'db>(db: &'db dyn crate::Db, pkg_id: PackageId<'db>) ->
         }
     }
 
+    // Mounted-package arm (BEP-066 slice 6a): a source-less dependency mounted
+    // as a blob serves its captured interface verbatim — the same seed
+    // mechanism generalized to any (non-reserved) alias. Distinct from the
+    // stdlib seed above: the stdlib map is an *optimization* over packages
+    // whose source is present, while a mounted package has NO files, so this
+    // arm is its only interface. `is_mounted_package` filters reserved names,
+    // so a blob can never shadow the stdlib or the user package. A corrupt
+    // blob falls through to honest derivation, which is empty for a file-less
+    // package — every reference then fails with the ordinary unresolved
+    // diagnostics rather than a panic.
+    if baml_compiler2_hir::package::is_mounted_package(db, &pkg_name) {
+        if let Some(mounted) = db.mounted_packages() {
+            if let Some(bytes) = mounted.by_package(db).get(pkg_name.as_str()) {
+                if let Ok(iface) = borsh::from_slice::<PackageInterface>(bytes) {
+                    return iface;
+                }
+            }
+        }
+    }
+
     // Honest derivation. Count stdlib-package derivations so a warm run can
     // assert zero (the seed served every stdlib package). The authoritative set
     // of stdlib packages is the embedded builtin manifest — a package is stdlib
@@ -1011,7 +1063,7 @@ fn exported_impls<'db>(db: &'db dyn crate::Db, pkg_id: PackageId<'db>) -> Vec<Ex
         let Ok(data) = crate::interfaces::impl_data(db, impl_loc).as_ref() else {
             continue;
         };
-        let Some(iface_qtn) = crate::interfaces::interface_loc_qtn(db, data.interface) else {
+        let Some(iface_qtn) = data.interface_qtn(db) else {
             continue;
         };
         // The impl's own file namespace — the scope its block lowered in
@@ -1124,8 +1176,23 @@ fn exported_impl_method<'db>(
         generic_param_bounds.push(ifaces);
     }
 
-    let iface_env = crate::generic_env::interface_generic_env(db, data.interface);
-    let (iface_self_param, _) = iface_env.interface_param_parts();
+    // The interface's symbolic `Self` parameter: from its generic env when the
+    // target is source-backed, from the mounted row otherwise (a user impl of
+    // a mounted interface still exports — its overrides are source-backed).
+    let iface_self_param: ParamTy = match &data.interface {
+        crate::interfaces::ImplInterfaceTarget::Source(loc) => {
+            crate::generic_env::interface_generic_env(db, *loc)
+                .interface_param_parts()
+                .0
+                .clone()
+        }
+        crate::interfaces::ImplInterfaceTarget::Mounted(qtn) => {
+            match crate::package_interface::mounted_type_row(db, qtn) {
+                Some(ExportedType::Interface { self_param, .. }) => self_param.clone(),
+                _ => return None,
+            }
+        }
+    };
     let self_bound =
         baml_type::Interface::new(iface_qtn.clone(), data.interface_args.clone(), Vec::new());
     let realized = crate::interfaces::realize_with_symbolic_self(
@@ -1133,7 +1200,7 @@ fn exported_impl_method<'db>(
         pkg_items,
         ns,
         &scope_generics,
-        iface_self_param,
+        &iface_self_param,
         &bounds,
         &self_bound,
         &data.for_ty_pattern,
@@ -1324,12 +1391,15 @@ impl<'db> PackageResolutionContext<'db> {
             for (dep_name, dep_iface) in &self.dep_interfaces {
                 if &path[0] == dep_name {
                     if let Some(exported) = dep_iface.lookup_type(&path[1..path.len() - 1], item) {
-                        // Interface rows are exported (BEP-066 slice 6a) but not
-                        // yet consumable through this path — treat them exactly
-                        // as the pre-export derivation did (absent), preserving
-                        // resolution byte-for-byte until the dualized resolution
-                        // context lands in a follow-up PR.
-                        if !matches!(exported, ExportedType::Interface { .. }) {
+                        // Interface rows resolve only for MOUNTED (source-less)
+                        // dependencies (BEP-066 slice 6a) — their rows are the
+                        // sole representation. A source-backed dependency's
+                        // interface rows stay invisible here, preserving the
+                        // pre-export resolution (its interfaces resolve through
+                        // source items on the loc path).
+                        if !matches!(exported, ExportedType::Interface { .. })
+                            || baml_compiler2_hir::package::is_mounted_package(db, dep_name)
+                        {
                             return Some((ResolvedSource::Builtin, exported.to_ty()));
                         }
                     }
@@ -1350,11 +1420,13 @@ impl<'db> PackageResolutionContext<'db> {
             let ty = def_to_ty(db, def);
             return Some((ResolvedSource::Item, ty));
         }
-        for (_dep_name, dep_iface) in &self.dep_interfaces {
+        for (dep_name, dep_iface) in &self.dep_interfaces {
             if let Some(exported) = dep_iface.lookup_type(namespace, item) {
-                // See the interface-row guard in `resolve_type`: exported but
-                // deliberately invisible here until consumption lands.
-                if !matches!(exported, ExportedType::Interface { .. }) {
+                // See the interface-row gate in `resolve_type`: interface rows
+                // resolve only for mounted dependencies.
+                if !matches!(exported, ExportedType::Interface { .. })
+                    || baml_compiler2_hir::package::is_mounted_package(db, dep_name)
+                {
                     return Some((ResolvedSource::Builtin, exported.to_ty()));
                 }
             }

--- a/baml_language/crates/baml_compiler2_tir/src/unify.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/unify.rs
@@ -375,6 +375,22 @@ pub(crate) fn normalized_alias_map<'db>(
     let mut aliases =
         crate::inference::collect_type_aliases(db, baml_compiler2_ppir::package_items(db, pkg_id));
     for dep in baml_compiler2_hir::package::package_dependency_closure(db, pkg_id) {
+        // A mounted (source-less) dependency's aliases live pre-resolved on
+        // its interface blob (BEP-066 slice 6a); its raw items are empty.
+        if let Some(mounted) = crate::package_interface::mounted_interface(db, &dep.name(db)) {
+            for types_in_ns in mounted.types.values() {
+                for exported in types_in_ns.values() {
+                    if let crate::package_interface::ExportedType::TypeAlias { qtn, resolved } =
+                        exported
+                    {
+                        aliases
+                            .entry(qtn.clone())
+                            .or_insert_with(|| resolved.clone());
+                    }
+                }
+            }
+            continue;
+        }
         for (qtn, ty) in
             crate::inference::collect_type_aliases(db, baml_compiler2_ppir::package_items(db, *dep))
         {
@@ -392,6 +408,14 @@ pub(crate) fn normalized_alias_map<'db>(
 /// by `nf` to fold a complete variant union (`Cmp.Less | Cmp.Equal | Cmp.More`) back to
 /// its enum (`Cmp`).
 pub(crate) fn enum_variant_names(db: &dyn crate::Db, enum_qtn: &TypeName) -> Option<Vec<Name>> {
+    // A mounted (source-less) package's enums live on its interface blob
+    // (BEP-066 slice 6a); its raw items are empty by design.
+    if let Some(row) = crate::package_interface::mounted_type_row(db, enum_qtn) {
+        let crate::package_interface::ExportedType::Enum { variants, .. } = row else {
+            return None;
+        };
+        return Some(variants.clone());
+    }
     let package_id = PackageId::new(db, enum_qtn.package().clone());
     let items = baml_compiler2_hir::package::package_items(db, package_id);
     let Some(Definition::Enum(enum_loc)) = items.lookup_type(enum_qtn.namespace(), enum_qtn.name())

--- a/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
@@ -360,6 +360,12 @@ pub enum DiagnosticId {
     /// (an existential), never as a bound.
     BuiltinInterfaceNotABound,
 
+    // Mounted packages (BEP-066 slice 6a, E0158)
+    /// A call whose callee resolves into a MOUNTED (source-less) dependency
+    /// package. References type from the mounted interface; calls need a
+    /// loc-backed resolution for lowering, which lands in a later slice-6a PR.
+    MountedPackageCallUnsupported,
+
     // Projection bases (E0156)
     /// The dotted projection shorthand (`Base.Member`) was written with the
     /// interface itself as the base (`Iterator.Element`). A projection's base
@@ -588,6 +594,7 @@ impl DiagnosticId {
             DiagnosticId::BuiltinInterfaceNotImplementable => "E0153",
             DiagnosticId::BuiltinInterfaceNotABound => "E0154",
             DiagnosticId::InterfaceProjectionBase => "E0156",
+            DiagnosticId::MountedPackageCallUnsupported => "E0158",
         }
     }
 }

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -553,8 +553,14 @@ fn check_interfaces(db: &dyn Db, file: SourceFile, file_id: FileId) -> Vec<Diagn
         // `primary` side left the file holding the `secondary` impl looking clean.
         let (primary, secondary) = if violation.primary.file_id == file_id {
             (violation.primary, violation.secondary)
-        } else if violation.secondary.file_id == file_id {
-            (violation.secondary, violation.primary)
+        } else if violation
+            .secondary
+            .is_some_and(|span| span.file_id == file_id)
+        {
+            (
+                violation.secondary.expect("checked is_some above"),
+                Some(violation.primary),
+            )
         } else {
             continue;
         };
@@ -562,18 +568,27 @@ fn check_interfaces(db: &dyn Db, file: SourceFile, file_id: FileId) -> Vec<Diagn
         // can't be ruled out, and the resolver assumes ≤1 impl), but the message
         // distinguishes them so the user knows whether it's a proven conflict or a
         // type too complex to analyze.
-        let message: &str = if violation.indeterminate {
+        let message: String = if violation.indeterminate {
             "these interface implementations are too complex to prove disjoint; \
              simplify the types involved so coherence can be decided"
+                .to_string()
         } else {
-            "overlapping interface implementations for the same receiver/interface"
+            "overlapping interface implementations for the same receiver/interface".to_string()
         };
-        diagnostics.push(
-            Diagnostic::error(DiagnosticId::OverlappingImplements, message)
-                .with_primary_span(primary)
-                .with_secondary(secondary, "conflicting implementation is here")
-                .with_phase(DiagnosticPhase::Type),
-        );
+        // A span-less partner is a MOUNTED (source-less) dependency's blob
+        // impl (BEP-066 slice 6a): primary-only attribution, the partner
+        // rendered structurally in the message.
+        let message = match &violation.secondary_desc {
+            Some(desc) => format!("{message} (conflicts with the mounted dependency's `{desc}`)"),
+            None => message,
+        };
+        let mut diag = Diagnostic::error(DiagnosticId::OverlappingImplements, message)
+            .with_primary_span(primary)
+            .with_phase(DiagnosticPhase::Type);
+        if let Some(secondary) = secondary {
+            diag = diag.with_secondary(secondary, "conflicting implementation is here");
+        }
+        diagnostics.push(diag);
     }
 
     // ── 2 + 3. Per-impl structural + signature/conformance diagnostics ────────
@@ -1952,6 +1967,9 @@ fn tir_type_error_to_diagnostic_id(
         TirTypeError::UnknownClassPropertyShorthand { .. } => DiagnosticId::NoSuchField,
         TirTypeError::UnresolvedName { .. } | TirTypeError::UnresolvedPropertyShorthand { .. } => {
             DiagnosticId::UnknownVariable
+        }
+        TirTypeError::MountedPackageCallUnsupported { .. } => {
+            DiagnosticId::MountedPackageCallUnsupported
         }
         TirTypeError::DeadCode { .. } => DiagnosticId::UnreachableCode,
         TirTypeError::VoidUsedAsValue => DiagnosticId::TypeMismatch,

--- a/baml_language/crates/baml_lsp2_actions/src/definition.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/definition.rs
@@ -460,6 +460,9 @@ fn resolve_field_access_at(
                 range: *source_map.field_name_spans.get(*field_index as usize)?,
             })
         }
+        // A mounted (source-less) dependency's callee has no source anywhere in
+        // this workspace — nothing to navigate to (BEP-066 slice 6a).
+        MemberResolution::External(_) => None,
     }
 }
 

--- a/baml_language/crates/baml_lsp2_actions/src/tokens/classify.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/tokens/classify.rs
@@ -127,6 +127,12 @@ pub(super) fn classify_member(res: &MemberResolution<'_>) -> (SemanticTokenType,
         | M::UnboundMethod { .. }
         | M::InterfaceConcreteMethod { .. }
         | M::InterfaceVirtualMethod { .. } => T::Method,
+        // A mounted (source-less) dependency's callee (BEP-066 slice 6a).
+        M::External(external) => match &external.target {
+            baml_compiler2_tir::inference::ExternalCallTarget::Free { .. } => T::Function,
+            baml_compiler2_tir::inference::ExternalCallTarget::Method { .. }
+            | baml_compiler2_tir::inference::ExternalCallTarget::Interface { .. } => T::Method,
+        },
     };
     (token_type, ModifierSet::empty())
 }

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -170,6 +170,16 @@ pub struct ProjectDatabase {
     /// handle would leave a stale memo on a reused database, e.g. the LSP's
     /// long-lived `ProjectDatabase`).
     seeded_callable_throws: Option<baml_workspace::SeededCallableThrows>,
+    /// Source-less dependency packages mounted as `borsh(PackageInterface)`
+    /// blobs, keyed by the mount alias (BEP-066 slice 6a).
+    ///
+    /// Same present-from-construction discipline as the `seeded_*` inputs
+    /// above: a real `#[salsa::input]` handle created **once** (empty) in the
+    /// constructors and thereafter mutated in place via its Salsa setter, so it
+    /// is always `Some` and `package_dependencies` / `package_interface` read
+    /// the mount map through a **tracked** dependency (an absent-then-added
+    /// handle would leave a stale memo on a reused database).
+    mounted_packages: Option<baml_workspace::MountedPackages>,
     /// Maps file paths to their `SourceFile` handles (user files only).
     ///
     /// `Arc`-wrapped (with `Arc::make_mut` at the mutation sites) so cloning a
@@ -224,6 +234,10 @@ impl baml_workspace::Db for ProjectDatabase {
 
     fn seeded_callable_throws(&self) -> Option<baml_workspace::SeededCallableThrows> {
         self.seeded_callable_throws
+    }
+
+    fn mounted_packages(&self) -> Option<baml_workspace::MountedPackages> {
+        self.mounted_packages
     }
 }
 
@@ -313,6 +327,7 @@ impl ProjectDatabase {
             seeded_throw_facts: None,
             seeded_stdlib_interface: None,
             seeded_callable_throws: None,
+            mounted_packages: None,
             file_map: Arc::new(HashMap::new()),
             compiler2_file_map: HashMap::new(),
             file_id_to_path: Arc::new(HashMap::new()),
@@ -327,6 +342,10 @@ impl ProjectDatabase {
             std::collections::BTreeMap::new(),
         ));
         db.seeded_callable_throws = Some(baml_workspace::SeededCallableThrows::new(
+            &db,
+            std::collections::BTreeMap::new(),
+        ));
+        db.mounted_packages = Some(baml_workspace::MountedPackages::new(
             &db,
             std::collections::BTreeMap::new(),
         ));
@@ -397,6 +416,55 @@ impl ProjectDatabase {
             .seeded_callable_throws
             .expect("SeededCallableThrows input is created in ProjectDatabase::new");
         seeds.set_by_path(self).to(by_path);
+    }
+
+    /// Add a compiler2-only virtual source file (a `<builtin>/…` path) to the
+    /// `Compiler2ExtraFiles` input — the channel `compiler2_all_files` reads
+    /// builtin stubs from (ordinary project files with a `<builtin>/` path are
+    /// filtered out there).
+    ///
+    /// Fixture/testing hook (BEP-066 slice 6a): compiling library files under
+    /// `<builtin>/<pkg>/…` makes `file_package` assign them the package name
+    /// `<pkg>`, so a test can derive a real `PackageInterface` blob for a
+    /// package that is not `user` and mount it elsewhere. Requires
+    /// `set_project_root` to have run (it creates the input).
+    pub fn add_compiler2_virtual_file(
+        &mut self,
+        path: impl AsRef<std::path::Path>,
+        content: &str,
+    ) -> SourceFile {
+        let path = path.as_ref().to_path_buf();
+        let file = self.add_file_internal(&path, content);
+        let file_id = file.file_id(self);
+        Arc::make_mut(&mut self.file_id_to_path).insert(file_id, path.clone());
+        self.compiler2_file_map.insert(path, file);
+        let extra = self
+            .compiler2_extra_files
+            .expect("set_project_root creates the Compiler2ExtraFiles input");
+        let mut files = extra.files(self).clone();
+        files.push(file);
+        extra.set_files(self).to(files);
+        file
+    }
+
+    /// Mount source-less dependency packages as serialized `PackageInterface`
+    /// blobs, keyed by the mount alias (BEP-066 slice 6a); each value is
+    /// `borsh(PackageInterface)`.
+    ///
+    /// Mutates the always-present `MountedPackages` input (created in `new`)
+    /// through its Salsa setter, so it bumps the revision and correctly
+    /// invalidates any already-computed `package_dependencies` /
+    /// `package_interface` memo — safe to call before *or* after queries have
+    /// run. Aliases colliding with the reserved package set (the stdlib
+    /// packages, `user`, `root`, `env`) are ignored by the readers.
+    pub fn set_mounted_packages(
+        &mut self,
+        by_package: std::collections::BTreeMap<String, Vec<u8>>,
+    ) {
+        let mounts = self
+            .mounted_packages
+            .expect("MountedPackages input is created in ProjectDatabase::new");
+        mounts.set_by_package(self).to(by_package);
     }
 
     /// Get all source files in the database, sorted by `FileId` for deterministic ordering.
@@ -1317,9 +1385,9 @@ impl ProjectDatabase {
         )
         .into_iter()
         .filter(|resolved| {
-            baml_compiler2_tir::interfaces::impl_data(self, resolved.impl_loc)
-                .as_ref()
-                .is_ok_and(|data| data.interface == iface_loc)
+            resolved
+                .data(self)
+                .is_some_and(|data| data.interface_loc() == Some(iface_loc))
         })
         .filter_map(|resolved| resolved.get_method(self, method_name));
         let method = methods.next()?;

--- a/baml_language/crates/baml_project/src/db.rs
+++ b/baml_language/crates/baml_project/src/db.rs
@@ -1290,7 +1290,10 @@ impl ProjectDatabase {
             Some(
                 MemberResolution::Field { .. }
                 | MemberResolution::Variant { .. }
-                | MemberResolution::InterfaceVirtualField { .. },
+                | MemberResolution::InterfaceVirtualField { .. }
+                // A mounted (source-less) callee has no `FunctionLoc` in this
+                // database (BEP-066 slice 6a).
+                | MemberResolution::External(_),
             )
             | None => None,
         }
@@ -1394,7 +1397,7 @@ impl ProjectDatabase {
         if methods.next().is_some() {
             return None;
         }
-        Some(method.method)
+        method.method_loc()
     }
 
     fn is_single_llm_graph(

--- a/baml_language/crates/baml_surface/src/export.rs
+++ b/baml_language/crates/baml_surface/src/export.rs
@@ -393,7 +393,7 @@ impl<'db> ImplIndex<'db> {
             .iter()
             .filter(|(imp, _)| {
                 crate::facts::impl_data(db, imp.loc())
-                    .is_some_and(|data| data.interface == iface.loc())
+                    .is_some_and(|data| data.interface_loc() == Some(iface.loc()))
             })
             .map(|(_, export)| export.id.clone())
             .collect();
@@ -543,7 +543,9 @@ fn export_impl(
     seen_bases: &mut std::collections::HashMap<String, u32>,
 ) -> Option<ImplExport> {
     let data = crate::facts::impl_data(db, imp.loc())?;
-    let iface: crate::Interface<'_> = data.interface.into();
+    // Impls of a MOUNTED (source-less) interface are not exported through the
+    // tooling surface yet — the interface has no handle to link against.
+    let iface: crate::Interface<'_> = data.interface_loc()?.into();
     let iface_qtn = iface.qualified_name(db);
     let pkg = baml_compiler2_hir::file_package::file_package(db, imp.file(db)).package;
 

--- a/baml_language/crates/baml_surface/src/handles.rs
+++ b/baml_language/crates/baml_surface/src/handles.rs
@@ -740,9 +740,11 @@ impl<'db> Impl<'db> {
             .collect()
     }
 
-    /// The implemented interface; `None` when the block is malformed.
+    /// The implemented interface; `None` when the block is malformed or the
+    /// target is a mounted (source-less) dependency's interface, which has no
+    /// source handle.
     pub fn interface(self, db: &'db dyn Db) -> Option<Interface<'db>> {
-        facts::impl_data(db, self.0).map(|data| data.interface.into())
+        facts::impl_data(db, self.0).and_then(|data| data.interface_loc().map(Into::into))
     }
 
     /// The interface's generic arguments as written on this block.
@@ -785,7 +787,17 @@ impl<'db> Impl<'db> {
             })
             .collect();
         let overridden: Vec<Name> = out.iter().map(|m| m.function.name(db)).collect();
-        for &default_loc in &item_data::interface_data(db, data.interface).default_methods {
+        // A mounted interface's default bodies have no locs; only the block's
+        // own overrides are listed for such a target.
+        let default_methods = data
+            .interface_loc()
+            .map(|iface_loc| {
+                item_data::interface_data(db, iface_loc)
+                    .default_methods
+                    .as_slice()
+            })
+            .unwrap_or(&[]);
+        for &default_loc in default_methods {
             let default: Function<'db> = default_loc.into();
             if !overridden.contains(&default.name(db)) {
                 out.push(ImplMethod {
@@ -1150,7 +1162,9 @@ impl<'db> Interface<'db> {
     pub fn implementors(self, db: &'db dyn Db) -> Vec<Impl<'db>> {
         project_impls(db)
             .into_iter()
-            .filter(|imp| facts::impl_data(db, imp.0).is_some_and(|data| data.interface == self.0))
+            .filter(|imp| {
+                facts::impl_data(db, imp.0).is_some_and(|data| data.interface_loc() == Some(self.0))
+            })
             .collect()
     }
 }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/package_interface.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/package_interface.rs
@@ -214,7 +214,8 @@ fn interface_export_carries_full_symbolic_surface() {
         requires,
         associated_types,
         fields,
-        methods,
+        required_methods,
+        default_methods,
     } = lookup(iface, &[], "Source")
     else {
         panic!("Source must export as ExportedType::Interface");
@@ -264,8 +265,9 @@ fn interface_export_carries_full_symbolic_surface() {
     assert_eq!(attrs.alias.as_deref(), Some("lbl"));
     assert_eq!(attrs.description.as_deref(), Some("source label"));
 
-    // Required AND default methods, signatures with symbolic `Self`.
-    let next = method(methods, "next");
+    // Required AND default methods (exported split), signatures with
+    // symbolic `Self`.
+    let next = method(required_methods, "next");
     assert!(
         matches!(&next.params[0].ty, Ty::TypeVar(p, _) if p.as_str() == "Self"),
         "required-method receiver stays the symbolic Self"
@@ -279,7 +281,7 @@ fn interface_export_carries_full_symbolic_surface() {
     assert_eq!(next.callable_fqn, "user.Source.next");
     assert!(next.interface_target.is_none());
 
-    let twice = method(methods, "twice");
+    let twice = method(default_methods, "twice");
     assert!(
         matches!(&twice.params[0].ty, Ty::TypeVar(p, _) if p.as_str() == "Self"),
         "default-method receiver stays the symbolic Self"
@@ -518,7 +520,8 @@ fn stdlib_interfaces_derive_enriched() {
     let ExportedType::Interface {
         requires,
         associated_types,
-        methods,
+        required_methods,
+        default_methods,
         ..
     } = lookup(baml, &["iter"], "Iterator")
     else {
@@ -551,10 +554,10 @@ fn stdlib_interfaces_derive_enriched() {
         "`type Error = never` exports its default"
     );
 
-    let next = method(methods, "next");
+    let next = method(required_methods, "next");
     assert_eq!(next.callable_fqn, "baml.iter.Iterator.next");
     assert!(matches!(&next.params[0].ty, Ty::TypeVar(p, _) if p.as_str() == "Self"));
-    let map = method(methods, "map");
+    let map = method(default_methods, "map");
     assert_eq!(
         map.generic_params
             .iter()
@@ -641,10 +644,13 @@ interface M {
     );
 
     // Method-level generic bound using `Self` (already symbolic — pinned).
-    let ExportedType::Interface { methods, .. } = lookup(iface, &[], "M") else {
+    let ExportedType::Interface {
+        required_methods, ..
+    } = lookup(iface, &[], "M")
+    else {
         panic!("M must export as ExportedType::Interface");
     };
-    let f = method(methods, "f");
+    let f = method(required_methods, "f");
     assert!(
         matches!(&f.generic_param_bounds[0][0].generics[0], Ty::TypeVar(p, _) if p.as_str() == "Self"),
         "method-bound `Self` must stay symbolic, got {:?}",
@@ -823,13 +829,13 @@ fn generic_impl_exports_params_bounds_and_patterns() {
 }
 
 #[test]
-fn dep_interface_rows_stay_invisible_to_resolution() {
-    // BEP-066 slice 6a exports dependency interface rows but nothing may
-    // consume them yet: both `PackageResolutionContext::resolve_type` paths
-    // (the namespace-qualified `resolve_type_in_own_then_deps` walk and the
-    // package-prefixed dep search) carry explicit guards that treat an
-    // `ExportedType::Interface` row as absent, preserving pre-export
-    // resolution byte-for-byte until the dualized resolution context lands.
+fn dep_interface_rows_resolve_only_for_mounted_packages() {
+    // BEP-066 slice 6a: an `ExportedType::Interface` row resolves through both
+    // `PackageResolutionContext::resolve_type` paths ONLY when the dependency
+    // is a MOUNTED (source-less) package — its rows are the sole
+    // representation. A source-backed dependency's interface rows stay
+    // invisible (its interfaces resolve through source items on the loc path),
+    // preserving pre-export resolution for every source-backed dep.
     use baml_compiler2_tir::package_interface::package_resolution_context;
 
     let mut db = make_db();
@@ -837,11 +843,21 @@ fn dep_interface_rows_stay_invisible_to_resolution() {
         "main.baml",
         "function f() -> int throws never {\n    1\n}\n",
     );
+    db.set_mounted_packages(
+        [(
+            "app".to_string(),
+            mounted::app_blob(&[(
+                "lib.baml",
+                "interface Marker {\n    function id(self) -> string throws never\n}\n",
+            )]),
+        )]
+        .into(),
+    );
     let res_ctx = package_resolution_context(&db, PackageId::new(&db, Name::new("user")));
 
     let path = |parts: &[&str]| -> Vec<Name> { parts.iter().map(|p| Name::new(*p)).collect() };
 
-    // The row IS exported…
+    // The source-backed row IS exported…
     let baml = package_interface(&db, PackageId::new(&db, Name::new("baml")));
     assert!(
         matches!(
@@ -851,25 +867,29 @@ fn dep_interface_rows_stay_invisible_to_resolution() {
         "baml.iter.Iterator is exported as an interface row"
     );
 
-    // …but the package-prefixed dep search must not resolve through it.
+    // …but the package-prefixed dep search must not resolve through it
+    // (baml has source; its interfaces resolve via source items).
     assert!(
         res_ctx
             .resolve_type(&db, &path(&["baml", "iter", "Iterator"]), &[])
             .is_none(),
-        "dep interface row must be invisible to package-prefixed resolution"
+        "source-backed dep interface row must stay invisible to package-prefixed resolution"
     );
-
-    // The namespace-qualified own-then-deps walk hits the same row via the
-    // dep's namespace and must skip it too.
     assert!(
         res_ctx
             .resolve_type(&db, &path(&["iter", "Iterator"]), &[])
             .is_none(),
-        "dep interface row must be invisible to the own-then-deps walk"
+        "source-backed dep interface row must stay invisible to the own-then-deps walk"
     );
 
+    // A MOUNTED dependency's interface row resolves on both paths.
+    let (_, ty) = res_ctx
+        .resolve_type(&db, &path(&["app", "Marker"]), &[])
+        .expect("mounted interface row resolves via the package-prefixed path");
+    assert!(matches!(ty, Ty::Interface(ref qtn, _, _, _) if qtn.name().as_str() == "Marker"));
+
     // Contrast: a dep CLASS in the same namespace still resolves through the
-    // interface rows on both paths — the guard is interface-specific.
+    // interface rows on both paths — the gate is interface-specific.
     let (_, ty) = res_ctx
         .resolve_type(&db, &path(&["baml", "iter", "Range"]), &[])
         .expect("dep class resolves via the package-prefixed path");
@@ -1006,4 +1026,434 @@ fn stdlib_impls_export_and_int_equals_is_complete() {
         Some(baml_compiler2_ast::BuiltinKind::Vm),
         "`$rust_function` bodies keep their builtin kind"
     );
+}
+
+// ── Mounted source-less packages (PR 3: type-position consumption) ─────────
+
+/// BEP-066 slice 6a, PR 3: a package mounted as a `borsh(PackageInterface)`
+/// blob — with NO source files — resolves in TYPE positions at check level.
+/// Each test compiles a fixture "library" package (files under
+/// `<builtin>/app/…` so `file_package` assigns them the package name `app`),
+/// captures its interface blob, mounts it in a FRESH database as `app`, and
+/// runs `collect_diagnostics` over consumer code. Calls into mounted packages
+/// are NOT yet supported (next PR) and are rejected with a dedicated
+/// diagnostic.
+pub(super) mod mounted {
+    use baml_base::Name;
+    use baml_compiler2_hir::package::PackageId;
+    use baml_compiler2_tir::package_interface::package_interface;
+    use baml_project::{ProjectDatabase, testing::assert_no_diagnostic_errors};
+
+    use super::super::support::make_db;
+
+    /// Compile `files` as the source of a library package named `app` and
+    /// capture its `borsh(PackageInterface)` blob. The files ride under
+    /// `<builtin>/app/…` so `file_package` assigns them the `app` package —
+    /// the blob's qualified names therefore read `app.…`, matching the mount
+    /// alias exactly (re-aliasing a blob under a different name is out of
+    /// scope for this PR).
+    pub(crate) fn app_blob(files: &[(&str, &str)]) -> Vec<u8> {
+        let mut db = make_db();
+        for (path, src) in files {
+            // The extra-files channel: `compiler2_all_files` filters ordinary
+            // project files with `<builtin>/` paths, so library fixtures ride
+            // the same input the stdlib stubs do.
+            db.add_compiler2_virtual_file(format!("<builtin>/app/{path}"), src);
+        }
+        assert_no_diagnostic_errors(&db);
+        let iface = package_interface(&db, PackageId::new(&db, Name::new("app")));
+        assert!(
+            iface.types.values().any(|ns| !ns.is_empty()),
+            "the library fixture must export at least one type"
+        );
+        borsh::to_vec(iface).expect("serialize app interface")
+    }
+
+    /// A fresh consumer database with `blob` mounted as `app` and NO `app`
+    /// source anywhere.
+    fn consumer_db(blob: Vec<u8>, files: &[(&str, &str)]) -> ProjectDatabase {
+        let mut db = make_db();
+        db.set_mounted_packages([("app".to_string(), blob)].into());
+        for (path, src) in files {
+            db.add_file(*path, *src);
+        }
+        db
+    }
+
+    /// The check-level error messages (with codes) for user files of `db`.
+    fn error_messages(db: &ProjectDatabase) -> Vec<String> {
+        baml_project::collect_diagnostics(db)
+            .iter()
+            .filter(|d| matches!(d.severity, baml_compiler_diagnostics::Severity::Error))
+            .map(|d| format!("[{}] {}", d.code(), d.message))
+            .collect()
+    }
+
+    #[track_caller]
+    fn assert_clean(db: &ProjectDatabase) {
+        let errors = error_messages(db);
+        assert!(errors.is_empty(), "expected no errors, got:\n{errors:#?}");
+    }
+
+    #[track_caller]
+    fn assert_error_containing(db: &ProjectDatabase, needle: &str) {
+        let errors = error_messages(db);
+        assert!(
+            errors.iter().any(|msg| msg.contains(needle)),
+            "expected an error containing {needle:?}, got:\n{errors:#?}"
+        );
+    }
+
+    /// The shared library fixture: a class implementing a library interface
+    /// (in-body impl), blob-side `Equals`/`Compare` impls, an enum, an alias,
+    /// and a free function.
+    const LIB: &str = r#"
+interface Describable {
+    function describe(self) -> string throws never
+}
+
+class Widget {
+    x int
+    label string
+
+    implements Describable {
+        function describe(self) -> string throws never {
+            self.label
+        }
+    }
+}
+
+implement baml.ops.Equals for Widget {
+    function eq(self, other: Self) -> bool throws never {
+        self.x == other.x
+    }
+}
+
+implement baml.ops.Compare for Widget {
+    function lt(self, other: Self) -> bool throws never {
+        self.x < other.x
+    }
+}
+
+enum Status {
+    Active
+    Retired
+}
+
+type Score = int
+
+interface Taggable {
+    function tag(self) -> string throws never
+}
+
+implement<T> Taggable for T {
+    function tag(self) -> string throws never {
+        "any"
+    }
+}
+
+function add(a: int, b: int) -> int throws never {
+    a + b
+}
+"#;
+
+    fn lib_blob() -> Vec<u8> {
+        app_blob(&[("lib.baml", LIB)])
+    }
+
+    #[test]
+    fn class_resolves_in_type_position() {
+        let db = consumer_db(
+            lib_blob(),
+            &[(
+                "main.baml",
+                r#"
+function f() -> int throws never {
+    let w: app.Widget[] = []
+    let o: app.Widget? = null
+    0
+}
+"#,
+            )],
+        );
+        assert_clean(&db);
+    }
+
+    #[test]
+    fn interface_annotation_and_bound_consult_blob_impls() {
+        let db = consumer_db(
+            lib_blob(),
+            &[(
+                "main.baml",
+                r#"
+function pick<T extends app.Describable>(a: T, b: T) -> T throws never {
+    a
+}
+
+function g(w: app.Widget) -> app.Widget throws never {
+    pick(w, w)
+}
+
+function h(w: app.Widget) -> int throws never {
+    let d: app.Describable = w
+    0
+}
+"#,
+            )],
+        );
+        assert_clean(&db);
+    }
+
+    #[test]
+    fn user_impl_of_mounted_interface_checks_conformance() {
+        let db = consumer_db(
+            lib_blob(),
+            &[(
+                "main.baml",
+                r#"
+class Card {
+    title string
+
+    implements app.Describable {
+        function describe(self) -> string throws never {
+            self.title
+        }
+    }
+}
+
+function f(c: Card) -> int throws never {
+    let d: app.Describable = c
+    0
+}
+"#,
+            )],
+        );
+        assert_clean(&db);
+    }
+
+    #[test]
+    fn user_impl_of_mounted_interface_missing_method_is_rejected() {
+        // E0113: the blob row's REQUIRED method list drives coverage.
+        let db = consumer_db(
+            lib_blob(),
+            &[(
+                "main.baml",
+                r#"
+class Card {
+    title string
+
+    implements app.Describable {
+    }
+}
+"#,
+            )],
+        );
+        assert_error_containing(&db, "describe");
+    }
+
+    #[test]
+    fn user_impl_of_mounted_interface_signature_mismatch_is_rejected() {
+        // E0120: the override must conform to the blob row's symbolic-Self
+        // signature.
+        let db = consumer_db(
+            lib_blob(),
+            &[(
+                "main.baml",
+                r#"
+class Card {
+    title string
+
+    implements app.Describable {
+        function describe(self) -> int throws never {
+            1
+        }
+    }
+}
+"#,
+            )],
+        );
+        assert_error_containing(&db, "describe");
+    }
+
+    #[test]
+    fn match_over_mounted_enum_is_exhaustiveness_checked() {
+        let blob = lib_blob();
+        let db = consumer_db(
+            blob.clone(),
+            &[(
+                "main.baml",
+                r#"
+function m(s: app.Status) -> int throws never {
+    match s {
+        app.Status.Active => 1
+        app.Status.Retired => 2
+    }
+}
+"#,
+            )],
+        );
+        assert_clean(&db);
+
+        // A missing arm gets the normal non-exhaustive diagnostic, fed by the
+        // blob's variant list.
+        let db = consumer_db(
+            blob,
+            &[(
+                "main.baml",
+                r#"
+function m(s: app.Status) -> int throws never {
+    match s {
+        app.Status.Active => 1
+    }
+}
+"#,
+            )],
+        );
+        assert_error_containing(&db, "Retired");
+    }
+
+    #[test]
+    fn alias_from_blob_expands() {
+        let db = consumer_db(
+            lib_blob(),
+            &[(
+                "main.baml",
+                r#"
+function a(s: app.Score) -> int throws never {
+    let t: app.Score = 5
+    s + t
+}
+"#,
+            )],
+        );
+        assert_clean(&db);
+    }
+
+    #[test]
+    fn operators_resolve_through_blob_impl_rows() {
+        // `==` is universal; `<` is the check-observable consumer of the blob's
+        // `Equals`/`Compare` rows (ordering requires `baml.ops.Compare`
+        // membership, discharged through the mounted impls table).
+        let db = consumer_db(
+            lib_blob(),
+            &[(
+                "main.baml",
+                r#"
+function cmp(a: app.Widget, b: app.Widget) -> bool throws never {
+    let eq: bool = a == b
+    a < b
+}
+"#,
+            )],
+        );
+        assert_clean(&db);
+    }
+
+    #[test]
+    fn absent_name_gets_normal_unresolved_diagnostic() {
+        let db = consumer_db(
+            lib_blob(),
+            &[(
+                "main.baml",
+                r#"
+function n() -> int throws never {
+    let x: app.Nope = 1
+    0
+}
+"#,
+            )],
+        );
+        assert_error_containing(&db, "Nope");
+    }
+
+    #[test]
+    fn function_reference_types_but_call_is_reserved() {
+        // A dep-function REFERENCE types correctly (the exported signature)…
+        let db = consumer_db(
+            lib_blob(),
+            &[(
+                "main.baml",
+                r#"
+function use_f(f: (a: int, b: int) -> int) -> int throws never {
+    0
+}
+
+function r() -> int throws never {
+    use_f(app.add)
+}
+"#,
+            )],
+        );
+        assert_clean(&db);
+
+        // …but a CALL is rejected with the reserved not-yet diagnostic
+        // (calls into mounted packages land in the next PR).
+        let db = consumer_db(
+            lib_blob(),
+            &[(
+                "main.baml",
+                r#"
+function c() -> int throws never {
+    app.add(1, 2)
+}
+"#,
+            )],
+        );
+        assert_error_containing(&db, "mounted");
+    }
+
+    #[test]
+    fn user_impl_overlapping_mounted_blanket_impl_is_coherence_checked() {
+        // The blob exports `implement<T> Taggable for T`. A user impl of
+        // `app.Taggable` for a local class overlaps it — E0132, attributed
+        // primary-only at the user's impl (the blob row has no span), with
+        // the partner rendered structurally.
+        let db = consumer_db(
+            lib_blob(),
+            &[(
+                "main.baml",
+                r#"
+class Mine {
+    x int
+}
+
+implement app.Taggable for Mine {
+    function tag(self) -> string throws never {
+        "mine"
+    }
+}
+"#,
+            )],
+        );
+        assert_error_containing(&db, "overlapping interface implementations");
+        assert_error_containing(&db, "mounted dependency");
+    }
+
+    #[test]
+    fn stream_companion_of_mounted_class_stays_unresolvable() {
+        // The blob exports no `$stream` rows, and `resolve_type_in`'s
+        // `$stream`-companion fallback deliberately consults raw source items
+        // only — so a companion reference to a mounted class cannot resolve
+        // (a compiler-synthesized one degrades to the ordinary E0002).
+        // A USER-written `$`-suffixed spelling never reaches type lowering at
+        // all (the parser drops the annotation without diagnostics —
+        // pre-existing behavior, identical for source-backed classes), so
+        // this pins the observable pieces: the `$stream` line neither
+        // resolves-to-something-bogus nor wedges the checker, and sibling
+        // resolution still runs (the E0002 on the next line).
+        let db = consumer_db(
+            lib_blob(),
+            &[(
+                "main.baml",
+                r#"
+function s() -> int throws never {
+    let w: app.Widget$stream? = null
+    let v: app.Nope? = null
+    0
+}
+"#,
+            )],
+        );
+        assert_error_containing(&db, "app.Nope");
+    }
 }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/package_interface.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/package_interface.rs
@@ -1075,7 +1075,7 @@ pub(super) mod mounted {
         let mut db = make_db();
         db.set_mounted_packages([("app".to_string(), blob)].into());
         for (path, src) in files {
-            db.add_file(*path, *src);
+            db.add_file(path, src);
         }
         db
     }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/package_interface.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/package_interface.rs
@@ -4,9 +4,9 @@
 //! surfaces (params/bounds/`requires`/associated types/fields/methods), class
 //! field attributes and per-parameter bounds, function bounds and stable
 //! fully-qualified names, and the full namespace set — plus borsh round-trip
-//! and cross-database byte determinism. Nothing consumes these rows yet; the
-//! resolution rewires land in follow-up PRs, and `cargo test -p baml_tests`
-//! snapshots prove the derivation stays behavior-invisible.
+//! and cross-database byte determinism. The mounted-package integration suites
+//! additionally pin their source-less type, call, runtime, and artifact
+//! consumption; these focused tests keep the derivation contract readable.
 
 use baml_base::Name;
 use baml_compiler2_hir::package::PackageId;
@@ -1035,9 +1035,8 @@ fn stdlib_impls_export_and_int_equals_is_complete() {
 /// Each test compiles a fixture "library" package (files under
 /// `<builtin>/app/…` so `file_package` assigns them the package name `app`),
 /// captures its interface blob, mounts it in a FRESH database as `app`, and
-/// runs `collect_diagnostics` over consumer code. Calls into mounted packages
-/// are NOT yet supported (next PR) and are rejected with a dedicated
-/// diagnostic.
+/// runs `collect_diagnostics` over consumer code. The call/runtime integration
+/// suites exercise the same blobs beyond this check-level module.
 pub(super) mod mounted {
     use baml_base::Name;
     use baml_compiler2_hir::package::PackageId;
@@ -1367,8 +1366,9 @@ function n() -> int throws never {
     }
 
     #[test]
-    fn function_reference_types_but_call_is_reserved() {
-        // A dep-function REFERENCE types correctly (the exported signature)…
+    fn function_reference_and_call_type_from_mounted_signature() {
+        // References and direct calls share the exported signature and both
+        // receive a loc-free External resolution.
         let db = consumer_db(
             lib_blob(),
             &[(
@@ -1379,27 +1379,12 @@ function use_f(f: (a: int, b: int) -> int) -> int throws never {
 }
 
 function r() -> int throws never {
-    use_f(app.add)
+    use_f(app.add) + app.add(1, 2)
 }
 "#,
             )],
         );
         assert_clean(&db);
-
-        // …but a CALL is rejected with the reserved not-yet diagnostic
-        // (calls into mounted packages land in the next PR).
-        let db = consumer_db(
-            lib_blob(),
-            &[(
-                "main.baml",
-                r#"
-function c() -> int throws never {
-    app.add(1, 2)
-}
-"#,
-            )],
-        );
-        assert_error_containing(&db, "mounted");
     }
 
     #[test]
@@ -1454,30 +1439,30 @@ implement app.Taggable for Mine {
     }
 
     #[test]
-    fn stream_companion_of_mounted_class_stays_unresolvable() {
-        // The blob exports no `$stream` rows, and `resolve_type_in`'s
-        // `$stream`-companion fallback deliberately consults raw source items
-        // only — so a companion reference to a mounted class cannot resolve
-        // (a compiler-synthesized one degrades to the ordinary E0002).
-        // A USER-written `$`-suffixed spelling never reaches type lowering at
-        // all (the parser drops the annotation without diagnostics —
-        // pre-existing behavior, identical for source-backed classes), so
-        // this pins the observable pieces: the `$stream` line neither
-        // resolves-to-something-bogus nor wedges the checker, and sibling
-        // resolution still runs (the E0002 on the next line).
+    fn stream_companion_of_mounted_class_resolves_in_consumer_expansion() {
+        // Canonical PPIR `$stream` companions are exported as ordinary type
+        // rows. A consumer-side declarative LLM expansion can therefore name
+        // the mounted return type's companion with no dependency source.
         let db = consumer_db(
             lib_blob(),
             &[(
                 "main.baml",
-                r#"
-function s() -> int throws never {
-    let w: app.Widget$stream? = null
-    let v: app.Nope? = null
-    0
+                r##"
+client<llm> Dummy {
+    provider openai
+    options {
+        model "gpt-4o"
+        api_key "test"
+    }
 }
-"#,
+
+function Ask() -> app.Widget {
+    client Dummy
+    prompt #"Return a widget"#
+}
+"##,
             )],
         );
-        assert_error_containing(&db, "app.Nope");
+        assert_clean(&db);
     }
 }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/package_interface.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/package_interface.rs
@@ -1403,6 +1403,30 @@ function c() -> int throws never {
     }
 
     #[test]
+    fn mounted_callable_default_metadata_does_not_leak_into_body() {
+        // Parameter defaults and function bodies have separate expression
+        // arenas. Both paths below are ExprId(0), so recording the mounted
+        // callable in the defaults arena must not mark the local body call as
+        // a call into a mounted package.
+        let db = consumer_db(
+            lib_blob(),
+            &[(
+                "main.baml",
+                r#"
+function local() -> int throws never {
+    1
+}
+
+function use(f: (a: int, b: int) -> int = app.add) -> int throws never {
+    local()
+}
+"#,
+            )],
+        );
+        assert_clean(&db);
+    }
+
+    #[test]
     fn user_impl_overlapping_mounted_blanket_impl_is_coherence_checked() {
         // The blob exports `implement<T> Taggable for T`. A user impl of
         // `app.Taggable` for a local class overlaps it — E0132, attributed

--- a/baml_language/crates/baml_tests/tests/interfaces.rs
+++ b/baml_language/crates/baml_tests/tests/interfaces.rs
@@ -11919,6 +11919,37 @@ fn union_fuzz_f16_unqualified_ambiguous_union_field_is_e0131() {
     );
 }
 
+#[test]
+fn conjunction_ambiguous_source_fields_keep_field_diagnostic() {
+    assert_compile_error_contains(
+        r#"
+        interface Left { value: string }
+        interface Right { value: int }
+        function read<T extends Left & Right>(value: T) -> string {
+            return value.value
+        }
+        "#,
+        "field `value` on class",
+    );
+}
+
+#[test]
+fn conjunction_ambiguous_source_fields_diagnostic_names_ambiguity() {
+    // The assertion above pins the field; this pins the ambiguity wording so a
+    // different `value`-mentioning diagnostic (unknown field, bound failure)
+    // cannot satisfy the suite (PR #4332 review).
+    assert_compile_error_contains(
+        r#"
+        interface Left { value: string }
+        interface Right { value: int }
+        function read<T extends Left & Right>(value: T) -> string {
+            return value.value
+        }
+        "#,
+        "is ambiguous because it is declared by multiple interfaces",
+    );
+}
+
 /// F17 [bad-diagnostic]: a failed `.as<Cargo<int>>` projection drops the `<int>`
 /// type argument from the message (`does not implement interface Cargo`), which
 /// is misleading because the type DOES implement `Cargo`, just at `<string>`.

--- a/baml_language/crates/baml_tests/tests/mounted_package_calls.rs
+++ b/baml_language/crates/baml_tests/tests/mounted_package_calls.rs
@@ -1,0 +1,547 @@
+//! BEP-066 slice 6a: CALLS into MOUNTED (source-less) packages, end to end —
+//! check → MIR → emit → link → run.
+//!
+//! # The two-database harness (the slice-6 dynamic-linking prototype)
+//!
+//! Phase 1 — the LIBRARY database: the library's source is compiled under
+//! `<builtin>/app/…` (the `Compiler2ExtraFiles` channel, so `file_package`
+//! assigns the files the package name `app`). Two artifacts are captured:
+//!
+//!   1. the CHECK artifact — `borsh(PackageInterface)`, the typed surface a
+//!      consumer checks against, and
+//!   2. the RUN artifact — the library's independently emitted symbolic
+//!      `CompilationUnit` set (its files ride the builtin emit group, so the
+//!      linked image is `stdlib ++ app`, a user-independent prefix exactly
+//!      like the stdlib slice).
+//!
+//! Phase 2 — the CONSUMER database: a FRESH `ProjectDatabase` with NO `app`
+//! source anywhere. The blob is mounted via `set_mounted_packages` (checking
+//! resolves `app.…` through the interface rows and records loc-free
+//! `MemberResolution::External` callees), and bytecode is generated with
+//! `generate_project_bytecode_with_mounted_units(consumer_db, library_units)`:
+//! the public seam links the units and seeds emit from that prefix, so the
+//! consumer's symbolic references (`app.add`, `app.Widget`, the interface
+//! method slots) LINK against the library's already-compiled definitions by
+//! fully-qualified name — the same name-keyed resolution slice 6's dynamic
+//! linker performs against a live image.
+//!
+//! The resulting single `Program` runs on the ordinary engine harness.
+
+use baml_base::Name;
+use baml_compiler2_emit::{
+    CompileOptions, OptLevel, emit_units, generate_project_bytecode_with_mounted_units,
+};
+use baml_compiler2_hir::package::PackageId;
+use baml_compiler2_tir::package_interface::package_interface;
+use baml_project::{ProjectDatabase, collect_diagnostics, testing::assert_no_diagnostic_errors};
+use baml_tests::engine::run_compiled;
+use bex_engine::BexExternalValue;
+use bex_vm_types::{CompilationUnit, Program};
+use indexmap::IndexMap;
+
+// ── The library fixture ─────────────────────────────────────────────────────
+
+/// The mounted library: free functions (plain, generic, throwing), classes
+/// with plain and `implements`-block methods, interfaces with concrete and
+/// blanket blob impls, and an enum — everything the consumer tests call into.
+const LIB: &str = r#"
+interface Describable {
+    function describe(self) -> string throws never
+}
+
+interface Mergeable {
+    function merge(self, other: Self) -> Self throws never
+}
+
+interface Tagged {
+    function tag(self) -> string throws never
+}
+
+class Widget {
+    x int
+    label string
+
+    function get_x(self) -> int throws never {
+        self.x
+    }
+
+    implements Describable {
+        function describe(self) -> string throws never {
+            self.label
+        }
+    }
+}
+
+class Bag {
+    n int
+
+    implements Mergeable {
+        function merge(self, other: Self) -> Self throws never {
+            Bag { n: self.n + other.n }
+        }
+    }
+}
+
+class Plain {
+    text string
+}
+
+implement Describable for Plain {
+    function describe(self) -> string throws never {
+        self.text
+    }
+}
+
+implement<T> Tagged for T {
+    function tag(self) -> string throws never {
+        "any"
+    }
+}
+
+class ParseError {
+    message string
+}
+
+function add(a: int, b: int) -> int throws never {
+    a + b
+}
+
+function apply_callback(cb: (x: int) -> int) -> int {
+    cb(41)
+}
+
+function widget_x(w: Widget) -> int throws never {
+    w.x
+}
+
+function merge_both<T extends Mergeable>(a: T, b: T) -> T throws never {
+    a.merge(b)
+}
+
+function tag_of<T extends Tagged>(value: T) -> string throws never {
+    value.tag()
+}
+
+function parse_positive(n: int) -> int throws ParseError {
+    if n < 0 {
+        throw ParseError { message: "negative" }
+    }
+    n
+}
+"#;
+
+const OPT: OptLevel = OptLevel::One;
+
+fn compile_options() -> CompileOptions {
+    CompileOptions {
+        emit_test_cases: false,
+    }
+}
+
+/// Phase 1: compile the library under `<builtin>/app/` and capture both
+/// artifacts — the `borsh(PackageInterface)` blob (check surface) and the
+/// symbolic `CompilationUnit` set (run surface; links to `stdlib ++ app`, a
+/// user-independent prefix image).
+fn compile_library() -> (Vec<u8>, Vec<CompilationUnit>) {
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(std::path::Path::new("/mounted-calls"));
+    db.add_compiler2_virtual_file("<builtin>/app/lib.baml", LIB);
+    assert_no_diagnostic_errors(&db);
+
+    let iface = package_interface(&db, PackageId::new(&db, Name::new("app")));
+    assert!(
+        matches!(
+            iface.lookup_type(&[], &Name::new("Widget$stream")),
+            Some(baml_compiler2_tir::package_interface::ExportedType::Class { .. })
+        ),
+        "canonical PPIR companions must be part of the mounted export surface"
+    );
+    let blob = borsh::to_vec(iface).expect("serialize app interface");
+
+    let units = emit_units(&db, &compile_options(), OPT).expect("library fixture emits units");
+    (blob, units)
+}
+
+/// Phase 2: a fresh consumer database — blob mounted as `app`, NO `app`
+/// source — checked clean, then spliced against the library image.
+fn consumer_program(user_src: &str) -> Program {
+    let (blob, lib_units) = compile_library();
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(std::path::Path::new("/mounted-calls"));
+    db.set_mounted_packages([("app".to_string(), blob)].into());
+    db.add_file("main.baml", user_src);
+    assert_no_diagnostic_errors(&db);
+
+    generate_project_bytecode_with_mounted_units(&db, &compile_options(), OPT, &lib_units)
+        .expect("consumer compiles against the mounted blob")
+}
+
+/// Compile the consumer and run `entry` (no arguments), returning the result.
+async fn run_consumer(user_src: &str, entry: &str) -> Result<BexExternalValue, String> {
+    let program = consumer_program(user_src);
+    let output = run_compiled(program, entry, IndexMap::new(), false).await;
+    output.result.map_err(|e| format!("{e:?}"))
+}
+
+#[track_caller]
+fn assert_ok(result: Result<BexExternalValue, String>, expected: BexExternalValue) {
+    match result {
+        Ok(value) => assert_eq!(value, expected),
+        Err(e) => panic!("execution failed: {e}"),
+    }
+}
+
+// ── Free functions ──────────────────────────────────────────────────────────
+
+/// `app.add(1, 2)` — a mounted free function called directly, its result used.
+#[tokio::test]
+async fn mounted_free_function_call_runs() {
+    let result = run_consumer(
+        r#"
+function main() -> int throws never {
+    app.add(1, 2)
+}
+"#,
+        "main",
+    )
+    .await;
+    assert_ok(result, BexExternalValue::Int(3));
+}
+
+/// A mounted free function used as a value (`use_f(app.add)`) — the reference
+/// links to the library's function object.
+#[tokio::test]
+async fn mounted_free_function_reference_runs() {
+    let result = run_consumer(
+        r#"
+function apply(f: (a: int, b: int) -> int, a: int, b: int) -> int {
+    f(a, b)
+}
+
+function main() -> int {
+    apply(app.add, 20, 22)
+}
+"#,
+        "main",
+    )
+    .await;
+    assert_ok(result, BexExternalValue::Int(42));
+}
+
+/// Omitted callback throws elaborates a synthetic effect parameter into the
+/// exported signature. It participates in call inference but is erased by
+/// `RuntimeGenericLayout`, so the cross-image frame remains aligned.
+#[tokio::test]
+async fn mounted_callback_effect_param_does_not_shift_runtime_frame() {
+    let result = run_consumer(
+        r#"
+function plus_one(x: int) -> int throws never {
+    x + 1
+}
+
+function main() -> int throws never {
+    app.apply_callback(plus_one)
+}
+"#,
+        "main",
+    )
+    .await;
+    assert_ok(result, BexExternalValue::Int(42));
+}
+
+// ── Mounted classes: construction, fields, methods ──────────────────────────
+
+/// Construct a mounted class, read a field, pass the value back into a
+/// mounted free function, and call a plain method on it.
+#[tokio::test]
+async fn mounted_class_construction_fields_and_methods_run() {
+    let result = run_consumer(
+        r#"
+function main() -> int throws never {
+    let w = app.Widget { x: 40, label: "w" }
+    w.x + app.widget_x(w) + w.get_x() - 2 * 40 + 2
+}
+"#,
+        "main",
+    )
+    .await;
+    assert_ok(result, BexExternalValue::Int(42));
+}
+
+/// An `implements`-block method on a mounted class value — dispatched through
+/// the interface slot, resolved by the VM against the library's registered
+/// impl rule.
+#[tokio::test]
+async fn mounted_class_implements_method_dispatches() {
+    let result = run_consumer(
+        r#"
+function main() -> string throws never {
+    let w = app.Widget { x: 1, label: "hello" }
+    w.describe()
+}
+"#,
+        "main",
+    )
+    .await;
+    assert_ok(result, BexExternalValue::String("hello".into()));
+}
+
+/// An out-of-body implementation exported only through `ExportedImpl.methods`
+/// is a concrete member candidate in the source-less consumer.
+#[tokio::test]
+async fn mounted_out_of_body_impl_method_dispatches() {
+    let result = run_consumer(
+        r#"
+function main() -> string throws never {
+    app.Plain { text: "out-of-body" }.describe()
+}
+"#,
+        "main",
+    )
+    .await;
+    assert_ok(result, BexExternalValue::String("out-of-body".into()));
+}
+
+// ── Interface dispatch through blob impls ───────────────────────────────────
+
+/// `x.merge(y)` where the impl row is mounted (`implements Mergeable` in the
+/// blob) — virtual dispatch lands on the library's compiled override.
+#[tokio::test]
+async fn interface_dispatch_through_mounted_impl_runs() {
+    let result = run_consumer(
+        r#"
+function main() -> int throws never {
+    let a = app.Bag { n: 40 }
+    let b = app.Bag { n: 2 }
+    let merged = a.merge(b)
+    merged.n
+}
+"#,
+        "main",
+    )
+    .await;
+    assert_ok(result, BexExternalValue::Int(42));
+}
+
+/// Dispatch through a mounted interface on an interface-typed (existential)
+/// receiver.
+#[tokio::test]
+async fn mounted_interface_existential_dispatch_runs() {
+    let result = run_consumer(
+        r#"
+function main() -> string throws never {
+    let d: app.Describable = app.Widget { x: 1, label: "via-existential" }
+    d.describe()
+}
+"#,
+        "main",
+    )
+    .await;
+    assert_ok(result, BexExternalValue::String("via-existential".into()));
+}
+
+// ── Generic mounted functions ───────────────────────────────────────────────
+
+/// A generic mounted function instantiated at a mounted type, its bound
+/// (`T extends Mergeable`) satisfied by a blob impl.
+#[tokio::test]
+async fn generic_mounted_function_with_blob_impl_bound_runs() {
+    let result = run_consumer(
+        r#"
+function main() -> int throws never {
+    let merged = app.merge_both(app.Bag { n: 2 }, app.Bag { n: 40 })
+    merged.n
+}
+"#,
+        "main",
+    )
+    .await;
+    assert_ok(result, BexExternalValue::Int(42));
+}
+
+/// A generic mounted function instantiated at a USER type, the bound
+/// satisfied by the blob's blanket impl (`implement<T> Tagged for T`).
+#[tokio::test]
+async fn generic_mounted_function_at_user_type_runs() {
+    let result = run_consumer(
+        r#"
+class Mine {
+    v int
+}
+
+function main() -> string throws never {
+    app.tag_of(Mine { v: 1 })
+}
+"#,
+        "main",
+    )
+    .await;
+    assert_ok(result, BexExternalValue::String("any".into()));
+}
+
+/// A direct member call on a user type supplied by the mounted blanket impl.
+/// This proves the TIR candidate path consumes loc-free impl method rows; the
+/// generic mounted-function test above only proves bound satisfaction.
+#[tokio::test]
+async fn mounted_blanket_impl_method_on_user_type_dispatches() {
+    let result = run_consumer(
+        r#"
+class Mine {
+    v int
+}
+
+function main() -> string throws never {
+    Mine { v: 1 }.tag()
+}
+"#,
+        "main",
+    )
+    .await;
+    assert_ok(result, BexExternalValue::String("any".into()));
+}
+
+// ── Canonical streaming companions ─────────────────────────────────────────
+
+/// PPIR-generated `$stream` types are ordinary exported rows. A declarative
+/// LLM function in the fresh consumer therefore synthesizes its return
+/// companion through `app.Widget$stream` without dependency source.
+#[test]
+fn mounted_stream_companion_supports_consumer_llm_expansion() {
+    let (blob, _) = compile_library();
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(std::path::Path::new("/mounted-calls"));
+    db.set_mounted_packages([("app".to_string(), blob)].into());
+    db.add_file(
+        "main.baml",
+        r##"
+client<llm> Dummy {
+    provider openai
+    options {
+        model "gpt-4o"
+        api_key "test"
+    }
+}
+
+function Ask() -> app.Widget {
+    client Dummy
+    prompt #"Return a widget"#
+}
+"##,
+    );
+    assert_no_diagnostic_errors(&db);
+}
+
+// ── Throws across the mount boundary ────────────────────────────────────────
+
+/// A mounted function that THROWS: the blob's throw-set feeds the caller's
+/// checking, and the throw is caught in user code at runtime.
+#[tokio::test]
+async fn mounted_function_throw_caught_in_user_code() {
+    let result = run_consumer(
+        r#"
+function classify(n: int) -> string {
+    let v = app.parse_positive(n) catch (e) {
+        let err: app.ParseError => {
+            return err.message
+        }
+    }
+    "ok"
+}
+
+function main() -> string {
+    let fine = classify(7)
+    let caught = classify(0 - 5)
+    fine + ":" + caught
+}
+"#,
+        "main",
+    )
+    .await;
+    assert_ok(result, BexExternalValue::String("ok:negative".into()));
+}
+
+/// A USER generic function bounded by a mounted interface
+/// (`T extends app.Mergeable`): the rigid-`Self` receiver resolves the member
+/// through the mounted row, and the call dispatches virtually at runtime.
+#[tokio::test]
+async fn user_generic_bounded_by_mounted_interface_runs() {
+    let result = run_consumer(
+        r#"
+function combine<T extends app.Mergeable>(a: T, b: T) -> T throws never {
+    a.merge(b)
+}
+
+function main() -> int throws never {
+    let merged = combine(app.Bag { n: 30 }, app.Bag { n: 12 })
+    merged.n
+}
+"#,
+        "main",
+    )
+    .await;
+    assert_ok(result, BexExternalValue::Int(42));
+}
+
+// ── UFCS and the reserved residue ───────────────────────────────────────────
+
+/// UFCS through an `implements`-block method lowers to a virtual call using
+/// the explicit first argument as its receiver.
+#[tokio::test]
+async fn mounted_ufcs_interface_method_dispatches() {
+    let result = run_consumer(
+        r#"
+function main() -> string throws never {
+    app.Widget.describe(app.Widget { x: 1, label: "l" })
+}
+"#,
+        "main",
+    )
+    .await;
+    assert_ok(result, BexExternalValue::String("l".into()));
+}
+
+/// A mounted compiler/VM builtin has no ordinary bytecode-unit symbol. This
+/// is the remaining E0158 residue; derive only the interface artifact because
+/// the fixture intentionally has no native implementation to link and run.
+#[test]
+fn mounted_builtin_call_stays_reserved() {
+    let mut lib_db = ProjectDatabase::new();
+    lib_db.set_project_root(std::path::Path::new("/mounted-calls"));
+    lib_db.add_compiler2_virtual_file(
+        "<builtin>/app/native.baml",
+        r#"
+function native_value() -> int throws never {
+    $rust_function
+}
+"#,
+    );
+    assert_no_diagnostic_errors(&lib_db);
+    let iface = package_interface(&lib_db, PackageId::new(&lib_db, Name::new("app")));
+    let blob = borsh::to_vec(iface).expect("serialize builtin app interface");
+
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(std::path::Path::new("/mounted-calls"));
+    db.set_mounted_packages([("app".to_string(), blob)].into());
+    db.add_file(
+        "main.baml",
+        r#"
+function main() -> int throws never {
+    let reference = app.native_value
+    app.native_value()
+}
+"#,
+    );
+    let errors: Vec<String> = collect_diagnostics(&db)
+        .iter()
+        .filter(|d| matches!(d.severity, baml_compiler_diagnostics::Severity::Error))
+        .map(|d| format!("[{}] {}", d.code(), d.message))
+        .collect();
+    let reserved = errors
+        .iter()
+        .filter(|error| error.contains("E0158") && error.contains("mounted"))
+        .count();
+    assert_eq!(
+        reserved, 2,
+        "both the bare reference and call must report reserved E0158, got:\n{errors:#?}"
+    );
+}

--- a/baml_language/crates/baml_tests/tests/mounted_package_parity.rs
+++ b/baml_language/crates/baml_tests/tests/mounted_package_parity.rs
@@ -1,0 +1,679 @@
+//! BEP-066 slice-6a capstone: consuming a dependency from source and from its
+//! `PackageInterface` blob must be observationally equivalent.
+//!
+//! The SOURCE path puts the rich `app` fixture and the consumer in one database.
+//! The BLOB path compiles `app` independently into its check artifact (borsh of
+//! `PackageInterface`) and run artifact (`CompilationUnit`s), then mounts the
+//! former in a fresh source-less consumer database and links the latter through
+//! `generate_project_bytecode_with_mounted_units`.
+//!
+//! The oracle pins four boundaries:
+//!
+//! 1. normalized diagnostic bytes (code, message, and user-source range),
+//! 2. runtime values and caught throws,
+//! 3. emitted-program and relocatable-unit invariants,
+//! 4. primary-only E0132 attribution for a user impl conflicting with a
+//!    span-less mounted impl.
+//!
+//! Unit import tables do not legitimately diverge: both paths name library
+//! symbols by the same fully-qualified B-693 identities. Raw consumer units and
+//! programs differ only in debug `FileId`s: removing the dependency source shifts
+//! the fresh consumer database's numeric id for `main.baml`. After normalizing
+//! those database-local ids (function span, line table, local-scope spans), every
+//! emitted byte is identical. Source paths/ranges and all executable content are
+//! unchanged.
+
+use baml_base::Name;
+use baml_compiler2_emit::{
+    CompileOptions, MountedPackageLinkError, OptLevel, decompose_units, emit_units,
+    generate_project_bytecode_with_mounted_units, generate_project_bytecode_with_opt,
+};
+use baml_compiler2_hir::package::PackageId;
+use baml_compiler2_tir::package_interface::{ExportedType, PackageInterface, package_interface};
+use baml_project::{ProjectDatabase, collect_diagnostics, testing::assert_no_diagnostic_errors};
+use baml_tests::engine::run_compiled;
+use bex_engine::BexExternalValue;
+use bex_vm_types::{CompilationUnit, Program};
+use indexmap::IndexMap;
+
+const ROOT: &str = "/mounted-parity";
+const OPT: OptLevel = OptLevel::One;
+
+/// A deliberately broad package surface: requires/default methods, associated
+/// defaults, attrs, generic class/function bounds, enum/alias rows, every impl
+/// shape, a callback-effect impl method, and a throwing function.
+const LIB: &str = r#"
+interface Named {
+    name string
+
+    function label(self) -> string throws never {
+        self.name
+    }
+}
+
+interface Measured requires Named {
+    type Unit = string
+
+    function measure(self) -> int throws never
+
+    function decorated(self) -> string throws never {
+        self.label()
+    }
+}
+
+class Widget {
+    name string @description("public label")
+    value int @alias("score")
+
+    implements Named {}
+
+    implements Measured {
+        function measure(self) -> int throws never {
+            self.value
+        }
+    }
+}
+
+class Box<T extends Named> {
+    value T
+
+    function inner_name(self) -> string throws never {
+        self.value.name
+    }
+}
+
+class Plain {
+    name string
+    value int
+
+    implements Named {}
+}
+
+implement Measured for Plain {
+    function measure(self) -> int throws never {
+        self.value
+    }
+}
+
+enum Status {
+    Active
+    Retired
+}
+
+type Score = int
+
+interface Tagged {
+    function tag(self) -> string throws never
+}
+
+implement<T> Tagged for T {
+    function tag(self) -> string throws never {
+        "any"
+    }
+}
+
+interface Applies {
+    function apply(self, cb: (x: int) -> int throws never) -> int throws unknown
+}
+
+class Runner {
+    base int
+
+    implements Applies {
+        function apply(self, cb: (x: int) -> int) -> int {
+            cb(self.base)
+        }
+    }
+}
+
+class ParseError {
+    message string
+}
+
+function measure_twice<T extends Measured>(value: T) -> int throws never {
+    value.measure() + value.measure()
+}
+
+function tag_of<T extends Tagged>(value: T) -> string throws never {
+    value.tag()
+}
+
+function parse_positive(value: int) -> int throws ParseError {
+    if value < 0 {
+        throw ParseError { message: "negative" }
+    }
+    value
+}
+"#;
+
+fn options() -> CompileOptions {
+    CompileOptions {
+        emit_test_cases: false,
+    }
+}
+
+fn library_db() -> ProjectDatabase {
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(std::path::Path::new(ROOT));
+    db.add_compiler2_virtual_file("<builtin>/app/lib.baml", LIB);
+    db
+}
+
+struct LibraryArtifacts {
+    blob: Vec<u8>,
+    interface: PackageInterface,
+    units: Vec<CompilationUnit>,
+}
+
+fn library_artifacts() -> LibraryArtifacts {
+    let db = library_db();
+    assert_no_diagnostic_errors(&db);
+    let interface = package_interface(&db, PackageId::new(&db, Name::new("app"))).clone();
+    let blob = borsh::to_vec(&interface).expect("serialize app package interface");
+    let round_trip =
+        borsh::from_slice::<PackageInterface>(&blob).expect("deserialize app package interface");
+    assert_eq!(
+        interface, round_trip,
+        "interface blob must round-trip exactly"
+    );
+    let units = emit_units(&db, &options(), OPT).expect("emit independent app units");
+    LibraryArtifacts {
+        blob,
+        interface,
+        units,
+    }
+}
+
+fn source_db(user: &str) -> ProjectDatabase {
+    let mut db = library_db();
+    db.add_file("main.baml", user);
+    db
+}
+
+fn blob_db(user: &str, blob: Vec<u8>) -> ProjectDatabase {
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(std::path::Path::new(ROOT));
+    db.set_mounted_packages([("app".to_string(), blob)].into());
+    db.add_file("main.baml", user);
+    db
+}
+
+fn compile_source(user: &str) -> Program {
+    let db = source_db(user);
+    assert_no_diagnostic_errors(&db);
+    generate_project_bytecode_with_opt(&db, &options(), OPT).expect("source-path compile")
+}
+
+fn compile_blob(user: &str, artifacts: &LibraryArtifacts) -> Program {
+    let db = blob_db(user, artifacts.blob.clone());
+    assert_no_diagnostic_errors(&db);
+    generate_project_bytecode_with_mounted_units(&db, &options(), OPT, &artifacts.units)
+        .expect("blob-path compile and link")
+}
+
+async fn run(program: Program, entry: &str) -> Result<BexExternalValue, String> {
+    run_compiled(program, entry, IndexMap::new(), false)
+        .await
+        .result
+        .map_err(|error| format!("{error:?}"))
+}
+
+async fn assert_runtime_parity(user: &str, entry: &str, expected: BexExternalValue) {
+    let artifacts = library_artifacts();
+    let source = compile_source(user);
+    let blob = compile_blob(user, &artifacts);
+    let source_result = run(source, entry).await;
+    let blob_result = run(blob, entry).await;
+    assert_eq!(source_result, blob_result, "runtime paths diverged");
+    assert_eq!(source_result, Ok(expected));
+}
+
+#[tokio::test]
+async fn rich_surface_runtime_is_identical() {
+    assert_runtime_parity(
+        r#"
+class Local {
+    name string
+    implements app.Named {}
+}
+
+function status_score(status: app.Status) -> int throws never {
+    match status {
+        app.Status.Active => 1
+        app.Status.Retired => 2
+    }
+}
+
+function main() -> int throws never {
+    let widget = app.Widget { name: "widget", value: 7 }
+    let plain = app.Plain { name: "plain", value: 4 }
+    let boxed = app.Box<app.Widget> { value: widget }
+    let score: app.Score = 3
+    let enum_score = status_score(app.Status.Retired)
+    let local = Local { name: "local" }
+    let tagged = app.tag_of(local)
+    let boxed_score = if boxed.inner_name() == "widget" { 1 } else { 0 }
+    let decorated_score = if widget.decorated() == "widget" { 1 } else { 0 }
+    let tagged_score = if tagged == "any" { 1 } else { 0 }
+    let inherited_default_score = if local.label() == "local" { 1 } else { 0 }
+    widget.measure()
+        + plain.measure()
+        + app.measure_twice(widget)
+        + score
+        + enum_score
+        + boxed_score
+        + decorated_score
+        + tagged_score
+        + inherited_default_score
+}
+"#,
+        "main",
+        BexExternalValue::Int(34),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn existential_default_and_out_of_body_dispatch_are_identical() {
+    assert_runtime_parity(
+        r#"
+function read(value: app.Measured) -> int throws never {
+    value.measure()
+}
+
+function main() -> int throws never {
+    let widget = app.Widget { name: "widget", value: 20 }
+    let plain = app.Plain { name: "plain", value: 22 }
+    read(widget) + read(plain)
+}
+"#,
+        "main",
+        BexExternalValue::Int(42),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn impl_method_callback_effect_metadata_and_frame_are_identical() {
+    assert_runtime_parity(
+        r#"
+function plus_one(value: int) -> int throws never {
+    value + 1
+}
+
+function main() -> int throws never {
+    app.Runner { base: 41 }.apply(plus_one)
+}
+"#,
+        "main",
+        BexExternalValue::Int(42),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn caught_library_throw_is_identical() {
+    assert_runtime_parity(
+        r#"
+function classify(value: int) -> string {
+    let parsed = app.parse_positive(value) catch (error) {
+        let typed: app.ParseError => {
+            return typed.message
+        }
+    }
+    "ok:" + parsed.to_string()
+}
+
+function main() -> string {
+    classify(7) + ":" + classify(0 - 1)
+}
+"#,
+        "main",
+        BexExternalValue::String("ok:7:negative".into()),
+    )
+    .await;
+}
+
+/// A stable byte record deliberately excludes `FileId`: the source database
+/// allocates one extra id for the library file, while the blob database has no
+/// such file. Codes, messages, severity, phase, and user-text ranges are the
+/// user-observable diagnostic contract and must match byte-for-byte.
+fn diagnostic_bytes(db: &ProjectDatabase) -> Vec<u8> {
+    let rows: Vec<String> = collect_diagnostics(db)
+        .into_iter()
+        .filter(|diagnostic| {
+            matches!(
+                diagnostic.severity,
+                baml_compiler_diagnostics::Severity::Error
+            )
+        })
+        .map(|diagnostic| {
+            let range = diagnostic
+                .primary_span()
+                .expect("consumer error has a primary span")
+                .range;
+            format!(
+                "{}\0{:?}\0{:?}\0{}..{}\0{}",
+                diagnostic.code(),
+                diagnostic.severity,
+                diagnostic.phase,
+                u32::from(range.start()),
+                u32::from(range.end()),
+                diagnostic.message
+            )
+        })
+        .collect();
+    rows.join("\n").into_bytes()
+}
+
+#[test]
+fn representative_error_diagnostics_are_byte_identical() {
+    let artifacts = library_artifacts();
+    let cases = [
+        (
+            "wrong arity",
+            r#"
+function main() -> int {
+    app.measure_twice()
+}
+"#,
+        ),
+        (
+            "unsatisfied bound",
+            r#"
+class Rock { value int }
+
+function main() -> int {
+    app.measure_twice(Rock { value: 1 })
+}
+"#,
+        ),
+        (
+            "non-exhaustive enum",
+            r#"
+function inspect(status: app.Status) -> int throws never {
+    match status {
+        app.Status.Active => 1
+    }
+}
+"#,
+        ),
+        (
+            "missing impl member",
+            r#"
+class Broken {
+    name string
+    implements app.Named {}
+    implements app.Measured {}
+}
+"#,
+        ),
+    ];
+
+    for (label, user) in cases {
+        let source = diagnostic_bytes(&source_db(user));
+        let blob = diagnostic_bytes(&blob_db(user, artifacts.blob.clone()));
+        assert!(!source.is_empty(), "{label}: fixture must produce an error");
+        assert_eq!(source, blob, "{label}: source/blob diagnostics diverged");
+    }
+}
+
+const ARTIFACT_USER: &str = r#"
+class Local {
+    name string
+    implements app.Named {}
+}
+
+function status_score(status: app.Status) -> int throws never {
+    match status {
+        app.Status.Active => 1
+        app.Status.Retired => 2
+    }
+}
+
+function main() -> int throws never {
+    let widget = app.Widget { name: "artifact", value: 20 }
+    let boxed = app.Box<app.Widget> { value: widget }
+    let enum_score = status_score(app.Status.Active)
+    let boxed_score = if boxed.inner_name() == "artifact" { 1 } else { 0 }
+    let tagged = app.tag_of(Local { name: "local" })
+    let tagged_score = if tagged == "any" { 1 } else { 0 }
+    app.measure_twice(widget)
+        + enum_score
+        + boxed_score
+        + tagged_score
+}
+"#;
+
+fn unit<'a>(units: &'a [CompilationUnit], path: &str) -> &'a CompilationUnit {
+    units
+        .iter()
+        .find(|unit| unit.source_file == path)
+        .unwrap_or_else(|| panic!("missing unit `{path}`"))
+}
+
+#[track_caller]
+fn assert_bytes_identical(label: &str, left: &[u8], right: &[u8]) {
+    if left == right {
+        return;
+    }
+    let first_difference = left
+        .iter()
+        .zip(right)
+        .position(|(left, right)| left != right)
+        .unwrap_or_else(|| left.len().min(right.len()));
+    panic!(
+        "{label}: byte streams differ first at {first_difference} (left len {}, right len {})",
+        left.len(),
+        right.len()
+    );
+}
+
+fn normalize_object_debug_file_ids(object: &mut bex_vm_types::Object) {
+    let bex_vm_types::Object::Function(function) = object else {
+        return;
+    };
+    let normalized = baml_base::FileId::new(0);
+    function.span.file_id = normalized;
+    for entry in &mut function.bytecode.line_table {
+        entry.span.file_id = normalized;
+    }
+    for local in &mut function.debug_locals {
+        local.scope_span.file_id = normalized;
+    }
+}
+
+fn normalized_unit(mut unit: CompilationUnit) -> CompilationUnit {
+    for object in &mut unit.code {
+        normalize_object_debug_file_ids(object);
+    }
+    if let Some(tail) = &mut unit.init_tail {
+        for object in &mut tail.objects {
+            normalize_object_debug_file_ids(object);
+        }
+    }
+    unit
+}
+
+fn normalized_program(mut program: Program) -> Program {
+    for object in program.objects.iter_mut() {
+        normalize_object_debug_file_ids(object);
+    }
+    program
+}
+
+#[test]
+fn emitted_program_dependency_and_consumer_units_are_byte_identical() {
+    let artifacts = library_artifacts();
+    let source_db = source_db(ARTIFACT_USER);
+    assert_no_diagnostic_errors(&source_db);
+    let source_program =
+        generate_project_bytecode_with_opt(&source_db, &options(), OPT).expect("source program");
+    let source_units = emit_units(&source_db, &options(), OPT).expect("source units");
+
+    let blob_db = blob_db(ARTIFACT_USER, artifacts.blob.clone());
+    assert_no_diagnostic_errors(&blob_db);
+    let blob_program =
+        generate_project_bytecode_with_mounted_units(&blob_db, &options(), OPT, &artifacts.units)
+            .expect("blob program");
+
+    let source_program_bytes = borsh::to_vec(&source_program).expect("serialize source program");
+    let blob_program_bytes = borsh::to_vec(&blob_program).expect("serialize blob program");
+
+    // The blob database intentionally has no app source with which to attribute
+    // flat objects during decomposition. Use the source manifest only as the
+    // inverse-link attribution oracle; the bytes being decomposed are the blob
+    // path's independently linked program.
+    let blob_units = decompose_units(&source_db, &options(), &blob_program)
+        .expect("decompose blob image with source manifest");
+    let source_user = unit(&source_units, "main.baml");
+    let blob_user = unit(&blob_units, "main.baml");
+    assert_ne!(
+        borsh::to_vec(source_user).expect("serialize raw source user unit"),
+        borsh::to_vec(blob_user).expect("serialize raw blob user unit"),
+        "the fixture must keep the database-local FileId distinction visible"
+    );
+    assert_bytes_identical(
+        "consumer unit after debug FileId normalization",
+        &borsh::to_vec(&normalized_unit(source_user.clone()))
+            .expect("serialize normalized source user unit"),
+        &borsh::to_vec(&normalized_unit(blob_user.clone()))
+            .expect("serialize normalized blob user unit"),
+    );
+
+    let imported_app_symbols: Vec<&str> = source_user
+        .object_imports
+        .iter()
+        .chain(&source_user.global_imports)
+        .map(|symbol| symbol.fq_name.as_str())
+        .filter(|name| name.starts_with("app."))
+        .collect();
+    assert!(
+        !imported_app_symbols.is_empty(),
+        "consumer must exercise symbolic app imports"
+    );
+    assert_eq!(source_user.object_imports, blob_user.object_imports);
+    assert_eq!(source_user.global_imports, blob_user.global_imports);
+
+    let source_app = unit(&source_units, "<builtin>/app/lib.baml");
+    let independent_app = unit(&artifacts.units, "<builtin>/app/lib.baml");
+    assert_bytes_identical(
+        "independent library unit",
+        &borsh::to_vec(source_app).expect("serialize source app unit"),
+        &borsh::to_vec(independent_app).expect("serialize independent app unit"),
+    );
+
+    assert_ne!(
+        source_program_bytes, blob_program_bytes,
+        "raw programs retain the consumer database's debug FileId"
+    );
+    assert_bytes_identical(
+        "linked program after debug FileId normalization",
+        &borsh::to_vec(&normalized_program(source_program))
+            .expect("serialize normalized source program"),
+        &borsh::to_vec(&normalized_program(blob_program))
+            .expect("serialize normalized blob program"),
+    );
+}
+
+#[test]
+fn exported_impl_method_preserves_synthetic_callback_effect_params() {
+    let artifacts = library_artifacts();
+    let runner = artifacts
+        .interface
+        .impls
+        .iter()
+        .find(|implementation| {
+            implementation.interface.name.name().as_str() == "Applies"
+                && matches!(
+                    &implementation.for_ty_pattern,
+                    baml_type::Ty::Class(qtn, _, _) if qtn.name().as_str() == "Runner"
+                )
+        })
+        .expect("Runner implements Applies row");
+    let apply = runner
+        .methods
+        .iter()
+        .find(|method| method.name.as_str() == "apply")
+        .expect("apply override export");
+    assert_eq!(apply.sig.generic_params.len(), 1);
+    assert!(baml_type::is_synthetic_effect_param(
+        apply.sig.generic_params[0].name()
+    ));
+    assert_eq!(apply.sig.generic_param_bounds, vec![Vec::new()]);
+}
+
+#[test]
+fn mounted_unit_api_preserves_dependency_link_errors() {
+    let artifacts = library_artifacts();
+    let mut duplicate_units = artifacts.units.clone();
+    duplicate_units.push(unit(&artifacts.units, "<builtin>/app/lib.baml").clone());
+    let db = blob_db("function main() -> int { 0 }", artifacts.blob);
+    let error =
+        generate_project_bytecode_with_mounted_units(&db, &options(), OPT, &duplicate_units)
+            .expect_err("duplicate dependency export must fail before consumer emit");
+    assert!(matches!(
+        error,
+        MountedPackageLinkError::DependencyLink(bex_vm_types::link::LinkError::DuplicateExport(_))
+    ));
+}
+
+#[test]
+fn user_vs_blob_overlap_is_e0132_primary_only_with_structural_partner() {
+    let artifacts = library_artifacts();
+    let db = blob_db(
+        r#"
+class Mine { value int }
+
+implement app.Tagged for Mine {
+    function tag(self) -> string throws never {
+        "mine"
+    }
+}
+"#,
+        artifacts.blob,
+    );
+    let overlap = collect_diagnostics(&db)
+        .into_iter()
+        .find(|diagnostic| diagnostic.code() == "E0132")
+        .expect("mounted blanket overlap must produce E0132");
+    assert_eq!(
+        overlap.message,
+        "overlapping interface implementations for the same receiver/interface \
+(conflicts with the mounted dependency's `implement app.Tagged for T`)"
+    );
+    assert_eq!(
+        overlap
+            .annotations
+            .iter()
+            .filter(|annotation| annotation.is_primary)
+            .count(),
+        1
+    );
+    assert_eq!(overlap.annotations.len(), 1, "blob side has no source span");
+    assert!(overlap.related_info.is_empty());
+}
+
+/// Two valid, independently checked mounted blobs cannot introduce a new
+/// blob-vs-blob overlap: the orphan rule requires either the interface or the
+/// receiver constructor to be local. Distinct packages therefore own distinct
+/// receiver constructors, while a package attempting to overlap a dependency's
+/// blanket impl is rejected by this same E0132 check before its blob is emitted.
+/// This makes user-vs-blob the only expressible load-time direction for valid
+/// slice-6a artifacts; malformed/tampered blobs belong to slice 6's artifact
+/// validation ledger.
+#[test]
+fn blob_vs_blob_overlap_is_not_expressible_for_valid_artifacts() {
+    // Keep the argument executable: the rich fixture's blanket impl is exported
+    // and therefore would reject any downstream overlapping source impl before
+    // that downstream package could become a second valid blob.
+    let artifacts = library_artifacts();
+    assert!(artifacts.interface.impls.iter().any(|implementation| {
+        implementation.interface.name.name().as_str() == "Tagged"
+            && matches!(implementation.for_ty_pattern, baml_type::Ty::TypeVar(_, _))
+    }));
+    assert!(matches!(
+        artifacts.interface.lookup_type(&[], &Name::new("Tagged")),
+        Some(ExportedType::Interface { .. })
+    ));
+}

--- a/baml_language/crates/baml_workspace/src/lib.rs
+++ b/baml_language/crates/baml_workspace/src/lib.rs
@@ -85,6 +85,22 @@ pub trait Db: salsa::Database {
     fn seeded_callable_throws(&self) -> Option<SeededCallableThrows> {
         None
     }
+
+    /// Source-less dependency packages mounted into this database as serialized
+    /// `PackageInterface` blobs, keyed by the package name (the mount alias).
+    ///
+    /// When present (BEP-066 slice 6a), each entry makes its name a *dependency*
+    /// of every user package (`package_dependencies`) whose `package_interface`
+    /// is served straight from the blob — the mounted package has **no source
+    /// files** (`package_items` is empty; that is the point). Cross-package
+    /// resolution for a mounted name goes through the interface rows instead of
+    /// raw items. Names colliding with the reserved package set (the stdlib
+    /// packages, `user`, `root`, `env`) are ignored entirely — see
+    /// `baml_compiler2_hir::package::mounted_package_names`. Defaults to `None`:
+    /// every other database resolves dependencies from source only.
+    fn mounted_packages(&self) -> Option<MountedPackages> {
+        None
+    }
 }
 
 /// Input: per-file `FunctionThrowFacts` from a previous compile, keyed by
@@ -125,6 +141,22 @@ pub struct SeededCallableThrows {
 /// low crate can name; `PackageInterface` has no such low-crate home.
 #[salsa::input]
 pub struct SeededStdlibInterface {
+    #[returns(ref)]
+    pub by_package: std::collections::BTreeMap<String, Vec<u8>>,
+}
+
+/// Input: source-less dependency packages mounted as serialized
+/// `PackageInterface` blobs, keyed by package name (the mount alias); each
+/// value is `borsh(PackageInterface)`.
+///
+/// Opaque bytes for the same reason as [`SeededStdlibInterface`]:
+/// `PackageInterface` lives in `baml_compiler2_tir`, which depends on this
+/// crate. `baml_compiler2_tir` deserializes a package's bytes when its
+/// `package_interface` is queried. A Salsa input, so mounting/unmounting a
+/// package invalidates dependents for free (the B-694 delivery mechanism
+/// generalized to any alias, per BEP-066 slice 6a).
+#[salsa::input]
+pub struct MountedPackages {
     #[returns(ref)]
     pub by_package: std::collections::BTreeMap<String, Vec<u8>>,
 }


### PR DESCRIPTION
**BEP-066 slice-6a stack, PR 3 of 5** — chained on #4327. The first consumer PR: a package mounted as a serialized `PackageInterface` blob (no source in the DB) now fully resolves in **type positions**; calls land in PR 4 (reserved diagnostic E0158 until then).

## The mount seam
- `MountedPackages` Salsa input (`alias → borsh(PackageInterface)`), present-from-construction like the B-694 seeds; served by a `package_interface` arm below the untouched stdlib seed; corrupt blobs fall through to ordinary unresolved diagnostics.
- Dependency policy: user packages depend on every mounted name; mounts see only the stdlib. Reserved names (`baml`, `user`, …) are ignored outright — a blob can never shadow the stdlib or the user package.

## Consumption
- `resolve_type_in` returns `Own(Definition) | Foreign(&ExportedType)`; `lower_path`'s Foreign arm mirrors Own exactly (arity, binding validation, existential default-filling by substitution of the pre-lowered symbolic-`Self` defaults — no double-fill, completeness checks).
- Fact queries split seed-or-source: aliases, enum variants (+ exhaustiveness), class fields/methods, assoc bounds/defaults/name-sets, `interface_requires` via the exported pre-flattened closure (fail-closed), UFCS/value-reference typing.
- Impl substrate: blob `ExportedImpl` rows materialize into native `ImplData` (`ImplInterfaceTarget::{Source,Mounted}`, `ImplRef::{Loc,Mounted}` — the loc-free `ResolvedImpl` twin); all five enumerators + coherence run unchanged over one `package_impls` seam; blob impls are pre-checked and never re-validated; user impls of mounted interfaces get full conformance checking. Coherence attributes primary-only at the user's impl with the dep side rendered structurally.
- Schema refinement: `ExportedType::Interface.methods` → `required_methods`/`default_methods` (E0113 coverage is undecidable from a merged list).
- PR 1's interface-row guards became the mounted gate: rows resolve iff mounted; source-backed dep resolution is byte-identical (tested both ways).

## Proof
12 new mounted-consumption tests (class/interface/enum/alias/impl/bound/negative shapes + coherence overlap + E0158 both-ways) · full baml_tests exit 0 (lib 1511/0) · tir 324/0 · project 82/0 · bytecode_cache 43/0 · **zero snapshot churn** · fmt/clippy clean on diff.

## For PR 4 (queued)
`MemberResolution::External` + MIR symbolic callees, blob-impl method dispatch + structural `{iface}$for${target}` reconstruction, the `$stream`-rows policy, and the conservative gaps listed in the commit message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for resolving types, interfaces, implementations, aliases, enum variants, fields, and methods from mounted dependency packages.
  - Added package discovery and serialized interface loading for source-less dependencies.
  - Added validation for mounted package coherence, generics, associated types, interface requirements, and default methods.

- **Bug Fixes**
  - Prevented crashes when source locations are unavailable.
  - Added diagnostic `E0158` for unsupported calls into mounted packages.
  - Improved conflict diagnostics for mounted dependency implementations.

- **Tests**
  - Expanded coverage for mounted packages, conformance, aliases, exhaustiveness, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->