### PR TITLE
feat(compiler): guarantee mounted package parity (BEP-066 slice 6a, PR 5 — capstone)

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -497,6 +497,74 @@ fn build_packages(
             }
         }
     }
+    // Mounted interfaces contribute the same declaration-side runtime facts as
+    // source interfaces. Their compiled objects/functions already live in the
+    // linked base image; these loc-free rows let a USER impl inherit a mounted
+    // default method, bake an associated default, and construct field links.
+    // Without this prepass a source `implements app.Named {}` got
+    // `label=app.Named.label`, while the blob path emitted an empty method
+    // table — a check-clean program whose virtual dispatch differed at runtime.
+    for package in baml_compiler2_hir::package::mounted_package_names(db) {
+        let Some(package_interface) =
+            baml_compiler2_tir::package_interface::mounted_interface(db, &package)
+        else {
+            continue;
+        };
+        let mut interfaces: Vec<_> = package_interface
+            .types
+            .values()
+            .flat_map(|namespace| namespace.values())
+            .filter_map(|exported| match exported {
+                baml_compiler2_tir::package_interface::ExportedType::Interface {
+                    qtn,
+                    self_param,
+                    generic_params,
+                    associated_types,
+                    fields,
+                    default_methods,
+                    ..
+                } => Some((
+                    qtn,
+                    self_param,
+                    generic_params,
+                    associated_types,
+                    fields,
+                    default_methods,
+                )),
+                _ => None,
+            })
+            .collect();
+        interfaces.sort_by_key(|(qtn, ..)| qtn.render_dotted(false));
+        for (qtn, self_param, generic_params, associated_types, fields, default_methods) in
+            interfaces
+        {
+            if !fields.is_empty() {
+                iface_field_decls
+                    .entry(qtn.clone())
+                    .or_insert_with(|| fields.iter().map(|(name, ..)| name.clone()).collect());
+            }
+            if !associated_types.is_empty() {
+                iface_assoc_decls.entry(qtn.clone()).or_insert_with(|| {
+                    (
+                        self_param.clone(),
+                        generic_params.clone(),
+                        associated_types
+                            .iter()
+                            .map(|associated| (associated.name.clone(), associated.default.clone()))
+                            .collect(),
+                    )
+                });
+            }
+            if !default_methods.is_empty() {
+                let entry = iface_defaults.entry(qtn.clone()).or_default();
+                for method in default_methods {
+                    entry
+                        .entry(method.name.clone())
+                        .or_insert_with(|| method.callable_fqn.clone());
+                }
+            }
+        }
+    }
     // The frame an inherited default of `iface_tn` is invoked with, for a rule
     // implementing it at `for_ty_pattern` / `interface_args` / `interface_assoc`:
     // the implementor type (`Self`) at slot 0, then the interface's generic args,
@@ -1177,6 +1245,34 @@ impl std::fmt::Display for LoweringError {
 
 impl std::error::Error for LoweringError {}
 
+/// Failure while compiling a consumer against independently emitted mounted
+/// dependency units.
+#[derive(Debug)]
+pub enum MountedPackageLinkError {
+    /// The dependency units did not form a valid, self-contained prefix image.
+    DependencyLink(bex_vm_types::link::LinkError),
+    /// The consumer failed during ordinary MIR lowering or bytecode emission.
+    Consumer(LoweringError),
+}
+
+impl std::fmt::Display for MountedPackageLinkError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DependencyLink(error) => write!(f, "link mounted dependency units: {error}"),
+            Self::Consumer(error) => write!(f, "compile mounted-package consumer: {error}"),
+        }
+    }
+}
+
+impl std::error::Error for MountedPackageLinkError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::DependencyLink(error) => Some(error),
+            Self::Consumer(error) => Some(error),
+        }
+    }
+}
+
 /// Extract `@description`, `@alias`, `@skip` from span-free HIR attributes.
 ///
 /// Returns `(description, alias, skip)`. Invalid attribute usage is diagnosed
@@ -1316,6 +1412,54 @@ pub fn generate_project_bytecode_with_stdlib(
     base: &Program,
 ) -> Result<Program, LoweringError> {
     generate_impl(db, options, opt, Some(base), false, None)
+}
+
+/// Compile and link a source consumer against independently emitted mounted
+/// dependency units.
+///
+/// This is the supported slice-6 seam between a package's two artifacts:
+///
+/// - `db` must already contain the dependency's serialized package-interface
+///   blobs through its mounted-packages input; those blobs drive checking and
+///   loc-free call resolution.
+/// - `dependency_units` are the matching runtime artifact, normally returned by
+///   [`emit_units`] in the dependency build. Together they must be one complete,
+///   duplicate-free prefix image in deterministic discovery order, including
+///   the builtin units exactly once, and must use the same compiler build and
+///   optimization level as the consumer.
+///
+/// The units are first linked symbolically. Their resulting image seeds the
+/// ordinary consumer emitter, whose fully-qualified imports resolve against the
+/// dependency definitions. The output is a single runnable [`Program`]. A bad
+/// dependency unit set is reported as
+/// [`MountedPackageLinkError::DependencyLink`]; consumer lowering and project
+/// diagnostics retain the ordinary [`LoweringError`] surface through
+/// [`MountedPackageLinkError::Consumer`].
+///
+/// # Slice 6a residue ledger
+///
+/// - E0158 remains only for mounted compiler/VM builtin-kind callables, which
+///   have no loc-free bytecode link contract.
+/// - Mounted declarations have no source spans, so definition navigation,
+///   rename, and other location-owning LSP handles remain unavailable.
+/// - Mount aliases must equal the package identity encoded in the blob;
+///   transitive re-export and package re-aliasing are not implemented.
+/// - Canonical `$stream` companion types are exported and consumer LLM
+///   expansion checks, but live Package.compile/sys-op loading is slice 6.
+/// - Artifact compatibility/version validation and loading into an already-live
+///   VM are slice 6 concerns; this seam produces a new combined `Program`.
+/// - First-class interface-method values still depend on the compiler's general
+///   synthesized-dispatcher support; direct, UFCS, and virtual calls are linked.
+pub fn generate_project_bytecode_with_mounted_units(
+    db: &dyn crate::Db,
+    options: &CompileOptions,
+    opt: OptLevel,
+    dependency_units: &[CompilationUnit],
+) -> Result<Program, MountedPackageLinkError> {
+    let base = bex_vm_types::link::link(dependency_units)
+        .map_err(MountedPackageLinkError::DependencyLink)?;
+    generate_impl(db, options, opt, Some(&base), false, None)
+        .map_err(MountedPackageLinkError::Consumer)
 }
 
 /// Incremental compile that lowers function bodies only for dirty files, reuses

