### PR TITLE
feat(app-beps): support arbitrary nesting depth for BEP pages

### DIFF
--- a/typescript2/app-beps/convex/schema.ts
+++ b/typescript2/app-beps/convex/schema.ts
@@ -125,7 +125,7 @@ export default defineSchema({
       title: v.string(),
       content: v.string(),
       order: v.number(),
-      parentSlug: v.optional(v.string()),              // Slug of the parent page (one level of nesting)
+      parentSlug: v.optional(v.string()),              // Slug of the immediate parent page (chains allow arbitrary nesting depth)
     }))),
 
     // Legacy fields (will be removed after migration)
@@ -152,7 +152,7 @@ export default defineSchema({
     title: v.string(),
     content: v.string(),
     order: v.number(),
-    parentSlug: v.optional(v.string()),                // Slug of the parent page (one level of nesting, e.g. "design")
+    parentSlug: v.optional(v.string()),                // Slug of the immediate parent page (chains allow arbitrary nesting depth)
     createdAt: v.number(),
     updatedAt: v.number(),
   })

--- a/typescript2/app-beps/src/components/bep/bep-import-dialog.tsx
+++ b/typescript2/app-beps/src/components/bep/bep-import-dialog.tsx
@@ -37,6 +37,7 @@ import {
   hasContent,
 } from "@/lib/import-utils";
 import { isReservedPageSlug } from "@/lib/bep-routes";
