### PR TITLE
fix(fmt): accept contextual keywords as identifiers in name positions

### DIFF
--- a/baml_language/crates/baml_fmt/src/ast/expressions.rs
+++ b/baml_language/crates/baml_fmt/src/ast/expressions.rs
@@ -4313,9 +4313,9 @@ pub enum ObjectFieldKey {
 impl FromCST for ObjectFieldKey {
     fn from_cst(elem: SyntaxElement) -> Result<Self, StrongAstError> {
         match elem.kind() {
-            SyntaxKind::WORD | SyntaxKind::KW_CLIENT => {
-                Ok(ObjectFieldKey::Word(t::Word::from_cst(elem)?))
-            }
+            // `client` (KW_CLIENT) is a keyword but a valid field name, e.g.
+            // `Agent { client: ... }` — mirror `parse_object_field`.
+            kind if t::is_word_like(kind) => Ok(ObjectFieldKey::Word(t::Word::from_cst(elem)?)),
             SyntaxKind::STRING_LITERAL => {
                 Ok(ObjectFieldKey::String(t::QuotedString::from_cst(elem)?))
             }

--- a/baml_language/crates/baml_fmt/src/ast/tokens.rs
+++ b/baml_language/crates/baml_fmt/src/ast/tokens.rs
@@ -593,13 +593,40 @@ impl Word {
         Self { token_span }
     }
 }
+
+/// True for token kinds the parser accepts as identifiers in name positions.
+///
+/// The lexer emits dedicated keyword kinds for these words, but the parser
+/// keeps them valid as field, parameter, method, and member-access names
+/// (e.g. a class field or parameter named `client`, or `x.implements(y)` on
+/// the reflection `type` value). The CST therefore contains the keyword kind
+/// where the strong AST expects a name, and [`Word::from_cst`] must accept it.
+/// Mirrors `at_member_name` and `parse_parameter` in `baml_compiler_parser`.
+#[must_use]
+pub fn is_word_like(kind: SyntaxKind) -> bool {
+    matches!(
+        kind,
+        SyntaxKind::WORD
+            | SyntaxKind::KW_CLIENT
+            | SyntaxKind::KW_IMPLEMENTS
+            | SyntaxKind::KW_IMPLEMENT
+            | SyntaxKind::KW_EXTENDS
+            | SyntaxKind::KW_REQUIRES
+            | SyntaxKind::KW_INTERFACE
+            | SyntaxKind::KW_SPAWN
+            | SyntaxKind::KW_AWAIT
+    )
+}
+
 impl FromCST for Word {
     fn from_cst(elem: SyntaxElement) -> Result<Self, StrongAstError> {
         let token = StrongAstError::assert_is_token(elem)?;
-        // `client` lexes as KW_CLIENT but remains a valid identifier (field,
-        // parameter, object key, ...) — mirror the parser's allowance.
-        if token.kind() != SyntaxKind::KW_CLIENT {
-            StrongAstError::assert_kind_token(&token, SyntaxKind::WORD)?;
+        if !is_word_like(token.kind()) {
+            return Err(StrongAstError::UnexpectedKind {
+                expected: SyntaxKind::WORD,
+                found: token.kind(),
+                at: token.text_range(),
+            });
         }
         Ok(Self::new_from_span(token.text_range()))
     }

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -601,6 +601,65 @@ mod linear_formatter_regression_tests {
 }
 
 #[cfg(test)]
+mod contextual_keyword_name_tests {
+    //! Regression tests for contextual keywords used as names. The lexer
+    //! emits a dedicated keyword kind for `client` (`KW_CLIENT`), and the
+    //! parser accepts it as a class field, parameter, and member-access
+    //! name (BEP-049 §10 `ctx.client`). The formatter used to reject those
+    //! files with "Expected token/node of kind WORD, but found `KW_CLIENT`".
+
+    use super::*;
+
+    fn assert_round_trips(source: &str) {
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).unwrap_or_else(|error| {
+            panic!("formatter should accept contextual keyword name: {error:?}\nsource:\n{source}")
+        });
+        assert_eq!(formatted, source);
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    #[test]
+    fn client_as_class_field_name() {
+        assert_round_trips("class Agent {\n    client: string?,\n    name: string,\n}\n");
+    }
+
+    #[test]
+    fn client_as_function_parameter_name() {
+        // A `let` statement keeps the body classified as an expression
+        // function; a bare `client` tail expression would trip the parser's
+        // LLM-function-body heuristic, which is out of the formatter's hands.
+        assert_round_trips(
+            "function call_llm(client: string, function_name: string) -> string {\n    let out = client;\n    out\n}\n",
+        );
+    }
+
+    #[test]
+    fn client_as_member_access_name() {
+        assert_round_trips(
+            "class Agent {\n    client: string?,\n}\n\nfunction f(a: Agent) -> string? {\n    let c = a.client;\n    c\n}\n",
+        );
+    }
+
+    #[test]
+    fn client_as_object_literal_key() {
+        assert_round_trips(
+            "class Agent {\n    client: string?,\n}\n\nfunction make(client: string?) -> Agent {\n    let a = Agent { client: client };\n    a\n}\n",
+        );
+    }
+
+    #[test]
+    fn keyword_method_names_round_trip() {
+        // `implements` and friends stay valid as member names (reflection
+        // API, e.g. `dog_t.implements(animal_t)`).
+        assert_round_trips(
+            "function f(dog_t: type, animal_t: type) -> bool {\n    dog_t.implements(animal_t)\n}\n",
+        );
+    }
+}
+
+#[cfg(test)]
 mod spawn_and_hug_format_tests {
     use super::*;
 


### PR DESCRIPTION
## Summary

Canary already accepts `client` (`KW_CLIENT`) as an identifier in the formatter (`Word::from_cst` and `ObjectFieldKey::from_cst` special-case it). This PR generalizes that special case to the full set of contextual keywords the parser allows in name positions, and centralizes it in one predicate.

## Problem

The parser accepts more than `client` as names: `at_member_name` / `parse_function` in `baml_compiler_parser` also keep `implements`, `implement`, `extends`, `requires`, and `interface` valid as method and member-access names (e.g. `dog_t.implements(animal_t)` on the reflection `type` value), and `spawn`/`await` are valid path segments. The formatter still crashed on those with:

```
error: while formatting: Expected token/node of kind WORD, but found KW_IMPLEMENTS
```

## Fix

- New shared `is_word_like` predicate in `baml_fmt::ast::tokens` mirroring the parser's name-position keyword set (`WORD`, `KW_CLIENT`, `KW_IMPLEMENTS`, `KW_IMPLEMENT`, `KW_EXTENDS`, `KW_REQUIRES`, `KW_INTERFACE`, `KW_SPAWN`, `KW_AWAIT`).
- `Word::from_cst` and `ObjectFieldKey::from_cst` use it instead of their `KW_CLIENT`-only special cases.

## Tests

- New regression module `contextual_keyword_name_tests`: `client` as class field name, parameter name, member-access name, object-literal key, and `implements` as a method name — each asserting round-trip + idempotency. Complements the existing `contextual_keyword_identifier_tests`.
- `cargo test -p baml_fmt`: 107 passed.
- Verified `target/debug/baml-cli fmt` formats a real file using `client: Client?` as a class field cleanly and idempotently, preserving all identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting support for contextual keywords used as names in fields, parameters, member access, object keys, and method names.
  * Expanded support across additional parser-recognized keywords while preserving valid source text during formatting.

* **Tests**
  * Added regression coverage for contextual keyword usage.
  * Verified formatting succeeds, preserves the original source, and remains idempotent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatter-only CST→AST acceptance change with targeted regression tests; no runtime, auth, or data-path impact.
> 
> **Overview**
> Fixes **baml_fmt** crashing when formatting valid BAML that uses contextual keywords as names (e.g. `client` fields, `dog_t.implements(...)`), which the parser already accepts but the strong AST rejected with “expected `WORD`, found `KW_*`”.
> 
> Introduces shared **`is_word_like`** in `ast/tokens`, aligned with the parser’s name-position keyword set (`client`, `implements`, `implement`, `extends`, `requires`, `interface`, `spawn`, `await`, plus ordinary `WORD`). **`Word::from_cst`** and **`ObjectFieldKey::from_cst`** now use that predicate instead of a **`KW_CLIENT`-only** special case.
> 
> Adds **`contextual_keyword_name_tests`** for round-trip/idempotent formatting of `client` as field, parameter, member access, object key, and `implements` as a method name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f4a865a22fd400679e7213ce4d8b25957ed111d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->