--- a/baml_language/crates/baml_compiler2_hir/src/package.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/package.rs
@@ -445,10 +445,12 @@ pub fn package_dependencies<'db>(
         // The "testing" and "assert" packages depend on "baml" only.
         "testing" | "assert" => vec![PackageId::new(db, Name::new("baml"))],
         // User packages depend on public builtin packages — plus every mounted
-        // source-less package (BEP-066 slice 6a). A mounted package itself
-        // keeps the stdlib list only: blobs were compiled against the stdlib,
-        // and mounted packages do not see each other (no mount declares a
-        // dependency on another mount).
+        // source-less package (BEP-066 slice 6a) and every auxiliary source
+        // package installed through `compiler2_extra_files`. The latter makes
+        // the source side of the source-vs-blob contract real: a package such
+        // as `<builtin>/app/…` is the same direct dependency whether its source
+        // or its mounted interface is present. A mounted/auxiliary package
+        // itself keeps the stdlib list only, avoiding dependency cycles.
         name => {
             let mut deps = vec![
                 PackageId::new(db, Name::new("baml")),
@@ -464,6 +466,23 @@ pub fn package_dependencies<'db>(
                     mounted
                         .into_iter()
                         .map(|mounted_name| PackageId::new(db, mounted_name)),
+                );
+            }
+            if name == "user" {
+                let source_packages: std::collections::BTreeSet<Name> =
+                    crate::compiler2_all_files(db)
+                        .into_iter()
+                        .map(|file| crate::file_package::file_package(db, file).package)
+                        .filter(|package| {
+                            package.as_str() != name
+                                && !is_reserved_package_name(package.as_str())
+                                && !is_mounted_package(db, package)
+                        })
+                        .collect();
+                deps.extend(
+                    source_packages
+                        .into_iter()
+                        .map(|package| PackageId::new(db, package)),
                 );
             }
             deps