+import { pageExportPath } from "@/lib/export-utils";
 import type { VersionMode } from "@/lib/types";
 
 interface BepImportDialogProps {
@@ -113,21 +114,22 @@ export function BepImportDialog({ bepId, bepNumber }: BepImportDialogProps) {
 
         // Determine file type based on path
         const isReadme = innerPath.toLowerCase() === "readme.md";
-        // Direct children of pages/ (pages/foo.md) or one level of nesting
-        // (pages/design/api.md → parentSlug "design")
+        // Any .md under pages/, at arbitrary depth: pages/foo.md,
+        // pages/design/api.md, pages/design/api/v2.md, ...
         const inPagesDir = innerPath.toLowerCase().startsWith("pages/");
-        const isPage = inPagesDir && pathParts.length === 3;
-        const isNestedPage = inPagesDir && pathParts.length === 4;
+        const isPage = inPagesDir && pathParts.length >= 3;
 
-        // Skip files that aren't README or in pages/ (deeper nesting is unsupported)
-        if (!isReadme && !isPage && !isNestedPage) {
+        // Skip files that aren't README or in pages/
+        if (!isReadme && !isPage) {
           continue;
         }
 
-        // Parent slug comes from the subdirectory name
-        const parentSlug = isNestedPage
-          ? sanitizeSlug(pathParts[2])
-          : undefined;
+        // Parent slug comes from the immediate containing directory
+        // (pages/design/api.md → "design"; pages/a/b/c.md → "b")
+        const parentSlug =
+          isPage && pathParts.length > 3
+            ? sanitizeSlug(pathParts[pathParts.length - 2])
+            : undefined;
 
         try {
           const text = await file.text();
@@ -452,8 +454,8 @@ export function BepImportDialog({ bepId, bepNumber }: BepImportDialogProps) {
             </div>
             <p className="text-xs text-muted-foreground mt-1">
               Select the exported BEP folder (e.g., BEP-001). Will import
-              README.md and files from pages/, including one level of
-              subfolders (e.g., pages/design/api.md).
+              README.md and files from pages/, including nested subfolders
+              at any depth (e.g., pages/design/api/v2.md).
             </p>
           </div>
 
@@ -533,7 +535,7 @@ export function BepImportDialog({ bepId, bepNumber }: BepImportDialogProps) {
                     <div className="flex items-center gap-2">
                       <FileText className="h-4 w-4 text-destructive/70" />
                       <span className="font-medium text-destructive">
-                        pages/{page.parentSlug ? `${page.parentSlug}/` : ""}{page.slug}.md
+                        {pageExportPath(page, bepData?.pages ?? [])}
                       </span>
                       <Badge variant="outline" className="font-mono text-xs text-destructive border-destructive/50">
                         {page.slug}

--- a/typescript2/app-beps/src/components/bep/bep-nav.tsx
+++ b/typescript2/app-beps/src/components/bep/bep-nav.tsx
@@ -85,12 +85,14 @@ export function BepNav({
   onAddPage,
 }: BepNavProps) {
   // Arrange sections as a tree: children (parentSlug) render under their
-  // parent, indented. Children whose parent isn't visible stay at top level.
+  // parent, indented one step per ancestor. Children whose parent isn't
+  // visible stay at top level.
   const visibleSections = sections.filter(
     (s) => s.hasContent || pageStatuses[s.id] === "new"
   );
   const visibleIds = new Set(visibleSections.map((s) => s.id));
-  const orderedSections: Array<Section & { depth: number }> = [];
+  const childrenByParent = new Map<string, Section[]>();
+  const rootSections: Section[] = [];
   for (const section of visibleSections) {
     // Self-referential pages (parentSlug === own id) render at top level
     if (
@@ -98,15 +100,26 @@ export function BepNav({
       section.parentSlug !== section.id &&
       visibleIds.has(section.parentSlug)
     ) {
-      continue;
-    }
-    orderedSections.push({ ...section, depth: 0 });
-    for (const child of visibleSections) {
-      if (child.id !== section.id && child.parentSlug === section.id) {
-        orderedSections.push({ ...child, depth: 1 });
-      }
+      const siblings = childrenByParent.get(section.parentSlug) ?? [];
+      siblings.push(section);
+      childrenByParent.set(section.parentSlug, siblings);
+    } else {
+      rootSections.push(section);
     }
   }
+  const orderedSections: Array<Section & { depth: number }> = [];
+  const placed = new Set<string>();
+  const appendSubtree = (section: Section, depth: number) => {
+    if (placed.has(section.id)) return;
+    placed.add(section.id);
+    orderedSections.push({ ...section, depth });
+    for (const child of childrenByParent.get(section.id) ?? []) {
+      appendSubtree(child, depth + 1);
+    }
+  };
+  for (const section of rootSections) appendSubtree(section, 0);
+  // Sections trapped in parent cycles have no root; render them at top level
+  for (const section of visibleSections) appendSubtree(section, 0);
 
   // Keep the active item visible inside the sidebar's own scroll container
   // without touching window scroll (scrollIntoView would also scroll
@@ -151,8 +164,13 @@ export function BepNav({
                   ? "bg-accent text-accent-foreground font-medium"
                   : "text-muted-foreground",
                 isDeleted && "opacity-50 line-through",
-                section.depth > 0 && "ml-4 border-l pl-3"
+                section.depth > 0 && "border-l pl-3"
               )}
+              style={
+                section.depth > 0
+                  ? { marginLeft: `${section.depth}rem` }
+                  : undefined
+              }
             >
               <span className="flex items-center justify-between gap-2">
                 <span className="truncate">{section.title}</span>

--- a/typescript2/app-beps/src/lib/export-all-utils.ts
+++ b/typescript2/app-beps/src/lib/export-all-utils.ts
@@ -38,12 +38,24 @@ export interface ExportAllPage {
 
 /**
  * Relative path of a page file within a BEP folder.
- * Nested pages live in a subfolder named after their parent slug.
+ * Nested pages live in subfolders mirroring their ancestor chain of
+ * parentSlug links, e.g. pages/design/api/v2.md. Unknown parents still
+ * contribute a folder; cycles terminate at the first repeated slug.
  */
-function pagePath(page: { slug: string; parentSlug?: string }): string {
-  return page.parentSlug
-    ? `pages/${page.parentSlug}/${page.slug}.md`
-    : `pages/${page.slug}.md`;
+function pagePath(
+  page: { slug: string; parentSlug?: string },
+  allPages: Array<{ slug: string; parentSlug?: string }>
+): string {
+  const bySlug = new Map(allPages.map((p) => [p.slug, p]));
+  const segments = [page.slug];
+  const seen = new Set(segments);
+  let parent = page.parentSlug;
+  while (parent && !seen.has(parent)) {
+    seen.add(parent);
+    segments.unshift(parent);
+    parent = bySlug.get(parent)?.parentSlug;
+  }
+  return `pages/${segments.join("/")}.md`;
 }
 
 export interface ExportAllData {
@@ -365,31 +377,39 @@ export function generateBepReadme(bep: ExportAllBep): string {
     md += `# ${bepNum}: ${bep.title}\n\n*No content available.*\n`;
   }
 
-  // Link to additional pages if any (children listed under their parent)
+  // Link to additional pages if any (children listed under their parent,
+  // indented one step per ancestor)
   if (bep.pages.length > 0) {
     md += `\n\n---\n\n## Additional Pages\n\n`;
+    const bySlug = new Map(bep.pages.map((p) => [p.slug, p]));
     const childrenByParent = new Map<string, ExportAllPage[]>();
+    const roots: ExportAllPage[] = [];
     for (const page of bep.pages) {
-      if (page.parentSlug) {
+      // Pages with a missing or self-referential parent list at top level
+      if (
+        page.parentSlug &&
+        page.parentSlug !== page.slug &&
+        bySlug.has(page.parentSlug)
+      ) {
         const list = childrenByParent.get(page.parentSlug) ?? [];
         list.push(page);
         childrenByParent.set(page.parentSlug, list);
+      } else {
+        roots.push(page);
       }
     }
-    for (const page of bep.pages) {
-      if (page.parentSlug) continue;
-      md += `- [${page.title}](./${pagePath(page)})\n`;
+    const listed = new Set<string>();
+    const listSubtree = (page: ExportAllPage, depth: number) => {
+      if (listed.has(page.slug)) return;
+      listed.add(page.slug);
+      md += `${"  ".repeat(depth)}- [${page.title}](./${pagePath(page, bep.pages)})\n`;
       for (const child of childrenByParent.get(page.slug) ?? []) {
-        md += `  - [${child.title}](./${pagePath(child)})\n`;
+        listSubtree(child, depth + 1);
       }
-    }
-    // Children whose parent slug doesn't match any page
-    for (const [parentSlug, children] of childrenByParent) {
-      if (bep.pages.some((p) => !p.parentSlug && p.slug === parentSlug)) continue;
-      for (const child of children) {
-        md += `- [${child.title}](./${pagePath(child)})\n`;
-      }
-    }
+    };
+    for (const page of roots) listSubtree(page, 0);
+    // Pages trapped in parent cycles have no root; surface them at top level
+    for (const page of bep.pages) listSubtree(page, 0);
   }
 
   return md;
@@ -452,24 +472,28 @@ BEP-001-your-proposal-slug/
 └── pages/              # Additional pages (addenda)
     ├── background.md
     ├── examples.md
-    └── design/         # One level of nesting is supported
+    └── design/         # Subfolders nest pages under a parent page
         ├── api.md      # Becomes a child of the "design" page
-        └── schema.md
+        ├── schema.md
+        └── api/
+            └── v2.md   # Becomes a child of the "api" page
 \`\`\`
 
 ### Page Hierarchy
 
-Pages support **one level of nesting**: a markdown file inside a subfolder of
-\`pages/\` (e.g., \`pages/design/api.md\`) is imported as a child of the page
-whose slug matches the folder name (\`design\`). In the API this is expressed
-with the optional \`parentSlug\` field on a page object.
+Pages can nest to **any depth**: a markdown file inside a subfolder of
+\`pages/\` is imported as a child of the page whose slug matches its immediate
+folder name (e.g., \`pages/design/api.md\` → child of \`design\`;
+\`pages/design/api/v2.md\` → child of \`api\`). In the API this is expressed
+with the optional \`parentSlug\` field on a page object, which names the
+immediate parent.
 
 Rules:
 - Slugs are unique per BEP, even across folders — \`pages/a/notes.md\` and
   \`pages/b/notes.md\` would collide.
-- The parent folder name should match an existing top-level page slug so the
-  child nests under it in the UI; otherwise the child is shown at top level.
-- Folders deeper than one level are not supported and will be skipped on import.
+- Each folder name should match the slug of a page one level up (e.g.,
+  \`pages/design/api/\` alongside \`pages/design/api.md\`) so children nest
+  under it in the UI; otherwise the child is shown at top level.
 
 ---
 
@@ -640,7 +664,7 @@ Downloads all BEPs as a ZIP archive. No authentication required.
 | \`slug\` | Yes | URL-safe identifier (e.g., \`"background"\`), unique per BEP |
 | \`title\` | Yes | Display title |
 | \`content\` | Yes | Full markdown content |
-| \`parentSlug\` | No | Slug of the parent page to nest under (one level) |
+| \`parentSlug\` | No | Slug of the immediate parent page to nest under (chains allow any depth) |
 
 ### Update (PUT /api/agent/beps)
 
@@ -788,7 +812,7 @@ export function generateAllBepsExportFiles(data: ExportAllData, apiBaseUrl: stri
     // Additional pages
     for (const page of bep.pages) {
       files.push({
-        path: `${bepFolder}/${pagePath(page)}`,
+        path: `${bepFolder}/${pagePath(page, bep.pages)}`,
         content: generatePageMd(page),
       });
     }

--- a/typescript2/app-beps/src/lib/export-utils.ts
+++ b/typescript2/app-beps/src/lib/export-utils.ts
@@ -29,12 +29,24 @@ export interface ExportPage {
 
 /**
  * Relative path of a page file within the export bundle.
- * Nested pages live in a subfolder named after their parent slug.
+ * Nested pages live in subfolders mirroring their ancestor chain of
+ * parentSlug links, e.g. pages/design/api/v2.md. Unknown parents still
+ * contribute a folder; cycles terminate at the first repeated slug.
  */
-export function pageExportPath(page: { slug: string; parentSlug?: string }): string {
-  return page.parentSlug
-    ? `pages/${page.parentSlug}/${page.slug}.md`
-    : `pages/${page.slug}.md`;
+export function pageExportPath(
+  page: { slug: string; parentSlug?: string },
+  allPages: Array<{ slug: string; parentSlug?: string }> = []
+): string {
+  const bySlug = new Map(allPages.map((p) => [p.slug, p]));
+  const segments = [page.slug];
+  const seen = new Set(segments);
+  let parent = page.parentSlug;
+  while (parent && !seen.has(parent)) {
+    seen.add(parent);
+    segments.unshift(parent);
+    parent = bySlug.get(parent)?.parentSlug;
+  }
+  return `pages/${segments.join("/")}.md`;
 }
 
 export interface ExportComment {
@@ -340,7 +352,7 @@ export function generateReadme(data: ExportData): string {
   if (pages.length > 0) {
     md += `---\n\n## Additional Pages\n\n`;
     for (const page of pages) {
-      md += `- [${page.title}](${pageExportPath(page)})\n`;
+      md += `- [${page.title}](${pageExportPath(page, pages)})\n`;
     }
     md += `\n`;
   }
@@ -815,7 +827,7 @@ export function generateMetadataJson(data: ExportData): string {
     files: [
       "README.md",
       "AGENT_CONTEXT.md",
-      ...pages.map((p) => pageExportPath(p)),
+      ...pages.map((p) => pageExportPath(p, pages)),
       "discussion/issues.md",
       "discussion/decisions.md",
       "history/versions.md",
@@ -885,7 +897,7 @@ ${contentSummary}${contentSummary.length >= 500 ? "..." : ""}
 ## Pages
 
 - Main Content (README.md) - includes current version comments only
-${pages.length > 0 ? pages.map((p) => `- ${p.title} (${pageExportPath(p)})`).join("\n") : ""}
+${pages.length > 0 ? pages.map((p) => `- ${p.title} (${pageExportPath(p, pages)})`).join("\n") : ""}
 
 ## Comment Overview
 
@@ -936,7 +948,7 @@ ${bepNum}/
 ├── AGENT_CONTEXT.md        # This file
 ├── metadata.json           # Machine-readable metadata${pages.length > 0 ? `
 ├── pages/                  # Additional pages + v${currentVersion} comments
-${pages.map((p) => `│   └── ${p.parentSlug ? `${p.parentSlug}/` : ""}${p.slug}.md`).join("\n")}` : ""}
+${pages.map((p) => `│   └── ${pageExportPath(p, pages).slice("pages/".length)}`).join("\n")}` : ""}
 ├── discussion/
 │   ├── issues.md           # Open and resolved issues
 │   └── decisions.md        # Recorded decisions
@@ -1011,7 +1023,7 @@ export function generateAllExportFiles(data: ExportData): ExportFile[] {
       ...(page.parentSlug ? { parent: page.parentSlug } : {}),
     });
     files.push({
-      path: pageExportPath(page),
+      path: pageExportPath(page, pages),
       content: `${pageFrontmatter}# ${page.title}\n\n${contentWithComments}\n`,
     });
   }

--- a/typescript2/app-beps/src/lib/static/bep-script.ts
+++ b/typescript2/app-beps/src/lib/static/bep-script.ts
@@ -146,11 +146,16 @@ def read_local_bep(folder: Path) -> dict:
 
     pages_dir = folder / "pages"
     if pages_dir.exists() and pages_dir.is_dir():
-        for page_file in sorted(pages_dir.glob("*.md")):
-            result["pages"].append({
+        for page_file in sorted(pages_dir.rglob("*.md")):
+            rel = page_file.relative_to(pages_dir)
+            page = {
                 "slug": page_file.stem,
                 "content": page_file.read_text(encoding="utf-8"),
-            })
+            }
+            # Nested pages: the immediate folder name is the parent page's slug
+            if len(rel.parts) > 1:
+                page["parent_slug"] = rel.parts[-2]
+            result["pages"].append(page)
 
     return result
 
@@ -483,7 +488,8 @@ def cmd_diff(args: argparse.Namespace) -> int:
     server_pages = {}
     for f_path, content in server_files.items():
         if f_path.startswith("pages/") and f_path.endswith(".md"):
-            slug = f_path[6:-3]  # Remove "pages/" and ".md"
+            # Slug is the basename; nested pages live at pages/<ancestors>/<slug>.md
+            slug = f_path.rsplit("/", 1)[-1][:-3]
             server_pages[slug] = content
 
     local_pages = {p["slug"]: p["content"] for p in local_bep["pages"]}
@@ -538,11 +544,14 @@ def cmd_push(args: argparse.Namespace) -> int:
         # Extract title from first heading or use slug
         title_match = re.search(r"^#\\s+(.+)$", page["content"], re.MULTILINE)
         title = title_match.group(1).strip() if title_match else page["slug"].title()
-        pages.append({
+        page_payload = {
             "slug": page["slug"],
             "title": title,
             "content": page["content"],
-        })
+        }
+        if page.get("parent_slug"):
+            page_payload["parentSlug"] = page["parent_slug"]
+        pages.append(page_payload)
 
     # Show diff first
     print("Changes to push:")


### PR DESCRIPTION
## Summary

BEP pages could previously nest only one level deep (`pages/design/api.md`). The `parentSlug` field already expressed a parent chain, so this extends every producer/consumer to walk it, enabling arbitrary depth (`pages/design/api/v2.md`, and beyond).

- **Import dialog**: accepts `.md` files at any depth under `pages/`; the immediate containing folder name becomes the page's `parentSlug` (previously files deeper than one folder were silently skipped)
- **Export** (`pageExportPath` / `pagePath`): builds the full ancestor-chain path, with guards for missing parents (old single-folder behavior preserved) and cycles (terminate at first repeated slug)
- **Nav sidebar**: renders the page tree recursively with per-depth indentation; pages trapped in parent cycles surface at top level instead of disappearing
- **Export-all README**: "Additional Pages" listing is now recursive, indented per level
- **Embedded `bep` CLI script**: reads `pages/` recursively (`rglob`), pushes `parentSlug` derived from the folder structure, and diffs server pages by basename slug so nested paths match
- **Docs/schema comments**: updated to describe the chain semantics

## Testing

- `tsc --noEmit` clean for all touched files (one pre-existing error from ungenerated `baml_sdk`, unrelated)
- `eslint` clean on all touched files
- Embedded Python script extracted and passed `py_compile`
- Verified `pageExportPath` behavior with bun for: 3-level chains, orphaned parents (legacy fallback), and cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBJriC255Sd33ZV2cL8Bzj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how folder imports map to page hierarchy and export paths, which can affect round-trips for deeply nested or malformed `parentSlug` data; slug uniqueness is still per BEP basename only.
> 
> **Overview**
> **BEP additional pages** can nest deeper than one folder level. The existing `parentSlug` field now drives a full ancestor chain everywhere content is read or written on disk.
> 
> **Import** accepts any `pages/**/*.md` depth and sets `parentSlug` from the immediate parent folder (deeper paths are no longer skipped). **Export** (`pageExportPath` / `pagePath`) emits paths like `pages/design/api/v2.md` by walking `parentSlug`, with cycle detection and sensible fallbacks for missing parents. **Sidebar nav** builds a recursive tree with per-level indentation; pages in parent cycles still show at the top level.
> 
> The embedded **`bep` CLI** recursively scans `pages/`, includes `parentSlug` on push, and diffs pages by basename slug. Export-all docs and schema comments are updated to describe unlimited nesting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64d1abfe58f3487dd41e222994223661b681ea2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing, exporting, and displaying pages nested to any depth.
  * Navigation now shows nested sections with depth-based indentation.
  * Generated links, metadata, documentation, and file structures reflect complete page hierarchies.
  * Nested Markdown files are discovered automatically, including parent-page relationships.

* **Bug Fixes**
  * Improved handling of unknown, missing, and cyclic parent references without causing infinite loops.
  * Corrected paths for deleted pages and deeply nested content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->