### PR TITLE
feat(lang): reflect moves to baml.reflect; type.of / type.of_value land; reflect.type_of removed (BEP-066 s1, PR 3)

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_llm/llm.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_llm/llm.baml
@@ -91,7 +91,7 @@ function build_request_stream(client: Client, function_name: string, args: map<s
 /// error name matches the operation and the documented
 /// `catch (baml.errors.ParseError)` pattern is reachable (no E0063).
 function parse<TStream, TFinal>(json: string) -> TFinal throws root.errors.ParseError {
-  let cache: StreamCache<TStream, TFinal> = StreamCache.new(reflect.type_of<TStream>(), reflect.type_of<TFinal>());
+  let cache: StreamCache<TStream, TFinal> = StreamCache.new(type.of<TStream>(), type.of<TFinal>());
   __sap_parse_final<TStream, TFinal>(json, cache) catch (_) {
     root.errors.LlmClient { message } => throw root.errors.ParseError { message: message },
   }
@@ -101,7 +101,7 @@ function parse<TStream, TFinal>(json: string) -> TFinal throws root.errors.Parse
 /// cache. Keeping the inference here avoids requiring an explicit static-method
 /// owner at each call site.
 function __new_stream_cache<TStream, TFinal>() -> StreamCache<TStream, TFinal> throws never {
-  let cache: StreamCache<TStream, TFinal> = StreamCache.new(reflect.type_of<TStream>(), reflect.type_of<TFinal>());
+  let cache: StreamCache<TStream, TFinal> = StreamCache.new(type.of<TStream>(), type.of<TFinal>());
   cache
 }
 

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_llm/llm_types.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_llm/llm_types.baml
@@ -318,14 +318,14 @@ class Client {
     match (self.client_type) {
       ClientType.Primitive => {
         let primitive = self.to_primitive_client();
-        // On the stream path `reflect.type_of<TFinal>()` is `BuiltinUnknown`:
+        // On the stream path `type.of<TFinal>()` is `BuiltinUnknown`:
         // the `$stream` companion calls this without explicit type-args and
         // inferred type-args don't reach MIR (see `__make_stream`'s registry
         // fallback). Resolve the real return type from the registry by name and
         // use it for the whole attempt — the Jinja template may render
         // `{{ ctx.output_format }}`, the closure's `${ctx.output_format}` needs
         // it, and `build_request_stream` keys provider config off it. (The
-        // oneshot path instead uses `reflect.type_of<T>()`, which DOES reach
+        // oneshot path instead uses `type.of<T>()`, which DOES reach
         // MIR there.) Caveat: for a *generic* streaming function the registry
         // holds the unspecialized return type, so `${ctx.output_format}` renders
         // the generic schema — the oneshot path renders the specialized one.
@@ -374,7 +374,7 @@ class Client {
   function __make_stream<TStream, TFinal>(self, sse: root.http.SseStream) -> Stream<TStream, TFinal> {
     let primitive = self.to_primitive_client()
     let acc = primitive.new_stream_accumulator()
-    let cache: StreamCache<TStream, TFinal> = StreamCache.new(reflect.type_of<TStream>(), reflect.type_of<TFinal>())
+    let cache: StreamCache<TStream, TFinal> = StreamCache.new(type.of<TStream>(), type.of<TFinal>())
     Stream { _client: primitive, _acc: acc, _sse: sse, _cache: cache }
   }
 
@@ -433,7 +433,7 @@ class Client {
     match (self.client_type) {
       ClientType.Primitive => {
         let primitive = self.to_primitive_client()
-        let return_type = reflect.type_of<T>()
+        let return_type = type.of<T>()
 
         // Render (new-mode closure or legacy Jinja) + specialize via the shared
         // `render_specialized_prompt`, the same path the static `build_request`

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_array/array.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_array/array.baml
@@ -1,0 +1,9 @@
+/// An array-kind view of a `type` value. Users never construct this class.
+class Type {
+  implements baml.reflect.TypeView {
+    //baml:vm
+    function as_type(self) -> type throws never { $rust_function }
+  }
+  //baml:mut_vm
+  function element_type(self) -> type throws never { $rust_function }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_class/class.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_class/class.baml
@@ -1,0 +1,17 @@
+class Field {
+  name string
+  type type?
+  meta baml.reflect.Meta
+}
+
+/// A class-kind view of a `type` value. Users never construct this class.
+class Type {
+  implements baml.reflect.TypeView {
+    //baml:vm
+    function as_type(self) -> type throws never { $rust_function }
+  }
+  //baml:mut_vm
+  function fields(self) -> Field[] throws never { $rust_function }
+  //baml:mut_vm
+  function meta(self) -> baml.reflect.Meta throws never { $rust_function }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_enum/enum.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_enum/enum.baml
@@ -1,0 +1,16 @@
+class Value {
+  name string
+  meta baml.reflect.Meta
+}
+
+/// An enum-kind view of a `type` value. Users never construct this class.
+class Type {
+  implements baml.reflect.TypeView {
+    //baml:vm
+    function as_type(self) -> type throws never { $rust_function }
+  }
+  //baml:mut_vm
+  function values(self) -> Value[] throws never { $rust_function }
+  //baml:mut_vm
+  function meta(self) -> baml.reflect.Meta throws never { $rust_function }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_function/function.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_function/function.baml
@@ -1,0 +1,18 @@
+class Parameter {
+  name string?
+  type type
+  optional bool
+}
+
+/// A function-kind view of a `type` value. Throws are intentionally not part
+/// of the slice-1 reflection surface.
+class Type {
+  implements baml.reflect.TypeView {
+    //baml:vm
+    function as_type(self) -> type throws never { $rust_function }
+  }
+  //baml:mut_vm
+  function params(self) -> Parameter[] throws never { $rust_function }
+  //baml:mut_vm
+  function return_type(self) -> type throws never { $rust_function }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_interface/interface.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_interface/interface.baml
@@ -1,0 +1,11 @@
+/// An interface-kind view of a `type` value. Users never construct this class.
+class Type {
+  implements baml.reflect.TypeView {
+    //baml:vm
+    function as_type(self) -> type throws never { $rust_function }
+  }
+  //baml:vm
+  function implemented_by(self, other: type) -> bool throws never { $rust_function }
+  //baml:mut_vm
+  function implementors(self) -> type[] throws never { $rust_function }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_literal/literal.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_literal/literal.baml
@@ -1,0 +1,7 @@
+/// A literal-kind view of a `type` value. Users never construct this class.
+class Type {
+  implements baml.reflect.TypeView {
+    //baml:vm
+    function as_type(self) -> type throws never { $rust_function }
+  }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_map/map.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_map/map.baml
@@ -1,0 +1,11 @@
+/// A map-kind view of a `type` value. Users never construct this class.
+class Type {
+  implements baml.reflect.TypeView {
+    //baml:vm
+    function as_type(self) -> type throws never { $rust_function }
+  }
+  //baml:mut_vm
+  function key_type(self) -> type throws never { $rust_function }
+  //baml:mut_vm
+  function value_type(self) -> type throws never { $rust_function }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_primitive/primitive.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_primitive/primitive.baml
@@ -1,0 +1,7 @@
+/// A primitive-kind view of a `type` value. Users never construct this class.
+class Type {
+  implements baml.reflect.TypeView {
+    //baml:vm
+    function as_type(self) -> type throws never { $rust_function }
+  }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_union/union.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_union/union.baml
@@ -1,0 +1,9 @@
+/// A union-kind view of a `type` value. Users never construct this class.
+class Type {
+  implements baml.reflect.TypeView {
+    //baml:vm
+    function as_type(self) -> type throws never { $rust_function }
+  }
+  //baml:mut_vm
+  function member_types(self) -> type[] throws never { $rust_function }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/reflect.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/reflect.baml
@@ -1,21 +1,3 @@
-/// Returns the runtime `type` value for the type argument `T`.
-///
-/// For concrete type arguments (no generic-parameter references), the `type`
-/// value is materialised at compile time via a single `LoadType` instruction —
-/// zero runtime overhead.
-///
-/// Usage:
-///   let t: type = reflect.type_of<User>()
-///   assert.equal(t.to_string(), "User")
-///   assert.equal(reflect.type_of<int[]>().to_string(), "int[]")
-///
-/// The returned `type` value supports:
-///   - `.to_string()` — returns the BAML type name (e.g. "User", "int[]", "map<string, User>")
-///   - `==` / `!=`   — structural equality (two `type_of<User>()` are equal)
-function type_of<T>() -> type {
-    $compiler_intrinsic
-}
-
 /// One parameter of a function signature (BEP-062).
 class Arg {
   /// The parameter's name. When the callable carries no name for a

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/reflect.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/reflect.baml
@@ -10,6 +10,22 @@ class Arg {
   type type
 }
 
+/// Metadata baked into reflected schema definitions.
+class Meta {
+  alias string?
+  description string?
+  docstring string?
+  other map<string, string>
+}
+
+/// Common identity-preserving surface shared by every reflection kind view.
+interface TypeView {
+  function as_type(self) -> type throws never
+}
+
+/// The closed set of reflection views for a runtime `type` value.
+type TypeKind = baml.reflect.class.Type | baml.reflect.enum.Type | baml.reflect.union.Type | baml.reflect.literal.Type | baml.reflect.array.Type | baml.reflect.map.Type | baml.reflect.interface.Type | baml.reflect.primitive.Type | baml.reflect.function.Type
+
 /// The runtime signature of a function value, reconstructed from the value
 /// itself (BEP-062). Positional (required) parameters appear in `args` in
 /// declaration order; named/optional parameters appear in `opts`, keyed by

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_type/type.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_type/type.baml
@@ -1,0 +1,43 @@
+/// Returns the runtime `type` value for the type argument `T` (BEP-066 K-13).
+///
+/// Spelled `type.of<T>()`: `type` is the keyword shorthand for this
+/// `baml.type` namespace, exactly as `reflect` is for `baml.reflect`.
+///
+/// For concrete type arguments (no generic-parameter references), the `type`
+/// value is materialised at compile time via a single `LoadType` instruction —
+/// zero runtime overhead.
+///
+/// Usage:
+///   let t: type = type.of<User>()
+///   assert.equal(t.to_string(), "User")
+///   assert.equal(type.of<int[]>().to_string(), "int[]")
+///
+/// The returned `type` value supports:
+///   - `.to_string()` — returns the BAML type name (e.g. "User", "int[]", "map<string, User>")
+///   - `==` / `!=`   — structural equality (two `of<User>()` are equal)
+function of<T>() -> type {
+    $compiler_intrinsic
+}
+
+/// Returns the runtime `type` value describing the concrete type of `v`
+/// (BEP-066 K-13).
+///
+/// The reconstructed type is the value's runtime type, never a literal type
+/// (K-12): `type.of_value(5)` is `int`, not `5`. Arrays and maps report the
+/// element/key/value types they carry (`type.of_value([1])` is `int[]`);
+/// function values report their reconstructed signature type; a `type` value
+/// reports `type` itself.
+///
+/// A value with no reconstructable BAML type — a compile-time definition
+/// object (a package, class, enum, interface, or impl rule) or an opaque
+/// native handle — yields the `unknown` type value, mirroring how
+/// `reflect.signature` / `reflect.call_any` treat unreconstructable types.
+///
+/// Usage:
+///   assert.equal(type.of_value(5), type.of<int>())
+///   assert.equal(type.of_value("hi").to_string(), "string")
+//baml:mut_vm
+//baml:fallible
+function of_value(v: unknown) -> type throws never {
+  $rust_function
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/type_class.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/type_class.baml
@@ -7,6 +7,32 @@
 /// Users never construct `Type` directly; they receive `type` values via
 /// `type.of<User>()` and call methods on them.
 class TypeValue {
+    /// Returns the precise kind view of this type value. The view preserves
+    /// the receiver's mint identity.
+    //baml:vm
+    function kind(self) -> baml.reflect.TypeKind throws never {
+        $rust_function
+    }
+
+    //baml:vm
+    function as_class(self) -> baml.reflect.class.Type? throws never { $rust_function }
+    //baml:vm
+    function as_enum(self) -> baml.reflect.enum.Type? throws never { $rust_function }
+    //baml:vm
+    function as_union(self) -> baml.reflect.union.Type? throws never { $rust_function }
+    //baml:vm
+    function as_literal(self) -> baml.reflect.literal.Type? throws never { $rust_function }
+    //baml:vm
+    function as_array(self) -> baml.reflect.array.Type? throws never { $rust_function }
+    //baml:vm
+    function as_map(self) -> baml.reflect.map.Type? throws never { $rust_function }
+    //baml:vm
+    function as_interface(self) -> baml.reflect.interface.Type? throws never { $rust_function }
+    //baml:vm
+    function as_primitive(self) -> baml.reflect.primitive.Type? throws never { $rust_function }
+    //baml:vm
+    function as_function(self) -> baml.reflect.function.Type? throws never { $rust_function }
+
     /// Returns the type name as a human-readable string.
     implements baml.ToString {
         function to_string(self) -> string throws never {

--- a/baml_language/crates/baml_builtins2/baml_std/baml/type_class.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/type_class.baml
@@ -1,11 +1,11 @@
 /// Companion class for the built-in `type` primitive.
 ///
 /// The BAML `type` primitive represents a runtime type value returned by
-/// `reflect.type_of<T>()`. This class provides methods on `type` values,
+/// `type.of<T>()`. This class provides methods on `type` values,
 /// mirroring how `class String` provides methods on `string`.
 ///
 /// Users never construct `Type` directly; they receive `type` values via
-/// `reflect.type_of<User>()` and call methods on them.
+/// `type.of<User>()` and call methods on them.
 class TypeValue {
     /// Returns the type name as a human-readable string.
     implements baml.ToString {

--- a/baml_language/crates/baml_builtins2/src/lib.rs
+++ b/baml_language/crates/baml_builtins2/src/lib.rs
@@ -140,6 +140,15 @@ pub const ALL: &[BuiltinFile] = &[
     builtin!("baml", "ns_random/random.baml"),
     // `baml.reflect` (BEP-066 I-9: `reflect` is a keyword shorthand for it).
     builtin!("baml", "ns_reflect/reflect.baml"),
+    builtin!("baml", "ns_reflect/ns_class/class.baml"),
+    builtin!("baml", "ns_reflect/ns_enum/enum.baml"),
+    builtin!("baml", "ns_reflect/ns_union/union.baml"),
+    builtin!("baml", "ns_reflect/ns_literal/literal.baml"),
+    builtin!("baml", "ns_reflect/ns_array/array.baml"),
+    builtin!("baml", "ns_reflect/ns_map/map.baml"),
+    builtin!("baml", "ns_reflect/ns_interface/interface.baml"),
+    builtin!("baml", "ns_reflect/ns_primitive/primitive.baml"),
+    builtin!("baml", "ns_reflect/ns_function/function.baml"),
     // `baml.type` (BEP-066 K-13: `type.of` / `type.of_value` resolve here).
     builtin!("baml", "ns_type/type.baml"),
     // --- boundary package ---

--- a/baml_language/crates/baml_builtins2/src/lib.rs
+++ b/baml_language/crates/baml_builtins2/src/lib.rs
@@ -138,11 +138,13 @@ pub const ALL: &[BuiltinFile] = &[
     builtin!("baml", "ns_ops/comparison.baml"),
     builtin!("baml", "ns_ops/math.baml"),
     builtin!("baml", "ns_random/random.baml"),
+    // `baml.reflect` (BEP-066 I-9: `reflect` is a keyword shorthand for it).
+    builtin!("baml", "ns_reflect/reflect.baml"),
+    // `baml.type` (BEP-066 K-13: `type.of` / `type.of_value` resolve here).
+    builtin!("baml", "ns_type/type.baml"),
     // --- boundary package ---
     builtin!("boundary", "core.baml"),
     builtin!("boundary", "ns_id/id.baml"),
-    // --- reflect package (standalone, accessible as `reflect.type_of(...)`) ---
-    builtin!("reflect", "reflect.baml"),
     // --- testing package ---
     builtin!("testing", "types.baml"),
     builtin!("testing", "registry.baml"),

--- a/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
+++ b/baml_language/crates/baml_builtins2_codegen/src/codegen.rs
@@ -215,7 +215,8 @@ fn emit_view_namespace_contents(out: &mut String, node: &ClassNamespaceNode, dep
 
     // Emit sub-namespace modules
     for (ns_name, sub_node) in &node.sub_namespaces {
-        writeln!(out, "{indent}pub mod {ns_name} {{").unwrap();
+        let rust_ns_name = rust_field_ident(ns_name);
+        writeln!(out, "{indent}pub mod {rust_ns_name} {{").unwrap();
         write!(out, "{indent}    use super::super::*;\n\n").unwrap();
         emit_view_namespace_contents(out, sub_node, depth + 1);
         writeln!(out, "{indent}}}\n").unwrap();
@@ -437,7 +438,11 @@ fn emit_view_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
             }
             // Generic, Named, Media, Null — fallback to a copied Value.
             _ => {
-                writeln!(out, "{inner}pub fn {field_name}(&self) -> Value {{").unwrap();
+                writeln!(
+                    out,
+                    "{inner}pub fn {field_name}(&self) -> bex_vm_types::Value {{"
+                )
+                .unwrap();
                 writeln!(out, "{inner2}self.instance.load_field({})", field.index).unwrap();
                 writeln!(out, "{inner}}}\n").unwrap();
             }
@@ -486,7 +491,7 @@ fn view_optional_type_and_expr(
             ),
         ),
         _ => (
-            "Option<Value>".to_string(),
+            "Option<bex_vm_types::Value>".to_string(),
             format!("self.instance.load_field({field_index})"),
         ),
     }
@@ -514,7 +519,8 @@ fn emit_copy_namespace_contents(out: &mut String, node: &ClassNamespaceNode, dep
     }
 
     for (ns_name, sub_node) in &node.sub_namespaces {
-        writeln!(out, "{indent}pub mod {ns_name} {{").unwrap();
+        let rust_ns_name = rust_field_ident(ns_name);
+        writeln!(out, "{indent}pub mod {rust_ns_name} {{").unwrap();
         writeln!(out, "{indent}    use super::super::*;").unwrap();
         writeln!(out, "{indent}    use std::sync::Arc;").unwrap();
         write!(out, "{indent}    use std::any::Any;\n\n").unwrap();
@@ -547,7 +553,7 @@ fn emit_copy_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
     writeln!(out, "{indent}impl {class_name} {{").unwrap();
     writeln!(
         out,
-        "{inner}pub fn to_value(self, vm: &mut BexVm) -> Value {{"
+        "{inner}pub fn to_value(self, vm: &mut BexVm) -> bex_vm_types::Value {{"
     )
     .unwrap();
     writeln!(out, "{inner2}let class_ptr = vm.resolve_class({fqn:?});").unwrap();
@@ -565,7 +571,7 @@ fn emit_copy_struct(out: &mut String, class_name: &str, def: &NativeClassDef, de
     // Build the fields vec
     write!(
         out,
-        "{inner2}Value::object(vm.alloc_instance(class_ptr, vec!["
+        "{inner2}bex_vm_types::Value::object(vm.alloc_instance(class_ptr, vec!["
     )
     .unwrap();
     for (i, field) in def.fields.iter().enumerate() {
@@ -596,23 +602,25 @@ fn copy_field_type(ty: &BamlType) -> String {
         | BamlType::Optional(_)
         | BamlType::Generic(_)
         | BamlType::Named(_)
-        | BamlType::Media(_) => "Value".to_string(),
+        | BamlType::Media(_) => "bex_vm_types::Value".to_string(),
     }
 }
 
 /// Generate the expression to convert a copy struct field to a Value.
 fn copy_field_to_value(field_name: &str, ty: &BamlType) -> String {
     match ty {
-        BamlType::RustType => format!("Value::object(vm.alloc_rust_data(self.{field_name}))"),
+        BamlType::RustType => {
+            format!("bex_vm_types::Value::object(vm.alloc_rust_data(self.{field_name}))")
+        }
         // `to_value` has no error channel (`fn to_value(self, vm) -> Value`),
         // so an out-of-i63 native i64 reaches this path only when caller-side
         // Rust constructed a struct field that violates the i63 BAML
         // contract. Fail loudly in *both* debug and release rather than
         // truncating silently via `Value::int`'s `debug_assert`.
         BamlType::Int => format!(
-            "Value::try_int(self.{field_name}).unwrap_or_else(|| panic!(\
+            "bex_vm_types::Value::try_int(self.{field_name}).unwrap_or_else(|| panic!(\
                 \"`{field_name}: int` is outside BAML int range [{{}}, {{}}], got {{}}\", \
-                Value::INT_MIN, Value::INT_MAX, self.{field_name}))"
+                bex_vm_types::Value::INT_MIN, bex_vm_types::Value::INT_MAX, self.{field_name}))"
         ),
         // Bigints are always heap-allocated, and allocation is fallible (the
         // value may exceed `MAX_BIGINT_BITS`). `to_value` has no error channel,
@@ -624,9 +632,11 @@ fn copy_field_to_value(field_name: &str, ty: &BamlType) -> String {
             "vm.try_alloc_bigint(self.{field_name}).unwrap_or_else(|p| panic!(\
                 \"failed to allocate bigint field `{field_name}`: {{p}}\"))"
         ),
-        BamlType::Float => format!("Value::object(vm.alloc_float(self.{field_name}))"),
-        BamlType::Bool => format!("Value::bool(self.{field_name})"),
-        BamlType::Null => "Value::NULL".to_string(),
+        BamlType::Float => {
+            format!("bex_vm_types::Value::object(vm.alloc_float(self.{field_name}))")
+        }
+        BamlType::Bool => format!("bex_vm_types::Value::bool(self.{field_name})"),
+        BamlType::Null => "bex_vm_types::Value::NULL".to_string(),
         // String, List, Map, Optional, Generic, Named, Media — already a Value
         _ => format!("self.{field_name}"),
     }
@@ -646,6 +656,10 @@ fn to_pascal_case(s: &str) -> String {
             result
         }
     }
+}
+
+fn namespace_pascal_case(path: &str) -> String {
+    path.split('.').map(to_pascal_case).collect()
 }
 
 /// Replace characters that are illegal in Rust identifiers with `_`. Synthetic
@@ -670,7 +684,7 @@ fn class_trait_name(namespace_prefix: &str, class_name: &str) -> String {
     if namespace_prefix.is_empty() {
         format!("BamlClass{class_name}")
     } else {
-        let ns_pascal = to_pascal_case(namespace_prefix);
+        let ns_pascal = namespace_pascal_case(namespace_prefix);
         format!("BamlClass{ns_pascal}{class_name}")
     }
 }
@@ -680,7 +694,10 @@ fn class_dispatch_name(namespace_prefix: &str, class_name: &str) -> String {
     if namespace_prefix.is_empty() {
         format!("__dispatch_{class_lower}")
     } else {
-        format!("__dispatch_{namespace_prefix}_{class_lower}")
+        format!(
+            "__dispatch_{}_{class_lower}",
+            sanitize_ident(&namespace_prefix.replace('.', "_"))
+        )
     }
 }
 
@@ -691,12 +708,12 @@ fn package_trait_name(package: &str) -> String {
 }
 
 fn namespace_trait_name(name: &str) -> String {
-    let pascal = to_pascal_case(name);
+    let pascal = namespace_pascal_case(name);
     format!("BamlNamespace{pascal}")
 }
 
 fn namespace_dispatch_name(name: &str) -> String {
-    format!("__dispatch_{name}")
+    format!("__dispatch_{}", sanitize_ident(&name.replace('.', "_")))
 }
 
 // ============================================================================
@@ -755,8 +772,13 @@ fn emit_subtree_traits(out: &mut String, node: &NamespaceNode, namespace_prefix:
     }
 
     for (ns_name, sub_node) in &node.sub_namespaces {
-        emit_subtree_traits(out, sub_node, ns_name);
-        emit_namespace_trait(out, ns_name, sub_node);
+        let child_prefix = if namespace_prefix.is_empty() {
+            ns_name.clone()
+        } else {
+            format!("{namespace_prefix}.{ns_name}")
+        };
+        emit_subtree_traits(out, sub_node, &child_prefix);
+        emit_namespace_trait(out, &child_prefix, sub_node);
     }
 }
 
@@ -809,16 +831,18 @@ fn emit_class_trait(
 // Namespace trait emission
 // ============================================================================
 
-fn emit_namespace_trait(out: &mut String, ns_name: &str, node: &NamespaceNode) {
-    let trait_name = namespace_trait_name(ns_name);
-    let dispatch_name = namespace_dispatch_name(ns_name);
+fn emit_namespace_trait(out: &mut String, namespace_prefix: &str, node: &NamespaceNode) {
+    let trait_name = namespace_trait_name(namespace_prefix);
+    let dispatch_name = namespace_dispatch_name(namespace_prefix);
 
     let mut supertraits: Vec<String> = Vec::new();
     for class_name in node.classes.keys() {
-        supertraits.push(class_trait_name(ns_name, class_name));
+        supertraits.push(class_trait_name(namespace_prefix, class_name));
     }
     for sub_ns in node.sub_namespaces.keys() {
-        supertraits.push(namespace_trait_name(sub_ns));
+        supertraits.push(namespace_trait_name(&format!(
+            "{namespace_prefix}.{sub_ns}"
+        )));
     }
 
     if supertraits.is_empty() {
@@ -851,7 +875,7 @@ fn emit_namespace_trait(out: &mut String, ns_name: &str, node: &NamespaceNode) {
         out.push_str("        match rest.split_once('.') {\n");
 
         for class_name in node.classes.keys() {
-            let child_dispatch = class_dispatch_name(ns_name, class_name);
+            let child_dispatch = class_dispatch_name(namespace_prefix, class_name);
             writeln!(
                 out,
                 "            Some(({class_name:?}, method)) => Self::{child_dispatch}(method),"
@@ -860,7 +884,7 @@ fn emit_namespace_trait(out: &mut String, ns_name: &str, node: &NamespaceNode) {
         }
 
         for sub_ns in node.sub_namespaces.keys() {
-            let child_dispatch = namespace_dispatch_name(sub_ns);
+            let child_dispatch = namespace_dispatch_name(&format!("{namespace_prefix}.{sub_ns}"));
             writeln!(
                 out,
                 "            Some(({sub_ns:?}, rest)) => Self::{child_dispatch}(rest),",
@@ -1133,7 +1157,11 @@ fn clean_param_list(b: &NativeBuiltin) -> String {
         ));
     }
     for p in &b.params {
-        parts.push(format!("{}: {}", p.name, baml_type_to_input(&p.ty, false)));
+        parts.push(format!(
+            "{}: {}",
+            rust_field_ident(&p.name),
+            baml_type_to_input(&p.ty, false)
+        ));
     }
 
     parts.join(", ")
@@ -1376,7 +1404,7 @@ fn emit_arg_extractions_indented(
                 let arg_idx = i;
                 emit_single_extraction_indented(
                     out,
-                    &p.name,
+                    &rust_field_ident(&p.name).to_string(),
                     arg_idx,
                     &p.ty,
                     indent,
@@ -1389,7 +1417,7 @@ fn emit_arg_extractions_indented(
                 let arg_idx = i + 1;
                 emit_single_extraction_indented(
                     out,
-                    &p.name,
+                    &rust_field_ident(&p.name).to_string(),
                     arg_idx,
                     &p.ty,
                     indent,
@@ -1420,7 +1448,7 @@ fn emit_arg_extractions_indented(
                 let arg_idx = i + 1;
                 emit_single_extraction_indented(
                     out,
-                    &p.name,
+                    &rust_field_ident(&p.name).to_string(),
                     arg_idx,
                     &p.ty,
                     indent,
@@ -1433,7 +1461,7 @@ fn emit_arg_extractions_indented(
         for (i, p) in b.params.iter().enumerate() {
             emit_single_extraction_indented(
                 out,
-                &p.name,
+                &rust_field_ident(&p.name).to_string(),
                 i,
                 &p.ty,
                 indent,
@@ -1694,7 +1722,11 @@ fn call_arg_list(b: &NativeBuiltin, needs_owned: bool, arraymap_needs_owned: boo
             BamlType::List(_) | BamlType::Map(_, _) | BamlType::Uint8Array => arraymap_is_ref,
             _ => is_ref,
         };
-        args.push(call_arg_for_type(&p.name, &p.ty, p_is_ref));
+        args.push(call_arg_for_type(
+            &rust_field_ident(&p.name).to_string(),
+            &p.ty,
+            p_is_ref,
+        ));
     }
 
     args.join(", ")
@@ -2077,7 +2109,7 @@ fn baml_type_to_output(ty: &BamlType) -> String {
 // ============================================================================
 
 fn receiver_param_name(recv: &Receiver) -> String {
-    recv.class_name.to_lowercase()
+    rust_field_ident(&recv.class_name.to_lowercase()).to_string()
 }
 
 /// Path to the generated `view::` struct for an instance-backed receiver, e.g.
@@ -2086,11 +2118,13 @@ fn receiver_view_path(recv: &Receiver) -> String {
     if recv.namespace.is_empty() {
         format!("view::{}", recv.class_name)
     } else {
-        format!(
-            "view::{}::{}",
-            recv.namespace.replace('.', "::"),
-            recv.class_name
-        )
+        let namespace = recv
+            .namespace
+            .split('.')
+            .map(|segment| rust_field_ident(segment).to_string())
+            .collect::<Vec<_>>()
+            .join("::");
+        format!("view::{}::{}", namespace, recv.class_name)
     }
 }
 
@@ -2545,7 +2579,7 @@ mod tests {
         );
         // to_value method
         assert!(
-            output.contains("fn to_value(self, vm: &mut BexVm) -> Value"),
+            output.contains("fn to_value(self, vm: &mut BexVm) -> bex_vm_types::Value"),
             "copy struct should have to_value method:\n{output}"
         );
     }

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_cli/src/describe_command_tests.rs
-assertion_line: 417
 expression: output
 ---
 class            baml.Bigint                      <builtin>/baml/bigint.baml:30
@@ -272,10 +271,25 @@ class            baml.random.SystemRandom         <builtin>/baml/ns_random/rando
 class            baml.random.Xoshiro256PlusPlus   <builtin>/baml/ns_random/random.baml:68
 class            baml.random.ChaCha20             <builtin>/baml/ns_random/random.baml:114
 class            baml.reflect.Arg                 <builtin>/baml/ns_reflect/reflect.baml:2
-class            baml.reflect.Signature           <builtin>/baml/ns_reflect/reflect.baml:17
-class            baml.reflect.InvalidArgumentError <builtin>/baml/ns_reflect/reflect.baml:39
-function         baml.reflect.signature           <builtin>/baml/ns_reflect/reflect.baml:52
-function         baml.reflect.call_any            <builtin>/baml/ns_reflect/reflect.baml:67
+class            baml.reflect.Meta                <builtin>/baml/ns_reflect/reflect.baml:14
+interface        baml.reflect.TypeView            <builtin>/baml/ns_reflect/reflect.baml:22
+type             baml.reflect.TypeKind            <builtin>/baml/ns_reflect/reflect.baml:27
+class            baml.reflect.Signature           <builtin>/baml/ns_reflect/reflect.baml:33
+class            baml.reflect.InvalidArgumentError <builtin>/baml/ns_reflect/reflect.baml:55
+function         baml.reflect.signature           <builtin>/baml/ns_reflect/reflect.baml:68
+function         baml.reflect.call_any            <builtin>/baml/ns_reflect/reflect.baml:83
+class            baml.reflect.array.Type          <builtin>/baml/ns_reflect/ns_array/array.baml:2
+class            baml.reflect.class.Field         <builtin>/baml/ns_reflect/ns_class/class.baml:1
+class            baml.reflect.class.Type          <builtin>/baml/ns_reflect/ns_class/class.baml:8
+class            baml.reflect.enum.Value          <builtin>/baml/ns_reflect/ns_enum/enum.baml:1
+class            baml.reflect.enum.Type           <builtin>/baml/ns_reflect/ns_enum/enum.baml:7
+class            baml.reflect.function.Parameter  <builtin>/baml/ns_reflect/ns_function/function.baml:1
+class            baml.reflect.function.Type       <builtin>/baml/ns_reflect/ns_function/function.baml:9
+class            baml.reflect.interface.Type      <builtin>/baml/ns_reflect/ns_interface/interface.baml:2
+class            baml.reflect.literal.Type        <builtin>/baml/ns_reflect/ns_literal/literal.baml:2
+class            baml.reflect.map.Type            <builtin>/baml/ns_reflect/ns_map/map.baml:2
+class            baml.reflect.primitive.Type      <builtin>/baml/ns_reflect/ns_primitive/primitive.baml:2
+class            baml.reflect.union.Type          <builtin>/baml/ns_reflect/ns_union/union.baml:2
 function         baml.sap.parse                   <builtin>/baml/ns_sap/sap.baml:5
 function         baml.sap.parse_type              <builtin>/baml/ns_sap/sap.baml:12
 function         baml.schema.json_schema          <builtin>/baml/ns_schema/schema.baml:8

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_cli/src/describe_command_tests.rs
+assertion_line: 417
 expression: output
 ---
 class            baml.Bigint                      <builtin>/baml/bigint.baml:30
@@ -270,6 +271,11 @@ interface        baml.random.Rng                  <builtin>/baml/ns_random/rando
 class            baml.random.SystemRandom         <builtin>/baml/ns_random/random.baml:45
 class            baml.random.Xoshiro256PlusPlus   <builtin>/baml/ns_random/random.baml:68
 class            baml.random.ChaCha20             <builtin>/baml/ns_random/random.baml:114
+class            baml.reflect.Arg                 <builtin>/baml/ns_reflect/reflect.baml:2
+class            baml.reflect.Signature           <builtin>/baml/ns_reflect/reflect.baml:17
+class            baml.reflect.InvalidArgumentError <builtin>/baml/ns_reflect/reflect.baml:39
+function         baml.reflect.signature           <builtin>/baml/ns_reflect/reflect.baml:52
+function         baml.reflect.call_any            <builtin>/baml/ns_reflect/reflect.baml:67
 function         baml.sap.parse                   <builtin>/baml/ns_sap/sap.baml:5
 function         baml.sap.parse_type              <builtin>/baml/ns_sap/sap.baml:12
 function         baml.schema.json_schema          <builtin>/baml/ns_schema/schema.baml:8
@@ -309,6 +315,8 @@ function         baml.toml.table_from_json        <builtin>/baml/ns_toml/toml.ba
 function         baml.toml.item_to_json           <builtin>/baml/ns_toml/toml.baml:61
 function         baml.toml.item_from_json         <builtin>/baml/ns_toml/toml.baml:74
 class            baml.toml.TomlParseError         <builtin>/baml/ns_toml/toml.baml:83
+function         baml.type.of                     <builtin>/baml/ns_type/type.baml:18
+function         baml.type.of_value               <builtin>/baml/ns_type/type.baml:41
 class            baml.ws.WsStream                 <builtin>/baml/ns_ws/ws.baml:4
 function         baml.ws.connect                  <builtin>/baml/ns_ws/ws.baml:24
 function         baml.ws._connect                 <builtin>/baml/ns_ws/ws.baml:32

--- a/baml_language/crates/baml_compiler2_ast/src/disambiguate.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/disambiguate.rs
@@ -20,6 +20,13 @@ pub fn is_field_attr(name: &str) -> bool {
     FIELD_ATTR_NAMES.contains(&name)
 }
 
+/// Whether a direct outer attribute on a class field belongs to field metadata.
+/// Known type transforms stay on the type; unknown names are user schema
+/// annotations and are hoisted for reflection read-back.
+pub(crate) fn should_hoist_field_attr(name: &str) -> bool {
+    is_field_attr(name) || !name.starts_with("stream.")
+}
+
 /// Post-lowering validation: report field attrs that appear in nested type
 /// positions (inside parens, on union members, inside generics).
 /// These were not hoisted during lowering because they weren't at the

--- a/baml_language/crates/baml_compiler2_ast/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lib.rs
@@ -2298,6 +2298,23 @@ class C {
     }
 
     #[test]
+    fn custom_schema_attr_is_hoisted_but_stream_attr_stays_on_type() {
+        let source = r#"
+class C {
+  f string @custom("read-back") @stream.done
+}
+"#;
+        let (items, diags) = parse_lower_validate(source);
+        assert!(diags.is_empty(), "expected no diagnostics, got {diags:?}");
+        let class = first_class(items);
+        let field = &class.fields[0];
+        assert_eq!(field.attributes.len(), 1);
+        assert_eq!(field.attributes[0].name.as_str(), "custom");
+        assert_eq!(field.type_expr.attrs().len(), 1);
+        assert_eq!(field.type_expr.attrs()[0].name.as_str(), "stream.done");
+    }
+
+    #[test]
     fn union_trailing_field_attr_hoisted_to_field() {
         // A | B | C @alias("x") → @alias hoisted to FieldDef, Union has no attrs.
         let source = r#"

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -856,7 +856,7 @@ pub fn synthesize_llm_builtin_call(
 /// the only argument is a single `json` identifier (a path expression)
 /// rather than a map of parent params. The explicit type args carry the
 /// stream-expanded and original return types so the stdlib `parse` can
-/// reify them via `reflect.type_of` instead of a name-keyed registry
+/// reify them via `type.of` instead of a name-keyed registry
 /// lookup (same threading as `call_llm_function<T>`).
 pub(crate) fn synthesize_llm_parse_call(
     type_args: Vec<crate::ast::TypeExpr>,
@@ -913,7 +913,7 @@ pub(crate) fn synthesize_llm_parse_call(
 ///
 /// Used by the PPIR to generate `$parse_stream` companion function bodies.
 /// The explicit type args carry the stream-expanded and original return
-/// types into `__make_stream`'s frame, where `reflect.type_of` reifies them
+/// types into `__make_stream`'s frame, where `type.of` reifies them
 /// for `StreamCache.new`.
 pub fn synthesize_llm_make_stream_call(
     type_args: Vec<crate::ast::TypeExpr>,

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -1116,7 +1116,7 @@ fn lower_class(
                     let all_outer_attrs = std::mem::take(expr.attrs_mut());
                     let (hoist, keep): (Vec<_>, Vec<_>) =
                         all_outer_attrs.into_iter().partition(|a| {
-                            crate::disambiguate::is_field_attr(a.name.as_str())
+                            crate::disambiguate::should_hoist_field_attr(a.name.as_str())
                                 && direct_attr_spans.contains(&a.span)
                         });
                     *expr.attrs_mut() = keep;

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -2633,7 +2633,7 @@ impl LoweringContext {
         // PATH_EXPR contains WORD (or keyword-as-ident) tokens joined by DOTs.
         //
         // When a PATH_EXPR is wrapped in another PATH_EXPR for generic-arg
-        // annotation (e.g. `reflect.type_of<User>` → outer PATH_EXPR wrapping
+        // annotation (e.g. `type.of<User>` → outer PATH_EXPR wrapping
         // inner PATH_EXPR + GENERIC_ARGS), the outer node has no direct token
         // children. In that case, delegate to the inner PATH_EXPR node.
         let mut segments: Vec<(Name, TextRange)> = Vec::new();

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -49,6 +49,9 @@ fn is_ident_token(kind: SyntaxKind) -> bool {
             | SyntaxKind::KW_CLIENT
             | SyntaxKind::KW_SPAWN
             | SyntaxKind::KW_AWAIT
+            | SyntaxKind::KW_CLASS
+            | SyntaxKind::KW_ENUM
+            | SyntaxKind::KW_FUNCTION
             | SyntaxKind::KW_IMPLEMENTS
             | SyntaxKind::KW_IMPLEMENT
             | SyntaxKind::KW_INTERFACE

--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -3389,6 +3389,15 @@ impl PullSink for StackifyCodegen<'_, '_> {
             // so the VM compares each arg invariantly; empty args →
             // class-pointer identity.
             TyTemplate::Class(tn, type_args_templates, _) => {
+                // A reflected `type` value is physically `Object::Type` but its
+                // reconstructed concrete type is one of the nine sealed kind
+                // classes. Kind tests must therefore use the structural value
+                // matcher; class-object pointer identity only applies to normal
+                // user instances.
+                if baml_type::type_kind::is_type_kind_class(tn) {
+                    emit_structural(self, ty_template);
+                    return Ok(());
+                }
                 let class_name_str = tn.display_name();
                 let Some(class_obj_idx) = self.class_object_index_for_type_name(tn) else {
                     emit_false(self);
@@ -3635,6 +3644,7 @@ fn realized_type_tag(ty: &RealizedTy) -> Option<i64> {
         RealizedTy::List(..) => Some(baml_type::typetag::LIST),
         RealizedTy::Map { .. } => Some(baml_type::typetag::MAP),
         RealizedTy::Function { .. } => Some(baml_type::typetag::FUNCTION),
+        RealizedTy::Type { .. } => Some(baml_type::typetag::TYPE),
         RealizedTy::Uint8Array { .. } => Some(baml_type::typetag::UINT8ARRAY),
         RealizedTy::Literal(lit, _, _) => Some(match lit {
             baml_base::Literal::Int(_) => baml_type::typetag::INT,

--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -1052,7 +1052,7 @@ pub(crate) use emit::compile_mir_function;
 fn is_builtin_function_name(name: &str) -> bool {
     matches!(
         name.split('.').next(),
-        Some("baml" | "boundary" | "reflect" | "assert" | "testing" | "log" | "env")
+        Some("baml" | "boundary" | "assert" | "testing" | "log" | "env")
     )
 }
 

--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -1177,35 +1177,62 @@ impl std::fmt::Display for LoweringError {
 
 impl std::error::Error for LoweringError {}
 
-/// Extract `@description`, `@alias`, `@skip` from span-free HIR attributes.
-///
-/// Returns `(description, alias, skip)`. Invalid attribute usage is diagnosed
-/// at HIR validation time; by this point, malformed attrs are simply skipped.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct SchemaAttrs {
+    description: Option<String>,
+    alias: Option<String>,
+    docstring: Option<String>,
+    other: indexmap::IndexMap<String, String>,
+    skip: bool,
+}
+
+/// Extract schema metadata from span-free HIR attributes and docstrings.
 fn extract_schema_attrs(
     attrs: &[baml_compiler2_hir::item_tree::Attribute],
-) -> (Option<String>, Option<String>, bool) {
-    let mut description = None;
-    let mut alias = None;
-    let mut skip = false;
+    docstring: Option<&str>,
+) -> SchemaAttrs {
+    let mut result = SchemaAttrs {
+        docstring: docstring.map(str::to_owned),
+        ..SchemaAttrs::default()
+    };
     for attr in attrs {
         match attr.name.as_str() {
             "description" | "alias" if attr.args.len() == 1 => {
                 let raw = attr.args[0].value.as_str();
                 let value = parse_string_attr_value(raw);
                 if attr.name.as_str() == "description" {
-                    description = value;
+                    result.description = value;
                 } else {
-                    alias = value;
+                    result.alias = value;
                 }
             }
             "description" | "alias" => {}
             "skip" => {
-                skip = true;
+                result.skip = true;
             }
-            _ => {}
+            _ => {
+                let value = match attr.args.as_slice() {
+                    [] => "true".to_string(),
+                    [arg] if arg.key.is_none() => {
+                        parse_string_attr_value(&arg.value).unwrap_or_else(|| arg.value.clone())
+                    }
+                    args => args
+                        .iter()
+                        .map(|arg| {
+                            let value = parse_string_attr_value(&arg.value)
+                                .unwrap_or_else(|| arg.value.clone());
+                            arg.key
+                                .as_ref()
+                                .map_or(value.clone(), |key| format!("{}={value}", key.as_str()))
+                        })
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                };
+                result.other.insert(attr.name.to_string(), value);
+            }
         }
     }
-    (description, alias, skip)
+    result
 }
 
 pub use bex_vm_types::Program as ProgramAlias;
@@ -1216,6 +1243,7 @@ type MergedFieldEntry = (
     String,
     baml_compiler2_hir::type_ref::TypeRefId,
     Vec<baml_compiler2_hir::item_tree::Attribute>,
+    Option<String>,
     Vec<Name>,
     Vec<Name>,
 );
@@ -1238,6 +1266,7 @@ fn collect_class_fields_with_implements(
             name,
             field.type_ref,
             field.attributes.clone(),
+            field.docstring.clone(),
             class
                 .generic_params
                 .iter()
@@ -2967,7 +2996,8 @@ fn emit_file_group(
             // validator enforces/link-checks them before emit.
             let merged_fields =
                 collect_class_fields_with_implements(&pkg_info.namespace_path, class);
-            for (idx, (name, type_ref, attrs, _gen_params, ns)) in merged_fields.iter().enumerate()
+            for (idx, (name, type_ref, attrs, docstring, _gen_params, ns)) in
+                merged_fields.iter().enumerate()
             {
                 field_indices.insert(name.clone(), idx);
                 let (field_type, field_template) = {
@@ -3005,18 +3035,20 @@ fn emit_file_group(
                         (resolved_ty, template)
                     }
                 };
-                let (field_desc, field_alias, field_skip) = extract_schema_attrs(attrs.as_slice());
+                let meta = extract_schema_attrs(attrs.as_slice(), docstring.as_deref());
                 fields.push(ClassField {
                     name: name.clone(),
                     field_type,
                     field_template,
-                    description: field_desc,
-                    alias: field_alias,
-                    skip: field_skip,
+                    description: meta.description,
+                    alias: meta.alias,
+                    docstring: meta.docstring,
+                    other: meta.other,
+                    skip: meta.skip,
                 });
             }
 
-            let (class_desc, class_alias, _class_skip) = extract_schema_attrs(&class.attributes);
+            let class_meta = extract_schema_attrs(&class.attributes, class.docstring.as_deref());
 
             let type_tag = bex_vm_types::type_tags::class_type_tag(&fq_name);
             if let Some(previous) = class_type_tags.insert(type_tag, fq_name.clone())
@@ -3076,8 +3108,10 @@ fn emit_file_group(
             let class_obj_idx = program.add_object(Object::Class(Box::new(Class {
                 name: fq_to_type_name(&fq_name),
                 fields,
-                description: class_desc,
-                alias: class_alias,
+                description: class_meta.description,
+                alias: class_meta.alias,
+                docstring: class_meta.docstring,
+                other: class_meta.other,
                 type_tag,
                 ty_attr: TyAttr::default(),
                 has_cleanup,
@@ -3129,7 +3163,7 @@ fn emit_file_group(
             let rebuild_indices = || {
                 let merged = collect_class_fields_with_implements(&pkg_info.namespace_path, class);
                 let mut m = HashMap::new();
-                for (idx, (name, _, _, _, _)) in merged.iter().enumerate() {
+                for (idx, (name, _, _, _, _, _)) in merged.iter().enumerate() {
                     m.insert(name.clone(), idx);
                 }
                 m
@@ -3159,23 +3193,27 @@ fn emit_file_group(
             let mut variant_map = HashMap::new();
             let mut variants = Vec::new();
             for (idx, variant) in enm.variants.iter().enumerate() {
-                let (var_desc, var_alias, var_skip) = extract_schema_attrs(&variant.attributes);
+                let meta = extract_schema_attrs(&variant.attributes, variant.docstring.as_deref());
                 variant_map.insert(variant.name.to_string(), idx);
                 variants.push(EnumVariant {
                     name: variant.name.to_string(),
-                    description: var_desc,
-                    alias: var_alias,
-                    skip: var_skip,
+                    description: meta.description,
+                    alias: meta.alias,
+                    docstring: meta.docstring,
+                    other: meta.other,
+                    skip: meta.skip,
                 });
             }
 
-            let (enum_desc, enum_alias, _enum_skip) = extract_schema_attrs(&enm.attributes);
+            let enum_meta = extract_schema_attrs(&enm.attributes, enm.docstring.as_deref());
 
             let enum_obj_idx = program.add_object(Object::Enum(Box::new(Enum {
                 name: fq_to_type_name(&fq_name),
                 variants,
-                description: enum_desc,
-                alias: enum_alias,
+                description: enum_meta.description,
+                alias: enum_meta.alias,
+                docstring: enum_meta.docstring,
+                other: enum_meta.other,
                 ty_attr: TyAttr::default(),
             })));
             enum_object_indices.insert(fq_name.clone(), enum_obj_idx);
@@ -5777,44 +5815,47 @@ mod tests {
             mk_attr("description", &[r#""A field""#]),
             mk_attr("alias", &[r#""myField""#]),
         ];
-        let (desc, alias, skip) = extract_schema_attrs(&attrs);
-        assert_eq!(desc, Some("A field".to_string()));
-        assert_eq!(alias, Some("myField".to_string()));
-        assert!(!skip);
+        let meta = extract_schema_attrs(&attrs, Some("docs"));
+        assert_eq!(meta.description, Some("A field".to_string()));
+        assert_eq!(meta.alias, Some("myField".to_string()));
+        assert_eq!(meta.docstring, Some("docs".to_string()));
+        assert!(!meta.skip);
     }
 
     #[test]
     fn extract_skip() {
         let attrs = vec![mk_attr("skip", &[])];
-        let (desc, alias, skip) = extract_schema_attrs(&attrs);
-        assert_eq!(desc, None);
-        assert_eq!(alias, None);
-        assert!(skip);
+        let meta = extract_schema_attrs(&attrs, None);
+        assert_eq!(meta.description, None);
+        assert_eq!(meta.alias, None);
+        assert!(meta.skip);
     }
 
     #[test]
-    fn extract_unknown_attrs_ignored() {
+    fn extract_custom_attrs_into_other() {
         let attrs = vec![
             mk_attr("stream.done", &["true"]),
             mk_attr("internal.opaque", &[]),
             mk_attr("description", &[r#""kept""#]),
         ];
-        let (desc, _, _) = extract_schema_attrs(&attrs);
-        assert_eq!(desc, Some("kept".to_string()));
+        let meta = extract_schema_attrs(&attrs, None);
+        assert_eq!(meta.description, Some("kept".to_string()));
+        assert_eq!(meta.other["stream.done"], "true");
+        assert_eq!(meta.other["internal.opaque"], "true");
     }
 
     #[test]
     fn extract_non_string_arg_ignored() {
         let attrs = vec![mk_attr("description", &["42"])];
-        let (desc, _, _) = extract_schema_attrs(&attrs);
-        assert_eq!(desc, None);
+        let meta = extract_schema_attrs(&attrs, None);
+        assert_eq!(meta.description, None);
     }
 
     #[test]
     fn extract_wrong_arg_count_ignored() {
         let attrs = vec![mk_attr("description", &[])]; // 0 args
-        let (desc, _, _) = extract_schema_attrs(&attrs);
-        assert_eq!(desc, None);
+        let meta = extract_schema_attrs(&attrs, None);
+        assert_eq!(meta.description, None);
     }
 
     #[test]
@@ -5823,30 +5864,28 @@ mod tests {
             mk_attr("description", &[r#""first""#]),
             mk_attr("description", &[r#""second""#]),
         ];
-        let (desc, _, _) = extract_schema_attrs(&attrs);
-        assert_eq!(desc, Some("second".to_string()));
+        let meta = extract_schema_attrs(&attrs, None);
+        assert_eq!(meta.description, Some("second".to_string()));
     }
 
     #[test]
     fn extract_raw_string_attr() {
         // Simulates @description(#"raw desc"#)
         let attrs = vec![mk_attr("description", &["#\"raw desc\"#"])];
-        let (desc, _, _) = extract_schema_attrs(&attrs);
-        assert_eq!(desc, Some("raw desc".to_string()));
+        let meta = extract_schema_attrs(&attrs, None);
+        assert_eq!(meta.description, Some("raw desc".to_string()));
     }
 
     #[test]
     fn extract_regular_string_attr_decodes_escapes() {
         let attrs = vec![mk_attr("description", &[r#""a\nb\tc\\d\"e""#])];
-        let (desc, _, _) = extract_schema_attrs(&attrs);
-        assert_eq!(desc, Some("a\nb\tc\\d\"e".to_string()));
+        let meta = extract_schema_attrs(&attrs, None);
+        assert_eq!(meta.description, Some("a\nb\tc\\d\"e".to_string()));
     }
 
     #[test]
     fn extract_no_attrs() {
-        let (desc, alias, skip) = extract_schema_attrs(&[]);
-        assert_eq!(desc, None);
-        assert_eq!(alias, None);
-        assert!(!skip);
+        let meta = extract_schema_attrs(&[], None);
+        assert_eq!(meta, SchemaAttrs::default());
     }
 }

--- a/baml_language/crates/baml_compiler2_hir/src/package.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/package.rs
@@ -371,7 +371,7 @@ mod tests {
 /// The *direct* dependencies of `package_id` (hardcoded for now).
 ///
 /// Note these lists are not uniformly flattened: `testing`/`assert` list `baml`
-/// but not `baml`'s own `log`/`reflect`. Callers that need every package whose
+/// but not `baml`'s own `log`. Callers that need every package whose
 /// items could be visible from `package_id` (interface coherence,
 /// `type_implements_with_deps`) must use [`package_dependency_closure`], not this
 /// direct list.
@@ -384,17 +384,13 @@ pub fn package_dependencies<'db>(
         // "log" has no deps — it only uses primitives, and "baml" depends on
         // it so the stdlib can emit log events.
         "log" => vec![],
-        // "reflect" has no deps — it only uses the `type` primitive.
-        "reflect" => vec![],
         // "boundary" has no deps — it only returns the current boundary id as
         // a primitive string.
         "boundary" => vec![],
-        // "baml" depends on "log" and "reflect" so stdlib code can call
-        // log.info/debug/etc. and reflect.type_of<T>() inside ns_llm.
-        "baml" => vec![
-            PackageId::new(db, Name::new("log")),
-            PackageId::new(db, Name::new("reflect")),
-        ],
+        // "baml" depends on "log" so stdlib code can call log.info/debug/etc.
+        // Reflection lives inside "baml" itself (`baml.reflect` / `baml.type`,
+        // BEP-066), so it is no dependency.
+        "baml" => vec![PackageId::new(db, Name::new("log"))],
         // The "testing" and "assert" packages depend on "baml" only.
         "testing" | "assert" => vec![PackageId::new(db, Name::new("baml"))],
         // User packages depend on public builtin packages.
@@ -404,7 +400,6 @@ pub fn package_dependencies<'db>(
             PackageId::new(db, Name::new("testing")),
             PackageId::new(db, Name::new("assert")),
             PackageId::new(db, Name::new("log")),
-            PackageId::new(db, Name::new("reflect")),
         ],
     }
 }

--- a/baml_language/crates/baml_compiler2_mir/src/ir.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/ir.rs
@@ -903,7 +903,7 @@ pub enum Rvalue {
     /// For templates containing `TypeArgRef(N)`, the VM substitutes
     /// `frame.type_args[N]` at execution time.
     ///
-    /// Emitted by the `reflect.type_of<T>()` intrinsic.
+    /// Emitted by the `type.of<T>()` intrinsic.
     /// Lowers to `Instruction::LoadType(const_idx)` in bytecode.
     LoadType(TyTemplate),
 }

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -1442,7 +1442,7 @@ struct LoweringContext<'db> {
     // Generic params of the enclosing lambda(s), accumulated outermost-first.
     // Empty at top-level; `lower_lambda` extends it with the lambda's own
     // `generic_params` while lowering its body and restores it afterward.
-    // `enclosing_generic_params()` appends this so that `reflect.type_of<T>`
+    // `enclosing_generic_params()` appends this so that `type.of<T>`
     // (and other type-arg resolution) inside a generic lambda body resolves the
     // lambda's `T` to the correct `TypeArgRef` slot — `func_loc` only knows the
     // enclosing top-level function's (and class's) params, never a lambda's.
@@ -8167,7 +8167,7 @@ impl<'db> LoweringContext<'db> {
         let target = self.builder.create_block();
         let unwind = self.catch_context.as_ref().map(|c| c.unwind_target);
 
-        // Check if callee is `reflect.type_of<T>()` — a value-producing intrinsic.
+        // Check if callee is `type.of<T>()` — a value-producing intrinsic.
         // Unlike void intrinsics (log.*), this emits an assignment
         // of `Rvalue::LoadType(template)` to `dest` rather than a StatementKind::Intrinsic.
         if let Some(template) = self.check_type_of_intrinsic(callee, expr_id) {
@@ -8223,7 +8223,7 @@ impl<'db> LoweringContext<'db> {
         // or inferred by TIR, materialise each as a `type` value on the stack
         // before the regular value args.
         // The VM pops these `ntypeargs` Object::Type values into the new frame's
-        // `type_args` vec so that inner `reflect.type_of<T>()` calls can
+        // `type_args` vec so that inner `type.of<T>()` calls can
         // substitute them at runtime.
         // Check if callee resolves to a builtin IO function (sys-op). Sys-op
         // glue reads only its declared value args plus any synthetic trailing
@@ -8726,14 +8726,14 @@ impl<'db> LoweringContext<'db> {
     }
 }
 
-// ─── 3.6: reflect.type_of intrinsic ─────────────────────────────────────────
+// ─── 3.6: type.of intrinsic (BEP-066, formerly reflect.type_of) ─────────────
 
 impl LoweringContext<'_> {
-    /// Detect a `reflect.type_of<T>()` call and, if found, resolve the type
+    /// Detect a `type.of<T>()` call and, if found, resolve the type
     /// argument and return the corresponding `TyTemplate`.
     ///
     /// Returns `Some(template)` when:
-    /// - The callee is the `baml.reflect.type_of` `$compiler_intrinsic`.
+    /// - The callee is the `baml.type.of` `$compiler_intrinsic`.
     /// - The call carries exactly one type argument.
     /// - The type argument resolves to a concrete `RuntimeTy` (no `TypeVar` leaves).
     ///
@@ -8749,7 +8749,7 @@ impl LoweringContext<'_> {
     ) -> Option<TyTemplate> {
         use baml_compiler2_ast::BuiltinKind;
 
-        // ── 1. Check the callee resolves to `baml.reflect.type_of` ──────────
+        // ── 1. Check the callee resolves to `baml.type.of` ─────────────
         let func_loc = if let AstExpr::Path(segments) = &self.body.exprs[callee] {
             if segments.len() == 1 {
                 let span_start = self
@@ -8800,7 +8800,7 @@ impl LoweringContext<'_> {
             self.db,
             baml_compiler2_hir::contributions::Definition::Function(func_loc),
         );
-        if item_ref.to_string().as_str() != "reflect.type_of" {
+        if item_ref.to_string().as_str() != "baml.type.of" {
             return None;
         }
 
@@ -8813,7 +8813,7 @@ impl LoweringContext<'_> {
         let type_arg = type_args.into_iter().next()?;
 
         // Include the enclosing class + function generic params so that `T`
-        // in `reflect.type_of<T>()` resolves to `Tir2Ty::TypeVar("T")` rather
+        // in `type.of<T>()` resolves to `Tir2Ty::TypeVar("T")` rather
         // than an unresolved-type error — both for free generic functions and
         // for methods on generic classes.  The order (class params first,
         // then function params) mirrors TIR's `enclosing_class_generic_params
@@ -9044,7 +9044,7 @@ impl LoweringContext<'_> {
         // out-of-range ref as a frame-layout error), so a generic callee's
         // frame is always seeded at full declared width; a `T` inferred to the
         // top type is an explicit `unknown` slot, which is how
-        // `reflect.type_of<T>()` under an unknown-typed call still reflects
+        // `type.of<T>()` under an unknown-typed call still reflects
         // the honest top type.
         self.emit_frame_type_arg_ops(&inferred_type_args)
     }

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -7875,7 +7875,7 @@ impl<'db> LoweringContext<'db> {
                 // type slot, same field-chain lowering.
                 else if let Some(members) = self
                     .tir_path_segment_type((self.current_metadata_scope, callee, prefix_idx))
-                    .and_then(Self::tir_union_members)
+                    .and_then(|ty| self.tir_union_members(ty))
                 {
                     let receiver_segments = &segments[..segments.len() - 1];
                     let recv_local = self.lower_path_receiver_to_local(
@@ -10336,7 +10336,7 @@ impl<'db> LoweringContext<'db> {
     ) -> bool {
         let Some(members) = self
             .tir_expr_type(self.expr_metadata_key(base))
-            .and_then(Self::tir_union_members)
+            .and_then(|ty| self.tir_union_members(ty))
         else {
             return false;
         };
@@ -10375,7 +10375,7 @@ impl<'db> LoweringContext<'db> {
     ) -> bool {
         let Some(members) = self
             .tir_expr_type(self.expr_metadata_key(base))
-            .and_then(Self::tir_union_members)
+            .and_then(|ty| self.tir_union_members(ty))
         else {
             return false;
         };
@@ -12605,9 +12605,14 @@ impl LoweringContext<'_> {
     /// layers — `(Dog | Named)?` after a null check still dispatches the
     /// field/method on the underlying union. Returns `None` when `ty` isn't a
     /// (optionally-wrapped) union.
-    fn tir_union_members(ty: &Tir2Ty) -> Option<Vec<Tir2Ty>> {
+    fn tir_union_members(&self, ty: &Tir2Ty) -> Option<Vec<Tir2Ty>> {
         match ty {
             Tir2Ty::Union(members, _) => Some(members.clone()),
+            Tir2Ty::TypeAlias(qtn, _) if !self.resolved_aliases.recursive.contains(qtn) => self
+                .resolved_aliases
+                .aliases
+                .get(qtn)
+                .and_then(|target| self.tir_union_members(target)),
             _ => None,
         }
     }
@@ -12813,6 +12818,11 @@ impl LoweringContext<'_> {
             RuntimeTy::Function { .. } => Some(baml_type::typetag::FUNCTION),
             RuntimeTy::Future(..) => Some(baml_type::typetag::FUTURE),
             RuntimeTy::Type { .. } => Some(baml_type::typetag::TYPE),
+            // Reflection-kind classes describe the reconstructed type of an
+            // `Object::Type`; the physical value deliberately keeps the shared
+            // TYPE tag. They therefore require the structural matcher and may
+            // never enter class-tag switch dispatch.
+            RuntimeTy::Class(tn, _, _) if baml_type::type_kind::is_type_kind_class(tn) => None,
             RuntimeTy::Class(tn, _, _) => self.class_type_tags.get(tn).copied(),
             _ => None,
         }

--- a/baml_language/crates/baml_compiler2_ppir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/lib.rs
@@ -413,7 +413,7 @@ pub fn ppir_expansion_items(db: &dyn Db, file: SourceFile) -> PpirExpansionItems
                 // The same `<STREAM_EXPANDED, ORIGINAL>` pair is also passed as
                 // explicit call-site type args in every companion body below, so
                 // the stdlib reifies the types from its frame
-                // (`reflect.type_of<TStream/TFinal>()`) instead of a name-keyed
+                // (`type.of<TStream/TFinal>()`) instead of a name-keyed
                 // registry lookup. Explicit args lower through
                 // `lower_type_expr_in_ns` with the companion's own namespace
                 // context — bare in-namespace names resolve correctly, with

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -2768,7 +2768,7 @@ impl<'db> TypeInferenceBuilder<'db> {
                 // `!explicit_args_used`.)
                 //
                 // An uninferable parameter records `Ty::Error`, NOT `unknown`: erasing it to
-                // the top type is silent unsoundness (observable via `reflect.type_of<T>()`),
+                // the top type is silent unsoundness (observable via `type.of<T>()`),
                 // so the recorded arg stays a loud error rather than a compatible-with-anything
                 // sentinel (the diagnostic is emitted by the call-site inference).
                 let ty = bindings
@@ -10138,6 +10138,21 @@ impl<'db> TypeInferenceBuilder<'db> {
                 if !matches!(root_ty, Ty::Unknown { .. }) {
                     return self.infer_local_rooted_path(segments, expr_id, false);
                 }
+                // 3.5. BEP-066 keyword shorthands: a bare leading `reflect` is
+                //      `baml.reflect`, a bare leading `type` (the expression
+                //      path-head form, K-13) is `baml.type`. Deliberately last
+                //      before the error path: any user definition of the name
+                //      (a local, checked above; a user package, step 1; a user
+                //      class/enum, step 3) shadows the shorthand, which only
+                //      kicks in on a full resolution miss. Delegate entirely —
+                //      the aliased lookup owns the diagnostics for its misses
+                //      (including the I-9 removed-`reflect.type_of` message).
+                if matches!(segments[0].as_str(), "reflect" | "type") {
+                    let mut aliased: Vec<Name> = Vec::with_capacity(segments.len() + 1);
+                    aliased.push(Name::new("baml"));
+                    aliased.extend_from_slice(segments);
+                    return self.infer_multi_segment_path(&aliased, expr_id);
+                }
                 // 4. Truly unresolved — report error if not a known namespace/package name.
                 let is_dep_package = self
                     .res_ctx
@@ -10330,6 +10345,22 @@ impl<'db> TypeInferenceBuilder<'db> {
         match self.resolve_package_item(pkg_items, &item_path, expr_id) {
             Some(ty) => ty,
             None => {
+                // I-9 (BEP-066): `reflect.type_of` was *removed*, not aliased —
+                // name the replacement instead of a bare "unresolved name".
+                // Both spellings funnel here: the bare `reflect.type_of` (via
+                // the keyword-shorthand alias) and the explicit
+                // `baml.reflect.type_of`.
+                if pkg_name.as_str() == "baml"
+                    && item_path.len() == 2
+                    && item_path[0].as_str() == "reflect"
+                    && item_path[1].as_str() == "type_of"
+                {
+                    self.context
+                        .report_simple(TirTypeError::RemovedReflectTypeOf, expr_id);
+                    return Ty::Unknown {
+                        attr: TyAttr::default(),
+                    };
+                }
                 // Find the first invalid segment in the path.
                 // The path is [ns_0, ns_1, ..., ns_n, item].
                 // Check each prefix of the namespace path to find the first invalid segment.

--- a/baml_language/crates/baml_compiler2_tir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/builder.rs
@@ -28,7 +28,7 @@ use baml_compiler2_hir::{
 };
 // The trait must be in scope so the builder (which implements it) can call the
 // defaulted type-algebra methods on itself — `self.is_subtype(a, b)`.
-use baml_type::normalize::TypeContext;
+use baml_type::{normalize::TypeContext, type_kind::is_type_kind_class};
 use rustc_hash::{FxHashMap, FxHashSet};
 use text_size::TextRange;
 
@@ -6113,6 +6113,16 @@ impl<'db> TypeInferenceBuilder<'db> {
             }
             ty => ty,
         };
+        if let Ty::Class(class_name, _, _) = &ty
+            && is_type_kind_class(class_name)
+        {
+            self.context.report_simple(
+                TirTypeError::CannotConstructReflectionKind {
+                    class_name: class_name.clone(),
+                },
+                expr_id,
+            );
+        }
         self.validate_type_generic_bounds(expr_id, &ty);
         // Class spread is nominal and invariant: the source must be the same
         // resolved class with compatible generic arguments. Besides preventing
@@ -6260,6 +6270,16 @@ impl<'db> TypeInferenceBuilder<'db> {
             obj_type_args,
         ) {
             return inferred;
+        }
+        if let Ty::Class(class_name, _, _) = expected
+            && is_type_kind_class(class_name)
+        {
+            self.context.report_simple(
+                TirTypeError::CannotConstructReflectionKind {
+                    class_name: class_name.clone(),
+                },
+                expr_id,
+            );
         }
         self.validate_type_generic_bounds(expr_id, expected);
         if let Ty::Class(class_name, type_args, _) = expected {

--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -131,6 +131,10 @@ pub enum TirTypeError {
         field_name: Name,
         suggestions: Vec<Name>,
     },
+    /// Runtime reflection-kind classes are sealed VM views, not user data.
+    CannotConstructReflectionKind {
+        class_name: crate::ty::QualifiedTypeName,
+    },
     /// Unreachable code after a diverging statement (return/break/continue).
     DeadCode {
         after: StmtId,
@@ -891,6 +895,11 @@ impl fmt::Display for TirTypeError {
                     )
                 }
             }
+            TirTypeError::CannotConstructReflectionKind { class_name } => write!(
+                f,
+                "reflection kind `{}` cannot be constructed; obtain it from a type value",
+                class_name.render_user_facing()
+            ),
             TirTypeError::DeadCode {
                 unreachable_count, ..
             } => {

--- a/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/infer_context.rs
@@ -110,6 +110,10 @@ pub enum TirTypeError {
     UnionMemberNoCommonInterface { union: Ty, member: Name },
     /// Name could not be resolved at all.
     UnresolvedName { name: Name },
+    /// The removed `reflect.type_of` spelling (BEP-066 I-9): the intrinsic was
+    /// renamed to `type.of`, and the old name errors with the replacement
+    /// spelled out rather than a bare "unresolved name".
+    RemovedReflectTypeOf,
     /// A shorthand property (`{ name }`) could not resolve its implicit value.
     /// Suggestions are in-scope values with similar names; the diagnostic
     /// renders them as explicit `name: suggestion` mappings.
@@ -820,6 +824,12 @@ impl fmt::Display for TirTypeError {
             }
             TirTypeError::UnresolvedName { name } => {
                 write!(f, "unresolved name: {name}")
+            }
+            TirTypeError::RemovedReflectTypeOf => {
+                write!(
+                    f,
+                    "`reflect.type_of` was renamed to `type.of` (BEP-066): write `type.of<T>()`"
+                )
             }
             TirTypeError::UnresolvedPropertyShorthand { name, suggestions } => {
                 if suggestions.is_empty() {

--- a/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
@@ -341,6 +341,22 @@ pub(crate) fn resolve_type_in<'db>(
             None
         }
     });
+    // BEP-066 keyword shorthand in type position: a leading `reflect` resolves
+    // as `baml.reflect` (e.g. `reflect.Signature`, `reflect.InvalidArgumentError`
+    // in annotations and catch arms). Runs strictly after the user-name lookups
+    // above, so any user type/namespace spelled `reflect` shadows the shorthand.
+    // (`type` needs no arm here: a bare `type` is the primitive, and dotted
+    // `type.…` TYPE paths don't exist until the kind classes land.)
+    let resolved = resolved.or_else(|| {
+        if segments.len() >= 2 && segments[0].as_str() == "reflect" {
+            let pkg_id = PackageId::new(db, baml_base::Name::new("baml"));
+            let pkg = baml_compiler2_ppir::package_items(db, pkg_id);
+            let ns: Vec<baml_base::Name> = segments[..segments.len() - 1].to_vec();
+            pkg.lookup_type(&ns, item)
+        } else {
+            None
+        }
+    });
     resolved.or_else(|| {
         let base = item.as_str().strip_suffix("$stream")?;
         let base_name = baml_base::Name::new(base);

--- a/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/lower_type_expr.rs
@@ -3,7 +3,7 @@
 use baml_compiler2_ast::{TypeExpr, TypeExprKind};
 use baml_compiler2_hir::{
     contributions::Definition,
-    package::{PackageId, PackageItems},
+    package::{PackageId, PackageItems, package_dependencies},
 };
 use rustc_hash::FxHashSet;
 
@@ -349,6 +349,14 @@ pub(crate) fn resolve_type_in<'db>(
     // `type.…` TYPE paths don't exist until the kind classes land.)
     let resolved = resolved.or_else(|| {
         if segments.len() >= 2 && segments[0].as_str() == "reflect" {
+            let owner_pkg = PackageId::new(db, package_items.package.clone());
+            let can_access_baml = package_items.package.as_str() == "baml"
+                || package_dependencies(db, owner_pkg)
+                    .iter()
+                    .any(|dep| dep.name(db).as_str() == "baml");
+            if !can_access_baml {
+                return None;
+            }
             let pkg_id = PackageId::new(db, baml_base::Name::new("baml"));
             let pkg = baml_compiler2_ppir::package_items(db, pkg_id);
             let ns: Vec<baml_base::Name> = segments[..segments.len() - 1].to_vec();

--- a/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
@@ -636,10 +636,16 @@ impl<'db> PackageResolutionContext<'db> {
         // `baml.reflect`. Strictly after every user lookup above, so any
         // user-defined `reflect` shadows the shorthand.
         if path.len() >= 2 && path[0].as_str() == "reflect" && self.can_access_baml_package() {
-            let baml_items =
-                baml_compiler2_ppir::package_items(db, PackageId::new(db, Name::new("baml")));
-            if let Some(def) = baml_items.lookup_type(&path[..path.len() - 1], item) {
-                return Some((ResolvedSource::Builtin, def_to_ty(db, def)));
+            let namespace = &path[..path.len() - 1];
+            if self.own_package_name.as_str() == "baml" {
+                if let Some(def) = self.own_items.lookup_type(namespace, item) {
+                    return Some((ResolvedSource::Builtin, def_to_ty(db, def)));
+                }
+            } else if let Some(exported) = self
+                .baml_dependency_interface()
+                .and_then(|interface| interface.lookup_type(namespace, item))
+            {
+                return Some((ResolvedSource::Builtin, exported.to_ty()));
             }
         }
 
@@ -651,11 +657,14 @@ impl<'db> PackageResolutionContext<'db> {
     /// BEP-066 keyword shorthands (`reflect` ≡ `baml.reflect`, `type` ≡
     /// `baml.type`) to resolve.
     fn can_access_baml_package(&self) -> bool {
-        self.own_package_name.as_str() == "baml"
-            || self
-                .dep_interfaces
-                .iter()
-                .any(|(n, _)| n.as_str() == "baml")
+        self.own_package_name.as_str() == "baml" || self.baml_dependency_interface().is_some()
+    }
+
+    fn baml_dependency_interface(&self) -> Option<&PackageInterface> {
+        self.dep_interfaces
+            .iter()
+            .find(|(name, _)| name.as_str() == "baml")
+            .map(|(_, interface)| interface)
     }
 
     fn resolve_type_in_own_then_deps(
@@ -728,9 +737,21 @@ impl<'db> PackageResolutionContext<'db> {
             && matches!(path[0].as_str(), "reflect" | "type")
             && self.can_access_baml_package()
         {
+            let namespace = &path[..path.len() - 1];
+            if self.own_package_name.as_str() != "baml"
+                && self
+                    .baml_dependency_interface()
+                    .and_then(|interface| interface.lookup_function(namespace, item))
+                    .is_none()
+            {
+                return None;
+            }
+            // Value consumers still need the source-backed `Definition` loc.
+            // The interface lookup above is the visibility gate; raw items are
+            // consulted only to materialize a function already proven exported.
             let baml_items =
                 baml_compiler2_ppir::package_items(db, PackageId::new(db, Name::new("baml")));
-            if let Some(def) = baml_items.lookup_value(&path[..path.len() - 1], item) {
+            if let Some(def) = baml_items.lookup_value(namespace, item) {
                 return Some((ResolvedSource::Builtin, def));
             }
         }

--- a/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
@@ -632,7 +632,30 @@ impl<'db> PackageResolutionContext<'db> {
             }
         }
 
+        // BEP-066 keyword shorthand: a leading `reflect` resolves as
+        // `baml.reflect`. Strictly after every user lookup above, so any
+        // user-defined `reflect` shadows the shorthand.
+        if path.len() >= 2 && path[0].as_str() == "reflect" && self.can_access_baml_package() {
+            let baml_items =
+                baml_compiler2_ppir::package_items(db, PackageId::new(db, Name::new("baml")));
+            if let Some(def) = baml_items.lookup_type(&path[..path.len() - 1], item) {
+                return Some((ResolvedSource::Builtin, def_to_ty(db, def)));
+            }
+        }
+
         None
+    }
+
+    /// Whether the `baml` package's items are visible from this package (it is
+    /// the own package or a declared dependency) — the precondition for the
+    /// BEP-066 keyword shorthands (`reflect` ≡ `baml.reflect`, `type` ≡
+    /// `baml.type`) to resolve.
+    fn can_access_baml_package(&self) -> bool {
+        self.own_package_name.as_str() == "baml"
+            || self
+                .dep_interfaces
+                .iter()
+                .any(|(n, _)| n.as_str() == "baml")
     }
 
     fn resolve_type_in_own_then_deps(
@@ -694,6 +717,21 @@ impl<'db> PackageResolutionContext<'db> {
                         return Some((ResolvedSource::Builtin, def));
                     }
                 }
+            }
+        }
+
+        // BEP-066 keyword shorthands: a leading `reflect` resolves as
+        // `baml.reflect`, a leading `type` (the `type.of` / `type.of_value`
+        // expression form, K-13) as `baml.type`. Strictly after every user
+        // lookup above, so any user-defined name shadows the shorthand.
+        if path.len() >= 2
+            && matches!(path[0].as_str(), "reflect" | "type")
+            && self.can_access_baml_package()
+        {
+            let baml_items =
+                baml_compiler2_ppir::package_items(db, PackageId::new(db, Name::new("baml")));
+            if let Some(def) = baml_items.lookup_value(&path[..path.len() - 1], item) {
+                return Some((ResolvedSource::Builtin, def));
             }
         }
         None

--- a/baml_language/crates/baml_compiler2_tir/src/resolve.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/resolve.rs
@@ -173,16 +173,27 @@ pub fn resolve_path_at<'db>(
     let own_pkg_id = PackageId::new(db, pkg_info.package);
     let res_ctx = crate::package_interface::package_resolution_context(db, own_pkg_id);
 
+    // BEP-066 keyword shorthands: when the head is no accessible package but
+    // spells `reflect` or `type`, the path resolves inside `baml` with the
+    // head as a namespace segment (`reflect.signature` ≡ `baml.reflect.signature`,
+    // `type.of` ≡ `baml.type.of`). A real package of that name wins above.
+    let (pkg_name, ns_head): (Name, &[Name]) = if res_ctx.items_for_package(db, &pkg_name).is_some()
+    {
+        (pkg_name, &segments[1..])
+    } else if matches!(segments[0].as_str(), "reflect" | "type") {
+        (Name::new("baml"), segments)
+    } else {
+        return ResolvedName::Unknown;
+    };
     let Some(pkg_items) = res_ctx.items_for_package(db, &pkg_name) else {
         return ResolvedName::Unknown;
     };
 
-    let after_pkg = &segments[1..];
     // The path already includes namespace segments, so look up directly.
-    let item = after_pkg
+    let item = ns_head
         .last()
         .expect("multi-segment path has elements after pkg prefix");
-    let ns = &after_pkg[..after_pkg.len() - 1];
+    let ns = &ns_head[..ns_head.len() - 1];
     if let Some(def) = pkg_items.lookup_value(ns, item) {
         return ResolvedName::Builtin(def);
     }
@@ -212,17 +223,25 @@ pub fn resolve_namespace_prefix(
     let res_ctx = crate::package_interface::package_resolution_context(db, own_pkg_id);
 
     // Segment 0 is a package: `root` is the file's own package; anything else is
-    // a literal package name.
+    // a literal package name. The BEP-066 keyword shorthands `reflect` / `type`
+    // name namespaces of `baml` (a real package of that name wins).
     let pkg_name = if first.as_str() == "root" {
         res_ctx.own_package_name.clone()
     } else {
         first.clone()
     };
+    let (pkg_name, ns_prefix): (Name, &[Name]) =
+        if res_ctx.items_for_package(db, &pkg_name).is_some() {
+            (pkg_name, &segments[1..])
+        } else if matches!(first.as_str(), "reflect" | "type") {
+            (Name::new("baml"), segments)
+        } else {
+            return None;
+        };
     let pkg_items = res_ctx.items_for_package(db, &pkg_name)?;
 
     // The remaining segments must be a (possibly empty) prefix of a real
     // namespace path in that package. Empty = the package root itself.
-    let ns_prefix = &segments[1..];
     let is_namespace = ns_prefix.is_empty()
         || pkg_items
             .namespaces

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -8367,6 +8367,47 @@ mod tests {
         );
     }
 
+    /// BEP-066 K-13 (M-9): `type` as an expression path head. `type` is a
+    /// contextual keyword, so in expression position `type.of<int>()` /
+    /// `type.of_value(x)` parse as ordinary member-call paths (a `Word` head);
+    /// no dedicated lookahead is needed because the type-alias form only
+    /// dispatches at the top level, where expressions cannot occur.
+    #[test]
+    fn type_as_expression_path_head_parses() {
+        let source = "function main() -> string {\n  let t = type.of<int>();\n  let u = type.of_value(1);\n  type.of<int[]>();\n  t.to_string()\n}\n";
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+        // The heads lower as plain path segments: WORD("type") followed by DOT.
+        let type_head_paths = root
+            .descendants_with_tokens()
+            .filter(|elem| {
+                matches!(
+                    elem,
+                    rowan::NodeOrToken::Token(t) if t.kind() == SyntaxKind::WORD
+                        && t.text() == "type"
+                )
+            })
+            .count();
+        assert_eq!(type_head_paths, 3, "all three `type.` heads parse as words");
+    }
+
+    /// The `type.of` expression form must not steal top-level `type X = ...`
+    /// alias declarations (their dispatch is unchanged).
+    #[test]
+    fn type_alias_declarations_unaffected_by_type_of() {
+        let source =
+            "type MyAlias = int | string\nfunction main() -> type {\n  type.of<MyAlias>()\n}\n";
+        let (root, errors) = parse_source(source);
+        assert_no_errors(&errors);
+        let has_alias = root
+            .descendants()
+            .any(|n| n.kind() == SyntaxKind::TYPE_ALIAS_DEF);
+        assert!(
+            has_alias,
+            "top-level `type X = ...` still parses as an alias"
+        );
+    }
+
     /// Parsing must stay lossless: the original source — shebang included —
     /// reconstructs exactly from the syntax tree. If `baml fmt` ever dropped
     /// or moved the shebang, the file would stop being executable.

--- a/baml_language/crates/baml_compiler_parser/src/parser.rs
+++ b/baml_language/crates/baml_compiler_parser/src/parser.rs
@@ -508,11 +508,13 @@ impl<'a> Parser<'a> {
 
     /// True when the current token can serve as a member name after `.`.
     ///
-    /// `interface`/`implements`/`extends` are keywords for declarations but
-    /// remain valid as member names — e.g. `dog_t.implements(animal_t)` on the
-    /// reflection `type` value.
+    /// Declaration keywords remain valid as member names — e.g.
+    /// `dog_t.implements(animal_t)` on the reflection `type` value.
     fn at_member_name(&self) -> bool {
         self.at(TokenKind::Word)
+            || self.at(TokenKind::Class)
+            || self.at(TokenKind::Enum)
+            || self.at(TokenKind::Function)
             || self.at(TokenKind::Implements)
             || self.at(TokenKind::Implement)
             || self.at(TokenKind::Extends)
@@ -3108,6 +3110,10 @@ impl<'a> Parser<'a> {
                 if self.at(TokenKind::Word)
                     || self.at(TokenKind::Spawn)
                     || self.at(TokenKind::Await)
+                    || self.at(TokenKind::Class)
+                    || self.at(TokenKind::Enum)
+                    || self.at(TokenKind::Interface)
+                    || self.at(TokenKind::Function)
                 {
                     self.bump(); // next segment
                 } else {
@@ -5290,7 +5296,18 @@ impl<'a> Parser<'a> {
             match self.tokens[idx].kind {
                 TokenKind::Dot => {
                     let next = self.skip_trivia_and_comments_from(idx + 1);
-                    if next < self.tokens.len() && self.tokens[next].kind == TokenKind::Word {
+                    if next < self.tokens.len()
+                        && matches!(
+                            self.tokens[next].kind,
+                            TokenKind::Word
+                                | TokenKind::Spawn
+                                | TokenKind::Await
+                                | TokenKind::Class
+                                | TokenKind::Enum
+                                | TokenKind::Interface
+                                | TokenKind::Function
+                        )
+                    {
                         idx = self.skip_trivia_and_comments_from(next + 1);
                     } else {
                         return false;
@@ -5365,7 +5382,11 @@ impl<'a> Parser<'a> {
                 // args (`foo<baml.spawn.SpawnParams<T, E>>(x)`), mirroring
                 // the type-path parser's segment set.
                 | TokenKind::Spawn
-                | TokenKind::Await => {}
+                | TokenKind::Await
+                | TokenKind::Class
+                | TokenKind::Enum
+                | TokenKind::Interface
+                | TokenKind::Function => {}
                 _ => return None,
             }
             i = self.skip_trivia_and_comments_from(i + 1);
@@ -5457,7 +5478,20 @@ impl<'a> Parser<'a> {
             return;
         }
         self.bump(); // first WORD
-        while self.at(TokenKind::Dot) && self.peek(1).map(|t| t.kind) == Some(TokenKind::Word) {
+        while self.at(TokenKind::Dot)
+            && self.peek(1).is_some_and(|t| {
+                matches!(
+                    t.kind,
+                    TokenKind::Word
+                        | TokenKind::Spawn
+                        | TokenKind::Await
+                        | TokenKind::Class
+                        | TokenKind::Enum
+                        | TokenKind::Interface
+                        | TokenKind::Function
+                )
+            })
+        {
             self.bump(); // .
             self.bump(); // WORD
         }
@@ -6856,7 +6890,11 @@ impl<'a> Parser<'a> {
                 // args (`foo<baml.spawn.SpawnParams<T, E>>(x)`), mirroring
                 // the type-path parser's segment set.
                 | TokenKind::Spawn
-                | TokenKind::Await => {}
+                | TokenKind::Await
+                | TokenKind::Class
+                | TokenKind::Enum
+                | TokenKind::Interface
+                | TokenKind::Function => {}
                 // Anything else — operators, braces, EOF-ish tokens — can't
                 // appear in a type, so this `<` is a comparison.
                 _ => return false,
@@ -7331,7 +7369,14 @@ impl<'a> Parser<'a> {
         let segment = |k: TokenKind| {
             matches!(
                 k,
-                TokenKind::Word | TokenKind::Client | TokenKind::Spawn | TokenKind::Await
+                TokenKind::Word
+                    | TokenKind::Client
+                    | TokenKind::Spawn
+                    | TokenKind::Await
+                    | TokenKind::Class
+                    | TokenKind::Enum
+                    | TokenKind::Interface
+                    | TokenKind::Function
             )
         };
 
@@ -7376,7 +7421,21 @@ impl<'a> Parser<'a> {
                 while p.at(TokenKind::Dot) {
                     shorthand_candidate = false;
                     p.bump();
-                    if !p.expect(TokenKind::Word) {
+                    if p.current().is_some_and(|t| {
+                        matches!(
+                            t.kind,
+                            TokenKind::Word
+                                | TokenKind::Spawn
+                                | TokenKind::Await
+                                | TokenKind::Class
+                                | TokenKind::Enum
+                                | TokenKind::Interface
+                                | TokenKind::Function
+                        )
+                    }) {
+                        p.bump();
+                    } else {
+                        p.error_unexpected_token("map key segment after '.'".to_string());
                         return;
                     }
                 }
@@ -12621,5 +12680,48 @@ function iterate(items: int[]) -> int {
                 .any(|node| node.kind() == SyntaxKind::BLOCK_EXPR),
             "the final brace must remain the loop body"
         );
+    }
+
+    #[test]
+    fn reflection_keyword_segments_parse_in_types_and_expressions() {
+        let source = r#"
+class KeywordKinds {
+    class_kind reflect.class.Type
+    enum_kind reflect.enum.Type
+    interface_kind reflect.interface.Type
+    function_kind reflect.function.Type
+}
+
+function class_kind_value() -> reflect.class.Type {
+    reflect.class.Type
+}
+
+function enum_kind_value() -> reflect.enum.Type {
+    reflect.enum.Type
+}
+
+function interface_kind_value() -> reflect.interface.Type {
+    reflect.interface.Type
+}
+
+function function_kind_value() -> reflect.function.Type {
+    reflect.function.Type
+}
+"#;
+        let (_, errors) = parse_source(source);
+        assert_no_errors(&errors);
+    }
+
+    #[test]
+    fn reflection_segment_keywords_remain_invalid_as_bare_expressions() {
+        for keyword in ["class", "enum", "interface", "function"] {
+            let source =
+                format!("function main() -> int {{\n    let value = {keyword};\n    1\n}}");
+            let (_, errors) = parse_source(&source);
+            assert!(
+                !errors.is_empty(),
+                "reserved keyword {keyword:?} unexpectedly parsed as a bare identifier"
+            );
+        }
     }
 }

--- a/baml_language/crates/baml_compiler_syntax/src/ast.rs
+++ b/baml_language/crates/baml_compiler_syntax/src/ast.rs
@@ -6,7 +6,8 @@ use crate::{SyntaxElement, SyntaxKind, SyntaxNode, SyntaxToken};
 
 /// Extract a dotted name from a token sequence (e.g., `baml.http.Request` → `"baml.http.Request"`).
 ///
-/// Finds the first WORD token, then consumes alternating DOT + WORD pairs.
+/// Finds the first WORD token, then consumes alternating DOT + identifier
+/// segments. Declaration keywords are identifiers only after a dot.
 fn extract_dotted_name<'a>(tokens: impl Iterator<Item = &'a SyntaxToken>) -> Option<String> {
     let mut parts = Vec::new();
     let mut iter = tokens.filter(|t| !t.kind().is_trivia());
@@ -21,9 +22,8 @@ fn extract_dotted_name<'a>(tokens: impl Iterator<Item = &'a SyntaxToken>) -> Opt
     };
     parts.push(first.text().to_string());
 
-    // Consume alternating DOT + WORD. `spawn`/`await` are reserved keywords
-    // but valid as namespace segments after a `.` (e.g. `baml.spawn.SpawnParams`
-    // in a type annotation), mirroring the parser's segment set.
+    // Consume alternating DOT + identifier segments, mirroring the parser's
+    // qualified-name carve-out.
     while let Some(t) = iter.next() {
         if t.kind() != SyntaxKind::DOT {
             break;
@@ -31,7 +31,13 @@ fn extract_dotted_name<'a>(tokens: impl Iterator<Item = &'a SyntaxToken>) -> Opt
         let Some(word) = iter.next() else { break };
         if !matches!(
             word.kind(),
-            SyntaxKind::WORD | SyntaxKind::KW_SPAWN | SyntaxKind::KW_AWAIT
+            SyntaxKind::WORD
+                | SyntaxKind::KW_SPAWN
+                | SyntaxKind::KW_AWAIT
+                | SyntaxKind::KW_CLASS
+                | SyntaxKind::KW_ENUM
+                | SyntaxKind::KW_INTERFACE
+                | SyntaxKind::KW_FUNCTION
         ) {
             break;
         }
@@ -251,7 +257,19 @@ impl UnionMemberParts {
         let name: Vec<_> = self
             .tokens
             .iter()
-            .take_while(|t| matches!(t.kind(), SyntaxKind::WORD | SyntaxKind::DOT))
+            .take_while(|t| {
+                matches!(
+                    t.kind(),
+                    SyntaxKind::WORD
+                        | SyntaxKind::DOT
+                        | SyntaxKind::KW_SPAWN
+                        | SyntaxKind::KW_AWAIT
+                        | SyntaxKind::KW_CLASS
+                        | SyntaxKind::KW_ENUM
+                        | SyntaxKind::KW_INTERFACE
+                        | SyntaxKind::KW_FUNCTION
+                )
+            })
             .collect();
         if let (Some(first), Some(last)) = (name.first(), name.last()) {
             return Some(rowan::TextRange::new(

--- a/baml_language/crates/baml_fmt/src/ast/expressions.rs
+++ b/baml_language/crates/baml_fmt/src/ast/expressions.rs
@@ -509,7 +509,14 @@ pub struct PathExpr {
 fn is_path_segment_kind(kind: SyntaxKind) -> bool {
     matches!(
         kind,
-        SyntaxKind::WORD | SyntaxKind::KW_CLIENT | SyntaxKind::KW_SPAWN | SyntaxKind::KW_AWAIT
+        SyntaxKind::WORD
+            | SyntaxKind::KW_CLIENT
+            | SyntaxKind::KW_SPAWN
+            | SyntaxKind::KW_AWAIT
+            | SyntaxKind::KW_CLASS
+            | SyntaxKind::KW_ENUM
+            | SyntaxKind::KW_INTERFACE
+            | SyntaxKind::KW_FUNCTION
     )
 }
 

--- a/baml_language/crates/baml_fmt/src/ast/types.rs
+++ b/baml_language/crates/baml_fmt/src/ast/types.rs
@@ -583,7 +583,25 @@ impl UnionTypeMember {
                 let mut rest = Vec::new();
                 while let Some(dot) = it.next_if_kind(SyntaxKind::DOT) {
                     let dot = t::Dot::from_cst(dot)?;
-                    let word: t::Word = it.expect_parse()?;
+                    let segment = it.expect_next("type path segment after `.`")?;
+                    let token = StrongAstError::assert_is_token(segment)?;
+                    if !matches!(
+                        token.kind(),
+                        SyntaxKind::WORD
+                            | SyntaxKind::KW_SPAWN
+                            | SyntaxKind::KW_AWAIT
+                            | SyntaxKind::KW_CLASS
+                            | SyntaxKind::KW_ENUM
+                            | SyntaxKind::KW_INTERFACE
+                            | SyntaxKind::KW_FUNCTION
+                    ) {
+                        return Err(StrongAstError::UnexpectedKindDesc {
+                            expected_desc: "type path segment".into(),
+                            found: token.kind(),
+                            at: token.text_range(),
+                        });
+                    }
+                    let word = t::Word::new_from_span(token.text_range());
                     rest.push((dot, word));
                 }
                 Ok(UnionTypeMember::Path(PathType { first, rest }))

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -1951,9 +1951,12 @@ fn tir_type_error_to_diagnostic_id(
             DiagnosticId::NoSuchField
         }
         TirTypeError::UnknownClassPropertyShorthand { .. } => DiagnosticId::NoSuchField,
-        TirTypeError::UnresolvedName { .. } | TirTypeError::UnresolvedPropertyShorthand { .. } => {
-            DiagnosticId::UnknownVariable
-        }
+        TirTypeError::UnresolvedName { .. }
+        | TirTypeError::UnresolvedPropertyShorthand { .. }
+        // The removed `reflect.type_of` spelling (BEP-066 I-9) is a
+        // name-resolution failure whose message names the `type.of`
+        // replacement — same id as a plain unresolved name.
+        | TirTypeError::RemovedReflectTypeOf => DiagnosticId::UnknownVariable,
         TirTypeError::DeadCode { .. } => DiagnosticId::UnreachableCode,
         TirTypeError::VoidUsedAsValue => DiagnosticId::TypeMismatch,
         TirTypeError::VoidFunctionResultUsed => DiagnosticId::TypeMismatch,

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -1951,6 +1951,7 @@ fn tir_type_error_to_diagnostic_id(
             DiagnosticId::NoSuchField
         }
         TirTypeError::UnknownClassPropertyShorthand { .. } => DiagnosticId::NoSuchField,
+        TirTypeError::CannotConstructReflectionKind { .. } => DiagnosticId::TypeMismatch,
         TirTypeError::UnresolvedName { .. }
         | TirTypeError::UnresolvedPropertyShorthand { .. }
         // The removed `reflect.type_of` spelling (BEP-066 I-9) is a

--- a/baml_language/crates/baml_lsp2_actions/src/completions.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/completions.rs
@@ -830,14 +830,24 @@ fn completions_for_package_path(
     let own_pkg_id = PackageId::new(db, pkg_info.package);
     let res_ctx = baml_compiler2_tir::package_interface::package_resolution_context(db, own_pkg_id);
 
-    // Check if the first segment is a known package name.
+    // Check if the first segment is a known package name. The BEP-066 keyword
+    // shorthands (`reflect.` ≡ `baml.reflect.`, `type.` ≡ `baml.type.`)
+    // complete as the `baml` namespaces they alias; a real package of that
+    // name wins.
     let first_segment = Name::new(&segments[0]);
-    let pkg_items = res_ctx.items_for_package(db, &first_segment)?;
+    let (pkg_items, namespace_path): (_, Vec<Name>) =
+        match res_ctx.items_for_package(db, &first_segment) {
+            Some(items) => (items, segments[1..].iter().map(Name::new).collect()),
+            None if matches!(segments[0].as_str(), "reflect" | "type") => {
+                let baml_items = res_ctx.items_for_package(db, &Name::new("baml"))?;
+                (baml_items, segments.iter().map(Name::new).collect())
+            }
+            None => return None,
+        };
 
     // The namespace path within the package.
     // For `baml.` we have segments=["baml"], so namespace_path=[].
     // For `baml.events.` we have segments=["baml", "events"], so namespace_path=["events"].
-    let namespace_path: Vec<Name> = segments[1..].iter().map(Name::new).collect();
 
     let mut items = Vec::new();
     let mut seen = std::collections::HashSet::new();
@@ -1479,7 +1489,7 @@ fn completions_for_value_position(
         }
     }
 
-    // ── Accessible package roots (`baml`, `reflect`, `log`, etc.) ─────────────
+    // ── Accessible package roots (`baml`, `log`, etc.) ────────────────────────
     for package_name in crate::listing::non_user_package_names(db) {
         items.push(
             Completion::new(package_name.as_str(), CompletionKind::Module)
@@ -1487,6 +1497,15 @@ fn completions_for_value_position(
                 .with_sort(format!("{:03}_{}", sort_prefix + 500, package_name)),
         );
     }
+    // The BEP-066 keyword shorthand `reflect` (≡ `baml.reflect`) completes like
+    // a package root even though it is a namespace of `baml`. (`type` is not
+    // offered bare: as an expression head it only carries `of`/`of_value`, and
+    // a bare `type` completion would collide with the primitive type name.)
+    items.push(
+        Completion::new("reflect", CompletionKind::Module)
+            .with_detail("baml.reflect")
+            .with_sort(format!("{:03}_reflect", sort_prefix + 500)),
+    );
 
     // ── Package-level values (functions, template strings, clients) ───────────
     let pkg_info = baml_compiler2_hir::file_package::file_package(db, file);

--- a/baml_language/crates/baml_lsp2_actions/src/completions_tests.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/completions_tests.rs
@@ -598,7 +598,7 @@ function Test() -> string {
         );
         assert!(
             labels.contains(&"reflect"),
-            "Should contain 'reflect' package root, got: {labels:?}"
+            "Should contain the 'reflect' shorthand (baml.reflect, BEP-066), got: {labels:?}"
         );
     }
 

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/semantic_tokens/interfaces_inferred_generic_type_args.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/semantic_tokens/interfaces_inferred_generic_type_args.baml
@@ -4,7 +4,7 @@
 // must carry the correct runtime `class_type_args`, and a method dispatched
 // through a multi-implementor interface must receive the resolved
 // class/interface type args in its frame. Without this, a method body that
-// reads its enclosing `T` at runtime — `reflect.type_of<T>()`, or constructing
+// reads its enclosing `T` at runtime — `type.of<T>()`, or constructing
 // `Other<T>{}` — resolves `T` to `unknown`; the new instance gets empty
 // `class_type_args`; and the runtime `IsType` dispatch guard falls through to
 // the WRONG implementor (a silent wrong answer, or a field-access panic when
@@ -184,7 +184,7 @@ test "inferred_static_ctor_dispatches_through_generic_interface" {
 interface Named<T> {
   function first(self) -> T throws unknown
   function tname(self) -> string throws never {
-    return reflect.type_of<T>().to_string()
+    return type.of<T>().to_string()
   }
 }
 
@@ -269,7 +269,7 @@ test "class_method_builds_generic_via_class_type_var" {
 
 interface Counter<T> {
   function element_type(self) -> string throws never {
-    return reflect.type_of<T>().to_string()
+    return type.of<T>().to_string()
   }
   function describe(self) -> string throws never
 }
@@ -307,7 +307,7 @@ test "default_method_forward_reads_interface_type_var" {
 // The interface request pins no type args (it has none), so the dispatch guard
 // is `Any` and can't name the implementor's class args statically. The matched
 // runtime instance still carries them, so the dispatched class-owned method
-// must resolve its class `T` (here via `reflect.type_of<T>()`).
+// must resolve its class `T` (here via `type.of<T>()`).
 
 interface Describable {
   function describe(self) -> string throws never
@@ -317,7 +317,7 @@ class TypedBox<T> {
     value: T,
     implements Describable {
         function describe(self) -> string {
-            return reflect.type_of<T>().to_string();
+            return type.of<T>().to_string();
         }
     }
 }
@@ -356,7 +356,7 @@ test "generic_class_behind_nongeneric_interface_reads_type_var" {
 // ═══════════════════════════════════════════════════════════════════════════
 
 function free_fn_tname<T>(a: T[]) -> string {
-    return reflect.type_of<T>().to_string();
+    return type.of<T>().to_string();
 }
 
 function free_fn_inferred_t() -> string {
@@ -460,7 +460,7 @@ test "inferred_ctor_default_method_collects_all" {
 // to `unknown` (the unseeded status quo), not lower `Self` to `void`.
 
 function echo_type<T>(a: T) -> string {
-    return reflect.type_of<T>().to_string();
+    return type.of<T>().to_string();
 }
 
 interface SelfEcho {
@@ -510,7 +510,7 @@ interface TypeProbe {
 class ProbeA {
     implements TypeProbe {
         function seen<U>(self, value: U) -> string {
-            return reflect.type_of<U>().to_string();
+            return type.of<U>().to_string();
         }
     }
 }
@@ -544,7 +544,7 @@ test "interface_dispatch_sees_inferred_method_type_arg" {
 // interfaces_inferred_generic_type_args.baml:4:1 (comment) len=76 "// must carry the correct runtime `class_type_args`, and a method dispatched"
 // interfaces_inferred_generic_type_args.baml:5:1 (comment) len=66 "// through a multi-implementor interface must receive the resolved"
 // interfaces_inferred_generic_type_args.baml:6:1 (comment) len=75 "// class/interface type args in its frame. Without this, a method body that"
-// interfaces_inferred_generic_type_args.baml:7:1 (comment) len=81 "// reads its enclosing `T` at runtime — `reflect.type_of<T>()`, or constructing"
+// interfaces_inferred_generic_type_args.baml:7:1 (comment) len=73 "// reads its enclosing `T` at runtime — `type.of<T>()`, or constructing"
 // interfaces_inferred_generic_type_args.baml:8:1 (comment) len=74 "// `Other<T>{}` — resolves `T` to `unknown`; the new instance gets empty"
 // interfaces_inferred_generic_type_args.baml:9:1 (comment) len=78 "// `class_type_args`; and the runtime `IsType` dispatch guard falls through to"
 // interfaces_inferred_generic_type_args.baml:10:1 (comment) len=77 "// the WRONG implementor (a silent wrong answer, or a field-access panic when"
@@ -908,13 +908,13 @@ test "interface_dispatch_sees_inferred_method_type_arg" {
 // interfaces_inferred_generic_type_args.baml:186:34 (keyword) len=6 "throws"
 // interfaces_inferred_generic_type_args.baml:186:41 (type) [defaultLibrary] len=5 "never"
 // interfaces_inferred_generic_type_args.baml:187:5 (keyword) len=6 "return"
-// interfaces_inferred_generic_type_args.baml:187:12 (namespace) [defaultLibrary] len=7 "reflect"
-// interfaces_inferred_generic_type_args.baml:187:19 (namespace) [defaultLibrary] len=1 "."
-// interfaces_inferred_generic_type_args.baml:187:20 (function) len=7 "type_of"
-// interfaces_inferred_generic_type_args.baml:187:27 (operator) len=1 "<"
-// interfaces_inferred_generic_type_args.baml:187:28 (type) len=1 "T"
-// interfaces_inferred_generic_type_args.baml:187:29 (operator) len=1 ">"
-// interfaces_inferred_generic_type_args.baml:187:33 (method) len=9 "to_string"
+// interfaces_inferred_generic_type_args.baml:187:12 (namespace) [defaultLibrary] len=4 "type"
+// interfaces_inferred_generic_type_args.baml:187:16 (namespace) [defaultLibrary] len=1 "."
+// interfaces_inferred_generic_type_args.baml:187:17 (function) len=2 "of"
+// interfaces_inferred_generic_type_args.baml:187:19 (operator) len=1 "<"
+// interfaces_inferred_generic_type_args.baml:187:20 (type) len=1 "T"
+// interfaces_inferred_generic_type_args.baml:187:21 (operator) len=1 ">"
+// interfaces_inferred_generic_type_args.baml:187:25 (method) len=9 "to_string"
 // interfaces_inferred_generic_type_args.baml:191:1 (keyword) len=5 "class"
 // interfaces_inferred_generic_type_args.baml:191:7 (class) [declaration] len=8 "ArrNamed"
 // interfaces_inferred_generic_type_args.baml:191:15 (operator) len=1 "<"
@@ -1128,13 +1128,13 @@ test "interface_dispatch_sees_inferred_method_type_arg" {
 // interfaces_inferred_generic_type_args.baml:271:41 (keyword) len=6 "throws"
 // interfaces_inferred_generic_type_args.baml:271:48 (type) [defaultLibrary] len=5 "never"
 // interfaces_inferred_generic_type_args.baml:272:5 (keyword) len=6 "return"
-// interfaces_inferred_generic_type_args.baml:272:12 (namespace) [defaultLibrary] len=7 "reflect"
-// interfaces_inferred_generic_type_args.baml:272:19 (namespace) [defaultLibrary] len=1 "."
-// interfaces_inferred_generic_type_args.baml:272:20 (function) len=7 "type_of"
-// interfaces_inferred_generic_type_args.baml:272:27 (operator) len=1 "<"
-// interfaces_inferred_generic_type_args.baml:272:28 (type) len=1 "T"
-// interfaces_inferred_generic_type_args.baml:272:29 (operator) len=1 ">"
-// interfaces_inferred_generic_type_args.baml:272:33 (method) len=9 "to_string"
+// interfaces_inferred_generic_type_args.baml:272:12 (namespace) [defaultLibrary] len=4 "type"
+// interfaces_inferred_generic_type_args.baml:272:16 (namespace) [defaultLibrary] len=1 "."
+// interfaces_inferred_generic_type_args.baml:272:17 (function) len=2 "of"
+// interfaces_inferred_generic_type_args.baml:272:19 (operator) len=1 "<"
+// interfaces_inferred_generic_type_args.baml:272:20 (type) len=1 "T"
+// interfaces_inferred_generic_type_args.baml:272:21 (operator) len=1 ">"
+// interfaces_inferred_generic_type_args.baml:272:25 (method) len=9 "to_string"
 // interfaces_inferred_generic_type_args.baml:274:3 (keyword) len=8 "function"
 // interfaces_inferred_generic_type_args.baml:274:12 (method) [declaration] len=8 "describe"
 // interfaces_inferred_generic_type_args.baml:274:21 (parameter) [declaration] len=4 "self"
@@ -1208,7 +1208,7 @@ test "interface_dispatch_sees_inferred_method_type_arg" {
 // interfaces_inferred_generic_type_args.baml:307:1 (comment) len=79 "// The interface request pins no type args (it has none), so the dispatch guard"
 // interfaces_inferred_generic_type_args.baml:308:1 (comment) len=79 "// is `Any` and can't name the implementor's class args statically. The matched"
 // interfaces_inferred_generic_type_args.baml:309:1 (comment) len=76 "// runtime instance still carries them, so the dispatched class-owned method"
-// interfaces_inferred_generic_type_args.baml:310:1 (comment) len=64 "// must resolve its class `T` (here via `reflect.type_of<T>()`)."
+// interfaces_inferred_generic_type_args.baml:310:1 (comment) len=56 "// must resolve its class `T` (here via `type.of<T>()`)."
 // interfaces_inferred_generic_type_args.baml:312:1 (keyword) len=9 "interface"
 // interfaces_inferred_generic_type_args.baml:312:11 (interface) [declaration] len=11 "Describable"
 // interfaces_inferred_generic_type_args.baml:313:3 (keyword) len=8 "function"
@@ -1231,13 +1231,13 @@ test "interface_dispatch_sees_inferred_method_type_arg" {
 // interfaces_inferred_generic_type_args.baml:319:27 (parameter) [declaration] len=4 "self"
 // interfaces_inferred_generic_type_args.baml:319:36 (type) [defaultLibrary] len=6 "string"
 // interfaces_inferred_generic_type_args.baml:320:13 (keyword) len=6 "return"
-// interfaces_inferred_generic_type_args.baml:320:20 (namespace) [defaultLibrary] len=7 "reflect"
-// interfaces_inferred_generic_type_args.baml:320:27 (namespace) [defaultLibrary] len=1 "."
-// interfaces_inferred_generic_type_args.baml:320:28 (function) len=7 "type_of"
-// interfaces_inferred_generic_type_args.baml:320:35 (operator) len=1 "<"
-// interfaces_inferred_generic_type_args.baml:320:36 (type) len=1 "T"
-// interfaces_inferred_generic_type_args.baml:320:37 (operator) len=1 ">"
-// interfaces_inferred_generic_type_args.baml:320:41 (method) len=9 "to_string"
+// interfaces_inferred_generic_type_args.baml:320:20 (namespace) [defaultLibrary] len=4 "type"
+// interfaces_inferred_generic_type_args.baml:320:24 (namespace) [defaultLibrary] len=1 "."
+// interfaces_inferred_generic_type_args.baml:320:25 (function) len=2 "of"
+// interfaces_inferred_generic_type_args.baml:320:27 (operator) len=1 "<"
+// interfaces_inferred_generic_type_args.baml:320:28 (type) len=1 "T"
+// interfaces_inferred_generic_type_args.baml:320:29 (operator) len=1 ">"
+// interfaces_inferred_generic_type_args.baml:320:33 (method) len=9 "to_string"
 // interfaces_inferred_generic_type_args.baml:325:1 (keyword) len=5 "class"
 // interfaces_inferred_generic_type_args.baml:325:7 (class) [declaration] len=10 "PlainThing"
 // interfaces_inferred_generic_type_args.baml:326:5 (property) [declaration] len=1 "n"
@@ -1295,13 +1295,13 @@ test "interface_dispatch_sees_inferred_method_type_arg" {
 // interfaces_inferred_generic_type_args.baml:358:30 (type) len=1 "T"
 // interfaces_inferred_generic_type_args.baml:358:38 (type) [defaultLibrary] len=6 "string"
 // interfaces_inferred_generic_type_args.baml:359:5 (keyword) len=6 "return"
-// interfaces_inferred_generic_type_args.baml:359:12 (namespace) [defaultLibrary] len=7 "reflect"
-// interfaces_inferred_generic_type_args.baml:359:19 (namespace) [defaultLibrary] len=1 "."
-// interfaces_inferred_generic_type_args.baml:359:20 (function) len=7 "type_of"
-// interfaces_inferred_generic_type_args.baml:359:27 (operator) len=1 "<"
-// interfaces_inferred_generic_type_args.baml:359:28 (type) len=1 "T"
-// interfaces_inferred_generic_type_args.baml:359:29 (operator) len=1 ">"
-// interfaces_inferred_generic_type_args.baml:359:33 (method) len=9 "to_string"
+// interfaces_inferred_generic_type_args.baml:359:12 (namespace) [defaultLibrary] len=4 "type"
+// interfaces_inferred_generic_type_args.baml:359:16 (namespace) [defaultLibrary] len=1 "."
+// interfaces_inferred_generic_type_args.baml:359:17 (function) len=2 "of"
+// interfaces_inferred_generic_type_args.baml:359:19 (operator) len=1 "<"
+// interfaces_inferred_generic_type_args.baml:359:20 (type) len=1 "T"
+// interfaces_inferred_generic_type_args.baml:359:21 (operator) len=1 ">"
+// interfaces_inferred_generic_type_args.baml:359:25 (method) len=9 "to_string"
 // interfaces_inferred_generic_type_args.baml:362:1 (keyword) len=8 "function"
 // interfaces_inferred_generic_type_args.baml:362:10 (function) [declaration] len=18 "free_fn_inferred_t"
 // interfaces_inferred_generic_type_args.baml:362:34 (type) [defaultLibrary] len=6 "string"
@@ -1541,13 +1541,13 @@ test "interface_dispatch_sees_inferred_method_type_arg" {
 // interfaces_inferred_generic_type_args.baml:462:26 (type) len=1 "T"
 // interfaces_inferred_generic_type_args.baml:462:32 (type) [defaultLibrary] len=6 "string"
 // interfaces_inferred_generic_type_args.baml:463:5 (keyword) len=6 "return"
-// interfaces_inferred_generic_type_args.baml:463:12 (namespace) [defaultLibrary] len=7 "reflect"
-// interfaces_inferred_generic_type_args.baml:463:19 (namespace) [defaultLibrary] len=1 "."
-// interfaces_inferred_generic_type_args.baml:463:20 (function) len=7 "type_of"
-// interfaces_inferred_generic_type_args.baml:463:27 (operator) len=1 "<"
-// interfaces_inferred_generic_type_args.baml:463:28 (type) len=1 "T"
-// interfaces_inferred_generic_type_args.baml:463:29 (operator) len=1 ">"
-// interfaces_inferred_generic_type_args.baml:463:33 (method) len=9 "to_string"
+// interfaces_inferred_generic_type_args.baml:463:12 (namespace) [defaultLibrary] len=4 "type"
+// interfaces_inferred_generic_type_args.baml:463:16 (namespace) [defaultLibrary] len=1 "."
+// interfaces_inferred_generic_type_args.baml:463:17 (function) len=2 "of"
+// interfaces_inferred_generic_type_args.baml:463:19 (operator) len=1 "<"
+// interfaces_inferred_generic_type_args.baml:463:20 (type) len=1 "T"
+// interfaces_inferred_generic_type_args.baml:463:21 (operator) len=1 ">"
+// interfaces_inferred_generic_type_args.baml:463:25 (method) len=9 "to_string"
 // interfaces_inferred_generic_type_args.baml:466:1 (keyword) len=9 "interface"
 // interfaces_inferred_generic_type_args.baml:466:11 (interface) [declaration] len=8 "SelfEcho"
 // interfaces_inferred_generic_type_args.baml:467:3 (keyword) len=8 "function"
@@ -1643,13 +1643,13 @@ test "interface_dispatch_sees_inferred_method_type_arg" {
 // interfaces_inferred_generic_type_args.baml:512:39 (type) len=1 "U"
 // interfaces_inferred_generic_type_args.baml:512:45 (type) [defaultLibrary] len=6 "string"
 // interfaces_inferred_generic_type_args.baml:513:13 (keyword) len=6 "return"
-// interfaces_inferred_generic_type_args.baml:513:20 (namespace) [defaultLibrary] len=7 "reflect"
-// interfaces_inferred_generic_type_args.baml:513:27 (namespace) [defaultLibrary] len=1 "."
-// interfaces_inferred_generic_type_args.baml:513:28 (function) len=7 "type_of"
-// interfaces_inferred_generic_type_args.baml:513:35 (operator) len=1 "<"
-// interfaces_inferred_generic_type_args.baml:513:36 (type) len=1 "U"
-// interfaces_inferred_generic_type_args.baml:513:37 (operator) len=1 ">"
-// interfaces_inferred_generic_type_args.baml:513:41 (method) len=9 "to_string"
+// interfaces_inferred_generic_type_args.baml:513:20 (namespace) [defaultLibrary] len=4 "type"
+// interfaces_inferred_generic_type_args.baml:513:24 (namespace) [defaultLibrary] len=1 "."
+// interfaces_inferred_generic_type_args.baml:513:25 (function) len=2 "of"
+// interfaces_inferred_generic_type_args.baml:513:27 (operator) len=1 "<"
+// interfaces_inferred_generic_type_args.baml:513:28 (type) len=1 "U"
+// interfaces_inferred_generic_type_args.baml:513:29 (operator) len=1 ">"
+// interfaces_inferred_generic_type_args.baml:513:33 (method) len=9 "to_string"
 // interfaces_inferred_generic_type_args.baml:518:1 (keyword) len=5 "class"
 // interfaces_inferred_generic_type_args.baml:518:7 (class) [declaration] len=6 "ProbeB"
 // interfaces_inferred_generic_type_args.baml:519:5 (keyword) len=10 "implements"

--- a/baml_language/crates/baml_lsp2_actions_tests/test_files/semantic_tokens/stream_llm_inferred_typeargs.baml
+++ b/baml_language/crates/baml_lsp2_actions_tests/test_files/semantic_tokens/stream_llm_inferred_typeargs.baml
@@ -13,7 +13,7 @@
 // like the one below work because TIR persists inferred instantiations in
 // `CallPlan.type_args` (including phase-0 reverse inference from the
 // expected return type) and MIR materializes them into the callee frame,
-// where `__make_stream` reifies them via `reflect.type_of<TStream/TFinal>()`.
+// where `__make_stream` reifies them via `type.of<TStream/TFinal>()`.
 // There is no name-keyed registry fallback anymore — a propagation gap
 // would surface as "Non-parsable type: ..." from `StreamCache.new`.
 // Runtime coverage: `streaming_parsing::stream_string_final_value` and
@@ -57,7 +57,7 @@ function call_stream_inferred() -> baml.llm.Stream<null | string, string> {
 // stream_llm_inferred_typeargs.baml:13:1 (comment) len=74 "// like the one below work because TIR persists inferred instantiations in"
 // stream_llm_inferred_typeargs.baml:14:1 (comment) len=69 "// `CallPlan.type_args` (including phase-0 reverse inference from the"
 // stream_llm_inferred_typeargs.baml:15:1 (comment) len=73 "// expected return type) and MIR materializes them into the callee frame,"
-// stream_llm_inferred_typeargs.baml:16:1 (comment) len=78 "// where `__make_stream` reifies them via `reflect.type_of<TStream/TFinal>()`."
+// stream_llm_inferred_typeargs.baml:16:1 (comment) len=70 "// where `__make_stream` reifies them via `type.of<TStream/TFinal>()`."
 // stream_llm_inferred_typeargs.baml:17:1 (comment) len=73 "// There is no name-keyed registry fallback anymore — a propagation gap"
 // stream_llm_inferred_typeargs.baml:18:1 (comment) len=68 "// would surface as \"Non-parsable type: ...\" from `StreamCache.new`."
 // stream_llm_inferred_typeargs.baml:19:1 (comment) len=71 "// Runtime coverage: `streaming_parsing::stream_string_final_value` and"

--- a/baml_language/crates/baml_tests/baml_src/ns_class_type_args_at_runtime/class_type_args_at_runtime.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_class_type_args_at_runtime/class_type_args_at_runtime.baml
@@ -10,13 +10,13 @@ class Box<T> {
     value T
 
     function describe(self) -> string {
-        reflect.type_of<T>().to_string()
+        type.of<T>().to_string()
     }
 }
 
 class Box2<T> {
     function make_describer(self) -> () -> string throws never {
-        return () -> string { reflect.type_of<T>().to_string() }
+        return () -> string { type.of<T>().to_string() }
     }
 }
 
@@ -48,7 +48,7 @@ function method_sees_composite_class_type_arg_fn() -> string {
     outer.describe()
 }
 
-// NOTE: reflect.type_of<T>().to_string() includes the namespace segment, so
+// NOTE: type.of<T>().to_string() includes the namespace segment, so
 // the result is "class_type_args_at_runtime.Box<int>", not bare "Box<int>".
 test "method_sees_composite_class_type_arg" {
     assert.is_true(baml.deep_equals(method_sees_composite_class_type_arg_fn(), "class_type_args_at_runtime.Box<int>"))

--- a/baml_language/crates/baml_tests/baml_src/ns_inferred_generic_type_args/inferred_generic_type_args.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_inferred_generic_type_args/inferred_generic_type_args.baml
@@ -4,7 +4,7 @@
 // must carry the correct runtime `class_type_args`, and a method dispatched
 // through a multi-implementor interface must receive the resolved
 // class/interface type args in its frame. Without this, a method body that
-// reads its enclosing `T` at runtime — `reflect.type_of<T>()`, or constructing
+// reads its enclosing `T` at runtime — `type.of<T>()`, or constructing
 // `Other<T>{}` — resolves `T` to `unknown`; the new instance gets empty
 // `class_type_args`; and the runtime `IsType` dispatch guard falls through to
 // the WRONG implementor (a silent wrong answer, or a field-access panic when
@@ -184,7 +184,7 @@ test "inferred_static_ctor_dispatches_through_generic_interface" {
 interface Named<T> {
   function first(self) -> T throws unknown
   function tname(self) -> string throws never {
-    return reflect.type_of<T>().to_string()
+    return type.of<T>().to_string()
   }
 }
 
@@ -269,7 +269,7 @@ test "class_method_builds_generic_via_class_type_var" {
 
 interface Counter<T> {
   function element_type(self) -> string throws never {
-    return reflect.type_of<T>().to_string()
+    return type.of<T>().to_string()
   }
   function describe(self) -> string throws never
 }
@@ -307,7 +307,7 @@ test "default_method_forward_reads_interface_type_var" {
 // The interface request pins no type args (it has none), so the dispatch guard
 // is `Any` and can't name the implementor's class args statically. The matched
 // runtime instance still carries them, so the dispatched class-owned method
-// must resolve its class `T` (here via `reflect.type_of<T>()`).
+// must resolve its class `T` (here via `type.of<T>()`).
 
 interface Describable {
   function describe(self) -> string throws never
@@ -317,7 +317,7 @@ class TypedBox<T> {
     value: T,
     implements Describable {
         function describe(self) -> string {
-            return reflect.type_of<T>().to_string();
+            return type.of<T>().to_string();
         }
     }
 }
@@ -356,7 +356,7 @@ test "generic_class_behind_nongeneric_interface_reads_type_var" {
 // ═══════════════════════════════════════════════════════════════════════════
 
 function free_fn_tname<T>(a: T[]) -> string {
-    return reflect.type_of<T>().to_string();
+    return type.of<T>().to_string();
 }
 
 function free_fn_inferred_t() -> string {
@@ -461,7 +461,7 @@ test "inferred_ctor_default_method_collects_all" {
 // against) and no longer the demoted `unknown` of the slotless era.
 
 function echo_type<T>(a: T) -> string {
-    return reflect.type_of<T>().to_string();
+    return type.of<T>().to_string();
 }
 
 interface SelfEcho {
@@ -508,7 +508,7 @@ interface TypeProbe {
 class ProbeA {
     implements TypeProbe {
         function seen<U>(self, value: U) -> string {
-            return reflect.type_of<U>().to_string();
+            return type.of<U>().to_string();
         }
     }
 }

--- a/baml_language/crates/baml_tests/baml_src/ns_instantiation_expr/instantiation_expr.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_instantiation_expr/instantiation_expr.baml
@@ -2,7 +2,7 @@
 //
 // `foo<int>` (concrete type args) is a pooled, interned value: identical
 // instantiations share one object (pointer-stable identity), and calling the
-// value seeds frame.type_args so type-reifying bodies (reflect.type_of<T>,
+// value seeds frame.type_args so type-reifying bodies (type.of<T>,
 // json natives) resolve T at runtime — i.e. it behaves exactly like the
 // equivalent direct call `foo<int>(...)`.
 
@@ -62,10 +62,10 @@ test "pair_two_type_args_value_runs" {
 class User { name string }
 
 function describe<T>() -> string {
-    reflect.type_of<T>().to_string()
+    type.of<T>().to_string()
 }
 
-// reflect.type_of<T> through an UNCALLED value now resolves T correctly (the
+// type.of<T> through an UNCALLED value now resolves T correctly (the
 // value carries its type args and seeds frame.type_args when called).
 function describe_user_value_fn() -> string {
     let f = describe<User>;
@@ -100,7 +100,7 @@ test "param_dependent_instantiation_runs" {
 }
 
 // Param-dependent value whose body REFLECTS on T: the runtime path seeds T from
-// the enclosing frame, so reflect.type_of<T> resolves correctly (previously
+// the enclosing frame, so type.of<T> resolves correctly (previously
 // erased to "unknown").
 function forward_reflect<T>() -> string {
     let g = describe<T>;
@@ -152,7 +152,7 @@ test "bound_method_value_runs" {
 // Companion: a (non-generic) lambda inside a generic function still reifies the
 // enclosing function's `U` (no regression from threading lambda params).
 function lambda_reflects_enclosing_U<U>() -> string {
-    let g = () -> string { reflect.type_of<U>().to_string() };
+    let g = () -> string { type.of<U>().to_string() };
     g()
 }
 

--- a/baml_language/crates/baml_tests/baml_src/ns_instantiation_expr/ns_qualified/q.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_instantiation_expr/ns_qualified/q.baml
@@ -1,5 +1,5 @@
 // A generic function in the nested namespace `instantiation_expr.qualified`,
 // to exercise multi-segment qualified instantiation values
 // (`user.instantiation_expr.qualified.q_describe<T>`).
-function q_describe<T>() -> string { reflect.type_of<T>().to_string() }
+function q_describe<T>() -> string { type.of<T>().to_string() }
 function q_id<T>(x: T) -> T { x }

--- a/baml_language/crates/baml_tests/baml_src/ns_interfaces/interfaces.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_interfaces/interfaces.baml
@@ -850,7 +850,7 @@ interface RtitAnimal {
     function speak(self) -> string throws never
 }
 function rtit_main() -> string {
-    return reflect.type_of<RtitAnimal>().to_string()
+    return type.of<RtitAnimal>().to_string()
 }
 test "reflect_type_of_interface_to_string" {
     assert.equal(rtit_main(), "interfaces.RtitAnimal")
@@ -866,7 +866,7 @@ class RitfDog {
     }
 }
 function ritf_main() -> bool {
-    return reflect.type_of<RitfDog>().implements(reflect.type_of<RitfAnimal>())
+    return type.of<RitfDog>().implements(type.of<RitfAnimal>())
 }
 test "reflect_implements_true_for_implementor" {
     assert.is_true(ritf_main())
@@ -880,7 +880,7 @@ class RiffRock {
     mass: int
 }
 function riff_main() -> bool {
-    return reflect.type_of<RiffRock>().implements(reflect.type_of<RiffAnimal>())
+    return type.of<RiffRock>().implements(type.of<RiffAnimal>())
 }
 test "reflect_implements_false_for_non_implementor" {
     assert.is_true(riff_main() == false)
@@ -896,8 +896,8 @@ class RibiDog {
     }
 }
 function ribi_main() -> bool {
-    let direct = reflect.type_of<RibiDog>().implements(reflect.type_of<RibiAnimal>())
-    let reverse = reflect.type_of<RibiAnimal>().implemented_by(reflect.type_of<RibiDog>())
+    let direct = type.of<RibiDog>().implements(type.of<RibiAnimal>())
+    let reverse = type.of<RibiAnimal>().implemented_by(type.of<RibiDog>())
     return direct == reverse
 }
 test "reflect_implemented_by_inverse_runtime" {
@@ -917,7 +917,7 @@ class RitvEmployee {
     }
 }
 function ritv_main() -> bool {
-    return reflect.type_of<RitvEmployee>().implements(reflect.type_of<RitvNamed>())
+    return type.of<RitvEmployee>().implements(type.of<RitvNamed>())
 }
 test "reflect_implements_transitive_via_requires" {
     assert.is_true(ritv_main())
@@ -938,10 +938,10 @@ class RillCat {
     }
 }
 function rill_main() -> bool {
-    let impls = reflect.type_of<RillAnimal>().implementors()
+    let impls = type.of<RillAnimal>().implementors()
     return impls.length() == 2
-        && impls[0] == reflect.type_of<RillCat>()
-        && impls[1] == reflect.type_of<RillDog>()
+        && impls[0] == type.of<RillCat>()
+        && impls[1] == type.of<RillDog>()
 }
 test "reflect_implementors_lists_lexicographic_order_and_identity" {
     assert.is_true(rill_main())
@@ -952,7 +952,7 @@ class RiefDog {
     breed: string
 }
 function rief_main() -> int {
-    return reflect.type_of<RiefDog>().implementors().length()
+    return type.of<RiefDog>().implementors().length()
 }
 test "reflect_implementors_empty_for_concrete_class" {
     assert.equal(rief_main(), 0)
@@ -960,7 +960,7 @@ test "reflect_implementors_empty_for_concrete_class" {
 
 // reflect_implementors_empty_for_primitive
 function riep_main() -> int {
-    return reflect.type_of<int>().implementors().length()
+    return type.of<int>().implementors().length()
 }
 test "reflect_implementors_empty_for_primitive" {
     assert.equal(riep_main(), 0)
@@ -976,7 +976,7 @@ class RiigDog {
     }
 }
 function riig_is_animal<T>() -> bool {
-    return reflect.type_of<T>().implements(reflect.type_of<RiigAnimal>())
+    return type.of<T>().implements(type.of<RiigAnimal>())
 }
 function riig_main() -> bool {
     return riig_is_animal<RiigDog>() && riig_is_animal<int>() == false
@@ -990,7 +990,7 @@ interface RidnAnimal {
     function speak(self) -> string throws never
 }
 function ridn_main() -> bool {
-    return reflect.type_of<RidnAnimal>().implements(reflect.type_of<RidnAnimal>())
+    return type.of<RidnAnimal>().implements(type.of<RidnAnimal>())
 }
 test "reflect_interface_does_not_implement_itself" {
     assert.is_true(ridn_main() == false)
@@ -1802,10 +1802,10 @@ implements OobvAnimal for OobvDog {
     function speak(self) -> string { return "woof" }
 }
 function oobv_main() -> bool {
-    let impls = reflect.type_of<OobvAnimal>().implementors()
-    return reflect.type_of<OobvDog>().implements(reflect.type_of<OobvAnimal>())
+    let impls = type.of<OobvAnimal>().implementors()
+    return type.of<OobvDog>().implements(type.of<OobvAnimal>())
         && impls.length() == 1
-        && impls[0] == reflect.type_of<OobvDog>()
+        && impls[0] == type.of<OobvDog>()
 }
 test "out_of_body_implements_is_visible_to_reflection_registry" {
     assert.is_true(oobv_main())
@@ -1882,7 +1882,7 @@ class GoopBox<T> {
 }
 implements<T> GoopDescriber<T> for GoopBox<T> {
     function describe<U>(self, value: U) -> string {
-        return reflect.type_of<T>().to_string() + ":" + reflect.type_of<U>().to_string()
+        return type.of<T>().to_string() + ":" + type.of<U>().to_string()
     }
 }
 function goop_main() -> string {

--- a/baml_language/crates/baml_tests/baml_src/ns_interfaces/interfaces_2.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_interfaces/interfaces_2.baml
@@ -174,8 +174,8 @@ implements<T> UrrsPrintable for UrrsBox<T> {
     function display(self) -> string { return "box" }
 }
 function urrs_main() -> bool {
-    let impls = reflect.type_of<UrrsPrintable>().implementors()
-    return reflect.type_of<UrrsBox<int>>().implements(reflect.type_of<UrrsPrintable>())
+    let impls = type.of<UrrsPrintable>().implementors()
+    return type.of<UrrsBox<int>>().implements(type.of<UrrsPrintable>())
         && impls.length() == 1
 }
 test "unified_rule_reflection_sees_generic_class_implementor_once" {
@@ -270,7 +270,7 @@ implements<T extends F2riNamed> F2riPrintable for T {
     function display(self) -> string { return self.name }
 }
 function f2ri_main() -> bool {
-    return reflect.type_of<F2riPerson>().implements(reflect.type_of<F2riPrintable>())
+    return type.of<F2riPerson>().implements(type.of<F2riPrintable>())
 }
 test "form2_reflect_implements_returns_true" {
     assert.is_true(f2ri_main())
@@ -295,9 +295,9 @@ implements<T extends F2rsNamed> F2rsPrintable for T {
     function display(self) -> string { return self.name }
 }
 function f2rs_main() -> bool {
-    let printable = reflect.type_of<F2rsPrintable>()
-    return printable.implemented_by(reflect.type_of<F2rsPerson>())
-        && printable.implemented_by(reflect.type_of<F2rsTeam>())
+    let printable = type.of<F2rsPrintable>()
+    return printable.implemented_by(type.of<F2rsPerson>())
+        && printable.implemented_by(type.of<F2rsTeam>())
         && printable.implementors().length() == 2
 }
 test "form2_reflect_implementors_includes_satisfying_classes" {
@@ -313,12 +313,12 @@ implements<T> BirrPrintable<T> for BirrContainer<T> {}
 function birr_main() -> bool {
     let int_printable: BirrPrintable<int> = BirrContainer<int> { value: 1 }
     let string_printable: BirrPrintable<string> = BirrContainer<string> { value: "two" }
-    return reflect.type_of<BirrContainer<int>>().implements(reflect.type_of<BirrPrintable<int>>())
-        && reflect.type_of<BirrContainer<string>>().implements(reflect.type_of<BirrPrintable<string>>())
-        && reflect.type_of<BirrPrintable<int>>().implemented_by(reflect.type_of<BirrContainer<int>>())
-        && reflect.type_of<BirrPrintable<string>>().implemented_by(reflect.type_of<BirrContainer<string>>())
-        && reflect.type_of<BirrPrintable<int>>().implementors().length() == 1
-        && reflect.type_of<BirrPrintable<string>>().implementors().length() == 1
+    return type.of<BirrContainer<int>>().implements(type.of<BirrPrintable<int>>())
+        && type.of<BirrContainer<string>>().implements(type.of<BirrPrintable<string>>())
+        && type.of<BirrPrintable<int>>().implemented_by(type.of<BirrContainer<int>>())
+        && type.of<BirrPrintable<string>>().implemented_by(type.of<BirrContainer<string>>())
+        && type.of<BirrPrintable<int>>().implementors().length() == 1
+        && type.of<BirrPrintable<string>>().implementors().length() == 1
 }
 test "blanket_interface_rule_reflection_includes_concrete_container_implementors" {
     assert.is_true(birr_main())
@@ -865,7 +865,7 @@ class Fz34IntBox {
 function fz34_main() -> bool {
     // IntBox only implements Box<int>, NOT Box<string>, so this is false —
     // `implements` respects the generic type argument.
-    return reflect.type_of<Fz34IntBox>().implements(reflect.type_of<Fz34Box<string>>())
+    return type.of<Fz34IntBox>().implements(type.of<Fz34Box<string>>())
 }
 test "fuzz_bug34_reflect_implements_respects_generic_type_args" {
     assert.is_true(fz34_main() == false)
@@ -883,7 +883,7 @@ class Fz35IntBox {
 function fz35_main() -> bool {
     // Box<string>.implemented_by(IntBox) is false — IntBox only implements
     // Box<int>, and `implemented_by` respects the type argument.
-    return reflect.type_of<Fz35Box<string>>().implemented_by(reflect.type_of<Fz35IntBox>())
+    return type.of<Fz35Box<string>>().implemented_by(type.of<Fz35IntBox>())
 }
 test "fuzz_bug35_reflect_implemented_by_respects_generic_type_args" {
     assert.is_true(fz35_main() == false)
@@ -906,7 +906,7 @@ class Fz36StringBox {
 function fz36_main() -> int {
     // Box<int>.implementors() returns just [IntBox] (length 1) — the type
     // argument filters out StringBox (which implements Box<string>).
-    return reflect.type_of<Fz36Box<int>>().implementors().length()
+    return type.of<Fz36Box<int>>().implementors().length()
 }
 test "fuzz_bug36_reflect_implementors_respects_generic_type_args" {
     assert.equal(fz36_main(), 1)
@@ -918,7 +918,7 @@ class Fz37A { implements Fz37I {} }
 class Fz37B { implements Fz37I {} }
 class Fz37C { implements Fz37I {} }
 function fz37_main() -> string {
-    let impls = reflect.type_of<Fz37I>().implementors()
+    let impls = type.of<Fz37I>().implementors()
     // Lexicographic by name: A,B,C
     return impls[0].to_string() + "," + impls[1].to_string() + "," + impls[2].to_string()
 }

--- a/baml_language/crates/baml_tests/baml_src/ns_interfaces/interfaces_3.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_interfaces/interfaces_3.baml
@@ -73,8 +73,8 @@ interface W306Box<T> {
     function get(self) -> T throws never
 }
 function w306_names<U>() -> string {
-    let naked = reflect.type_of<U>().to_string()
-    let wrapped = reflect.type_of<W306Box<U>>().to_string()
+    let naked = type.of<U>().to_string()
+    let wrapped = type.of<W306Box<U>>().to_string()
     return "naked=" + naked + " wrapped=" + wrapped
 }
 function w306_main() -> string {
@@ -99,10 +99,10 @@ class W307StringBox {
     }
 }
 function w307_box_impls_intbox<T>() -> bool {
-    return reflect.type_of<W307Box<T>>().implemented_by(reflect.type_of<W307IntBox>())
+    return type.of<W307Box<T>>().implemented_by(type.of<W307IntBox>())
 }
 function w307_box_impls_stringbox<T>() -> bool {
-    return reflect.type_of<W307Box<T>>().implemented_by(reflect.type_of<W307StringBox>())
+    return type.of<W307Box<T>>().implemented_by(type.of<W307StringBox>())
 }
 function w307_main() -> bool {
     return w307_box_impls_intbox<int>()
@@ -166,8 +166,8 @@ implements W315Debuggable for int {
     function debugW315(self) -> string { return "int" }
 }
 function w315_main() -> int {
-    let a = reflect.type_of<int>().implements(reflect.type_of<W315Debuggable>())
-    let impls = reflect.type_of<W315Debuggable>().implementors()
+    let a = type.of<int>().implements(type.of<W315Debuggable>())
+    let impls = type.of<W315Debuggable>().implementors()
     if a { return 1000 + impls.length() }
     return impls.length()
 }
@@ -270,7 +270,7 @@ test "wf3_concrete_field_shadows_interface_views_pins" {
 }
 
 // wf3: generic-interface reflection is per-instantiation. A bare generic head
-// (`reflect.type_of<W3bgBox>()`) is an arity error like any other type
+// (`type.of<W3bgBox>()`) is an arity error like any other type
 // position (pinned in tests/interfaces.rs); each written instantiation
 // reflects exactly its own implementors.
 interface W3bgBox<T> {
@@ -287,9 +287,9 @@ class W3bgStringBox {
     }
 }
 function w3bg_main() -> bool {
-    let int_box = reflect.type_of<W3bgBox<int>>()
-    return int_box.implemented_by(reflect.type_of<W3bgIntBox>())
-        && !int_box.implemented_by(reflect.type_of<W3bgStringBox>())
+    let int_box = type.of<W3bgBox<int>>()
+    return int_box.implemented_by(type.of<W3bgIntBox>())
+        && !int_box.implemented_by(type.of<W3bgStringBox>())
         && int_box.implementors().length() == 1
 }
 test "wf3_generic_interface_reflection_is_per_instantiation" {
@@ -307,7 +307,7 @@ implements<T> W3biPrintable for W3biBox<T> {
     function display(self) -> string { return "box" }
 }
 function w3bi_main() -> string {
-    let p = reflect.type_of<W3biPrintable>()
+    let p = type.of<W3biPrintable>()
     return p.implementors()[0].to_string()
 }
 test "wf3_blanket_implementor_identity_is_bare_class_pins" {
@@ -337,9 +337,9 @@ class Ufp2UBox {
     }
 }
 function ufp2_main() -> int {
-    let ub = reflect.type_of<Ufp2UBox>()
-    let fwd = reflect.type_of<Ufp2Box<(int | string)?>>()
-    let rev = reflect.type_of<Ufp2Box<(string | int)?>>()
+    let ub = type.of<Ufp2UBox>()
+    let fwd = type.of<Ufp2Box<(int | string)?>>()
+    let rev = type.of<Ufp2Box<(string | int)?>>()
     let a = 0
     if ub.implements(fwd) { a = a + 1 }
     if ub.implements(rev) { a = a + 10 }
@@ -382,11 +382,11 @@ class Ufp5UBox {
     implements Ufp5Box<int | int> { function get(self) -> int | int { return self.value } }
 }
 function ufp5_main() -> int {
-    let ub = reflect.type_of<Ufp5UBox>()
+    let ub = type.of<Ufp5UBox>()
     let a = 0
     // UBox implements Box<int | int>, NOT Box<int | string>.
-    if ub.implements(reflect.type_of<Ufp5Box<int | int>>()) { a = a + 1 }
-    if ub.implements(reflect.type_of<Ufp5Box<int | string>>()) { a = a + 10 }
+    if ub.implements(type.of<Ufp5Box<int | int>>()) { a = a + 1 }
+    if ub.implements(type.of<Ufp5Box<int | string>>()) { a = a + 10 }
     return a
 }
 test "union_fuzz_pr_reflection_duplicate_union_members_not_equivalent" {
@@ -464,9 +464,9 @@ class Uf06UBox {
     }
 }
 function uf06_main() -> int {
-    let ub = reflect.type_of<Uf06UBox>()
-    let fwd = reflect.type_of<Uf06Box<int | string>>()
-    let rev = reflect.type_of<Uf06Box<string | int>>()
+    let ub = type.of<Uf06UBox>()
+    let fwd = type.of<Uf06Box<int | string>>()
+    let rev = type.of<Uf06Box<string | int>>()
     let d1 = 0
     if ub.implements(fwd) { d1 = 1 }
     let d2 = 0

--- a/baml_language/crates/baml_tests/baml_src/ns_interfaces_associated_types/interfaces_associated_types.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_interfaces_associated_types/interfaces_associated_types.baml
@@ -614,16 +614,16 @@ class RfiStringSource {
 
 function rfi_main() -> int {
     let score = 0
-    if reflect.type_of<RfiIntSource>().implements(reflect.type_of<RfiSource<Item = int>>()) {
+    if type.of<RfiIntSource>().implements(type.of<RfiSource<Item = int>>()) {
         score = score + 1
     }
-    if reflect.type_of<RfiIntSource>().implements(reflect.type_of<RfiSource<Item = string>>()) {
+    if type.of<RfiIntSource>().implements(type.of<RfiSource<Item = string>>()) {
         score = score + 10
     }
-    if reflect.type_of<RfiStringSource>().implements(reflect.type_of<RfiSource<Item = string>>()) {
+    if type.of<RfiStringSource>().implements(type.of<RfiSource<Item = string>>()) {
         score = score + 100
     }
-    if reflect.type_of<RfiStringSource>().implements(reflect.type_of<RfiSource<Item = int>>()) {
+    if type.of<RfiStringSource>().implements(type.of<RfiSource<Item = int>>()) {
         score = score + 1000
     }
     return score
@@ -652,15 +652,15 @@ class RfmStringSource {
 }
 
 function rfm_main() -> int {
-    let int_impls = reflect.type_of<RfmSource<Item = int>>().implementors()
-    let string_impls = reflect.type_of<RfmSource<Item = string>>().implementors()
+    let int_impls = type.of<RfmSource<Item = int>>().implementors()
+    let string_impls = type.of<RfmSource<Item = string>>().implementors()
     let score = 0
     score = score + int_impls.length()
-    if int_impls.length() > 0 && int_impls[0] == reflect.type_of<RfmIntSource>() {
+    if int_impls.length() > 0 && int_impls[0] == type.of<RfmIntSource>() {
         score = score + 10
     }
     score = score + (string_impls.length() * 100)
-    if string_impls.length() > 0 && string_impls[0] == reflect.type_of<RfmStringSource>() {
+    if string_impls.length() > 0 && string_impls[0] == type.of<RfmStringSource>() {
         score = score + 1000
     }
     return score
@@ -693,9 +693,9 @@ class RfgBox<T> {
 }
 
 function rfg_main() -> int {
-    let box_int = reflect.type_of<RfgBox<int>>()
-    let int_source = reflect.type_of<RfgSource<Item = int>>()
-    let string_source = reflect.type_of<RfgSource<Item = string>>()
+    let box_int = type.of<RfgBox<int>>()
+    let int_source = type.of<RfgSource<Item = int>>()
+    let string_source = type.of<RfgSource<Item = string>>()
 
     let score = 0
     if box_int.implements(int_source) {
@@ -750,10 +750,10 @@ implement<T extends RgbSource<Item = int>> RgbIntSourced for T {}
 
 function rgb_main() -> int {
     let score = 0
-    if reflect.type_of<RgbIntSource>().implements(reflect.type_of<RgbIntSourced>()) {
+    if type.of<RgbIntSource>().implements(type.of<RgbIntSourced>()) {
         score = score + 1
     }
-    if reflect.type_of<RgbStrSource>().implements(reflect.type_of<RgbIntSourced>()) {
+    if type.of<RgbStrSource>().implements(type.of<RgbIntSourced>()) {
         score = score + 10
     }
     return score
@@ -783,10 +783,10 @@ implement<T extends RpaContainer<int>> RpaNeedsIntContainer for T {}
 
 function rpa_main() -> int {
     let score = 0
-    if reflect.type_of<RpaIntBox>().implements(reflect.type_of<RpaNeedsIntContainer>()) {
+    if type.of<RpaIntBox>().implements(type.of<RpaNeedsIntContainer>()) {
         score = score + 1
     }
-    if reflect.type_of<RpaStrBox>().implements(reflect.type_of<RpaNeedsIntContainer>()) {
+    if type.of<RpaStrBox>().implements(type.of<RpaNeedsIntContainer>()) {
         score = score + 10
     }
     return score
@@ -811,10 +811,10 @@ implements RltDebuggable for int {
 
 function rlt_main() -> int {
     let score = 0
-    if reflect.type_of<1>().implements(reflect.type_of<RltDebuggable>()) {
+    if type.of<1>().implements(type.of<RltDebuggable>()) {
         score = score + 1
     }
-    if reflect.type_of<int>().implements(reflect.type_of<RltDebuggable>()) {
+    if type.of<int>().implements(type.of<RltDebuggable>()) {
         score = score + 10
     }
     return score
@@ -839,10 +839,10 @@ implements RevNamed for RevColor {
 
 function rev_main() -> int {
     let score = 0
-    if reflect.type_of<RevColor.Red>().implements(reflect.type_of<RevNamed>()) {
+    if type.of<RevColor.Red>().implements(type.of<RevNamed>()) {
         score = score + 1
     }
-    if reflect.type_of<RevColor>().implements(reflect.type_of<RevNamed>()) {
+    if type.of<RevColor>().implements(type.of<RevNamed>()) {
         score = score + 10
     }
     return score

--- a/baml_language/crates/baml_tests/baml_src/ns_projection_patterns/projection_patterns.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_projection_patterns/projection_patterns.baml
@@ -151,7 +151,7 @@ interface Labeled {
     }
 
     function label_name(self) -> string throws never {
-        reflect.type_of<Self.Label>().to_string()
+        type.of<Self.Label>().to_string()
     }
 }
 

--- a/baml_language/crates/baml_tests/baml_src/ns_prompt_tag_runtime/prompt_tag_runtime.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_prompt_tag_runtime/prompt_tag_runtime.baml
@@ -236,12 +236,12 @@ test "prompt_parent_tostring_override_owns_media_subtree" {
 // ─── ${ctx.output_format} (M5b) ───────────────────────────────────────────────
 
 // BEP-049 M5b: `${ctx.output_format}` renders the return type's schema.
-// `render_output_format(reflect.type_of<Person>())` produces the schema string
+// `render_output_format(type.of<Person>())` produces the schema string
 // the orchestrator will later populate `Context.output_format` with; here we
 // wire it by hand and assert the assembled prompt embeds the schema.
 function pt_ctx_output_format_fn() -> string {
     let cc = baml.llm.ContextClient { name: "c", provider: "openai", default_role: "user", allowed_roles: ["user"] }
-    let of = baml.llm.render_output_format(reflect.type_of<Person>())
+    let of = baml.llm.render_output_format(type.of<Person>())
     let ctx = baml.llm.Context { client: cc, tags: {}, output_format: of }
     let render = baml.llm.prompt`Answer using this schema:
 ${ctx.output_format}`
@@ -278,7 +278,7 @@ test "render_prompt_companion_interpolates_ctx_output_format" {
 // optional params called with most omitted.
 function pt_output_format_with_prefix_fn() -> string {
     let cc = baml.llm.ContextClient { name: "c", provider: "openai", default_role: "user", allowed_roles: ["user"] }
-    let rt = reflect.type_of<Person>()
+    let rt = type.of<Person>()
     let ctx = baml.llm.Context { client: cc, tags: {}, output_format: baml.llm.render_output_format(rt), _output_format: baml.llm.build_output_format(rt) }
     let render = baml.llm.prompt`${ctx.output_format_with(prefix = "Use this exact schema:")}`
     render(ctx).text()
@@ -300,7 +300,7 @@ test "prompt_interpolates_ctx_output_format_with" {
 // before it) is omitted. Must render the schema, not panic.
 function pt_output_format_with_omitted_leading_fn() -> string {
     let cc = baml.llm.ContextClient { name: "c", provider: "openai", default_role: "user", allowed_roles: ["user"] }
-    let rt = reflect.type_of<Person>()
+    let rt = type.of<Person>()
     let ctx = baml.llm.Context { client: cc, tags: {}, output_format: baml.llm.render_output_format(rt), _output_format: baml.llm.build_output_format(rt) }
     let render = baml.llm.prompt`${ctx.output_format_with(quote_class_fields = true)}`
     render(ctx).text()
@@ -316,7 +316,7 @@ test "prompt_output_format_with_omits_leading_optional_arg" {
 // the optional `nickname` field with `string or omit`.
 function pt_output_format_with_null_as_omit_fn() -> string {
     let cc = baml.llm.ContextClient { name: "c", provider: "openai", default_role: "user", allowed_roles: ["user"] }
-    let rt = reflect.type_of<PersonNick>()
+    let rt = type.of<PersonNick>()
     let ctx = baml.llm.Context { client: cc, tags: {}, output_format: baml.llm.render_output_format(rt), _output_format: baml.llm.build_output_format(rt) }
     let render = baml.llm.prompt`${ctx.output_format_with(render_null_as = "omit")}`
     render(ctx).text()

--- a/baml_language/crates/baml_tests/baml_src/ns_provider_stdlib/provider_stdlib.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_provider_stdlib/provider_stdlib.baml
@@ -5,7 +5,7 @@ class ProviderSchemaExample {
 }
 
 function provider_schema() -> json {
-  baml.schema.json_schema(reflect.type_of<ProviderSchemaExample>())
+  baml.schema.json_schema(type.of<ProviderSchemaExample>())
 }
 
 function provider_schema_values() -> string {

--- a/baml_language/crates/baml_tests/baml_src/ns_reflect_type_of/reflect_type_of.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_reflect_type_of/reflect_type_of.baml
@@ -202,9 +202,9 @@ test "of_value_array_reports_element_type" {
     assert.is_true(type.of_value(xs) == type.of<int[]>())
 }
 
-test "of_value_of_a_type_value_is_type" {
-    // A `type` value's concrete type is the `type` primitive itself.
-    assert.is_true(type.of_value(type.of<User>()) == type.of<type>())
+test "of_value_of_a_type_value_is_precise_kind" {
+    // A reflected class type value has the sealed class-kind view as its concrete type.
+    assert.is_true(type.of_value(type.of<User>()) == type.of<baml.reflect.class.Type>())
 }
 
 test "of_value_widened_unknown_slot" {

--- a/baml_language/crates/baml_tests/baml_src/ns_reflect_type_of/reflect_type_of.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_reflect_type_of/reflect_type_of.baml
@@ -1,4 +1,4 @@
-// Tests for `reflect.type_of<T>()` with concrete type arguments.
+// Tests for `type.of<T>()` with concrete type arguments.
 //
 // Converted from crates/baml_tests/tests/reflect_type_of.rs.
 //
@@ -26,44 +26,44 @@ enum RgbColor { Red, Green, Blue }
 // ─── Basic to_string tests ───────────────────────────────────────────────────
 
 test "type_of_class_to_string" {
-    let s = reflect.type_of<User>().to_string();
+    let s = type.of<User>().to_string();
     assert.is_true(baml.deep_equals(s, "reflect_type_of.User"))
 }
 
 test "type_of_int_to_string" {
-    assert.is_true(baml.deep_equals(reflect.type_of<int>().to_string(), "int"))
+    assert.is_true(baml.deep_equals(type.of<int>().to_string(), "int"))
 }
 
 test "type_of_string_to_string" {
-    assert.is_true(baml.deep_equals(reflect.type_of<string>().to_string(), "string"))
+    assert.is_true(baml.deep_equals(type.of<string>().to_string(), "string"))
 }
 
 test "type_of_bool_to_string" {
-    assert.is_true(baml.deep_equals(reflect.type_of<bool>().to_string(), "bool"))
+    assert.is_true(baml.deep_equals(type.of<bool>().to_string(), "bool"))
 }
 
 test "type_of_array_to_string" {
-    let s = reflect.type_of<User[]>().to_string();
+    let s = type.of<User[]>().to_string();
     assert.is_true(baml.deep_equals(s, "reflect_type_of.User[]"))
 }
 
 test "type_of_optional_to_string" {
-    let s = reflect.type_of<User?>().to_string();
+    let s = type.of<User?>().to_string();
     assert.is_true(baml.deep_equals(s, "reflect_type_of.User | null"))
 }
 
 test "type_of_map_to_string" {
-    let s = reflect.type_of<map<string, User>>().to_string();
+    let s = type.of<map<string, User>>().to_string();
     assert.is_true(baml.deep_equals(s, "map<string, reflect_type_of.User>"))
 }
 
 test "type_of_generic_class_runs_without_crash" {
-    let s = reflect.type_of<Container<User>>().to_string();
+    let s = type.of<Container<User>>().to_string();
     assert.is_true(baml.deep_equals(s, "reflect_type_of.Container<reflect_type_of.User>"))
 }
 
 test "type_of_generic_class_to_string_matches_source" {
-    let matches = reflect.type_of<Container<User>>().to_string() == "reflect_type_of.Container<reflect_type_of.User>";
+    let matches = type.of<Container<User>>().to_string() == "reflect_type_of.Container<reflect_type_of.User>";
     assert.is_true(baml.deep_equals(matches, true))
 }
 
@@ -71,21 +71,21 @@ test "type_of_generic_class_to_string_matches_source" {
 
 test "type_of_map_eq" {
     assert.is_true(baml.deep_equals(
-        reflect.type_of<map<string, User>>() == reflect.type_of<map<string, User>>(),
+        type.of<map<string, User>>() == type.of<map<string, User>>(),
         true
     ))
 }
 
 test "type_of_generic_class_eq" {
     assert.is_true(baml.deep_equals(
-        reflect.type_of<Container<User>>() == reflect.type_of<Container<User>>(),
+        type.of<Container<User>>() == type.of<Container<User>>(),
         true
     ))
 }
 
 test "type_of_generic_class_neq_different_arg" {
     assert.is_true(baml.deep_equals(
-        reflect.type_of<Container<User>>() == reflect.type_of<Container<int>>(),
+        type.of<Container<User>>() == type.of<Container<int>>(),
         false
     ))
 }
@@ -93,9 +93,9 @@ test "type_of_generic_class_neq_different_arg" {
 // ─── Phase 7: parametric class forwarding via generic bodies ─────────────────
 
 // Kept as a top-level generic function: forwarding a type parameter through a
-// generic body into `reflect.type_of` is itself the feature under test here.
+// generic body into `type.of` is itself the feature under test here.
 function wrap_in_container<T>() -> type {
-    reflect.type_of<Container<T>>()
+    type.of<Container<T>>()
 }
 
 test "wrap_in_container_to_string" {
@@ -107,14 +107,14 @@ test "wrap_in_container_to_string" {
 
 test "type_of_same_class_eq" {
     assert.is_true(baml.deep_equals(
-        reflect.type_of<User>() == reflect.type_of<User>(),
+        type.of<User>() == type.of<User>(),
         true
     ))
 }
 
 test "type_of_different_class_neq" {
     assert.is_true(baml.deep_equals(
-        reflect.type_of<User>() == reflect.type_of<int>(),
+        type.of<User>() == type.of<int>(),
         false
     ))
 }
@@ -123,42 +123,42 @@ test "type_of_assign_and_compare" {
     // Locals holding `type` values, compared inside a test block: the exact
     // shape the pre-#3782 lowering bug broke (locals lowered to `const null`,
     // making this compare `null == null`).
-    let a: type = reflect.type_of<User>();
-    let b: type = reflect.type_of<User>();
+    let a: type = type.of<User>();
+    let b: type = type.of<User>();
     assert.is_true(baml.deep_equals(a == b, true))
 }
 
 // ─── Enum and union coverage ─────────────────────────────────────────────────
 
 test "type_of_enum_to_string" {
-    let s = reflect.type_of<RgbColor>().to_string();
+    let s = type.of<RgbColor>().to_string();
     assert.is_true(baml.deep_equals(s, "reflect_type_of.RgbColor"))
 }
 
 test "type_of_enum_eq" {
     assert.is_true(baml.deep_equals(
-        reflect.type_of<RgbColor>() == reflect.type_of<RgbColor>(),
+        type.of<RgbColor>() == type.of<RgbColor>(),
         true
     ))
 }
 
 test "type_of_enum_neq_class" {
     assert.is_true(baml.deep_equals(
-        reflect.type_of<RgbColor>() == reflect.type_of<User>(),
+        type.of<RgbColor>() == type.of<User>(),
         false
     ))
 }
 
 test "type_of_union_eq" {
     assert.is_true(baml.deep_equals(
-        reflect.type_of<int | string>() == reflect.type_of<int | string>(),
+        type.of<int | string>() == type.of<int | string>(),
         true
     ))
 }
 
 test "type_of_union_neq_different_member" {
     assert.is_true(baml.deep_equals(
-        reflect.type_of<int | string>() == reflect.type_of<int | bool>(),
+        type.of<int | string>() == type.of<int | bool>(),
         false
     ))
 }
@@ -167,7 +167,70 @@ test "type_of_union_neq_different_member" {
 
 test "type_of_to_string_works_as_map_key" {
     let m: map<string, int> = {};
-    m[reflect.type_of<User>().to_string()] = 1;
-    m[reflect.type_of<int>().to_string()] = 2;
-    assert.is_true(baml.deep_equals(m[reflect.type_of<User>().to_string()], 1))
+    m[type.of<User>().to_string()] = 1;
+    m[type.of<int>().to_string()] = 2;
+    assert.is_true(baml.deep_equals(m[type.of<User>().to_string()], 1))
+}
+
+// ─── type.of_value (BEP-066 K-13) ────────────────────────────────────────────
+
+test "of_value_int" {
+    assert.is_true(type.of_value(5) == type.of<int>())
+}
+
+test "of_value_never_yields_a_literal_type" {
+    // K-12: the reconstructed type is the value type, never the literal.
+    assert.equal(type.of_value(5).to_string(), "int");
+    assert.equal(type.of_value("hi").to_string(), "string");
+    assert.equal(type.of_value(true).to_string(), "bool")
+}
+
+test "of_value_string_and_bool" {
+    assert.is_true(type.of_value("hi") == type.of<string>());
+    assert.is_true(type.of_value(true) == type.of<bool>());
+    assert.is_true(type.of_value(null) == type.of<null>())
+}
+
+test "of_value_class_instance" {
+    let u = User { name: "a" };
+    assert.is_true(type.of_value(u) == type.of<User>());
+    assert.equal(type.of_value(u).to_string(), "reflect_type_of.User")
+}
+
+test "of_value_array_reports_element_type" {
+    let xs: int[] = [1, 2];
+    assert.is_true(type.of_value(xs) == type.of<int[]>())
+}
+
+test "of_value_of_a_type_value_is_type" {
+    // A `type` value's concrete type is the `type` primitive itself.
+    assert.is_true(type.of_value(type.of<User>()) == type.of<type>())
+}
+
+test "of_value_widened_unknown_slot" {
+    // Through an `unknown`-typed slot the runtime tag still drives the answer.
+    let v: unknown = 42;
+    assert.is_true(type.of_value(v) == type.of<int>())
+}
+
+function of_value_helper(q: string) -> string throws never {
+    return q
+}
+
+test "of_value_function_value_reports_function_type" {
+    let f: baml.AnyFunction = of_value_helper;
+    let t = type.of_value(f);
+    // The reconstructed signature type mentions the arrow, not `unknown`.
+    assert.is_true(t != type.of<unknown>())
+}
+
+// ─── `reflect` shorthand and its qualified form (BEP-066 I-9) ────────────────
+
+test "reflect_signature_bare_and_qualified_agree" {
+    let f: baml.AnyFunction = of_value_helper;
+    let bare = reflect.signature(f);
+    let qualified = baml.reflect.signature(f);
+    assert.equal(bare.returns.to_string(), "string");
+    assert.is_true(bare.returns == qualified.returns);
+    assert.is_true(bare.errors == qualified.errors)
 }

--- a/baml_language/crates/baml_tests/baml_src/ns_reflect_type_of_generic/reflect_type_of_generic.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_reflect_type_of_generic/reflect_type_of_generic.baml
@@ -1,4 +1,4 @@
-// Tests for `reflect.type_of<T>()` inside generic functions.
+// Tests for `type.of<T>()` inside generic functions.
 //
 // Converted from crates/baml_tests/tests/reflect_type_of_generic.rs.
 //
@@ -15,7 +15,7 @@ class User { name string }
 // ─── Bare-T tests ─────────────────────────────────────────────────────────────
 
 function describe<T>() -> string {
-    reflect.type_of<T>().to_string()
+    type.of<T>().to_string()
 }
 
 function describe_user_fn() -> string {
@@ -45,7 +45,7 @@ test "describe_string_returns_string" {
 // ─── Composite template tests ─────────────────────────────────────────────────
 
 function array_of<T>() -> type {
-    reflect.type_of<T[]>()
+    type.of<T[]>()
 }
 
 function array_of_user_to_string_fn() -> string {
@@ -67,11 +67,11 @@ test "array_of_int_to_string" {
 // ─── Equality tests ───────────────────────────────────────────────────────────
 
 function described_type<T>() -> type {
-    reflect.type_of<T>()
+    type.of<T>()
 }
 
 function described_type_eq_concrete_fn() -> bool {
-    described_type<User>() == reflect.type_of<User>()
+    described_type<User>() == type.of<User>()
 }
 
 test "described_type_eq_concrete" {
@@ -79,7 +79,7 @@ test "described_type_eq_concrete" {
 }
 
 function described_type_neq_different_fn() -> bool {
-    described_type<int>() == reflect.type_of<User>()
+    described_type<int>() == type.of<User>()
 }
 
 test "described_type_neq_different" {
@@ -89,7 +89,7 @@ test "described_type_neq_different" {
 // ─── Closure captures type args ───────────────────────────────────────────────
 
 function make_describer<T>() -> () -> string throws never {
-    return () -> string { reflect.type_of<T>().to_string() }
+    return () -> string { type.of<T>().to_string() }
 }
 
 function closure_captures_type_arg_user_fn() -> string {
@@ -117,7 +117,7 @@ function fwd<T>() -> type {
 }
 
 function fwd_user_eq_reflect_type_of_user_fn() -> bool {
-    fwd<User>() == reflect.type_of<User>()
+    fwd<User>() == type.of<User>()
 }
 
 test "fwd_user_eq_reflect_type_of_user" {
@@ -125,7 +125,7 @@ test "fwd_user_eq_reflect_type_of_user" {
 }
 
 function fwd_int_neq_user_fn() -> bool {
-    fwd<int>() == reflect.type_of<User>()
+    fwd<int>() == type.of<User>()
 }
 
 test "fwd_int_neq_user" {
@@ -133,7 +133,7 @@ test "fwd_int_neq_user" {
 }
 
 function level1<T>() -> type {
-    reflect.type_of<T>()
+    type.of<T>()
 }
 
 function level2<T>() -> type {
@@ -145,7 +145,7 @@ function level3<T>() -> type {
 }
 
 function three_level_forwarding_eq_concrete_fn() -> bool {
-    level3<User>() == reflect.type_of<User>()
+    level3<User>() == type.of<User>()
 }
 
 test "three_level_forwarding_eq_concrete" {
@@ -153,7 +153,7 @@ test "three_level_forwarding_eq_concrete" {
 }
 
 function level1_str<T>() -> string {
-    reflect.type_of<T>().to_string()
+    type.of<T>().to_string()
 }
 
 function level2_str<T>() -> string {
@@ -175,7 +175,7 @@ test "three_level_forwarding_to_string" {
 // ─── Closure capturing composite type ─────────────────────────────────────────
 
 function make_array_describer<T>() -> () -> string throws never {
-    return () -> string { reflect.type_of<T[]>().to_string() }
+    return () -> string { type.of<T[]>().to_string() }
 }
 
 function closure_captures_type_arg_array_of_user_fn() -> string {
@@ -188,7 +188,7 @@ test "closure_captures_type_arg_array_of_user" {
 }
 
 function make_opt_describer<T>() -> () -> string throws never {
-    return () -> string { reflect.type_of<T?>().to_string() }
+    return () -> string { type.of<T?>().to_string() }
 }
 
 function closure_captures_type_arg_optional_of_int_fn() -> string {
@@ -206,7 +206,7 @@ class Box<T> {
     value T
 
     function describe(self) -> string {
-        reflect.type_of<T>().to_string()
+        type.of<T>().to_string()
     }
 }
 
@@ -227,7 +227,7 @@ class Inner<U> {
     v U
 
     function name(self) -> string {
-        reflect.type_of<U>().to_string()
+        type.of<U>().to_string()
     }
 }
 
@@ -252,7 +252,7 @@ class InnerShow<U> {
     v U
 
     function show(self) -> string {
-        reflect.type_of<U>().to_string()
+        type.of<U>().to_string()
     }
 }
 
@@ -277,7 +277,7 @@ class Leaf<T> {
     v T
 
     function describe(self) -> string {
-        reflect.type_of<T>().to_string()
+        type.of<T>().to_string()
     }
 }
 

--- a/baml_language/crates/baml_tests/baml_src/ns_self_frame_slot/self_frame_slot.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_self_frame_slot/self_frame_slot.baml
@@ -1,7 +1,7 @@
 // The `Self` frame slot: interface-owned default-method bodies carry the
 // receiver's concrete type at frame slot 0 (layout
 // `[Self ++ interface generics ++ associated types ++ fn generics]`), so
-// body-position `Self` — `is` tests, match arms, `reflect.type_of<Self>()` —
+// body-position `Self` — `is` tests, match arms, `type.of<Self>()` —
 // resolves to the *implementor* type at runtime through every seeding path:
 // the impl rule's realized frame (virtual/existential dispatch and plain
 // concrete-receiver calls), bound methods (frame materialized at bind time),
@@ -35,13 +35,13 @@ interface Kinded {
 
     /// Reflect the concrete implementor type.
     function kind_name(self) -> string throws never {
-        reflect.type_of<Self>().to_string()
+        type.of<Self>().to_string()
     }
 
     /// A closure created in the default body captures the frame — including
     /// the `Self` slot — positionally.
     function kind_namer(self) -> (() -> string throws never) throws never {
-        return () -> string { reflect.type_of<Self>().to_string() };
+        return () -> string { type.of<Self>().to_string() };
     }
 }
 
@@ -213,9 +213,9 @@ interface Store<T> {
     /// Reads all three frame regions: `Self` (slot 0), the interface generic,
     /// and the associated type.
     function describe(self) -> string throws never {
-        reflect.type_of<Self>().to_string()
-            + "/" + reflect.type_of<T>().to_string()
-            + "/" + reflect.type_of<Self.Key>().to_string()
+        type.of<Self>().to_string()
+            + "/" + type.of<T>().to_string()
+            + "/" + type.of<Self.Key>().to_string()
     }
 }
 
@@ -277,7 +277,7 @@ implements Marked for int {
         other is Self
     }
     function type_name(self) -> string throws never {
-        reflect.type_of<Self>().to_string()
+        type.of<Self>().to_string()
     }
 }
 
@@ -289,7 +289,7 @@ implements<T> Marked for T[] {
         other is Self
     }
     function type_name(self) -> string throws never {
-        reflect.type_of<Self>().to_string()
+        type.of<Self>().to_string()
     }
 }
 
@@ -302,7 +302,7 @@ class Croc {
             other is Self
         }
         function type_name(self) -> string throws never {
-            reflect.type_of<Self>().to_string()
+            type.of<Self>().to_string()
         }
     }
 }
@@ -317,7 +317,7 @@ class Crate<T> {
             other is Self
         }
         function type_name(self) -> string throws never {
-            reflect.type_of<Self>().to_string()
+            type.of<Self>().to_string()
         }
     }
 }

--- a/baml_language/crates/baml_tests/baml_src/ns_streaming_parsing/streaming_parsing.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_streaming_parsing/streaming_parsing.baml
@@ -80,7 +80,7 @@ function repoint_request(req: baml.http.Request, addr: string) -> baml.http.Requ
 // Pin for the `$parse_stream` companion's type-arg threading: its body is
 // synthesized by PPIR as `CLIENT.__make_stream<STREAM_EXPANDED, ORIGINAL>(sse)`
 // (see `synthesize_llm_make_stream_call`), so `StreamCache.new` gets its types
-// from the frame via `reflect.type_of` — no function-name string is involved.
+// from the frame via `type.of` — no function-name string is involved.
 // Class-typed and namespaced to exercise resolution of the PPIR-synthetic
 // `Doc$stream` in the explicit type args. The two chunks split mid-string so
 // the partial parser sees an incomplete object before the final one.

--- a/baml_language/crates/baml_tests/baml_src/ns_type_reflection/type_reflection.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_type_reflection/type_reflection.baml
@@ -93,7 +93,7 @@ test "deep_equals_type_values_different" {
 
 function union_order_eq_fn() -> bool {
     // Same comparison as "union_order_eq_canonical_in_test_block", function context.
-    reflect.type_of<int | string>() == reflect.type_of<string | int>()
+    type.of<int | string>() == type.of<string | int>()
 }
 
 test "union_order_eq_canonical_in_function" {
@@ -104,14 +104,14 @@ test "union_order_eq_canonical_in_function" {
 test "union_order_eq_canonical_in_test_block" {
     // Same comparison inline in a test block — must agree with the function
     // context (regression for the pre-#3782 context divergence).
-    let a = reflect.type_of<int | string>();
-    let b = reflect.type_of<string | int>();
+    let a = type.of<int | string>();
+    let b = type.of<string | int>();
     assert.is_true(baml.deep_equals(a == b, true))
 }
 
 function union_order_deep_equals_fn() -> bool {
-    let a = reflect.type_of<int | string>();
-    let b = reflect.type_of<string | int>();
+    let a = type.of<int | string>();
+    let b = type.of<string | int>();
     baml.deep_equals(a, b)
 }
 
@@ -122,7 +122,7 @@ test "union_order_deep_equals_syntactic_in_function" {
 }
 
 test "union_order_deep_equals_syntactic_in_test_block" {
-    let a = reflect.type_of<int | string>();
-    let b = reflect.type_of<string | int>();
+    let a = type.of<int | string>();
+    let b = type.of<string | int>();
     assert.is_true(baml.deep_equals(baml.deep_equals(a, b), false))
 }

--- a/baml_language/crates/baml_tests/baml_src/ns_type_reflection/type_reflection.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_type_reflection/type_reflection.baml
@@ -1,4 +1,5 @@
-// Tests for `Object::Type` structural equality via `baml.llm.get_return_type`.
+// Tests for BEP-066 minted `Object::Type` identity via
+// `baml.llm.get_return_type`.
 //
 // Converted from crates/baml_tests/tests/type_reflection.rs.
 //
@@ -73,23 +74,14 @@ test "deep_equals_type_values_different" {
     assert.is_true(baml.deep_equals(baml.deep_equals(a, b), false))
 }
 
-// ─── CHARACTERIZATION: `==` vs `baml.deep_equals` on permuted unions ────────
+// ─── BEP-066 PR 4: unified type equality on permuted unions ─────────────────
 //
-// These tests PIN A KNOWN INCONSISTENCY — they are not an endorsement of it.
-// BAML currently has divergent equality implementations for `type` values:
-//
-//   * `==` lowers through the `baml.ops.equals_equals` driver, which compares
-//     type values with `vm.equivalent(..)` — CANONICAL equivalence, so union
-//     member order does not matter (bex_vm/src/package_baml/ops.rs).
-//   * `baml.deep_equals` compares with the derived `PartialEq` on `RealizedTy`
-//     — SYNTACTIC equality, so union member order DOES matter
-//     (bex_vm/src/package_baml/root.rs).
-//
-// Both behave identically in test-block and function contexts (the historical
-// context divergence was #3782's lowering bug, now fixed). The follow-up
-// s1-mint-identity PR replaces all equality sites with a single mint-identity
-// comparison; when it lands these pins must be updated together with it.
-// Full diagnosis: thoughts/antonio/s1-vm-bug-diagnosis.md.
+// PR 1 deliberately pinned the old divergence: `==` canonicalized while
+// `baml.deep_equals` compared the `RealizedTy` payload syntactically. BEP-066
+// slice-1 PR 4 flips those pins: all three VM equality sites compare the same
+// mint. Static mints digest the canonical form, so union order is irrelevant
+// to both operations. Function and test-block contexts remain paired as the
+// regression net for #3782.
 
 function union_order_eq_fn() -> bool {
     // Same comparison as "union_order_eq_canonical_in_test_block", function context.
@@ -116,13 +108,13 @@ function union_order_deep_equals_fn() -> bool {
 }
 
 test "union_order_deep_equals_syntactic_in_function" {
-    // `baml.deep_equals` : permuted unions compare UNEQUAL (syntactic path),
-    // disagreeing with `==` above. Known bug, resolved by s1-mint-identity.
-    assert.is_true(baml.deep_equals(union_order_deep_equals_fn(), false))
+    // Flipped in BEP-066 slice-1 PR 4: deep_equals now uses the same static
+    // canonical mint as `==`.
+    assert.is_true(baml.deep_equals(union_order_deep_equals_fn(), true))
 }
 
 test "union_order_deep_equals_syntactic_in_test_block" {
     let a = type.of<int | string>();
     let b = type.of<string | int>();
-    assert.is_true(baml.deep_equals(baml.deep_equals(a, b), false))
+    assert.is_true(baml.deep_equals(baml.deep_equals(a, b), true))
 }

--- a/baml_language/crates/baml_tests/projects/compiles/reflect_shadowing/main.baml
+++ b/baml_language/crates/baml_tests/projects/compiles/reflect_shadowing/main.baml
@@ -1,0 +1,60 @@
+// BEP-066: `reflect` is a keyword shorthand for `baml.reflect` (and `type`,
+// as an expression path head, for `baml.type`). A user-defined name wins:
+// the shorthand only kicks in when ordinary resolution misses.
+
+class reflect {
+    label string
+
+    function describe(self) -> string {
+        return "user-" + self.label
+    }
+}
+
+// A user class named `reflect` resolves over the shorthand: construction and
+// member access on it hit the class, not the `baml.reflect` namespace.
+function user_class_shadows_shorthand() -> string {
+    let r = reflect { label: "shadow" }
+    return r.describe()
+}
+
+// Type-rooted path access on the user class also wins over the shorthand:
+// `reflect.describe` is the class's unbound method, not a `baml.reflect`
+// lookup.
+function unbound_user_method() -> string {
+    let m = reflect.describe
+    return m(reflect { label: "x" })
+}
+
+// A local named `reflect` shadows both the class and the shorthand.
+function local_shadows_shorthand() -> int {
+    let reflect = 1
+    return reflect + 1
+}
+
+function helper(q: string) -> string throws never {
+    return q + "!"
+}
+
+// Even with the user class shadowing the bare name, the explicit
+// `baml.reflect` path still reaches the stdlib namespace.
+function qualified_still_works() -> string {
+    let f: baml.AnyFunction = helper
+    let sig = baml.reflect.signature(f)
+    return sig.returns.to_string()
+}
+
+test "user class shadows shorthand" {
+    assert.equal(user_class_shadows_shorthand(), "user-shadow")
+}
+
+test "unbound user method over shorthand" {
+    assert.equal(unbound_user_method(), "user-x")
+}
+
+test "local shadows shorthand" {
+    assert.equal(local_shadows_shorthand(), 2)
+}
+
+test "qualified baml.reflect still works" {
+    assert.equal(qualified_still_works(), "string")
+}

--- a/baml_language/crates/baml_tests/projects/compiles/reflect_type_of_user_generic/main.baml
+++ b/baml_language/crates/baml_tests/projects/compiles/reflect_type_of_user_generic/main.baml
@@ -3,7 +3,7 @@
 // Phase 6's stdlib cleanup dropped `type_def: type` from `primitive.parse<T>(body)`
 // because the compiler now threads `T`'s runtime type through generic call
 // boundaries automatically. The same mechanism lets user code write
-// `reflect.type_of<T>()` inside a generic function and have `T` resolve to
+// `type.of<T>()` inside a generic function and have `T` resolve to
 // the caller-supplied type at runtime.
 //
 // This project pins the user-facing TIR/MIR shape of that auto-threading.
@@ -12,11 +12,11 @@
 class Person { name string }
 
 function reflect_type<T>() -> type {
-    reflect.type_of<T>()
+    type.of<T>()
 }
 
 function reflect_array<T>() -> type {
-    reflect.type_of<T[]>()
+    type.of<T[]>()
 }
 
 function reflect_person() -> type {

--- a/baml_language/crates/baml_tests/projects/compiles/stream_llm_inferred_typeargs/main.baml
+++ b/baml_language/crates/baml_tests/projects/compiles/stream_llm_inferred_typeargs/main.baml
@@ -13,7 +13,7 @@
 // like the one below work because TIR persists inferred instantiations in
 // `CallPlan.type_args` (including phase-0 reverse inference from the
 // expected return type) and MIR materializes them into the callee frame,
-// where `__make_stream` reifies them via `reflect.type_of<TStream/TFinal>()`.
+// where `__make_stream` reifies them via `type.of<TStream/TFinal>()`.
 // There is no name-keyed registry fallback anymore — a propagation gap
 // would surface as "Non-parsable type: ..." from `StreamCache.new`.
 // Runtime coverage: `streaming_parsing::stream_string_final_value` and

--- a/baml_language/crates/baml_tests/projects/compiles/type_kinds/main.baml
+++ b/baml_language/crates/baml_tests/projects/compiles/type_kinds/main.baml
@@ -1,0 +1,42 @@
+class Foo {
+  value int
+}
+
+enum Color {
+  Red
+  Blue
+}
+
+interface Marker {}
+
+type Callback = (value: int) -> bool throws never
+
+function classify(t: type) -> string {
+  match (t.kind()) {
+    baml.reflect.class.Type => "class",
+    baml.reflect.enum.Type => "enum",
+    baml.reflect.union.Type => "union",
+    baml.reflect.literal.Type => "literal",
+    baml.reflect.array.Type => "array",
+    baml.reflect.map.Type => "map",
+    baml.reflect.interface.Type => "interface",
+    baml.reflect.primitive.Type => "primitive",
+    baml.reflect.function.Type => "function"
+  }
+}
+
+function read_class(view: baml.reflect.class.Type) -> type throws never {
+  view.as_type()
+}
+
+function exercise_all_kinds() -> bool {
+  classify(type.of<Foo>()) == "class"
+    && classify(type.of<Color>()) == "enum"
+    && classify(type.of<int | string>()) == "union"
+    && classify(type.of<"fixed">()) == "literal"
+    && classify(type.of<Foo[]>()) == "array"
+    && classify(type.of<map<string, Foo>>()) == "map"
+    && classify(type.of<Marker>()) == "interface"
+    && classify(type.of<int>()) == "primitive"
+    && classify(type.of<Callback>()) == "function"
+}

--- a/baml_language/crates/baml_tests/projects/diagnostic_errors/removed_reflect_type_of/main.baml
+++ b/baml_language/crates/baml_tests/projects/diagnostic_errors/removed_reflect_type_of/main.baml
@@ -1,0 +1,12 @@
+// BEP-066 I-9: `reflect.type_of` was REMOVED (renamed to `type.of`), not
+// aliased. Both the bare shorthand spelling and the fully qualified one must
+// error with a diagnostic that names the replacement, not a bare
+// "unresolved name".
+
+function old_bare_spelling() -> type {
+    reflect.type_of<int>()
+}
+
+function old_qualified_spelling() -> type {
+    baml.reflect.type_of<string>()
+}

--- a/baml_language/crates/baml_tests/projects/diagnostic_errors/self_in_body/main.baml
+++ b/baml_language/crates/baml_tests/projects/diagnostic_errors/self_in_body/main.baml
@@ -39,7 +39,7 @@ class Box<T> {
         }
     }
     function turbofish_self(self) -> string {
-        reflect.type_of<Self>().to_string()
+        type.of<Self>().to_string()
     }
 }
 
@@ -51,7 +51,7 @@ interface Tester {
         other is Self
     }
     function describe(self) -> string throws never {
-        reflect.type_of<Self>().to_string()
+        type.of<Self>().to_string()
     }
     function bind_self(self, other: Self) -> bool throws never {
         let a: Self = other;

--- a/baml_language/crates/baml_tests/projects/diagnostic_errors/type_kinds/main.baml
+++ b/baml_language/crates/baml_tests/projects/diagnostic_errors/type_kinds/main.baml
@@ -1,0 +1,16 @@
+function non_exhaustive(t: type) -> string {
+  match (t.kind()) {
+    baml.reflect.class.Type => "class",
+    baml.reflect.enum.Type => "enum",
+    baml.reflect.union.Type => "union",
+    baml.reflect.literal.Type => "literal",
+    baml.reflect.array.Type => "array",
+    baml.reflect.map.Type => "map",
+    baml.reflect.interface.Type => "interface",
+    baml.reflect.primitive.Type => "primitive"
+  }
+}
+
+function kinds_are_not_constructible() -> baml.reflect.class.Type {
+  baml.reflect.class.Type {}
+}

--- a/baml_language/crates/baml_tests/projects/diagnostic_errors/type_reflection_strict/reflect_intrinsic_errors.baml
+++ b/baml_language/crates/baml_tests/projects/diagnostic_errors/type_reflection_strict/reflect_intrinsic_errors.baml
@@ -1,4 +1,4 @@
-// Negative cases for the `reflect.type_of` compiler intrinsic itself.
+// Negative cases for the `type.of` compiler intrinsic itself.
 // These complement `strict_normalization.baml` (which exercises Ty::Type
 // strictness via `baml.llm.get_return_type`) by hitting the intrinsic path
 // directly.
@@ -9,18 +9,18 @@ class User { name string }
 // to a non-`type` slot. Validates Phase 2's strictness all the way through
 // Phase 4's `LoadType` lowering.
 function reflect_type_to_int() -> int {
-    let x: int = reflect.type_of<User>();
+    let x: int = type.of<User>();
     return x;
 }
 
-// Unknown type referenced inside `reflect.type_of<...>`.
+// Unknown type referenced inside `type.of<...>`.
 function unknown_type_in_reflect() -> type {
-    reflect.type_of<NonExistent>()
+    type.of<NonExistent>()
 }
 
 // Arity mismatch on the intrinsic: it declares one type parameter, caller
 // passes two. Validates Phase 1's `WrongTypeArgArity` against the new
 // builtin.
 function too_many_type_args() -> type {
-    reflect.type_of<int, string>()
+    type.of<int, string>()
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
+assertion_line: 149
 ---
 function $init() -> null {
     call $init_let_0
@@ -365,10 +366,4 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
+assertion_line: 149
 ---
 function lambdas.$init_test_ns_lambdas_lambdas(registry: testing.TestCollector) -> null {
     load_var registry
@@ -482,7 +483,7 @@ function lambdas.lambdas_inferred_return_type_lambda() -> int {
 
 function lambdas.lambdas_inferred_signature() -> string {
     make_closure .<lambda(lambdas_inferred_signature, 0)>, 0
-    call reflect.signature
+    call baml.reflect.signature
     store_var sig
     load_var sig
     load_field .returns
@@ -502,7 +503,7 @@ function lambdas.lambdas_inferred_signature() -> string {
 
 function lambdas.lambdas_inferred_throwing_signature() -> string {
     make_closure .<lambda(lambdas_inferred_throwing_signature, 0)>, 0
-    call reflect.signature
+    call baml.reflect.signature
     store_var sig
     load_var sig
     load_field .returns

--- a/baml_language/crates/baml_tests/snapshots/baml_src/reflect_type_of.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/reflect_type_of.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
+assertion_line: 149
 ---
 function reflect_type_of.$init_test_ns_reflect_type_of_reflect_type_of(registry: testing.TestCollector) -> null {
     load_var registry
@@ -156,7 +157,75 @@ function reflect_type_of.$init_test_ns_reflect_type_of_reflect_type_of(registry:
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
+    load_var registry
+    load_const "root.reflect_type_of"
+    load_const "of_value_int"
+    make_closure .<lambda($init_test_ns_reflect_type_of_reflect_type_of, 22)>, 0
     load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.reflect_type_of"
+    load_const "of_value_never_yields_a_literal_type"
+    make_closure .<lambda($init_test_ns_reflect_type_of_reflect_type_of, 23)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.reflect_type_of"
+    load_const "of_value_string_and_bool"
+    make_closure .<lambda($init_test_ns_reflect_type_of_reflect_type_of, 24)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.reflect_type_of"
+    load_const "of_value_class_instance"
+    make_closure .<lambda($init_test_ns_reflect_type_of_reflect_type_of, 25)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.reflect_type_of"
+    load_const "of_value_array_reports_element_type"
+    make_closure .<lambda($init_test_ns_reflect_type_of_reflect_type_of, 26)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.reflect_type_of"
+    load_const "of_value_of_a_type_value_is_type"
+    make_closure .<lambda($init_test_ns_reflect_type_of_reflect_type_of, 27)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.reflect_type_of"
+    load_const "of_value_widened_unknown_slot"
+    make_closure .<lambda($init_test_ns_reflect_type_of_reflect_type_of, 28)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.reflect_type_of"
+    load_const "of_value_function_value_reports_function_type"
+    make_closure .<lambda($init_test_ns_reflect_type_of_reflect_type_of, 29)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.reflect_type_of"
+    load_const "reflect_signature_bare_and_qualified_agree"
+    make_closure .<lambda($init_test_ns_reflect_type_of_reflect_type_of, 30)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_const null
+    return
+}
+
+function reflect_type_of.of_value_helper(q: string) -> string {
+    load_var q
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/reflect_type_of.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/reflect_type_of.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
-assertion_line: 149
 ---
 function reflect_type_of.$init_test_ns_reflect_type_of_reflect_type_of(registry: testing.TestCollector) -> null {
     load_var registry
@@ -194,7 +193,7 @@ function reflect_type_of.$init_test_ns_reflect_type_of_reflect_type_of(registry:
     pop 1
     load_var registry
     load_const "root.reflect_type_of"
-    load_const "of_value_of_a_type_value_is_type"
+    load_const "of_value_of_a_type_value_is_precise_kind"
     make_closure .<lambda($init_test_ns_reflect_type_of_reflect_type_of, 27)>, 0
     load_const null
     call testing.TestCollector.register_test_at

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 2875
 ---
 === PPIR ===
 
@@ -1221,7 +1222,7 @@ class baml.llm.PlannerState$stream {
   rr_client_names: string[]
 }
 function baml.llm.__new_stream_cache() -> StreamCache<TStream, TFinal>  [expr] {
-  { let cache: StreamCache<TStream, TFinal> = StreamCache.new(reflect.type_of(), reflect.type_of()) } cache
+  { let cache: StreamCache<TStream, TFinal> = StreamCache.new(type.of(), type.of()) } cache
 }
 function baml.llm.build_request(client: Client, function_name: string, args: map<string, unknown>, prompt_closure: (Context) -> PromptAst throws never? = null) -> root.http.Request  [expr] {
   { let return_type = get_return_type(function_name); let primitive_client = client.to_primitive_client(); let template = prompt_template_for(function_name, prompt_closure); let specialized_prompt = primitive_client.render_specialized_prompt(template, args, return_type, prompt_closure) } primitive_client.build_request(specialized_prompt, return_type)
@@ -1233,7 +1234,7 @@ function baml.llm.call_llm_function(client: Client, function_name: string, args:
   { let jinja_string = match (prompt_closure) { null => get_jinja_template(function_name), _ => "" }; let context = baml.llm.ExecutionContext { jinja_string: jinja_string, args: args, function_name: function_name, prompt_closure: prompt_closure }; let result: T = client.execute_oneshot(context, 0) } result
 }
 function baml.llm.parse(json: string) -> TFinal  [expr] {
-  { let cache: StreamCache<TStream, TFinal> = StreamCache.new(reflect.type_of(), reflect.type_of()) } __sap_parse_final(json, cache) catch (_) { root.errors.LlmClient { message: message } => throw root.errors.ParseError { message: message } }
+  { let cache: StreamCache<TStream, TFinal> = StreamCache.new(type.of(), type.of()) } __sap_parse_final(json, cache) catch (_) { root.errors.LlmClient { message: message } => throw root.errors.ParseError { message: message } }
 }
 function baml.llm.prompt_template_for(function_name: string, prompt_closure: (Context) -> PromptAst throws never?) -> string  [expr] {
   {  } match (prompt_closure) { null => get_jinja_template(function_name), _ => "" }
@@ -1480,7 +1481,7 @@ class baml.llm.VertexAiOptions$stream {
 }
 enum baml.llm.ClientType {Primitive, Fallback, RoundRobin}
 function baml.llm.__make_stream(self: ?, sse: root.http.SseStream) -> baml.llm.Stream<TStream, TFinal>  [expr] {
-  { let primitive = self.to_primitive_client(); let acc = primitive.new_stream_accumulator(); let cache: baml.llm.StreamCache<TStream, TFinal> = StreamCache.new(reflect.type_of(), reflect.type_of()) } baml.llm.Stream { _client: primitive, _acc: acc, _sse: sse, _cache: cache }
+  { let primitive = self.to_primitive_client(); let acc = primitive.new_stream_accumulator(); let cache: baml.llm.StreamCache<TStream, TFinal> = StreamCache.new(type.of(), type.of()) } baml.llm.Stream { _client: primitive, _acc: acc, _sse: sse, _cache: cache }
 }
 function baml.llm.__sap_parse_final(json: string, cache: baml.llm.StreamCache<TStream, TFinal>) -> TFinal  [builtin]
 function baml.llm.__sap_parse_partial(json: string, cache: baml.llm.StreamCache<TStream, TFinal>) -> TStream | root.stream.StreamNoYield  [builtin]
@@ -1506,7 +1507,7 @@ function baml.llm.build_request(self: ?, prompt: baml.llm.PromptAst, return_type
 function baml.llm.build_request_stream(self: ?, prompt: baml.llm.PromptAst, return_type: type) -> root.http.Request  [builtin]
 function baml.llm.content(self: ?) -> string  [builtin]
 function baml.llm.execute_once_oneshot(self: ?, context: ExecutionContext, active_delay_ms: int) -> T  [expr] {
-  {  } match (self.client_type) { baml.llm.ClientType.Primitive => { let primitive = self.to_primitive_client(); let return_type = reflect.type_of(); let specialized = primitive.render_specialized_prompt(context.jinja_string, context.args, return_type, context.prompt_closure); let http_request = primitive.build_request(specialized, return_type); let http_response = root.http.send(http_request) } if (http_response.ok()) { let body = http_response.text(); let result: T = primitive.parse(body) catch (e) { _ => { if (active_delay_ms Gt 0) {  } root.sys.sleep(root.time.Duration.from_nanoseconds(active_delay_ms Mul 1000000n)); throw e } } } result else { let error_body = http_response.text() catch (e) { _ => {  } "" }; if (active_delay_ms Gt 0) {  } root.sys.sleep(root.time.Duration.from_nanoseconds(active_delay_ms Mul 1000000n)); throw root.errors.DevOther { message: "HTTP request fail..." Add error_body } }, baml.llm.ClientType.Fallback => { for sub in self.sub_clients { let result2: T = sub.execute_oneshot(context, active_delay_ms) catch (e) { _ => { continue } }; return result2 }; throw root.errors.DevOther { message: "All orchestration..." } }, baml.llm.ClientType.RoundRobin => { if (self.sub_clients.length() Eq 0) { throw root.errors.DevOther { message: "RoundRobin client..." } }; let idx = self.counter Mod self.sub_clients.length(); self.counter Add= 1; let result3: T = self.sub_clients[idx].execute_oneshot(context, active_delay_ms); return result3 } }
+  {  } match (self.client_type) { baml.llm.ClientType.Primitive => { let primitive = self.to_primitive_client(); let return_type = type.of(); let specialized = primitive.render_specialized_prompt(context.jinja_string, context.args, return_type, context.prompt_closure); let http_request = primitive.build_request(specialized, return_type); let http_response = root.http.send(http_request) } if (http_response.ok()) { let body = http_response.text(); let result: T = primitive.parse(body) catch (e) { _ => { if (active_delay_ms Gt 0) {  } root.sys.sleep(root.time.Duration.from_nanoseconds(active_delay_ms Mul 1000000n)); throw e } } } result else { let error_body = http_response.text() catch (e) { _ => {  } "" }; if (active_delay_ms Gt 0) {  } root.sys.sleep(root.time.Duration.from_nanoseconds(active_delay_ms Mul 1000000n)); throw root.errors.DevOther { message: "HTTP request fail..." Add error_body } }, baml.llm.ClientType.Fallback => { for sub in self.sub_clients { let result2: T = sub.execute_oneshot(context, active_delay_ms) catch (e) { _ => { continue } }; return result2 }; throw root.errors.DevOther { message: "All orchestration..." } }, baml.llm.ClientType.RoundRobin => { if (self.sub_clients.length() Eq 0) { throw root.errors.DevOther { message: "RoundRobin client..." } }; let idx = self.counter Mod self.sub_clients.length(); self.counter Add= 1; let result3: T = self.sub_clients[idx].execute_oneshot(context, active_delay_ms); return result3 } }
 }
 function baml.llm.execute_once_stream(self: ?, context: ExecutionContext, active_delay_ms: int) -> baml.llm.Stream<TStream, TFinal>  [expr] {
   {  } match (self.client_type) { baml.llm.ClientType.Primitive => { let primitive = self.to_primitive_client(); let return_type = get_return_type(context.function_name); let specialized = primitive.render_specialized_prompt(context.jinja_string, context.args, return_type, context.prompt_closure); let http_request = primitive.build_request_stream(specialized, return_type); let sse = root.http.fetch_sse(http_request); let stream: baml.llm.Stream<TStream, TFinal> = self.__make_stream(sse); return stream }, baml.llm.ClientType.Fallback => { for sub in self.sub_clients { let result2: baml.llm.Stream<TStream, TFinal> = sub.execute_stream(context, active_delay_ms) catch (e) { _ => { continue } }; return result2 }; throw root.errors.DevOther { message: "All orchestration..." } }, baml.llm.ClientType.RoundRobin => { if (self.sub_clients.length() Eq 0) { throw root.errors.DevOther { message: "RoundRobin client..." } }; let idx = self.counter Mod self.sub_clients.length(); self.counter Add= 1; let result3: baml.llm.Stream<TStream, TFinal> = self.sub_clients[idx].execute_stream(context, active_delay_ms); return result3 } }
@@ -1924,6 +1925,44 @@ function baml.random.random_int(self: ?) -> int  [expr] {
 function baml.random.random_int(self: ?) -> int  [builtin]
 function baml.random.random_int(self: ?) -> int  [builtin]
 function baml.random.random_int(self: ?) -> int  [builtin]
+
+--- <builtin>/baml/ns_reflect/reflect.baml ---
+class baml.reflect.Arg {
+  name: string
+  type: type
+}
+class baml.reflect.Arg$stream {
+  name: string | null
+  type: unknown
+}
+class baml.reflect.InvalidArgumentError {
+  argument: string
+  expected: type
+  got: type
+}
+class baml.reflect.InvalidArgumentError$stream {
+  argument: string | null
+  expected: unknown
+  got: unknown
+}
+class baml.reflect.Signature {
+  name: string?
+  args: baml.reflect.Arg[]
+  opts: map<string, baml.reflect.Arg>
+  returns: type
+  errors: type
+  docstring: string?
+}
+class baml.reflect.Signature$stream {
+  name: string | null
+  args: baml.reflect.Arg$stream[]
+  opts: map<string, baml.reflect.Arg$stream>
+  returns: unknown
+  errors: unknown
+  docstring: string | null
+}
+function baml.reflect.call_any(f: baml.AnyFunction<Returns = R, Throws = E>, args: map<string, unknown>) -> R  [builtin]
+function baml.reflect.signature(f: baml.AnyFunction) -> baml.reflect.Signature  [builtin]
 
 --- <builtin>/baml/ns_sap/sap.baml ---
 function baml.sap.parse(text: string) -> T  [expr] {
@@ -2396,6 +2435,10 @@ function baml.toml.table_from_json(j: baml.json.json) -> baml.toml.Table  [expr]
 function baml.toml.to_json(self: ?) -> baml.json.json  [expr] {
   {  } baml.json.from(self.items)
 }
+
+--- <builtin>/baml/ns_type/type.baml ---
+function baml.type.of() -> type  [builtin]
+function baml.type.of_value(v: unknown) -> type  [builtin]
 
 --- <builtin>/baml/ns_ws/ws.baml ---
 class baml.ws.WsStream {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 2875
 ---
 === PPIR ===
 
@@ -1926,6 +1925,109 @@ function baml.random.random_int(self: ?) -> int  [builtin]
 function baml.random.random_int(self: ?) -> int  [builtin]
 function baml.random.random_int(self: ?) -> int  [builtin]
 
+--- <builtin>/baml/ns_reflect/ns_array/array.baml ---
+class baml.reflect.array.Type {
+}
+class baml.reflect.array.Type$stream {
+}
+function baml.reflect.array.as_type(self: ?) -> type  [builtin]
+function baml.reflect.array.element_type(self: ?) -> type  [builtin]
+
+--- <builtin>/baml/ns_reflect/ns_class/class.baml ---
+class baml.reflect.class.Field {
+  name: string
+  type: type?
+  meta: baml.reflect.Meta
+}
+class baml.reflect.class.Field$stream {
+  name: string | null
+  type: unknown | null
+  meta: baml.reflect.Meta$stream | null
+}
+class baml.reflect.class.Type {
+}
+class baml.reflect.class.Type$stream {
+}
+function baml.reflect.class.as_type(self: ?) -> type  [builtin]
+function baml.reflect.class.fields(self: ?) -> baml.reflect.class.Field[]  [builtin]
+function baml.reflect.class.meta(self: ?) -> baml.reflect.Meta  [builtin]
+
+--- <builtin>/baml/ns_reflect/ns_enum/enum.baml ---
+class baml.reflect.enum.Type {
+}
+class baml.reflect.enum.Type$stream {
+}
+class baml.reflect.enum.Value {
+  name: string
+  meta: baml.reflect.Meta
+}
+class baml.reflect.enum.Value$stream {
+  name: string | null
+  meta: baml.reflect.Meta$stream | null
+}
+function baml.reflect.enum.as_type(self: ?) -> type  [builtin]
+function baml.reflect.enum.meta(self: ?) -> baml.reflect.Meta  [builtin]
+function baml.reflect.enum.values(self: ?) -> baml.reflect.enum.Value[]  [builtin]
+
+--- <builtin>/baml/ns_reflect/ns_function/function.baml ---
+class baml.reflect.function.Parameter {
+  name: string?
+  type: type
+  optional: bool
+}
+class baml.reflect.function.Parameter$stream {
+  name: string | null
+  type: unknown
+  optional: bool | null
+}
+class baml.reflect.function.Type {
+}
+class baml.reflect.function.Type$stream {
+}
+function baml.reflect.function.as_type(self: ?) -> type  [builtin]
+function baml.reflect.function.params(self: ?) -> baml.reflect.function.Parameter[]  [builtin]
+function baml.reflect.function.return_type(self: ?) -> type  [builtin]
+
+--- <builtin>/baml/ns_reflect/ns_interface/interface.baml ---
+class baml.reflect.interface.Type {
+}
+class baml.reflect.interface.Type$stream {
+}
+function baml.reflect.interface.as_type(self: ?) -> type  [builtin]
+function baml.reflect.interface.implemented_by(self: ?, other: type) -> bool  [builtin]
+function baml.reflect.interface.implementors(self: ?) -> type[]  [builtin]
+
+--- <builtin>/baml/ns_reflect/ns_literal/literal.baml ---
+class baml.reflect.literal.Type {
+}
+class baml.reflect.literal.Type$stream {
+}
+function baml.reflect.literal.as_type(self: ?) -> type  [builtin]
+
+--- <builtin>/baml/ns_reflect/ns_map/map.baml ---
+class baml.reflect.map.Type {
+}
+class baml.reflect.map.Type$stream {
+}
+function baml.reflect.map.as_type(self: ?) -> type  [builtin]
+function baml.reflect.map.key_type(self: ?) -> type  [builtin]
+function baml.reflect.map.value_type(self: ?) -> type  [builtin]
+
+--- <builtin>/baml/ns_reflect/ns_primitive/primitive.baml ---
+class baml.reflect.primitive.Type {
+}
+class baml.reflect.primitive.Type$stream {
+}
+function baml.reflect.primitive.as_type(self: ?) -> type  [builtin]
+
+--- <builtin>/baml/ns_reflect/ns_union/union.baml ---
+class baml.reflect.union.Type {
+}
+class baml.reflect.union.Type$stream {
+}
+function baml.reflect.union.as_type(self: ?) -> type  [builtin]
+function baml.reflect.union.member_types(self: ?) -> type[]  [builtin]
+
 --- <builtin>/baml/ns_reflect/reflect.baml ---
 class baml.reflect.Arg {
   name: string
@@ -1945,6 +2047,18 @@ class baml.reflect.InvalidArgumentError$stream {
   expected: unknown
   got: unknown
 }
+class baml.reflect.Meta {
+  alias: string?
+  description: string?
+  docstring: string?
+  other: map<string, string>
+}
+class baml.reflect.Meta$stream {
+  alias: string | null
+  description: string | null
+  docstring: string | null
+  other: map<string, string>
+}
 class baml.reflect.Signature {
   name: string?
   args: baml.reflect.Arg[]
@@ -1961,6 +2075,8 @@ class baml.reflect.Signature$stream {
   errors: unknown
   docstring: string | null
 }
+type baml.reflect.TypeKind = baml.reflect.class.Type | baml.reflect.enum.Type | baml.reflect.union.Type | baml.reflect.literal.Type | baml.reflect.array.Type | baml.reflect.map.Type | baml.reflect.interface.Type | baml.reflect.primitive.Type | baml.reflect.function.Type
+type baml.reflect.TypeKind$stream = baml.reflect.class.Type$stream | baml.reflect.enum.Type$stream | baml.reflect.union.Type$stream | baml.reflect.literal.Type$stream | baml.reflect.array.Type$stream | baml.reflect.map.Type$stream | baml.reflect.interface.Type$stream | baml.reflect.primitive.Type$stream | baml.reflect.function.Type$stream
 function baml.reflect.call_any(f: baml.AnyFunction<Returns = R, Throws = E>, args: map<string, unknown>) -> R  [builtin]
 function baml.reflect.signature(f: baml.AnyFunction) -> baml.reflect.Signature  [builtin]
 
@@ -2532,9 +2648,19 @@ class baml.TypeValue {
 class baml.TypeValue$stream {
 }
 function baml._to_string_impl(self: ?) -> string  [builtin]
+function baml.as_array(self: ?) -> baml.reflect.array.Type?  [builtin]
+function baml.as_class(self: ?) -> baml.reflect.class.Type?  [builtin]
+function baml.as_enum(self: ?) -> baml.reflect.enum.Type?  [builtin]
+function baml.as_function(self: ?) -> baml.reflect.function.Type?  [builtin]
+function baml.as_interface(self: ?) -> baml.reflect.interface.Type?  [builtin]
+function baml.as_literal(self: ?) -> baml.reflect.literal.Type?  [builtin]
+function baml.as_map(self: ?) -> baml.reflect.map.Type?  [builtin]
+function baml.as_primitive(self: ?) -> baml.reflect.primitive.Type?  [builtin]
+function baml.as_union(self: ?) -> baml.reflect.union.Type?  [builtin]
 function baml.implemented_by(self: ?, other: type) -> bool  [builtin]
 function baml.implementors(self: ?) -> type[]  [builtin]
 function baml.implements(self: ?, other: type) -> bool  [builtin]
+function baml.kind(self: ?) -> baml.reflect.TypeKind  [builtin]
 function baml.to_string(self: ?) -> string  [expr] {
   {  } self._to_string_impl()
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 2966
 ---
 === MIR2 ===
 
@@ -9016,6 +9017,10 @@ fn baml.random.ChaCha20.Rng.random = builtin(vm)
 
 fn baml.random.ChaCha20.Rng.random_int = builtin(vm)
 
+fn baml.reflect.signature = builtin(vm)
+
+fn baml.reflect.call_any = builtin(vm)
+
 fn baml.sap.parse(text: string) -> T {
     // Locals:
     let _0: T // _0 // return
@@ -12125,6 +12130,10 @@ fn baml.toml.item_from_json(json: int | float | string | bool | null | baml.json
         return;
     }
 }
+
+fn baml.type.of = builtin(intrinsic)
+
+fn baml.type.of_value = builtin(vm)
 
 fn baml.ws.WsStream.send = builtin(io)
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 2966
 ---
 === MIR2 ===
 
@@ -9017,6 +9016,48 @@ fn baml.random.ChaCha20.Rng.random = builtin(vm)
 
 fn baml.random.ChaCha20.Rng.random_int = builtin(vm)
 
+fn baml.reflect.array.Type.baml.reflect.TypeView.as_type = builtin(vm)
+
+fn baml.reflect.array.Type.element_type = builtin(vm)
+
+fn baml.reflect.class.Type.baml.reflect.TypeView.as_type = builtin(vm)
+
+fn baml.reflect.class.Type.fields = builtin(vm)
+
+fn baml.reflect.class.Type.meta = builtin(vm)
+
+fn baml.reflect.enum.Type.baml.reflect.TypeView.as_type = builtin(vm)
+
+fn baml.reflect.enum.Type.values = builtin(vm)
+
+fn baml.reflect.enum.Type.meta = builtin(vm)
+
+fn baml.reflect.function.Type.baml.reflect.TypeView.as_type = builtin(vm)
+
+fn baml.reflect.function.Type.params = builtin(vm)
+
+fn baml.reflect.function.Type.return_type = builtin(vm)
+
+fn baml.reflect.interface.Type.baml.reflect.TypeView.as_type = builtin(vm)
+
+fn baml.reflect.interface.Type.implemented_by = builtin(vm)
+
+fn baml.reflect.interface.Type.implementors = builtin(vm)
+
+fn baml.reflect.literal.Type.baml.reflect.TypeView.as_type = builtin(vm)
+
+fn baml.reflect.map.Type.baml.reflect.TypeView.as_type = builtin(vm)
+
+fn baml.reflect.map.Type.key_type = builtin(vm)
+
+fn baml.reflect.map.Type.value_type = builtin(vm)
+
+fn baml.reflect.primitive.Type.baml.reflect.TypeView.as_type = builtin(vm)
+
+fn baml.reflect.union.Type.baml.reflect.TypeView.as_type = builtin(vm)
+
+fn baml.reflect.union.Type.member_types = builtin(vm)
+
 fn baml.reflect.signature = builtin(vm)
 
 fn baml.reflect.call_any = builtin(vm)
@@ -12300,6 +12341,26 @@ fn baml.String.from_utf8 = builtin(vm)
 fn baml.String.to_code_points = builtin(vm)
 
 fn baml.String.from_code_points = builtin(vm)
+
+fn baml.TypeValue.kind = builtin(vm)
+
+fn baml.TypeValue.as_class = builtin(vm)
+
+fn baml.TypeValue.as_enum = builtin(vm)
+
+fn baml.TypeValue.as_union = builtin(vm)
+
+fn baml.TypeValue.as_literal = builtin(vm)
+
+fn baml.TypeValue.as_array = builtin(vm)
+
+fn baml.TypeValue.as_map = builtin(vm)
+
+fn baml.TypeValue.as_interface = builtin(vm)
+
+fn baml.TypeValue.as_primitive = builtin(vm)
+
+fn baml.TypeValue.as_function = builtin(vm)
 
 fn baml.TypeValue.baml.ToString.to_string(self: baml.TypeValue) -> string {
     // Locals:

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 2915
 ---
 === TIR2 ===
 
@@ -1981,7 +1982,7 @@ function baml.llm.build_request_stream(client: baml.llm.Client, function_name: s
 }
 function baml.llm.parse<TStream, TFinal>(json: string) -> TFinal throws baml.errors.ParseError {
   { : TFinal
-    let cache: StreamCache<TStream, TFinal> = StreamCache.new(reflect.type_of<TStream>(), reflect.type_of<TFinal>()) : baml.llm.StreamCache<TStream, TFinal>
+    let cache: StreamCache<TStream, TFinal> = StreamCache.new(type.of<TStream>(), type.of<TFinal>()) : baml.llm.StreamCache<TStream, TFinal>
     catch (__sap_parse_final<TFinal>(json, cache) : TFinal) : TFinal
       catch (_)
         root.errors.LlmClient { message: message } =>
@@ -1990,7 +1991,7 @@ function baml.llm.parse<TStream, TFinal>(json: string) -> TFinal throws baml.err
 }
 function baml.llm.__new_stream_cache<TStream, TFinal>() -> baml.llm.StreamCache<TStream, TFinal> throws never {
   { : baml.llm.StreamCache<TStream, TFinal>
-    let cache: StreamCache<TStream, TFinal> = StreamCache.new(reflect.type_of<TStream>(), reflect.type_of<TFinal>()) : baml.llm.StreamCache<TStream, TFinal>
+    let cache: StreamCache<TStream, TFinal> = StreamCache.new(type.of<TStream>(), type.of<TFinal>()) : baml.llm.StreamCache<TStream, TFinal>
     cache : baml.llm.StreamCache<TStream, TFinal>
   }
 }
@@ -2283,7 +2284,7 @@ function baml.llm.Client.__make_stream<TStream, TFinal>(self: baml.llm.Client, s
   { : baml.llm.Stream<TStream, TFinal>
     let primitive = self.to_primitive_client() : baml.llm.PrimitiveClient
     let acc = primitive.new_stream_accumulator() : baml.llm.StreamAccumulator
-    let cache: StreamCache<TStream, TFinal> = StreamCache.new(reflect.type_of<TStream>(), reflect.type_of<TFinal>()) : baml.llm.StreamCache<TStream, TFinal>
+    let cache: StreamCache<TStream, TFinal> = StreamCache.new(type.of<TStream>(), type.of<TFinal>()) : baml.llm.StreamCache<TStream, TFinal>
     Stream { _client: primitive, _acc: acc, _sse: sse, _cache: cache } : baml.llm.Stream<TStream, TFinal>
   }
 }
@@ -2340,7 +2341,7 @@ function baml.llm.Client.execute_once_oneshot<T>(self: baml.llm.Client, context:
       ClientType.Primitive =>
         { : T
           let primitive = self.to_primitive_client() : baml.llm.PrimitiveClient
-          let return_type = reflect.type_of() : type
+          let return_type = type.of() : type
           let specialized = primitive.render_specialized_prompt(context.jinja_string, context.args, return_type, context.prompt_closure) : baml.llm.PromptAst
           let http_request = primitive.build_request(specialized, return_type) : baml.http.Request
           let http_response = root.http.send(http_request) : baml.http.Response
@@ -2986,6 +2987,42 @@ class baml.random.Xoshiro256PlusPlus$stream {
 }
 class baml.random.ChaCha20$stream {
   _state: $rust_type
+}
+
+--- <builtin>/baml/ns_reflect/reflect.baml ---
+class baml.reflect.Arg {
+  name: string
+  type: type
+}
+class baml.reflect.Signature {
+  name: string | null
+  args: baml.reflect.Arg[]
+  opts: map<string, baml.reflect.Arg>
+  returns: type
+  errors: type
+  docstring: string | null
+}
+class baml.reflect.InvalidArgumentError {
+  argument: string
+  expected: type
+  got: type
+}
+class baml.reflect.Arg$stream {
+  name: string | null
+  type: unknown
+}
+class baml.reflect.Signature$stream {
+  name: string | null
+  args: baml.reflect.Arg$stream[]
+  opts: map<string, baml.reflect.Arg$stream>
+  returns: unknown
+  errors: unknown
+  docstring: string | null
+}
+class baml.reflect.InvalidArgumentError$stream {
+  argument: string | null
+  expected: unknown
+  got: unknown
 }
 
 --- <builtin>/baml/ns_sap/sap.baml ---
@@ -3782,6 +3819,8 @@ class baml.toml.Table$stream {
 class baml.toml.TomlParseError$stream {
   message: string | null
 }
+
+--- <builtin>/baml/ns_type/type.baml ---
 
 --- <builtin>/baml/ns_ws/ws.baml ---
 class baml.ws.WsStream {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 2915
 ---
 === TIR2 ===
 
@@ -2989,11 +2988,100 @@ class baml.random.ChaCha20$stream {
   _state: $rust_type
 }
 
+--- <builtin>/baml/ns_reflect/ns_array/array.baml ---
+class baml.reflect.array.Type {
+}
+class baml.reflect.array.Type$stream {
+}
+
+--- <builtin>/baml/ns_reflect/ns_class/class.baml ---
+class baml.reflect.class.Field {
+  name: string
+  type: type | null
+  meta: baml.reflect.Meta
+}
+class baml.reflect.class.Type {
+}
+class baml.reflect.class.Field$stream {
+  name: string | null
+  type: unknown | null
+  meta: baml.reflect.Meta$stream | null
+}
+class baml.reflect.class.Type$stream {
+}
+
+--- <builtin>/baml/ns_reflect/ns_enum/enum.baml ---
+class baml.reflect.enum.Value {
+  name: string
+  meta: baml.reflect.Meta
+}
+class baml.reflect.enum.Type {
+}
+class baml.reflect.enum.Value$stream {
+  name: string | null
+  meta: baml.reflect.Meta$stream | null
+}
+class baml.reflect.enum.Type$stream {
+}
+
+--- <builtin>/baml/ns_reflect/ns_function/function.baml ---
+class baml.reflect.function.Parameter {
+  name: string | null
+  type: type
+  optional: bool
+}
+class baml.reflect.function.Type {
+}
+class baml.reflect.function.Parameter$stream {
+  name: string | null
+  type: unknown
+  optional: bool | null
+}
+class baml.reflect.function.Type$stream {
+}
+
+--- <builtin>/baml/ns_reflect/ns_interface/interface.baml ---
+class baml.reflect.interface.Type {
+}
+class baml.reflect.interface.Type$stream {
+}
+
+--- <builtin>/baml/ns_reflect/ns_literal/literal.baml ---
+class baml.reflect.literal.Type {
+}
+class baml.reflect.literal.Type$stream {
+}
+
+--- <builtin>/baml/ns_reflect/ns_map/map.baml ---
+class baml.reflect.map.Type {
+}
+class baml.reflect.map.Type$stream {
+}
+
+--- <builtin>/baml/ns_reflect/ns_primitive/primitive.baml ---
+class baml.reflect.primitive.Type {
+}
+class baml.reflect.primitive.Type$stream {
+}
+
+--- <builtin>/baml/ns_reflect/ns_union/union.baml ---
+class baml.reflect.union.Type {
+}
+class baml.reflect.union.Type$stream {
+}
+
 --- <builtin>/baml/ns_reflect/reflect.baml ---
 class baml.reflect.Arg {
   name: string
   type: type
 }
+class baml.reflect.Meta {
+  alias: string | null
+  description: string | null
+  docstring: string | null
+  other: map<string, string>
+}
+type baml.reflect.TypeKind = baml.reflect.class.Type | baml.reflect.enum.Type | baml.reflect.union.Type | baml.reflect.literal.Type | baml.reflect.array.Type | baml.reflect.map.Type | baml.reflect.interface.Type | baml.reflect.primitive.Type | baml.reflect.function.Type
 class baml.reflect.Signature {
   name: string | null
   args: baml.reflect.Arg[]
@@ -3011,6 +3099,13 @@ class baml.reflect.Arg$stream {
   name: string | null
   type: unknown
 }
+class baml.reflect.Meta$stream {
+  alias: string | null
+  description: string | null
+  docstring: string | null
+  other: map<string, string>
+}
+type baml.reflect.TypeKind$stream = baml.reflect.class.Type$stream | baml.reflect.enum.Type$stream | baml.reflect.union.Type$stream | baml.reflect.literal.Type$stream | baml.reflect.array.Type$stream | baml.reflect.map.Type$stream | baml.reflect.interface.Type$stream | baml.reflect.primitive.Type$stream | baml.reflect.function.Type$stream
 class baml.reflect.Signature$stream {
   name: string | null
   args: baml.reflect.Arg$stream[]

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 3105
 ---
 function baml.Array.at(self: baml.Array<#0>, index: int) -> #0 | null {
 }
@@ -6294,6 +6295,12 @@ function baml.random.Xoshiro256PlusPlus.new(seed: uint8array) -> baml.random.Xos
     return
 }
 
+function baml.reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
+}
+
+function baml.reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> baml.reflect.Signature {
+}
+
 function baml.sap.parse(text: string) -> #0 {
     load_type #0
     load_type #0
@@ -8322,6 +8329,9 @@ function baml.toml.table_from_json(j: baml.json.json) -> baml.toml.Table {
     load_var items
     init_instance baml.toml.Table .items
     return
+}
+
+function baml.type.of_value(v: unknown) -> type {
 }
 
 function baml.ws.WsStream.close(self: baml.ws.WsStream) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 3105
 ---
 function baml.Array.at(self: baml.Array<#0>, index: int) -> #0 | null {
 }
@@ -918,6 +917,33 @@ function baml.ToString.to_string(self: baml.ToString) -> string {
 function baml.TypeValue._to_string_impl(self: baml.TypeValue) -> string {
 }
 
+function baml.TypeValue.as_array(self: baml.TypeValue) -> baml.reflect.array.Type | null {
+}
+
+function baml.TypeValue.as_class(self: baml.TypeValue) -> baml.reflect.class.Type | null {
+}
+
+function baml.TypeValue.as_enum(self: baml.TypeValue) -> baml.reflect.enum.Type | null {
+}
+
+function baml.TypeValue.as_function(self: baml.TypeValue) -> baml.reflect.function.Type | null {
+}
+
+function baml.TypeValue.as_interface(self: baml.TypeValue) -> baml.reflect.interface.Type | null {
+}
+
+function baml.TypeValue.as_literal(self: baml.TypeValue) -> baml.reflect.literal.Type | null {
+}
+
+function baml.TypeValue.as_map(self: baml.TypeValue) -> baml.reflect.map.Type | null {
+}
+
+function baml.TypeValue.as_primitive(self: baml.TypeValue) -> baml.reflect.primitive.Type | null {
+}
+
+function baml.TypeValue.as_union(self: baml.TypeValue) -> baml.reflect.union.Type | null {
+}
+
 function baml.TypeValue.baml.ToString.to_string(self: baml.TypeValue) -> string {
     load_var self
     call baml.TypeValue._to_string_impl
@@ -931,6 +957,9 @@ function baml.TypeValue.implementors(self: baml.TypeValue) -> type[] {
 }
 
 function baml.TypeValue.implements(self: baml.TypeValue, other: type) -> bool {
+}
+
+function baml.TypeValue.kind(self: baml.TypeValue) -> baml.reflect.class.Type | baml.reflect.enum.Type | baml.reflect.union.Type | baml.reflect.literal.Type | baml.reflect.array.Type | baml.reflect.map.Type | baml.reflect.interface.Type | baml.reflect.primitive.Type | baml.reflect.function.Type {
 }
 
 function baml.Uint8Array._to_string_impl(self: baml.Uint8Array) -> string {
@@ -6295,10 +6324,73 @@ function baml.random.Xoshiro256PlusPlus.new(seed: uint8array) -> baml.random.Xos
     return
 }
 
+function baml.reflect.array.Type.baml.reflect.TypeView.as_type(self: baml.reflect.array.Type) -> type {
+}
+
+function baml.reflect.array.Type.element_type(self: baml.reflect.array.Type) -> type {
+}
+
 function baml.reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
 }
 
+function baml.reflect.class.Type.baml.reflect.TypeView.as_type(self: baml.reflect.class.Type) -> type {
+}
+
+function baml.reflect.class.Type.fields(self: baml.reflect.class.Type) -> baml.reflect.class.Field[] {
+}
+
+function baml.reflect.class.Type.meta(self: baml.reflect.class.Type) -> baml.reflect.Meta {
+}
+
+function baml.reflect.enum.Type.baml.reflect.TypeView.as_type(self: baml.reflect.enum.Type) -> type {
+}
+
+function baml.reflect.enum.Type.meta(self: baml.reflect.enum.Type) -> baml.reflect.Meta {
+}
+
+function baml.reflect.enum.Type.values(self: baml.reflect.enum.Type) -> baml.reflect.enum.Value[] {
+}
+
+function baml.reflect.function.Type.baml.reflect.TypeView.as_type(self: baml.reflect.function.Type) -> type {
+}
+
+function baml.reflect.function.Type.params(self: baml.reflect.function.Type) -> baml.reflect.function.Parameter[] {
+}
+
+function baml.reflect.function.Type.return_type(self: baml.reflect.function.Type) -> type {
+}
+
+function baml.reflect.interface.Type.baml.reflect.TypeView.as_type(self: baml.reflect.interface.Type) -> type {
+}
+
+function baml.reflect.interface.Type.implemented_by(self: baml.reflect.interface.Type, other: type) -> bool {
+}
+
+function baml.reflect.interface.Type.implementors(self: baml.reflect.interface.Type) -> type[] {
+}
+
+function baml.reflect.literal.Type.baml.reflect.TypeView.as_type(self: baml.reflect.literal.Type) -> type {
+}
+
+function baml.reflect.map.Type.baml.reflect.TypeView.as_type(self: baml.reflect.map.Type) -> type {
+}
+
+function baml.reflect.map.Type.key_type(self: baml.reflect.map.Type) -> type {
+}
+
+function baml.reflect.map.Type.value_type(self: baml.reflect.map.Type) -> type {
+}
+
+function baml.reflect.primitive.Type.baml.reflect.TypeView.as_type(self: baml.reflect.primitive.Type) -> type {
+}
+
 function baml.reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> baml.reflect.Signature {
+}
+
+function baml.reflect.union.Type.baml.reflect.TypeView.as_type(self: baml.reflect.union.Type) -> type {
+}
+
+function baml.reflect.union.Type.member_types(self: baml.reflect.union.Type) -> type[] {
 }
 
 function baml.sap.parse(text: string) -> #0 {

--- a/baml_language/crates/baml_tests/snapshots/compiles/anyfunction_reflect/baml_tests__compiles__anyfunction_reflect__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/anyfunction_reflect/baml_tests__compiles__anyfunction_reflect__04_5_mir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 3575
 ---
 === MIR2 ===
 fn user.web_search(q: string) -> Doc[] {
@@ -79,7 +80,7 @@ fn user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = unknown
     // Locals:
     let _0: string // _0 // return
     let _1: baml.AnyFunction<Returns = unknown, Throws = unknown> // f // param
-    let _2: reflect.Signature // sig
+    let _2: baml.reflect.Signature // sig
     let _3: string // parts
     let _4: string
     let _5: string
@@ -88,21 +89,21 @@ fn user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = unknown
     let _8: (baml.TypeValue) -> string throws never
     let _9: string
     let _10: int
-    let _11: (reflect.Arg[]) -> int throws never
+    let _11: (baml.reflect.Arg[]) -> int throws never
     let _12: type
-    let _13: reflect.Arg[]
-    let _14: baml.iter.Iterator<Error = never, Item = reflect.Arg>
+    let _13: baml.reflect.Arg[]
+    let _14: baml.iter.Iterator<Error = never, Item = baml.reflect.Arg>
     let _15: unknown
     let _16: bool
-    let _17: reflect.Arg
-    let _18: reflect.Arg // arg
+    let _17: baml.reflect.Arg
+    let _18: baml.reflect.Arg // arg
     let _19: string
     let _20: string
     let _21: string
     let _22: string
     let _23: (baml.TypeValue) -> string throws never
     let _24: string[]
-    let _25: (map<string, reflect.Arg>) -> string[] throws never
+    let _25: (map<string, baml.reflect.Arg>) -> string[] throws never
     let _26: type
     let _27: type
     let _28: baml.iter.Iterator<Error = never, Item = string>
@@ -110,13 +111,13 @@ fn user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = unknown
     let _30: bool
     let _31: string
     let _32: string // key
-    let _33: null | reflect.Arg // opt
-    let _34: (map<string, reflect.Arg>, string) -> null | reflect.Arg throws never
+    let _33: null | baml.reflect.Arg // opt
+    let _34: (map<string, baml.reflect.Arg>, string) -> null | baml.reflect.Arg throws never
     let _35: string
     let _36: type
     let _37: type
     let _38: bool
-    let _39: null | reflect.Arg
+    let _39: null | baml.reflect.Arg
     let _40: bool
     let _41: string
     let _42: string
@@ -125,7 +126,7 @@ fn user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = unknown
     let _45: (baml.TypeValue) -> string throws never
 
     bb0: {
-        _2 = call const fn reflect.signature(copy _1) -> [bb1];
+        _2 = call const fn baml.reflect.signature(copy _1) -> [bb1];
     }
 
     bb1: {
@@ -153,11 +154,11 @@ fn user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = unknown
     bb5: {
         _3 = copy _4 + copy _9;
         _13 = copy _2.1;
-        _14 = virtual_call iter as baml.iter.Iterable<Error = never, Item = reflect.Arg>(copy _13) -> [bb6];
+        _14 = virtual_call iter as baml.iter.Iterable<Error = never, Item = baml.reflect.Arg>(copy _13) -> [bb6];
     }
 
     bb6: {
-        _15 = virtual_call next as baml.iter.Iterator<Error = never, Item = reflect.Arg>(copy _14) -> [bb7];
+        _15 = virtual_call next as baml.iter.Iterator<Error = never, Item = baml.reflect.Arg>(copy _14) -> [bb7];
     }
 
     bb7: {
@@ -184,7 +185,7 @@ fn user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = unknown
     bb10: {
         _25 = copy _2.2;
         _26 = load_type(string);
-        _27 = load_type(reflect.Arg);
+        _27 = load_type(baml.reflect.Arg);
         _24 = call const fn baml.Map.keys<copy _26, copy _27>(copy _25) -> [bb11];
     }
 
@@ -208,7 +209,7 @@ fn user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = unknown
         _34 = copy _2.2;
         _35 = copy _32;
         _36 = load_type(string);
-        _37 = load_type(reflect.Arg);
+        _37 = load_type(baml.reflect.Arg);
         _33 = call const fn baml.Map.get<copy _36, copy _37>(copy _34, copy _35) -> [bb15];
     }
 
@@ -297,7 +298,7 @@ fn user.typed_dispatch(name: string, args: map<string, unknown>) -> string | Doc
         _10 = copy _4;
         _11 = load_type(Doc[] | string);
         _12 = load_type(ToolError);
-        _0 = call const fn reflect.call_any<copy _11, copy _12>(copy _10, copy _2) -> [bb13, unwind: bb8];
+        _0 = call const fn baml.reflect.call_any<copy _11, copy _12>(copy _10, copy _2) -> [bb13, unwind: bb8];
     }
 
     bb7: {
@@ -311,7 +312,7 @@ fn user.typed_dispatch(name: string, args: map<string, unknown>) -> string | Doc
     }
 
     bb9: {
-        _14 = is_type(copy _9, reflect.InvalidArgumentError);
+        _14 = is_type(copy _9, baml.reflect.InvalidArgumentError);
         branch copy _14 -> [bb11, bb10];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/anyfunction_reflect/baml_tests__compiles__anyfunction_reflect__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/anyfunction_reflect/baml_tests__compiles__anyfunction_reflect__04_tir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 3545
 ---
 === TIR2 ===
 class user.ToolError {
@@ -38,7 +39,7 @@ function user.heterogeneous_tool_map() -> map<string, baml.AnyFunction<Returns =
 }
 function user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> string throws never {
   { : never
-    let sig = reflect.signature(f) : reflect.Signature
+    let sig = reflect.signature(f) : baml.reflect.Signature
     let parts = sig.returns.to_string() + sig.errors.to_string() + sig.args.length().to_string() : string
     for arg in sig.args
       { : void
@@ -46,7 +47,7 @@ function user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = u
       }
     for key in sig.opts.keys()
       { : void
-        let opt = sig.opts.get(key) : reflect.Arg | null
+        let opt = sig.opts.get(key) : baml.reflect.Arg | null
         if (opt != null : bool) : void
           { : void
             parts = parts + key + opt.type.to_string() : string

--- a/baml_language/crates/baml_tests/snapshots/compiles/anyfunction_reflect/baml_tests__compiles__anyfunction_reflect__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/anyfunction_reflect/baml_tests__compiles__anyfunction_reflect__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 3718
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.bare_and_pinned() -> int {
@@ -41,7 +36,7 @@ function user.heterogeneous_tool_map() -> map<string, baml.AnyFunction<Returns =
 
 function user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> string {
     load_var f
-    call reflect.signature
+    call baml.reflect.signature
     store_var sig
     load_var sig
     load_field .returns
@@ -66,14 +61,14 @@ function user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = u
     store_var parts
     load_var sig
     load_field .args
-    load_type baml.iter.Iterable<Error = never, Item = reflect.Arg>
+    load_type baml.iter.Iterable<Error = never, Item = baml.reflect.Arg>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
     store_var _14
 
   L0:
     load_var _14
-    load_type baml.iter.Iterator<Error = never, Item = reflect.Arg>
+    load_type baml.iter.Iterator<Error = never, Item = baml.reflect.Arg>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
     store_var _15
@@ -100,7 +95,7 @@ function user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = u
 
   L2:
     load_type string
-    load_type reflect.Arg
+    load_type baml.reflect.Arg
     load_var sig
     load_field .opts
     call baml.Map.keys
@@ -124,7 +119,7 @@ function user.signature_access(f: baml.AnyFunction<Returns = unknown, Throws = u
     load_var _29
     store_var key
     load_type string
-    load_type reflect.Arg
+    load_type baml.reflect.Arg
     load_var sig
     load_field .opts
     load_var key
@@ -181,7 +176,7 @@ function user.typed_dispatch(name: string, args: map<string, unknown>) -> Doc[] 
     load_type Doc[] | string
     load_type ToolError
     load_var2 4 2
-    call reflect.call_any
+    call baml.reflect.call_any
     jump L9
     load_var e
     is_type ToolError
@@ -190,7 +185,7 @@ function user.typed_dispatch(name: string, args: map<string, unknown>) -> Doc[] 
 
   L4:
     load_var e
-    is_type reflect.InvalidArgumentError
+    is_type baml.reflect.InvalidArgumentError
     pop_jump_if_false L5
     jump L6
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/arm_header_comments/baml_tests__compiles__arm_header_comments__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/arm_header_comments/baml_tests__compiles__arm_header_comments__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 4000
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user._thrower() -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/backtick_decl_slots/baml_tests__compiles__backtick_decl_slots__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/backtick_decl_slots/baml_tests__compiles__backtick_decl_slots__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 4282
 ---
 function $init() -> null {
     call $init_let_0
@@ -15,12 +16,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.Fast$new(lenient: bool) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/backtick_dedent/baml_tests__compiles__backtick_dedent__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/backtick_dedent/baml_tests__compiles__backtick_dedent__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 4564
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.FarIndented() -> string {

--- a/baml_language/crates/baml_tests/snapshots/compiles/backtick_strings/baml_tests__compiles__backtick_strings__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/backtick_strings/baml_tests__compiles__backtick_strings__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 4846
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.BacktickEquality() -> bool {

--- a/baml_language/crates/baml_tests/snapshots/compiles/bigint_arith/baml_tests__compiles__bigint_arith__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/bigint_arith/baml_tests__compiles__bigint_arith__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 5128
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.AddBigints() -> bigint {

--- a/baml_language/crates/baml_tests/snapshots/compiles/bigint_cmp/baml_tests__compiles__bigint_cmp__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/bigint_cmp/baml_tests__compiles__bigint_cmp__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 5407
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.EqDistinctAllocs() -> bool {

--- a/baml_language/crates/baml_tests/snapshots/compiles/bigint_literal/baml_tests__compiles__bigint_literal__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/bigint_literal/baml_tests__compiles__bigint_literal__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 5690
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.GetBigint() -> bigint {

--- a/baml_language/crates/baml_tests/snapshots/compiles/byte_string_literals/baml_tests__compiles__byte_string_literals__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/byte_string_literals/baml_tests__compiles__byte_string_literals__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 5973
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.ByteStringBasic() -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/catch_all_keyword/baml_tests__compiles__catch_all_keyword__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/catch_all_keyword/baml_tests__compiles__catch_all_keyword__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 6255
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.CatchAllTyped(x: int) -> string {

--- a/baml_language/crates/baml_tests/snapshots/compiles/catch_all_panics/baml_tests__compiles__catch_all_panics__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/catch_all_panics/baml_tests__compiles__catch_all_panics__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 6541
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.CatchAllPanicsTyped(x: int) -> string {

--- a/baml_language/crates/baml_tests/snapshots/compiles/catch_arm_return/baml_tests__compiles__catch_arm_return__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/catch_arm_return/baml_tests__compiles__catch_arm_return__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 6824
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.may_throw(x: int) -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/catch_interface_refinement/baml_tests__compiles__catch_interface_refinement__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/catch_interface_refinement/baml_tests__compiles__catch_interface_refinement__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 7107
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.QuotaExceeded.Failure.is_transient(self: QuotaExceeded) -> bool {

--- a/baml_language/crates/baml_tests/snapshots/compiles/catch_throw/baml_tests__compiles__catch_throw__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/catch_throw/baml_tests__compiles__catch_throw__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 7389
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.AlsoMayFail(x: int) -> string {

--- a/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/closure_loop_variable/baml_tests__compiles__closure_loop_variable__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 7672
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.sum_array(arr: int[]) -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/closures/baml_tests__compiles__closures__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/closures/baml_tests__compiles__closures__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 7950
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.Box.unwrap(self: Box<#0>) -> #0 {

--- a/baml_language/crates/baml_tests/snapshots/compiles/comment_after_string_in_config/baml_tests__compiles__comment_after_string_in_config__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/comment_after_string_in_config/baml_tests__compiles__comment_after_string_in_config__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 8232
 ---
 function $init() -> null {
     call $init_let_0
@@ -15,12 +16,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.OpenRouterMistralSmall3_1_24b$new(lenient: bool) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/comment_in_type/baml_tests__compiles__comment_in_type__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 8514
 ---
 function $init() -> null {
     call $init_let_0
@@ -15,12 +16,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.CommentAfterArrow(client: baml.llm.Client) -> string {

--- a/baml_language/crates/baml_tests/snapshots/compiles/config_dictionary/baml_tests__compiles__config_dictionary__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/config_dictionary/baml_tests__compiles__config_dictionary__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 8797
 ---
 function $init() -> null {
     call $init_let_0
@@ -15,12 +16,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.MyClient$new(lenient: bool) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/config_model_string/baml_tests__compiles__config_model_string__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/config_model_string/baml_tests__compiles__config_model_string__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 9080
 ---
 function $init() -> null {
     call $init_let_0
@@ -15,12 +16,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.MyAwsClient$new(lenient: bool) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/deep_method_call/baml_tests__compiles__deep_method_call__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/deep_method_call/baml_tests__compiles__deep_method_call__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 9363
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.B.greet(self: B) -> string {

--- a/baml_language/crates/baml_tests/snapshots/compiles/function_call/baml_tests__compiles__function_call__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/function_call/baml_tests__compiles__function_call__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 9685
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.Bar() -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/generic_field_chain/baml_tests__compiles__generic_field_chain__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/generic_field_chain/baml_tests__compiles__generic_field_chain__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 10020
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.test_generic_capture(box: Box<User>) -> string {

--- a/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 10307
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.Both.Sized.size(self: Both) -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/generic_match_typevar_arm/baml_tests__compiles__generic_match_typevar_arm__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/generic_match_typevar_arm/baml_tests__compiles__generic_match_typevar_arm__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 10598
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.unwrap_or(o: Opt<#0> | Non, default: #0) -> #0 {

--- a/baml_language/crates/baml_tests/snapshots/compiles/host_callable_call/baml_tests__compiles__host_callable_call__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/host_callable_call/baml_tests__compiles__host_callable_call__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 10887
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.call_with_callback(callback: (int) -> string throws never, x: int) -> string {

--- a/baml_language/crates/baml_tests/snapshots/compiles/is_operator/baml_tests__compiles__is_operator__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/is_operator/baml_tests__compiles__is_operator__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 11169
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.both_ints(a: int | string, b: int | string) -> bool {

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_alias_basic/baml_tests__compiles__json_alias_basic__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_alias_basic/baml_tests__compiles__json_alias_basic__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 11452
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.MakeWrapper() -> Wrapper {

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_cross_namespace_static_call/baml_tests__compiles__json_cross_namespace_static_call__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_cross_namespace_static_call/baml_tests__compiles__json_cross_namespace_static_call__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 11774
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.decode_auto(j: baml.json.json) -> pkg.inner.AutoBox<int> {

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_llm_return_type/baml_tests__compiles__json_llm_return_type__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 12111
 ---
 function $init() -> null {
     call $init_let_0
@@ -15,12 +16,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.ExtractAny(client: baml.llm.Client) -> baml.json.json {

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_map_literal/baml_tests__compiles__json_map_literal__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_map_literal/baml_tests__compiles__json_map_literal__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 12398
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.NestedMapLiteral() -> baml.json.json {

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_parse_stringify_intrinsics/baml_tests__compiles__json_parse_stringify_intrinsics__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_parse_stringify_intrinsics/baml_tests__compiles__json_parse_stringify_intrinsics__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 12682
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.match_parsed(s: string) -> string {

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_to_from_string_composite_generic/baml_tests__compiles__json_to_from_string_composite_generic__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_to_from_string_composite_generic/baml_tests__compiles__json_to_from_string_composite_generic__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 12977
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.decode_container(s: string) -> Container<User> {

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_to_from_string_concrete/baml_tests__compiles__json_to_from_string_concrete__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_to_from_string_concrete/baml_tests__compiles__json_to_from_string_concrete__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 13269
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.deserialize_user(s: string) -> User {

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_to_from_string_generic_forwarding/baml_tests__compiles__json_to_from_string_generic_forwarding__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_to_from_string_generic_forwarding/baml_tests__compiles__json_to_from_string_generic_forwarding__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 13563
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.fetch_as(s: string) -> #0 {

--- a/baml_language/crates/baml_tests/snapshots/compiles/json_to_from_string_three_level/baml_tests__compiles__json_to_from_string_three_level__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/json_to_from_string_three_level/baml_tests__compiles__json_to_from_string_three_level__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 13855
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.level1(s: string) -> #0 {

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 14146
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.test_apply_twice_inferred() -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_basic/baml_tests__compiles__lambda_basic__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_basic/baml_tests__compiles__lambda_basic__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 14429
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.test_annotated() -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 14712
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.test_annotated() -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_field_access/baml_tests__compiles__lambda_field_access__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_field_access/baml_tests__compiles__lambda_field_access__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 14995
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.test_captured_field_access(obj: Outer) -> string {

--- a/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 15281
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.branch_locals(b: bool) -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/literal_union_arithmetic/baml_tests__compiles__literal_union_arithmetic__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/literal_union_arithmetic/baml_tests__compiles__literal_union_arithmetic__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 15564
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.bothSidesUnion() -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/literal_union_widening/baml_tests__compiles__literal_union_widening__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/literal_union_widening/baml_tests__compiles__literal_union_widening__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 15846
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.annotatedLiteralUnion() -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/llm_image_outputs/baml_tests__compiles__llm_image_outputs__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 16128
 ---
 function $init() -> null {
     call $init_let_0
@@ -15,12 +16,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.GenerateImage(prompt: string, client: baml.llm.Client) -> image {

--- a/baml_language/crates/baml_tests/snapshots/compiles/llm_parse_catchable_parse_error/baml_tests__compiles__llm_parse_catchable_parse_error__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/llm_parse_catchable_parse_error/baml_tests__compiles__llm_parse_catchable_parse_error__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 16410
 ---
 function $init() -> null {
     call $init_let_0
@@ -15,12 +16,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.ExtractInvoice(text: string, client: baml.llm.Client) -> Invoice {

--- a/baml_language/crates/baml_tests/snapshots/compiles/method_explicit_type_args/baml_tests__compiles__method_explicit_type_args__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/method_explicit_type_args/baml_tests__compiles__method_explicit_type_args__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 16693
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.Foo.zero(self: Foo) -> #0 | null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/namespaces_basic/baml_tests__compiles__namespaces_basic__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/namespaces_basic/baml_tests__compiles__namespaces_basic__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 17021
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.GetResponse(cfg: Config) -> llm.Response {

--- a/baml_language/crates/baml_tests/snapshots/compiles/namespaces_nested/baml_tests__compiles__namespaces_nested__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/namespaces_nested/baml_tests__compiles__namespaces_nested__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 17394
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.CallOpenAI(cfg: AppConfig) -> llm.openai.OpenAIResponse {

--- a/baml_language/crates/baml_tests/snapshots/compiles/namespaces_root_fallback/baml_tests__compiles__namespaces_root_fallback__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/namespaces_root_fallback/baml_tests__compiles__namespaces_root_fallback__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 17773
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.llm.UseConfig(cfg: Config) -> llm.Response {

--- a/baml_language/crates/baml_tests/snapshots/compiles/namespaces_shadow/baml_tests__compiles__namespaces_shadow__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/namespaces_shadow/baml_tests__compiles__namespaces_shadow__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 18146
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,10 +9,4 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/namespaces_type_resolution/baml_tests__compiles__namespaces_type_resolution__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/namespaces_type_resolution/baml_tests__compiles__namespaces_type_resolution__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 18597
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.RootAliasParam(cfg: Config) -> string {

--- a/baml_language/crates/baml_tests/snapshots/compiles/numeric_invariance_ok/baml_tests__compiles__numeric_invariance_ok__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/numeric_invariance_ok/baml_tests__compiles__numeric_invariance_ok__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 19041
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.BigintFieldOk() -> BigintCounter {

--- a/baml_language/crates/baml_tests/snapshots/compiles/numeric_literal_method_call/baml_tests__compiles__numeric_literal_method_call__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/numeric_literal_method_call/baml_tests__compiles__numeric_literal_method_call__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 19331
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.BigintToStringBareLiteral() -> string {

--- a/baml_language/crates/baml_tests/snapshots/compiles/o1_allowed_roles/baml_tests__compiles__o1_allowed_roles__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/o1_allowed_roles/baml_tests__compiles__o1_allowed_roles__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 19621
 ---
 function $init() -> null {
     call $init_let_0
@@ -21,12 +22,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.Gpt4oClient$new(lenient: bool) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/optional_function_parameters/baml_tests__compiles__optional_function_parameters__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 19904
 ---
 function $init() -> null {
     call $init_let_0
@@ -15,12 +16,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.AskDocs(query: string, max_results: int, filter: string, client: baml.llm.Client) -> string {

--- a/baml_language/crates/baml_tests/snapshots/compiles/paren_union_test/baml_tests__compiles__paren_union_test__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/paren_union_test/baml_tests__compiles__paren_union_test__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 20186
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,10 +9,4 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/parser_expressions/baml_tests__compiles__parser_expressions__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/parser_expressions/baml_tests__compiles__parser_expressions__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 20585
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.Calculate() -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 21382
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.ConditionalLogic(age: int) -> string {

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_class_destructure_namespaces/baml_tests__compiles__patterns_class_destructure_namespaces__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_class_destructure_namespaces/baml_tests__compiles__patterns_class_destructure_namespaces__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 22206
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.DeepGenericDestructureNamespaceQualifiedLet() -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_new/baml_tests__compiles__patterns_new__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 22546
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.bare_type_arm(v: int | string) -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/reflect_shadowing/baml_tests__compiles__reflect_shadowing__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/reflect_shadowing/baml_tests__compiles__reflect_shadowing__03_ppir.snap
@@ -1,0 +1,32 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 22632
+---
+=== PPIR ===
+class user.reflect {
+  label: string
+}
+class user.reflect$stream {
+  label: string | null
+}
+function user.$init_test_main(registry: testing.TestCollector) -> ?  [expr] {
+  { registry.register_test_at("root", "user class shadow...", () -> void { {  } assert.equal(user_class_shadows_shorthand(), "user-shadow") }, null); registry.register_test_at("root", "unbound user meth...", () -> void { {  } assert.equal(unbound_user_method(), "user-x") }, null); registry.register_test_at("root", "local shadows sho...", () -> void { {  } assert.equal(local_shadows_shorthand(), 2) }, null); registry.register_test_at("root", "qualified baml.re...", () -> void { {  } assert.equal(qualified_still_works(), "string") }, null) } null
+}
+function user.describe(self: ?) -> string  [expr] {
+  { return "user-" Add self.label }
+}
+function user.helper(q: string) -> string  [expr] {
+  { return q Add "!" }
+}
+function user.local_shadows_shorthand() -> int  [expr] {
+  { let reflect = 1; return reflect Add 1 }
+}
+function user.qualified_still_works() -> string  [expr] {
+  { let f: baml.AnyFunction = helper; let sig = baml.reflect.signature(f); return sig.returns.to_string() }
+}
+function user.unbound_user_method() -> string  [expr] {
+  { let m = reflect.describe; return m(user.reflect { label: "x" }) }
+}
+function user.user_class_shadows_shorthand() -> string  [expr] {
+  { let r = user.reflect { label: "shadow" }; return r.describe() }
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/reflect_shadowing/baml_tests__compiles__reflect_shadowing__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/reflect_shadowing/baml_tests__compiles__reflect_shadowing__04_5_mir.snap
@@ -1,0 +1,231 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 22686
+---
+=== MIR2 ===
+fn user.$init_test_main(registry: testing.TestCollector) -> null {
+    // Locals:
+    let _0: null // _0 // return
+    let _1: testing.TestCollector // registry // param
+    let _2: void
+    let _3: () -> void throws unknown
+    let _4: void
+    let _5: () -> void throws unknown
+    let _6: void
+    let _7: () -> void throws unknown
+    let _8: void
+    let _9: () -> void throws unknown
+
+    bb0: {
+        _3 = make_closure lambda[0]();
+        _2 = call const fn testing.TestCollector.register_test_at(copy _1, const "root", const "user class shadows shorthand", copy _3, const null) -> [bb1];
+    }
+
+    bb1: {
+        _5 = make_closure lambda[1]();
+        _4 = call const fn testing.TestCollector.register_test_at(copy _1, const "root", const "unbound user method over shorthand", copy _5, const null) -> [bb2];
+    }
+
+    bb2: {
+        _7 = make_closure lambda[2]();
+        _6 = call const fn testing.TestCollector.register_test_at(copy _1, const "root", const "local shadows shorthand", copy _7, const null) -> [bb3];
+    }
+
+    bb3: {
+        _9 = make_closure lambda[3]();
+        _8 = call const fn testing.TestCollector.register_test_at(copy _1, const "root", const "qualified baml.reflect still works", copy _9, const null) -> [bb4];
+    }
+
+    bb4: {
+        _0 = const null;
+        goto -> bb5;
+    }
+
+    bb5: {
+        return;
+    }
+}
+
+// lambda[0]
+fn .<lambda($init_test_main, 0)>() -> void {
+    // Locals:
+    let _0: void // _0 // return
+    let _1: string
+
+    bb0: {
+        _1 = call const fn user.user_class_shadows_shorthand() -> [bb1];
+    }
+
+    bb1: {
+        _0 = call const fn assert.equal(copy _1, const "user-shadow") -> [bb2];
+    }
+
+    bb2: {
+        return;
+    }
+}
+
+// lambda[1]
+fn .<lambda($init_test_main, 1)>() -> void {
+    // Locals:
+    let _0: void // _0 // return
+    let _1: string
+
+    bb0: {
+        _1 = call const fn user.unbound_user_method() -> [bb1];
+    }
+
+    bb1: {
+        _0 = call const fn assert.equal(copy _1, const "user-x") -> [bb2];
+    }
+
+    bb2: {
+        return;
+    }
+}
+
+// lambda[2]
+fn .<lambda($init_test_main, 2)>() -> void {
+    // Locals:
+    let _0: void // _0 // return
+    let _1: int
+
+    bb0: {
+        _1 = call const fn user.local_shadows_shorthand() -> [bb1];
+    }
+
+    bb1: {
+        _0 = call const fn assert.equal(copy _1, const 2_i64) -> [bb2];
+    }
+
+    bb2: {
+        return;
+    }
+}
+
+// lambda[3]
+fn .<lambda($init_test_main, 3)>() -> void {
+    // Locals:
+    let _0: void // _0 // return
+    let _1: string
+
+    bb0: {
+        _1 = call const fn user.qualified_still_works() -> [bb1];
+    }
+
+    bb1: {
+        _0 = call const fn assert.equal(copy _1, const "string") -> [bb2];
+    }
+
+    bb2: {
+        return;
+    }
+}
+
+fn user.reflect.describe(self: reflect) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: reflect // self // param
+    let _2: string
+
+    bb0: {
+        _2 = copy _1.0;
+        _0 = const "user-" + copy _2;
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.user_class_shadows_shorthand() -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: reflect // r
+
+    bb0: {
+        _1 = user.reflect { const "shadow" };
+        _0 = call const fn user.reflect.describe(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.unbound_user_method() -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: (reflect) -> string throws never // m
+    let _2: (reflect) -> string throws never
+    let _3: reflect
+
+    bb0: {
+        _1 = const fn user.reflect.describe;
+        _2 = copy _1;
+        _3 = user.reflect { const "x" };
+        _0 = call copy _2(copy _3) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.local_shadows_shorthand() -> int {
+    // Locals:
+    let _0: int // _0 // return
+    let _1: int // reflect
+    let _2: int
+
+    bb0: {
+        _1 = const 1_i64;
+        _2 = copy _1;
+        _0 = copy _2 + const 1_i64;
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.helper(q: string) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: string // q // param
+
+    bb0: {
+        _0 = copy _1 + const "!";
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.qualified_still_works() -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: baml.AnyFunction<Returns = unknown, Throws = unknown> // f
+    let _2: baml.reflect.Signature // sig
+    let _3: baml.AnyFunction<Returns = unknown, Throws = unknown>
+    let _4: (baml.TypeValue) -> string throws never
+
+    bb0: {
+        _1 = const fn user.helper;
+        _3 = copy _1;
+        _2 = call const fn baml.reflect.signature(copy _3) -> [bb1];
+    }
+
+    bb1: {
+        _4 = copy _2.3;
+        _0 = call const fn baml.TypeValue.baml.ToString.to_string(copy _4) -> [bb2];
+    }
+
+    bb2: {
+        return;
+    }
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/reflect_shadowing/baml_tests__compiles__reflect_shadowing__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/reflect_shadowing/baml_tests__compiles__reflect_shadowing__04_tir.snap
@@ -1,0 +1,79 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 22656
+---
+=== TIR2 ===
+class user.reflect {
+  label: string
+}
+function user.reflect.describe(self: user.reflect) -> string throws never {
+  { : never
+    return "user-" + self.label : string
+  }
+}
+function user.user_class_shadows_shorthand() -> string throws never {
+  { : never
+    let r = reflect { label: "shadow" } : user.reflect
+    return r.describe() : string
+  }
+}
+function user.unbound_user_method() -> string throws never {
+  { : never
+    let m = reflect.describe : (self: user.reflect) -> string throws never
+    return m(reflect { label: "x" }) : string
+  }
+}
+function user.local_shadows_shorthand() -> int throws never {
+  { : never
+    let reflect = 1 : 1 -> int
+    return reflect + 1 : int
+  }
+}
+function user.helper(q: string) -> string throws never {
+  { : never
+    return q + "!" : string
+  }
+}
+function user.qualified_still_works() -> string throws never {
+  { : never
+    let f: baml.AnyFunction = helper : (q: string) -> string throws never -> baml.AnyFunction<Returns = unknown, Throws = unknown>
+    let sig = baml.reflect.signature(f) : baml.reflect.Signature
+    return sig.returns.to_string() : string
+  }
+}
+function user.$init_test_main(registry: testing.TestCollector) -> ? throws never {
+  { : null
+    registry.register_test_at("root", "user class shadow...", () -> void { ... }, null) : void
+      () -> void { ... } : () -> void throws unknown
+        {
+          assert.equal(user_class_shadows_shorthand(), "user-shadow")
+        }
+    registry.register_test_at("root", "unbound user meth...", () -> void { ... }, null) : void
+      () -> void { ... } : () -> void throws unknown
+        {
+          assert.equal(unbound_user_method(), "user-x")
+        }
+    registry.register_test_at("root", "local shadows sho...", () -> void { ... }, null) : void
+      () -> void { ... } : () -> void throws unknown
+        {
+          assert.equal(local_shadows_shorthand(), 2)
+        }
+    registry.register_test_at("root", "qualified baml.re...", () -> void { ... }, null) : void
+      () -> void { ... } : () -> void throws unknown
+        {
+          assert.equal(qualified_still_works(), "string")
+        }
+    null : null
+  }
+}
+lambda user.$init_test_main {
+}
+lambda user.$init_test_main {
+}
+lambda user.$init_test_main {
+}
+lambda user.$init_test_main {
+}
+class user.reflect$stream {
+  label: string | null
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/reflect_shadowing/baml_tests__compiles__reflect_shadowing__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/reflect_shadowing/baml_tests__compiles__reflect_shadowing__05_diagnostics.snap
@@ -1,0 +1,6 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 22746
+---
+=== COMPILER2 DIAGNOSTICS ===
+No errors found.

--- a/baml_language/crates/baml_tests/snapshots/compiles/reflect_shadowing/baml_tests__compiles__reflect_shadowing__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/reflect_shadowing/baml_tests__compiles__reflect_shadowing__06_codegen.snap
@@ -1,0 +1,97 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 22829
+---
+function $init_test(registry: unknown) -> null {
+    load_var ?1
+    call ?
+    pop 1
+    load_const ?
+    return
+}
+
+function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
+}
+
+function boundary.id() -> boundary.LocalId {
+}
+
+function boundary.id.current() -> string {
+}
+
+function user.$init_test_main(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "root"
+    load_const "user class shadows shorthand"
+    make_closure .<lambda($init_test_main, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root"
+    load_const "unbound user method over shorthand"
+    make_closure .<lambda($init_test_main, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root"
+    load_const "local shadows shorthand"
+    make_closure .<lambda($init_test_main, 2)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root"
+    load_const "qualified baml.reflect still works"
+    make_closure .<lambda($init_test_main, 3)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_const null
+    return
+}
+
+function user.helper(q: string) -> string {
+    load_var q
+    load_const "!"
+    bin_op +
+    return
+}
+
+function user.local_shadows_shorthand() -> int {
+    load_const 1
+    load_const 1
+    add_int
+    return
+}
+
+function user.qualified_still_works() -> string {
+    load_const user.helper
+    call baml.reflect.signature
+    load_field .returns
+    call baml.TypeValue.baml.ToString.to_string
+    return
+}
+
+function user.reflect.describe(self: reflect) -> string {
+    load_const "user-"
+    load_var self
+    load_field .label
+    bin_op +
+    return
+}
+
+function user.unbound_user_method() -> string {
+    load_const "x"
+    init_instance user.reflect .label
+    call user.reflect.describe
+    return
+}
+
+function user.user_class_shadows_shorthand() -> string {
+    load_const "shadow"
+    init_instance user.reflect .label
+    call user.reflect.describe
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/reflect_shadowing/baml_tests__compiles__reflect_shadowing__10_formatter__main.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/reflect_shadowing/baml_tests__compiles__reflect_shadowing__10_formatter__main.snap
@@ -1,0 +1,64 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 22859
+---
+// BEP-066: `reflect` is a keyword shorthand for `baml.reflect` (and `type`,
+// as an expression path head, for `baml.type`). A user-defined name wins:
+// the shorthand only kicks in when ordinary resolution misses.
+
+class reflect {
+    label: string,
+
+    function describe(self) -> string {
+        return "user-" + self.label;
+    }
+}
+
+// A user class named `reflect` resolves over the shorthand: construction and
+// member access on it hit the class, not the `baml.reflect` namespace.
+function user_class_shadows_shorthand() -> string {
+    let r = reflect { label: "shadow" };
+    return r.describe();
+}
+
+// Type-rooted path access on the user class also wins over the shorthand:
+// `reflect.describe` is the class's unbound method, not a `baml.reflect`
+// lookup.
+function unbound_user_method() -> string {
+    let m = reflect.describe;
+    return m(reflect { label: "x" });
+}
+
+// A local named `reflect` shadows both the class and the shorthand.
+function local_shadows_shorthand() -> int {
+    let reflect = 1;
+    return reflect + 1;
+}
+
+function helper(q: string) -> string throws never {
+    return q + "!";
+}
+
+// Even with the user class shadowing the bare name, the explicit
+// `baml.reflect` path still reaches the stdlib namespace.
+function qualified_still_works() -> string {
+    let f: baml.AnyFunction = helper;
+    let sig = baml.reflect.signature(f);
+    return sig.returns.to_string();
+}
+
+test "user class shadows shorthand" {
+    assert.equal(user_class_shadows_shorthand(), "user-shadow")
+}
+
+test "unbound user method over shorthand" {
+    assert.equal(unbound_user_method(), "user-x")
+}
+
+test "local shadows shorthand" {
+    assert.equal(local_shadows_shorthand(), 2)
+}
+
+test "qualified baml.reflect still works" {
+    assert.equal(qualified_still_works(), "string")
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/reflect_type_of_user_generic/baml_tests__compiles__reflect_type_of_user_generic__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/reflect_type_of_user_generic/baml_tests__compiles__reflect_type_of_user_generic__03_ppir.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 28188
+assertion_line: 22914
 ---
 === PPIR ===
 class user.Person {
@@ -10,7 +10,7 @@ class user.Person$stream {
   name: string | null
 }
 function user.reflect_array() -> type  [expr] {
-  {  } reflect.type_of()
+  {  } type.of()
 }
 function user.reflect_int_array() -> type  [expr] {
   {  } reflect_array()
@@ -19,5 +19,5 @@ function user.reflect_person() -> type  [expr] {
   {  } reflect_type()
 }
 function user.reflect_type() -> type  [expr] {
-  {  } reflect.type_of()
+  {  } type.of()
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/reflect_type_of_user_generic/baml_tests__compiles__reflect_type_of_user_generic__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/reflect_type_of_user_generic/baml_tests__compiles__reflect_type_of_user_generic__04_tir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 22938
 ---
 === TIR2 ===
 class user.Person {
@@ -7,12 +8,12 @@ class user.Person {
 }
 function user.reflect_type<T>() -> type throws never {
   { : type
-    reflect.type_of() : type
+    type.of() : type
   }
 }
 function user.reflect_array<T>() -> type throws never {
   { : type
-    reflect.type_of() : type
+    type.of() : type
   }
 }
 function user.reflect_person() -> type throws never {

--- a/baml_language/crates/baml_tests/snapshots/compiles/reflect_type_of_user_generic/baml_tests__compiles__reflect_type_of_user_generic__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/reflect_type_of_user_generic/baml_tests__compiles__reflect_type_of_user_generic__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 23111
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.reflect_array() -> type {

--- a/baml_language/crates/baml_tests/snapshots/compiles/reflect_type_of_user_generic/baml_tests__compiles__reflect_type_of_user_generic__10_formatter__main.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/reflect_type_of_user_generic/baml_tests__compiles__reflect_type_of_user_generic__10_formatter__main.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 23141
 ---
 // Phase 6 user-facing pin.
 //
 // Phase 6's stdlib cleanup dropped `type_def: type` from `primitive.parse<T>(body)`
 // because the compiler now threads `T`'s runtime type through generic call
 // boundaries automatically. The same mechanism lets user code write
-// `reflect.type_of<T>()` inside a generic function and have `T` resolve to
+// `type.of<T>()` inside a generic function and have `T` resolve to
 // the caller-supplied type at runtime.
 //
 // This project pins the user-facing TIR/MIR shape of that auto-threading.
@@ -17,11 +18,11 @@ class Person {
 }
 
 function reflect_type<T>() -> type {
-    reflect.type_of<T>()
+    type.of<T>()
 }
 
 function reflect_array<T>() -> type {
-    reflect.type_of<T[]>()
+    type.of<T[]>()
 }
 
 function reflect_person() -> type {

--- a/baml_language/crates/baml_tests/snapshots/compiles/retry_policy/baml_tests__compiles__retry_policy__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/retry_policy/baml_tests__compiles__retry_policy__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 23393
 ---
 function $init() -> null {
     call $init_let_0
@@ -17,12 +18,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.MyClient$new(lenient: bool) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/scientific_notation_float/baml_tests__compiles__scientific_notation_float__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/scientific_notation_float/baml_tests__compiles__scientific_notation_float__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 23677
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.DecimalMantissa() -> float {

--- a/baml_language/crates/baml_tests/snapshots/compiles/stream_crossfile/baml_tests__compiles__stream_crossfile__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/stream_crossfile/baml_tests__compiles__stream_crossfile__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 24005
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,10 +9,4 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 24338
 ---
 function $init() -> null {
     call $init_let_0
@@ -15,12 +16,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.TestClient$new(lenient: bool) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__10_formatter__main.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/stream_llm_inferred_typeargs/baml_tests__compiles__stream_llm_inferred_typeargs__10_formatter__main.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 24368
 ---
 // Call-shape pin.
 //
@@ -16,7 +17,7 @@ source: crates/baml_tests/src/generated_tests.rs
 // like the one below work because TIR persists inferred instantiations in
 // `CallPlan.type_args` (including phase-0 reverse inference from the
 // expected return type) and MIR materializes them into the callee frame,
-// where `__make_stream` reifies them via `reflect.type_of<TStream/TFinal>()`.
+// where `__make_stream` reifies them via `type.of<TStream/TFinal>()`.
 // There is no name-keyed registry fallback anymore — a propagation gap
 // would surface as "Non-parsable type: ..." from `StreamCache.new`.
 // Runtime coverage: `streaming_parsing::stream_string_final_value` and

--- a/baml_language/crates/baml_tests/snapshots/compiles/string_methods/baml_tests__compiles__string_methods__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/string_methods/baml_tests__compiles__string_methods__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 24620
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,10 +9,4 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_basic/baml_tests__compiles__test_expr_basic__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_basic/baml_tests__compiles__test_expr_basic__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 24903
 ---
 function $init_test(registry: unknown) -> null {
     load_var ?1
@@ -16,12 +17,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.$init_test_main(registry: testing.TestCollector) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_name_concat/baml_tests__compiles__test_expr_name_concat__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_name_concat/baml_tests__compiles__test_expr_name_concat__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 25185
 ---
 function $init_test(registry: unknown) -> null {
     load_var ?1
@@ -16,12 +17,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.$init_test_main(registry: testing.TestCollector) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_throwing_body/baml_tests__compiles__test_expr_throwing_body__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_throwing_body/baml_tests__compiles__test_expr_throwing_body__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 25467
 ---
 function $init_test(registry: unknown) -> null {
     load_var ?1
@@ -16,12 +17,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.$init_test_main(registry: testing.TestCollector) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_expr_with_runner/baml_tests__compiles__test_expr_with_runner__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_expr_with_runner/baml_tests__compiles__test_expr_with_runner__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 25749
 ---
 function $init_test(registry: unknown) -> null {
     load_var ?1
@@ -16,12 +17,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.$init_test_main(registry: testing.TestCollector) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_old_and_new/baml_tests__compiles__test_old_and_new__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_old_and_new/baml_tests__compiles__test_old_and_new__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 26031
 ---
 function $init_test(registry: unknown) -> null {
     load_var ?1
@@ -16,12 +17,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.$init_test_main(registry: testing.TestCollector) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_raw_string_name/baml_tests__compiles__test_raw_string_name__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_raw_string_name/baml_tests__compiles__test_raw_string_name__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 26313
 ---
 function $init_test(registry: unknown) -> null {
     load_var ?1
@@ -16,12 +17,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.$init_test_main(registry: testing.TestCollector) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/test_with_not_keyword/baml_tests__compiles__test_with_not_keyword__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/test_with_not_keyword/baml_tests__compiles__test_with_not_keyword__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 26595
 ---
 function $init_test(registry: unknown) -> null {
     load_var ?1
@@ -16,12 +17,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.$init_test_main(registry: testing.TestCollector) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_basic/baml_tests__compiles__testset_basic__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_basic/baml_tests__compiles__testset_basic__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 26877
 ---
 function $init_test(registry: unknown) -> null {
     load_var ?1
@@ -16,12 +17,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.$init_test_main(registry: testing.TestCollector) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_dynamic/baml_tests__compiles__testset_dynamic__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_dynamic/baml_tests__compiles__testset_dynamic__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 27159
 ---
 function $init_test(registry: unknown) -> null {
     load_var ?1
@@ -16,12 +17,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.$init_test_main(registry: testing.TestCollector) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_nested/baml_tests__compiles__testset_nested__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_nested/baml_tests__compiles__testset_nested__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 27441
 ---
 function $init_test(registry: unknown) -> null {
     load_var ?1
@@ -16,12 +17,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.$init_test_main(registry: testing.TestCollector) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_vibes_nested/baml_tests__compiles__testset_vibes_nested__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 27723
 ---
 function $init() -> null {
     call $init_let_0
@@ -23,12 +24,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.$init_test_main(registry: testing.TestCollector) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/testset_with_setup/baml_tests__compiles__testset_with_setup__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/testset_with_setup/baml_tests__compiles__testset_with_setup__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 28005
 ---
 function $init_test(registry: unknown) -> null {
     load_var ?1
@@ -16,12 +17,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.$init_test_main(registry: testing.TestCollector) -> null {

--- a/baml_language/crates/baml_tests/snapshots/compiles/top_level_header_comment/baml_tests__compiles__top_level_header_comment__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/top_level_header_comment/baml_tests__compiles__top_level_header_comment__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 28287
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.Foo() -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/top_level_let/baml_tests__compiles__top_level_let__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/top_level_let/baml_tests__compiles__top_level_let__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 28569
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,10 +9,4 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_annotation/baml_tests__compiles__type_annotation__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_annotation/baml_tests__compiles__type_annotation__06_codegen.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 28968
 ---
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
 }
@@ -8,12 +9,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function user.test_let_binding(function_name: string) -> string {

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_kinds/baml_tests__compiles__type_kinds__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_kinds/baml_tests__compiles__type_kinds__03_ppir.snap
@@ -1,0 +1,22 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== PPIR ===
+class user.Foo {
+  value: int
+}
+class user.Foo$stream {
+  value: int | null
+}
+enum user.Color {Red, Blue}
+type user.Callback = (value: int) -> bool throws never
+type user.Callback$stream = unknown
+function user.classify(t: type) -> string  [expr] {
+  {  } match (t.kind()) { baml.reflect.class.Type => "class", baml.reflect.enum.Type => "enum", baml.reflect.union.Type => "union", baml.reflect.literal.Type => "literal", baml.reflect.array.Type => "array", baml.reflect.map.Type => "map", baml.reflect.interface.Type => "interface", baml.reflect.primitive.Type => "primitive", baml.reflect.function.Type => "function" }
+}
+function user.exercise_all_kinds() -> bool  [expr] {
+  {  } classify(type.of()) Eq "class" And classify(type.of()) Eq "enum" And classify(type.of()) Eq "union" And classify(type.of()) Eq "literal" And classify(type.of()) Eq "array" And classify(type.of()) Eq "map" And classify(type.of()) Eq "interface" And classify(type.of()) Eq "primitive" And classify(type.of()) Eq "function"
+}
+function user.read_class(view: baml.reflect.class.Type) -> type  [expr] {
+  {  } view.as_type()
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_kinds/baml_tests__compiles__type_kinds__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_kinds/baml_tests__compiles__type_kinds__04_5_mir.snap
@@ -1,0 +1,314 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== MIR2 ===
+fn user.classify(t: type) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: type // t // param
+    let _2: baml.reflect.array.Type | baml.reflect.class.Type | baml.reflect.enum.Type | baml.reflect.function.Type | baml.reflect.interface.Type | baml.reflect.literal.Type | baml.reflect.map.Type | baml.reflect.primitive.Type | baml.reflect.union.Type
+    let _3: bool
+    let _4: bool
+    let _5: bool
+    let _6: bool
+    let _7: bool
+    let _8: bool
+    let _9: bool
+    let _10: bool
+
+    bb0: {
+        _2 = call const fn baml.TypeValue.kind(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _3 = is_type(copy _2, baml.reflect.class.Type);
+        branch copy _3 -> [bb17, bb2];
+    }
+
+    bb2: {
+        _4 = is_type(copy _2, baml.reflect.enum.Type);
+        branch copy _4 -> [bb16, bb3];
+    }
+
+    bb3: {
+        _5 = is_type(copy _2, baml.reflect.union.Type);
+        branch copy _5 -> [bb15, bb4];
+    }
+
+    bb4: {
+        _6 = is_type(copy _2, baml.reflect.literal.Type);
+        branch copy _6 -> [bb14, bb5];
+    }
+
+    bb5: {
+        _7 = is_type(copy _2, baml.reflect.array.Type);
+        branch copy _7 -> [bb13, bb6];
+    }
+
+    bb6: {
+        _8 = is_type(copy _2, baml.reflect.map.Type);
+        branch copy _8 -> [bb12, bb7];
+    }
+
+    bb7: {
+        _9 = is_type(copy _2, baml.reflect.interface.Type);
+        branch copy _9 -> [bb11, bb8];
+    }
+
+    bb8: {
+        _10 = is_type(copy _2, baml.reflect.primitive.Type);
+        branch copy _10 -> [bb10, bb9];
+    }
+
+    bb9: {
+        _0 = const "function";
+        goto -> bb18;
+    }
+
+    bb10: {
+        _0 = const "primitive";
+        goto -> bb18;
+    }
+
+    bb11: {
+        _0 = const "interface";
+        goto -> bb18;
+    }
+
+    bb12: {
+        _0 = const "map";
+        goto -> bb18;
+    }
+
+    bb13: {
+        _0 = const "array";
+        goto -> bb18;
+    }
+
+    bb14: {
+        _0 = const "literal";
+        goto -> bb18;
+    }
+
+    bb15: {
+        _0 = const "union";
+        goto -> bb18;
+    }
+
+    bb16: {
+        _0 = const "enum";
+        goto -> bb18;
+    }
+
+    bb17: {
+        _0 = const "class";
+        goto -> bb18;
+    }
+
+    bb18: {
+        return;
+    }
+}
+
+fn user.read_class(view: baml.reflect.class.Type) -> type {
+    // Locals:
+    let _0: type // _0 // return
+    let _1: baml.reflect.class.Type // view // param
+
+    bb0: {
+        _0 = virtual_call as_type as baml.reflect.TypeView(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn user.exercise_all_kinds() -> bool {
+    // Locals:
+    let _0: bool // _0 // return
+    let _1: bool
+    let _2: bool
+    let _3: bool
+    let _4: bool
+    let _5: bool
+    let _6: bool
+    let _7: bool
+    let _8: bool
+    let _9: string
+    let _10: type
+    let _11: string
+    let _12: type
+    let _13: string
+    let _14: type
+    let _15: string
+    let _16: type
+    let _17: string
+    let _18: type
+    let _19: string
+    let _20: type
+    let _21: string
+    let _22: type
+    let _23: string
+    let _24: type
+    let _25: string
+    let _26: type
+
+    bb0: {
+        _10 = load_type(Foo);
+        goto -> bb1;
+    }
+
+    bb1: {
+        _9 = call const fn user.classify(copy _10) -> [bb2];
+    }
+
+    bb2: {
+        _8 = copy _9 == const "class";
+        _7 = short_circuit(&&) copy _8 -> [eval: bb3, join: bb6];
+    }
+
+    bb3: {
+        _12 = load_type(Color);
+        goto -> bb4;
+    }
+
+    bb4: {
+        _11 = call const fn user.classify(copy _12) -> [bb5];
+    }
+
+    bb5: {
+        _7 = copy _11 == const "enum";
+        goto -> bb6;
+    }
+
+    bb6: {
+        _6 = short_circuit(&&) copy _7 -> [eval: bb7, join: bb10];
+    }
+
+    bb7: {
+        _14 = load_type(int | string);
+        goto -> bb8;
+    }
+
+    bb8: {
+        _13 = call const fn user.classify(copy _14) -> [bb9];
+    }
+
+    bb9: {
+        _6 = copy _13 == const "union";
+        goto -> bb10;
+    }
+
+    bb10: {
+        _5 = short_circuit(&&) copy _6 -> [eval: bb11, join: bb14];
+    }
+
+    bb11: {
+        _16 = load_type("fixed");
+        goto -> bb12;
+    }
+
+    bb12: {
+        _15 = call const fn user.classify(copy _16) -> [bb13];
+    }
+
+    bb13: {
+        _5 = copy _15 == const "literal";
+        goto -> bb14;
+    }
+
+    bb14: {
+        _4 = short_circuit(&&) copy _5 -> [eval: bb15, join: bb18];
+    }
+
+    bb15: {
+        _18 = load_type(Foo[]);
+        goto -> bb16;
+    }
+
+    bb16: {
+        _17 = call const fn user.classify(copy _18) -> [bb17];
+    }
+
+    bb17: {
+        _4 = copy _17 == const "array";
+        goto -> bb18;
+    }
+
+    bb18: {
+        _3 = short_circuit(&&) copy _4 -> [eval: bb19, join: bb22];
+    }
+
+    bb19: {
+        _20 = load_type(map<string, Foo>);
+        goto -> bb20;
+    }
+
+    bb20: {
+        _19 = call const fn user.classify(copy _20) -> [bb21];
+    }
+
+    bb21: {
+        _3 = copy _19 == const "map";
+        goto -> bb22;
+    }
+
+    bb22: {
+        _2 = short_circuit(&&) copy _3 -> [eval: bb23, join: bb26];
+    }
+
+    bb23: {
+        _22 = load_type(Marker);
+        goto -> bb24;
+    }
+
+    bb24: {
+        _21 = call const fn user.classify(copy _22) -> [bb25];
+    }
+
+    bb25: {
+        _2 = copy _21 == const "interface";
+        goto -> bb26;
+    }
+
+    bb26: {
+        _1 = short_circuit(&&) copy _2 -> [eval: bb27, join: bb30];
+    }
+
+    bb27: {
+        _24 = load_type(int);
+        goto -> bb28;
+    }
+
+    bb28: {
+        _23 = call const fn user.classify(copy _24) -> [bb29];
+    }
+
+    bb29: {
+        _1 = copy _23 == const "primitive";
+        goto -> bb30;
+    }
+
+    bb30: {
+        _0 = short_circuit(&&) copy _1 -> [eval: bb31, join: bb34];
+    }
+
+    bb31: {
+        _26 = load_type((int) -> bool throws never);
+        goto -> bb32;
+    }
+
+    bb32: {
+        _25 = call const fn user.classify(copy _26) -> [bb33];
+    }
+
+    bb33: {
+        _0 = copy _25 == const "function";
+        goto -> bb34;
+    }
+
+    bb34: {
+        return;
+    }
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_kinds/baml_tests__compiles__type_kinds__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_kinds/baml_tests__compiles__type_kinds__04_tir.snap
@@ -1,0 +1,46 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== TIR2 ===
+class user.Foo {
+  value: int
+}
+enum user.Color
+type user.Callback = (value: int) -> bool throws never
+function user.classify(t: type) -> string throws never {
+  { : "class" | "enum" | "union" | "literal" | "array" | "map" | "interface" | "primitive" | "function"
+    match (t.kind() : baml.reflect.TypeKind) : "class" | "enum" | "union" | "literal" | "array" | "map" | "interface" | "primitive" | "function"
+      baml.reflect.class.Type =>
+        "class" : "class"
+      baml.reflect.enum.Type =>
+        "enum" : "enum"
+      baml.reflect.union.Type =>
+        "union" : "union"
+      baml.reflect.literal.Type =>
+        "literal" : "literal"
+      baml.reflect.array.Type =>
+        "array" : "array"
+      baml.reflect.map.Type =>
+        "map" : "map"
+      baml.reflect.interface.Type =>
+        "interface" : "interface"
+      baml.reflect.primitive.Type =>
+        "primitive" : "primitive"
+      baml.reflect.function.Type =>
+        "function" : "function"
+  }
+}
+function user.read_class(view: baml.reflect.class.Type) -> type throws never {
+  { : type
+    view.as_type() : type
+  }
+}
+function user.exercise_all_kinds() -> bool throws never {
+  { : bool
+    classify(type.of<Foo>()) == "class" && classify(type.of<Color>()) == "enum" && classify(type.of<int | string>()) == "union" && classify(type.of<"fixed">()) == "literal" && classify(type.of<Foo[]>()) == "array" && classify(type.of<map<string, Foo>>()) == "map" && classify(type.of<Marker>()) == "interface" && classify(type.of<int>()) == "primitive" && classify(type.of<Callback>()) == "function" : bool
+  }
+}
+class user.Foo$stream {
+  value: int | null
+}
+type user.Callback$stream = unknown

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_kinds/baml_tests__compiles__type_kinds__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_kinds/baml_tests__compiles__type_kinds__05_diagnostics.snap
@@ -1,0 +1,5 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== COMPILER2 DIAGNOSTICS ===
+No errors found.

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_kinds/baml_tests__compiles__type_kinds__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_kinds/baml_tests__compiles__type_kinds__06_codegen.snap
@@ -1,0 +1,183 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
+}
+
+function boundary.id() -> boundary.LocalId {
+}
+
+function boundary.id.current() -> string {
+}
+
+function user.classify(t: type) -> string {
+    load_var t
+    call baml.TypeValue.kind
+    store_var _2
+    load_var _2
+    is_type baml.reflect.class.Type
+    pop_jump_if_false L0
+    jump L15
+
+  L0:
+    load_var _2
+    is_type baml.reflect.enum.Type
+    pop_jump_if_false L1
+    jump L14
+
+  L1:
+    load_var _2
+    is_type baml.reflect.union.Type
+    pop_jump_if_false L2
+    jump L13
+
+  L2:
+    load_var _2
+    is_type baml.reflect.literal.Type
+    pop_jump_if_false L3
+    jump L12
+
+  L3:
+    load_var _2
+    is_type baml.reflect.array.Type
+    pop_jump_if_false L4
+    jump L11
+
+  L4:
+    load_var _2
+    is_type baml.reflect.map.Type
+    pop_jump_if_false L5
+    jump L10
+
+  L5:
+    load_var _2
+    is_type baml.reflect.interface.Type
+    pop_jump_if_false L6
+    jump L9
+
+  L6:
+    load_var _2
+    is_type baml.reflect.primitive.Type
+    pop_jump_if_false L7
+    jump L8
+
+  L7:
+    load_const "function"
+    jump L16
+
+  L8:
+    load_const "primitive"
+    jump L16
+
+  L9:
+    load_const "interface"
+    jump L16
+
+  L10:
+    load_const "map"
+    jump L16
+
+  L11:
+    load_const "array"
+    jump L16
+
+  L12:
+    load_const "literal"
+    jump L16
+
+  L13:
+    load_const "union"
+    jump L16
+
+  L14:
+    load_const "enum"
+    jump L16
+
+  L15:
+    load_const "class"
+
+  L16:
+    return
+}
+
+function user.exercise_all_kinds() -> bool {
+    load_type Foo
+    call user.classify
+    load_const "class"
+    cmp_op ==
+    jump_if_false L0
+    pop 1
+    load_type Color
+    call user.classify
+    load_const "enum"
+    cmp_op ==
+
+  L0:
+    jump_if_false L1
+    pop 1
+    load_type int | string
+    call user.classify
+    load_const "union"
+    cmp_op ==
+
+  L1:
+    jump_if_false L2
+    pop 1
+    load_type "fixed"
+    call user.classify
+    load_const "literal"
+    cmp_op ==
+
+  L2:
+    jump_if_false L3
+    pop 1
+    load_type Foo[]
+    call user.classify
+    load_const "array"
+    cmp_op ==
+
+  L3:
+    jump_if_false L4
+    pop 1
+    load_type map<string, Foo>
+    call user.classify
+    load_const "map"
+    cmp_op ==
+
+  L4:
+    jump_if_false L5
+    pop 1
+    load_type Marker
+    call user.classify
+    load_const "interface"
+    cmp_op ==
+
+  L5:
+    jump_if_false L6
+    pop 1
+    load_type int
+    call user.classify
+    load_const "primitive"
+    cmp_op ==
+
+  L6:
+    jump_if_false L7
+    pop 1
+    load_type (int) -> bool throws never
+    call user.classify
+    load_const "function"
+    cmp_op ==
+
+  L7:
+    return
+}
+
+function user.read_class(view: baml.reflect.class.Type) -> type {
+    load_var view
+    load_type baml.reflect.TypeView
+    load_const "as_type"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _0
+    load_var _0
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/compiles/type_kinds/baml_tests__compiles__type_kinds__10_formatter__main.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/type_kinds/baml_tests__compiles__type_kinds__10_formatter__main.snap
@@ -1,0 +1,45 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+class Foo {
+    value: int,
+}
+
+enum Color {
+    Red,
+    Blue,
+}
+
+interface Marker {}
+
+type Callback = (value: int) -> bool throws never;
+
+function classify(t: type) -> string {
+    match (t.kind()) {
+        baml.reflect.class.Type => "class",
+        baml.reflect.enum.Type => "enum",
+        baml.reflect.union.Type => "union",
+        baml.reflect.literal.Type => "literal",
+        baml.reflect.array.Type => "array",
+        baml.reflect.map.Type => "map",
+        baml.reflect.interface.Type => "interface",
+        baml.reflect.primitive.Type => "primitive",
+        baml.reflect.function.Type => "function",
+    }
+}
+
+function read_class(view: baml.reflect.class.Type) -> type throws never {
+    view.as_type()
+}
+
+function exercise_all_kinds() -> bool {
+    classify(type.of<Foo>()) == "class"
+        && classify(type.of<Color>()) == "enum"
+        && classify(type.of<int | string>()) == "union"
+        && classify(type.of<"fixed">()) == "literal"
+        && classify(type.of<Foo[]>()) == "array"
+        && classify(type.of<map<string, Foo>>()) == "map"
+        && classify(type.of<Marker>()) == "interface"
+        && classify(type.of<int>()) == "primitive"
+        && classify(type.of<Callback>()) == "function"
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/removed_reflect_type_of/baml_tests__diagnostic_errors__removed_reflect_type_of__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/removed_reflect_type_of/baml_tests__diagnostic_errors__removed_reflect_type_of__03_ppir.snap
@@ -1,0 +1,11 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 44295
+---
+=== PPIR ===
+function user.old_bare_spelling() -> type  [expr] {
+  {  } reflect.type_of()
+}
+function user.old_qualified_spelling() -> type  [expr] {
+  {  } baml.reflect.type_of()
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/removed_reflect_type_of/baml_tests__diagnostic_errors__removed_reflect_type_of__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/removed_reflect_type_of/baml_tests__diagnostic_errors__removed_reflect_type_of__04_tir.snap
@@ -1,0 +1,17 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 44319
+---
+=== TIR2 ===
+function user.old_bare_spelling() -> type throws never {
+  { : unknown
+    reflect.type_of() : unknown
+  }
+  !! 284..299: `reflect.type_of` was renamed to `type.of` (BEP-066): write `type.of<T>()`
+}
+function user.old_qualified_spelling() -> type throws never {
+  { : unknown
+    baml.reflect.type_of() : unknown
+  }
+  !! 358..378: `reflect.type_of` was renamed to `type.of` (BEP-066): write `type.of<T>()`
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/removed_reflect_type_of/baml_tests__diagnostic_errors__removed_reflect_type_of__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/removed_reflect_type_of/baml_tests__diagnostic_errors__removed_reflect_type_of__05_diagnostics.snap
@@ -1,0 +1,20 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 44379
+---
+=== COMPILER2 DIAGNOSTICS ===
+  [type] E0003
+
+  × `reflect.type_of` was renamed to `type.of` (BEP-066): write `type.of<T>()`
+   ╭─[main.baml:7:5]
+ 7 │     reflect.type_of<int>()
+   ·     ───────────────
+   ╰────
+
+  [type] E0003
+
+  × `reflect.type_of` was renamed to `type.of` (BEP-066): write `type.of<T>()`
+    ╭─[main.baml:11:5]
+ 11 │     baml.reflect.type_of<string>()
+    ·     ────────────────────
+    ╰────

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/removed_reflect_type_of/baml_tests__diagnostic_errors__removed_reflect_type_of__10_formatter__main.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/removed_reflect_type_of/baml_tests__diagnostic_errors__removed_reflect_type_of__10_formatter__main.snap
@@ -1,0 +1,16 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 44455
+---
+// BEP-066 I-9: `reflect.type_of` was REMOVED (renamed to `type.of`), not
+// aliased. Both the bare shorthand spelling and the fully qualified one must
+// error with a diagnostic that names the replacement, not a bare
+// "unresolved name".
+
+function old_bare_spelling() -> type {
+    reflect.type_of<int>()
+}
+
+function old_qualified_spelling() -> type {
+    baml.reflect.type_of<string>()
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/self_in_body/baml_tests__diagnostic_errors__self_in_body__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/self_in_body/baml_tests__diagnostic_errors__self_in_body__03_ppir.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 54919
+assertion_line: 44948
 ---
 === PPIR ===
 class user.Box {
@@ -16,7 +16,7 @@ function user.check(self: ?, other: Self) -> bool  [expr] {
   {  } other is Self
 }
 function user.describe(self: ?) -> string  [expr] {
-  {  } reflect.type_of().to_string()
+  {  } type.of().to_string()
 }
 function user.is_self(self: ?, other: user.Box<int> | user.Box<string>) -> bool  [expr] {
   {  } other is Self
@@ -28,7 +28,7 @@ function user.nested_self(self: ?, w: user.Box<Self>) -> int  [expr] {
   {  } match (w) { s: user.Box<Self> => 1, _ => 0 }
 }
 function user.turbofish_self(self: ?) -> string  [expr] {
-  {  } reflect.type_of().to_string()
+  {  } type.of().to_string()
 }
 function user.which(self: ?, other: user.Box<int> | user.Box<string>) -> string  [expr] {
   {  } match (other) { s: Self => "self", _ => "other" }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/self_in_body/baml_tests__diagnostic_errors__self_in_body__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/self_in_body/baml_tests__diagnostic_errors__self_in_body__04_tir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 44972
 ---
 === TIR2 ===
 class user.Box {
@@ -42,9 +43,9 @@ function user.Box.nested_self(self: user.Box<T>, w: user.Box<!error>) -> int thr
 }
 function user.Box.turbofish_self(self: user.Box<T>) -> string throws never {
   { : string
-    reflect.type_of<Self>().to_string() : string
+    type.of<Self>().to_string() : string
   }
-  !! 1609..1632: unresolved type: Self
+  !! 1609..1624: unresolved type: Self
 }
 function user.Tester.check(self: user.Tester, other: Self) -> bool throws never {
   { : bool
@@ -53,7 +54,7 @@ function user.Tester.check(self: user.Tester, other: Self) -> bool throws never 
 }
 function user.Tester.describe(self: user.Tester) -> string throws never {
   { : string
-    reflect.type_of<Self>().to_string() : string
+    type.of<Self>().to_string() : string
   }
 }
 function user.Tester.bind_self(self: user.Tester, other: Self) -> bool throws never {

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/self_in_body/baml_tests__diagnostic_errors__self_in_body__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/self_in_body/baml_tests__diagnostic_errors__self_in_body__05_diagnostics.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 45032
 ---
 === COMPILER2 DIAGNOSTICS ===
   [type] E0002
@@ -38,6 +39,6 @@ source: crates/baml_tests/src/generated_tests.rs
 
   × unresolved type: Self
     ╭─[main.baml:42:9]
- 42 │         reflect.type_of<Self>().to_string()
-    ·         ───────────────────────
+ 42 │         type.of<Self>().to_string()
+    ·         ───────────────
     ╰────

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/self_in_body/baml_tests__diagnostic_errors__self_in_body__10_formatter__main.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/self_in_body/baml_tests__diagnostic_errors__self_in_body__10_formatter__main.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 45108
 ---
 // `Self` in a method *body* type position.
 //
@@ -42,7 +43,7 @@ class Box<T> {
         }
     }
     function turbofish_self(self) -> string {
-        reflect.type_of<Self>().to_string()
+        type.of<Self>().to_string()
     }
 }
 
@@ -54,7 +55,7 @@ interface Tester {
         other is Self
     }
     function describe(self) -> string throws never {
-        reflect.type_of<Self>().to_string()
+        type.of<Self>().to_string()
     }
     function bind_self(self, other: Self) -> bool throws never {
         let a: Self = other;

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_kinds/baml_tests__diagnostic_errors__type_kinds__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_kinds/baml_tests__diagnostic_errors__type_kinds__03_ppir.snap
@@ -1,0 +1,10 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== PPIR ===
+function user.kinds_are_not_constructible() -> baml.reflect.class.Type  [expr] {
+  {  } baml.reflect.class.Type {  }
+}
+function user.non_exhaustive(t: type) -> string  [expr] {
+  {  } match (t.kind()) { baml.reflect.class.Type => "class", baml.reflect.enum.Type => "enum", baml.reflect.union.Type => "union", baml.reflect.literal.Type => "literal", baml.reflect.array.Type => "array", baml.reflect.map.Type => "map", baml.reflect.interface.Type => "interface", baml.reflect.primitive.Type => "primitive" }
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_kinds/baml_tests__diagnostic_errors__type_kinds__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_kinds/baml_tests__diagnostic_errors__type_kinds__04_tir.snap
@@ -1,0 +1,32 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== TIR2 ===
+function user.non_exhaustive(t: type) -> string throws never {
+  { : "class" | "enum" | "union" | "literal" | "array" | "map" | "interface" | "primitive"
+    match (t.kind() : baml.reflect.TypeKind) : "class" | "enum" | "union" | "literal" | "array" | "map" | "interface" | "primitive"
+      baml.reflect.class.Type =>
+        "class" : "class"
+      baml.reflect.enum.Type =>
+        "enum" : "enum"
+      baml.reflect.union.Type =>
+        "union" : "union"
+      baml.reflect.literal.Type =>
+        "literal" : "literal"
+      baml.reflect.array.Type =>
+        "array" : "array"
+      baml.reflect.map.Type =>
+        "map" : "map"
+      baml.reflect.interface.Type =>
+        "interface" : "interface"
+      baml.reflect.primitive.Type =>
+        "primitive" : "primitive"
+  }
+  !! 47..402: non-exhaustive match on `baml.reflect.TypeKind`; missing: baml.reflect.function.Type {}
+}
+function user.kinds_are_not_constructible() -> baml.reflect.class.Type throws never {
+  { : baml.reflect.class.Type
+    baml.reflect.class.Type {  } : baml.reflect.class.Type
+  }
+  !! 476..502: reflection kind `baml.reflect.class.Type` cannot be constructed; obtain it from a type value
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_kinds/baml_tests__diagnostic_errors__type_kinds__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_kinds/baml_tests__diagnostic_errors__type_kinds__05_diagnostics.snap
@@ -1,0 +1,27 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+=== COMPILER2 DIAGNOSTICS ===
+  [type] E0062
+
+  × non-exhaustive match on type baml.reflect.TypeKind; missing: baml.reflect.function.Type {}
+    ╭─[main.baml:2:3]
+  2 │ ╭─▶   match (t.kind()) {
+  3 │ │       baml.reflect.class.Type => "class",
+  4 │ │       baml.reflect.enum.Type => "enum",
+  5 │ │       baml.reflect.union.Type => "union",
+  6 │ │       baml.reflect.literal.Type => "literal",
+  7 │ │       baml.reflect.array.Type => "array",
+  8 │ │       baml.reflect.map.Type => "map",
+  9 │ │       baml.reflect.interface.Type => "interface",
+ 10 │ │       baml.reflect.primitive.Type => "primitive"
+ 11 │ ╰─▶   }
+    ╰────
+
+  [type] E0001
+
+  × reflection kind `baml.reflect.class.Type` cannot be constructed; obtain it from a type value
+    ╭─[main.baml:15:3]
+ 15 │   baml.reflect.class.Type {}
+    ·   ──────────────────────────
+    ╰────

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_kinds/baml_tests__diagnostic_errors__type_kinds__10_formatter__main.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_kinds/baml_tests__diagnostic_errors__type_kinds__10_formatter__main.snap
@@ -1,0 +1,19 @@
+---
+source: crates/baml_tests/src/generated_tests.rs
+---
+function non_exhaustive(t: type) -> string {
+    match (t.kind()) {
+        baml.reflect.class.Type => "class",
+        baml.reflect.enum.Type => "enum",
+        baml.reflect.union.Type => "union",
+        baml.reflect.literal.Type => "literal",
+        baml.reflect.array.Type => "array",
+        baml.reflect.map.Type => "map",
+        baml.reflect.interface.Type => "interface",
+        baml.reflect.primitive.Type => "primitive",
+    }
+}
+
+function kinds_are_not_constructible() -> baml.reflect.class.Type {
+    baml.reflect.class.Type {  }
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_reflection_strict/baml_tests__diagnostic_errors__type_reflection_strict__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_reflection_strict/baml_tests__diagnostic_errors__type_reflection_strict__03_ppir.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 58354
+assertion_line: 47296
 ---
 === PPIR ===
 class user.User {
@@ -10,13 +10,13 @@ class user.User$stream {
   name: string | null
 }
 function user.reflect_type_to_int() -> int  [expr] {
-  { let x: int = reflect.type_of(); return x }
+  { let x: int = type.of(); return x }
 }
 function user.too_many_type_args() -> type  [expr] {
-  {  } reflect.type_of()
+  {  } type.of()
 }
 function user.unknown_type_in_reflect() -> type  [expr] {
-  {  } reflect.type_of()
+  {  } type.of()
 }
 function user.assign_type_to_int(function_name: string) -> int  [expr] {
   { let x: int = baml.llm.get_return_type(function_name); return x }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_reflection_strict/baml_tests__diagnostic_errors__type_reflection_strict__04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_reflection_strict/baml_tests__diagnostic_errors__type_reflection_strict__04_tir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 47328
 ---
 === TIR2 ===
 class user.User {
@@ -7,22 +8,22 @@ class user.User {
 }
 function user.reflect_type_to_int() -> int throws never {
   { : never
-    let x: int = reflect.type_of() : type -> int
+    let x: int = type.of() : type -> int
     return x : int
   }
-  !! 504..527: type mismatch: expected int, got type
+  !! 496..511: type mismatch: expected int, got type
 }
 function user.unknown_type_in_reflect() -> type throws never {
   { : type
-    reflect.type_of() : type
+    type.of() : type
   }
-  !! 653..683: unresolved type: NonExistent
+  !! 629..651: unresolved type: NonExistent
 }
 function user.too_many_type_args() -> type throws never {
   { : type
-    reflect.type_of() : type
+    type.of() : type
   }
-  !! 889..919: function `type_of` expects 1 type argument(s), got 2
+  !! 857..879: function `of` expects 1 type argument(s), got 2
 }
 class user.User$stream {
   name: string | null

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_reflection_strict/baml_tests__diagnostic_errors__type_reflection_strict__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_reflection_strict/baml_tests__diagnostic_errors__type_reflection_strict__05_diagnostics.snap
@@ -1,30 +1,31 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 47396
 ---
 === COMPILER2 DIAGNOSTICS ===
   [type] E0001
 
   × mismatched types
     ╭─[reflect_intrinsic_errors.baml:12:18]
- 12 │     let x: int = reflect.type_of<User>();
-    ·                  ───────────┬───────────
-    ·                             ╰── expected `int`, found `type`
+ 12 │     let x: int = type.of<User>();
+    ·                  ───────┬───────
+    ·                         ╰── expected `int`, found `type`
     ╰────
 
   [type] E0002
 
   × unresolved type: NonExistent
     ╭─[reflect_intrinsic_errors.baml:18:5]
- 18 │     reflect.type_of<NonExistent>()
-    ·     ──────────────────────────────
+ 18 │     type.of<NonExistent>()
+    ·     ──────────────────────
     ╰────
 
   [type] E0005
 
-  × function `type_of` expects 1 type argument(s), got 2
+  × function `of` expects 1 type argument(s), got 2
     ╭─[reflect_intrinsic_errors.baml:25:5]
- 25 │     reflect.type_of<int, string>()
-    ·     ──────────────────────────────
+ 25 │     type.of<int, string>()
+    ·     ──────────────────────
     ╰────
 
   [type] E0001

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_reflection_strict/baml_tests__diagnostic_errors__type_reflection_strict__10_formatter__reflect_intrinsic_errors.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/type_reflection_strict/baml_tests__diagnostic_errors__type_reflection_strict__10_formatter__reflect_intrinsic_errors.snap
@@ -1,7 +1,8 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
+assertion_line: 47476
 ---
-// Negative cases for the `reflect.type_of` compiler intrinsic itself.
+// Negative cases for the `type.of` compiler intrinsic itself.
 // These complement `strict_normalization.baml` (which exercises Ty::Type
 // strictness via `baml.llm.get_return_type`) by hitting the intrinsic path
 // directly.
@@ -14,18 +15,18 @@ class User {
 // to a non-`type` slot. Validates Phase 2's strictness all the way through
 // Phase 4's `LoadType` lowering.
 function reflect_type_to_int() -> int {
-    let x: int = reflect.type_of<User>();
+    let x: int = type.of<User>();
     return x;
 }
 
-// Unknown type referenced inside `reflect.type_of<...>`.
+// Unknown type referenced inside `type.of<...>`.
 function unknown_type_in_reflect() -> type {
-    reflect.type_of<NonExistent>()
+    type.of<NonExistent>()
 }
 
 // Arity mismatch on the intrinsic: it declares one type parameter, caller
 // passes two. Validates Phase 1's `WrongTypeArgArity` against the new
 // builtin.
 function too_many_type_args() -> type {
-    reflect.type_of<int, string>()
+    type.of<int, string>()
 }

--- a/baml_language/crates/baml_tests/src/compiler2_mir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_mir/mod.rs
@@ -506,9 +506,9 @@ fn source_param_interface_dispatch_respects_shadowed_local_binding() {
     );
 }
 
-// ─── Phase 4: reflect.type_of concrete types ─────────────────────────────────
+// ─── Phase 4: type.of concrete types ─────────────────────────────────
 
-/// `reflect.type_of<User>()` should lower to `_N = load_type(Concrete(User))`.
+/// `type.of<User>()` should lower to `_N = load_type(Concrete(User))`.
 #[test]
 fn reflect_type_of_class() {
     let mut db = make_db();
@@ -517,14 +517,14 @@ fn reflect_type_of_class() {
         r#"
         class User { name string }
         function f() -> type {
-            reflect.type_of<User>()
+            type.of<User>()
         }
         "#,
     );
     mir_snapshot!("reflect_type_of_class", render_mir(&db, file));
 }
 
-/// `reflect.type_of<int[]>()` — concrete array type.
+/// `type.of<int[]>()` — concrete array type.
 #[test]
 fn reflect_type_of_array() {
     let mut db = make_db();
@@ -532,16 +532,16 @@ fn reflect_type_of_array() {
         "test.baml",
         r#"
         function f() -> type {
-            reflect.type_of<int[]>()
+            type.of<int[]>()
         }
         "#,
     );
     mir_snapshot!("reflect_type_of_array", render_mir(&db, file));
 }
 
-// ─── Phase 5: reflect.type_of with generic type params ───────────────────────
+// ─── Phase 5: type.of with generic type params ───────────────────────
 
-/// `reflect.type_of<T>()` inside a generic function should lower to
+/// `type.of<T>()` inside a generic function should lower to
 /// `_N = load_type(TypeArgRef(0))`.
 #[test]
 fn reflect_type_of_bare_typevar() {
@@ -550,14 +550,14 @@ fn reflect_type_of_bare_typevar() {
         "test.baml",
         r#"
         function f<T>() -> type {
-            reflect.type_of<T>()
+            type.of<T>()
         }
         "#,
     );
     mir_snapshot!("reflect_type_of_bare_typevar", render_mir(&db, file));
 }
 
-/// `reflect.type_of<T[]>()` — composite array wrapping a type-var.
+/// `type.of<T[]>()` — composite array wrapping a type-var.
 /// Should lower to `_N = load_type(Array(TypeArgRef(0)))`.
 #[test]
 fn reflect_type_of_array_of_typevar() {
@@ -566,7 +566,7 @@ fn reflect_type_of_array_of_typevar() {
         "test.baml",
         r#"
         function f<T>() -> type {
-            reflect.type_of<T[]>()
+            type.of<T[]>()
         }
         "#,
     );

--- a/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
@@ -1,14 +1,15 @@
 //! Core type inference snapshot tests.
 
 use baml_base::Name;
-use baml_compiler2_hir::{package::PackageId, scope::ScopeKind};
+use baml_compiler2_hir::{contributions::Definition, package::PackageId, scope::ScopeKind};
 use baml_compiler2_tir::{
-    inference::infer_scope_types,
+    inference::{infer_scope_types, resolve_type_alias},
     package_interface::{ExportedType, package_interface, package_resolution_context},
     resolve::{ResolvedName, resolve_name_at_in_scope},
     ty::{FunctionParamMode, QualifiedTypeName, Ty, TyAttr},
     type_context::GlobalTypeContext,
 };
+use salsa::Setter;
 use text_size::TextSize;
 
 use super::support::{expr_type_in_function, make_db, render_tir};
@@ -32,6 +33,15 @@ fn find_function_scope_id<'db>(
                     .is_some_and(|scope_name| scope_name.as_str() == name)
         })
         .unwrap_or_else(|| panic!("missing function scope {name}"))
+}
+
+fn add_compiler2_virtual_file(db: &mut baml_project::ProjectDatabase, path: &str, source: &str) {
+    let file = db.add_file(path, source);
+    let extra = baml_compiler2_hir::Db::compiler2_extra_files(db)
+        .expect("make_db installs compiler2 builtin files");
+    let mut files = extra.files(db).clone();
+    files.push(file);
+    extra.set_files(db).to(files);
 }
 
 #[test]
@@ -502,6 +512,133 @@ fn package_interface_exports_optional_param_mode() {
         Some("limit")
     );
     assert_eq!(exported.params[1].mode, FunctionParamMode::Optional);
+}
+
+#[test]
+fn reflect_type_shorthand_requires_baml_package_access() {
+    let mut db = make_db();
+    add_compiler2_virtual_file(
+        &mut db,
+        "<builtin>/boundary/reflect_probe.baml",
+        "type ForbiddenReflect = reflect.Signature\n",
+    );
+    db.add_file(
+        "allowed_reflect.baml",
+        "type AllowedReflect = reflect.Signature\n",
+    );
+
+    let boundary_items =
+        baml_compiler2_ppir::package_items(&db, PackageId::new(&db, Name::new("boundary")));
+    let Some(Definition::TypeAlias(forbidden_loc)) =
+        boundary_items.lookup_type(&[], &Name::new("ForbiddenReflect"))
+    else {
+        panic!("boundary probe alias should exist");
+    };
+    let forbidden = resolve_type_alias(&db, forbidden_loc);
+    assert!(
+        !forbidden.diagnostics.is_empty(),
+        "boundary has no baml dependency, so reflect.Signature must be unresolved; got {:?}",
+        forbidden.ty
+    );
+
+    let user_items =
+        baml_compiler2_ppir::package_items(&db, PackageId::new(&db, Name::new("user")));
+    let Some(Definition::TypeAlias(allowed_loc)) =
+        user_items.lookup_type(&[], &Name::new("AllowedReflect"))
+    else {
+        panic!("user probe alias should exist");
+    };
+    let allowed = resolve_type_alias(&db, allowed_loc);
+    assert!(
+        allowed.diagnostics.is_empty(),
+        "user packages depend on baml, so reflect.Signature should resolve: {:?}",
+        allowed.diagnostics
+    );
+    assert!(
+        matches!(&allowed.ty, Ty::Class(name, ..)
+            if name.package().as_str() == "baml"
+                && *name.namespace() == [Name::new("reflect")]
+                && name.name().as_str() == "Signature"),
+        "expected baml.reflect.Signature, got {:?}",
+        allowed.ty
+    );
+}
+
+#[test]
+fn keyword_shorthands_hide_non_exported_baml_members() {
+    let mut db = make_db();
+    add_compiler2_virtual_file(
+        &mut db,
+        "<builtin>/baml/ns_reflect/raw_only.baml",
+        "interface RawOnly {}\ntemplate_string raw_only() `raw`\n",
+    );
+
+    let user_pkg = PackageId::new(&db, Name::new("user"));
+    let res_ctx = package_resolution_context(&db, user_pkg);
+    let baml_name = Name::new("baml");
+    let reflect_ns = [Name::new("reflect")];
+    let raw_only_type = Name::new("RawOnly");
+    let raw_only_value = Name::new("raw_only");
+
+    let raw_baml_items = res_ctx
+        .items_for_package(&db, &baml_name)
+        .expect("user packages can access baml");
+    assert!(
+        raw_baml_items
+            .lookup_type(&reflect_ns, &raw_only_type)
+            .is_some(),
+        "the fixture must exist in the raw namespace map"
+    );
+    assert!(
+        raw_baml_items
+            .lookup_value(&reflect_ns, &raw_only_value)
+            .is_some(),
+        "the fixture must exist in the raw namespace map"
+    );
+
+    let exported_baml = res_ctx
+        .dep_interfaces
+        .iter()
+        .find(|(name, _)| name == &baml_name)
+        .map(|(_, interface)| interface)
+        .expect("user packages have baml's exported interface");
+    assert!(
+        exported_baml
+            .lookup_type(&reflect_ns, &raw_only_type)
+            .is_none(),
+        "interfaces are not part of this branch's exported type surface"
+    );
+    assert!(
+        exported_baml
+            .lookup_function(&reflect_ns, &raw_only_value)
+            .is_none(),
+        "template strings are not part of the exported value surface"
+    );
+
+    assert!(
+        res_ctx
+            .resolve_type(&db, &[Name::new("reflect"), raw_only_type], &[],)
+            .is_none(),
+        "the reflect shorthand must not expose a raw-only type"
+    );
+    assert!(
+        res_ctx
+            .resolve_value(&db, &[Name::new("reflect"), raw_only_value], &[],)
+            .is_none(),
+        "the reflect shorthand must not expose a raw-only value"
+    );
+    assert!(
+        res_ctx
+            .resolve_value(&db, &[Name::new("reflect"), Name::new("signature")], &[],)
+            .is_some(),
+        "an exported reflect function must remain visible"
+    );
+    assert!(
+        res_ctx
+            .resolve_value(&db, &[Name::new("type"), Name::new("of")], &[],)
+            .is_some(),
+        "an exported type-shorthand function must remain visible"
+    );
 }
 
 #[test]

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/compiler2_tir/phase5.rs
-assertion_line: 396
 expression: output
 ---
 namespace baml:
@@ -22,7 +21,7 @@ namespace baml:
   class TaggedString { methods: [] }
   type ToJson
   type ToString
-  class TypeValue { methods: [_to_string_impl, implements, implemented_by, implementors, to_string] }
+  class TypeValue { methods: [kind, as_class, as_enum, as_union, as_literal, as_array, as_map, as_interface, as_primitive, as_function, _to_string_impl, implements, implemented_by, implementors, to_string] }
   class Uint8Array { methods: [length, at, push, pop, concat, includes, reverse, slice, zeroes, from_array, to_array, from_hex, to_hex, from_base64, to_base64, _to_string_impl, sort, to_string] }
   function _cleanup_begin<T>
   function _compare_shim<T>
@@ -294,9 +293,33 @@ namespace baml.random:
 namespace baml.reflect:
   class Arg { methods: [] }
   class InvalidArgumentError { methods: [] }
+  class Meta { methods: [] }
   class Signature { methods: [] }
+  type TypeKind
+  type TypeView
   function call_any<R, E>
   function signature
+namespace baml.reflect.array:
+  class Type { methods: [element_type, as_type] }
+namespace baml.reflect.class:
+  class Field { methods: [] }
+  class Type { methods: [fields, meta, as_type] }
+namespace baml.reflect.enum:
+  class Type { methods: [values, meta, as_type] }
+  class Value { methods: [] }
+namespace baml.reflect.function:
+  class Parameter { methods: [] }
+  class Type { methods: [params, return_type, as_type] }
+namespace baml.reflect.interface:
+  class Type { methods: [implemented_by, implementors, as_type] }
+namespace baml.reflect.literal:
+  class Type { methods: [as_type] }
+namespace baml.reflect.map:
+  class Type { methods: [key_type, value_type, as_type] }
+namespace baml.reflect.primitive:
+  class Type { methods: [as_type] }
+namespace baml.reflect.union:
+  class Type { methods: [member_types, as_type] }
 namespace baml.sap:
   function parse<T>
   function parse_type

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/compiler2_tir/phase5.rs
+assertion_line: 396
 expression: output
 ---
 namespace baml:
@@ -290,6 +291,12 @@ namespace baml.random:
   type Rng
   class SystemRandom { methods: [get, random, random_int] }
   class Xoshiro256PlusPlus { methods: [new, _new, random, random_int] }
+namespace baml.reflect:
+  class Arg { methods: [] }
+  class InvalidArgumentError { methods: [] }
+  class Signature { methods: [] }
+  function call_any<R, E>
+  function signature
 namespace baml.sap:
   function parse<T>
   function parse_type
@@ -336,6 +343,9 @@ namespace baml.toml:
   function item_from_json
   function item_to_json
   function table_from_json
+namespace baml.type:
+  function of<T>
+  function of_value
 namespace baml.ws:
   class WsStream { methods: [send, next, close] }
   function _connect

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/tests/bytecode_format/main.rs
+assertion_line: 42
 ---
 function assert.approx_equal(actual: float, expected: float, eps: float) -> null {
   77   0    load_var 3             (eps)
@@ -33,19 +34,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 795 ntypeargs=0   (assert.format_operand)
+       26   call 796 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 795 ntypeargs=0   (assert.format_operand)
+       29   call 796 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 795 ntypeargs=0   (assert.format_operand)
+       32   call 796 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 795 ntypeargs=0   (assert.format_operand)
+       35   call 796 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -99,11 +100,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 795 ntypeargs=0   (assert.format_operand)
+       8    call 796 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 795 ntypeargs=0   (assert.format_operand)
+       11   call 796 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -164,12 +165,6 @@ function boundary.id() -> boundary.LocalId {
 function boundary.id.current() -> string {
 }
 
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
-}
-
 function testing.$invoke_collector(collector: (testing.TestCollector) -> void throws unknown, c: testing.TestCollector) -> void {
   92   0   load_var2 2 1   
        1   call_indirect   
@@ -177,7 +172,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  102   0   make_closure 1501 0   
+  102   0   make_closure 1502 0   
         1   return                
 }
 
@@ -202,7 +197,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1496 1    
+       17   make_closure 1497 1    
        18   return                 
 }
 
@@ -241,7 +236,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1480 2    
+       29   make_closure 1481 2    
        30   return                 
 }
 
@@ -260,12 +255,12 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1490 1    
+       11   make_closure 1491 1    
        12   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  96   0   make_closure 1499 0   
+  96   0   make_closure 1500 0   
        1   return                
 }
 
@@ -461,7 +456,7 @@ function testing.TestCollector.register_test_at(self: testing.TestCollector, own
        4   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
        5   load_var2 3 4          
        6   load_var 5             (runner)
-       7   call 737 ntypeargs=0   (testing.TestCollector.register_test)
+       7   call 738 ntypeargs=0   (testing.TestCollector.register_test)
        8   return                 
 }
 
@@ -581,7 +576,7 @@ function testing.TestCollector.register_test_set_at(self: testing.TestCollector,
        4   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
        5   load_var2 3 4          
        6   load_var 5             (runner)
-       7   call 738 ntypeargs=0   (testing.TestCollector.register_test_set)
+       7   call 739 ntypeargs=0   (testing.TestCollector.register_test_set)
        8   return                 
 }
 
@@ -611,11 +606,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   224   22   load_var2 1 5                      
-        23   call 753 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 754 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   225   25   load_var 1                         (self)
-        26   call 745 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 746 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   229   28   load_type 5                        
@@ -652,7 +647,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   232   58   load_var2 9 2                      
-        59   call 752 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 753 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   235   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -727,7 +722,7 @@ function testing.TestRegistry.list_filtered(self: testing.TestRegistry, profile_
   215   0   load_var2 1 2          
         1   load_var2 3 4          
         2   load_var 5             (cli_exclude)
-        3   call 773 ntypeargs=0   (testing.select_names_layered)
+        3   call 774 ntypeargs=0   (testing.select_names_layered)
         4   return                 
 }
 
@@ -744,9 +739,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   188   0   load_var 1             (self)
-        1   call 754 ntypeargs=0   (testing.testset_children)
+        1   call 755 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 764 ntypeargs=0   (testing.run_testset)
+        3   call 765 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -754,7 +749,7 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
   204   0    load_var2 1 2          
         1    load_var2 3 4          
         2    load_var 5             (cli_exclude)
-        3    call 773 ntypeargs=0   (testing.select_names_layered)
+        3    call 774 ntypeargs=0   (testing.select_names_layered)
         4    store_var 6            (selected_names)
 
   205   5    load_var 2             (profile_include)
@@ -791,22 +786,22 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
         36   jump +4                (to 40)
 
   208   37   load_var2 1 6          
-        38   call 749 ntypeargs=0   (testing.TestRegistry.run_selected)
+        38   call 750 ntypeargs=0   (testing.TestRegistry.run_selected)
         39   jump +3                (to 42)
 
   206   40   load_var 1             (self)
-        41   call 748 ntypeargs=0   (testing.TestRegistry.run_all)
+        41   call 749 ntypeargs=0   (testing.TestRegistry.run_all)
 
   210   42   load_var 6             (selected_names)
-        43   call 779 ntypeargs=0   (testing.flatten_with_tolerated)
+        43   call 780 ntypeargs=0   (testing.flatten_with_tolerated)
         44   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   192   0   load_var2 1 2          
-        1   call 755 ntypeargs=0   (testing.testset_children_selected)
+        1   call 756 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 764 ntypeargs=0   (testing.run_testset)
+        3   call 765 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -839,7 +834,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 763 ntypeargs=0               (testing.run_test)
+        26   call 764 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   162   28   load_type 5                        
@@ -876,7 +871,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   166   58   load_var2 9 2                      
-        59   call 746 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 747 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   169   61   load_const 12                      ("Test not found: ")
@@ -911,11 +906,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   175   22   load_var2 1 5                      
-        23   call 753 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 754 ntypeargs=0               (testing.testset_children)
+        23   call 754 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 755 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 764 ntypeargs=0               (testing.run_testset)
+        27   call 765 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   178   29   load_type 5                        
@@ -952,7 +947,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   181   59   load_var2 9 2                      
-        60   call 747 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 748 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   184   62   load_const 12                      ("TestSet not found: ")
@@ -1043,7 +1038,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         69   store_var 10                       (_27)
 
   141   70   load_var 9                         (sub)
-        71   call 745 ntypeargs=0               (testing.TestRegistry.serialize)
+        71   call 746 ntypeargs=0               (testing.TestRegistry.serialize)
         72   store_var 11                       (_28)
 
   139   73   load_var2 2 10                     
@@ -1332,7 +1327,7 @@ function testing.any_pattern_matches(pats: string[], canonical_id: string) -> bo
 
   510   14   load_var2 2 4                      
 
-  509   15   call 766 ntypeargs=0               (testing.glob_match)
+  509   15   call 767 ntypeargs=0               (testing.glob_match)
 
   510   16   pop_jump_if_false -11              (to 5)
 
@@ -1371,7 +1366,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         23   store_var_load_var 7               (name)
 
   753   24   load_var 3                         (all_failed_names)
-        25   call 782 ntypeargs=0               (testing.failure_matches_selected)
+        25   call 783 ntypeargs=0               (testing.failure_matches_selected)
         26   pop_jump_if_false +2               (to 28)
         27   jump +8                            (to 35)
 
@@ -1384,7 +1379,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         34   jump -21                           (to 13)
 
   754   35   load_var2 7 2                      
-        36   call 782 ntypeargs=0               (testing.failure_matches_selected)
+        36   call 783 ntypeargs=0               (testing.failure_matches_selected)
         37   pop_jump_if_false +2               (to 39)
         38   jump +8                            (to 46)
 
@@ -1428,7 +1423,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
         16   store_var_load_var 5               (name)
 
   824   17   load_var 2                         (out)
-        18   call 781 ntypeargs=0               (testing.name_in)
+        18   call 782 ntypeargs=0               (testing.name_in)
         19   unary_op !                         
         20   pop_jump_if_false -14              (to 6)
         21   load_var2 2 5                      
@@ -1458,7 +1453,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
         43   pop_jump_if_false +2               (to 45)
         44   jump -13                           (to 31)
         45   load_var2 8 2                      
-        46   call 784 ntypeargs=0               (testing.collect_all_failed_names)
+        46   call 785 ntypeargs=0               (testing.collect_all_failed_names)
         47   pop 1                              
         48   jump -17                           (to 31)
 
@@ -1559,7 +1554,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
         79    store_var_load_var 17   (sentinel)
 
   808   80    load_var 3              (selected_names)
-        81    call 781 ntypeargs=0    (testing.name_in)
+        81    call 782 ntypeargs=0    (testing.name_in)
         82    pop_jump_if_false +2    (to 84)
         83    jump +21                (to 104)
         84    load_var 14             (nested)
@@ -1605,7 +1600,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
 
   805   123   load_var2 14 15         
         124   load_var2 3 4           
-        125   call 783 ntypeargs=0    (testing.collect_leaf_identities)
+        125   call 784 ntypeargs=0    (testing.collect_leaf_identities)
         126   pop 1                   
         127   jump +30                (to 157)
 
@@ -1681,7 +1676,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         22   load_var 5                         (r)
         23   load_field 5                       (results)
         24   load_var 2                         (out)
-        25   call 785 ntypeargs=0               (testing.collect_leaf_messages)
+        25   call 786 ntypeargs=0               (testing.collect_leaf_messages)
         26   pop 1                              
         27   jump -22                           (to 5)
         28   load_var 6                         (_8)
@@ -1774,7 +1769,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
   618   40   load_var2 1 6                      
 
-  617   41   call 776 ntypeargs=0               (testing.collect_subtree_names)
+  617   41   call 777 ntypeargs=0               (testing.collect_subtree_names)
 
   618   42   load_type 10                       
         43   load_const 11                      ("iter")
@@ -1802,8 +1797,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   631   0    load_var2 1 2          
-        1    call 753 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 775 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 754 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 776 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +89               (to 92)
         4    load_var 3             (e)
         5    store_var 4            (_5)
@@ -1902,10 +1897,10 @@ function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testi
 
 function testing.collect_subtree_names_layered(registry: testing.TestRegistry, ts: testing.TestSetRegistration, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> string[] {
   639   0     load_var2 1 2           
-        1     call 753 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
+        1     call 754 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
         2     load_var2 3 4           
         3     load_var2 5 6           
-        4     call 773 ntypeargs=0    (testing.select_names_layered)
+        4     call 774 ntypeargs=0    (testing.select_names_layered)
         5     jump +109               (to 114)
         6     load_var 7              (e)
         7     store_var 8             (_9)
@@ -1988,7 +1983,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   647   83    load_var2 3 4           
         84    load_var2 5 6           
-        85    call 769 ntypeargs=0    (testing.leaf_selected_layered)
+        85    call 770 ntypeargs=0    (testing.leaf_selected_layered)
         86    pop_jump_if_false +2    (to 88)
         87    jump +4                 (to 91)
         88    load_type 18            
@@ -2007,7 +2002,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   643   100   load_var2 3 4           
         101   load_var2 5 6           
-        102   call 769 ntypeargs=0    (testing.leaf_selected_layered)
+        102   call 770 ntypeargs=0    (testing.leaf_selected_layered)
         103   pop_jump_if_false +2    (to 105)
         104   jump +4                 (to 108)
         105   load_type 18            
@@ -2114,7 +2109,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   688   74    load_var 12                        (tsr)
         75    load_field 5                       (results)
         76    load_var 13                        (ft)
-        77    call 778 ntypeargs=0               (testing.count_leaves)
+        77    call 779 ntypeargs=0               (testing.count_leaves)
         78    store_var 10                       (delta)
         79    jump +30                           (to 109)
 
@@ -2206,7 +2201,7 @@ function testing.expansion_error_report(name: string) -> testing.TestSetReport {
 
 function testing.failure_matches_selected(selected: string, failed_names: string[]) -> bool {
   774   0    load_var2 1 2                      
-        1    call 781 ntypeargs=0               (testing.name_in)
+        1    call 782 ntypeargs=0               (testing.name_in)
         2    pop_jump_if_false +2               (to 4)
         3    jump +40                           (to 43)
 
@@ -2311,7 +2306,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   711   37    load_var 1             (report)
         38    load_field 5           (results)
         39    load_var 3             (top_tolerated)
-        40    call 778 ntypeargs=0   (testing.count_leaves)
+        40    call 779 ntypeargs=0   (testing.count_leaves)
         41    store_var 4            (counts)
 
   717   42    load_type 2            
@@ -2321,7 +2316,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   718   45    load_var 1             (report)
         46    load_field 5           (results)
         47    load_var 6             (messages)
-        48    call 785 ntypeargs=0   (testing.collect_leaf_messages)
+        48    call 786 ntypeargs=0   (testing.collect_leaf_messages)
         49    pop 1                  
 
   719   50    load_type 2            
@@ -2329,7 +2324,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
         52    store_var 7            (all_failed_names)
 
   720   53    load_var2 1 7          
-        54    call 784 ntypeargs=0   (testing.collect_all_failed_names)
+        54    call 785 ntypeargs=0   (testing.collect_all_failed_names)
         55    pop 1                  
 
   721   56    load_type 2            
@@ -2343,7 +2338,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
 
   722   64    load_var2 1 3          
         65    load_var2 2 8          
-        66    call 783 ntypeargs=0   (testing.collect_leaf_identities)
+        66    call 784 ntypeargs=0   (testing.collect_leaf_identities)
         67    pop 1                  
 
   727   68    load_var 8             (executed)
@@ -2397,7 +2392,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   730   112   load_var2 2 1          
         113   load_field 4           (failed_names)
         114   load_var 7             (all_failed_names)
-        115   call 780 ntypeargs=0   (testing.classify_selected_names)
+        115   call 781 ntypeargs=0   (testing.classify_selected_names)
         116   store_var 9            (identities)
         117   jump +3                (to 120)
 
@@ -2564,7 +2559,7 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
 function testing.leaf_selected(name: string, include: string[], exclude: string[]) -> bool {
   520   0    load_var2 3 1          
-        1    call 767 ntypeargs=0   (testing.any_pattern_matches)
+        1    call 768 ntypeargs=0   (testing.any_pattern_matches)
         2    pop_jump_if_false +2   (to 4)
         3    jump +14               (to 17)
 
@@ -2578,7 +2573,7 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
         11   jump +4                (to 15)
 
   526   12   load_var2 2 1          
-        13   call 767 ntypeargs=0   (testing.any_pattern_matches)
+        13   call 768 ntypeargs=0   (testing.any_pattern_matches)
         14   jump +4                (to 18)
 
   524   15   load_const 1           (true)
@@ -2591,12 +2586,12 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
 function testing.leaf_selected_layered(name: string, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> bool {
   533   0   load_var2 1 2          
         1   load_var 3             (profile_exclude)
-        2   call 768 ntypeargs=0   (testing.leaf_selected)
+        2   call 769 ntypeargs=0   (testing.leaf_selected)
         3   jump_if_false +5       (to 8)
         4   pop 1                  
         5   load_var2 1 4          
         6   load_var 5             (cli_exclude)
-        7   call 768 ntypeargs=0   (testing.leaf_selected)
+        7   call 769 ntypeargs=0   (testing.leaf_selected)
         8   return                 
 }
 
@@ -2692,7 +2687,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   399   25   load_var 5                         (child)
-        26   make_closure 1381 1                
+        26   make_closure 1382 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   load_type 7                        
@@ -2710,7 +2705,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         40   call 521 ntypeargs=2               (baml.future.all_complete)
         41   await                              
 
-  406   42   call 761 ntypeargs=0               (testing.aggregate_reports)
+  406   42   call 762 ntypeargs=0               (testing.aggregate_reports)
         43   return                             
 }
 
@@ -2771,11 +2766,11 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         48   pop_jump_if_false -40              (to 8)
 
   117   49   load_var 3                         (named_results)
-        50   call 761 ntypeargs=0               (testing.aggregate_reports)
+        50   call 762 ntypeargs=0               (testing.aggregate_reports)
         51   jump +3                            (to 54)
 
   122   52   load_var 3                         (named_results)
-        53   call 761 ntypeargs=0               (testing.aggregate_reports)
+        53   call 762 ntypeargs=0               (testing.aggregate_reports)
         54   return                             
 }
 
@@ -2785,7 +2780,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   411   3    load_var 1             (body)
-        4    make_closure 1392 1    
+        4    make_closure 1393 1    
         5    store_var 3            (base_run)
 
   435   6    load_var 2             (runner)
@@ -2817,7 +2812,7 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         7    jump +3                (to 10)
 
   447   8    load_var 1             (children)
-        9    call 762 ntypeargs=0   (testing.run_children_parallel)
+        9    call 763 ntypeargs=0   (testing.run_children_parallel)
         10   return                 
 }
 
@@ -2828,7 +2823,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         3   load_type 0            
         4   alloc_array 0          
         5   load_var2 2 3          
-        6   call 773 ntypeargs=0   (testing.select_names_layered)
+        6   call 774 ntypeargs=0   (testing.select_names_layered)
         7   return                 
 }
 
@@ -2859,7 +2854,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
   591   21   load_field 0                       (name)
         22   load_var2 2 3                      
         23   load_var2 4 5                      
-        24   call 769 ntypeargs=0               (testing.leaf_selected_layered)
+        24   call 770 ntypeargs=0               (testing.leaf_selected_layered)
         25   pop_jump_if_false -15              (to 10)
 
   592   26   load_var2 6 9                      
@@ -2889,19 +2884,19 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   598   49   load_field 0                       (name)
         50   load_var2 2 3                      
-        51   call 772 ntypeargs=0               (testing.subtree_may_be_selected)
+        51   call 773 ntypeargs=0               (testing.subtree_may_be_selected)
         52   jump_if_false +6                   (to 58)
         53   pop 1                              
         54   load_var 12                        (ts)
         55   load_field 0                       (name)
         56   load_var2 4 5                      
-        57   call 772 ntypeargs=0               (testing.subtree_may_be_selected)
+        57   call 773 ntypeargs=0               (testing.subtree_may_be_selected)
         58   pop_jump_if_false -20              (to 38)
 
   599   59   load_var2 1 12                     
         60   load_var2 2 3                      
         61   load_var2 4 5                      
-        62   call 777 ntypeargs=0               (testing.collect_subtree_names_layered)
+        62   call 778 ntypeargs=0               (testing.collect_subtree_names_layered)
 
   600   63   load_type 10                       
         64   load_const 11                      ("iter")
@@ -2969,7 +2964,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         37   jump_if_false +4                   (to 41)
         38   pop 1                              
         39   load_var2 3 6                      
-        40   call 766 ntypeargs=0               (testing.glob_match)
+        40   call 767 ntypeargs=0               (testing.glob_match)
         41   pop_jump_if_false -32              (to 9)
 
   550   42   load_const 9                       (true)
@@ -2984,7 +2979,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
 
 function testing.subtree_may_be_selected(prefix: string, include: string[], exclude: string[]) -> bool {
   572   0    load_var2 1 3                      
-        1    call 770 ntypeargs=0               (testing.subtree_excluded)
+        1    call 771 ntypeargs=0               (testing.subtree_excluded)
         2    pop_jump_if_false +2               (to 4)
         3    jump +32                           (to 35)
 
@@ -3012,7 +3007,7 @@ function testing.subtree_may_be_selected(prefix: string, include: string[], excl
         24   pop_jump_if_false +2               (to 26)
         25   jump +6                            (to 31)
         26   load_var2 6 1                      
-        27   call 771 ntypeargs=0               (testing.pattern_may_match_descendant)
+        27   call 772 ntypeargs=0               (testing.pattern_may_match_descendant)
 
   579   28   pop_jump_if_false -11              (to 17)
 
@@ -3040,7 +3035,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   294   6    load_var2 1 2         
 
   296   7    load_var 3            (runner)
-        8    make_closure 1358 2   
+        8    make_closure 1359 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   return                
 }
@@ -3057,7 +3052,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   303   8    load_var2 1 2         
-        9    make_closure 1360 2   
+        9    make_closure 1361 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   return                
 }
@@ -3078,7 +3073,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   315   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1362 3   
+        13   make_closure 1363 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   return                
 }
@@ -3112,7 +3107,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 756 ntypeargs=0               (testing.test_child)
+        26   call 757 ntypeargs=0               (testing.test_child)
         27   store_var 6                        (_10)
         28   load_var2 2 6                      
         29   call 4 ntypeargs=0                 (baml.Array.push)
@@ -3138,7 +3133,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
 
   264   48   load_var2 1 8                      
 
-  263   49   call 757 ntypeargs=0               (testing.testset_child)
+  263   49   call 758 ntypeargs=0               (testing.testset_child)
         50   store_var 9                        (_21)
 
   264   51   load_var2 2 9                      
@@ -3176,7 +3171,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   272   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 759 ntypeargs=0               (testing._name_selected)
+        23   call 760 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   273   25   load_var 6                         (t)
@@ -3185,7 +3180,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 6                         (t)
         30   load_field 2                       (runner)
-        31   call 756 ntypeargs=0               (testing.test_child)
+        31   call 757 ntypeargs=0               (testing.test_child)
         32   store_var 7                        (_13)
         33   load_var2 3 7                      
         34   call 4 ntypeargs=0                 (baml.Array.push)
@@ -3213,12 +3208,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   284   55   load_field 0                       (name)
         56   load_var 2                         (names)
-        57   call 760 ntypeargs=0               (testing._has_selected_descendant)
+        57   call 761 ntypeargs=0               (testing._has_selected_descendant)
         58   pop_jump_if_false -14              (to 44)
 
   285   59   load_var2 1 10                     
         60   load_var 2                         (names)
-        61   call 758 ntypeargs=0               (testing.testset_child_selected)
+        61   call 759 ntypeargs=0               (testing.testset_child_selected)
         62   store_var 11                       (_26)
         63   load_var2 3 11                     
         64   call 4 ntypeargs=0                 (baml.Array.push)
@@ -3238,7 +3233,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 800 ntypeargs=0   (user.score)
+       7    call 801 ntypeargs=0   (user.score)
        8    store_var 3            (base)
 
   11   9    load_var 3             (base)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/tests/bytecode_format/main.rs
-assertion_line: 42
 ---
 function assert.approx_equal(actual: float, expected: float, eps: float) -> null {
   77   0    load_var 3             (eps)
@@ -34,19 +33,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 796 ntypeargs=0   (assert.format_operand)
+       26   call 827 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 796 ntypeargs=0   (assert.format_operand)
+       29   call 827 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 796 ntypeargs=0   (assert.format_operand)
+       32   call 827 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 796 ntypeargs=0   (assert.format_operand)
+       35   call 827 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -64,11 +63,11 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
        49   bin_op +               
        50   load_var 8             (_22)
        51   bin_op +               
-       52   call 247 ntypeargs=0   (baml.sys.panic)
+       52   call 257 ntypeargs=0   (baml.sys.panic)
        53   jump +3                (to 56)
 
   78   54   load_const 6           ("assertion failed: epsilon must be a non-negative number")
-       55   call 247 ntypeargs=0   (baml.sys.panic)
+       55   call 257 ntypeargs=0   (baml.sys.panic)
        56   return                 
 }
 
@@ -84,13 +83,13 @@ function assert.contains(haystack: string, needle: string) -> null {
   100   6   jump +3                (to 9)
 
   101   7   load_const 1           ("assertion failed: string does not contain expected substring")
-        8   call 247 ntypeargs=0   (baml.sys.panic)
+        8   call 257 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   50   0    load_var2 1 2          
-       1    call 651 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 661 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -100,11 +99,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 796 ntypeargs=0   (assert.format_operand)
+       8    call 827 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 796 ntypeargs=0   (assert.format_operand)
+       11   call 827 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -114,7 +113,7 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
        17   bin_op +               
        18   load_var 4             (_9)
        19   bin_op +               
-       20   call 247 ntypeargs=0   (baml.sys.panic)
+       20   call 257 ntypeargs=0   (baml.sys.panic)
        21   return                 
 }
 
@@ -136,14 +135,14 @@ function assert.is_true(condition: bool) -> null {
   5   5   jump +3                (to 8)
 
   6   6   load_const 1           ("assertion failed: expected true")
-      7   call 247 ntypeargs=0   (baml.sys.panic)
+      7   call 257 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 651 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 661 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -152,7 +151,7 @@ function assert.not_null(value: unknown | null) -> null {
   14   6   jump +3                (to 9)
 
   15   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 247 ntypeargs=0   (baml.sys.panic)
+       8   call 257 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -172,7 +171,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  102   0   make_closure 1502 0   
+  102   0   make_closure 1560 0   
         1   return                
 }
 
@@ -193,11 +192,11 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        12   pop_jump_if_false +4   (to 16)
 
   69   13   load_const 2           ("testing.PassRate requires 0.0 <= threshold <= 1.0")
-       14   call 247 ntypeargs=0   (baml.sys.panic)
+       14   call 257 ntypeargs=0   (baml.sys.panic)
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1497 1    
+       17   make_closure 1555 1    
        18   return                 
 }
 
@@ -227,16 +226,16 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        20   pop_jump_if_false +8   (to 28)
 
   5    21   load_const 1           ("testing.Quorum requires 0 <= m <= n")
-       22   call 247 ntypeargs=0   (baml.sys.panic)
+       22   call 257 ntypeargs=0   (baml.sys.panic)
        23   pop 1                  
        24   jump +4                (to 28)
 
   3    25   load_const 2           ("testing.Quorum requires n > 0")
-       26   call 247 ntypeargs=0   (baml.sys.panic)
+       26   call 257 ntypeargs=0   (baml.sys.panic)
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1481 2    
+       29   make_closure 1539 2    
        30   return                 
 }
 
@@ -251,16 +250,16 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        6    pop_jump_if_false +4   (to 10)
 
   36   7    load_const 1           ("testing.Retry requires max_attempts > 0")
-       8    call 247 ntypeargs=0   (baml.sys.panic)
+       8    call 257 ntypeargs=0   (baml.sys.panic)
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1491 1    
+       11   make_closure 1549 1    
        12   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  96   0   make_closure 1500 0   
+  96   0   make_closure 1558 0   
        1   return                
 }
 
@@ -456,7 +455,7 @@ function testing.TestCollector.register_test_at(self: testing.TestCollector, own
        4   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
        5   load_var2 3 4          
        6   load_var 5             (runner)
-       7   call 738 ntypeargs=0   (testing.TestCollector.register_test)
+       7   call 769 ntypeargs=0   (testing.TestCollector.register_test)
        8   return                 
 }
 
@@ -576,7 +575,7 @@ function testing.TestCollector.register_test_set_at(self: testing.TestCollector,
        4   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
        5   load_var2 3 4          
        6   load_var 5             (runner)
-       7   call 739 ntypeargs=0   (testing.TestCollector.register_test_set)
+       7   call 770 ntypeargs=0   (testing.TestCollector.register_test_set)
        8   return                 
 }
 
@@ -606,11 +605,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   224   22   load_var2 1 5                      
-        23   call 754 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 785 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   225   25   load_var 1                         (self)
-        26   call 746 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 777 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   229   28   load_type 5                        
@@ -647,7 +646,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   232   58   load_var2 9 2                      
-        59   call 753 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 784 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   235   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -670,7 +669,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         10   pop_jump_if_false +2   (to 12)
         11   jump +36               (to 47)
 
-  242   12   call 249 ntypeargs=0   (baml.sys.now_ms)
+  242   12   call 259 ntypeargs=0   (baml.sys.now_ms)
         13   store_var 4            (start)
 
   243   14   load_var 2             (ts)
@@ -687,7 +686,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         24   call_indirect          
         25   pop 1                  
 
-  245   26   call 249 ntypeargs=0   (baml.sys.now_ms)
+  245   26   call 259 ntypeargs=0   (baml.sys.now_ms)
         27   store_var 6            (_19)
 
   247   28   load_var 5             (sub_collector)
@@ -722,7 +721,7 @@ function testing.TestRegistry.list_filtered(self: testing.TestRegistry, profile_
   215   0   load_var2 1 2          
         1   load_var2 3 4          
         2   load_var 5             (cli_exclude)
-        3   call 774 ntypeargs=0   (testing.select_names_layered)
+        3   call 805 ntypeargs=0   (testing.select_names_layered)
         4   return                 
 }
 
@@ -739,9 +738,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   188   0   load_var 1             (self)
-        1   call 755 ntypeargs=0   (testing.testset_children)
+        1   call 786 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 765 ntypeargs=0   (testing.run_testset)
+        3   call 796 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -749,7 +748,7 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
   204   0    load_var2 1 2          
         1    load_var2 3 4          
         2    load_var 5             (cli_exclude)
-        3    call 774 ntypeargs=0   (testing.select_names_layered)
+        3    call 805 ntypeargs=0   (testing.select_names_layered)
         4    store_var 6            (selected_names)
 
   205   5    load_var 2             (profile_include)
@@ -786,22 +785,22 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
         36   jump +4                (to 40)
 
   208   37   load_var2 1 6          
-        38   call 750 ntypeargs=0   (testing.TestRegistry.run_selected)
+        38   call 781 ntypeargs=0   (testing.TestRegistry.run_selected)
         39   jump +3                (to 42)
 
   206   40   load_var 1             (self)
-        41   call 749 ntypeargs=0   (testing.TestRegistry.run_all)
+        41   call 780 ntypeargs=0   (testing.TestRegistry.run_all)
 
   210   42   load_var 6             (selected_names)
-        43   call 780 ntypeargs=0   (testing.flatten_with_tolerated)
+        43   call 811 ntypeargs=0   (testing.flatten_with_tolerated)
         44   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   192   0   load_var2 1 2          
-        1   call 756 ntypeargs=0   (testing.testset_children_selected)
+        1   call 787 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 765 ntypeargs=0   (testing.run_testset)
+        3   call 796 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -834,7 +833,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 764 ntypeargs=0               (testing.run_test)
+        26   call 795 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   162   28   load_type 5                        
@@ -871,7 +870,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   166   58   load_var2 9 2                      
-        59   call 747 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 778 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   169   61   load_const 12                      ("Test not found: ")
@@ -906,11 +905,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   175   22   load_var2 1 5                      
-        23   call 754 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 755 ntypeargs=0               (testing.testset_children)
+        23   call 785 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 786 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 765 ntypeargs=0               (testing.run_testset)
+        27   call 796 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   178   29   load_type 5                        
@@ -947,7 +946,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   181   59   load_var2 9 2                      
-        60   call 748 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 779 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   184   62   load_const 12                      ("TestSet not found: ")
@@ -1038,7 +1037,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         69   store_var 10                       (_27)
 
   141   70   load_var 9                         (sub)
-        71   call 746 ntypeargs=0               (testing.TestRegistry.serialize)
+        71   call 777 ntypeargs=0               (testing.TestRegistry.serialize)
         72   store_var 11                       (_28)
 
   139   73   load_var2 2 10                     
@@ -1094,7 +1093,7 @@ function testing._int_to_float(value: int) -> float {
         6   throw_if_panic         
 
   127   7   load_const 1           ("failed to convert int to float")
-        8   call 247 ntypeargs=0   (baml.sys.panic)
+        8   call 257 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
@@ -1192,7 +1191,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   362   54    load_var 12                        (outcome)
         55    load_const 10                      ("pass")
-        56    call 651 ntypeargs=0               (baml.ops.equals_equals)
+        56    call 661 ntypeargs=0               (baml.ops.equals_equals)
         57    pop_jump_if_false +2               (to 59)
         58    jump +57                           (to 115)
 
@@ -1258,7 +1257,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   377   108   load_var 12                        (outcome)
         109   load_const 16                      ("error")
-        110   call 651 ntypeargs=0               (baml.ops.equals_equals)
+        110   call 661 ntypeargs=0               (baml.ops.equals_equals)
         111   pop_jump_if_false -91              (to 20)
 
   378   112   load_const 17                      (true)
@@ -1327,7 +1326,7 @@ function testing.any_pattern_matches(pats: string[], canonical_id: string) -> bo
 
   510   14   load_var2 2 4                      
 
-  509   15   call 767 ntypeargs=0               (testing.glob_match)
+  509   15   call 798 ntypeargs=0               (testing.glob_match)
 
   510   16   pop_jump_if_false -11              (to 5)
 
@@ -1366,7 +1365,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         23   store_var_load_var 7               (name)
 
   753   24   load_var 3                         (all_failed_names)
-        25   call 783 ntypeargs=0               (testing.failure_matches_selected)
+        25   call 814 ntypeargs=0               (testing.failure_matches_selected)
         26   pop_jump_if_false +2               (to 28)
         27   jump +8                            (to 35)
 
@@ -1379,7 +1378,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         34   jump -21                           (to 13)
 
   754   35   load_var2 7 2                      
-        36   call 783 ntypeargs=0               (testing.failure_matches_selected)
+        36   call 814 ntypeargs=0               (testing.failure_matches_selected)
         37   pop_jump_if_false +2               (to 39)
         38   jump +8                            (to 46)
 
@@ -1423,7 +1422,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
         16   store_var_load_var 5               (name)
 
   824   17   load_var 2                         (out)
-        18   call 782 ntypeargs=0               (testing.name_in)
+        18   call 813 ntypeargs=0               (testing.name_in)
         19   unary_op !                         
         20   pop_jump_if_false -14              (to 6)
         21   load_var2 2 5                      
@@ -1453,7 +1452,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
         43   pop_jump_if_false +2               (to 45)
         44   jump -13                           (to 31)
         45   load_var2 8 2                      
-        46   call 785 ntypeargs=0               (testing.collect_all_failed_names)
+        46   call 816 ntypeargs=0               (testing.collect_all_failed_names)
         47   pop 1                              
         48   jump -17                           (to 31)
 
@@ -1529,7 +1528,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
         57    load_var 14             (nested)
         58    load_field 0            (outcome)
         59    load_const 3            ("pass")
-        60    call 651 ntypeargs=0    (baml.ops.equals_equals)
+        60    call 661 ntypeargs=0    (baml.ops.equals_equals)
         61    store_var 15            (nested_tolerated)
 
   804   62    load_var 14             (nested)
@@ -1554,7 +1553,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
         79    store_var_load_var 17   (sentinel)
 
   808   80    load_var 3              (selected_names)
-        81    call 782 ntypeargs=0    (testing.name_in)
+        81    call 813 ntypeargs=0    (testing.name_in)
         82    pop_jump_if_false +2    (to 84)
         83    jump +21                (to 104)
         84    load_var 14             (nested)
@@ -1600,14 +1599,14 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
 
   805   123   load_var2 14 15         
         124   load_var2 3 4           
-        125   call 784 ntypeargs=0    (testing.collect_leaf_identities)
+        125   call 815 ntypeargs=0    (testing.collect_leaf_identities)
         126   pop 1                   
         127   jump +30                (to 157)
 
   792   128   load_var 13             (_25)
         129   load_field 0            (outcome)
         130   load_const 7            ("pass")
-        131   call 651 ntypeargs=0    (baml.ops.equals_equals)
+        131   call 661 ntypeargs=0    (baml.ops.equals_equals)
 
   794   132   pop_jump_if_false +2    (to 134)
         133   jump +18                (to 151)
@@ -1676,7 +1675,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
         22   load_var 5                         (r)
         23   load_field 5                       (results)
         24   load_var 2                         (out)
-        25   call 786 ntypeargs=0               (testing.collect_leaf_messages)
+        25   call 817 ntypeargs=0               (testing.collect_leaf_messages)
         26   pop 1                              
         27   jump -22                           (to 5)
         28   load_var 6                         (_8)
@@ -1700,7 +1699,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   841   45   load_field 0                       (outcome)
         46   load_const 10                      ("pass")
-        47   call 651 ntypeargs=0               (baml.ops.equals_equals)
+        47   call 661 ntypeargs=0               (baml.ops.equals_equals)
         48   unary_op !                         
         49   pop_jump_if_false -15              (to 34)
 
@@ -1769,7 +1768,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
   618   40   load_var2 1 6                      
 
-  617   41   call 777 ntypeargs=0               (testing.collect_subtree_names)
+  617   41   call 808 ntypeargs=0               (testing.collect_subtree_names)
 
   618   42   load_type 10                       
         43   load_const 11                      ("iter")
@@ -1797,8 +1796,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   631   0    load_var2 1 2          
-        1    call 754 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 776 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 785 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 807 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +89               (to 92)
         4    load_var 3             (e)
         5    store_var 4            (_5)
@@ -1897,10 +1896,10 @@ function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testi
 
 function testing.collect_subtree_names_layered(registry: testing.TestRegistry, ts: testing.TestSetRegistration, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> string[] {
   639   0     load_var2 1 2           
-        1     call 754 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
+        1     call 785 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
         2     load_var2 3 4           
         3     load_var2 5 6           
-        4     call 774 ntypeargs=0    (testing.select_names_layered)
+        4     call 805 ntypeargs=0    (testing.select_names_layered)
         5     jump +109               (to 114)
         6     load_var 7              (e)
         7     store_var 8             (_9)
@@ -1983,7 +1982,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   647   83    load_var2 3 4           
         84    load_var2 5 6           
-        85    call 770 ntypeargs=0    (testing.leaf_selected_layered)
+        85    call 801 ntypeargs=0    (testing.leaf_selected_layered)
         86    pop_jump_if_false +2    (to 88)
         87    jump +4                 (to 91)
         88    load_type 18            
@@ -2002,7 +2001,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   643   100   load_var2 3 4           
         101   load_var2 5 6           
-        102   call 770 ntypeargs=0    (testing.leaf_selected_layered)
+        102   call 801 ntypeargs=0    (testing.leaf_selected_layered)
         103   pop_jump_if_false +2    (to 105)
         104   jump +4                 (to 108)
         105   load_type 18            
@@ -2065,7 +2064,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         37    load_var 12                        (tsr)
         38    load_field 0                       (outcome)
         39    load_const 7                       ("pass")
-        40    call 651 ntypeargs=0               (baml.ops.equals_equals)
+        40    call 661 ntypeargs=0               (baml.ops.equals_equals)
         41    store_var 13                       (ft)
 
   687   42    load_var 12                        (tsr)
@@ -2109,14 +2108,14 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   688   74    load_var 12                        (tsr)
         75    load_field 5                       (results)
         76    load_var 13                        (ft)
-        77    call 779 ntypeargs=0               (testing.count_leaves)
+        77    call 810 ntypeargs=0               (testing.count_leaves)
         78    store_var 10                       (delta)
         79    jump +30                           (to 109)
 
   675   80    load_var 11                        (_13)
         81    load_field 0                       (outcome)
         82    load_const 8                       ("pass")
-        83    call 651 ntypeargs=0               (baml.ops.equals_equals)
+        83    call 661 ntypeargs=0               (baml.ops.equals_equals)
 
   677   84    pop_jump_if_false +2               (to 86)
         85    jump +18                           (to 103)
@@ -2201,7 +2200,7 @@ function testing.expansion_error_report(name: string) -> testing.TestSetReport {
 
 function testing.failure_matches_selected(selected: string, failed_names: string[]) -> bool {
   774   0    load_var2 1 2                      
-        1    call 782 ntypeargs=0               (testing.name_in)
+        1    call 813 ntypeargs=0               (testing.name_in)
         2    pop_jump_if_false +2               (to 4)
         3    jump +40                           (to 43)
 
@@ -2262,7 +2261,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   709   0     load_var 1             (report)
         1     load_field 0           (outcome)
         2     load_const 0           ("pass")
-        3     call 651 ntypeargs=0   (baml.ops.equals_equals)
+        3     call 661 ntypeargs=0   (baml.ops.equals_equals)
         4     store_var 3            (top_tolerated)
 
   710   5     load_var 1             (report)
@@ -2306,7 +2305,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   711   37    load_var 1             (report)
         38    load_field 5           (results)
         39    load_var 3             (top_tolerated)
-        40    call 779 ntypeargs=0   (testing.count_leaves)
+        40    call 810 ntypeargs=0   (testing.count_leaves)
         41    store_var 4            (counts)
 
   717   42    load_type 2            
@@ -2316,7 +2315,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   718   45    load_var 1             (report)
         46    load_field 5           (results)
         47    load_var 6             (messages)
-        48    call 786 ntypeargs=0   (testing.collect_leaf_messages)
+        48    call 817 ntypeargs=0   (testing.collect_leaf_messages)
         49    pop 1                  
 
   719   50    load_type 2            
@@ -2324,7 +2323,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
         52    store_var 7            (all_failed_names)
 
   720   53    load_var2 1 7          
-        54    call 785 ntypeargs=0   (testing.collect_all_failed_names)
+        54    call 816 ntypeargs=0   (testing.collect_all_failed_names)
         55    pop 1                  
 
   721   56    load_type 2            
@@ -2338,7 +2337,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
 
   722   64    load_var2 1 3          
         65    load_var2 2 8          
-        66    call 784 ntypeargs=0   (testing.collect_leaf_identities)
+        66    call 815 ntypeargs=0   (testing.collect_leaf_identities)
         67    pop 1                  
 
   727   68    load_var 8             (executed)
@@ -2392,7 +2391,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   730   112   load_var2 2 1          
         113   load_field 4           (failed_names)
         114   load_var 7             (all_failed_names)
-        115   call 781 ntypeargs=0   (testing.classify_selected_names)
+        115   call 812 ntypeargs=0   (testing.classify_selected_names)
         116   store_var 9            (identities)
         117   jump +3                (to 120)
 
@@ -2552,14 +2551,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
   485   96    load_var2 1 2           
         97    call 155 ntypeargs=0    (baml.String.index_of)
         98    load_const 6            (null)
-        99    call 651 ntypeargs=0    (baml.ops.equals_equals)
+        99    call 661 ntypeargs=0    (baml.ops.equals_equals)
         100   unary_op !              
         101   return                  
 }
 
 function testing.leaf_selected(name: string, include: string[], exclude: string[]) -> bool {
   520   0    load_var2 3 1          
-        1    call 768 ntypeargs=0   (testing.any_pattern_matches)
+        1    call 799 ntypeargs=0   (testing.any_pattern_matches)
         2    pop_jump_if_false +2   (to 4)
         3    jump +14               (to 17)
 
@@ -2573,7 +2572,7 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
         11   jump +4                (to 15)
 
   526   12   load_var2 2 1          
-        13   call 768 ntypeargs=0   (testing.any_pattern_matches)
+        13   call 799 ntypeargs=0   (testing.any_pattern_matches)
         14   jump +4                (to 18)
 
   524   15   load_const 1           (true)
@@ -2586,12 +2585,12 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
 function testing.leaf_selected_layered(name: string, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> bool {
   533   0   load_var2 1 2          
         1   load_var 3             (profile_exclude)
-        2   call 769 ntypeargs=0   (testing.leaf_selected)
+        2   call 800 ntypeargs=0   (testing.leaf_selected)
         3   jump_if_false +5       (to 8)
         4   pop 1                  
         5   load_var2 1 4          
         6   load_var 5             (cli_exclude)
-        7   call 769 ntypeargs=0   (testing.leaf_selected)
+        7   call 800 ntypeargs=0   (testing.leaf_selected)
         8   return                 
 }
 
@@ -2687,7 +2686,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   399   25   load_var 5                         (child)
-        26   make_closure 1382 1                
+        26   make_closure 1440 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   load_type 7                        
@@ -2702,10 +2701,10 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
   405   37   load_type 7                        
         38   load_type 8                        
         39   load_var 2                         (futures)
-        40   call 521 ntypeargs=2               (baml.future.all_complete)
+        40   call 531 ntypeargs=2               (baml.future.all_complete)
         41   await                              
 
-  406   42   call 762 ntypeargs=0               (testing.aggregate_reports)
+  406   42   call 793 ntypeargs=0               (testing.aggregate_reports)
         43   return                             
 }
 
@@ -2761,16 +2760,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         43   pop 1                              
         44   load_var 8                         (outcome)
         45   load_const 7                       ("pass")
-        46   call 651 ntypeargs=0               (baml.ops.equals_equals)
+        46   call 661 ntypeargs=0               (baml.ops.equals_equals)
         47   unary_op !                         
         48   pop_jump_if_false -40              (to 8)
 
   117   49   load_var 3                         (named_results)
-        50   call 762 ntypeargs=0               (testing.aggregate_reports)
+        50   call 793 ntypeargs=0               (testing.aggregate_reports)
         51   jump +3                            (to 54)
 
   122   52   load_var 3                         (named_results)
-        53   call 762 ntypeargs=0               (testing.aggregate_reports)
+        53   call 793 ntypeargs=0               (testing.aggregate_reports)
         54   return                             
 }
 
@@ -2780,7 +2779,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   411   3    load_var 1             (body)
-        4    make_closure 1393 1    
+        4    make_closure 1451 1    
         5    store_var 3            (base_run)
 
   435   6    load_var 2             (runner)
@@ -2812,7 +2811,7 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         7    jump +3                (to 10)
 
   447   8    load_var 1             (children)
-        9    call 763 ntypeargs=0   (testing.run_children_parallel)
+        9    call 794 ntypeargs=0   (testing.run_children_parallel)
         10   return                 
 }
 
@@ -2823,7 +2822,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         3   load_type 0            
         4   alloc_array 0          
         5   load_var2 2 3          
-        6   call 774 ntypeargs=0   (testing.select_names_layered)
+        6   call 805 ntypeargs=0   (testing.select_names_layered)
         7   return                 
 }
 
@@ -2854,7 +2853,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
   591   21   load_field 0                       (name)
         22   load_var2 2 3                      
         23   load_var2 4 5                      
-        24   call 770 ntypeargs=0               (testing.leaf_selected_layered)
+        24   call 801 ntypeargs=0               (testing.leaf_selected_layered)
         25   pop_jump_if_false -15              (to 10)
 
   592   26   load_var2 6 9                      
@@ -2884,19 +2883,19 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   598   49   load_field 0                       (name)
         50   load_var2 2 3                      
-        51   call 773 ntypeargs=0               (testing.subtree_may_be_selected)
+        51   call 804 ntypeargs=0               (testing.subtree_may_be_selected)
         52   jump_if_false +6                   (to 58)
         53   pop 1                              
         54   load_var 12                        (ts)
         55   load_field 0                       (name)
         56   load_var2 4 5                      
-        57   call 773 ntypeargs=0               (testing.subtree_may_be_selected)
+        57   call 804 ntypeargs=0               (testing.subtree_may_be_selected)
         58   pop_jump_if_false -20              (to 38)
 
   599   59   load_var2 1 12                     
         60   load_var2 2 3                      
         61   load_var2 4 5                      
-        62   call 778 ntypeargs=0               (testing.collect_subtree_names_layered)
+        62   call 809 ntypeargs=0               (testing.collect_subtree_names_layered)
 
   600   63   load_type 10                       
         64   load_const 11                      ("iter")
@@ -2947,13 +2946,13 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         21   load_const 6                       ("*")
         22   call 155 ntypeargs=0               (baml.String.index_of)
         23   load_const 7                       (null)
-        24   call 651 ntypeargs=0               (baml.ops.equals_equals)
+        24   call 661 ntypeargs=0               (baml.ops.equals_equals)
         25   jump_if_false +7                   (to 32)
         26   pop 1                              
         27   load_var2 3 6                      
         28   call 155 ntypeargs=0               (baml.String.index_of)
         29   load_const 7                       (null)
-        30   call 651 ntypeargs=0               (baml.ops.equals_equals)
+        30   call 661 ntypeargs=0               (baml.ops.equals_equals)
         31   unary_op !                         
         32   pop_jump_if_false +2               (to 34)
         33   jump +11                           (to 44)
@@ -2964,7 +2963,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         37   jump_if_false +4                   (to 41)
         38   pop 1                              
         39   load_var2 3 6                      
-        40   call 767 ntypeargs=0               (testing.glob_match)
+        40   call 798 ntypeargs=0               (testing.glob_match)
         41   pop_jump_if_false -32              (to 9)
 
   550   42   load_const 9                       (true)
@@ -2979,7 +2978,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
 
 function testing.subtree_may_be_selected(prefix: string, include: string[], exclude: string[]) -> bool {
   572   0    load_var2 1 3                      
-        1    call 771 ntypeargs=0               (testing.subtree_excluded)
+        1    call 802 ntypeargs=0               (testing.subtree_excluded)
         2    pop_jump_if_false +2               (to 4)
         3    jump +32                           (to 35)
 
@@ -3007,7 +3006,7 @@ function testing.subtree_may_be_selected(prefix: string, include: string[], excl
         24   pop_jump_if_false +2               (to 26)
         25   jump +6                            (to 31)
         26   load_var2 6 1                      
-        27   call 772 ntypeargs=0               (testing.pattern_may_match_descendant)
+        27   call 803 ntypeargs=0               (testing.pattern_may_match_descendant)
 
   579   28   pop_jump_if_false -11              (to 17)
 
@@ -3035,7 +3034,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   294   6    load_var2 1 2         
 
   296   7    load_var 3            (runner)
-        8    make_closure 1359 2   
+        8    make_closure 1417 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   return                
 }
@@ -3052,7 +3051,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   303   8    load_var2 1 2         
-        9    make_closure 1361 2   
+        9    make_closure 1419 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   return                
 }
@@ -3073,7 +3072,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   315   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1363 3   
+        13   make_closure 1421 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   return                
 }
@@ -3107,7 +3106,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 757 ntypeargs=0               (testing.test_child)
+        26   call 788 ntypeargs=0               (testing.test_child)
         27   store_var 6                        (_10)
         28   load_var2 2 6                      
         29   call 4 ntypeargs=0                 (baml.Array.push)
@@ -3133,7 +3132,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
 
   264   48   load_var2 1 8                      
 
-  263   49   call 758 ntypeargs=0               (testing.testset_child)
+  263   49   call 789 ntypeargs=0               (testing.testset_child)
         50   store_var 9                        (_21)
 
   264   51   load_var2 2 9                      
@@ -3171,7 +3170,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   272   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 760 ntypeargs=0               (testing._name_selected)
+        23   call 791 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   273   25   load_var 6                         (t)
@@ -3180,7 +3179,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 6                         (t)
         30   load_field 2                       (runner)
-        31   call 757 ntypeargs=0               (testing.test_child)
+        31   call 788 ntypeargs=0               (testing.test_child)
         32   store_var 7                        (_13)
         33   load_var2 3 7                      
         34   call 4 ntypeargs=0                 (baml.Array.push)
@@ -3208,12 +3207,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   284   55   load_field 0                       (name)
         56   load_var 2                         (names)
-        57   call 761 ntypeargs=0               (testing._has_selected_descendant)
+        57   call 792 ntypeargs=0               (testing._has_selected_descendant)
         58   pop_jump_if_false -14              (to 44)
 
   285   59   load_var2 1 10                     
         60   load_var 2                         (names)
-        61   call 759 ntypeargs=0               (testing.testset_child_selected)
+        61   call 790 ntypeargs=0               (testing.testset_child_selected)
         62   store_var 11                       (_26)
         63   load_var2 3 11                     
         64   call 4 ntypeargs=0                 (baml.Array.push)
@@ -3233,7 +3232,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 801 ntypeargs=0   (user.score)
+       7    call 832 ntypeargs=0   (user.score)
        8    store_var 3            (base)
 
   11   9    load_var 3             (base)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/tests/bytecode_format/main.rs
-assertion_line: 43
 ---
 function assert.approx_equal(actual: float, expected: float, eps: float) -> null {
   77   0    load_var 3             (eps)
@@ -34,19 +33,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 796 ntypeargs=0   (assert.format_operand)
+       26   call 827 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 796 ntypeargs=0   (assert.format_operand)
+       29   call 827 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 796 ntypeargs=0   (assert.format_operand)
+       32   call 827 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 796 ntypeargs=0   (assert.format_operand)
+       35   call 827 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -64,11 +63,11 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
        49   bin_op +               
        50   load_var 8             (_22)
        51   bin_op +               
-       52   call 247 ntypeargs=0   (baml.sys.panic)
+       52   call 257 ntypeargs=0   (baml.sys.panic)
        53   jump +3                (to 56)
 
   78   54   load_const 6           ("assertion failed: epsilon must be a non-negative number")
-       55   call 247 ntypeargs=0   (baml.sys.panic)
+       55   call 257 ntypeargs=0   (baml.sys.panic)
        56   return                 
 }
 
@@ -84,13 +83,13 @@ function assert.contains(haystack: string, needle: string) -> null {
   100   6   jump +3                (to 9)
 
   101   7   load_const 1           ("assertion failed: string does not contain expected substring")
-        8   call 247 ntypeargs=0   (baml.sys.panic)
+        8   call 257 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   50   0    load_var2 1 2          
-       1    call 651 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 661 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -100,11 +99,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 796 ntypeargs=0   (assert.format_operand)
+       8    call 827 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 796 ntypeargs=0   (assert.format_operand)
+       11   call 827 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -114,7 +113,7 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
        17   bin_op +               
        18   load_var 4             (_9)
        19   bin_op +               
-       20   call 247 ntypeargs=0   (baml.sys.panic)
+       20   call 257 ntypeargs=0   (baml.sys.panic)
        21   return                 
 }
 
@@ -136,14 +135,14 @@ function assert.is_true(condition: bool) -> null {
   5   5   jump +3                (to 8)
 
   6   6   load_const 1           ("assertion failed: expected true")
-      7   call 247 ntypeargs=0   (baml.sys.panic)
+      7   call 257 ntypeargs=0   (baml.sys.panic)
       8   return                 
 }
 
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 651 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 661 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -152,7 +151,7 @@ function assert.not_null(value: unknown | null) -> null {
   14   6   jump +3                (to 9)
 
   15   7   load_const 1           ("assertion failed: expected non-null value")
-       8   call 247 ntypeargs=0   (baml.sys.panic)
+       8   call 257 ntypeargs=0   (baml.sys.panic)
        9   return                 
 }
 
@@ -172,7 +171,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  102   0   make_closure 1501 0   
+  102   0   make_closure 1559 0   
         1   store_var 1           (_0)
         2   load_var 1            (_0)
         3   return                
@@ -195,11 +194,11 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        12   pop_jump_if_false +4   (to 16)
 
   69   13   load_const 2           ("testing.PassRate requires 0.0 <= threshold <= 1.0")
-       14   call 247 ntypeargs=0   (baml.sys.panic)
+       14   call 257 ntypeargs=0   (baml.sys.panic)
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1496 1    
+       17   make_closure 1554 1    
        18   store_var 2            (_0)
        19   load_var 2             (_0)
        20   return                 
@@ -231,16 +230,16 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        20   pop_jump_if_false +8   (to 28)
 
   5    21   load_const 1           ("testing.Quorum requires 0 <= m <= n")
-       22   call 247 ntypeargs=0   (baml.sys.panic)
+       22   call 257 ntypeargs=0   (baml.sys.panic)
        23   pop 1                  
        24   jump +4                (to 28)
 
   3    25   load_const 2           ("testing.Quorum requires n > 0")
-       26   call 247 ntypeargs=0   (baml.sys.panic)
+       26   call 257 ntypeargs=0   (baml.sys.panic)
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1480 2    
+       29   make_closure 1538 2    
        30   store_var 3            (_0)
        31   load_var 3             (_0)
        32   return                 
@@ -257,18 +256,18 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        6    pop_jump_if_false +4   (to 10)
 
   36   7    load_const 1           ("testing.Retry requires max_attempts > 0")
-       8    call 247 ntypeargs=0   (baml.sys.panic)
+       8    call 257 ntypeargs=0   (baml.sys.panic)
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1490 1    
+       11   make_closure 1548 1    
        12   store_var 2            (_0)
        13   load_var 2             (_0)
        14   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  96   0   make_closure 1499 0   
+  96   0   make_closure 1557 0   
        1   store_var 1           (_0)
        2   load_var 1            (_0)
        3   return                
@@ -476,7 +475,7 @@ function testing.TestCollector.register_test_at(self: testing.TestCollector, own
 
   62   6   load_var2 6 3          
        7   load_var2 4 5          
-       8   call 738 ntypeargs=0   (testing.TestCollector.register_test)
+       8   call 769 ntypeargs=0   (testing.TestCollector.register_test)
        9   return                 
 }
 
@@ -600,7 +599,7 @@ function testing.TestCollector.register_test_set_at(self: testing.TestCollector,
 
   67   6   load_var2 6 3          
        7   load_var2 4 5          
-       8   call 739 ntypeargs=0   (testing.TestCollector.register_test_set)
+       8   call 770 ntypeargs=0   (testing.TestCollector.register_test_set)
        9   return                 
 }
 
@@ -630,11 +629,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   224   22   load_var2 1 5                      
-        23   call 754 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 785 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   225   25   load_var 1                         (self)
-        26   call 746 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 777 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   229   28   load_type 5                        
@@ -671,7 +670,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   232   58   load_var2 9 2                      
-        59   call 753 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 784 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   235   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -694,7 +693,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         10   pop_jump_if_false +2   (to 12)
         11   jump +37               (to 48)
 
-  242   12   call 249 ntypeargs=0   (baml.sys.now_ms)
+  242   12   call 259 ntypeargs=0   (baml.sys.now_ms)
         13   store_var 5            (start)
 
   243   14   load_var 2             (ts)
@@ -711,7 +710,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         24   call_indirect          
         25   pop 1                  
 
-  245   26   call 249 ntypeargs=0   (baml.sys.now_ms)
+  245   26   call 259 ntypeargs=0   (baml.sys.now_ms)
         27   load_var 5             (start)
         28   sub_int                
         29   store_var 7            (elapsed)
@@ -750,7 +749,7 @@ function testing.TestRegistry.list_filtered(self: testing.TestRegistry, profile_
   215   0   load_var2 1 2          
         1   load_var2 3 4          
         2   load_var 5             (cli_exclude)
-        3   call 774 ntypeargs=0   (testing.select_names_layered)
+        3   call 805 ntypeargs=0   (testing.select_names_layered)
         4   return                 
 }
 
@@ -769,9 +768,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   188   0   load_var 1             (self)
-        1   call 755 ntypeargs=0   (testing.testset_children)
+        1   call 786 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 765 ntypeargs=0   (testing.run_testset)
+        3   call 796 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -779,7 +778,7 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
   204   0    load_var2 1 2          
         1    load_var2 3 4          
         2    load_var 5             (cli_exclude)
-        3    call 774 ntypeargs=0   (testing.select_names_layered)
+        3    call 805 ntypeargs=0   (testing.select_names_layered)
         4    store_var 6            (selected_names)
 
   205   5    load_var 2             (profile_include)
@@ -816,22 +815,22 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
         36   jump +4                (to 40)
 
   208   37   load_var2 1 6          
-        38   call 750 ntypeargs=0   (testing.TestRegistry.run_selected)
+        38   call 781 ntypeargs=0   (testing.TestRegistry.run_selected)
         39   jump +3                (to 42)
 
   206   40   load_var 1             (self)
-        41   call 749 ntypeargs=0   (testing.TestRegistry.run_all)
+        41   call 780 ntypeargs=0   (testing.TestRegistry.run_all)
 
   210   42   load_var 6             (selected_names)
-        43   call 780 ntypeargs=0   (testing.flatten_with_tolerated)
+        43   call 811 ntypeargs=0   (testing.flatten_with_tolerated)
         44   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   192   0   load_var2 1 2          
-        1   call 756 ntypeargs=0   (testing.testset_children_selected)
+        1   call 787 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 765 ntypeargs=0   (testing.run_testset)
+        3   call 796 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -864,7 +863,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 764 ntypeargs=0               (testing.run_test)
+        26   call 795 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   162   28   load_type 5                        
@@ -901,7 +900,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   166   58   load_var2 9 2                      
-        59   call 747 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 778 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   169   61   load_const 12                      ("Test not found: ")
@@ -936,11 +935,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   175   22   load_var2 1 5                      
-        23   call 754 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 755 ntypeargs=0               (testing.testset_children)
+        23   call 785 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 786 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 765 ntypeargs=0               (testing.run_testset)
+        27   call 796 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   178   29   load_type 5                        
@@ -977,7 +976,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   181   59   load_var2 9 2                      
-        60   call 748 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 779 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   184   62   load_const 12                      ("TestSet not found: ")
@@ -1069,7 +1068,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         71   store_var 12                       (_27)
 
   141   72   load_var 11                        (sub)
-        73   call 746 ntypeargs=0               (testing.TestRegistry.serialize)
+        73   call 777 ntypeargs=0               (testing.TestRegistry.serialize)
         74   store_var 13                       (_28)
 
   139   75   load_var2 3 12                     
@@ -1131,7 +1130,7 @@ function testing._int_to_float(value: int) -> float {
         6   throw_if_panic         
 
   127   7   load_const 1           ("failed to convert int to float")
-        8   call 247 ntypeargs=0   (baml.sys.panic)
+        8   call 257 ntypeargs=0   (baml.sys.panic)
         9   return                 
 }
 
@@ -1239,7 +1238,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   362   58    load_var 13                        (outcome)
         59    load_const 10                      ("pass")
-        60    call 651 ntypeargs=0               (baml.ops.equals_equals)
+        60    call 661 ntypeargs=0               (baml.ops.equals_equals)
         61    pop_jump_if_false +2               (to 63)
         62    jump +59                           (to 121)
 
@@ -1306,7 +1305,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   377   114   load_var 13                        (outcome)
         115   load_const 16                      ("error")
-        116   call 651 ntypeargs=0               (baml.ops.equals_equals)
+        116   call 661 ntypeargs=0               (baml.ops.equals_equals)
         117   pop_jump_if_false -97              (to 20)
 
   378   118   load_const 17                      (true)
@@ -1378,7 +1377,7 @@ function testing.any_pattern_matches(pats: string[], canonical_id: string) -> bo
         15   store_var 5                        (p)
 
   510   16   load_var2 2 5                      
-        17   call 767 ntypeargs=0               (testing.glob_match)
+        17   call 798 ntypeargs=0               (testing.glob_match)
         18   pop_jump_if_false -13              (to 5)
 
   511   19   load_const 5                       (true)
@@ -1416,7 +1415,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         23   store_var_load_var 8               (name)
 
   753   24   load_var 3                         (all_failed_names)
-        25   call 783 ntypeargs=0               (testing.failure_matches_selected)
+        25   call 814 ntypeargs=0               (testing.failure_matches_selected)
         26   pop_jump_if_false +2               (to 28)
         27   jump +8                            (to 35)
 
@@ -1429,7 +1428,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         34   jump -21                           (to 13)
 
   754   35   load_var2 8 2                      
-        36   call 783 ntypeargs=0               (testing.failure_matches_selected)
+        36   call 814 ntypeargs=0               (testing.failure_matches_selected)
         37   pop_jump_if_false +2               (to 39)
         38   jump +8                            (to 46)
 
@@ -1475,7 +1474,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
         16   store_var_load_var 6               (name)
 
   824   17   load_var 2                         (out)
-        18   call 782 ntypeargs=0               (testing.name_in)
+        18   call 813 ntypeargs=0               (testing.name_in)
         19   unary_op !                         
         20   pop_jump_if_false -14              (to 6)
         21   load_var2 2 6                      
@@ -1508,7 +1507,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
         46   store_var_load_var 10              (nested)
 
   829   47   load_var 2                         (out)
-        48   call 785 ntypeargs=0               (testing.collect_all_failed_names)
+        48   call 816 ntypeargs=0               (testing.collect_all_failed_names)
         49   pop 1                              
         50   jump -19                           (to 31)
 
@@ -1586,7 +1585,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
         57    load_var 15             (nested)
         58    load_field 0            (outcome)
         59    load_const 3            ("pass")
-        60    call 651 ntypeargs=0    (baml.ops.equals_equals)
+        60    call 661 ntypeargs=0    (baml.ops.equals_equals)
         61    store_var 16            (nested_tolerated)
 
   804   62    load_var 15             (nested)
@@ -1611,7 +1610,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
         79    store_var_load_var 18   (sentinel)
 
   808   80    load_var 3              (selected_names)
-        81    call 782 ntypeargs=0    (testing.name_in)
+        81    call 813 ntypeargs=0    (testing.name_in)
         82    pop_jump_if_false +2    (to 84)
         83    jump +21                (to 104)
         84    load_var 15             (nested)
@@ -1657,7 +1656,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
 
   805   123   load_var2 15 16         
         124   load_var2 3 4           
-        125   call 784 ntypeargs=0    (testing.collect_leaf_identities)
+        125   call 815 ntypeargs=0    (testing.collect_leaf_identities)
         126   pop 1                   
         127   jump +31                (to 158)
 
@@ -1666,7 +1665,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
 
   794   130   load_field 0            (outcome)
         131   load_const 7            ("pass")
-        132   call 651 ntypeargs=0    (baml.ops.equals_equals)
+        132   call 661 ntypeargs=0    (baml.ops.equals_equals)
         133   pop_jump_if_false +2    (to 135)
         134   jump +18                (to 152)
 
@@ -1736,7 +1735,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   849   24   load_field 5                       (results)
         25   load_var 2                         (out)
-        26   call 786 ntypeargs=0               (testing.collect_leaf_messages)
+        26   call 817 ntypeargs=0               (testing.collect_leaf_messages)
         27   pop 1                              
         28   jump -23                           (to 5)
 
@@ -1762,7 +1761,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   841   47   load_field 0                       (outcome)
         48   load_const 10                      ("pass")
-        49   call 651 ntypeargs=0               (baml.ops.equals_equals)
+        49   call 661 ntypeargs=0               (baml.ops.equals_equals)
         50   unary_op !                         
         51   pop_jump_if_false -15              (to 36)
 
@@ -1836,7 +1835,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         43   store_var 9                        (ts)
 
   618   44   load_var2 1 9                      
-        45   call 777 ntypeargs=0               (testing.collect_subtree_names)
+        45   call 808 ntypeargs=0               (testing.collect_subtree_names)
         46   load_type 10                       
         47   load_const 11                      ("iter")
         48   virtual_call nargs=1 ntypeargs=0   
@@ -1866,8 +1865,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   631   0    load_var2 1 2          
-        1    call 754 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 776 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 785 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 807 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +91               (to 94)
         4    load_var 3             (e)
         5    store_var 4            (_5)
@@ -1969,10 +1968,10 @@ function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testi
 
 function testing.collect_subtree_names_layered(registry: testing.TestRegistry, ts: testing.TestSetRegistration, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> string[] {
   639   0     load_var2 1 2           
-        1     call 754 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
+        1     call 785 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
         2     load_var2 3 4           
         3     load_var2 5 6           
-        4     call 774 ntypeargs=0    (testing.select_names_layered)
+        4     call 805 ntypeargs=0    (testing.select_names_layered)
         5     jump +111               (to 116)
         6     load_var 7              (e)
         7     store_var 8             (_9)
@@ -2055,7 +2054,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   647   83    load_var2 3 4           
         84    load_var2 5 6           
-        85    call 770 ntypeargs=0    (testing.leaf_selected_layered)
+        85    call 801 ntypeargs=0    (testing.leaf_selected_layered)
         86    pop_jump_if_false +2    (to 88)
         87    jump +4                 (to 91)
         88    load_type 18            
@@ -2074,7 +2073,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   643   100   load_var2 3 4           
         101   load_var2 5 6           
-        102   call 770 ntypeargs=0    (testing.leaf_selected_layered)
+        102   call 801 ntypeargs=0    (testing.leaf_selected_layered)
         103   pop_jump_if_false +2    (to 105)
         104   jump +4                 (to 108)
         105   load_type 18            
@@ -2140,7 +2139,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         37    load_var 13                        (tsr)
         38    load_field 0                       (outcome)
         39    load_const 7                       ("pass")
-        40    call 651 ntypeargs=0               (baml.ops.equals_equals)
+        40    call 661 ntypeargs=0               (baml.ops.equals_equals)
         41    store_var 14                       (ft)
 
   687   42    load_var 13                        (tsr)
@@ -2184,7 +2183,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   688   74    load_var 13                        (tsr)
         75    load_field 5                       (results)
         76    load_var 14                        (ft)
-        77    call 779 ntypeargs=0               (testing.count_leaves)
+        77    call 810 ntypeargs=0               (testing.count_leaves)
         78    store_var 10                       (delta)
         79    jump +31                           (to 110)
 
@@ -2193,7 +2192,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
 
   677   82    load_field 0                       (outcome)
         83    load_const 8                       ("pass")
-        84    call 651 ntypeargs=0               (baml.ops.equals_equals)
+        84    call 661 ntypeargs=0               (baml.ops.equals_equals)
         85    pop_jump_if_false +2               (to 87)
         86    jump +18                           (to 104)
 
@@ -2279,7 +2278,7 @@ function testing.expansion_error_report(name: string) -> testing.TestSetReport {
 
 function testing.failure_matches_selected(selected: string, failed_names: string[]) -> bool {
   774   0    load_var2 1 2                      
-        1    call 782 ntypeargs=0               (testing.name_in)
+        1    call 813 ntypeargs=0               (testing.name_in)
         2    pop_jump_if_false +2               (to 4)
         3    jump +43                           (to 46)
 
@@ -2339,7 +2338,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   709   0     load_var 1             (report)
         1     load_field 0           (outcome)
         2     load_const 0           ("pass")
-        3     call 651 ntypeargs=0   (baml.ops.equals_equals)
+        3     call 661 ntypeargs=0   (baml.ops.equals_equals)
         4     store_var 3            (top_tolerated)
 
   710   5     load_var 1             (report)
@@ -2383,7 +2382,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   711   37    load_var 1             (report)
         38    load_field 5           (results)
         39    load_var 3             (top_tolerated)
-        40    call 779 ntypeargs=0   (testing.count_leaves)
+        40    call 810 ntypeargs=0   (testing.count_leaves)
         41    store_var 4            (counts)
 
   717   42    load_type 2            
@@ -2393,7 +2392,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   718   45    load_var 1             (report)
         46    load_field 5           (results)
         47    load_var 6             (messages)
-        48    call 786 ntypeargs=0   (testing.collect_leaf_messages)
+        48    call 817 ntypeargs=0   (testing.collect_leaf_messages)
         49    pop 1                  
 
   719   50    load_type 2            
@@ -2401,7 +2400,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
         52    store_var 7            (all_failed_names)
 
   720   53    load_var2 1 7          
-        54    call 785 ntypeargs=0   (testing.collect_all_failed_names)
+        54    call 816 ntypeargs=0   (testing.collect_all_failed_names)
         55    pop 1                  
 
   721   56    load_type 2            
@@ -2415,7 +2414,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
 
   722   64    load_var2 1 3          
         65    load_var2 2 8          
-        66    call 784 ntypeargs=0   (testing.collect_leaf_identities)
+        66    call 815 ntypeargs=0   (testing.collect_leaf_identities)
         67    pop 1                  
 
   727   68    load_var 8             (executed)
@@ -2469,7 +2468,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   730   112   load_var2 2 1          
         113   load_field 4           (failed_names)
         114   load_var 7             (all_failed_names)
-        115   call 781 ntypeargs=0   (testing.classify_selected_names)
+        115   call 812 ntypeargs=0   (testing.classify_selected_names)
         116   store_var 9            (identities)
         117   jump +3                (to 120)
 
@@ -2630,14 +2629,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
   485   98    load_var2 1 2           
         99    call 155 ntypeargs=0    (baml.String.index_of)
         100   load_const 6            (null)
-        101   call 651 ntypeargs=0    (baml.ops.equals_equals)
+        101   call 661 ntypeargs=0    (baml.ops.equals_equals)
         102   unary_op !              
         103   return                  
 }
 
 function testing.leaf_selected(name: string, include: string[], exclude: string[]) -> bool {
   520   0    load_var2 3 1          
-        1    call 768 ntypeargs=0   (testing.any_pattern_matches)
+        1    call 799 ntypeargs=0   (testing.any_pattern_matches)
         2    pop_jump_if_false +2   (to 4)
         3    jump +14               (to 17)
 
@@ -2651,7 +2650,7 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
         11   jump +4                (to 15)
 
   526   12   load_var2 2 1          
-        13   call 768 ntypeargs=0   (testing.any_pattern_matches)
+        13   call 799 ntypeargs=0   (testing.any_pattern_matches)
         14   jump +4                (to 18)
 
   524   15   load_const 1           (true)
@@ -2664,12 +2663,12 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
 function testing.leaf_selected_layered(name: string, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> bool {
   533   0   load_var2 1 2          
         1   load_var 3             (profile_exclude)
-        2   call 769 ntypeargs=0   (testing.leaf_selected)
+        2   call 800 ntypeargs=0   (testing.leaf_selected)
         3   jump_if_false +5       (to 8)
         4   pop 1                  
         5   load_var2 1 4          
         6   load_var 5             (cli_exclude)
-        7   call 769 ntypeargs=0   (testing.leaf_selected)
+        7   call 800 ntypeargs=0   (testing.leaf_selected)
         8   return                 
 }
 
@@ -2768,7 +2767,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   399   25   load_var 5                         (child)
-        26   make_closure 1382 1                
+        26   make_closure 1440 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   load_type 7                        
@@ -2783,10 +2782,10 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
   405   37   load_type 7                        
         38   load_type 8                        
         39   load_var 2                         (futures)
-        40   call 521 ntypeargs=2               (baml.future.all_complete)
+        40   call 531 ntypeargs=2               (baml.future.all_complete)
         41   await                              
 
-  406   42   call 762 ntypeargs=0               (testing.aggregate_reports)
+  406   42   call 793 ntypeargs=0               (testing.aggregate_reports)
         43   return                             
 }
 
@@ -2849,16 +2848,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         47   pop 1                              
         48   load_var 8                         (outcome)
         49   load_const 7                       ("pass")
-        50   call 651 ntypeargs=0               (baml.ops.equals_equals)
+        50   call 661 ntypeargs=0               (baml.ops.equals_equals)
         51   unary_op !                         
         52   pop_jump_if_false -44              (to 8)
 
   117   53   load_var 3                         (named_results)
-        54   call 762 ntypeargs=0               (testing.aggregate_reports)
+        54   call 793 ntypeargs=0               (testing.aggregate_reports)
         55   jump +3                            (to 58)
 
   122   56   load_var 3                         (named_results)
-        57   call 762 ntypeargs=0               (testing.aggregate_reports)
+        57   call 793 ntypeargs=0               (testing.aggregate_reports)
         58   return                             
 }
 
@@ -2868,7 +2867,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   411   3    load_var 1             (body)
-        4    make_closure 1393 1    
+        4    make_closure 1451 1    
         5    store_var 3            (base_run)
 
   435   6    load_var 2             (runner)
@@ -2904,7 +2903,7 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         9    jump +3                (to 12)
 
   447   10   load_var 1             (children)
-        11   call 763 ntypeargs=0   (testing.run_children_parallel)
+        11   call 794 ntypeargs=0   (testing.run_children_parallel)
         12   return                 
 }
 
@@ -2915,7 +2914,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         3   load_type 0            
         4   alloc_array 0          
         5   load_var2 2 3          
-        6   call 774 ntypeargs=0   (testing.select_names_layered)
+        6   call 805 ntypeargs=0   (testing.select_names_layered)
         7   return                 
 }
 
@@ -2946,7 +2945,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
   591   21   load_field 0                       (name)
         22   load_var2 2 3                      
         23   load_var2 4 5                      
-        24   call 770 ntypeargs=0               (testing.leaf_selected_layered)
+        24   call 801 ntypeargs=0               (testing.leaf_selected_layered)
         25   pop_jump_if_false -15              (to 10)
 
   592   26   load_var2 7 10                     
@@ -2976,19 +2975,19 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   598   49   load_field 0                       (name)
         50   load_var2 2 3                      
-        51   call 773 ntypeargs=0               (testing.subtree_may_be_selected)
+        51   call 804 ntypeargs=0               (testing.subtree_may_be_selected)
         52   jump_if_false +6                   (to 58)
         53   pop 1                              
         54   load_var 13                        (ts)
         55   load_field 0                       (name)
         56   load_var2 4 5                      
-        57   call 773 ntypeargs=0               (testing.subtree_may_be_selected)
+        57   call 804 ntypeargs=0               (testing.subtree_may_be_selected)
         58   pop_jump_if_false -20              (to 38)
 
   599   59   load_var2 1 13                     
         60   load_var2 2 3                      
         61   load_var2 4 5                      
-        62   call 778 ntypeargs=0               (testing.collect_subtree_names_layered)
+        62   call 809 ntypeargs=0               (testing.collect_subtree_names_layered)
 
   600   63   load_type 10                       
         64   load_const 11                      ("iter")
@@ -3043,13 +3042,13 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         21   load_const 6                       ("*")
         22   call 155 ntypeargs=0               (baml.String.index_of)
         23   load_const 7                       (null)
-        24   call 651 ntypeargs=0               (baml.ops.equals_equals)
+        24   call 661 ntypeargs=0               (baml.ops.equals_equals)
         25   jump_if_false +7                   (to 32)
         26   pop 1                              
         27   load_var2 3 6                      
         28   call 155 ntypeargs=0               (baml.String.index_of)
         29   load_const 7                       (null)
-        30   call 651 ntypeargs=0               (baml.ops.equals_equals)
+        30   call 661 ntypeargs=0               (baml.ops.equals_equals)
         31   unary_op !                         
         32   pop_jump_if_false +2               (to 34)
         33   jump +11                           (to 44)
@@ -3060,7 +3059,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         37   jump_if_false +4                   (to 41)
         38   pop 1                              
         39   load_var2 3 6                      
-        40   call 767 ntypeargs=0               (testing.glob_match)
+        40   call 798 ntypeargs=0               (testing.glob_match)
         41   pop_jump_if_false -32              (to 9)
 
   550   42   load_const 9                       (true)
@@ -3075,7 +3074,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
 
 function testing.subtree_may_be_selected(prefix: string, include: string[], exclude: string[]) -> bool {
   572   0    load_var2 1 3                      
-        1    call 771 ntypeargs=0               (testing.subtree_excluded)
+        1    call 802 ntypeargs=0               (testing.subtree_excluded)
         2    pop_jump_if_false +2               (to 4)
         3    jump +34                           (to 37)
 
@@ -3106,7 +3105,7 @@ function testing.subtree_may_be_selected(prefix: string, include: string[], excl
         27   store_var_load_var 7               (pattern)
 
   579   28   load_var 1                         (prefix)
-        29   call 772 ntypeargs=0               (testing.pattern_may_match_descendant)
+        29   call 803 ntypeargs=0               (testing.pattern_may_match_descendant)
         30   pop_jump_if_false -13              (to 17)
 
   580   31   load_const 6                       (true)
@@ -3133,7 +3132,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   294   6    load_var2 1 2         
 
   296   7    load_var 3            (runner)
-        8    make_closure 1359 2   
+        8    make_closure 1417 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   store_var 4           (_0)
         11   load_var 4            (_0)
@@ -3152,7 +3151,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   303   8    load_var2 1 2         
-        9    make_closure 1361 2   
+        9    make_closure 1419 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   store_var 3           (_0)
         12   load_var 3            (_0)
@@ -3175,7 +3174,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   315   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1363 3   
+        13   make_closure 1421 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   store_var 4           (_0)
         16   load_var 4            (_0)
@@ -3211,7 +3210,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 6                         (t)
         25   load_field 2                       (runner)
-        26   call 757 ntypeargs=0               (testing.test_child)
+        26   call 788 ntypeargs=0               (testing.test_child)
         27   store_var 7                        (_10)
         28   load_var2 3 7                      
         29   call 4 ntypeargs=0                 (baml.Array.push)
@@ -3238,7 +3237,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         49   store_var 10                       (ts)
 
   264   50   load_var2 1 10                     
-        51   call 758 ntypeargs=0               (testing.testset_child)
+        51   call 789 ntypeargs=0               (testing.testset_child)
         52   store_var 11                       (_21)
         53   load_var2 3 11                     
         54   call 4 ntypeargs=0                 (baml.Array.push)
@@ -3277,7 +3276,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   272   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 760 ntypeargs=0               (testing._name_selected)
+        23   call 791 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   273   25   load_var 7                         (t)
@@ -3286,7 +3285,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 7                         (t)
         30   load_field 2                       (runner)
-        31   call 757 ntypeargs=0               (testing.test_child)
+        31   call 788 ntypeargs=0               (testing.test_child)
         32   store_var 8                        (_13)
         33   load_var2 4 8                      
         34   call 4 ntypeargs=0                 (baml.Array.push)
@@ -3314,12 +3313,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   284   55   load_field 0                       (name)
         56   load_var 2                         (names)
-        57   call 761 ntypeargs=0               (testing._has_selected_descendant)
+        57   call 792 ntypeargs=0               (testing._has_selected_descendant)
         58   pop_jump_if_false -14              (to 44)
 
   285   59   load_var2 1 11                     
         60   load_var 2                         (names)
-        61   call 759 ntypeargs=0               (testing.testset_child_selected)
+        61   call 790 ntypeargs=0               (testing.testset_child_selected)
         62   store_var 12                       (_26)
         63   load_var2 4 12                     
         64   call 4 ntypeargs=0                 (baml.Array.push)
@@ -3341,7 +3340,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 801 ntypeargs=0   (user.score)
+       7    call 832 ntypeargs=0   (user.score)
        8    store_var 4            (base)
 
   11   9    load_var 4             (base)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/tests/bytecode_format/main.rs
+assertion_line: 43
 ---
 function assert.approx_equal(actual: float, expected: float, eps: float) -> null {
   77   0    load_var 3             (eps)
@@ -33,19 +34,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 795 ntypeargs=0   (assert.format_operand)
+       26   call 796 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 795 ntypeargs=0   (assert.format_operand)
+       29   call 796 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 795 ntypeargs=0   (assert.format_operand)
+       32   call 796 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 795 ntypeargs=0   (assert.format_operand)
+       35   call 796 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -99,11 +100,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 795 ntypeargs=0   (assert.format_operand)
+       8    call 796 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 795 ntypeargs=0   (assert.format_operand)
+       11   call 796 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -164,12 +165,6 @@ function boundary.id() -> boundary.LocalId {
 function boundary.id.current() -> string {
 }
 
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
-}
-
 function testing.$invoke_collector(collector: (testing.TestCollector) -> void throws unknown, c: testing.TestCollector) -> void {
   92   0   load_var2 2 1   
        1   call_indirect   
@@ -177,7 +172,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  102   0   make_closure 1500 0   
+  102   0   make_closure 1501 0   
         1   store_var 1           (_0)
         2   load_var 1            (_0)
         3   return                
@@ -204,7 +199,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   74   16   load_var 1             (threshold)
-       17   make_closure 1495 1    
+       17   make_closure 1496 1    
        18   store_var 2            (_0)
        19   load_var 2             (_0)
        20   return                 
@@ -245,7 +240,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1479 2    
+       29   make_closure 1480 2    
        30   store_var 3            (_0)
        31   load_var 3             (_0)
        32   return                 
@@ -266,14 +261,14 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   41   10   load_var 1             (max_attempts)
-       11   make_closure 1489 1    
+       11   make_closure 1490 1    
        12   store_var 2            (_0)
        13   load_var 2             (_0)
        14   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  96   0   make_closure 1498 0   
+  96   0   make_closure 1499 0   
        1   store_var 1           (_0)
        2   load_var 1            (_0)
        3   return                
@@ -481,7 +476,7 @@ function testing.TestCollector.register_test_at(self: testing.TestCollector, own
 
   62   6   load_var2 6 3          
        7   load_var2 4 5          
-       8   call 737 ntypeargs=0   (testing.TestCollector.register_test)
+       8   call 738 ntypeargs=0   (testing.TestCollector.register_test)
        9   return                 
 }
 
@@ -605,7 +600,7 @@ function testing.TestCollector.register_test_set_at(self: testing.TestCollector,
 
   67   6   load_var2 6 3          
        7   load_var2 4 5          
-       8   call 738 ntypeargs=0   (testing.TestCollector.register_test_set)
+       8   call 739 ntypeargs=0   (testing.TestCollector.register_test_set)
        9   return                 
 }
 
@@ -635,11 +630,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   224   22   load_var2 1 5                      
-        23   call 753 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 754 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   225   25   load_var 1                         (self)
-        26   call 745 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 746 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   229   28   load_type 5                        
@@ -676,7 +671,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   232   58   load_var2 9 2                      
-        59   call 752 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 753 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   235   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -755,7 +750,7 @@ function testing.TestRegistry.list_filtered(self: testing.TestRegistry, profile_
   215   0   load_var2 1 2          
         1   load_var2 3 4          
         2   load_var 5             (cli_exclude)
-        3   call 773 ntypeargs=0   (testing.select_names_layered)
+        3   call 774 ntypeargs=0   (testing.select_names_layered)
         4   return                 
 }
 
@@ -774,9 +769,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   188   0   load_var 1             (self)
-        1   call 754 ntypeargs=0   (testing.testset_children)
+        1   call 755 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 764 ntypeargs=0   (testing.run_testset)
+        3   call 765 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -784,7 +779,7 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
   204   0    load_var2 1 2          
         1    load_var2 3 4          
         2    load_var 5             (cli_exclude)
-        3    call 773 ntypeargs=0   (testing.select_names_layered)
+        3    call 774 ntypeargs=0   (testing.select_names_layered)
         4    store_var 6            (selected_names)
 
   205   5    load_var 2             (profile_include)
@@ -821,22 +816,22 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
         36   jump +4                (to 40)
 
   208   37   load_var2 1 6          
-        38   call 749 ntypeargs=0   (testing.TestRegistry.run_selected)
+        38   call 750 ntypeargs=0   (testing.TestRegistry.run_selected)
         39   jump +3                (to 42)
 
   206   40   load_var 1             (self)
-        41   call 748 ntypeargs=0   (testing.TestRegistry.run_all)
+        41   call 749 ntypeargs=0   (testing.TestRegistry.run_all)
 
   210   42   load_var 6             (selected_names)
-        43   call 779 ntypeargs=0   (testing.flatten_with_tolerated)
+        43   call 780 ntypeargs=0   (testing.flatten_with_tolerated)
         44   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   192   0   load_var2 1 2          
-        1   call 755 ntypeargs=0   (testing.testset_children_selected)
+        1   call 756 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 764 ntypeargs=0   (testing.run_testset)
+        3   call 765 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -869,7 +864,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 763 ntypeargs=0               (testing.run_test)
+        26   call 764 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   162   28   load_type 5                        
@@ -906,7 +901,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   166   58   load_var2 9 2                      
-        59   call 746 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 747 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   169   61   load_const 12                      ("Test not found: ")
@@ -941,11 +936,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   175   22   load_var2 1 5                      
-        23   call 753 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 754 ntypeargs=0               (testing.testset_children)
+        23   call 754 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 755 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 764 ntypeargs=0               (testing.run_testset)
+        27   call 765 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   178   29   load_type 5                        
@@ -982,7 +977,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   181   59   load_var2 9 2                      
-        60   call 747 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 748 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   184   62   load_const 12                      ("TestSet not found: ")
@@ -1074,7 +1069,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         71   store_var 12                       (_27)
 
   141   72   load_var 11                        (sub)
-        73   call 745 ntypeargs=0               (testing.TestRegistry.serialize)
+        73   call 746 ntypeargs=0               (testing.TestRegistry.serialize)
         74   store_var 13                       (_28)
 
   139   75   load_var2 3 12                     
@@ -1383,7 +1378,7 @@ function testing.any_pattern_matches(pats: string[], canonical_id: string) -> bo
         15   store_var 5                        (p)
 
   510   16   load_var2 2 5                      
-        17   call 766 ntypeargs=0               (testing.glob_match)
+        17   call 767 ntypeargs=0               (testing.glob_match)
         18   pop_jump_if_false -13              (to 5)
 
   511   19   load_const 5                       (true)
@@ -1421,7 +1416,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         23   store_var_load_var 8               (name)
 
   753   24   load_var 3                         (all_failed_names)
-        25   call 782 ntypeargs=0               (testing.failure_matches_selected)
+        25   call 783 ntypeargs=0               (testing.failure_matches_selected)
         26   pop_jump_if_false +2               (to 28)
         27   jump +8                            (to 35)
 
@@ -1434,7 +1429,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         34   jump -21                           (to 13)
 
   754   35   load_var2 8 2                      
-        36   call 782 ntypeargs=0               (testing.failure_matches_selected)
+        36   call 783 ntypeargs=0               (testing.failure_matches_selected)
         37   pop_jump_if_false +2               (to 39)
         38   jump +8                            (to 46)
 
@@ -1480,7 +1475,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
         16   store_var_load_var 6               (name)
 
   824   17   load_var 2                         (out)
-        18   call 781 ntypeargs=0               (testing.name_in)
+        18   call 782 ntypeargs=0               (testing.name_in)
         19   unary_op !                         
         20   pop_jump_if_false -14              (to 6)
         21   load_var2 2 6                      
@@ -1513,7 +1508,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
         46   store_var_load_var 10              (nested)
 
   829   47   load_var 2                         (out)
-        48   call 784 ntypeargs=0               (testing.collect_all_failed_names)
+        48   call 785 ntypeargs=0               (testing.collect_all_failed_names)
         49   pop 1                              
         50   jump -19                           (to 31)
 
@@ -1616,7 +1611,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
         79    store_var_load_var 18   (sentinel)
 
   808   80    load_var 3              (selected_names)
-        81    call 781 ntypeargs=0    (testing.name_in)
+        81    call 782 ntypeargs=0    (testing.name_in)
         82    pop_jump_if_false +2    (to 84)
         83    jump +21                (to 104)
         84    load_var 15             (nested)
@@ -1662,7 +1657,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
 
   805   123   load_var2 15 16         
         124   load_var2 3 4           
-        125   call 783 ntypeargs=0    (testing.collect_leaf_identities)
+        125   call 784 ntypeargs=0    (testing.collect_leaf_identities)
         126   pop 1                   
         127   jump +31                (to 158)
 
@@ -1741,7 +1736,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   849   24   load_field 5                       (results)
         25   load_var 2                         (out)
-        26   call 785 ntypeargs=0               (testing.collect_leaf_messages)
+        26   call 786 ntypeargs=0               (testing.collect_leaf_messages)
         27   pop 1                              
         28   jump -23                           (to 5)
 
@@ -1841,7 +1836,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         43   store_var 9                        (ts)
 
   618   44   load_var2 1 9                      
-        45   call 776 ntypeargs=0               (testing.collect_subtree_names)
+        45   call 777 ntypeargs=0               (testing.collect_subtree_names)
         46   load_type 10                       
         47   load_const 11                      ("iter")
         48   virtual_call nargs=1 ntypeargs=0   
@@ -1871,8 +1866,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   631   0    load_var2 1 2          
-        1    call 753 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 775 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 754 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 776 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +91               (to 94)
         4    load_var 3             (e)
         5    store_var 4            (_5)
@@ -1974,10 +1969,10 @@ function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testi
 
 function testing.collect_subtree_names_layered(registry: testing.TestRegistry, ts: testing.TestSetRegistration, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> string[] {
   639   0     load_var2 1 2           
-        1     call 753 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
+        1     call 754 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
         2     load_var2 3 4           
         3     load_var2 5 6           
-        4     call 773 ntypeargs=0    (testing.select_names_layered)
+        4     call 774 ntypeargs=0    (testing.select_names_layered)
         5     jump +111               (to 116)
         6     load_var 7              (e)
         7     store_var 8             (_9)
@@ -2060,7 +2055,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   647   83    load_var2 3 4           
         84    load_var2 5 6           
-        85    call 769 ntypeargs=0    (testing.leaf_selected_layered)
+        85    call 770 ntypeargs=0    (testing.leaf_selected_layered)
         86    pop_jump_if_false +2    (to 88)
         87    jump +4                 (to 91)
         88    load_type 18            
@@ -2079,7 +2074,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   643   100   load_var2 3 4           
         101   load_var2 5 6           
-        102   call 769 ntypeargs=0    (testing.leaf_selected_layered)
+        102   call 770 ntypeargs=0    (testing.leaf_selected_layered)
         103   pop_jump_if_false +2    (to 105)
         104   jump +4                 (to 108)
         105   load_type 18            
@@ -2189,7 +2184,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   688   74    load_var 13                        (tsr)
         75    load_field 5                       (results)
         76    load_var 14                        (ft)
-        77    call 778 ntypeargs=0               (testing.count_leaves)
+        77    call 779 ntypeargs=0               (testing.count_leaves)
         78    store_var 10                       (delta)
         79    jump +31                           (to 110)
 
@@ -2284,7 +2279,7 @@ function testing.expansion_error_report(name: string) -> testing.TestSetReport {
 
 function testing.failure_matches_selected(selected: string, failed_names: string[]) -> bool {
   774   0    load_var2 1 2                      
-        1    call 781 ntypeargs=0               (testing.name_in)
+        1    call 782 ntypeargs=0               (testing.name_in)
         2    pop_jump_if_false +2               (to 4)
         3    jump +43                           (to 46)
 
@@ -2388,7 +2383,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   711   37    load_var 1             (report)
         38    load_field 5           (results)
         39    load_var 3             (top_tolerated)
-        40    call 778 ntypeargs=0   (testing.count_leaves)
+        40    call 779 ntypeargs=0   (testing.count_leaves)
         41    store_var 4            (counts)
 
   717   42    load_type 2            
@@ -2398,7 +2393,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   718   45    load_var 1             (report)
         46    load_field 5           (results)
         47    load_var 6             (messages)
-        48    call 785 ntypeargs=0   (testing.collect_leaf_messages)
+        48    call 786 ntypeargs=0   (testing.collect_leaf_messages)
         49    pop 1                  
 
   719   50    load_type 2            
@@ -2406,7 +2401,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
         52    store_var 7            (all_failed_names)
 
   720   53    load_var2 1 7          
-        54    call 784 ntypeargs=0   (testing.collect_all_failed_names)
+        54    call 785 ntypeargs=0   (testing.collect_all_failed_names)
         55    pop 1                  
 
   721   56    load_type 2            
@@ -2420,7 +2415,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
 
   722   64    load_var2 1 3          
         65    load_var2 2 8          
-        66    call 783 ntypeargs=0   (testing.collect_leaf_identities)
+        66    call 784 ntypeargs=0   (testing.collect_leaf_identities)
         67    pop 1                  
 
   727   68    load_var 8             (executed)
@@ -2474,7 +2469,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   730   112   load_var2 2 1          
         113   load_field 4           (failed_names)
         114   load_var 7             (all_failed_names)
-        115   call 780 ntypeargs=0   (testing.classify_selected_names)
+        115   call 781 ntypeargs=0   (testing.classify_selected_names)
         116   store_var 9            (identities)
         117   jump +3                (to 120)
 
@@ -2642,7 +2637,7 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
 function testing.leaf_selected(name: string, include: string[], exclude: string[]) -> bool {
   520   0    load_var2 3 1          
-        1    call 767 ntypeargs=0   (testing.any_pattern_matches)
+        1    call 768 ntypeargs=0   (testing.any_pattern_matches)
         2    pop_jump_if_false +2   (to 4)
         3    jump +14               (to 17)
 
@@ -2656,7 +2651,7 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
         11   jump +4                (to 15)
 
   526   12   load_var2 2 1          
-        13   call 767 ntypeargs=0   (testing.any_pattern_matches)
+        13   call 768 ntypeargs=0   (testing.any_pattern_matches)
         14   jump +4                (to 18)
 
   524   15   load_const 1           (true)
@@ -2669,12 +2664,12 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
 function testing.leaf_selected_layered(name: string, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> bool {
   533   0   load_var2 1 2          
         1   load_var 3             (profile_exclude)
-        2   call 768 ntypeargs=0   (testing.leaf_selected)
+        2   call 769 ntypeargs=0   (testing.leaf_selected)
         3   jump_if_false +5       (to 8)
         4   pop 1                  
         5   load_var2 1 4          
         6   load_var 5             (cli_exclude)
-        7   call 768 ntypeargs=0   (testing.leaf_selected)
+        7   call 769 ntypeargs=0   (testing.leaf_selected)
         8   return                 
 }
 
@@ -2773,7 +2768,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   399   25   load_var 5                         (child)
-        26   make_closure 1381 1                
+        26   make_closure 1382 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   load_type 7                        
@@ -2791,7 +2786,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         40   call 521 ntypeargs=2               (baml.future.all_complete)
         41   await                              
 
-  406   42   call 761 ntypeargs=0               (testing.aggregate_reports)
+  406   42   call 762 ntypeargs=0               (testing.aggregate_reports)
         43   return                             
 }
 
@@ -2859,11 +2854,11 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         52   pop_jump_if_false -44              (to 8)
 
   117   53   load_var 3                         (named_results)
-        54   call 761 ntypeargs=0               (testing.aggregate_reports)
+        54   call 762 ntypeargs=0               (testing.aggregate_reports)
         55   jump +3                            (to 58)
 
   122   56   load_var 3                         (named_results)
-        57   call 761 ntypeargs=0               (testing.aggregate_reports)
+        57   call 762 ntypeargs=0               (testing.aggregate_reports)
         58   return                             
 }
 
@@ -2873,7 +2868,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   411   3    load_var 1             (body)
-        4    make_closure 1392 1    
+        4    make_closure 1393 1    
         5    store_var 3            (base_run)
 
   435   6    load_var 2             (runner)
@@ -2909,7 +2904,7 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         9    jump +3                (to 12)
 
   447   10   load_var 1             (children)
-        11   call 762 ntypeargs=0   (testing.run_children_parallel)
+        11   call 763 ntypeargs=0   (testing.run_children_parallel)
         12   return                 
 }
 
@@ -2920,7 +2915,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         3   load_type 0            
         4   alloc_array 0          
         5   load_var2 2 3          
-        6   call 773 ntypeargs=0   (testing.select_names_layered)
+        6   call 774 ntypeargs=0   (testing.select_names_layered)
         7   return                 
 }
 
@@ -2951,7 +2946,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
   591   21   load_field 0                       (name)
         22   load_var2 2 3                      
         23   load_var2 4 5                      
-        24   call 769 ntypeargs=0               (testing.leaf_selected_layered)
+        24   call 770 ntypeargs=0               (testing.leaf_selected_layered)
         25   pop_jump_if_false -15              (to 10)
 
   592   26   load_var2 7 10                     
@@ -2981,19 +2976,19 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   598   49   load_field 0                       (name)
         50   load_var2 2 3                      
-        51   call 772 ntypeargs=0               (testing.subtree_may_be_selected)
+        51   call 773 ntypeargs=0               (testing.subtree_may_be_selected)
         52   jump_if_false +6                   (to 58)
         53   pop 1                              
         54   load_var 13                        (ts)
         55   load_field 0                       (name)
         56   load_var2 4 5                      
-        57   call 772 ntypeargs=0               (testing.subtree_may_be_selected)
+        57   call 773 ntypeargs=0               (testing.subtree_may_be_selected)
         58   pop_jump_if_false -20              (to 38)
 
   599   59   load_var2 1 13                     
         60   load_var2 2 3                      
         61   load_var2 4 5                      
-        62   call 777 ntypeargs=0               (testing.collect_subtree_names_layered)
+        62   call 778 ntypeargs=0               (testing.collect_subtree_names_layered)
 
   600   63   load_type 10                       
         64   load_const 11                      ("iter")
@@ -3065,7 +3060,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         37   jump_if_false +4                   (to 41)
         38   pop 1                              
         39   load_var2 3 6                      
-        40   call 766 ntypeargs=0               (testing.glob_match)
+        40   call 767 ntypeargs=0               (testing.glob_match)
         41   pop_jump_if_false -32              (to 9)
 
   550   42   load_const 9                       (true)
@@ -3080,7 +3075,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
 
 function testing.subtree_may_be_selected(prefix: string, include: string[], exclude: string[]) -> bool {
   572   0    load_var2 1 3                      
-        1    call 770 ntypeargs=0               (testing.subtree_excluded)
+        1    call 771 ntypeargs=0               (testing.subtree_excluded)
         2    pop_jump_if_false +2               (to 4)
         3    jump +34                           (to 37)
 
@@ -3111,7 +3106,7 @@ function testing.subtree_may_be_selected(prefix: string, include: string[], excl
         27   store_var_load_var 7               (pattern)
 
   579   28   load_var 1                         (prefix)
-        29   call 771 ntypeargs=0               (testing.pattern_may_match_descendant)
+        29   call 772 ntypeargs=0               (testing.pattern_may_match_descendant)
         30   pop_jump_if_false -13              (to 17)
 
   580   31   load_const 6                       (true)
@@ -3138,7 +3133,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   294   6    load_var2 1 2         
 
   296   7    load_var 3            (runner)
-        8    make_closure 1358 2   
+        8    make_closure 1359 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   store_var 4           (_0)
         11   load_var 4            (_0)
@@ -3157,7 +3152,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   303   8    load_var2 1 2         
-        9    make_closure 1360 2   
+        9    make_closure 1361 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   store_var 3           (_0)
         12   load_var 3            (_0)
@@ -3180,7 +3175,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   315   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1362 3   
+        13   make_closure 1363 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   store_var 4           (_0)
         16   load_var 4            (_0)
@@ -3216,7 +3211,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 6                         (t)
         25   load_field 2                       (runner)
-        26   call 756 ntypeargs=0               (testing.test_child)
+        26   call 757 ntypeargs=0               (testing.test_child)
         27   store_var 7                        (_10)
         28   load_var2 3 7                      
         29   call 4 ntypeargs=0                 (baml.Array.push)
@@ -3243,7 +3238,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         49   store_var 10                       (ts)
 
   264   50   load_var2 1 10                     
-        51   call 757 ntypeargs=0               (testing.testset_child)
+        51   call 758 ntypeargs=0               (testing.testset_child)
         52   store_var 11                       (_21)
         53   load_var2 3 11                     
         54   call 4 ntypeargs=0                 (baml.Array.push)
@@ -3282,7 +3277,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   272   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 759 ntypeargs=0               (testing._name_selected)
+        23   call 760 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   273   25   load_var 7                         (t)
@@ -3291,7 +3286,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 7                         (t)
         30   load_field 2                       (runner)
-        31   call 756 ntypeargs=0               (testing.test_child)
+        31   call 757 ntypeargs=0               (testing.test_child)
         32   store_var 8                        (_13)
         33   load_var2 4 8                      
         34   call 4 ntypeargs=0                 (baml.Array.push)
@@ -3319,12 +3314,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   284   55   load_field 0                       (name)
         56   load_var 2                         (names)
-        57   call 760 ntypeargs=0               (testing._has_selected_descendant)
+        57   call 761 ntypeargs=0               (testing._has_selected_descendant)
         58   pop_jump_if_false -14              (to 44)
 
   285   59   load_var2 1 11                     
         60   load_var 2                         (names)
-        61   call 758 ntypeargs=0               (testing.testset_child_selected)
+        61   call 759 ntypeargs=0               (testing.testset_child_selected)
         62   store_var 12                       (_26)
         63   load_var2 4 12                     
         64   call 4 ntypeargs=0                 (baml.Array.push)
@@ -3346,7 +3341,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 800 ntypeargs=0   (user.score)
+       7    call 801 ntypeargs=0   (user.score)
        8    store_var 4            (base)
 
   11   9    load_var 4             (base)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/tests/bytecode_format/main.rs
+assertion_line: 41
 ---
 function assert.approx_equal(actual: float, expected: float, eps: float) -> null {
     load_var eps
@@ -180,12 +181,6 @@ function boundary.id() -> boundary.LocalId {
 }
 
 function boundary.id.current() -> string {
-}
-
-function reflect.call_any(f: baml.AnyFunction<Returns = #0, Throws = #1>, args: map<string, unknown>) -> #0 {
-}
-
-function reflect.signature(f: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> reflect.Signature {
 }
 
 function testing.$invoke_collector(collector: (testing.TestCollector) -> void throws unknown, c: testing.TestCollector) -> void {

--- a/baml_language/crates/baml_tests/tests/env.rs
+++ b/baml_language/crates/baml_tests/tests/env.rs
@@ -142,7 +142,7 @@ async fn runtime_constructed_openai_client_defaults_api_key_from_env() {
                     },
                 };
                 let prompt = baml.llm.assemble_prompt_ast(["Say hi"], []);
-                pc.build_request(prompt, reflect.type_of<string>()).headers
+                pc.build_request(prompt, type.of<string>()).headers
             }
         "#
     );
@@ -184,7 +184,7 @@ async fn anthropic_clients_default_api_key_from_env_at_runtime() {
                     },
                 };
                 let prompt = baml.llm.assemble_prompt_ast(["Say hi"], []);
-                let runtime = runtime_client.build_request(prompt, reflect.type_of<string>()).headers.get("x-api-key") ?? "missing";
+                let runtime = runtime_client.build_request(prompt, type.of<string>()).headers.get("x-api-key") ?? "missing";
                 { "declared": declared, "runtime": runtime }
             }
         "#

--- a/baml_language/crates/baml_tests/tests/interfaces.rs
+++ b/baml_language/crates/baml_tests/tests/interfaces.rs
@@ -1257,8 +1257,8 @@ fn reflect_class_implements_interface() {
         }
 
         function main() -> bool {
-            let dog_t = reflect.type_of<Dog>()
-            let animal_t = reflect.type_of<Animal>()
+            let dog_t = type.of<Dog>()
+            let animal_t = type.of<Animal>()
             return dog_t.implements(animal_t)
         }
         "#,
@@ -1279,8 +1279,8 @@ fn reflect_implemented_by_is_reverse() {
         }
 
         function main() -> bool {
-            let dog_t = reflect.type_of<Dog>()
-            let animal_t = reflect.type_of<Animal>()
+            let dog_t = type.of<Dog>()
+            let animal_t = type.of<Animal>()
             return animal_t.implemented_by(dog_t)
         }
         "#,
@@ -1308,7 +1308,7 @@ fn reflect_implementors_returns_type_array() {
         }
 
         function main() -> int {
-            let animal_t = reflect.type_of<Animal>()
+            let animal_t = type.of<Animal>()
             return animal_t.implementors().length()
         }
         "#,
@@ -3066,7 +3066,7 @@ async fn reflect_type_of_interface_to_string() {
             function speak(self) -> string throws never
         }
         function main() -> string {
-            return reflect.type_of<Animal>().to_string()
+            return type.of<Animal>().to_string()
         }
     "#
     );
@@ -3089,7 +3089,7 @@ async fn reflect_implements_true_for_implementor() {
             }
         }
         function main() -> bool {
-            return reflect.type_of<Dog>().implements(reflect.type_of<Animal>())
+            return type.of<Dog>().implements(type.of<Animal>())
         }
     "#
     );
@@ -3107,7 +3107,7 @@ async fn reflect_implements_false_for_non_implementor() {
             mass: int
         }
         function main() -> bool {
-            return reflect.type_of<Rock>().implements(reflect.type_of<Animal>())
+            return type.of<Rock>().implements(type.of<Animal>())
         }
     "#
     );
@@ -3127,8 +3127,8 @@ async fn reflect_implemented_by_inverse_runtime() {
             }
         }
         function main() -> bool {
-            let direct = reflect.type_of<Dog>().implements(reflect.type_of<Animal>())
-            let reverse = reflect.type_of<Animal>().implemented_by(reflect.type_of<Dog>())
+            let direct = type.of<Dog>().implements(type.of<Animal>())
+            let reverse = type.of<Animal>().implemented_by(type.of<Dog>())
             return direct == reverse
         }
     "#
@@ -3152,7 +3152,7 @@ async fn reflect_implements_transitive_via_requires() {
             }
         }
         function main() -> bool {
-            return reflect.type_of<Employee>().implements(reflect.type_of<Named>())
+            return type.of<Employee>().implements(type.of<Named>())
         }
     "#
     );
@@ -3180,10 +3180,10 @@ async fn reflect_implementors_lists_lexicographic_order_and_identity() {
             }
         }
         function main() -> bool {
-            let impls = reflect.type_of<Animal>().implementors()
+            let impls = type.of<Animal>().implementors()
             return impls.length() == 2
-                && impls[0] == reflect.type_of<Cat>()
-                && impls[1] == reflect.type_of<Dog>()
+                && impls[0] == type.of<Cat>()
+                && impls[1] == type.of<Dog>()
         }
     "#
     );
@@ -3198,7 +3198,7 @@ async fn reflect_implementors_empty_for_concrete_class() {
             breed: string
         }
         function main() -> int {
-            return reflect.type_of<Dog>().implementors().length()
+            return type.of<Dog>().implementors().length()
         }
     "#
     );
@@ -3210,7 +3210,7 @@ async fn reflect_implementors_empty_for_primitive() {
     let output = baml_test!(
         r#"
         function main() -> int {
-            return reflect.type_of<int>().implementors().length()
+            return type.of<int>().implementors().length()
         }
     "#
     );
@@ -3230,7 +3230,7 @@ async fn reflect_implements_inside_generic_function() {
             }
         }
         function is_animal<T>() -> bool {
-            return reflect.type_of<T>().implements(reflect.type_of<Animal>())
+            return type.of<T>().implements(type.of<Animal>())
         }
         function main() -> bool {
             return is_animal<Dog>() && is_animal<int>() == false
@@ -3249,7 +3249,7 @@ async fn reflect_interface_does_not_implement_itself() {
             function speak(self) -> string throws never
         }
         function main() -> bool {
-            return reflect.type_of<Animal>().implements(reflect.type_of<Animal>())
+            return type.of<Animal>().implements(type.of<Animal>())
         }
     "#
     );
@@ -5617,10 +5617,10 @@ async fn out_of_body_implements_is_visible_to_reflection_registry() {
             function speak(self) -> string { return "woof" }
         }
         function main() -> bool {
-            let impls = reflect.type_of<Animal>().implementors()
-            return reflect.type_of<Dog>().implements(reflect.type_of<Animal>())
+            let impls = type.of<Animal>().implementors()
+            return type.of<Dog>().implements(type.of<Animal>())
                 && impls.length() == 1
-                && impls[0] == reflect.type_of<Dog>()
+                && impls[0] == type.of<Dog>()
         }
         "#
     );
@@ -5841,7 +5841,7 @@ async fn generic_out_of_body_override_preserves_method_type_args_runtime() {
 
         implements<T> Describer<T> for Box<T> {
             function describe<U>(self, value: U) -> string {
-                return reflect.type_of<T>().to_string() + ":" + reflect.type_of<U>().to_string()
+                return type.of<T>().to_string() + ":" + type.of<U>().to_string()
             }
         }
 
@@ -6780,8 +6780,8 @@ async fn unified_rule_reflection_sees_generic_class_implementor_once() {
             function display(self) -> string { return "box" }
         }
         function main() -> bool {
-            let impls = reflect.type_of<Printable>().implementors()
-            return reflect.type_of<Box<int>>().implements(reflect.type_of<Printable>())
+            let impls = type.of<Printable>().implementors()
+            return type.of<Box<int>>().implements(type.of<Printable>())
                 && impls.length() == 1
         }
     "#
@@ -6924,7 +6924,7 @@ async fn form2_reflect_implements_returns_true() {
             function display(self) -> string { return self.name }
         }
         function main() -> bool {
-            return reflect.type_of<Person>().implements(reflect.type_of<Printable>())
+            return type.of<Person>().implements(type.of<Printable>())
         }
     "#
     );
@@ -6953,9 +6953,9 @@ async fn form2_reflect_implementors_includes_satisfying_classes() {
             function display(self) -> string { return self.name }
         }
         function main() -> bool {
-            let printable = reflect.type_of<Printable>()
-            return printable.implemented_by(reflect.type_of<Person>())
-                && printable.implemented_by(reflect.type_of<Team>())
+            let printable = type.of<Printable>()
+            return printable.implemented_by(type.of<Person>())
+                && printable.implemented_by(type.of<Team>())
                 && printable.implementors().length() == 2
         }
     "#
@@ -6975,12 +6975,12 @@ async fn blanket_interface_rule_reflection_includes_concrete_container_implement
         function main() -> bool {
             let int_printable: Printable<int> = Container<int> { value: 1 }
             let string_printable: Printable<string> = Container<string> { value: "two" }
-            return reflect.type_of<Container<int>>().implements(reflect.type_of<Printable<int>>())
-                && reflect.type_of<Container<string>>().implements(reflect.type_of<Printable<string>>())
-                && reflect.type_of<Printable<int>>().implemented_by(reflect.type_of<Container<int>>())
-                && reflect.type_of<Printable<string>>().implemented_by(reflect.type_of<Container<string>>())
-                && reflect.type_of<Printable<int>>().implementors().length() == 1
-                && reflect.type_of<Printable<string>>().implementors().length() == 1
+            return type.of<Container<int>>().implements(type.of<Printable<int>>())
+                && type.of<Container<string>>().implements(type.of<Printable<string>>())
+                && type.of<Printable<int>>().implemented_by(type.of<Container<int>>())
+                && type.of<Printable<string>>().implemented_by(type.of<Container<string>>())
+                && type.of<Printable<int>>().implementors().length() == 1
+                && type.of<Printable<string>>().implementors().length() == 1
         }
     "#
     );
@@ -9485,7 +9485,7 @@ class IntBox {
 function main() -> bool {
     // IntBox only implements Box<int>, NOT Box<string>, so this is false —
     // `implements` respects the generic type argument.
-    return reflect.type_of<IntBox>().implements(reflect.type_of<Box<string>>())
+    return type.of<IntBox>().implements(type.of<Box<string>>())
 }
 "##
     );
@@ -9508,7 +9508,7 @@ class IntBox {
 function main() -> bool {
     // Box<string>.implemented_by(IntBox) is false — IntBox only implements
     // Box<int>, and `implemented_by` respects the type argument.
-    return reflect.type_of<Box<string>>().implemented_by(reflect.type_of<IntBox>())
+    return type.of<Box<string>>().implemented_by(type.of<IntBox>())
 }
 "##
     );
@@ -9536,7 +9536,7 @@ class StringBox {
 function main() -> int {
     // Box<int>.implementors() returns just [IntBox] (length 1) — the type
     // argument filters out StringBox (which implements Box<string>).
-    return reflect.type_of<Box<int>>().implementors().length()
+    return type.of<Box<int>>().implementors().length()
 }
 "##
     );
@@ -9555,7 +9555,7 @@ class B { implements I {} }
 class C { implements I {} }
 
 function main() -> string {
-    let impls = reflect.type_of<I>().implementors()
+    let impls = type.of<I>().implementors()
     // Lexicographic by name: A,B,C
     return impls[0].to_string() + "," + impls[1].to_string() + "," + impls[2].to_string()
 }
@@ -10174,7 +10174,7 @@ fn wf3_generic_default_method_overlapping_type_arg_impls_rejected() {
     );
 }
 
-/// wf3 #6 [high]: `reflect.type_of<Box<U>>()` inside a generic fn must substitute
+/// wf3 #6 [high]: `type.of<Box<U>>()` inside a generic fn must substitute
 /// the outer type param `U` into the interface arg — rendering `Box<int>`, not
 /// `Box<void>`. `_plan/wf3/generics-reflection/gen_reflect_naked_vs_wrapped.baml`
 #[tokio::test]
@@ -10185,8 +10185,8 @@ async fn wf3_reflect_type_of_wrapped_generic_substitutes_param_runtime() {
             function get(self) -> T throws never
         }
         function names<U>() -> string {
-            let naked = reflect.type_of<U>().to_string()
-            let wrapped = reflect.type_of<Box<U>>().to_string()
+            let naked = type.of<U>().to_string()
+            let wrapped = type.of<Box<U>>().to_string()
             return "naked=" + naked + " wrapped=" + wrapped
         }
         function main() -> string {
@@ -10221,10 +10221,10 @@ async fn wf3_reflect_implemented_by_generic_arg_substitution_runtime() {
             }
         }
         function box_impls_intbox<T>() -> bool {
-            return reflect.type_of<Box<T>>().implemented_by(reflect.type_of<IntBox>())
+            return type.of<Box<T>>().implemented_by(type.of<IntBox>())
         }
         function box_impls_stringbox<T>() -> bool {
-            return reflect.type_of<Box<T>>().implemented_by(reflect.type_of<StringBox>())
+            return type.of<Box<T>>().implemented_by(type.of<StringBox>())
         }
         function main() -> bool {
             return box_impls_intbox<int>()
@@ -10561,8 +10561,8 @@ async fn wf3_out_of_body_primitive_impl_visible_to_reflection_runtime() {
             function debug(self) -> string { return "int" }
         }
         function main() -> int {
-            let a = reflect.type_of<int>().implements(reflect.type_of<Debuggable>())
-            let impls = reflect.type_of<Debuggable>().implementors()
+            let a = type.of<int>().implements(type.of<Debuggable>())
+            let impls = type.of<Debuggable>().implementors()
             if a { return 1000 + impls.length() }
             return impls.length()
         }
@@ -11062,7 +11062,7 @@ async fn wf3_concrete_field_shadows_interface_views_pins() {
 }
 
 /// wf3: a bare generic interface in a type-argument position
-/// (`reflect.type_of<Box>()`, no type args) is an arity error like any other
+/// (`type.of<Box>()`, no type args) is an arity error like any other
 /// type position — a generic head is written fully explicit or inferred
 /// wholesale, never a partial wildcard. (This replaces the old undocumented
 /// wildcard-matching behavior; a deliberate every-instantiation reflection
@@ -11081,8 +11081,8 @@ async fn wf3_bare_generic_interface_reflection_is_arity_error() {
             }
         }
         function main() -> bool {
-            let bare = reflect.type_of<Box>()
-            return bare.implemented_by(reflect.type_of<IntBox>())
+            let bare = type.of<Box>()
+            return bare.implemented_by(type.of<IntBox>())
         }
         "#,
         "type `Box` expects 1 type argument(s), got 0",
@@ -11106,7 +11106,7 @@ async fn wf3_blanket_implementor_identity_is_bare_class_pins() {
             function display(self) -> string { return "box" }
         }
         function main() -> string {
-            let p = reflect.type_of<Printable>()
+            let p = type.of<Printable>()
             return p.implementors()[0].to_string()
         }
         "#
@@ -11200,9 +11200,9 @@ async fn union_fuzz_pr_reflection_nested_union_arg_order_insensitive() {
           }
         }
         function main() -> int {
-          let ub = reflect.type_of<UBox>()
-          let fwd = reflect.type_of<Box<(int | string)?>>()
-          let rev = reflect.type_of<Box<(string | int)?>>()
+          let ub = type.of<UBox>()
+          let fwd = type.of<Box<(int | string)?>>()
+          let rev = type.of<Box<(string | int)?>>()
           let a = 0
           if ub.implements(fwd) { a = a + 1 }
           if ub.implements(rev) { a = a + 10 }
@@ -11369,11 +11369,11 @@ async fn union_fuzz_pr_reflection_duplicate_union_members_not_equivalent() {
           implements Box<int | int> { function get(self) -> int | int { return self.value } }
         }
         function main() -> int {
-          let ub = reflect.type_of<UBox>()
+          let ub = type.of<UBox>()
           let a = 0
           // UBox implements Box<int | int>, NOT Box<int | string>.
-          if ub.implements(reflect.type_of<Box<int | int>>()) { a = a + 1 }
-          if ub.implements(reflect.type_of<Box<int | string>>()) { a = a + 10 }
+          if ub.implements(type.of<Box<int | int>>()) { a = a + 1 }
+          if ub.implements(type.of<Box<int | string>>()) { a = a + 10 }
           return a
         }
         "#
@@ -11552,9 +11552,9 @@ async fn union_fuzz_f06_reflection_generic_union_arg_order_insensitive() {
           }
         }
         function main() -> int {
-          let ub = reflect.type_of<UBox>()
-          let fwd = reflect.type_of<Box<int | string>>()
-          let rev = reflect.type_of<Box<string | int>>()
+          let ub = type.of<UBox>()
+          let fwd = type.of<Box<int | string>>()
+          let rev = type.of<Box<string | int>>()
           let d1 = 0
           if ub.implements(fwd) { d1 = 1 }
           let d2 = 0

--- a/baml_language/crates/baml_tests/tests/interfaces_associated_types.rs
+++ b/baml_language/crates/baml_tests/tests/interfaces_associated_types.rs
@@ -4028,10 +4028,10 @@ async fn reflection_bounded_impl_cycle_terminates() {
 
         function main() -> int {
             let score = 0
-            if reflect.type_of<Node>().implements(reflect.type_of<A>()) {
+            if type.of<Node>().implements(type.of<A>()) {
                 score = score + 1
             }
-            if reflect.type_of<Node>().implements(reflect.type_of<B>()) {
+            if type.of<Node>().implements(type.of<B>()) {
                 score = score + 10
             }
             return score

--- a/baml_language/crates/baml_tests/tests/prompt_tag_runtime.rs
+++ b/baml_language/crates/baml_tests/tests/prompt_tag_runtime.rs
@@ -318,7 +318,7 @@ function main() -> baml.llm.PromptAst {
 #[tokio::test]
 async fn prompt_interpolates_ctx_output_format() {
     // BEP-049 M5b: `${ctx.output_format}` renders the return type's schema.
-    // `render_output_format(reflect.type_of<Person>())` produces the schema
+    // `render_output_format(type.of<Person>())` produces the schema
     // string the orchestrator will later populate `Context.output_format` with;
     // here we wire it by hand and assert the assembled prompt embeds the schema.
     let output = baml_test!(
@@ -330,7 +330,7 @@ class Person {
 
 function main() -> baml.llm.PromptAst {
   let cc = baml.llm.ContextClient { name: "c", provider: "openai", default_role: "user", allowed_roles: ["user"] }
-  let of = baml.llm.render_output_format(reflect.type_of<Person>())
+  let of = baml.llm.render_output_format(type.of<Person>())
   let ctx = baml.llm.Context { client: cc, tags: {}, output_format: of }
   let render = baml.llm.prompt`Answer using this schema:
 ${ctx.output_format}`
@@ -366,7 +366,7 @@ class Person {
 
 function main() -> baml.llm.PromptAst {
   let cc = baml.llm.ContextClient { name: "c", provider: "openai", default_role: "user", allowed_roles: ["user"] }
-  let rt = reflect.type_of<Person>()
+  let rt = type.of<Person>()
   let ctx = baml.llm.Context { client: cc, tags: {}, output_format: baml.llm.render_output_format(rt), _output_format: baml.llm.build_output_format(rt) }
   let render = baml.llm.prompt`${ctx.output_format_with(prefix = "Use this exact schema:")}`
   render(ctx)
@@ -402,7 +402,7 @@ class Person {
 
 function main() -> baml.llm.PromptAst {
   let cc = baml.llm.ContextClient { name: "c", provider: "openai", default_role: "user", allowed_roles: ["user"] }
-  let rt = reflect.type_of<Person>()
+  let rt = type.of<Person>()
   let ctx = baml.llm.Context { client: cc, tags: {}, output_format: baml.llm.render_output_format(rt), _output_format: baml.llm.build_output_format(rt) }
   let render = baml.llm.prompt`${ctx.output_format_with(quote_class_fields = true)}`
   render(ctx)
@@ -427,7 +427,7 @@ class Person {
 
 function main() -> baml.llm.PromptAst {
   let cc = baml.llm.ContextClient { name: "c", provider: "openai", default_role: "user", allowed_roles: ["user"] }
-  let rt = reflect.type_of<Person>()
+  let rt = type.of<Person>()
   let ctx = baml.llm.Context { client: cc, tags: {}, output_format: baml.llm.render_output_format(rt), _output_format: baml.llm.build_output_format(rt) }
   let render = baml.llm.prompt`${ctx.output_format_with(render_null_as = "omit")}`
   render(ctx)

--- a/baml_language/crates/baml_tests/tests/reflect_call_any.rs
+++ b/baml_language/crates/baml_tests/tests/reflect_call_any.rs
@@ -395,8 +395,8 @@ async fn signature_object_literal_construction() {
             let manual = reflect.Signature {
                 args: [],
                 opts: {},
-                returns: reflect.type_of<int>(),
-                errors: reflect.type_of<never>(),
+                returns: type.of<int>(),
+                errors: type.of<never>(),
                 docstring: null,
             }
             return manual.returns.to_string() + "|" + manual.errors.to_string()

--- a/baml_language/crates/baml_tests/tests/streaming_parsing.rs
+++ b/baml_language/crates/baml_tests/tests/streaming_parsing.rs
@@ -56,7 +56,7 @@ fn streaming_llm_source(base_url: &str) -> String {
 /// `<TStream, TFinal>` — they are inferred from the let-binding annotation
 /// (TIR phase-0 reverse inference, persisted in `CallPlan.type_args`,
 /// materialized into the callee frame by MIR) and reified inside
-/// `__make_stream` via `reflect.type_of<TStream/TFinal>()`. There is no
+/// `__make_stream` via `type.of<TStream/TFinal>()`. There is no
 /// name-keyed registry fallback anymore; a propagation gap surfaces as a
 /// "Non-parsable type: ..." crash from `StreamCache.new`.
 #[tokio::test]
@@ -107,7 +107,7 @@ async fn stream_string_final_value() {
 ///      doesn't exist.
 /// The stream type now travels only through the PPIR-synthesized companion
 /// (signature + explicit type args) and is reified via
-/// `reflect.type_of<TStream/TFinal>()` in `__make_stream` — there is no
+/// `type.of<TStream/TFinal>()` in `__make_stream` — there is no
 /// baked `stream_return_type` metadata left to diverge. See
 /// thoughts/sam-projects/bridge-generics/streaming/00 + 01 and the
 /// live-OpenAI coverage in `sdk_tests/.../test_streaming_class_e2e.py`.

--- a/baml_language/crates/baml_tests/tests/type_kinds.rs
+++ b/baml_language/crates/baml_tests/tests/type_kinds.rs
@@ -1,0 +1,261 @@
+//! BEP-066 slice-1 capstone oracles for the nine sealed reflection-kind views.
+
+use baml_tests::baml_test;
+use bex_engine::BexExternalValue;
+
+#[tokio::test]
+async fn kind_union_is_exhaustive_and_classifies_all_nine_kinds() {
+    let output = baml_test!(
+        r#"
+        class Foo { value int }
+        enum Color { Red Blue }
+        interface Marker {}
+        type Callback = (x: int, label: string) -> bool throws never
+
+        function classify(t: type) -> string {
+            match (t.kind()) {
+                baml.reflect.class.Type => "class",
+                baml.reflect.enum.Type => "enum",
+                baml.reflect.union.Type => "union",
+                baml.reflect.literal.Type => "literal",
+                baml.reflect.array.Type => "array",
+                baml.reflect.map.Type => "map",
+                baml.reflect.interface.Type => "interface",
+                baml.reflect.primitive.Type => "primitive",
+                baml.reflect.function.Type => "function"
+            }
+        }
+
+        function main() -> bool {
+            classify(type.of<Foo>()) == "class"
+                && classify(type.of<Color>()) == "enum"
+                && classify(type.of<int | string>()) == "union"
+                && classify(type.of<"fixed">()) == "literal"
+                && classify(type.of<int[]>()) == "array"
+                && classify(type.of<map<string, int>>()) == "map"
+                && classify(type.of<Marker>()) == "interface"
+                && classify(type.of<int>()) == "primitive"
+                && classify(type.of<Callback>()) == "function"
+        }
+        "#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn kind_casts_are_nullable_identity_preserving_views() {
+    let output = baml_test!(
+        r#"
+        class Foo { value int }
+
+        function main() -> bool throws string {
+            let t = type.of<Foo>();
+            let view = t.as_class() ?? throw "expected class kind";
+            let optional_count = t.as_class()?.fields()?.length();
+
+            t.kind().as_type() == t
+                && view.as_type() == t
+                && view == (t.as_class() ?? throw "expected the same class kind")
+                && optional_count == 1
+                && t.as_enum() == null
+                && type.of<int>().as_class() == null
+                && type.of<int>().as_primitive()?.as_type() == type.of<int>()
+                && type.of<Foo>() is type
+        }
+        "#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn class_and_enum_readback_preserves_schema_metadata() {
+    let output = baml_test!(
+        r#"
+        /// Person docs
+        class Person {
+            /// Name docs
+            name string @alias("full_name") @description("Name description") @custom("field-extra")
+            @@alias("PersonAlias")
+            @@description("Person description")
+            @@custom("class-extra")
+        }
+
+        /// Color docs
+        enum Color {
+            /// Red docs
+            Red @alias("rouge") @description("Red description") @custom("variant-extra")
+            Blue
+            @@alias("ColorAlias")
+            @@description("Color description")
+            @@custom("enum-extra")
+        }
+
+        function main() -> bool throws string {
+            let class_view = type.of<Person>().as_class() ?? throw "class";
+            let class_meta = class_view.meta();
+            let field = class_view.fields()[0];
+            let enum_view = type.of<Color>().as_enum() ?? throw "enum";
+            let enum_meta = enum_view.meta();
+            let red = enum_view.values()[0];
+
+            class_meta.alias == "PersonAlias"
+                && class_meta.description == "Person description"
+                && class_meta.docstring == "Person docs"
+                && class_meta.other.get("custom") == "class-extra"
+                && field.name == "name"
+                && field.type == type.of<string>()
+                && field.meta.alias == "full_name"
+                && field.meta.description == "Name description"
+                && field.meta.docstring == "Name docs"
+                && field.meta.other.get("custom") == "field-extra"
+                && enum_meta.alias == "ColorAlias"
+                && enum_meta.description == "Color description"
+                && enum_meta.docstring == "Color docs"
+                && enum_meta.other.get("custom") == "enum-extra"
+                && red.name == "Red"
+                && red.meta.alias == "rouge"
+                && red.meta.description == "Red description"
+                && red.meta.docstring == "Red docs"
+                && red.meta.other.get("custom") == "variant-extra"
+        }
+        "#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn nested_type_walker_and_kind_specific_readback_work_end_to_end() {
+    let output = baml_test!(
+        r#"
+        interface Marker {
+            function mark(self) -> string throws never
+        }
+
+        class Foo {
+            value int
+            implements Marker {
+                function mark(self) -> string throws never { "foo" }
+            }
+        }
+        enum Color { Red }
+        type Callback = (x: int, label: string) -> bool throws string
+
+        function walk(t: type) -> int {
+            match (t.kind()) {
+                let class_view: baml.reflect.class.Type => 1,
+                let enum_view: baml.reflect.enum.Type => 1,
+                let union_view: baml.reflect.union.Type => {
+                    let count = 1;
+                    for let member in union_view.member_types() {
+                        count += walk(member)
+                    }
+                    count
+                },
+                let literal_view: baml.reflect.literal.Type => 1,
+                let array_view: baml.reflect.array.Type => 1 + walk(array_view.element_type()),
+                let map_view: baml.reflect.map.Type => 1,
+                let interface_view: baml.reflect.interface.Type => 1,
+                let primitive_view: baml.reflect.primitive.Type => 1,
+                let function_view: baml.reflect.function.Type => 1
+            }
+        }
+
+        function read_views(
+            union_view: baml.reflect.union.Type,
+            array_view: baml.reflect.array.Type,
+            map_view: baml.reflect.map.Type,
+            interface_view: baml.reflect.interface.Type,
+            function_view: baml.reflect.function.Type
+        ) -> bool throws never {
+            let params = function_view.params();
+            let function_schema = match (type.of<baml.reflect.function.Type>().kind()) {
+                let class_view: baml.reflect.class.Type => class_view,
+                _ => return false
+            };
+            union_view.member_types().length() == 2
+                && array_view.element_type() == type.of<Foo>()
+                && map_view.key_type() == type.of<string>()
+                && map_view.value_type() == type.of<Foo>()
+                && interface_view.implemented_by(type.of<Foo>())
+                && params.length() == 2
+                && params[0].name == "x"
+                && params[0].type == type.of<int>()
+                && params[0].optional == false
+                && params[1].name == "label"
+                && params[1].type == type.of<string>()
+                && function_view.return_type() == type.of<bool>()
+                && function_schema.fields().length() == 0
+        }
+
+        function intrinsic_checks() -> bool throws never {
+            type.of_value(1) == type.of<int>()
+                && type.of_value(1).as_primitive() != null
+                && type.of<Foo>().to_string() == "Foo"
+                && type.of<int>().to_string() == "int"
+                && type.of<Color>().to_string() != ""
+                && type.of<int | string>().to_string() != ""
+                && type.of<"fixed">().to_string() != ""
+                && type.of<Foo[]>().to_string() != ""
+                && type.of<map<string, Foo>>().to_string() != ""
+                && type.of<Marker>().to_string() != ""
+                && type.of<Callback>().to_string() != ""
+        }
+
+        function casts_are_never_throwing(t: type) -> bool throws never {
+            t.as_class() != null
+                && t.as_enum() == null
+                && t.as_union() == null
+                && t.as_literal() == null
+                && t.as_array() == null
+                && t.as_map() == null
+                && t.as_interface() == null
+                && t.as_primitive() == null
+                && t.as_function() == null
+        }
+
+        function all_positive_kind_casts_work() -> bool throws never {
+            type.of<Foo>().as_class() != null
+                && type.of<Color>().as_enum() != null
+                && type.of<int | string>().as_union() != null
+                && type.of<"fixed">().as_literal() != null
+                && type.of<Foo[]>().as_array() != null
+                && type.of<map<string, Foo>>().as_map() != null
+                && type.of<Marker>().as_interface() != null
+                && type.of<int>().as_primitive() != null
+                && type.of<Callback>().as_function() != null
+        }
+
+        function kind_identity(t: type) -> bool throws never {
+            t.kind().as_type() == t
+        }
+
+        function every_kind_preserves_identity() -> bool throws never {
+            kind_identity(type.of<Foo>())
+                && kind_identity(type.of<Color>())
+                && kind_identity(type.of<int | string>())
+                && kind_identity(type.of<"fixed">())
+                && kind_identity(type.of<Foo[]>())
+                && kind_identity(type.of<map<string, Foo>>())
+                && kind_identity(type.of<Marker>())
+                && kind_identity(type.of<int>())
+                && kind_identity(type.of<Callback>())
+        }
+
+        function main() -> bool throws unknown {
+            let union_view = type.of<int | string>().as_union() ?? throw "union";
+            let array_view = type.of<Foo[]>().as_array() ?? throw "array";
+            let map_view = type.of<map<string, Foo>>().as_map() ?? throw "map";
+            let interface_view = type.of<Marker>().as_interface() ?? throw "interface";
+            let function_view = type.of<Callback>().as_function() ?? throw "function";
+
+            walk(type.of<(Foo | string[])[]>()) == 5
+                && read_views(union_view, array_view, map_view, interface_view, function_view)
+                && intrinsic_checks()
+                && casts_are_never_throwing(type.of<Foo>())
+                && all_positive_kind_casts_work()
+                && every_kind_preserves_identity()
+        }
+        "#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}

--- a/baml_language/crates/baml_tests/tests/type_value_equality.rs
+++ b/baml_language/crates/baml_tests/tests/type_value_equality.rs
@@ -1,22 +1,11 @@
-//! Function-context pins for equality on `type` values.
+//! Function-context pins for BEP-066 minted equality on `type` values.
 //!
-//! CHARACTERIZATION of a known inconsistency (do not read these as the
-//! intended semantics): BAML currently has divergent equality
-//! implementations for `type` values —
-//!
-//! * `==` lowers through the `baml.ops.equals_equals` driver and compares
-//!   type values with `vm.equivalent(..)` (canonical equivalence — union
-//!   member order is irrelevant): `bex_vm/src/package_baml/ops.rs`.
-//! * `baml.deep_equals` uses the derived `PartialEq` on `RealizedTy`
-//!   (syntactic equality — union member order matters):
-//!   `bex_vm/src/package_baml/root.rs`.
-//!
-//! The follow-up s1-mint-identity PR replaces both with a single
-//! mint-identity comparison; update these pins together with it.
-//! Diagnosis: thoughts/antonio/s1-vm-bug-diagnosis.md. The matching
-//! test-block-context pins live in
-//! `baml_src/ns_type_reflection/type_reflection.baml` — both contexts must
-//! agree (the historical context divergence was the #3782 lowering bug).
+//! PR 1 characterized a known inconsistency: `==` canonicalized `RealizedTy`
+//! while `baml.deep_equals` compared it syntactically. BEP-066 slice-1 PR 4
+//! deliberately flips the deep-equality pin. Every equality path now compares
+//! the mint, and equivalent static spellings receive the same canonical digest.
+//! Matching test-block pins live in
+//! `baml_src/ns_type_reflection/type_reflection.baml`.
 
 use baml_tests::baml_test;
 use bex_engine::BexExternalValue;
@@ -37,7 +26,7 @@ async fn permuted_union_double_equals_is_canonical() {
 }
 
 #[tokio::test]
-async fn permuted_union_deep_equals_is_syntactic() {
+async fn permuted_union_deep_equals_uses_the_canonical_mint() {
     let output = baml_test!(
         r#"
         function main() -> bool {
@@ -47,7 +36,54 @@ async fn permuted_union_deep_equals_is_syntactic() {
         }
         "#
     );
-    // Syntactic comparison: member order matters, disagreeing with `==`
-    // above. Known bug — resolved by s1-mint-identity.
-    assert_eq!(output.result, Ok(BexExternalValue::Bool(false)));
+    // Flipped in BEP-066 slice-1 PR 4: deep_equals agrees with `==` because
+    // both compare the same canonical static mint.
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn static_declaration_identity_survives_re_evaluation_and_a_helper_boundary() {
+    let output = baml_test!(
+        r#"
+        class Foo { value int }
+
+        function foo_type() -> type {
+            type.of<Foo>()
+        }
+
+        function main() -> bool {
+            type.of<Foo>() == type.of<Foo>()
+                && type.of<Foo>() == foo_type()
+                && foo_type() == foo_type()
+        }
+        "#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn of_value_reuses_the_static_class_identity() {
+    let output = baml_test!(
+        r#"
+        class Foo { value int }
+
+        function main() -> bool {
+            let foo = Foo { value: 1 };
+            type.of_value(foo) == type.of<Foo>()
+        }
+        "#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+#[tokio::test]
+async fn optional_and_explicit_null_union_share_a_static_identity() {
+    let output = baml_test!(
+        r#"
+        function main() -> bool {
+            type.of<string?>() == type.of<string | null>()
+        }
+        "#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
 }

--- a/baml_language/crates/baml_tests/tests/type_value_equality.rs
+++ b/baml_language/crates/baml_tests/tests/type_value_equality.rs
@@ -26,8 +26,8 @@ async fn permuted_union_double_equals_is_canonical() {
     let output = baml_test!(
         r#"
         function main() -> bool {
-            let a = reflect.type_of<int | string>();
-            let b = reflect.type_of<string | int>();
+            let a = type.of<int | string>();
+            let b = type.of<string | int>();
             a == b
         }
         "#
@@ -41,8 +41,8 @@ async fn permuted_union_deep_equals_is_syntactic() {
     let output = baml_test!(
         r#"
         function main() -> bool {
-            let a = reflect.type_of<int | string>();
-            let b = reflect.type_of<string | int>();
+            let a = type.of<int | string>();
+            let b = type.of<string | int>();
             baml.deep_equals(a, b)
         }
         "#

--- a/baml_language/crates/baml_type/src/lib.rs
+++ b/baml_language/crates/baml_type/src/lib.rs
@@ -43,6 +43,7 @@ mod runtime_ty;
 pub mod simplify_sap;
 pub mod template;
 pub mod throw_facts;
+pub mod type_kind;
 pub mod typetag;
 pub use attr::*;
 pub use defs::*;

--- a/baml_language/crates/baml_type/src/normalize.rs
+++ b/baml_language/crates/baml_type/src/normalize.rs
@@ -472,6 +472,113 @@ pub fn is_subtype<C: TypeContext>(sub: &Ty, sup: &Ty, ctx: &C) -> bool {
     ctx.is_subtype(sub, sup)
 }
 
+/// A deterministic 64-bit digest of `ty`'s **canonical form** under `ctx` —
+/// the identity basis for statically-spelled runtime `type` values (BEP-066
+/// `MintId::Static`).
+///
+/// Exact basis: canonicalize `ty` (the same walk [`TypeContext::equivalent`]
+/// performs on each operand — unique representative of the equirecursive
+/// equivalence class, so μ-recursion, union ordering, attr erasure, and every
+/// context fact are already folded in), serialize its derived `Hash` token
+/// stream with every numeric token in big-endian fixed width (`usize`/`isize`
+/// widened to 64 bits), then feed those bytes into fixed-seed FNV-1a-64
+/// (offset basis `0xcbf29ce484222325`, prime `0x100000001b3`). Consequences:
+///
+/// * `equivalent(a, b, ctx)` ⟹ `canonical_digest(a, ctx) ==
+///   canonical_digest(b, ctx)` — equivalent spellings (`string?` vs
+///   `string | null`, permuted unions, renamed recursive aliases) share a
+///   digest. The converse holds up to 64-bit collision odds, which the mint
+///   design accepts (a collision over-equates two *static* types).
+/// * The digest hashes only value data (names as strings, structure, de
+///   Bruijn indices — canonical `NormalTy` equality is α-invariant and its
+///   display metadata is hash-transparent). No pointers, no interner state:
+///   two processes running the same build over the same program facts produce
+///   identical digests.
+/// * The digest is **not** an on-wire format (BEP-066 H-4: identity never
+///   crosses the boundary). It may change across compiler versions — nothing
+///   may persist it; a decoded type value re-derives its mint.
+/// * Determinism requires only that `ctx` answers from immutable program
+///   facts, as the VM's context does; digests minted under *different* fact
+///   sets (e.g. a fact-free boundary context) agree exactly when
+///   canonicalization never consults a fact that differs.
+pub fn canonical_digest<C: TypeContext>(ty: &Ty, ctx: &C) -> u64 {
+    /// FNV-1a, 64-bit. Local on purpose: the digest contract above is this
+    /// exact algorithm; routing through a swappable `Hasher` dependency would
+    /// invite silently changing the basis.
+    struct Fnv1a(u64);
+
+    impl std::hash::Hasher for Fnv1a {
+        fn finish(&self) -> u64 {
+            self.0
+        }
+
+        fn write(&mut self, bytes: &[u8]) {
+            for byte in bytes {
+                self.0 ^= u64::from(*byte);
+                self.0 = self.0.wrapping_mul(0x100_0000_01b3);
+            }
+        }
+
+        // `Hasher`'s default integer methods use native-endian bytes, which
+        // would make the digest architecture-dependent. Override the complete
+        // numeric surface so the derived `Hash` walk becomes a canonical byte
+        // serialization. Lengths and enum discriminants written as pointer-
+        // sized integers are widened, making 32- and 64-bit processes agree.
+        fn write_u8(&mut self, value: u8) {
+            self.write(&value.to_be_bytes());
+        }
+
+        fn write_u16(&mut self, value: u16) {
+            self.write(&value.to_be_bytes());
+        }
+
+        fn write_u32(&mut self, value: u32) {
+            self.write(&value.to_be_bytes());
+        }
+
+        fn write_u64(&mut self, value: u64) {
+            self.write(&value.to_be_bytes());
+        }
+
+        fn write_u128(&mut self, value: u128) {
+            self.write(&value.to_be_bytes());
+        }
+
+        fn write_usize(&mut self, value: usize) {
+            self.write_u64(value as u64);
+        }
+
+        fn write_i8(&mut self, value: i8) {
+            self.write(&value.to_be_bytes());
+        }
+
+        fn write_i16(&mut self, value: i16) {
+            self.write(&value.to_be_bytes());
+        }
+
+        fn write_i32(&mut self, value: i32) {
+            self.write(&value.to_be_bytes());
+        }
+
+        fn write_i64(&mut self, value: i64) {
+            self.write(&value.to_be_bytes());
+        }
+
+        fn write_i128(&mut self, value: i128) {
+            self.write(&value.to_be_bytes());
+        }
+
+        fn write_isize(&mut self, value: isize) {
+            self.write_i64(value as i64);
+        }
+    }
+
+    let canonical = NormalTy::canonical(ty, ctx);
+    let mut hasher = Fnv1a(0xcbf2_9ce4_8422_2325);
+    std::hash::Hash::hash(&canonical, &mut hasher);
+    std::hash::Hasher::finish(&hasher)
+}
+
 /// True only when `a` and `b` provably canonicalize to different forms, judged
 /// from their outermost constructor alone — a cheap reject for [`TypeContext::
 /// equivalent`] that skips the two canonicalization walks on the common
@@ -662,6 +769,9 @@ impl NormalTy {
             NormalTy::Type => Category::Type,
             NormalTy::Resource => Category::Resource,
             NormalTy::PromptAst => Category::PromptAst,
+            NormalTy::Class(name, _) if crate::type_kind::is_type_kind_class(name) => {
+                Category::Type
+            }
             NormalTy::Class(..) => Category::Class,
             NormalTy::List(_) => Category::List,
             NormalTy::Map { .. } => Category::Map,
@@ -1921,6 +2031,14 @@ impl NormalTy {
                 a1.iter()
                     .zip(a2.iter())
                     .all(|(a, b)| a.invariant_compatible(b, ctx, assumptions))
+            }
+            // BEP-066: the nine reflection-kind classes form one sealed family
+            // beneath the `type` carrier. Because membership is hard-coded to
+            // builtin qualified names, user classes cannot acquire this edge.
+            (NormalTy::Class(name, _), NormalTy::Type)
+                if crate::type_kind::is_type_kind_class(name) =>
+            {
+                true
             }
             (NormalTy::List(a), NormalTy::List(b)) => a.invariant_compatible(b, ctx, assumptions),
             (NormalTy::Map { key: k1, value: v1 }, NormalTy::Map { key: k2, value: v2 }) => {

--- a/baml_language/crates/baml_type/src/template.rs
+++ b/baml_language/crates/baml_type/src/template.rs
@@ -199,7 +199,7 @@ impl TyTemplate {
             // frame always supplies every slot the template can reference: the
             // compiler seeds generic frames at full declared width, with an
             // unconstrained parameter seeded as an explicit `unknown` (so
-            // `reflect.type_of<T>()` under an unknown-typed call still reflects
+            // `type.of<T>()` under an unknown-typed call still reflects
             // the honest top type through a real slot). An out-of-range index is
             // therefore a frame-layout bug — reported, never silently realized.
             Self::TypeArgRef(n) => match type_args.get(*n as usize) {

--- a/baml_language/crates/baml_type/src/type_kind.rs
+++ b/baml_language/crates/baml_type/src/type_kind.rs
@@ -1,0 +1,99 @@
+//! Closed BEP-066 reflection-kind classification.
+
+use crate::{ConcreteRealizedTy, Name, QualifiedTypeName, RealizedTy, TyAttr};
+
+/// The nine sealed runtime views of a reflected `type` value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TypeKind {
+    Class,
+    Enum,
+    Union,
+    Literal,
+    Array,
+    Map,
+    Interface,
+    Primitive,
+    Function,
+}
+
+impl TypeKind {
+    pub const ALL: [Self; 9] = [
+        Self::Class,
+        Self::Enum,
+        Self::Union,
+        Self::Literal,
+        Self::Array,
+        Self::Map,
+        Self::Interface,
+        Self::Primitive,
+        Self::Function,
+    ];
+
+    pub const fn namespace(self) -> &'static str {
+        match self {
+            Self::Class => "class",
+            Self::Enum => "enum",
+            Self::Union => "union",
+            Self::Literal => "literal",
+            Self::Array => "array",
+            Self::Map => "map",
+            Self::Interface => "interface",
+            Self::Primitive => "primitive",
+            Self::Function => "function",
+        }
+    }
+
+    /// The builtin class that is the sealed view for this kind.
+    pub fn class_name(self) -> QualifiedTypeName {
+        QualifiedTypeName::new(
+            Name::new("baml"),
+            vec![Name::new("reflect"), Name::new(self.namespace())],
+            Name::new("Type"),
+        )
+    }
+
+    pub fn concrete_class_ty(self) -> ConcreteRealizedTy {
+        ConcreteRealizedTy::Class(self.class_name(), Vec::new(), TyAttr::default())
+    }
+}
+
+/// Classify every realized runtime type into exactly one reflection kind.
+pub fn classify_type(ty: &RealizedTy) -> TypeKind {
+    match ty {
+        RealizedTy::Class(..) => TypeKind::Class,
+        RealizedTy::Enum(..) => TypeKind::Enum,
+        RealizedTy::Union(..) => TypeKind::Union,
+        RealizedTy::Literal(..) | RealizedTy::EnumVariant(..) => TypeKind::Literal,
+        RealizedTy::List(..) => TypeKind::Array,
+        RealizedTy::Map { .. } => TypeKind::Map,
+        RealizedTy::Interface(..) => TypeKind::Interface,
+        RealizedTy::Function { .. } => TypeKind::Function,
+        _ => TypeKind::Primitive,
+    }
+}
+
+/// Whether a nominal class is one of the nine sealed reflection-kind classes.
+pub fn is_type_kind_class(name: &QualifiedTypeName) -> bool {
+    name.package().as_str() == "baml"
+        && name.namespace().len() == 2
+        && name.namespace()[0].as_str() == "reflect"
+        && TypeKind::ALL
+            .iter()
+            .any(|kind| name.namespace()[1].as_str() == kind.namespace())
+        && name.name().as_str() == "Type"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn kind_names_are_closed_and_recognized() {
+        for kind in TypeKind::ALL {
+            assert!(is_type_kind_class(&kind.class_name()));
+        }
+        assert!(!is_type_kind_class(&QualifiedTypeName::from_dotted_path(
+            "baml.reflect.Type"
+        )));
+    }
+}

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -5,7 +5,7 @@
 //! representation (`BexValue`, `BexExternalValue`).
 
 use ::bex_heap::{BexValue, HeapPermit, PermitProof, TlabHolder};
-use ::bex_vm_types::{HeapPtr, Object, ObjectType, RootHaver, Value, ValueKind};
+use ::bex_vm_types::{HeapPtr, Object, ObjectType, Value, ValueKind};
 use baml_type::{Literal, Ty};
 use bex_external_types::{
     BexExternalAdt, BexExternalValue, HostValueKind, RuntimeTy, UnionMetadata,
@@ -13,7 +13,7 @@ use bex_external_types::{
 };
 use bex_vm::BexVm;
 
-use crate::{BexEngine, EngineError};
+use crate::{BexEngine, EngineError, thread::BexThread};
 
 /// Narrow a host-supplied [`RuntimeTy`] to the [`baml_type::RealizedTy`] the VM
 /// heap stores for a value's type (an array's element type, a map's key/value
@@ -376,8 +376,9 @@ impl BexEngine {
             }),
             Object::Bigint(bi) => Ok(BexExternalValue::Bigint((**bi).clone())),
             Object::Collector(c) => Ok(BexExternalValue::Adt(BexExternalAdt::Collector(c.clone()))),
-            Object::Type(ty) => Ok(BexExternalValue::Adt(BexExternalAdt::Type(
-                (**ty).clone().into(),
+            // Identity never crosses the host boundary (BEP-066 H-4).
+            Object::Type(type_value) => Ok(BexExternalValue::Adt(BexExternalAdt::Type(
+                type_value.ty.clone().into(),
             ))),
             Object::Uint8Array(bytes) => Ok(BexExternalValue::Uint8Array(bytes.to_vec())),
             Object::RustData(arc) => Ok(bex_external_types::try_convert_rust_data(arc)
@@ -713,9 +714,9 @@ impl BexEngine {
     /// external input — from `--json-args`, language bindings, or buggy
     /// sys ops — surfaces as a graceful error instead of crashing the
     /// process.
-    pub(crate) fn convert_external_to_vm_value<T: RootHaver + TlabHolder>(
+    pub(crate) fn convert_external_to_vm_value(
         &self,
-        holder: &mut impl HeapPermit<T>,
+        holder: &mut impl HeapPermit<BexThread>,
         external: BexExternalValue,
     ) -> Result<Value, EngineError> {
         // Default: no declared-type context. Inbound `HostValue` arguments
@@ -731,9 +732,9 @@ impl BexEngine {
     /// context for their payload subtree; unannotated children inherit their
     /// list, map, or class-field type from the parent. This also lets nested
     /// `BexExternalValue::HostValue` values bind to an [`Object::HostClosure`].
-    pub(crate) fn convert_external_to_vm_value_with_ty<T: RootHaver + TlabHolder>(
+    pub(crate) fn convert_external_to_vm_value_with_ty(
         &self,
-        holder: &mut impl HeapPermit<T>,
+        holder: &mut impl HeapPermit<BexThread>,
         external: BexExternalValue,
         expected_ty: Option<&RuntimeTy>,
     ) -> Result<Value, EngineError> {
@@ -977,7 +978,9 @@ impl BexEngine {
             }
             BexExternalValue::Adt(BexExternalAdt::Type(ty)) => {
                 let ty = realize_host_ty(ty)?;
-                Value::object(holder.holder_mut().tlab_mut().alloc_type(ty))
+                // The wire carries the definition only (H-4); derive a fresh
+                // static identity with the receiving VM's complete fact context.
+                Value::object(holder.holder_mut().vm.alloc_static_type(ty))
             }
             BexExternalValue::Adt(BexExternalAdt::PromptAst(_)) => {
                 return Err(EngineError::CannotConvert {
@@ -4067,17 +4070,23 @@ mod union_container_selection_tests {
                     name: "HAPPY".to_string(),
                     description: None,
                     alias: None,
+                    docstring: None,
+                    other: indexmap::IndexMap::new(),
                     skip: false,
                 },
                 EnumVariant {
                     name: "SAD".to_string(),
                     description: None,
                     alias: None,
+                    docstring: None,
+                    other: indexmap::IndexMap::new(),
                     skip: false,
                 },
             ],
             description: None,
             alias: None,
+            docstring: None,
+            other: indexmap::IndexMap::new(),
             ty_attr: TyAttr::default(),
         })));
         let happy = RuntimeTy::EnumVariant(mood.clone(), Name::new("HAPPY"), TyAttr::default());

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -978,7 +978,7 @@ fn truncate_preview(mut value: String, max_chars: usize) -> String {
 }
 
 /// Extract an owned `RuntimeTy` from a `SysOp::BamlHostCallHostValue` type-arg operand
-/// (an `Object::Type(Box<RuntimeTy>)`).
+/// (an `Object::Type(Box<TypeValue>)`).
 ///
 /// The VM packs the sys-op args as `[handle, args_array, ret_ty, throws_ty]`
 /// (see `bex_vm::vm`'s `CallIndirect`-`HostClosure` path): `ret_ty` is
@@ -1012,7 +1012,7 @@ fn host_call_type_arg(
     // pointer would dangle. The caller clones the `RuntimeTy` out before awaiting.
     match unsafe { ptr.get() } {
         // `Object::Type` stores a realized type; widen it to the boundary `RuntimeTy`.
-        Object::Type(ty) => Ok((**ty).clone().into()),
+        Object::Type(type_value) => Ok(type_value.ty.clone().into()),
         _ => Err(bad_slot()),
     }
 }
@@ -5782,5 +5782,59 @@ mod concurrent_tests {
         //     assert!(result.is_ok(), "concurrent call failed: {:?}", result);
         // }
         // ```
+    }
+}
+
+#[cfg(test)]
+mod mint_identity_tests {
+    use std::sync::Arc;
+
+    use baml_project::testing::compile_source;
+    use bex_vm_types::{Object, types::MintId};
+    use sys_native::SysOpsExt;
+    use tokio_util::sync::CancellationToken;
+
+    use super::BexEngine;
+
+    fn engine() -> Arc<BexEngine> {
+        let program = compile_source("function main() -> null { null }");
+        Arc::new(
+            BexEngine::new(program, Arc::new(sys_native::SysOps::native()), Vec::new())
+                .expect("engine construction should succeed"),
+        )
+    }
+
+    async fn mint_in_engine(engine: &Arc<BexEngine>, ty: baml_type::RealizedTy) -> MintId {
+        let mut thread = engine
+            .new_root_thread(CancellationToken::new(), false)
+            .await;
+        let ptr = thread.vm.alloc_static_type(ty);
+        let Object::Type(type_value) = thread.vm.get_object(ptr) else {
+            panic!("alloc_static_type must allocate Object::Type")
+        };
+        type_value.mint()
+    }
+
+    #[tokio::test]
+    async fn static_digest_is_canonical_and_deterministic_across_engines() {
+        let left = baml_type::RealizedTy::Union(
+            vec![
+                baml_type::RealizedTy::int(),
+                baml_type::RealizedTy::string(),
+            ],
+            baml_type::TyAttr::default(),
+        );
+        let right = baml_type::RealizedTy::Union(
+            vec![
+                baml_type::RealizedTy::string(),
+                baml_type::RealizedTy::int(),
+            ],
+            baml_type::TyAttr::default(),
+        );
+
+        let first = mint_in_engine(&engine(), left).await;
+        let second = mint_in_engine(&engine(), right).await;
+        assert_eq!(first, second);
+        assert!(matches!(first, MintId::Static(_)));
     }
 }

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -3698,7 +3698,7 @@ impl BexEngine {
     /// declaration order. Empty for a non-generic function. Sourced from the
     /// `Function`'s `display_type_params`, so it includes type params that
     /// appear only in the body (e.g. `one_type_arg<T>()` whose `T` shows up
-    /// solely via `reflect.type_of<T>()`), which a signature-only scan misses.
+    /// solely via `type.of<T>()`), which a signature-only scan misses.
     fn function_generic_params(&self, name: &str) -> Vec<String> {
         let Some(resolved) = self.resolve_function_name(name) else {
             return vec![];

--- a/baml_language/crates/bex_engine/tests/generics_explicit.rs
+++ b/baml_language/crates/bex_engine/tests/generics_explicit.rs
@@ -118,13 +118,13 @@ async fn typed_arm_on_enclosing_typevar_matches() {
 // 01pt3: inbound (host-call) generics — named `_types=` channel
 // ===========================================================================
 
-/// A body-only `TypeVar` (`T` appears only via `reflect.type_of<T>()`, never in
+/// A body-only `TypeVar` (`T` appears only via `type.of<T>()`, never in
 /// the signature) is bound through the named channel and threads into the
 /// frame. Proves the path doesn't rely on argument inference.
 #[tokio::test]
 async fn inbound_named_binding_threads_to_reflect() {
     let source = r#"
-        function one_type_arg<T>() -> string { reflect.type_of<T>().to_string() }
+        function one_type_arg<T>() -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     let out = call_named(
@@ -143,7 +143,7 @@ async fn inbound_named_binding_threads_to_reflect() {
 #[tokio::test]
 async fn inbound_missing_binding_rejected() {
     let source = r#"
-        function one_type_arg<T>() -> string { reflect.type_of<T>().to_string() }
+        function one_type_arg<T>() -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     let err = call_named(source, "one_type_arg", vec![], vec![])

--- a/baml_language/crates/bex_engine/tests/generics_inference.rs
+++ b/baml_language/crates/bex_engine/tests/generics_inference.rs
@@ -57,7 +57,7 @@ fn s(v: &str) -> BEV {
 /// A free generic function reflecting its single `TypeVar` as a string — the
 /// observable proof of what `T` was bound to.
 const IDENTITY: &str = r#"
-    function identity<T>(x: T) -> string { reflect.type_of<T>().to_string() }
+    function identity<T>(x: T) -> string { type.of<T>().to_string() }
     function main() -> int { 0 }
 "#;
 
@@ -107,7 +107,7 @@ async fn infer_identity_generic_instance() {
     // T4-ish: a fully-bound GenericBox[int] instance ⇒ T = GenericBox<int>.
     let source = r#"
         class GenericBox<T> { value T }
-        function identity<T>(x: T) -> string { reflect.type_of<T>().to_string() }
+        function identity<T>(x: T) -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     let arg = BEV::instance_generic(
@@ -137,7 +137,7 @@ async fn infer_make_triple_structural() {
     // unbound var would fail Gate A before the body runs). Render mentions each.
     let source = r#"
         function make_triple<A, B, C>(a: A, b: B[], c: map<string, C>) -> string {
-            reflect.type_of<A | B | C>().to_string()
+            type.of<A | B | C>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -168,7 +168,7 @@ async fn infer_second_of_nested_generic() {
     // T9: second_of<T>(p: GenericPair<int, T>) with GenericPair<int, string> ⇒ T=string.
     let source = r#"
         class GenericPair<A, B> { first A second B }
-        function second_of<T>(p: GenericPair<int, T>) -> string { reflect.type_of<T>().to_string() }
+        function second_of<T>(p: GenericPair<int, T>) -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     let arg = BEV::instance_generic(
@@ -183,7 +183,7 @@ async fn infer_second_of_nested_generic() {
 // ── §C: union merge (same var, multiple positions) ─────────────────────────
 
 const CHOOSE: &str = r#"
-    function choose<T>(left: T, right: T) -> string { reflect.type_of<T>().to_string() }
+    function choose<T>(left: T, right: T) -> string { type.of<T>().to_string() }
     function main() -> int { 0 }
 "#;
 
@@ -224,7 +224,7 @@ async fn partial_explicit_seed_then_infer() {
     // while B=string and C=bool are still inferred.
     let source = r#"
         function make_triple<A, B, C>(a: A, b: B[], c: map<string, C>) -> string {
-            reflect.type_of<A | B | C>().to_string()
+            type.of<A | B | C>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -296,7 +296,7 @@ async fn explicit_binding_widens_inferred_type() {
 async fn body_only_var_still_requires_binding() {
     // T19: one_type_arg() with no value carrying T ⇒ Gate A rejects.
     let source = r#"
-        function one_type_arg<T>() -> string { reflect.type_of<T>().to_string() }
+        function one_type_arg<T>() -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     let err = call_infer(source, "one_type_arg", vec![])
@@ -403,7 +403,7 @@ async fn g3_nested_unbound_under_bare_formal_is_rust_type() {
     // instance is unbound under a bare-`T` formal ⇒ the whole value is rust_type.
     let source = r#"
         class GenericBox<T> { value T }
-        function identity<T>(x: T) -> string { reflect.type_of<T>().to_string() }
+        function identity<T>(x: T) -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     let inner = BEV::instance(
@@ -428,7 +428,7 @@ async fn j13_closure_typed_param_poisons_typevars_must_specify() {
     // is rejected (must-specify), not silently inferred.
     let source = r#"
         function apply<T, R>(f: (T) -> R, x: T) -> string {
-            reflect.type_of<T>().to_string()
+            type.of<T>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -447,7 +447,7 @@ async fn j13_closure_poisoned_typevars_succeed_when_specified() {
     // §J J13 (positive): the same call succeeds once `T` and `R` are specified.
     let source = r#"
         function apply<T, R>(f: (T) -> R, x: T) -> string {
-            reflect.type_of<T>().to_string()
+            type.of<T>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -514,7 +514,7 @@ async fn infer_identity_empty_map_binds_rust_type_map() {
 // ── §I: nullable-only TypeVar T? ───────────────────────────────────────────
 
 const MAYBE_ID: &str = r#"
-    function maybe_id<T>(x: T?) -> string { reflect.type_of<T>().to_string() }
+    function maybe_id<T>(x: T?) -> string { type.of<T>().to_string() }
     function main() -> int { 0 }
 "#;
 
@@ -549,7 +549,7 @@ async fn infer_maybe_id_null_value() {
 /// introspection fix is not exercised here).
 const TAG_OR_VALUE_REFLECT: &str = r#"
     function tag_or_value<T>(x: T | string | null) -> string {
-        reflect.type_of<T>().to_string()
+        type.of<T>().to_string()
     }
     function main() -> int { 0 }
 "#;
@@ -637,7 +637,7 @@ async fn infer_nonempty_map_binds_key_despite_valueless_values() {
     // map-key TypeVar K must bind to `string` rather than collapsing the whole
     // map to NoEvidence (which previously left K unbound and Gate-A rejected).
     let src = r#"
-        function map_key<K>(m: map<K, int[]>) -> string { reflect.type_of<K>().to_string() }
+        function map_key<K>(m: map<K, int[]>) -> string { type.of<K>().to_string() }
         function main() -> int { 0 }
     "#;
     let mut entries = indexmap::IndexMap::new();
@@ -671,7 +671,7 @@ async fn gatea_class_method_body_only_var_should_reject() {
     // ALL class methods and `T` silently erased to `unknown`.
     let src = r#"
         class Helper {
-            function reflect_t<T>() -> string { reflect.type_of<T>().to_string() }
+            function reflect_t<T>() -> string { type.of<T>().to_string() }
         }
         function main() -> int { 0 }
     "#;
@@ -690,7 +690,7 @@ async fn unbound_generic_instance_should_be_host_only() {
     // into, so `T` defaults to `rust_type`.
     let source = r#"
         class GenericBox<T> { value T }
-        function identity<T>(x: T) -> string { reflect.type_of<T>().to_string() }
+        function identity<T>(x: T) -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     // Instance whose wire type_args are EMPTY (unbound generic class encoding).
@@ -760,7 +760,7 @@ async fn g1_unbound_instance_under_forcing_formal_recovers_field_type() {
     // wire carries no type-args), distinct from the bare-`T` host-only path.
     let source = r#"
         class GenericPair<A, B> { first A second B }
-        function second_of<T>(p: GenericPair<int, T>) -> string { reflect.type_of<T>().to_string() }
+        function second_of<T>(p: GenericPair<int, T>) -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     let unbound = BEV::instance(
@@ -804,7 +804,7 @@ fn int_map(value_type: RuntimeTy, entries: &[(&str, BEV)]) -> BEV {
 
 /// `pair<T>(a: T[], b: T[])` — `T` in two **invariant** (list-element) positions.
 const PAIR: &str = r#"
-    function pair<T>(a: T[], b: T[]) -> string { reflect.type_of<T>().to_string() }
+    function pair<T>(a: T[], b: T[]) -> string { type.of<T>().to_string() }
     function main() -> int { 0 }
 "#;
 
@@ -871,7 +871,7 @@ async fn infer_merge_invariant_map_value_conflict_rejects() {
     // map-value ⇒ reject.
     let src = r#"
         function merge<T>(a: map<string, T>, b: map<string, T>) -> string {
-            reflect.type_of<T>().to_string()
+            type.of<T>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -893,7 +893,7 @@ async fn infer_combine_invariant_class_arg_conflict_rejects() {
     let src = r#"
         class GenericBox<T> { value T }
         function combine<T>(x: GenericBox<T>, y: GenericBox<T>) -> string {
-            reflect.type_of<T>().to_string()
+            type.of<T>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -921,7 +921,7 @@ async fn infer_glue_invariant_vs_covariant_conflict_rejects() {
     // J7/E4: glue(int, string[]) ⇒ arr⇒T==string (invariant) but bare⇒int <: T
     // (covariant); int <: string is false ⇒ reject (the key cross-variance case).
     let src = r#"
-        function glue<T>(bare: T, arr: T[]) -> string { reflect.type_of<T>().to_string() }
+        function glue<T>(bare: T, arr: T[]) -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     let arr_arg = arr(RuntimeTy::string(), vec![s("x")]);
@@ -939,7 +939,7 @@ async fn infer_glue_invariant_and_covariant_agree_binds() {
     // J11/G4 regression: glue(int, int[]) ⇒ invariant (T==int) + covariant
     // (int <: int) AGREE ⇒ T = int; must succeed.
     let src = r#"
-        function glue<T>(bare: T, arr: T[]) -> string { reflect.type_of<T>().to_string() }
+        function glue<T>(bare: T, arr: T[]) -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     let arr_arg = arr(RuntimeTy::int(), vec![BEV::Int(2)]);
@@ -957,7 +957,7 @@ async fn infer_triple_choose_three_covariant_join() {
     // covariant bare-arg occurrences union-merge (n-ary, not pairwise-special).
     let src = r#"
         function triple_choose<T>(a: T, b: T, c: T) -> string {
-            reflect.type_of<T>().to_string()
+            type.of<T>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -988,7 +988,7 @@ async fn infer_make_triple_heterogeneous_list_element_unions() {
     // invariant conflict BETWEEN two separate args).
     let src = r#"
         function make_triple<A, B, C>(a: A, b: B[], c: map<string, C>) -> string {
-            reflect.type_of<A | B | C>().to_string()
+            type.of<A | B | C>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -1017,7 +1017,7 @@ async fn infer_two_typevar_union_is_uninferrable_rejects() {
     // members). Both T and U stay unbound ⇒ Gate A rejects.
     let src = r#"
         function two_in_union<T, U>(x: T | U | int) -> string {
-            reflect.type_of<T | U>().to_string()
+            type.of<T | U>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -1038,7 +1038,7 @@ async fn infer_identity_known_class_instance() {
     // BAML class recovered from the instance value).
     let src = r#"
         class StringIntPair { my_string string my_int int }
-        function identity<T>(x: T) -> string { reflect.type_of<T>().to_string() }
+        function identity<T>(x: T) -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     let arg = BEV::instance(
@@ -1073,7 +1073,7 @@ async fn infer_extract_four_vars_from_nested_generic() {
     let src = r#"
         class GenericPair<A, B> { first A second B }
         function extract<A, B, C, D>(a: GenericPair<GenericPair<A, B>, GenericPair<C, D>>) -> string {
-            reflect.type_of<A | B | C | D>().to_string()
+            type.of<A | B | C | D>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -1119,7 +1119,7 @@ async fn explicit_binding_contradicted_by_scalar_actual_rejects() {
     // case.) The friendly error names the function and both types, no jargon.
     let src = r#"
         function make_triple<A, B, C>(a: A, b: B[], c: map<string, C>) -> string {
-            reflect.type_of<A | B | C>().to_string()
+            type.of<A | B | C>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -1163,7 +1163,7 @@ async fn infer_choose_divergent_generic_instances_union() {
     // same actuals conflict (§J E3).
     let src = r#"
         class GenericBox<T> { value T }
-        function choose<T>(left: T, right: T) -> string { reflect.type_of<T>().to_string() }
+        function choose<T>(left: T, right: T) -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     let x = BEV::instance_generic(
@@ -1196,7 +1196,7 @@ async fn infer_tag_or_value_binds_generic_instance() {
     let src = r#"
         class GenericBox<T> { value T }
         function tag_or_value<T>(x: T | string | null) -> string {
-            reflect.type_of<T>().to_string()
+            type.of<T>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -1224,7 +1224,7 @@ async fn infer_identity_enum_binds_enum_type() {
     // from a resolved variant value).
     let src = r#"
         enum SomeEnum { VARIANT OTHER }
-        function identity<T>(x: T) -> string { reflect.type_of<T>().to_string() }
+        function identity<T>(x: T) -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     let arg = BEV::Variant {
@@ -1260,7 +1260,7 @@ async fn a3_nested_fully_bound_generic_instance() {
     // `infer_identity_generic_instance`, the single-level bound box.)
     let source = r#"
         class GenericBox<T> { value T }
-        function identity<T>(x: T) -> string { reflect.type_of<T>().to_string() }
+        function identity<T>(x: T) -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     let inner = BEV::instance_generic(
@@ -1298,7 +1298,7 @@ const READ_T: &str = r#"
       mixed T | string | null
     }
     function read_t<T>(shape: ContainerShapes<T>) -> string {
-        reflect.type_of<T>().to_string()
+        type.of<T>().to_string()
     }
     function main() -> int { 0 }
 "#;
@@ -1357,7 +1357,7 @@ async fn b4_list_head_recursive_generic_wire_arg() {
     let src = r#"
         class GenericRecursive<T> { value T next GenericRecursive<T>? }
         function list_head_t<T>(list: GenericRecursive<T>) -> string {
-            reflect.type_of<T>().to_string()
+            type.of<T>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -1383,7 +1383,7 @@ async fn b7_first_or_empty_list_free_fn_binds_rust_type() {
     // element evidence ⇒ the *element* T = rust_type (NOT rust_type[]; that is
     // identity([]), where T is the whole list). The B6/B7 split is the point.
     let src = r#"
-        function first_or<T>(xs: T[]) -> string { reflect.type_of<T>().to_string() }
+        function first_or<T>(xs: T[]) -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     let out = call_infer(src, "first_or", vec![arr(RuntimeTy::int(), vec![])])
@@ -1406,7 +1406,7 @@ async fn b9_values_of_empty_map_free_fn_binds_rust_type() {
     // `map<_,T>` just as B7 shows for `T[]`).
     let src = r#"
         function values_of<T>(m: map<string, T>) -> string {
-            reflect.type_of<T>().to_string()
+            type.of<T>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -1430,9 +1430,9 @@ async fn b9_values_of_empty_map_free_fn_binds_rust_type() {
 const GENERIC_BOX_METHODS: &str = r#"
     class GenericBox<T> {
       value T
-      function get(self) -> string { reflect.type_of<T>().to_string() }
+      function get(self) -> string { type.of<T>().to_string() }
       function pair_with<U>(self, other: U) -> string {
-          reflect.type_of<T | U>().to_string()
+          type.of<T | U>().to_string()
       }
       function new<V>(value: V) -> GenericBox<V> { GenericBox<V> { value: value } }
     }
@@ -1507,7 +1507,7 @@ async fn l4_named_static_distinct_method_vars() {
           second B
           third C
           function make<D, E>(d: D, e: E) -> string {
-              reflect.type_of<D | E>().to_string()
+              type.of<D | E>().to_string()
           }
         }
         function main() -> int { 0 }
@@ -1530,7 +1530,7 @@ async fn l5_unbound_receiver_method_recovers_class_var_from_field() {
     // (no `[...]`) carries no wire type-args, but the method's `self: GenericBox<T>`
     // formal FORCES recursion into the `value` field — exactly the G1 forcing-formal
     // path — so the class `T` is recovered from the field VALUE (`5` ⇒ int), NOT
-    // left as host-only rust_type. `reflect.type_of<T | U>` then renders
+    // left as host-only rust_type. `type.of<T | U>` then renders
     // `int | string` (U=string from `other`). (The 03b L5 sketch guessed rust_type
     // under uncertainty and told us to assert whatever the implementation renders;
     // the forcing-formal recovery wins, which is the sounder outcome.)
@@ -1563,7 +1563,7 @@ async fn het_array_element_type_unifies() {
     // Directly asserts the unified element type (distinct from B8, which reads
     // the union via make_triple's `B[]`).
     let src = r#"
-        function elem_type<T>(xs: T[]) -> string { reflect.type_of<T>().to_string() }
+        function elem_type<T>(xs: T[]) -> string { type.of<T>().to_string() }
         function main() -> int { 0 }
     "#;
     let xs = arr(RuntimeTy::int(), vec![BEV::Int(1), s("x")]);
@@ -1617,7 +1617,7 @@ async fn unbound_recursive_recovers_t_from_fields() {
     let src = r#"
         class GenericRecursive<T> { value T next GenericRecursive<T>? }
         function list_head_t<T>(list: GenericRecursive<T>) -> string {
-            reflect.type_of<T>().to_string()
+            type.of<T>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -1643,7 +1643,7 @@ async fn unbound_outer_pair_with_bound_inner_recovers_all_vars() {
     let src = r#"
         class GenericPair<A, B> { first A second B }
         function extract<A, B, C, D>(a: GenericPair<GenericPair<A, B>, GenericPair<C, D>>) -> string {
-            reflect.type_of<A | B | C | D>().to_string()
+            type.of<A | B | C | D>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -1685,7 +1685,7 @@ async fn fully_unbound_nested_pair_recovers_all_vars_deeply() {
     let src = r#"
         class GenericPair<A, B> { first A second B }
         function extract<A, B, C, D>(a: GenericPair<GenericPair<A, B>, GenericPair<C, D>>) -> string {
-            reflect.type_of<A | B | C | D>().to_string()
+            type.of<A | B | C | D>().to_string()
         }
         function main() -> int { 0 }
     "#;
@@ -1724,7 +1724,7 @@ async fn triple_choose_join_includes_enum_and_concrete_class() {
         enum SomeEnum { VARIANT OTHER }
         class StringIntPair { my_string string my_int int }
         function triple_choose<T>(a: T, b: T, c: T) -> string {
-            reflect.type_of<T>().to_string()
+            type.of<T>().to_string()
         }
         function main() -> int { 0 }
     "#;

--- a/baml_language/crates/bex_engine/tests/host_value_callable.rs
+++ b/baml_language/crates/bex_engine/tests/host_value_callable.rs
@@ -63,7 +63,7 @@ use sys_native::SysOpsExt;
 // type-test against the substituted type at monomorphization. Both are
 // real compiler / VM changes; absent those, the host-call typechecking
 // must stay in Rust (as it is today) or use a different BAML construct
-// (e.g. an explicit `reflect.type_of<T>().matches(v)` builtin if added).
+// (e.g. an explicit `type.of<T>().matches(v)` builtin if added).
 // ============================================================================
 
 #[ignore = "documents a compiler gap: generic-typed patterns don't substitute T at runtime"]

--- a/baml_language/crates/bex_heap/src/accessor.rs
+++ b/baml_language/crates/bex_heap/src/accessor.rs
@@ -317,14 +317,15 @@ impl<'a> BexValue<'a> {
     ) -> Result<baml_type::RuntimeTy, AccessError> {
         fn from_ptr(ptr: &HeapPtr) -> Result<baml_type::RuntimeTy, AccessError> {
             let obj = unsafe { ptr.get() };
-            let Object::Type(ty) = obj else {
+            let Object::Type(tv) = obj else {
                 return Err(AccessError::TypeMismatch {
                     expected: "type",
                     actual: obj.to_string(),
                 });
             };
             // `Object::Type` stores a realized type; widen it into `RuntimeTy`.
-            Ok((**ty).clone().into())
+            // The mint stays behind (BEP-066 H-4: identity never crosses).
+            Ok(tv.ty.clone().into())
         }
 
         match self {
@@ -609,8 +610,9 @@ fn convert_object(
             })
         }
         Object::Collector(c) => Ok(BexExternalValue::Adt(BexExternalAdt::Collector(c.clone()))),
-        Object::Type(ty) => Ok(BexExternalValue::Adt(BexExternalAdt::Type(
-            (**ty).clone().into(),
+        // Only the described type crosses the boundary (BEP-066 H-4).
+        Object::Type(tv) => Ok(BexExternalValue::Adt(BexExternalAdt::Type(
+            tv.ty.clone().into(),
         ))),
         Object::Bigint(bi) => Ok(BexExternalValue::Bigint((**bi).clone())),
         Object::Uint8Array(bytes) => Ok(BexExternalValue::Uint8Array(bytes.to_vec())),

--- a/baml_language/crates/bex_heap/src/gc.rs
+++ b/baml_language/crates/bex_heap/src/gc.rs
@@ -1390,10 +1390,14 @@ mod tests {
                 name: "A".to_string(),
                 description: None,
                 alias: None,
+                docstring: None,
+                other: Default::default(),
                 skip: false,
             }],
             description: None,
             alias: None,
+            docstring: None,
+            other: Default::default(),
             ty_attr: baml_type::TyAttr::default(),
         }))];
         let debug = HeapDebuggerConfig {
@@ -1434,10 +1438,14 @@ mod tests {
                 }),
                 description: None,
                 alias: None,
+                docstring: None,
+                other: Default::default(),
                 skip: false,
             }],
             description: None,
             alias: None,
+            docstring: None,
+            other: Default::default(),
             type_tag: 100,
             ty_attr: baml_type::TyAttr::default(),
             has_cleanup: false,
@@ -2079,6 +2087,8 @@ mod tests {
             fields: vec![],
             description: None,
             alias: None,
+            docstring: None,
+            other: Default::default(),
             type_tag: 0,
             ty_attr: TyAttr::default(),
             has_cleanup: false,
@@ -2122,6 +2132,8 @@ mod tests {
             variants: vec![],
             description: None,
             alias: None,
+            docstring: None,
+            other: Default::default(),
             ty_attr: TyAttr::default(),
         })));
         let var_ptr = tlab.alloc_variant(enum_ptr, 1);
@@ -2347,6 +2359,8 @@ mod tests {
             fields: vec![],
             description: None,
             alias: None,
+            docstring: None,
+            other: Default::default(),
             type_tag: 42,
             ty_attr: TyAttr::default(),
             has_cleanup: false,
@@ -2373,6 +2387,8 @@ mod tests {
             variants: vec![],
             description: None,
             alias: None,
+            docstring: None,
+            other: Default::default(),
             ty_attr: TyAttr::default(),
         })));
 
@@ -2387,15 +2403,19 @@ mod tests {
     fn test_gc_leaf_type_preserved() {
         let heap = BexHeap::new(vec![]);
         let mut tlab = Tlab::new(Arc::clone(&heap));
-        let ptr = tlab.alloc(Object::Type(Box::new(baml_type::RealizedTy::Int {
-            attr: baml_type::TyAttr::default(),
-        })));
+        let minted = bex_vm_types::types::TypeValue::from_parts(
+            baml_type::RealizedTy::int(),
+            bex_vm_types::types::MintId::Static(0xC0FFEE),
+        );
+        let ptr = tlab.alloc(Object::Type(Box::new(minted.clone())));
 
         let (_, new_roots, _) = unsafe { heap.collect_garbage(&[ptr]) };
-        let Object::Type(ty) = (unsafe { new_roots[0].get() }) else {
+        let Object::Type(tv) = (unsafe { new_roots[0].get() }) else {
             panic!("not type")
         };
-        assert!(matches!(**ty, baml_type::RealizedTy::Int { .. }));
+        assert!(matches!(tv.ty, baml_type::RealizedTy::Int { .. }));
+        // The mint is inline data, so a GC copy preserves identity (I-4).
+        assert_eq!(**tv, minted);
     }
 
     #[test]
@@ -2794,6 +2814,8 @@ mod tests {
             fields: vec![],
             description: None,
             alias: None,
+            docstring: None,
+            other: Default::default(),
             type_tag: 0,
             ty_attr: TyAttr::default(),
             has_cleanup: false,
@@ -2811,6 +2833,8 @@ mod tests {
             variants: vec![],
             description: None,
             alias: None,
+            docstring: None,
+            other: Default::default(),
             ty_attr: TyAttr::default(),
         })));
         let variant_container = tlab.alloc(Object::Variant(Variant {

--- a/baml_language/crates/bex_heap/src/heap.rs
+++ b/baml_language/crates/bex_heap/src/heap.rs
@@ -17,7 +17,7 @@ use std::{
     collections::HashMap,
     sync::{
         Arc, Mutex, RwLock,
-        atomic::{AtomicUsize, Ordering},
+        atomic::{AtomicU64, AtomicUsize, Ordering},
     },
 };
 
@@ -180,6 +180,16 @@ pub struct BexHeap {
 
     /// Next handle key to allocate.
     next_handle_key: AtomicUsize,
+
+    /// Next `MintId::Runtime` counter value (BEP-066 I-1): one per structured
+    /// type construction, engine-wide. Lives on the heap — next to the handle
+    /// counter — because the heap is the one object every allocation path
+    /// already shares, including spawned VMs (each `Tlab` holds an
+    /// `Arc<BexHeap>`), so two threads can never mint the same runtime
+    /// identity. Monotonic and never reused; no producer exists until the
+    /// slice-2 constructors, but the allocator lands with the identity
+    /// semantics (`bex_vm_types::types::MintId`).
+    next_runtime_mint: AtomicU64,
 
     /// BEP-042: instances whose `cleanup` finalizer must run after the current
     /// collection. Populated during a collection (`copy_collection` /
@@ -347,6 +357,7 @@ impl BexHeap {
             gen2_cards: UnsafeCell::new(CardTable::new()),
             handles: RwLock::new(HashMap::new()),
             next_handle_key: AtomicUsize::new(0),
+            next_runtime_mint: AtomicU64::new(0),
             pending_finalizers: Mutex::new(Vec::new()),
             pending_unhandled_spawn_errors: Mutex::new(Vec::new()),
             has_finalizable_classes,
@@ -1085,6 +1096,16 @@ impl BexHeap {
         Handle::new(handle_key, Arc::clone(self) as Arc<dyn WeakHeapRef>)
     }
 
+    /// Mint a fresh `MintId::Runtime` identity (BEP-066 I-1): the next value
+    /// of the engine-wide monotonic counter. Every VM sharing this heap —
+    /// including spawned children — draws from the same counter, so two
+    /// constructor evaluations can never mint the same identity. `Relaxed`
+    /// suffices: uniqueness needs only the atomicity of `fetch_add`, no
+    /// ordering with other memory.
+    pub fn mint_runtime_id(&self) -> bex_vm_types::types::MintId {
+        bex_vm_types::types::MintId::Runtime(self.next_runtime_mint.fetch_add(1, Ordering::Relaxed))
+    }
+
     /// Collect all handle roots for garbage collection.
     ///
     /// Returns a Vec of HeapPtr values for all live handles.
@@ -1212,6 +1233,21 @@ mod tests {
         let stats = heap.stats();
         assert_eq!(stats.tlab_chunks, 1);
         assert!(stats.total_objects >= 51); // Expanded for TLAB
+    }
+
+    #[test]
+    fn runtime_mints_are_heap_wide_and_disjoint_from_static_mints() {
+        use bex_vm_types::types::MintId;
+
+        let heap = BexHeap::new(vec![]);
+        let shared = Arc::clone(&heap);
+
+        let first = heap.mint_runtime_id();
+        let second = shared.mint_runtime_id();
+        assert_eq!(first, MintId::Runtime(0));
+        assert_eq!(second, MintId::Runtime(1));
+        assert_ne!(first, second);
+        assert_ne!(first, MintId::Static(0));
     }
 
     // Note: Handle tests removed as they require HeapPtr creation which depends

--- a/baml_language/crates/bex_heap/src/tlab.rs
+++ b/baml_language/crates/bex_heap/src/tlab.rs
@@ -243,9 +243,15 @@ impl Tlab {
     }
 
     /// Allocate a type descriptor object on the heap.
+    ///
+    /// Takes an assembled [`bex_vm_types::types::TypeValue`] — a type plus
+    /// its minted identity — so no allocation site can produce a mintless
+    /// type object. Static materialization inside the VM should go through
+    /// `BexVm::alloc_static_type`, which derives (and memoizes) the digest
+    /// with the VM as the fact context.
     #[inline]
-    pub fn alloc_type(&mut self, ty: baml_type::RealizedTy) -> HeapPtr {
-        self.alloc(Object::Type(Box::new(ty)))
+    pub fn alloc_type(&mut self, tv: bex_vm_types::types::TypeValue) -> HeapPtr {
+        self.alloc(Object::Type(Box::new(tv)))
     }
 
     /// Allocate a future object on the heap.
@@ -390,8 +396,8 @@ pub trait TlabHolder {
         self.tlab_mut().alloc_collector(collector)
     }
 
-    fn alloc_type(&mut self, ty: baml_type::RealizedTy) -> HeapPtr {
-        self.tlab_mut().alloc_type(ty)
+    fn alloc_type(&mut self, tv: bex_vm_types::types::TypeValue) -> HeapPtr {
+        self.tlab_mut().alloc_type(tv)
     }
 
     fn alloc_future(&mut self, future: bex_vm_types::Future) -> HeapPtr {
@@ -604,6 +610,8 @@ mod tests {
                     }),
                     description: None,
                     alias: None,
+                    docstring: None,
+                    other: Default::default(),
                     skip: false,
                 },
                 bex_vm_types::ClassField {
@@ -616,11 +624,15 @@ mod tests {
                     }),
                     description: None,
                     alias: None,
+                    docstring: None,
+                    other: Default::default(),
                     skip: false,
                 },
             ],
             description: None,
             alias: None,
+            docstring: None,
+            other: Default::default(),
             type_tag: 100,
             ty_attr: baml_type::TyAttr::default(),
             has_cleanup: false,
@@ -658,23 +670,31 @@ mod tests {
                     name: "Red".to_string(),
                     description: None,
                     alias: None,
+                    docstring: None,
+                    other: Default::default(),
                     skip: false,
                 },
                 bex_vm_types::EnumVariant {
                     name: "Green".to_string(),
                     description: None,
                     alias: None,
+                    docstring: None,
+                    other: Default::default(),
                     skip: false,
                 },
                 bex_vm_types::EnumVariant {
                     name: "Blue".to_string(),
                     description: None,
                     alias: None,
+                    docstring: None,
+                    other: Default::default(),
                     skip: false,
                 },
             ],
             description: None,
             alias: None,
+            docstring: None,
+            other: Default::default(),
             ty_attr: baml_type::TyAttr::default(),
         })));
 

--- a/baml_language/crates/bex_vm/build.rs
+++ b/baml_language/crates/bex_vm/build.rs
@@ -5,7 +5,6 @@ fn main() {
     // required trait method, so forgetting the Rust side is a compile error.
     for (package, file) in [
         ("baml", "nativefunctions_generated.rs"),
-        ("reflect", "reflectfunctions_generated.rs"),
         ("boundary", "boundaryfunctions_generated.rs"),
     ] {
         let (vm_builtins, _io_builtins, class_defs) =

--- a/baml_language/crates/bex_vm/src/lib.rs
+++ b/baml_language/crates/bex_vm/src/lib.rs
@@ -18,7 +18,6 @@ pub mod kperf;
 pub mod package_baml;
 pub mod package_boundary;
 pub mod package_load;
-pub mod package_reflect;
 mod type_context;
 mod type_match;
 pub mod types;

--- a/baml_language/crates/bex_vm/src/package_baml/mod.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/mod.rs
@@ -36,6 +36,7 @@ mod media;
 mod ops;
 mod ops_math;
 mod random;
+mod reflect;
 mod resolve;
 pub(crate) use resolve::ImplResolver;
 mod root;
@@ -392,10 +393,6 @@ type NativeResolver = fn(&str) -> Option<NativeFunction>;
 
 const VM_NATIVE_PACKAGES: &[(&str, NativeResolver)] = &[
     ("baml.", PackageBamlImpl::get_native_fn),
-    (
-        "reflect.",
-        <crate::package_reflect::PackageReflectImpl as crate::package_reflect::BamlPackageReflect>::get_native_fn,
-    ),
     (
         "boundary.",
         <crate::package_boundary::PackageBoundaryImpl as crate::package_boundary::BamlPackageBoundary>::get_native_fn,

--- a/baml_language/crates/bex_vm/src/package_baml/mod.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/mod.rs
@@ -47,6 +47,7 @@ mod sys;
 mod time;
 mod toml;
 mod type_class;
+mod type_kinds;
 mod uint8array;
 mod yaml;
 

--- a/baml_language/crates/bex_vm/src/package_baml/ops.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/ops.rs
@@ -19,7 +19,7 @@ use std::{
     sync::Arc,
 };
 
-use baml_type::{Name, RealizedTy, TyAttr, TypeName, normalize::TypeContext};
+use baml_type::{Name, RealizedTy, TyAttr, TypeName};
 use bex_str::BexStr;
 use bex_vm_types::{
     HeapPtr, ValueKind,
@@ -560,17 +560,10 @@ impl EqualsDriver {
             (Object::Collector(x), Object::Collector(y)) => step(Arc::ptr_eq(&x.0, &y.0)),
             (Object::Collector(_), _) => Cmp::NotEqual,
 
-            // Two `type` values are equal when they denote the same type. Compare
-            // through the *full* program context (`vm` as the `TypeContext`), not derived
-            // `==` nor the resolver's fact-opaque equivalence: this is user-facing type
-            // equality, so it must see nominal facts. Union member order is non-canonical
-            // (`type_of<int | string>` ≡ `type_of<string | int>`), and an
-            // interface-membership union absorbs (`type_of<Shape | Sq>` ≡ `type_of<Shape>`
-            // when `Sq` implements `Shape`). Using `vm` here is safe — this is a *client*
-            // of the resolver, not on its re-entrant path, so the membership lookup this
-            // may trigger bottoms out in the resolver's fact-opaque internals without
-            // looping.
-            (Object::Type(x), Object::Type(y)) => step(vm.equivalent(x.as_ty(), y.as_ty())),
+            // BEP-066: all `type` equality paths compare the minted identity.
+            // Canonically equivalent static spellings received the same digest
+            // when materialized; runtime constructions receive unique counters.
+            (Object::Type(x), Object::Type(y)) => step(x.mint() == y.mint()),
             (Object::Type(_), _) => Cmp::NotEqual,
 
             // `Sentinel` (heap_debug builds only) is an internal freed/uninit

--- a/baml_language/crates/bex_vm/src/package_baml/reflect.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/reflect.rs
@@ -83,7 +83,7 @@ fn alloc_arg(
         Some(n) => Value::object(vm.alloc_string(n.as_str())),
         None => Value::object(vm.alloc_string(format!("$arg{position}"))),
     };
-    let ty = Value::object(vm.tlab.alloc_type(ty));
+    let ty = Value::object(vm.alloc_static_type(ty));
     copy::reflect::Arg { name, r#type: ty }.to_value(vm)
 }
 
@@ -124,8 +124,8 @@ fn signature_impl(vm: &mut BexVm, f_val: Value) -> Result<Value, VmRustFnError> 
     }
     let args = Value::object(vm.tlab.alloc_array(ty_arg(), positional));
     let opts = Value::object(vm.tlab.alloc_map(RealizedTy::string(), ty_arg(), opts));
-    let returns = Value::object(vm.tlab.alloc_type(sig.ret.clone()));
-    let errors = Value::object(vm.tlab.alloc_type(sig.throws));
+    let returns = Value::object(vm.alloc_static_type(sig.ret.clone()));
+    let errors = Value::object(vm.alloc_static_type(sig.throws));
     let docstring = opt_string(vm, sig.docstring.as_ref());
     let name = opt_string(vm, sig.name.as_ref());
     Ok(copy::reflect::Signature {
@@ -147,8 +147,8 @@ fn raise_invalid_argument(
     got: RealizedTy,
 ) -> NativeCallResult {
     let argument = Value::object(vm.alloc_string(argument));
-    let expected = Value::object(vm.tlab.alloc_type(expected));
-    let got = Value::object(vm.tlab.alloc_type(got));
+    let expected = Value::object(vm.alloc_static_type(expected));
+    let got = Value::object(vm.alloc_static_type(got));
     let err = copy::reflect::InvalidArgumentError {
         argument,
         expected,

--- a/baml_language/crates/bex_vm/src/package_baml/reflect.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/reflect.rs
@@ -1,66 +1,36 @@
-//! Native implementations for the `reflect` stdlib package (BEP-062):
-//! `reflect.signature` and `reflect.call_any`.
+//! Native implementations for the `baml.reflect` namespace (BEP-062, moved
+//! into the `baml` package by BEP-066): `reflect.signature` and
+//! `reflect.call_any` (`reflect` is the keyword shorthand for `baml.reflect`).
 //!
-//! Dispatch and the class constructors are generated from `reflect.baml` by
-//! `baml_builtins2_codegen`, exactly as for [`crate::package_baml`]: declaring
-//! a `$rust_function` adds a required trait method here, and each class gets a
-//! `copy::` struct whose fields are checked by the compiler. Adding to the
-//! package is therefore a single edit to `reflect.baml` plus the implementation
-//! it demands. (`reflect.type_of` is a compiler intrinsic, so it never reaches
-//! a native at all.)
+//! Dispatch and the class constructors are generated from
+//! `baml_std/baml/ns_reflect/reflect.baml` by `baml_builtins2_codegen` into
+//! the `baml` package's trait hierarchy: declaring a `$rust_function` there
+//! adds a required [`BamlNamespaceReflect`] method here, and each class gets a
+//! `copy::reflect::` struct whose fields are checked by the compiler. Adding
+//! to the namespace is therefore a single edit to `reflect.baml` plus the
+//! implementation it demands. (`type.of` is a compiler intrinsic, so it never
+//! reaches a native at all; `type.of_value` lives in
+//! [`crate::package_baml::type_class`].)
 
 use baml_type::{RealizedTy, Ty, TyAttr, normalize};
 use bex_heap::TlabHolder;
-// `Instance`/`Type`/the read guards are referenced by the generated module.
-use bex_vm_types::{
-    ArrayReadGuard, MapReadGuard,
-    types::{Instance, Value},
-};
+use bex_vm_types::types::Value;
 use indexmap::IndexMap;
 
+use super::{
+    BamlNamespaceReflect, NativeCallResult, PackageBamlImpl, PassThroughContinuation, copy,
+};
 use crate::{
     BexVm,
     errors::{VmBamlError, VmRustFnError},
-    package_baml::{
-        NativeCallResult, NativeFunction, NativeFunctionResult, PassThroughContinuation,
-    },
     vm::CallableSignature,
 };
 
 /// Element tag for the `Arg[]` / `map<string, Arg>` containers. The class
 /// instances themselves are built through the generated `copy::` structs.
-const ARG_FQN: &str = "reflect.Arg";
+const ARG_FQN: &str = "baml.reflect.Arg";
 
-// The `BamlPackageReflect` trait and its `get_native_fn` dispatcher, generated
-// from `reflect.baml` exactly like the `baml` package's (see
-// `crate::package_baml`). Declaring a `$rust_function` there adds a required
-// trait method here, so the two can never drift.
-#[allow(
-    unused_variables,
-    unsafe_code,
-    non_camel_case_types,
-    clippy::wildcard_imports,
-    clippy::pub_underscore_fields,
-    clippy::used_underscore_binding,
-    clippy::elidable_lifetime_names,
-    clippy::get_first,
-    clippy::iter_not_returning_iterator,
-    clippy::needless_lifetimes,
-    clippy::redundant_closure_call,
-    clippy::new_ret_no_self,
-    clippy::too_many_arguments,
-    non_snake_case
-)]
-mod generated {
-    use super::*;
-    include!(concat!(env!("OUT_DIR"), "/reflectfunctions_generated.rs"));
-}
-pub use generated::*;
-
-/// The VM's `reflect` native implementations.
-pub struct PackageReflectImpl;
-
-impl BamlPackageReflect for PackageReflectImpl {
+impl BamlNamespaceReflect for PackageBamlImpl {
     fn signature(vm: &mut BexVm, f: &Value) -> Result<Value, VmRustFnError> {
         signature_impl(vm, *f)
     }
@@ -114,7 +84,7 @@ fn alloc_arg(
         None => Value::object(vm.alloc_string(format!("$arg{position}"))),
     };
     let ty = Value::object(vm.tlab.alloc_type(ty));
-    copy::Arg { name, r#type: ty }.to_value(vm)
+    copy::reflect::Arg { name, r#type: ty }.to_value(vm)
 }
 
 /// A `string?` field: the string, or null.
@@ -158,7 +128,7 @@ fn signature_impl(vm: &mut BexVm, f_val: Value) -> Result<Value, VmRustFnError> 
     let errors = Value::object(vm.tlab.alloc_type(sig.throws));
     let docstring = opt_string(vm, sig.docstring.as_ref());
     let name = opt_string(vm, sig.name.as_ref());
-    Ok(copy::Signature {
+    Ok(copy::reflect::Signature {
         name,
         args,
         opts,
@@ -179,7 +149,7 @@ fn raise_invalid_argument(
     let argument = Value::object(vm.alloc_string(argument));
     let expected = Value::object(vm.tlab.alloc_type(expected));
     let got = Value::object(vm.tlab.alloc_type(got));
-    let err = copy::InvalidArgumentError {
+    let err = copy::reflect::InvalidArgumentError {
         argument,
         expected,
         got,

--- a/baml_language/crates/bex_vm/src/package_baml/resolve.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/resolve.rs
@@ -16,6 +16,7 @@ use std::borrow::Cow;
 
 use baml_type::{
     Literal, MediaKind, Name, RealizedTy, TyAttr, TyTemplate, TypeName, normalize::TypeContext,
+    type_kind::is_type_kind_class,
 };
 use bex_vm_types::{
     errors::VmInternalError,
@@ -338,6 +339,15 @@ impl<'vm> ImplResolver<'vm> {
         concrete: &RealizedTy,
         bindings: &mut [Option<RealizedTy>],
     ) -> bool {
+        // Reflection kind classes are the sealed runtime refinements of `type`.
+        // Keep `implement I for type` rules applicable when the dynamic receiver
+        // is one of those refinements (notably TypeValue's tostring override).
+        if matches!(pattern, TyTemplate::Type { .. })
+            && matches!(concrete, RealizedTy::Class(name, _, _) if is_type_kind_class(name))
+        {
+            return true;
+        }
+
         // A fully-realized pattern carries no frame refs or holes: compare it to the
         // concrete type semantically (union-order-insensitive, matching the type
         // checker) through the canonical fact-opaque `StructuralEquivCtx`. The

--- a/baml_language/crates/bex_vm/src/package_baml/root.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/root.rs
@@ -905,6 +905,8 @@ fn deep_copy_value_recursive(
                 Object::Future(_) => unreachable!("Future short-circuited above"),
                 Object::UnscheduledFuture(f) => vm.tlab.alloc(Object::UnscheduledFuture(f)),
                 Object::Collector(c) => vm.tlab.alloc(Object::Collector(c)),
+                // A deep copy denotes the same type value: clone the complete
+                // `TypeValue`, including its mint (BEP-066 I-1/I-4).
                 Object::Type(ty) => vm.tlab.alloc(Object::Type(ty)),
                 // Closures, bound methods, and cells are shallow-copied: the captured
                 // state is shared by design (mutation semantics).
@@ -1007,7 +1009,9 @@ fn deep_equals_recursive(
                     a_var.enm == b_var.enm && a_var.index == b_var.index
                 }
 
-                (Object::Type(a_ty), Object::Type(b_ty)) => a_ty == b_ty,
+                // BEP-066: deep equality agrees with `==` by comparing the
+                // stable mint, never the type payload or moving heap pointer.
+                (Object::Type(a_ty), Object::Type(b_ty)) => a_ty.mint() == b_ty.mint(),
 
                 (Object::Enum(a_enum), Object::Enum(b_enum)) => {
                     a_enum.name == b_enum.name

--- a/baml_language/crates/bex_vm/src/package_baml/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/type_class.rs
@@ -17,11 +17,51 @@ impl BamlNamespaceType for PackageBamlImpl {
         let ty = vm
             .value_concrete_ty(*v)
             .map_or_else(baml_type::RealizedTy::unknown, baml_type::RealizedTy::from);
-        Ok(Value::object(vm.tlab.alloc_type(ty)))
+        Ok(Value::object(vm.alloc_static_type(ty)))
     }
 }
 
 impl BamlClassTypeValue for PackageBamlImpl {
+    fn kind(_vm: &BexVm, self_value: &Value) -> Value {
+        *self_value
+    }
+
+    fn as_class(vm: &BexVm, self_value: &Value) -> Option<Value> {
+        as_kind(vm, *self_value, baml_type::type_kind::TypeKind::Class)
+    }
+
+    fn as_enum(vm: &BexVm, self_value: &Value) -> Option<Value> {
+        as_kind(vm, *self_value, baml_type::type_kind::TypeKind::Enum)
+    }
+
+    fn as_union(vm: &BexVm, self_value: &Value) -> Option<Value> {
+        as_kind(vm, *self_value, baml_type::type_kind::TypeKind::Union)
+    }
+
+    fn as_literal(vm: &BexVm, self_value: &Value) -> Option<Value> {
+        as_kind(vm, *self_value, baml_type::type_kind::TypeKind::Literal)
+    }
+
+    fn as_array(vm: &BexVm, self_value: &Value) -> Option<Value> {
+        as_kind(vm, *self_value, baml_type::type_kind::TypeKind::Array)
+    }
+
+    fn as_map(vm: &BexVm, self_value: &Value) -> Option<Value> {
+        as_kind(vm, *self_value, baml_type::type_kind::TypeKind::Map)
+    }
+
+    fn as_interface(vm: &BexVm, self_value: &Value) -> Option<Value> {
+        as_kind(vm, *self_value, baml_type::type_kind::TypeKind::Interface)
+    }
+
+    fn as_primitive(vm: &BexVm, self_value: &Value) -> Option<Value> {
+        as_kind(vm, *self_value, baml_type::type_kind::TypeKind::Primitive)
+    }
+
+    fn as_function(vm: &BexVm, self_value: &Value) -> Option<Value> {
+        as_kind(vm, *self_value, baml_type::type_kind::TypeKind::Function)
+    }
+
     /// Returns the `RealizedTy`'s display name.  Includes namespaces and (for
     /// non-`user` packages) the package prefix, so two distinct types never
     /// collide on this string — package names are unique within a workspace,
@@ -35,7 +75,7 @@ impl BamlClassTypeValue for PackageBamlImpl {
             return bex_str::BexStr::from("<type: ?>");
         };
         match vm.get_object(ptr) {
-            Object::Type(ty) => bex_str::BexStr::from(ty.to_string()),
+            Object::Type(type_value) => bex_str::BexStr::from(type_value.ty.to_string()),
             _ => bex_str::BexStr::from("<type: ?>"),
         }
     }
@@ -111,18 +151,23 @@ impl BamlClassTypeValue for PackageBamlImpl {
             .collect();
         entries
             .into_iter()
-            .map(|(ty, _, _)| Value::object(vm.tlab.alloc(Object::Type(Box::new(ty)))))
+            .map(|(ty, _, _)| Value::object(vm.alloc_static_type(ty)))
             .collect()
     }
 }
 
 /// The concrete `RealizedTy` wrapped by a `type` value (class, enum, interface,
 /// primitive, container, …), or `None` if `value` isn't a `type`.
-fn type_value_ty(vm: &BexVm, value: Value) -> Option<baml_type::RealizedTy> {
+pub(super) fn type_value_ty(vm: &BexVm, value: Value) -> Option<baml_type::RealizedTy> {
     match vm.get_object(value.as_object_ptr()?) {
-        Object::Type(ty) => Some(ty.as_ref().clone()),
+        Object::Type(type_value) => Some(type_value.ty.clone()),
         _ => None,
     }
+}
+
+fn as_kind(vm: &BexVm, value: Value, expected: baml_type::type_kind::TypeKind) -> Option<Value> {
+    let ty = type_value_ty(vm, value)?;
+    (baml_type::type_kind::classify_type(&ty) == expected).then_some(value)
 }
 
 /// A realized interface instantiation as reflected off a value: the type's
@@ -138,10 +183,10 @@ type RealizedTypeInstantiation = (
 /// interface instantiations.
 fn ty_name_args_and_assoc(vm: &BexVm, value: Value) -> Option<RealizedTypeInstantiation> {
     let ptr = value.as_object_ptr()?;
-    let Object::Type(ty) = vm.get_object(ptr) else {
+    let Object::Type(type_value) = vm.get_object(ptr) else {
         return None;
     };
-    match ty.as_ref() {
+    match &type_value.ty {
         baml_type::RealizedTy::Class(name, args, _) => {
             Some((name.clone(), args.clone(), Vec::new()))
         }

--- a/baml_language/crates/bex_vm/src/package_baml/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/type_class.rs
@@ -1,7 +1,25 @@
 use bex_vm_types::types::{Object, Value};
 
-use super::{BamlClassTypeValue, PackageBamlImpl, resolve};
-use crate::BexVm;
+use super::{BamlClassTypeValue, BamlNamespaceType, PackageBamlImpl, resolve};
+use crate::{BexVm, errors::VmRustFnError};
+
+impl BamlNamespaceType for PackageBamlImpl {
+    /// BEP-066 K-13: `type.of_value(v)` — the runtime `type` value describing
+    /// `v`'s concrete type, reconstructed by [`BexVm::value_concrete_ty`].
+    ///
+    /// K-12 holds by construction: `value_concrete_ty` reports value types
+    /// (`int` for `5`), never literal types. A value with no reconstructable
+    /// BAML type — a compile-time definition object (package, class, enum,
+    /// interface, impl rule) or an opaque native handle — yields the `unknown`
+    /// type value, the same fail-open convention `reflect.signature` /
+    /// `reflect.call_any` use for unreconstructable argument types.
+    fn of_value(vm: &mut BexVm, v: &Value) -> Result<Value, VmRustFnError> {
+        let ty = vm
+            .value_concrete_ty(*v)
+            .map_or_else(baml_type::RealizedTy::unknown, baml_type::RealizedTy::from);
+        Ok(Value::object(vm.tlab.alloc_type(ty)))
+    }
+}
 
 impl BamlClassTypeValue for PackageBamlImpl {
     /// Returns the `RealizedTy`'s display name.  Includes namespaces and (for
@@ -136,7 +154,7 @@ fn ty_name_args_and_assoc(vm: &BexVm, value: Value) -> Option<RealizedTypeInstan
 }
 
 /// BEP-044 wf3 #G19: a synthetic `TypeName` for a primitive type, so reflection on a
-/// primitive type value (`reflect.type_of<int>()`) has a name to key by, the way
+/// primitive type value (`type.of<int>()`) has a name to key by, the way
 /// non-primitive types carry their own `TypeName`. Impl *matching* for primitives is
 /// structural — the registry bakes their for-types as `Concrete(RuntimeTy::Int { .. })`
 /// etc. (`baml_compiler2_mir`'s `tir2_to_template`), matched by `resolve::match_template`

--- a/baml_language/crates/bex_vm/src/package_baml/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/type_class.rs
@@ -5,7 +5,7 @@ use crate::{BexVm, errors::VmRustFnError};
 
 impl BamlNamespaceType for PackageBamlImpl {
     /// BEP-066 K-13: `type.of_value(v)` — the runtime `type` value describing
-    /// `v`'s concrete type, reconstructed by [`BexVm::value_concrete_ty`].
+    /// `v`'s concrete type, reconstructed by `BexVm::value_concrete_ty`.
     ///
     /// K-12 holds by construction: `value_concrete_ty` reports value types
     /// (`int` for `5`), never literal types. A value with no reconstructable

--- a/baml_language/crates/bex_vm/src/package_baml/type_kinds.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/type_kinds.rs
@@ -1,0 +1,268 @@
+//! BEP-066 reflection kind views over the existing minted `Object::Type`.
+
+use bex_heap::TlabHolder;
+use bex_vm_types::types::{Object, Value};
+use indexmap::IndexMap;
+
+use super::{
+    BamlClassReflectArrayType, BamlClassReflectClassType, BamlClassReflectEnumType,
+    BamlClassReflectFunctionType, BamlClassReflectInterfaceType, BamlClassReflectLiteralType,
+    BamlClassReflectMapType, BamlClassReflectPrimitiveType, BamlClassReflectUnionType,
+    BamlClassTypeValue, BamlNamespaceReflectArray, BamlNamespaceReflectClass,
+    BamlNamespaceReflectEnum, BamlNamespaceReflectFunction, BamlNamespaceReflectInterface,
+    BamlNamespaceReflectLiteral, BamlNamespaceReflectMap, BamlNamespaceReflectPrimitive,
+    BamlNamespaceReflectUnion, PackageBamlImpl, copy,
+};
+use crate::BexVm;
+
+impl BamlNamespaceReflectArray for PackageBamlImpl {}
+impl BamlNamespaceReflectClass for PackageBamlImpl {}
+impl BamlNamespaceReflectEnum for PackageBamlImpl {}
+impl BamlNamespaceReflectFunction for PackageBamlImpl {}
+impl BamlNamespaceReflectInterface for PackageBamlImpl {}
+impl BamlNamespaceReflectLiteral for PackageBamlImpl {}
+impl BamlNamespaceReflectMap for PackageBamlImpl {}
+impl BamlNamespaceReflectPrimitive for PackageBamlImpl {}
+impl BamlNamespaceReflectUnion for PackageBamlImpl {}
+
+fn reflected_ty(vm: &BexVm, value: Value) -> baml_type::RealizedTy {
+    super::type_class::type_value_ty(vm, value)
+        .unwrap_or_else(|| unreachable!("kind method receiver must be Object::Type"))
+}
+
+fn reflected_class(vm: &BexVm, value: Value) -> (bex_vm_types::Class, Vec<baml_type::RealizedTy>) {
+    let baml_type::RealizedTy::Class(name, args, _) = reflected_ty(vm, value) else {
+        unreachable!("class.Type receiver must wrap a class type")
+    };
+    let ptr = vm
+        .lookup_type(&name)
+        .unwrap_or_else(|| unreachable!("reflected class {name} must be loaded"));
+    let Object::Class(class) = vm.get_object(ptr) else {
+        unreachable!("reflected class name resolved to a non-class")
+    };
+    ((**class).clone(), args)
+}
+
+fn reflected_enum(vm: &BexVm, value: Value) -> bex_vm_types::Enum {
+    let baml_type::RealizedTy::Enum(name, _) = reflected_ty(vm, value) else {
+        unreachable!("enum.Type receiver must wrap an enum type")
+    };
+    let ptr = vm
+        .lookup_type(&name)
+        .unwrap_or_else(|| unreachable!("reflected enum {name} must be loaded"));
+    let Object::Enum(enm) = vm.get_object(ptr) else {
+        unreachable!("reflected enum name resolved to a non-enum")
+    };
+    (**enm).clone()
+}
+
+fn opt_string(vm: &mut BexVm, value: Option<&str>) -> Value {
+    value.map_or(Value::NULL, |s| Value::object(vm.alloc_string(s)))
+}
+
+fn alloc_meta(
+    vm: &mut BexVm,
+    alias: Option<&str>,
+    description: Option<&str>,
+    docstring: Option<&str>,
+    other: &IndexMap<String, String>,
+) -> Value {
+    let mut entries = IndexMap::with_capacity(other.len());
+    for (key, value) in other {
+        entries.insert(
+            bex_str::BexStr::from(key.as_str()),
+            Value::object(vm.alloc_string(value.as_str())),
+        );
+    }
+    let other = Value::object(vm.alloc_map(
+        baml_type::RealizedTy::string(),
+        baml_type::RealizedTy::string(),
+        entries,
+    ));
+    let alias = opt_string(vm, alias);
+    let description = opt_string(vm, description);
+    let docstring = opt_string(vm, docstring);
+    copy::reflect::Meta {
+        alias,
+        description,
+        docstring,
+        other,
+    }
+    .to_value(vm)
+}
+
+macro_rules! impl_as_type {
+    ($trait_name:ident) => {
+        fn as_type(_vm: &BexVm, r#type: &Value) -> Value {
+            *r#type
+        }
+    };
+}
+
+impl BamlClassReflectClassType for PackageBamlImpl {
+    impl_as_type!(BamlClassReflectClassType);
+
+    fn fields(vm: &mut BexVm, r#type: &Value) -> Vec<Value> {
+        let (class, args) = reflected_class(vm, *r#type);
+        class
+            .fields
+            .iter()
+            .map(|field| {
+                let name = Value::object(vm.alloc_string(field.name.as_str()));
+                let ty = field
+                    .field_template
+                    .substitute(&args, vm)
+                    .unwrap_or_else(|err| {
+                        unreachable!("emitted class field template must realize: {err}")
+                    });
+                let r#type = Value::object(vm.alloc_static_type(ty));
+                let meta = alloc_meta(
+                    vm,
+                    field.alias.as_deref(),
+                    field.description.as_deref(),
+                    field.docstring.as_deref(),
+                    &field.other,
+                );
+                copy::reflect::class::Field { name, r#type, meta }.to_value(vm)
+            })
+            .collect()
+    }
+
+    fn meta(vm: &mut BexVm, r#type: &Value) -> Value {
+        let (class, _) = reflected_class(vm, *r#type);
+        alloc_meta(
+            vm,
+            class.alias.as_deref(),
+            class.description.as_deref(),
+            class.docstring.as_deref(),
+            &class.other,
+        )
+    }
+}
+
+impl BamlClassReflectEnumType for PackageBamlImpl {
+    impl_as_type!(BamlClassReflectEnumType);
+
+    fn values(vm: &mut BexVm, r#type: &Value) -> Vec<Value> {
+        let enm = reflected_enum(vm, *r#type);
+        enm.variants
+            .iter()
+            .map(|variant| {
+                let name = Value::object(vm.alloc_string(variant.name.as_str()));
+                let meta = alloc_meta(
+                    vm,
+                    variant.alias.as_deref(),
+                    variant.description.as_deref(),
+                    variant.docstring.as_deref(),
+                    &variant.other,
+                );
+                copy::reflect::r#enum::Value { name, meta }.to_value(vm)
+            })
+            .collect()
+    }
+
+    fn meta(vm: &mut BexVm, r#type: &Value) -> Value {
+        let enm = reflected_enum(vm, *r#type);
+        alloc_meta(
+            vm,
+            enm.alias.as_deref(),
+            enm.description.as_deref(),
+            enm.docstring.as_deref(),
+            &enm.other,
+        )
+    }
+}
+
+impl BamlClassReflectUnionType for PackageBamlImpl {
+    impl_as_type!(BamlClassReflectUnionType);
+
+    fn member_types(vm: &mut BexVm, r#type: &Value) -> Vec<Value> {
+        let baml_type::RealizedTy::Union(members, _) = reflected_ty(vm, *r#type) else {
+            unreachable!("union.Type receiver must wrap a union type")
+        };
+        members
+            .into_iter()
+            .map(|ty| Value::object(vm.alloc_static_type(ty)))
+            .collect()
+    }
+}
+
+impl BamlClassReflectArrayType for PackageBamlImpl {
+    impl_as_type!(BamlClassReflectArrayType);
+
+    fn element_type(vm: &mut BexVm, r#type: &Value) -> Value {
+        let baml_type::RealizedTy::List(element, _) = reflected_ty(vm, *r#type) else {
+            unreachable!("array.Type receiver must wrap an array type")
+        };
+        Value::object(vm.alloc_static_type(*element))
+    }
+}
+
+impl BamlClassReflectMapType for PackageBamlImpl {
+    impl_as_type!(BamlClassReflectMapType);
+
+    fn key_type(vm: &mut BexVm, r#type: &Value) -> Value {
+        let baml_type::RealizedTy::Map { key, .. } = reflected_ty(vm, *r#type) else {
+            unreachable!("map.Type receiver must wrap a map type")
+        };
+        Value::object(vm.alloc_static_type(*key))
+    }
+
+    fn value_type(vm: &mut BexVm, r#type: &Value) -> Value {
+        let baml_type::RealizedTy::Map { value, .. } = reflected_ty(vm, *r#type) else {
+            unreachable!("map.Type receiver must wrap a map type")
+        };
+        Value::object(vm.alloc_static_type(*value))
+    }
+}
+
+impl BamlClassReflectFunctionType for PackageBamlImpl {
+    impl_as_type!(BamlClassReflectFunctionType);
+
+    fn params(vm: &mut BexVm, r#type: &Value) -> Vec<Value> {
+        let baml_type::RealizedTy::Function { params, .. } = reflected_ty(vm, *r#type) else {
+            unreachable!("function.Type receiver must wrap a function type")
+        };
+        params
+            .into_iter()
+            .map(|param| {
+                let name = opt_string(vm, param.name.as_ref().map(baml_type::Name::as_str));
+                let optional = param.is_optional();
+                let r#type = Value::object(vm.alloc_static_type(param.ty));
+                copy::reflect::function::Parameter {
+                    name,
+                    r#type,
+                    optional,
+                }
+                .to_value(vm)
+            })
+            .collect()
+    }
+
+    fn return_type(vm: &mut BexVm, r#type: &Value) -> Value {
+        let baml_type::RealizedTy::Function { ret, .. } = reflected_ty(vm, *r#type) else {
+            unreachable!("function.Type receiver must wrap a function type")
+        };
+        Value::object(vm.alloc_static_type(*ret))
+    }
+}
+
+impl BamlClassReflectInterfaceType for PackageBamlImpl {
+    impl_as_type!(BamlClassReflectInterfaceType);
+
+    fn implemented_by(vm: &BexVm, r#type: &Value, other: &Value) -> bool {
+        <PackageBamlImpl as BamlClassTypeValue>::implemented_by(vm, r#type, other)
+    }
+
+    fn implementors(vm: &mut BexVm, r#type: &Value) -> Vec<Value> {
+        <PackageBamlImpl as BamlClassTypeValue>::implementors(vm, r#type)
+    }
+}
+
+impl BamlClassReflectLiteralType for PackageBamlImpl {
+    impl_as_type!(BamlClassReflectLiteralType);
+}
+
+impl BamlClassReflectPrimitiveType for PackageBamlImpl {
+    impl_as_type!(BamlClassReflectPrimitiveType);
+}

--- a/baml_language/crates/bex_vm/src/package_boundary/mod.rs
+++ b/baml_language/crates/bex_vm/src/package_boundary/mod.rs
@@ -1,9 +1,9 @@
 //! Native implementations for the `boundary` stdlib package.
 //!
 //! Dispatch and the class constructors are generated from `boundary`'s `.baml`
-//! sources by `baml_builtins2_codegen`, exactly as for [`crate::package_baml`]
-//! and [`crate::package_reflect`]: declaring a `$rust_function` adds a required
-//! trait method, so the declaration and its implementation cannot drift.
+//! sources by `baml_builtins2_codegen`, exactly as for [`crate::package_baml`]:
+//! declaring a `$rust_function` adds a required trait method, so the
+//! declaration and its implementation cannot drift.
 
 pub(crate) mod id;
 

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -86,8 +86,8 @@ use bex_vm_types::{
     StackIndex, UnaryOp, Value, Variant, VmGlobals,
     bytecode::{self, Instruction},
     types::{
-        BoundMethod, Closure, ConstValue, Function, FunctionOrigin, FunctionType, Instance, Type,
-        UnscheduledFuture,
+        BoundMethod, Closure, ConstValue, Function, FunctionOrigin, FunctionType, Instance, MintId,
+        Type, TypeValue, UnscheduledFuture,
     },
 };
 use indexmap::IndexMap;
@@ -272,9 +272,9 @@ impl Frame {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::sync::Arc;
     #[cfg(not(target_arch = "wasm32"))]
     use std::sync::atomic::AtomicBool;
+    use std::{collections::HashMap, sync::Arc};
 
     use bex_heap::{BexHeap, CollectionLevel, Tlab};
     use bex_vm_types::{
@@ -330,6 +330,7 @@ pub(crate) mod tests {
             id_overrides: Vec::new(),
             argv: Arc::from([]),
             pending_call_type_args: Vec::new(),
+            static_mint_cache: HashMap::new(),
             packages: Arc::new(crate::package_load::PackageIndex::default()),
         }
     }
@@ -752,6 +753,16 @@ pub struct BexVm {
     /// re-enter the VM (via `YieldToCall`) therefore see their own type-args
     /// even if the inner callback uses different ones.
     pending_call_type_args: Vec<baml_type::RealizedTy>,
+
+    /// Memo for `MintId::Static` digests (BEP-066), keyed by the *spelled*
+    /// `RealizedTy`. `LoadType` runs on every generic call, and the digest is
+    /// a canonicalization walk (`baml_type::normalize::canonical_digest` with
+    /// this VM as the fact context) — this cache skips re-walking repeated
+    /// spellings. Pure memoization: the digest is a deterministic function of
+    /// the spelling under this VM's immutable program facts, so a per-VM cache
+    /// (spawned VMs start empty) can never produce a divergent mint. Distinct
+    /// spellings of equivalent types get separate entries with equal digests.
+    static_mint_cache: HashMap<baml_type::RealizedTy, u64>,
 }
 
 /// VM execution state.
@@ -1260,6 +1271,7 @@ impl BexVm {
             id_overrides: Vec::new(),
             argv,
             pending_call_type_args: Vec::new(),
+            static_mint_cache: HashMap::new(),
             packages,
         }
     }
@@ -1277,6 +1289,28 @@ impl BexVm {
         &self.pending_call_type_args
     }
 
+    /// Materialize a statically described runtime `type` value.
+    ///
+    /// The mint is the deterministic digest of the type's canonical form with
+    /// this VM as the complete program-fact context. Digests are memoized by
+    /// spelling because `LoadType` can materialize the same template many times;
+    /// equivalent spellings may occupy separate cache entries, but derive the
+    /// same digest. All VM-side static type producers route through this method
+    /// so an `Object::Type` cannot be allocated without its identity.
+    pub fn alloc_static_type(&mut self, ty: baml_type::RealizedTy) -> HeapPtr {
+        let type_value = if let Some(&digest) = self.static_mint_cache.get(&ty) {
+            TypeValue::from_parts(ty, MintId::Static(digest))
+        } else {
+            let type_value = TypeValue::static_new(ty, self);
+            let MintId::Static(digest) = type_value.mint() else {
+                unreachable!("TypeValue::static_new always creates a static mint")
+            };
+            self.static_mint_cache.insert(type_value.ty.clone(), digest);
+            type_value
+        };
+        self.tlab.alloc_type(type_value)
+    }
+
     fn take_type_args(
         &mut self,
         start: usize,
@@ -1290,10 +1324,10 @@ impl BexVm {
         for slot in start..end {
             let value = self.stack[StackIndex::from_raw(slot)];
             let ptr = self.as_object_ptr(value, ObjectType::Type)?;
-            let Object::Type(ty) = self.get_object(ptr) else {
+            let Object::Type(type_value) = self.get_object(ptr) else {
                 unreachable!("as_object_ptr guarantees Type variant");
             };
-            type_args.push(*ty.clone());
+            type_args.push(type_value.ty.clone());
         }
         drop(
             self.stack
@@ -1759,7 +1793,7 @@ impl BexVm {
         let value = self.stack.ensure_pop();
         let ptr = self.as_object_ptr(value, ObjectType::Type)?;
         match self.get_object(ptr) {
-            Object::Type(ty) => Ok(*ty.clone()),
+            Object::Type(type_value) => Ok(type_value.ty.clone()),
             other => Err(VmInternalError::TypeError {
                 expected: ObjectType::Type.into(),
                 got: ObjectType::of(other).into(),
@@ -2055,11 +2089,11 @@ impl BexVm {
                     ObjectType::of(other)
                 ),
             },
-            // A `type` value (e.g. `type.of<T>()`) — its concrete type is
-            // the `type` primitive, the subject of `implement I for type`.
-            Object::Type(_) => ConcreteRealizedTy::Type {
-                attr: TyAttr::default(),
-            },
+            // A `type` value reports its precise sealed reflection-kind class.
+            // Each kind class is a subtype of the `type` carrier.
+            Object::Type(type_value) => {
+                baml_type::type_kind::classify_type(&type_value.ty).concrete_class_ty()
+            }
             // Arrays/maps carry their element/key/value types, so the faithful
             // `list<T>` / `map<K, V>` is reconstructed from the value itself.
             Object::Array(arr) => {
@@ -2522,7 +2556,7 @@ impl BexVm {
         match callable_kind {
             FunctionKind::Native(_) => {
                 for ty in type_args {
-                    let ty_ptr = self.tlab.alloc(Object::Type(Box::new(ty)));
+                    let ty_ptr = self.alloc_static_type(ty);
                     self.stack.push(Value::object(ty_ptr));
                 }
                 self.stack.extend(args.iter().copied());
@@ -3418,7 +3452,7 @@ impl BexVm {
     ) -> Result<(baml_type::TypeName, Vec<baml_type::RealizedTy>), VmError> {
         let iface_ptr = self.as_object_ptr(iface_value, ObjectType::Type)?;
         match self.get_object(iface_ptr) {
-            Object::Type(ty) => match ty.as_ref() {
+            Object::Type(type_value) => match &type_value.ty {
                 baml_type::RealizedTy::Interface(qtn, args, _assoc, _attr) => {
                     Ok((qtn.clone(), args.clone()))
                 }
@@ -4322,8 +4356,8 @@ impl BexVm {
     /// `baml.host.call_host_value` in `sys_ops/.../io_generated.rs`):
     ///   args\[0\] = `handle`     (`Object::HostClosure` → `BexExternalValue::HostValue`)
     ///   args\[1\] = `args_pack`  (`Object::Array` of `[positional: Object::Array, optional: Object::Map]`)
-    ///   args\[2\] = `ret_ty`     (`Object::Type<RuntimeTy>`) — `type_arg_0` (`T`)
-    ///   args\[3\] = `throws_ty`  (`Object::Type<RuntimeTy>`) — `type_arg_1` (`E`)
+    ///   args\[2\] = `ret_ty`     (`Object::Type<TypeValue>`) — `type_arg_0` (`T`)
+    ///   args\[3\] = `throws_ty`  (`Object::Type<TypeValue>`) — `type_arg_1` (`E`)
     ///
     /// TODO: `throws_ty` is packed here but the engine doesn't yet read it
     /// — a future phase will validate the host's thrown value against `E`
@@ -4395,8 +4429,8 @@ impl BexVm {
             baml_type::RealizedTy::unknown(),
             vec![Value::object(positional_ptr), Value::object(optional_ptr)],
         );
-        let ret_ty_ptr = self.tlab.alloc(Object::Type(Box::new(ret_ty)));
-        let throws_ty_ptr = self.tlab.alloc(Object::Type(Box::new(throws_ty)));
+        let ret_ty_ptr = self.alloc_static_type(ret_ty);
+        let throws_ty_ptr = self.alloc_static_type(throws_ty);
         // PR4b: host-closure calls ride the sys-op pair too. No Function
         // object backs them, so function_id 0 (unassigned).
         self.prof_enter_sysop(0, call_site, VmCaptureMask::disabled());
@@ -5346,8 +5380,10 @@ impl BexVm {
                     }
                 }),
                 (Object::Type(lt), Object::Type(rt)) => Value::bool(match op {
-                    CmpOp::Eq => lt == rt,
-                    CmpOp::NotEq => lt != rt,
+                    // BEP-066: compare the stable identity token. Static
+                    // canonicalization and runtime freshness happen at minting.
+                    CmpOp::Eq => lt.mint() == rt.mint(),
+                    CmpOp::NotEq => lt.mint() != rt.mint(),
                     _ => {
                         return Err(VmInternalError::CannotApplyCmpOp {
                             left: bex_vm_types::types::Type::Object(ObjectType::Type),
@@ -6345,7 +6381,7 @@ impl BexVm {
                             // `Converter<int>` + `Converter<float>`); non-generic
                             // interfaces carry none and resolve by name + `Self`.
                             // Associated types are outputs, not part of the key.
-                            Object::Type(ty) => match ty.as_ref() {
+                            Object::Type(type_value) => match &type_value.ty {
                                 baml_type::RealizedTy::Interface(qtn, args, _assoc, _attr) => {
                                     (qtn.clone(), args.clone())
                                 }
@@ -6983,7 +7019,7 @@ impl BexVm {
                         }
                     };
 
-                    let value = Value::object(self.alloc_type(ty));
+                    let value = Value::object(self.alloc_static_type(ty));
                     self.stack.push(value);
                 }
 
@@ -7027,7 +7063,7 @@ impl BexVm {
                     let (iface_qtn, iface_args) = {
                         let iface_ptr = self.as_object_ptr(iface_value, ObjectType::Type)?;
                         match self.get_object(iface_ptr) {
-                            Object::Type(ty) => match ty.as_ref() {
+                            Object::Type(type_value) => match &type_value.ty {
                                 baml_type::RealizedTy::Interface(qtn, args, _assoc, _attr) => {
                                     (qtn.clone(), args.clone())
                                 }

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -2055,7 +2055,7 @@ impl BexVm {
                     ObjectType::of(other)
                 ),
             },
-            // A `type` value (e.g. `reflect.type_of<T>()`) — its concrete type is
+            // A `type` value (e.g. `type.of<T>()`) — its concrete type is
             // the `type` primitive, the subject of `implement I for type`.
             Object::Type(_) => ConcreteRealizedTy::Type {
                 attr: TyAttr::default(),
@@ -2136,7 +2136,7 @@ impl BexVm {
             // A future carries the `<T, E>` it was spawned at (resolved against
             // the spawning frame), so its concrete type is the faithful
             // `Future<T, E>` — the subject of `is`/`match` arms and
-            // `reflect.type_of`.
+            // `type.of`.
             Object::Future(fut) => ConcreteRealizedTy::Future(
                 Box::new(fut.returns().clone()),
                 Box::new(fut.throws().clone()),
@@ -3949,7 +3949,7 @@ impl BexVm {
     /// `HeapPtr` is `callee` unchanged — keeping the `BoundMethod` identity so
     /// that `execute_call_from_locals_offset` can extract the receiver's
     /// `class_type_args` to seed `frame.type_args` (needed for
-    /// `reflect.type_of<T>()` inside generic methods invoked indirectly).
+    /// `type.of<T>()` inside generic methods invoked indirectly).
     /// `execute_call_from_locals_offset` and `load_function` both unwrap the
     /// `BoundMethod` to its inner `Function` for dispatch.
     fn resolve_bound_method_callee(&self, callee: HeapPtr, args: &mut Vec<Value>) -> HeapPtr {
@@ -4568,7 +4568,7 @@ impl BexVm {
 
         // For GenericFunction callees (`let f = foo<int>; f(x)`), the bound
         // concrete type args seed frame.type_args so type-reifying bodies
-        // (reflect.type_of<T>, json natives) resolve T at runtime. (The
+        // (type.of<T>, json natives) resolve T at runtime. (The
         // Closure/BoundMethod type args are classified in the consolidated match
         // above; GenericFunction is specific to generic instantiation values.)
         let gf_type_args: Box<[baml_type::RealizedTy]> = match self.get_object(callee_ptr) {

--- a/baml_language/crates/bex_vm/tests/load_type.rs
+++ b/baml_language/crates/bex_vm/tests/load_type.rs
@@ -18,7 +18,7 @@ use bex_vm::{BexVm, VmExecState};
 use bex_vm_types::{
     ConstValue, FunctionCaptureProps, GlobalIndex, Instruction, Object, ObjectIndex, Value,
     bytecode::Bytecode,
-    types::{Function, FunctionKind, FunctionOrigin, Program},
+    types::{Function, FunctionKind, FunctionOrigin, MintId, Program},
 };
 
 /// Minimal valid BAML source used as the base for all tests.
@@ -121,7 +121,8 @@ fn run_with_bytecode_keep_vm(
 // ─── 3.1 & 3.5 ── LoadType with a fully-concrete template ───────────────────
 
 /// `LoadType(k)` where `k` is a `ConstValue::Type(TyTemplate::from(int))`
-/// should push an `Object::Type` whose inner `RuntimeTy` is `RuntimeTy::int()`.
+/// should push an `Object::Type` whose `TypeValue` carries `RealizedTy::int()`
+/// and a deterministic static mint.
 #[test]
 fn load_type_concrete_int() {
     let template = TyTemplate::from(baml_type::RealizedTy::int());
@@ -135,11 +136,14 @@ fn load_type_concrete_int() {
         panic!("expected Object, got {result:?}");
     };
     match vm.get_object(ptr) {
-        Object::Type(ty) => assert_eq!(
-            **ty,
-            RealizedTy::int(),
-            "LoadType(int) should materialise RealizedTy::int"
-        ),
+        Object::Type(type_value) => {
+            assert_eq!(
+                type_value.ty,
+                RealizedTy::int(),
+                "LoadType(int) should materialise RealizedTy::int"
+            );
+            assert!(matches!(type_value.mint(), MintId::Static(_)));
+        }
         other => panic!("expected Object::Type, got {other:?}"),
     }
 }
@@ -172,11 +176,11 @@ fn load_type_concrete_string_different_from_int() {
     };
 
     let int_ty = match vm_int.get_object(p_int) {
-        Object::Type(ty) => (**ty).clone(),
+        Object::Type(type_value) => type_value.ty.clone(),
         other => panic!("expected Object::Type for int, got {other:?}"),
     };
     let str_ty = match vm_str.get_object(p_str) {
-        Object::Type(ty) => (**ty).clone(),
+        Object::Type(type_value) => type_value.ty.clone(),
         other => panic!("expected Object::Type for string, got {other:?}"),
     };
 
@@ -241,9 +245,9 @@ fn load_type_type_arg_ref_substitutes_from_frame() {
     };
     let obj = vm.get_object(ptr);
     match obj {
-        Object::Type(ty) => {
+        Object::Type(type_value) => {
             assert_eq!(
-                **ty,
+                type_value.ty,
                 RealizedTy::string(),
                 "TypeArgRef(0) should resolve to string"
             );
@@ -255,7 +259,8 @@ fn load_type_type_arg_ref_substitutes_from_frame() {
 // ─── 3.5 ── Composite template Array(TypeArgRef(0)) ─────────────────────────
 
 /// `TyTemplate::Array(TypeArgRef(0))` with `frame.type_args[0] = RuntimeTy::int()`
-/// should produce `Object::Type(RuntimeTy::list(int))`.
+/// should produce an `Object::Type` whose `TypeValue` carries
+/// `RealizedTy::list(int)`.
 #[test]
 fn load_type_array_of_type_arg_ref() {
     let template = TyTemplate::list(TyTemplate::TypeArgRef(0));
@@ -301,9 +306,9 @@ fn load_type_array_of_type_arg_ref() {
     };
     let obj = vm.get_object(ptr);
     match obj {
-        Object::Type(ty) => {
+        Object::Type(type_value) => {
             assert_eq!(
-                **ty,
+                type_value.ty,
                 RealizedTy::list(RealizedTy::int()),
                 "Array(TypeArgRef(0)) with int → int[]"
             );
@@ -386,9 +391,9 @@ fn call_ntypeargs_threads_type_arg_into_callee() {
     };
     let obj = vm.get_object(ptr);
     match obj {
-        Object::Type(ty) => {
+        Object::Type(type_value) => {
             assert_eq!(
-                **ty,
+                type_value.ty,
                 RealizedTy::string(),
                 "inner function should receive RealizedTy::string() via type arg"
             );

--- a/baml_language/crates/bex_vm/tests/method_class_type_args.rs
+++ b/baml_language/crates/bex_vm/tests/method_class_type_args.rs
@@ -111,6 +111,8 @@ fn alloc_instance_ntypeargs_stores_class_type_args() {
         fields: vec![],
         description: None,
         alias: None,
+        docstring: None,
+        other: indexmap::IndexMap::new(),
         type_tag: 100,
         ty_attr: TyAttr::default(),
         has_cleanup: false,
@@ -163,6 +165,8 @@ fn alloc_instance_ntypeargs_zero_gives_empty_class_type_args() {
         fields: vec![],
         description: None,
         alias: None,
+        docstring: None,
+        other: indexmap::IndexMap::new(),
         type_tag: 101,
         ty_attr: TyAttr::default(),
         has_cleanup: false,
@@ -249,9 +253,9 @@ fn method_frame_type_args_seeded_with_class_type_args() {
         panic!("expected Object, got {result:?}");
     };
     match vm.get_object(ptr) {
-        Object::Type(ty) => {
+        Object::Type(type_value) => {
             assert_eq!(
-                **ty,
+                type_value.ty,
                 RealizedTy::int(),
                 "TypeArgRef(0) with class_type_args=[int] should yield int"
             );
@@ -299,9 +303,9 @@ fn method_frame_type_args_seeded_string() {
         panic!("expected Object")
     };
     match vm.get_object(ptr) {
-        Object::Type(ty) => {
+        Object::Type(type_value) => {
             assert_eq!(
-                **ty,
+                type_value.ty,
                 RealizedTy::string(),
                 "TypeArgRef(0) with class_type_args=[string] should yield string"
             );

--- a/baml_language/crates/bex_vm_types/src/link.rs
+++ b/baml_language/crates/bex_vm_types/src/link.rs
@@ -853,6 +853,8 @@ mod tests {
             fields: Vec::new(),
             description: None,
             alias: None,
+            docstring: None,
+            other: indexmap::IndexMap::new(),
             type_tag,
             ty_attr: baml_type::TyAttr::default(),
             has_cleanup: false,

--- a/baml_language/crates/bex_vm_types/src/types.rs
+++ b/baml_language/crates/bex_vm_types/src/types.rs
@@ -15,6 +15,7 @@ mod future;
 mod interface;
 mod object;
 mod package;
+mod type_value;
 mod value;
 
 use std::collections::HashMap;
@@ -32,6 +33,7 @@ pub use interface::*;
 pub use object::*;
 pub use package::*;
 pub use tokio_util::sync::CancellationToken;
+pub use type_value::*;
 pub use value::*;
 
 use crate::{heap_ptr::HeapPtr, indexable::ObjectPool};

--- a/baml_language/crates/bex_vm_types/src/types/class.rs
+++ b/baml_language/crates/bex_vm_types/src/types/class.rs
@@ -1,5 +1,6 @@
 use baml_type::RuntimeTy;
 use borsh::{BorshDeserialize, BorshSerialize};
+use indexmap::IndexMap;
 
 use crate::{AtomicValueSlot, CleanupLatch, HeapPtr, Value};
 
@@ -20,6 +21,8 @@ pub struct ClassField {
     pub field_template: baml_type::TyTemplate,
     pub description: Option<String>,
     pub alias: Option<String>,
+    pub docstring: Option<String>,
+    pub other: IndexMap<String, String>,
     pub skip: bool,
 }
 
@@ -38,6 +41,10 @@ pub struct Class {
 
     /// Class-level serialization alias.
     pub alias: Option<String>,
+
+    /// Class-level source documentation and custom annotations.
+    pub docstring: Option<String>,
+    pub other: IndexMap<String, String>,
 
     /// Type tag for this class, used by `TypeTag` instruction for jump table dispatch.
     /// Assigned during codegen as `CLASS_BASE + class_index`.

--- a/baml_language/crates/bex_vm_types/src/types/enums.rs
+++ b/baml_language/crates/bex_vm_types/src/types/enums.rs
@@ -1,4 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+use indexmap::IndexMap;
 
 use crate::HeapPtr;
 
@@ -8,6 +9,8 @@ pub struct EnumVariant {
     pub name: String,
     pub description: Option<String>,
     pub alias: Option<String>,
+    pub docstring: Option<String>,
+    pub other: IndexMap<String, String>,
     pub skip: bool,
 }
 
@@ -26,6 +29,10 @@ pub struct Enum {
 
     /// Enum-level serialization alias.
     pub alias: Option<String>,
+
+    /// Enum-level source documentation and custom annotations.
+    pub docstring: Option<String>,
+    pub other: IndexMap<String, String>,
 
     /// Enum-level type attribute.
     pub ty_attr: baml_type::TyAttr,

--- a/baml_language/crates/bex_vm_types/src/types/object.rs
+++ b/baml_language/crates/bex_vm_types/src/types/object.rs
@@ -121,8 +121,13 @@ pub enum Object {
     /// Collector object (opaque handle to `bex_events::Collector`).
     Collector(CollectorRef),
 
-    /// A type descriptor value — wraps a `baml_type::RealizedTy`.
-    Type(Box<baml_type::RealizedTy>),
+    /// A type descriptor value — wraps a [`crate::types::TypeValue`]: the
+    /// described `baml_type::RealizedTy` plus the minted identity that
+    /// `==`/hash compare (BEP-066). The mint is inline plain data, so a GC
+    /// copy or `baml.deep_copy` preserves identity; the wire form
+    /// (`ObjectWire::Type`) carries only the type — identity never crosses a
+    /// boundary (H-4) and is re-derived on decode.
+    Type(Box<crate::types::TypeValue>),
 
     #[cfg(feature = "heap_debug")]
     Sentinel(crate::types::SentinelKind),
@@ -205,6 +210,12 @@ enum ObjectWire {
     // enum's size. Borsh treats `Box<T>` transparently, so the wire form is
     // unchanged.
     UnscheduledFuture(Box<UnscheduledFuture>),
+    /// Carries only the described type — never the mint (BEP-066 H-4:
+    /// identity does not cross a serialization boundary). Decode re-derives a
+    /// `Static` mint. No compiled `Program` bakes an `Object::Type` into its
+    /// object pool today (`ConstValue::Type` templates materialize through
+    /// the VM's `LoadType`), so this round trip is exercised only by
+    /// unit/link tooling.
     Type(Box<baml_type::RealizedTy>),
 }
 
@@ -238,7 +249,8 @@ impl BorshSerialize for Object {
             Self::Float(v) => ObjectWire::Float(*v),
             Self::Future(v) => ObjectWire::Future(v.clone()),
             Self::UnscheduledFuture(v) => ObjectWire::UnscheduledFuture(v.clone()),
-            Self::Type(v) => ObjectWire::Type(v.clone()),
+            // The mint stays behind (H-4) — only the described type crosses.
+            Self::Type(v) => ObjectWire::Type(Box::new(v.ty.clone())),
             Self::RustData(_) => {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
@@ -305,7 +317,24 @@ impl BorshDeserialize for Object {
             ObjectWire::Float(v) => Self::Float(v),
             ObjectWire::Future(v) => Self::Future(v),
             ObjectWire::UnscheduledFuture(v) => Self::UnscheduledFuture(v),
-            ObjectWire::Type(v) => Self::Type(v),
+            ObjectWire::Type(v) => {
+                // Re-derive the static mint (H-4: identity never rides the
+                // wire). Borsh decode has no fact source to consult, so the
+                // digest is fact-free here; that matches the VM's digest for
+                // every type whose canonical form needs no program fact
+                // (classes, enums, primitives, containers, plain unions).
+                // No compiled `Program` pools an `Object::Type` today — see
+                // the `ObjectWire::Type` doc — so a fact-dependent payload
+                // (recursive alias, absorbing union) cannot reach this path
+                // from real programs.
+                #[expect(
+                    deprecated,
+                    reason = "borsh decode is a boundary with no fact context to supply; \
+                              see the fact-free digest note above"
+                )]
+                let ctx = baml_type::normalize::NoFacts;
+                Self::Type(Box::new(crate::types::TypeValue::static_new(*v, &ctx)))
+            }
         })
     }
 }
@@ -349,7 +378,7 @@ impl std::fmt::Display for Object {
             ),
             Object::RustData(_) => write!(f, "<rust_data>"),
             Object::Collector(_) => write!(f, "<collector>"),
-            Object::Type(ty) => write!(f, "<type: {ty}>"),
+            Object::Type(tv) => write!(f, "<type: {}>", tv.ty),
             Object::Future(future) => write!(f, "{}", future.read()),
             Object::UnscheduledFuture(_) => write!(f, "<unscheduled: spawn>"),
             Object::Float(v) => write!(f, "{v}"),
@@ -461,5 +490,38 @@ impl std::fmt::Display for ObjectType {
             ObjectType::RustData => write!(f, "rust_data"),
             ObjectType::Float => write!(f, "float"),
         }
+    }
+}
+
+#[cfg(test)]
+mod type_wire_tests {
+    use borsh::BorshDeserialize;
+
+    use super::*;
+    use crate::types::{MintId, TypeValue};
+
+    #[test]
+    fn type_wire_omits_identity_and_keeps_the_existing_payload_format() {
+        let ty = baml_type::RealizedTy::list(baml_type::RealizedTy::string());
+        let object = Object::Type(Box::new(TypeValue::from_parts(
+            ty.clone(),
+            MintId::Runtime(91),
+        )));
+
+        let encoded_object = borsh::to_vec(&object).expect("type object serializes");
+        let encoded_legacy_shape =
+            borsh::to_vec(&ObjectWire::Type(Box::new(ty.clone()))).expect("wire proxy serializes");
+        assert_eq!(
+            encoded_object, encoded_legacy_shape,
+            "adding a mint must not change the ObjectWire::Type bytes"
+        );
+
+        let decoded = Object::try_from_slice(&encoded_object).expect("type object deserializes");
+        let Object::Type(type_value) = decoded else {
+            panic!("decoded object should be a type")
+        };
+        assert_eq!(type_value.ty, ty);
+        assert!(matches!(type_value.mint(), MintId::Static(_)));
+        assert_ne!(type_value.mint(), MintId::Runtime(91));
     }
 }

--- a/baml_language/crates/bex_vm_types/src/types/object.rs
+++ b/baml_language/crates/bex_vm_types/src/types/object.rs
@@ -58,7 +58,7 @@ pub enum Object {
     /// compile time so identical instantiations share one object
     /// (pointer-stable `foo<int> === foo<int>`). When called, the VM resolves
     /// `function` via the global table and seeds `frame.type_args` from
-    /// `type_args`, so type-reifying bodies (`reflect.type_of<T>`, json natives)
+    /// `type_args`, so type-reifying bodies (`type.of<T>`, json natives)
     /// work through the value.
     GenericFunction(GenericFunction),
 

--- a/baml_language/crates/bex_vm_types/src/types/type_value.rs
+++ b/baml_language/crates/bex_vm_types/src/types/type_value.rs
@@ -1,0 +1,176 @@
+//! The payload of a runtime `type` value: a described type plus its minted
+//! identity (BEP-066 slice 1).
+//!
+//! Equality and hashing on a [`TypeValue`] are **exactly the mint** — never
+//! the heap pointer (the GC is copying, so a pointer can never be an identity
+//! token — I-4) and never a fresh structural walk of `ty` (the three
+//! historically divergent equality paths this replaces). The mint is plain
+//! data carried inline in the object, so GC copies and `baml.deep_copy`
+//! preserve identity by construction (I-1: a copy *is* the same type value).
+
+use baml_type::{RealizedTy, normalize::TypeContext};
+
+/// A minted identity token for a runtime `type` value.
+///
+/// The enum discriminant participates in derived equality, so a `Static` and
+/// a `Runtime` mint never compare equal — even on a raw `u64` collision — and
+/// a constructed type can never alias a static declaration (I-1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MintId {
+    /// A static spelling (`type.of<T>()`, a reflected signature, a wire-named
+    /// type): the deterministic canonical-form digest computed by
+    /// `baml_type::normalize::canonical_digest`. Equivalent static spellings
+    /// (`string?` vs `string | null`, permuted unions) share a digest, so
+    /// every reference to a static declaration is the same value with no
+    /// intern table (I-2), and re-materializations (a second `type.of<T>()`,
+    /// a sys-op round trip) rebuild the same identity.
+    Static(u64),
+    /// One per constructor evaluation (I-1): allocated from the monotonic
+    /// engine-wide counter on `BexHeap` (`mint_runtime_id`), shared by
+    /// spawned VMs. No producer exists yet in slice 1 — the structured
+    /// constructors land in slice 2 — but the variant is part of the
+    /// equality/hash contract now so the semantics cannot drift.
+    Runtime(u64),
+}
+
+/// What an `Object::Type` wraps: the described type and its identity.
+///
+/// `==`/`Hash` are mint-only (see [`MintId`]); `ty` is carried data that the
+/// VM reads for rendering, parsing, dispatch, and reflection. Two values with
+/// different `ty` payloads and equal mints cannot arise from the constructors
+/// below: a `Static` mint is a function of `ty`'s canonical form, and a
+/// `Runtime` mint is globally unique.
+#[derive(Debug, Clone)]
+pub struct TypeValue {
+    /// The type this value denotes.
+    pub ty: RealizedTy,
+    mint: MintId,
+}
+
+impl TypeValue {
+    /// Mint a type value for a **statically spelled** type: the mint is the
+    /// canonical-form digest of `ty` under `ctx`.
+    ///
+    /// `ctx` decides which facts the canonical form folds in (alias
+    /// expansion, union absorption); every site materializing types for the
+    /// same program must supply the same fact source — inside the VM that is
+    /// the VM itself (use `BexVm::alloc_static_type`, which also memoizes the
+    /// walk).
+    pub fn static_new<C: TypeContext>(ty: RealizedTy, ctx: &C) -> Self {
+        let digest = baml_type::normalize::canonical_digest(ty.as_ty(), ctx);
+        Self {
+            ty,
+            mint: MintId::Static(digest),
+        }
+    }
+
+    /// Assemble a type value from an already-derived mint.
+    ///
+    /// For the memoized static-digest path (`BexVm::alloc_static_type`), the
+    /// slice-2 runtime constructors (a counter mint from
+    /// `BexHeap::mint_runtime_id`), and tests pinning mint semantics. The
+    /// caller owns the invariant that `mint` was produced for `ty` — a
+    /// mismatched pair breaks type-value equality program-wide.
+    pub fn from_parts(ty: RealizedTy, mint: MintId) -> Self {
+        Self { ty, mint }
+    }
+
+    /// This value's identity token.
+    pub fn mint(&self) -> MintId {
+        self.mint
+    }
+}
+
+/// Identity comparison (I-1/I-2): the mint, nothing else. `ty` is deliberately
+/// excluded — see the struct doc.
+impl PartialEq for TypeValue {
+    fn eq(&self, other: &Self) -> bool {
+        self.mint == other.mint
+    }
+}
+
+impl Eq for TypeValue {}
+
+/// Identity hashing (I-4): consistent with `==` by hashing exactly what `==`
+/// compares.
+impl std::hash::Hash for TypeValue {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.mint.hash(state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::hash::{BuildHasher, RandomState};
+
+    use super::*;
+
+    /// Runtime mints are counter-identities: distinct counters are distinct
+    /// types even for byte-identical `ty` payloads (I-1), and the variant
+    /// discriminant keeps `Runtime` disjoint from `Static` even when the raw
+    /// `u64`s collide.
+    #[test]
+    fn mint_distinctness() {
+        assert_ne!(MintId::Runtime(0), MintId::Runtime(1));
+        assert_ne!(MintId::Runtime(7), MintId::Static(7));
+        assert_eq!(MintId::Runtime(3), MintId::Runtime(3));
+        assert_eq!(MintId::Static(3), MintId::Static(3));
+
+        let a = TypeValue::from_parts(RealizedTy::int(), MintId::Runtime(0));
+        let b = TypeValue::from_parts(RealizedTy::int(), MintId::Runtime(1));
+        let c = TypeValue::from_parts(RealizedTy::int(), MintId::Static(0));
+        assert_ne!(a, b, "distinct runtime mints are distinct identities");
+        assert_ne!(a, c, "a runtime mint never equals a static mint");
+        assert_eq!(a, a.clone(), "a copy preserves identity (I-1)");
+    }
+
+    /// `Hash` must be consistent with `==` (I-4): equal values hash equal,
+    /// and the `ty` payload is excluded from both.
+    #[test]
+    fn hash_consistent_with_eq() {
+        let a = TypeValue::from_parts(RealizedTy::int(), MintId::Static(42));
+        let b = TypeValue::from_parts(RealizedTy::string(), MintId::Static(42));
+        assert_eq!(a, b, "mint-equal values are equal regardless of payload");
+        // Same-RandomState comparison isn't available through `hash_one`
+        // twice (each `RandomState::new()` is keyed); use one state for both.
+        let state = RandomState::new();
+        assert_eq!(state.hash_one(&a), state.hash_one(&b));
+        // Unequal values need not hash differently, but hashing a different
+        // mint directly must remain supported by the same implementation.
+        let c = TypeValue::from_parts(RealizedTy::int(), MintId::Static(43));
+        assert_ne!(a, c);
+        let _ = state.hash_one(&c);
+    }
+
+    /// The static digest is a pure function of the canonical form: equivalent
+    /// spellings share a mint, distinct types do not, and derivation is
+    /// deterministic across independent derivations (two "processes" worth of
+    /// state in one test — nothing session-local feeds the digest).
+    #[test]
+    fn static_digest_deterministic_and_canonical() {
+        #[expect(
+            deprecated,
+            reason = "unit test of the fact-free digest itself; the VM paths under test \
+                      elsewhere supply the real fact context"
+        )]
+        let ctx = baml_type::normalize::NoFacts;
+
+        let optional = RealizedTy::Union(
+            vec![RealizedTy::string(), RealizedTy::null()],
+            baml_type::TyAttr::default(),
+        );
+        let reversed = RealizedTy::Union(
+            vec![RealizedTy::null(), RealizedTy::string()],
+            baml_type::TyAttr::default(),
+        );
+        let a = TypeValue::static_new(optional.clone(), &ctx);
+        let b = TypeValue::static_new(reversed, &ctx);
+        assert_eq!(a, b, "permuted union spellings share a static mint");
+
+        let again = TypeValue::static_new(optional, &ctx);
+        assert_eq!(a.mint(), again.mint(), "derivation is deterministic");
+
+        let other = TypeValue::static_new(RealizedTy::int(), &ctx);
+        assert_ne!(a, other, "distinct types get distinct static mints");
+    }
+}

--- a/baml_language/crates/bridge_ctypes/src/value_encode.rs
+++ b/baml_language/crates/bridge_ctypes/src/value_encode.rs
@@ -161,7 +161,7 @@ pub fn external_to_outbound(
             }))
         }
 
-        // A reflected BAML type returned as a value (`reflect.type_of<T>()`)
+        // A reflected BAML type returned as a value (`type.of<T>()`)
         // crosses the boundary as a first-class `Ty`, sharing the inbound
         // representation. Must precede the opaque-ADT catch-all, which would
         // otherwise box it into a handle.

--- a/baml_language/sdk_tests/crates/csharp/phase6_slice/baml_src/ns_csharp_phase6/main.baml
+++ b/baml_language/sdk_tests/crates/csharp/phase6_slice/baml_src/ns_csharp_phase6/main.baml
@@ -53,7 +53,7 @@ function identity<T>(value: T) -> T {
 }
 
 function type_name<T>() -> string {
-  reflect.type_of<T>().to_string()
+  type.of<T>().to_string()
 }
 
 function head<T>(values: T[]) -> T {

--- a/baml_language/sdk_tests/fixtures/function_calls/baml_src/ns_generic_tests/types.baml
+++ b/baml_language/sdk_tests/fixtures/function_calls/baml_src/ns_generic_tests/types.baml
@@ -20,7 +20,7 @@
 // ---------------------------------------------------------------------------
 
 // A generic box carrying *methods* that read the class TypeVar back out via
-// `reflect.type_of` (drives the "bound via caller" case): the host constructs
+// `type.of` (drives the "bound via caller" case): the host constructs
 // a concrete `GenericBox<int>` and the method reports the bound type name. Also
 // the fully-bound (`GenericBox<int>`) and outbound (`-> GenericBox<T>`) vehicle.
 class GenericBox<T> {
@@ -28,13 +28,13 @@ class GenericBox<T> {
 
   // Reflect the class-level binding the caller pinned at construction.
   function get(self) -> string {
-    reflect.type_of<T>().to_string()
+    type.of<T>().to_string()
   }
 
   // Method-level TypeVar `U` fused with the class `T`: `U` is inferred from
   // the argument, then reflected alongside `T` as a union.
   function pair_with<U>(self, other: U) -> string {
-    reflect.type_of<T | U>().to_string()
+    type.of<T | U>().to_string()
   }
 
   // Static constructor (no `self`): binds its OWN `V` via the caller's
@@ -53,7 +53,7 @@ class GenericBox<T> {
   }
 
   function static_pair<U>(left: T, right: U) -> string {
-    reflect.type_of<T | U>().to_string()
+    type.of<T | U>().to_string()
   }
 }
 
@@ -67,7 +67,7 @@ class NamedStatic<A, B, C> {
   third C
 
   function make<D, E>(d: D, e: E) -> string {
-    reflect.type_of<D | E>().to_string()
+    type.of<D | E>().to_string()
   }
 }
 
@@ -112,7 +112,7 @@ class GenericNameCollision<foo_bar> {
   value foo_bar
 
   function pair<fooBar>(self, other: fooBar) -> string {
-    reflect.type_of<foo_bar | fooBar>().to_string()
+    type.of<foo_bar | fooBar>().to_string()
   }
 
   function make<fooBar>(value: fooBar) -> GenericNameCollision<fooBar> {
@@ -121,7 +121,7 @@ class GenericNameCollision<foo_bar> {
 }
 
 function generic_name_collision<foo_bar, fooBar>(left: foo_bar, right: fooBar) -> string {
-  reflect.type_of<foo_bar | fooBar>().to_string()
+  type.of<foo_bar | fooBar>().to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -136,15 +136,15 @@ function identity<T>(x: T) -> T {
 // Return-position-only TypeVars with NO argument to infer from: the binding
 // can only come from the host's explicit `_types=`. The cleanest proof the
 // inbound path doesn't rely on argument inference. `T` (and `A`/`B`) appear
-// solely in the body via `reflect.type_of`, never in a parameter.
+// solely in the body via `type.of`, never in a parameter.
 // ---------------------------------------------------------------------------
 
 function one_type_arg<T>() -> string {
-  reflect.type_of<T>().to_string()
+  type.of<T>().to_string()
 }
 
 function two_type_args<A, B>() -> string {
-  reflect.type_of<A | B>().to_string()
+  type.of<A | B>().to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -164,7 +164,7 @@ function second_of<T>(p: GenericPair<int, T>) -> T {
 // ---------------------------------------------------------------------------
 
 function tag_or_value<T>(x: T | string | null) -> string {
-  reflect.type_of<T>().to_string()
+  type.of<T>().to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -214,7 +214,7 @@ function make_triple<A, B, C>(a: A, b: B[], c: map<string, C>) -> GenericTriple<
 // ---------------------------------------------------------------------------
 
 function extract<A, B, C, D>(a: GenericPair<GenericPair<A, B>, GenericPair<C, D>>) -> string {
-  reflect.type_of<A | B | C | D>().to_string()
+  type.of<A | B | C | D>().to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -303,34 +303,34 @@ function make_int_str_bool_triple() -> GenericTriple<int, string, bool> {
 // Two invariant list-element occurrences: pair(int[], string[]) rejects;
 // pair(int[], int[]) binds T = int.
 function pair<T>(a: T[], b: T[]) -> string {
-  reflect.type_of<T>().to_string()
+  type.of<T>().to_string()
 }
 
 // Two invariant map-value occurrences: conflicting value types reject.
 function merge<T>(a: map<string, T>, b: map<string, T>) -> string {
-  reflect.type_of<T>().to_string()
+  type.of<T>().to_string()
 }
 
 // Two invariant generic-class-arg occurrences: GenericBox<int> vs GenericBox<string> rejects.
 function combine<T>(x: GenericBox<T>, y: GenericBox<T>) -> string {
-  reflect.type_of<T>().to_string()
+  type.of<T>().to_string()
 }
 
 // Invariant (`arr: T[]`) × covariant (`bare: T`) in one call: glue(int, string[])
 // rejects; glue(int, int[]) binds T = int.
 function glue<T>(bare: T, arr: T[]) -> string {
-  reflect.type_of<T>().to_string()
+  type.of<T>().to_string()
 }
 
 // §D n-ary covariant join: three covariant bare-arg occurrences union-merge.
 function triple_choose<T>(a: T, b: T, c: T) -> string {
-  reflect.type_of<T>().to_string()
+  type.of<T>().to_string()
 }
 
 // §J multiple unconstrained TypeVars in one union: un-inferrable ⇒ reject (two
 // free vars beside a concrete `int` member have no principled split).
 function two_in_union<T, U>(x: T | U | int) -> string {
-  reflect.type_of<T | U>().to_string()
+  type.of<T | U>().to_string()
 }
 
 // ---------------------------------------------------------------------------
@@ -362,7 +362,7 @@ function first_or<T>(xs: T[]) -> T? {
 // `T = int | string`. Reflects `T` so the host can read the unified element type
 // directly (distinct from B8, which only reads back the round-tripped values).
 function elem_type<T>(xs: T[]) -> string {
-  reflect.type_of<T>().to_string()
+  type.of<T>().to_string()
 }
 
 function values_of<T>(m: map<string, T>) -> T[] {

--- a/baml_language/sdk_tests/fixtures/function_calls/baml_src/ns_go_type_tests/main.baml
+++ b/baml_language/sdk_tests/fixtures/function_calls/baml_src/ns_go_type_tests/main.baml
@@ -25,53 +25,53 @@ function round_trip_type(value: type) -> type {
 }
 
 function reflected_int() -> type {
-  reflect.type_of<int>()
+  type.of<int>()
 }
 
 function reflected_container() -> type {
-  reflect.type_of<map<string, int[]>>()
+  type.of<map<string, int[]>>()
 }
 
 function reflected_union() -> type {
-  reflect.type_of<int | string>()
+  type.of<int | string>()
 }
 
 function reflected_primitives() -> type[] {
   [
-    reflect.type_of<string>(),
-    reflect.type_of<int>(),
-    reflect.type_of<bigint>(),
-    reflect.type_of<float>(),
-    reflect.type_of<bool>(),
-    reflect.type_of<null>(),
-    reflect.type_of<uint8array>(),
-    reflect.type_of<type>(),
+    type.of<string>(),
+    type.of<int>(),
+    type.of<bigint>(),
+    type.of<float>(),
+    type.of<bool>(),
+    type.of<null>(),
+    type.of<uint8array>(),
+    type.of<type>(),
   ]
 }
 
 function reflected_literals() -> type[] {
   [
-    reflect.type_of<"literal">(),
-    reflect.type_of<42>(),
-    reflect.type_of<42n>(),
-    reflect.type_of<true>(),
+    type.of<"literal">(),
+    type.of<42>(),
+    type.of<42n>(),
+    type.of<true>(),
   ]
 }
 
 function get_reflected_class() -> type {
-  reflect.type_of<ReflectedClass>()
+  type.of<ReflectedClass>()
 }
 
 function get_reflected_enum() -> type {
-  reflect.type_of<ReflectedEnum>()
+  type.of<ReflectedEnum>()
 }
 
 function get_reflected_alias() -> type {
-  reflect.type_of<ReflectedAlias>()
+  type.of<ReflectedAlias>()
 }
 
 function reflected_generic_class() -> type {
-  reflect.type_of<user.generic_tests.GenericBox<int>>()
+  type.of<user.generic_tests.GenericBox<int>>()
 }
 
 function round_trip_optional_type(value: type?) -> type? {

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/lib.rs
@@ -825,6 +825,69 @@ mod tests {
     }
 
     #[test]
+    fn reflect_kind_namespaces_are_routed_legally_across_the_generated_surface() {
+        let mut pool: SymbolPool = HashMap::new();
+        let kind_namespaces = [
+            ("class", "class_"),
+            ("enum", "enum"),
+            ("interface", "interface"),
+            ("function", "function"),
+        ];
+
+        for (source, _) in kind_namespaces {
+            let type_name = cg_name("baml", &["reflect", source], "Type");
+            pool.insert(type_name.clone(), class(type_name));
+        }
+
+        let consumer_name = cg_name("user", &["consumer"], "KindViews");
+        pool.insert(
+            consumer_name.clone(),
+            Symbol::Class(Class {
+                generic_params: Vec::new(),
+                name: consumer_name,
+                docstring: None,
+                properties: kind_namespaces
+                    .iter()
+                    .map(|(source, _)| ClassProperty {
+                        name: BaseName::new(format!("{source}_type")),
+                        docstring: None,
+                        ty: class_ty(cg_name("baml", &["reflect", source], "Type"), vec![]),
+                    })
+                    .collect(),
+                static_methods: vec![],
+                instance_methods: vec![],
+                origin: origin("x.baml", 0),
+            }),
+        );
+
+        let out = to_source_code(&pool, &[], NamingConvention::PreserveCase);
+        let reflect_pyi = &out[&PathBuf::from("baml/reflect/__init__.pyi")];
+        let consumer_py = &out[&PathBuf::from("consumer/__init__.py")];
+        let consumer_pyi = &out[&PathBuf::from("consumer/__init__.pyi")];
+        let typemap = &out[&PathBuf::from("_typemap.py")];
+
+        for (source, routed) in kind_namespaces {
+            assert!(out.contains_key(&PathBuf::from(format!("baml/reflect/{routed}/__init__.py"))));
+            if source != routed {
+                assert!(
+                    !out.contains_key(&PathBuf::from(format!("baml/reflect/{source}/__init__.py")))
+                );
+            }
+            assert!(reflect_pyi.contains(&format!("from . import {routed}\n")));
+
+            let reference = format!("baml.reflect.{routed}.Type");
+            assert!(consumer_py.contains(&reference));
+            assert!(consumer_pyi.contains(&reference));
+            assert!(typemap.contains(&format!(
+                "\"baml.reflect.{source}.Type\": (\"baml_sdk.baml.reflect.{routed}\", \"Type\")"
+            )));
+        }
+
+        assert!(!consumer_py.contains("baml.reflect.class.Type"));
+        assert!(!consumer_pyi.contains("baml.reflect.class.Type"));
+    }
+
+    #[test]
     fn enum_body_renders() {
         let mut pool: SymbolPool = HashMap::new();
         let n = cg_name("user", &["lorem"], "Sentiment");

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/routing.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/routing.rs
@@ -58,27 +58,26 @@ pub(crate) fn route(name: &Name, symbol: &Symbol) -> LeafPath {
     route_inner(name, !matches!(symbol, Symbol::Function(_)))
 }
 
+/// Python's hard keywords. A keyword cannot be used in a dotted reference or
+/// relative import, so every routed occurrence receives a trailing `_`.
+const PYTHON_KEYWORDS: &[&str] = &[
+    "False", "None", "True", "and", "as", "assert", "async", "await", "break", "class", "continue",
+    "def", "del", "elif", "else", "except", "finally", "for", "from", "global", "if", "import",
+    "in", "is", "lambda", "nonlocal", "not", "or", "pass", "raise", "return", "try", "while",
+    "with", "yield",
+];
+
 /// Sanitize a path segment so it's a usable Python module identifier.
-/// Handles `assert` (the BAML stdlib package whose name collides with
-/// Python's `assert` keyword — `from . import assert` is a `SyntaxError`)
-/// and `type` (the `baml.type` carrier namespace, BEP-066: a submodule
-/// named `type` re-exported from `baml/__init__.pyi` shadows the builtin
-/// `type` in sibling annotations — pyright's reportInvalidTypeForm
-/// "Module cannot be used as a type"; BEP-066 H-1 prescribes the `type_`
-/// mangling). The routed leaf becomes `…/assert_/…` / `baml/type_/…` and
-/// cross-leaf references render accordingly. The runtime BAML FQN passed
-/// to `_define_function` is built from `Name`, not `LeafPath`, so it is
-/// *not* affected.
 ///
-/// TODO(reserved-keywords): generalize to all Python keywords and any
-/// other invalid identifiers. User packages or namespaces named after
-/// keywords (`class`, `def`, `pass`, …) would hit the same issue, but
-/// none exist today; broaden this set when one shows up.
+/// In addition to the hard keywords above, `type` retains its existing
+/// trailing-underscore spelling. The `baml.type` carrier submodule would
+/// otherwise shadow the builtin `type` in sibling annotations. Runtime BAML
+/// FQNs are built from `Name`, not `LeafPath`, so routing does not alter them.
 fn sanitize_python_module_segment(seg: &str) -> String {
-    match seg {
-        "assert" => "assert_".to_string(),
-        "type" => "type_".to_string(),
-        _ => seg.to_string(),
+    if seg == "type" || PYTHON_KEYWORDS.contains(&seg) {
+        format!("{seg}_")
+    } else {
+        seg.to_string()
     }
 }
 
@@ -318,6 +317,29 @@ mod tests {
         let n = name("user", &["assert"], "Foo");
         let lp = route(&n, &class_sym(&n));
         assert_eq!(lp.segments, vec!["assert_".to_string()]);
+    }
+
+    #[test]
+    fn every_python_keyword_segment_is_sanitized_in_packages_and_namespaces() {
+        for &keyword in PYTHON_KEYWORDS {
+            let expected = format!("{keyword}_");
+
+            let package_name = name(keyword, &[], "Thing");
+            let package_leaf = route(&package_name, &class_sym(&package_name));
+            assert_eq!(
+                package_leaf.segments,
+                vec!["vendor".to_string(), expected.clone()],
+                "package segment {keyword:?}",
+            );
+
+            let namespace_name = name("user", &[keyword], "Thing");
+            let namespace_leaf = route(&namespace_name, &class_sym(&namespace_name));
+            assert_eq!(
+                namespace_leaf.segments,
+                vec![expected],
+                "namespace segment {keyword:?}",
+            );
+        }
     }
 
     #[test]

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/routing.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/routing.rs
@@ -59,22 +59,26 @@ pub(crate) fn route(name: &Name, symbol: &Symbol) -> LeafPath {
 }
 
 /// Sanitize a path segment so it's a usable Python module identifier.
-/// Today only handles `assert` (the BAML stdlib package whose name
-/// collides with Python's `assert` keyword — `from . import assert` is
-/// a `SyntaxError`); the routed leaf becomes `vendor/assert_/…` and any
-/// cross-leaf type reference renders as `vendor.assert_.…`. The runtime
-/// BAML FQN passed to `_define_function` (e.g. `"assert.is_true"`) is
-/// built from `Name`, not from `LeafPath`, so it is *not* affected.
+/// Handles `assert` (the BAML stdlib package whose name collides with
+/// Python's `assert` keyword — `from . import assert` is a `SyntaxError`)
+/// and `type` (the `baml.type` carrier namespace, BEP-066: a submodule
+/// named `type` re-exported from `baml/__init__.pyi` shadows the builtin
+/// `type` in sibling annotations — pyright's reportInvalidTypeForm
+/// "Module cannot be used as a type"; BEP-066 H-1 prescribes the `type_`
+/// mangling). The routed leaf becomes `…/assert_/…` / `baml/type_/…` and
+/// cross-leaf references render accordingly. The runtime BAML FQN passed
+/// to `_define_function` is built from `Name`, not `LeafPath`, so it is
+/// *not* affected.
 ///
 /// TODO(reserved-keywords): generalize to all Python keywords and any
 /// other invalid identifiers. User packages or namespaces named after
 /// keywords (`class`, `def`, `pass`, …) would hit the same issue, but
 /// none exist today; broaden this set when one shows up.
 fn sanitize_python_module_segment(seg: &str) -> String {
-    if seg == "assert" {
-        "assert_".to_string()
-    } else {
-        seg.to_string()
+    match seg {
+        "assert" => "assert_".to_string(),
+        "type" => "type_".to_string(),
+        _ => seg.to_string(),
     }
 }
 
@@ -314,5 +318,21 @@ mod tests {
         let n = name("user", &["assert"], "Foo");
         let lp = route(&n, &class_sym(&n));
         assert_eq!(lp.segments, vec!["assert_".to_string()]);
+    }
+
+    #[test]
+    fn type_namespace_segment_is_sanitized() {
+        // The `baml.type` carrier namespace (BEP-066): a generated
+        // submodule literally named `type` shadows the builtin `type`
+        // in `baml/__init__.pyi` annotations (pyright
+        // reportInvalidTypeForm). H-1's `type_` mangling applies to the
+        // module segment; the runtime BAML FQN (`baml.type.of`) is
+        // unaffected.
+        let n = name("baml", &["type"], "of_value");
+        let lp = route(&n, &func_sym());
+        assert_eq!(
+            lp.segments,
+            vec!["baml".to_string(), "type_".to_string()]
+        );
     }
 }

--- a/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/routing.rs
+++ b/baml_language/sdks/python/rust/sdkgen_python_pydantic2/src/routing.rs
@@ -330,9 +330,6 @@ mod tests {
         // unaffected.
         let n = name("baml", &["type"], "of_value");
         let lp = route(&n, &func_sym());
-        assert_eq!(
-            lp.segments,
-            vec!["baml".to_string(), "type_".to_string()]
-        );
+        assert_eq!(lp.segments, vec!["baml".to_string(), "type_".to_string()]);
     }
 }

--- a/baml_language/sdks/rust/bridge_rust/tests/live_engine.rs
+++ b/baml_language/sdks/rust/bridge_rust/tests/live_engine.rs
@@ -20,7 +20,7 @@ function rt_list(x: int[]) -> int[] { x }
 function no_op() -> void {}
 function opt_probe(a: int, o: int? = 5) -> int?[] { [a, o] }
 function gid<T>(x: T) -> T { x }
-function gname<T>() -> string { reflect.type_of<T>().to_string() }
+function gname<T>() -> string { type.of<T>().to_string() }
 "#;
 
 /// Initialize the process-global runtime once for every test in this
@@ -211,7 +211,7 @@ fn return_only_type_param_is_bound_from_type_args() {
     ensure_runtime();
     // gname<T>() has no argument carrying `T`, so the binding can only come
     // from the explicit type_args — proving they are honored, not merely
-    // recovered from argument inference. `reflect.type_of<T>()` reflects the
+    // recovered from argument inference. `type.of<T>()` reflects the
     // bound type's name back as a string.
     let int_name = runtime::invoke_sync::<String, Infallible>(
         "user.gname",


### PR DESCRIPTION
**BEP-066 slice-1 stack, PR 3 of 5** — chained on #4328.

## What
- **The move**: `reflect` stops being a root package and becomes the `baml.reflect` namespace (manifest, deps, emit allowlist, native wiring folded into the baml package dispatch, `ARG_FQN` updates). SDK routing needed nothing — no special cases existed; symbols route under `baml/` automatically.
- **The shorthand**: bare `reflect.…` and `type.…` in expression position re-resolve as `baml.…` on full miss — one uniform rule mirrored through TIR, hover/semantic tokens, and completions. User names always shadow the shorthand (pinned by a corpus project including a user *class* named `reflect`).
- **`type.of<T>()` / `type.of_value(v)`** via a carrier namespace (`baml/ns_type/type.baml`): `of` is the existing compiler intrinsic re-keyed (`"baml.type.of"`), `of_value` a new native over `value_concrete_ty` — fail-open to the `unknown` type value for definition objects, `throws never`-honest; K-12 pinned (`of_value(5)` equals `type.of<int>()`). **Zero parser changes** — expression-position `type.of<…>()` already parses; alias declarations are top-level-only, so the feared ambiguity is vacuous (pinned by parser tests).
- **I-9 removal**: `reflect.type_of` (bare or qualified) hits a targeted funnel — `` `reflect.type_of` was renamed to `type.of` (BEP-066) `` — with no DiagnosticId discriminant shift. Every internal call site migrated in this commit (stdlib ×5 files, 16 baml_src suites, 4 projects, inline-Rust BAML in baml_tests + bex_engine, sdk fixtures, LSP fixtures).

## Gates
68 baml_tests binaries 0 failed · bex_vm 21/0 · tir 324/0 · LSP 468/0 (2 reviewed expectation updates) · project 82/0 · parser 154/0 · surface 17/0 · bytecode_cache 43/0 · workspace check clean. Snapshot accepts grouped by five causes in the commit message (stub-listing filter, new namespaces, FQN rendering, spelling migration, new projects).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `type.of<T>()` to obtain runtime type information.
  * Added `type.of_value(...)` to derive runtime types from values, returning `unknown` when reconstruction is unavailable.
  * Unified reflection and type utilities under the `baml` namespace.

* **Bug Fixes**
  * Improved namespace resolution, editor completions, and Python routing for the new type namespace.

* **Diagnostics**
  * Added guidance to replace removed `reflect.type_of<T>()` usage with `type.of<T>()`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->