--- a/baml_language/crates/baml_compiler2_tir/src/inference.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/inference.rs
@@ -852,10 +852,9 @@ pub struct ExternalCallable {
     /// `treat_as_static_method` distinction in `callee_declared_generics`.
     pub owner_generic_params: Vec<crate::ty::ParamTy>,
     /// The callee's exported generic params: user-declared params first, then
-    /// any synthetic effect params preserved by the export kind. Impl-method
-    /// rows currently carry the declared prefix only. Only user-declared
-    /// params are call-site suppliable ([`Self::user_generic_params`]), and
-    /// `RuntimeGenericLayout` erases effects from every runtime frame.
+    /// any synthetic effect params. Only user-declared params are call-site
+    /// suppliable ([`Self::user_generic_params`]), and `RuntimeGenericLayout`
+    /// erases effects from every runtime frame.
     pub generic_params: Vec<crate::ty::ParamTy>,
     /// Per-param interface-bound conjunctions, parallel to
     /// [`generic_params`](Self::generic_params) (when synthetic effect params

--- a/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
+++ b/baml_language/crates/baml_compiler2_tir/src/package_interface.rs
@@ -182,11 +182,9 @@ pub struct ExportedFunction {
     pub return_type: Ty,
     pub declared_throws: Option<Ty>,
     pub callable_throws: Ty,
-    /// Function-level generic parameters. Ordinary function/interface/class
-    /// exports include synthetic callback-effect parameters introduced by
-    /// signature elaboration; `ExportedImplMethod` currently carries only the
-    /// override's declared params. Runtime layout erases synthetic effects in
-    /// either case.
+    /// Function-level generic parameters: user-declared parameters followed by
+    /// synthetic callback-effect parameters introduced by signature
+    /// elaboration. Runtime layout erases the synthetic effects.
     pub generic_params: Vec<ParamTy>,
     /// Per-parameter interface-bound conjunctions, parallel to
     /// `generic_params` (when synthetic effect parameters are present they are
@@ -273,7 +271,7 @@ pub enum ExportedImplOrigin {
 /// One impl-body method override, exported with a *structural* identity: the
 /// owner is the enclosing [`ExportedImpl`] itself (interface head + for-type),
 /// and `name` picks the interface member it overrides. Deliberately NOT MIR's
-/// `{iface-display}$for${target-display}` source-text naming — the consumer PR
+/// `{iface-display}$for${target-display}` source-text naming — the consumer
 /// reconstructs MIR's symbol from this structural pair. `sig.callable_fqn`
 /// alone is NOT unique for a free-impl method (it renders owner-less,
 /// `pkg.ns….name`); identity is `(enclosing impl, name)`.
@@ -530,9 +528,7 @@ impl ExportedType {
             ExportedType::Enum { qtn, .. } => Ty::Enum(qtn.clone(), TyAttr::default()),
             ExportedType::TypeAlias { qtn, .. } => Ty::TypeAlias(qtn.clone(), TyAttr::default()),
             // Mirrors `def_to_ty`'s Interface arm (empty args/assoc — the
-            // own-package resolution shape). Unreachable through today's
-            // resolution paths, which skip dep-interface rows until the
-            // dualized resolution context lands (BEP-066 slice 6a follow-up).
+            // unspecialized declaration shape).
             ExportedType::Interface { qtn, .. } => {
                 Ty::Interface(qtn.clone(), vec![], vec![], TyAttr::default())
             }
@@ -1202,9 +1198,19 @@ fn exported_impl_method<'db>(
         .iter()
         .map(|(param, _)| param.clone())
         .collect();
-    let scope_generics =
-        crate::generic_env::append_params(&impl_param_names, &spec.generic_param_names());
-    let own_params = &scope_generics[impl_param_names.len()..];
+    // Unlike `InterfaceMethodSpec`, whose generic list is the user-written
+    // declaration, the function environment also contains signature
+    // elaboration's synthetic callback-effect params. They must cross the blob
+    // boundary too: source and mounted call inference consult the same free
+    // type variables even though runtime layout later erases them.
+    let impl_param_count = impl_param_names.len();
+    let scope_generics = crate::function_generic_params(db, method_loc);
+    debug_assert_eq!(
+        &scope_generics[..impl_param_count],
+        impl_param_names.as_slice(),
+        "an impl method's function environment must begin with the impl parameters"
+    );
+    let own_params = &scope_generics[impl_param_count..];
     let mut bounds: crate::lower_type_expr::TypeVarBoundsMap =
         data.generic_params.iter().cloned().collect();
     // Lowering diagnostics are dropped, matching every export path: the
@@ -1213,7 +1219,11 @@ fn exported_impl_method<'db>(
     let mut diags = Vec::new();
     let mut generic_params = Vec::new();
     let mut generic_param_bounds = Vec::new();
-    for (param, declared) in own_params.iter().zip(spec.generic_bounds()) {
+    let declared_count = spec.generic_bounds().len();
+    for (param, declared) in own_params[..declared_count]
+        .iter()
+        .zip(spec.generic_bounds())
+    {
         let ifaces = crate::interfaces::lower_generic_param_interface_bounds(
             db,
             spec.bound_store(),
@@ -1226,6 +1236,11 @@ fn exported_impl_method<'db>(
         bounds.insert(param.clone(), ifaces.clone());
         generic_params.push(param.clone());
         generic_param_bounds.push(ifaces);
+    }
+    for param in &own_params[declared_count..] {
+        bounds.insert(param.clone(), Vec::new());
+        generic_params.push(param.clone());
+        generic_param_bounds.push(Vec::new());
     }
 
     // The interface's symbolic `Self` parameter: from its generic env when the

--- a/baml_language/crates/baml_tests/src/compiler2_tir/package_interface.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/package_interface.rs
@@ -4,9 +4,9 @@
 //! surfaces (params/bounds/`requires`/associated types/fields/methods), class
 //! field attributes and per-parameter bounds, function bounds and stable
 //! fully-qualified names, and the full namespace set — plus borsh round-trip
-//! and cross-database byte determinism. Nothing consumes these rows yet; the
-//! resolution rewires land in follow-up PRs, and `cargo test -p baml_tests`
-//! snapshots prove the derivation stays behavior-invisible.
+//! and cross-database byte determinism. The mounted-package integration suites
+//! additionally pin their source-less type, call, runtime, and artifact
+//! consumption; these focused tests keep the derivation contract readable.
 
 use baml_base::Name;
 use baml_compiler2_hir::package::PackageId;
@@ -1035,9 +1035,8 @@ fn stdlib_impls_export_and_int_equals_is_complete() {
 /// Each test compiles a fixture "library" package (files under
 /// `<builtin>/app/…` so `file_package` assigns them the package name `app`),
 /// captures its interface blob, mounts it in a FRESH database as `app`, and
-/// runs `collect_diagnostics` over consumer code. Calls into mounted packages
-/// are NOT yet supported (next PR) and are rejected with a dedicated
-/// diagnostic.
+/// runs `collect_diagnostics` over consumer code. The call/runtime integration
+/// suites exercise the same blobs beyond this check-level module.
 pub(super) mod mounted {
     use baml_base::Name;
     use baml_compiler2_hir::package::PackageId;

--- a/baml_language/crates/baml_tests/tests/mounted_package_calls.rs
+++ b/baml_language/crates/baml_tests/tests/mounted_package_calls.rs
@@ -9,16 +9,17 @@
 //!
 //!   1. the CHECK artifact — `borsh(PackageInterface)`, the typed surface a
 //!      consumer checks against, and
-//!   2. the RUN artifact — the library's compiled `Program` (its files ride
-//!      the builtin emit group, so the image is `stdlib ++ app`, a
-//!      user-independent prefix exactly like the stdlib slice).
+//!   2. the RUN artifact — the library's independently emitted symbolic
+//!      `CompilationUnit` set (its files ride the builtin emit group, so the
+//!      linked image is `stdlib ++ app`, a user-independent prefix exactly
+//!      like the stdlib slice).
 //!
 //! Phase 2 — the CONSUMER database: a FRESH `ProjectDatabase` with NO `app`
 //! source anywhere. The blob is mounted via `set_mounted_packages` (checking
 //! resolves `app.…` through the interface rows and records loc-free
 //! `MemberResolution::External` callees), and bytecode is generated with
-//! `generate_project_bytecode_with_stdlib(consumer_db, base = library
-//! program)`: the splice seeds the emit tables from the base image, so the
+//! `generate_project_bytecode_with_mounted_units(consumer_db, library_units)`:
+//! the public seam links the units and seeds emit from that prefix, so the
 //! consumer's symbolic references (`app.add`, `app.Widget`, the interface
 //! method slots) LINK against the library's already-compiled definitions by
 //! fully-qualified name — the same name-keyed resolution slice 6's dynamic
@@ -27,13 +28,15 @@
 //! The resulting single `Program` runs on the ordinary engine harness.
 
 use baml_base::Name;
-use baml_compiler2_emit::{CompileOptions, OptLevel, generate_project_bytecode_with_stdlib};
+use baml_compiler2_emit::{
+    CompileOptions, OptLevel, emit_units, generate_project_bytecode_with_mounted_units,
+};
 use baml_compiler2_hir::package::PackageId;
 use baml_compiler2_tir::package_interface::package_interface;
 use baml_project::{ProjectDatabase, collect_diagnostics, testing::assert_no_diagnostic_errors};
 use baml_tests::engine::run_compiled;
 use bex_engine::BexExternalValue;
-use bex_vm_types::Program;
+use bex_vm_types::{CompilationUnit, Program};
 use indexmap::IndexMap;
 
 // ── The library fixture ─────────────────────────────────────────────────────
@@ -137,9 +140,9 @@ fn compile_options() -> CompileOptions {
 
 /// Phase 1: compile the library under `<builtin>/app/` and capture both
 /// artifacts — the `borsh(PackageInterface)` blob (check surface) and the
-/// compiled `Program` (run surface; `stdlib ++ app`, a user-independent
-/// prefix image).
-fn compile_library() -> (Vec<u8>, Program) {
+/// symbolic `CompilationUnit` set (run surface; links to `stdlib ++ app`, a
+/// user-independent prefix image).
+fn compile_library() -> (Vec<u8>, Vec<CompilationUnit>) {
     let mut db = ProjectDatabase::new();
     db.set_project_root(std::path::Path::new("/mounted-calls"));
     db.add_compiler2_virtual_file("<builtin>/app/lib.baml", LIB);
@@ -155,23 +158,21 @@ fn compile_library() -> (Vec<u8>, Program) {
     );
     let blob = borsh::to_vec(iface).expect("serialize app interface");
 
-    let program =
-        baml_compiler2_emit::generate_project_bytecode_with_opt(&db, &compile_options(), OPT)
-            .expect("library fixture compiles");
-    (blob, program)
+    let units = emit_units(&db, &compile_options(), OPT).expect("library fixture emits units");
+    (blob, units)
 }
 
 /// Phase 2: a fresh consumer database — blob mounted as `app`, NO `app`
 /// source — checked clean, then spliced against the library image.
 fn consumer_program(user_src: &str) -> Program {
-    let (blob, lib_program) = compile_library();
+    let (blob, lib_units) = compile_library();
     let mut db = ProjectDatabase::new();
     db.set_project_root(std::path::Path::new("/mounted-calls"));
     db.set_mounted_packages([("app".to_string(), blob)].into());
     db.add_file("main.baml", user_src);
     assert_no_diagnostic_errors(&db);
 
-    generate_project_bytecode_with_stdlib(&db, &compile_options(), OPT, &lib_program)
+    generate_project_bytecode_with_mounted_units(&db, &compile_options(), OPT, &lib_units)
         .expect("consumer compiles against the mounted blob")
 }
 

--- a/baml_language/crates/baml_tests/tests/mounted_package_parity.rs
+++ b/baml_language/crates/baml_tests/tests/mounted_package_parity.rs
@@ -1,0 +1,679 @@
+//! BEP-066 slice-6a capstone: consuming a dependency from source and from its
+//! `PackageInterface` blob must be observationally equivalent.
+//!
+//! The SOURCE path puts the rich `app` fixture and the consumer in one database.
+//! The BLOB path compiles `app` independently into its check artifact (borsh of
+//! `PackageInterface`) and run artifact (`CompilationUnit`s), then mounts the
+//! former in a fresh source-less consumer database and links the latter through
+//! `generate_project_bytecode_with_mounted_units`.
+//!
+//! The oracle pins four boundaries:
+//!
+//! 1. normalized diagnostic bytes (code, message, and user-source range),
+//! 2. runtime values and caught throws,
+//! 3. emitted-program and relocatable-unit invariants,
+//! 4. primary-only E0132 attribution for a user impl conflicting with a
+//!    span-less mounted impl.
+//!
+//! Unit import tables do not legitimately diverge: both paths name library
+//! symbols by the same fully-qualified B-693 identities. Raw consumer units and
+//! programs differ only in debug `FileId`s: removing the dependency source shifts
+//! the fresh consumer database's numeric id for `main.baml`. After normalizing
+//! those database-local ids (function span, line table, local-scope spans), every
+//! emitted byte is identical. Source paths/ranges and all executable content are
+//! unchanged.
+
+use baml_base::Name;
+use baml_compiler2_emit::{
+    CompileOptions, MountedPackageLinkError, OptLevel, decompose_units, emit_units,
+    generate_project_bytecode_with_mounted_units, generate_project_bytecode_with_opt,
+};
+use baml_compiler2_hir::package::PackageId;
+use baml_compiler2_tir::package_interface::{ExportedType, PackageInterface, package_interface};
+use baml_project::{ProjectDatabase, collect_diagnostics, testing::assert_no_diagnostic_errors};
+use baml_tests::engine::run_compiled;
+use bex_engine::BexExternalValue;
+use bex_vm_types::{CompilationUnit, Program};
+use indexmap::IndexMap;
+
+const ROOT: &str = "/mounted-parity";
+const OPT: OptLevel = OptLevel::One;
+
+/// A deliberately broad package surface: requires/default methods, associated
+/// defaults, attrs, generic class/function bounds, enum/alias rows, every impl
+/// shape, a callback-effect impl method, and a throwing function.
+const LIB: &str = r#"
+interface Named {
+    name string
+
+    function label(self) -> string throws never {
+        self.name
+    }
+}
+
+interface Measured requires Named {
+    type Unit = string
+
+    function measure(self) -> int throws never
+
+    function decorated(self) -> string throws never {
+        self.label()
+    }
+}
+
+class Widget {
+    name string @description("public label")
+    value int @alias("score")
+
+    implements Named {}
+
+    implements Measured {
+        function measure(self) -> int throws never {
+            self.value
+        }
+    }
+}
+
+class Box<T extends Named> {
+    value T
+
+    function inner_name(self) -> string throws never {
+        self.value.name
+    }
+}
+
+class Plain {
+    name string
+    value int
+
+    implements Named {}
+}
+
+implement Measured for Plain {
+    function measure(self) -> int throws never {
+        self.value
+    }
+}
+
+enum Status {
+    Active
+    Retired
+}
+
+type Score = int
+
+interface Tagged {
+    function tag(self) -> string throws never
+}
+
+implement<T> Tagged for T {
+    function tag(self) -> string throws never {
+        "any"
+    }
+}
+
+interface Applies {
+    function apply(self, cb: (x: int) -> int throws never) -> int throws unknown
+}
+
+class Runner {
+    base int
+
+    implements Applies {
+        function apply(self, cb: (x: int) -> int) -> int {
+            cb(self.base)
+        }
+    }
+}
+
+class ParseError {
+    message string
+}
+
+function measure_twice<T extends Measured>(value: T) -> int throws never {
+    value.measure() + value.measure()
+}
+
+function tag_of<T extends Tagged>(value: T) -> string throws never {
+    value.tag()
+}
+
+function parse_positive(value: int) -> int throws ParseError {
+    if value < 0 {
+        throw ParseError { message: "negative" }
+    }
+    value
+}
+"#;
+
+fn options() -> CompileOptions {
+    CompileOptions {
+        emit_test_cases: false,
+    }
+}
+
+fn library_db() -> ProjectDatabase {
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(std::path::Path::new(ROOT));
+    db.add_compiler2_virtual_file("<builtin>/app/lib.baml", LIB);
+    db
+}
+
+struct LibraryArtifacts {
+    blob: Vec<u8>,
+    interface: PackageInterface,
+    units: Vec<CompilationUnit>,
+}
+
+fn library_artifacts() -> LibraryArtifacts {
+    let db = library_db();
+    assert_no_diagnostic_errors(&db);
+    let interface = package_interface(&db, PackageId::new(&db, Name::new("app"))).clone();
+    let blob = borsh::to_vec(&interface).expect("serialize app package interface");
+    let round_trip =
+        borsh::from_slice::<PackageInterface>(&blob).expect("deserialize app package interface");
+    assert_eq!(
+        interface, round_trip,
+        "interface blob must round-trip exactly"
+    );
+    let units = emit_units(&db, &options(), OPT).expect("emit independent app units");
+    LibraryArtifacts {
+        blob,
+        interface,
+        units,
+    }
+}
+
+fn source_db(user: &str) -> ProjectDatabase {
+    let mut db = library_db();
+    db.add_file("main.baml", user);
+    db
+}
+
+fn blob_db(user: &str, blob: Vec<u8>) -> ProjectDatabase {
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(std::path::Path::new(ROOT));
+    db.set_mounted_packages([("app".to_string(), blob)].into());
+    db.add_file("main.baml", user);
+    db
+}
+
+fn compile_source(user: &str) -> Program {
+    let db = source_db(user);
+    assert_no_diagnostic_errors(&db);
+    generate_project_bytecode_with_opt(&db, &options(), OPT).expect("source-path compile")
+}
+
+fn compile_blob(user: &str, artifacts: &LibraryArtifacts) -> Program {
+    let db = blob_db(user, artifacts.blob.clone());
+    assert_no_diagnostic_errors(&db);
+    generate_project_bytecode_with_mounted_units(&db, &options(), OPT, &artifacts.units)
+        .expect("blob-path compile and link")
+}
+
+async fn run(program: Program, entry: &str) -> Result<BexExternalValue, String> {
+    run_compiled(program, entry, IndexMap::new(), false)
+        .await
+        .result
+        .map_err(|error| format!("{error:?}"))
+}
+
+async fn assert_runtime_parity(user: &str, entry: &str, expected: BexExternalValue) {
+    let artifacts = library_artifacts();
+    let source = compile_source(user);
+    let blob = compile_blob(user, &artifacts);
+    let source_result = run(source, entry).await;
+    let blob_result = run(blob, entry).await;
+    assert_eq!(source_result, blob_result, "runtime paths diverged");
+    assert_eq!(source_result, Ok(expected));
+}
+
+#[tokio::test]
+async fn rich_surface_runtime_is_identical() {
+    assert_runtime_parity(
+        r#"
+class Local {
+    name string
+    implements app.Named {}
+}
+
+function status_score(status: app.Status) -> int throws never {
+    match status {
+        app.Status.Active => 1
+        app.Status.Retired => 2
+    }
+}
+
+function main() -> int throws never {
+    let widget = app.Widget { name: "widget", value: 7 }
+    let plain = app.Plain { name: "plain", value: 4 }
+    let boxed = app.Box<app.Widget> { value: widget }
+    let score: app.Score = 3
+    let enum_score = status_score(app.Status.Retired)
+    let local = Local { name: "local" }
+    let tagged = app.tag_of(local)
+    let boxed_score = if boxed.inner_name() == "widget" { 1 } else { 0 }
+    let decorated_score = if widget.decorated() == "widget" { 1 } else { 0 }
+    let tagged_score = if tagged == "any" { 1 } else { 0 }
+    let inherited_default_score = if local.label() == "local" { 1 } else { 0 }
+    widget.measure()
+        + plain.measure()
+        + app.measure_twice(widget)
+        + score
+        + enum_score
+        + boxed_score
+        + decorated_score
+        + tagged_score
+        + inherited_default_score
+}
+"#,
+        "main",
+        BexExternalValue::Int(34),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn existential_default_and_out_of_body_dispatch_are_identical() {
+    assert_runtime_parity(
+        r#"
+function read(value: app.Measured) -> int throws never {
+    value.measure()
+}
+
+function main() -> int throws never {
+    let widget = app.Widget { name: "widget", value: 20 }
+    let plain = app.Plain { name: "plain", value: 22 }
+    read(widget) + read(plain)
+}
+"#,
+        "main",
+        BexExternalValue::Int(42),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn impl_method_callback_effect_metadata_and_frame_are_identical() {
+    assert_runtime_parity(
+        r#"
+function plus_one(value: int) -> int throws never {
+    value + 1
+}
+
+function main() -> int throws never {
+    app.Runner { base: 41 }.apply(plus_one)
+}
+"#,
+        "main",
+        BexExternalValue::Int(42),
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn caught_library_throw_is_identical() {
+    assert_runtime_parity(
+        r#"
+function classify(value: int) -> string {
+    let parsed = app.parse_positive(value) catch (error) {
+        let typed: app.ParseError => {
+            return typed.message
+        }
+    }
+    "ok:" + parsed.to_string()
+}
+
+function main() -> string {
+    classify(7) + ":" + classify(0 - 1)
+}
+"#,
+        "main",
+        BexExternalValue::String("ok:7:negative".into()),
+    )
+    .await;
+}
+
+/// A stable byte record deliberately excludes `FileId`: the source database
+/// allocates one extra id for the library file, while the blob database has no
+/// such file. Codes, messages, severity, phase, and user-text ranges are the
+/// user-observable diagnostic contract and must match byte-for-byte.
+fn diagnostic_bytes(db: &ProjectDatabase) -> Vec<u8> {
+    let rows: Vec<String> = collect_diagnostics(db)
+        .into_iter()
+        .filter(|diagnostic| {
+            matches!(
+                diagnostic.severity,
+                baml_compiler_diagnostics::Severity::Error
+            )
+        })
+        .map(|diagnostic| {
+            let range = diagnostic
+                .primary_span()
+                .expect("consumer error has a primary span")
+                .range;
+            format!(
+                "{}\0{:?}\0{:?}\0{}..{}\0{}",
+                diagnostic.code(),
+                diagnostic.severity,
+                diagnostic.phase,
+                u32::from(range.start()),
+                u32::from(range.end()),
+                diagnostic.message
+            )
+        })
+        .collect();
+    rows.join("\n").into_bytes()
+}
+
+#[test]
+fn representative_error_diagnostics_are_byte_identical() {
+    let artifacts = library_artifacts();
+    let cases = [
+        (
+            "wrong arity",
+            r#"
+function main() -> int {
+    app.measure_twice()
+}
+"#,
+        ),
+        (
+            "unsatisfied bound",
+            r#"
+class Rock { value int }
+
+function main() -> int {
+    app.measure_twice(Rock { value: 1 })
+}
+"#,
+        ),
+        (
+            "non-exhaustive enum",
+            r#"
+function inspect(status: app.Status) -> int throws never {
+    match status {
+        app.Status.Active => 1
+    }
+}
+"#,
+        ),
+        (
+            "missing impl member",
+            r#"
+class Broken {
+    name string
+    implements app.Named {}
+    implements app.Measured {}
+}
+"#,
+        ),
+    ];
+
+    for (label, user) in cases {
+        let source = diagnostic_bytes(&source_db(user));
+        let blob = diagnostic_bytes(&blob_db(user, artifacts.blob.clone()));
+        assert!(!source.is_empty(), "{label}: fixture must produce an error");
+        assert_eq!(source, blob, "{label}: source/blob diagnostics diverged");
+    }
+}
+
+const ARTIFACT_USER: &str = r#"
+class Local {
+    name string
+    implements app.Named {}
+}
+
+function status_score(status: app.Status) -> int throws never {
+    match status {
+        app.Status.Active => 1
+        app.Status.Retired => 2
+    }
+}
+
+function main() -> int throws never {
+    let widget = app.Widget { name: "artifact", value: 20 }
+    let boxed = app.Box<app.Widget> { value: widget }
+    let enum_score = status_score(app.Status.Active)
+    let boxed_score = if boxed.inner_name() == "artifact" { 1 } else { 0 }
+    let tagged = app.tag_of(Local { name: "local" })
+    let tagged_score = if tagged == "any" { 1 } else { 0 }
+    app.measure_twice(widget)
+        + enum_score
+        + boxed_score
+        + tagged_score
+}
+"#;
+
+fn unit<'a>(units: &'a [CompilationUnit], path: &str) -> &'a CompilationUnit {
+    units
+        .iter()
+        .find(|unit| unit.source_file == path)
+        .unwrap_or_else(|| panic!("missing unit `{path}`"))
+}
+
+#[track_caller]
+fn assert_bytes_identical(label: &str, left: &[u8], right: &[u8]) {
+    if left == right {
+        return;
+    }
+    let first_difference = left
+        .iter()
+        .zip(right)
+        .position(|(left, right)| left != right)
+        .unwrap_or_else(|| left.len().min(right.len()));
+    panic!(
+        "{label}: byte streams differ first at {first_difference} (left len {}, right len {})",
+        left.len(),
+        right.len()
+    );
+}
+
+fn normalize_object_debug_file_ids(object: &mut bex_vm_types::Object) {
+    let bex_vm_types::Object::Function(function) = object else {
+        return;
+    };
+    let normalized = baml_base::FileId::new(0);
+    function.span.file_id = normalized;
+    for entry in &mut function.bytecode.line_table {
+        entry.span.file_id = normalized;
+    }
+    for local in &mut function.debug_locals {
+        local.scope_span.file_id = normalized;
+    }
+}
+
+fn normalized_unit(mut unit: CompilationUnit) -> CompilationUnit {
+    for object in &mut unit.code {
+        normalize_object_debug_file_ids(object);
+    }
+    if let Some(tail) = &mut unit.init_tail {
+        for object in &mut tail.objects {
+            normalize_object_debug_file_ids(object);
+        }
+    }
+    unit
+}
+
+fn normalized_program(mut program: Program) -> Program {
+    for object in program.objects.iter_mut() {
+        normalize_object_debug_file_ids(object);
+    }
+    program
+}
+
+#[test]
+fn emitted_program_dependency_and_consumer_units_are_byte_identical() {
+    let artifacts = library_artifacts();
+    let source_db = source_db(ARTIFACT_USER);
+    assert_no_diagnostic_errors(&source_db);
+    let source_program =
+        generate_project_bytecode_with_opt(&source_db, &options(), OPT).expect("source program");
+    let source_units = emit_units(&source_db, &options(), OPT).expect("source units");
+
+    let blob_db = blob_db(ARTIFACT_USER, artifacts.blob.clone());
+    assert_no_diagnostic_errors(&blob_db);
+    let blob_program =
+        generate_project_bytecode_with_mounted_units(&blob_db, &options(), OPT, &artifacts.units)
+            .expect("blob program");
+
+    let source_program_bytes = borsh::to_vec(&source_program).expect("serialize source program");
+    let blob_program_bytes = borsh::to_vec(&blob_program).expect("serialize blob program");
+
+    // The blob database intentionally has no app source with which to attribute
+    // flat objects during decomposition. Use the source manifest only as the
+    // inverse-link attribution oracle; the bytes being decomposed are the blob
+    // path's independently linked program.
+    let blob_units = decompose_units(&source_db, &options(), &blob_program)
+        .expect("decompose blob image with source manifest");
+    let source_user = unit(&source_units, "main.baml");
+    let blob_user = unit(&blob_units, "main.baml");
+    assert_ne!(
+        borsh::to_vec(source_user).expect("serialize raw source user unit"),
+        borsh::to_vec(blob_user).expect("serialize raw blob user unit"),
+        "the fixture must keep the database-local FileId distinction visible"
+    );
+    assert_bytes_identical(
+        "consumer unit after debug FileId normalization",
+        &borsh::to_vec(&normalized_unit(source_user.clone()))
+            .expect("serialize normalized source user unit"),
+        &borsh::to_vec(&normalized_unit(blob_user.clone()))
+            .expect("serialize normalized blob user unit"),
+    );
+
+    let imported_app_symbols: Vec<&str> = source_user
+        .object_imports
+        .iter()
+        .chain(&source_user.global_imports)
+        .map(|symbol| symbol.fq_name.as_str())
+        .filter(|name| name.starts_with("app."))
+        .collect();
+    assert!(
+        !imported_app_symbols.is_empty(),
+        "consumer must exercise symbolic app imports"
+    );
+    assert_eq!(source_user.object_imports, blob_user.object_imports);
+    assert_eq!(source_user.global_imports, blob_user.global_imports);
+
+    let source_app = unit(&source_units, "<builtin>/app/lib.baml");
+    let independent_app = unit(&artifacts.units, "<builtin>/app/lib.baml");
+    assert_bytes_identical(
+        "independent library unit",
+        &borsh::to_vec(source_app).expect("serialize source app unit"),
+        &borsh::to_vec(independent_app).expect("serialize independent app unit"),
+    );
+
+    assert_ne!(
+        source_program_bytes, blob_program_bytes,
+        "raw programs retain the consumer database's debug FileId"
+    );
+    assert_bytes_identical(
+        "linked program after debug FileId normalization",
+        &borsh::to_vec(&normalized_program(source_program))
+            .expect("serialize normalized source program"),
+        &borsh::to_vec(&normalized_program(blob_program))
+            .expect("serialize normalized blob program"),
+    );
+}
+
+#[test]
+fn exported_impl_method_preserves_synthetic_callback_effect_params() {
+    let artifacts = library_artifacts();
+    let runner = artifacts
+        .interface
+        .impls
+        .iter()
+        .find(|implementation| {
+            implementation.interface.name.name().as_str() == "Applies"
+                && matches!(
+                    &implementation.for_ty_pattern,
+                    baml_type::Ty::Class(qtn, _, _) if qtn.name().as_str() == "Runner"
+                )
+        })
+        .expect("Runner implements Applies row");
+    let apply = runner
+        .methods
+        .iter()
+        .find(|method| method.name.as_str() == "apply")
+        .expect("apply override export");
+    assert_eq!(apply.sig.generic_params.len(), 1);
+    assert!(baml_type::is_synthetic_effect_param(
+        apply.sig.generic_params[0].name()
+    ));
+    assert_eq!(apply.sig.generic_param_bounds, vec![Vec::new()]);
+}
+
+#[test]
+fn mounted_unit_api_preserves_dependency_link_errors() {
+    let artifacts = library_artifacts();
+    let mut duplicate_units = artifacts.units.clone();
+    duplicate_units.push(unit(&artifacts.units, "<builtin>/app/lib.baml").clone());
+    let db = blob_db("function main() -> int { 0 }", artifacts.blob);
+    let error =
+        generate_project_bytecode_with_mounted_units(&db, &options(), OPT, &duplicate_units)
+            .expect_err("duplicate dependency export must fail before consumer emit");
+    assert!(matches!(
+        error,
+        MountedPackageLinkError::DependencyLink(bex_vm_types::link::LinkError::DuplicateExport(_))
+    ));
+}
+
+#[test]
+fn user_vs_blob_overlap_is_e0132_primary_only_with_structural_partner() {
+    let artifacts = library_artifacts();
+    let db = blob_db(
+        r#"
+class Mine { value int }
+
+implement app.Tagged for Mine {
+    function tag(self) -> string throws never {
+        "mine"
+    }
+}
+"#,
+        artifacts.blob,
+    );
+    let overlap = collect_diagnostics(&db)
+        .into_iter()
+        .find(|diagnostic| diagnostic.code() == "E0132")
+        .expect("mounted blanket overlap must produce E0132");
+    assert_eq!(
+        overlap.message,
+        "overlapping interface implementations for the same receiver/interface \
+(conflicts with the mounted dependency's `implement app.Tagged for T`)"
+    );
+    assert_eq!(
+        overlap
+            .annotations
+            .iter()
+            .filter(|annotation| annotation.is_primary)
+            .count(),
+        1
+    );
+    assert_eq!(overlap.annotations.len(), 1, "blob side has no source span");
+    assert!(overlap.related_info.is_empty());
+}
+
+/// Two valid, independently checked mounted blobs cannot introduce a new
+/// blob-vs-blob overlap: the orphan rule requires either the interface or the
+/// receiver constructor to be local. Distinct packages therefore own distinct
+/// receiver constructors, while a package attempting to overlap a dependency's
+/// blanket impl is rejected by this same E0132 check before its blob is emitted.
+/// This makes user-vs-blob the only expressible load-time direction for valid
+/// slice-6a artifacts; malformed/tampered blobs belong to slice 6's artifact
+/// validation ledger.
+#[test]
+fn blob_vs_blob_overlap_is_not_expressible_for_valid_artifacts() {
+    // Keep the argument executable: the rich fixture's blanket impl is exported
+    // and therefore would reject any downstream overlapping source impl before
+    // that downstream package could become a second valid blob.
+    let artifacts = library_artifacts();
+    assert!(artifacts.interface.impls.iter().any(|implementation| {
+        implementation.interface.name.name().as_str() == "Tagged"
+            && matches!(implementation.for_ty_pattern, baml_type::Ty::TypeVar(_, _))
+    }));
+    assert!(matches!(
+        artifacts.interface.lookup_type(&[], &Name::new("Tagged")),
+        Some(ExportedType::Interface { .. })
+    ));
+}


### PR DESCRIPTION
**BEP-066 slice-6a stack, PR 5 of 5 — the capstone.** Chained on #4332. With this green, the slice-6a stack is complete: a package consumed as an interface blob is provably indistinguishable from the same package consumed as source.

## The parity oracle (`mounted_package_parity.rs`)
- Source-vs-blob **runtime parity** across the full surface: interfaces + requires + assoc defaults + default methods, attrs, generics/bounds, enums, aliases, in-body/out-of-body/blanket impls, user impls of mounted interfaces, caught-throw behavior.
- **Byte-identical diagnostic fingerprints** (code/message/severity/phase/user range) for the misuse variants: wrong arity, unsatisfied bound, non-exhaustive match, missing impl members.
- **Byte-identical artifacts**: dependency units, package metadata, consumer import tables raw-identical; consumer units + whole programs identical after normalizing database-local debug FileIds — the sole legitimate difference (the known B-693 §9b wart), with paths/ranges/symbols/executable bytes identical.

## What the oracle caught (fixed in the implementation, never weakened in the oracle)
1. Source auxiliary packages didn't participate in user dependency resolution the way mounted ones do.
2. Mounted interface defaults/assoc-defaults/fields/method tables seeded emission differently from source interfaces.
3. Impl-method exports mishandled synthetic callback-effect parameters vs enclosing impl generics.

## Also in this PR
- **Coherence-fails-open hole closed and proven**: user-vs-blob impl overlap yields exactly one primary-only E0132 attributed at the user's impl, dep side rendered structurally.
- **Public link seam**: the two-DB compile-and-link harness promoted from test scaffolding to a documented API — slice 6's `Package.compile` consumes this.
- **Residue ledger** documented adjacent to the public API (E0158 builtin residue, span-dependent LSP ops, re-aliasing/transitive re-export, live `$stream` loading, artifact versioning, dispatcher synthesis) — slice 6 starts from a ledger, not archaeology.

## Gates
Full baml_tests green · all-features mounted call/parity suites 26/26 · HIR/TIR/project · bytecode_cache 43/43 · fmt/clippy/rustdoc all-features `-D warnings` · **zero snapshot churn**.

Implemented by a Codex (gpt-5.6-sol) worker under stack-manager review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for compiling applications against mounted, source-less packages, including their default methods, type defaults, and field definitions.
  - Added dependency linking for precompiled package artifacts before consumer compilation.

- **Bug Fixes**
  - Improved handling of generic callback-effect metadata in exported functions and implementation methods.
  - Improved package discovery and dependency resolution for auxiliary and mounted source packages.

- **Tests**
  - Added comprehensive parity coverage for source-based and serialized mounted packages, including runtime behavior, diagnostics, imports, and linking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->