### PR TITLE
fix(app-beps): address CodeRabbit review on page nesting (#4339 follow-up)

### DIFF
--- a/typescript2/app-beps/src/lib/export-all-utils.ts
+++ b/typescript2/app-beps/src/lib/export-all-utils.ts
@@ -472,6 +472,7 @@ BEP-001-your-proposal-slug/
 └── pages/              # Additional pages (addenda)
     ├── background.md
     ├── examples.md
+    ├── design.md       # Parent page for files in design/
     └── design/         # Subfolders nest pages under a parent page
         ├── api.md      # Becomes a child of the "design" page
         ├── schema.md

--- a/typescript2/app-beps/src/lib/export-utils.ts
+++ b/typescript2/app-beps/src/lib/export-utils.ts
@@ -348,12 +348,39 @@ export function generateReadme(data: ExportData): string {
     md += `${contentWithComments}\n\n`;
   }
 
-  // Additional pages (linked)
+  // Additional pages (children listed under their parent, indented one step
+  // per ancestor)
   if (pages.length > 0) {
     md += `---\n\n## Additional Pages\n\n`;
+    const bySlug = new Map(pages.map((p) => [p.slug, p]));
+    const childrenByParent = new Map<string, ExportPage[]>();
+    const roots: ExportPage[] = [];
     for (const page of pages) {
-      md += `- [${page.title}](${pageExportPath(page, pages)})\n`;
+      // Pages with a missing or self-referential parent list at top level
+      if (
+        page.parentSlug &&
+        page.parentSlug !== page.slug &&
+        bySlug.has(page.parentSlug)
+      ) {
+        const list = childrenByParent.get(page.parentSlug) ?? [];
+        list.push(page);
+        childrenByParent.set(page.parentSlug, list);
+      } else {
+        roots.push(page);
+      }
     }
+    const listed = new Set<string>();
+    const listSubtree = (page: ExportPage, depth: number) => {
+      if (listed.has(page.slug)) return;
+      listed.add(page.slug);
+      md += `${"  ".repeat(depth)}- [${page.title}](${pageExportPath(page, pages)})\n`;
+      for (const child of childrenByParent.get(page.slug) ?? []) {
+        listSubtree(child, depth + 1);
+      }
+    };
+    for (const page of roots) listSubtree(page, 0);
+    // Pages trapped in parent cycles have no root; surface them at top level
+    for (const page of pages) listSubtree(page, 0);
     md += `\n`;
   }
 

--- a/typescript2/app-beps/src/lib/static/bep-script.ts
+++ b/typescript2/app-beps/src/lib/static/bep-script.ts
@@ -484,35 +484,45 @@ def cmd_diff(args: argparse.Namespace) -> int:
         else:
             print(f"README.md: {server_lines} → {local_lines} lines")
 
-    # Compare pages
+    # Compare pages (tracking each page's immediate parent to detect moves)
     server_pages = {}
     for f_path, content in server_files.items():
         if f_path.startswith("pages/") and f_path.endswith(".md"):
             # Slug is the basename; nested pages live at pages/<ancestors>/<slug>.md
-            slug = f_path.rsplit("/", 1)[-1][:-3]
-            server_pages[slug] = content
+            parts = f_path[:-3].split("/")[1:]
+            slug = parts[-1]
+            parent = parts[-2] if len(parts) > 1 else None
+            server_pages[slug] = (parent, content)
 
-    local_pages = {p["slug"]: p["content"] for p in local_bep["pages"]}
+    local_pages = {
+        p["slug"]: (p.get("parent_slug"), p["content"]) for p in local_bep["pages"]
+    }
 
     all_slugs = set(server_pages.keys()) | set(local_pages.keys())
     for slug in sorted(all_slugs):
-        server_content = server_pages.get(slug, "")
-        local_content = local_pages.get(slug, "")
+        server_parent, server_content = server_pages.get(slug, (None, ""))
+        local_parent, local_content = local_pages.get(slug, (None, ""))
 
         if slug not in server_pages:
             print(f"pages/{slug}.md: NEW ({len(local_content.splitlines())} lines)")
         elif slug not in local_pages:
             print(f"pages/{slug}.md: DELETED")
-        elif server_content != local_content:
-            print(f"pages/{slug}.md: MODIFIED")
-            if args.full:
-                diff = difflib.unified_diff(
-                    server_content.splitlines(keepends=True),
-                    local_content.splitlines(keepends=True),
-                    fromfile=f"server/pages/{slug}.md",
-                    tofile=f"local/pages/{slug}.md",
+        else:
+            if server_parent != local_parent:
+                print(
+                    f"pages/{slug}.md: MOVED "
+                    f"({server_parent or '(top level)'} -> {local_parent or '(top level)'})"
                 )
-                print("".join(diff))
+            if server_content != local_content:
+                print(f"pages/{slug}.md: MODIFIED")
+                if args.full:
+                    diff = difflib.unified_diff(
+                        server_content.splitlines(keepends=True),
+                        local_content.splitlines(keepends=True),
+                        fromfile=f"server/pages/{slug}.md",
+                        tofile=f"local/pages/{slug}.md",
+                    )
+                    print("".join(diff))
 
     return 0
 


### PR DESCRIPTION
Follow-up to #4339, which was merged while CodeRabbit's requested changes were still outstanding. This applies those review fixes:

- `generateReadme` (export-utils.ts) now renders the "Additional Pages" list as a `parentSlug` hierarchy — children indented under their parent, with the same missing-parent and cycle handling as `generateBepReadme` in export-all-utils.ts.
- The embedded Python CLI's `cmd_diff` (bep-script.ts) now tracks each page's immediate parent (from the server file path and the local folder layout) and reports `MOVED (old-parent -> new-parent)` when a page changes parents, so `diff` is consistent with what `push` sends via `parentSlug`. A page can now report both MOVED and MODIFIED.
- The NEW-BEP directory-structure example (export-all-utils.ts) includes `design.md` beside `design/`, so the documented hierarchy no longer shows an orphaned parent.

Verified: `tsc --noEmit` (no new errors), embedded Python extracted and `py_compile`d, plus behavioral spot-checks of the hierarchy rendering (nesting, missing parents, self-reference, cycles) and the diff move/modify detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WBJriC255Sd33ZV2cL8Bzj

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Export formatting and CLI diff output only; no auth, API, or persistence behavior changes.
> 
> **Overview**
> Follow-up polish for **nested BEP pages** (`parentSlug` / `pages/.../` layout).
> 
> **Single-BEP export** (`generateReadme` in `export-utils.ts`): the **Additional Pages** section is no longer a flat bullet list. It now mirrors **`generateBepReadme`**—children indented under their parent, with the same handling for missing parents, self-parents, and cycles (orphans listed at top level).
> 
> **Embedded `bep` CLI** (`cmd_diff` in `bep-script.ts`): page comparison tracks each slug’s **immediate parent** (from server file paths and local `pages/` nesting). When only the parent changes, it prints **`MOVED (old -> new)`**; content changes can still show **MODIFIED** in the same run, matching what **`push`** sends via `parentSlug`.
> 
> **Docs** (`export-all-utils.ts`): the NEW-BEP directory example adds **`design.md`** next to **`design/`** so the sample tree shows a parent page for nested files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f75bdf15e6ec5348b0b825c58d3efd85c65abf13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Exported README listings now preserve page hierarchy with nested indentation.
  - Pages with missing, self-referential, or circular parent relationships are surfaced safely at the top level.
  - Exported page links now use hierarchy-aware paths.
  - Added clearer guidance for the `design/` directory in generated instructions.

- **Bug Fixes**
  - Page comparison reports now identify moved pages separately from content changes.
  - Full content differences remain available when requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->