### PR TITLE
fix(fmt): keep dotted member chains atomic, break only at call boundaries

### DIFF
--- a/baml_language/crates/baml_fmt/src/ast/expressions.rs
+++ b/baml_language/crates/baml_fmt/src/ast/expressions.rs
@@ -5669,13 +5669,15 @@ impl PrintChain<'_> {
     /// Applies when the whole prefix up to the final call fits the line.
     /// Should be passed a sub-printer to avoid printing partial output in
     /// the event that the layout does not apply.
-    fn try_print_tail_call_broken(&self, shape: &Shape, printer: &mut Printer) -> Option<PrintInfo> {
+    fn try_print_tail_call_broken(
+        &self,
+        shape: &Shape,
+        printer: &mut Printer,
+    ) -> Option<PrintInfo> {
         let (last, prefix) = self.chain_members.split_last()?;
         let question_dot = match last {
             PrintChainItem::Call(_) | PrintChainItem::Index(_) => None,
-            PrintChainItem::OptionalCall(qd, _) | PrintChainItem::OptionalIndex(qd, _) => {
-                Some(*qd)
-            }
+            PrintChainItem::OptionalCall(qd, _) | PrintChainItem::OptionalIndex(qd, _) => Some(*qd),
             PrintChainItem::FieldAccess(..)
             | PrintChainItem::OptionalFieldAccess(..)
             | PrintChainItem::GenericArgs(..) => return None,
@@ -5687,6 +5689,10 @@ impl PrintChain<'_> {
         if printer.output.len() > shape.width {
             return None;
         }
+        // `shape.width` is the remaining line budget measured from the
+        // chain's start column (`width + indent + first_line_offset ==
+        // line_width`), and this sub-printer's output also starts at that
+        // column, so the args' budget is what the prefix left over.
         let args_shape = Shape {
             width: shape.width.saturating_sub(printer.output.len()),
             indent: shape.indent,
@@ -5701,6 +5707,14 @@ impl PrintChain<'_> {
             }
             _ => unreachable!("checked above"),
         };
+        // The final call/index may still overflow the prefix line: its
+        // multi-line layout keeps the opening bracket (plus any squished
+        // trivia) on that line without re-checking the budget. Reject the
+        // layout in that case so the chain breaks at call boundaries instead.
+        let first_line_len = printer.output.find('\n').unwrap_or(printer.output.len());
+        if first_line_len > shape.width {
+            return None;
+        }
         Some(info)
     }
 }

--- a/baml_language/crates/baml_fmt/src/ast/expressions.rs
+++ b/baml_language/crates/baml_fmt/src/ast/expressions.rs
@@ -5276,15 +5276,28 @@ impl<'a> PrintChain<'a> {
 }
 
 impl PrintMultiLine for PrintChain<'_> {
-    /// Prints the chained expression, with each field member on a new line.
+    /// Prints the chained expression broken at method-call boundaries,
+    /// prettier/rustfmt style.
     ///
-    /// Uses similar rules to rustfmt
+    /// Plain member accesses (namespace segments, field accesses, generic
+    /// type segments) are atomic with their receiver and never split, no
+    /// matter how long the path is. Break points sit before the `.name` of
+    /// each call group; the first call group stays glued to the receiver
+    /// line when it fits:
+    ///
+    /// ```baml
+    /// root.ai.Agent<Itinerary>.new()
+    ///     .with_client(client)
+    ///     .run(spec)
+    /// ```
     fn print_multi_line(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
         let first_single_line = match self.first {
             Expression::Path(path_expr) => {
                 printer.print_raw_token(&path_expr.first);
                 true
             }
+            // Call/Index print directly: routing them through
+            // `Expression::print` would rebuild this same chain and recurse.
             Expression::Call(call_expr) => {
                 let first_info = printer.print(call_expr, shape.clone());
                 !first_info.multi_lined
@@ -5298,85 +5311,89 @@ impl PrintMultiLine for PrintChain<'_> {
                 !first_info.multi_lined
             }
         };
+        let mut multi_lined = !first_single_line;
 
-        let offset = printer.current_line_len().saturating_sub(shape.indent);
-        // Only indent the chain when it actually has somewhere to break across
-        // lines — i.e. it has multiple field-access steps, or the first chunk
-        // already pushed past one indent. Single-call chains like
-        // `f(longarg)` or `obj.method(longarg)` should let the trailing
-        // `(args)` wrap at the *outer* indent rather than chain_indent + 4.
-        let field_access_steps = self
-            .chain_members
-            .iter()
-            .filter(|m| {
-                matches!(
-                    m,
-                    PrintChainItem::FieldAccess(..) | PrintChainItem::OptionalFieldAccess(..)
-                )
-            })
-            .count();
-        let should_indent_chain =
-            (first_single_line && field_access_steps > 1) || offset > printer.config.indent_width;
-        let chain_indent = if should_indent_chain {
-            shape.indent + printer.config.indent_width
-        } else {
-            shape.indent
-        };
-
+        let chain_indent = shape.indent + printer.config.indent_width;
         let mut line_remaining_width = printer.current_line_remaining_width();
-        let mut it = self.chain_members.iter();
-        if first_single_line && offset <= printer.config.indent_width {
-            // Try to print the second item on the same line if it's a field access and fits.
-            let peeked = it.next();
-            let second_len = match peeked {
-                Some(&PrintChainItem::FieldAccess(dot, word)) => {
-                    Some(usize::from(dot.span().len() + word.span().len()))
-                }
-                Some(&PrintChainItem::OptionalFieldAccess(qd, word)) => {
-                    Some(usize::from(qd.span().len() + word.span().len()))
-                }
-                _ => None,
-            };
-            if let Some(second_len) = second_len {
-                let item = peeked.unwrap();
-                if line_remaining_width >= second_len {
-                    Self::print_field_access_item(item, printer);
-                    line_remaining_width = line_remaining_width.saturating_sub(second_len);
-                } else {
-                    printer.print_newline();
-                    printer.print_spaces(chain_indent);
-                    Self::print_field_access_item(item, printer);
-                    line_remaining_width = printer
-                        .config
-                        .line_width
-                        .saturating_sub(chain_indent + second_len);
-                }
-            } else if let Some(item) = peeked {
-                Self::print_non_field_item(item, chain_indent, &mut line_remaining_width, printer);
+        let mut rest: &[PrintChainItem<'_>] = &self.chain_members;
+
+        // A call/index applied directly to the receiver (`base?.(x).field`)
+        // cannot break away from it: glue it to the receiver's line.
+        while let Some((item, tail)) = rest.split_first() {
+            if Self::is_plain_access(item) {
+                break;
             }
+            multi_lined |=
+                Self::print_non_field_item(item, chain_indent, &mut line_remaining_width, printer);
+            rest = tail;
         }
-        for item in it {
-            match item {
-                &PrintChainItem::FieldAccess(_, _) | &PrintChainItem::OptionalFieldAccess(_, _) => {
-                    printer.print_newline();
-                    printer.print_spaces(chain_indent);
-                    Self::print_field_access_item(item, printer);
-                    let item_len = match *item {
-                        PrintChainItem::FieldAccess(dot, word) => {
-                            usize::from(dot.span().len() + word.span().len())
-                        }
-                        PrintChainItem::OptionalFieldAccess(qd, word) => {
-                            usize::from(qd.span().len() + word.span().len())
-                        }
-                        _ => unreachable!(),
-                    };
-                    line_remaining_width = printer
-                        .config
-                        .line_width
-                        .saturating_sub(chain_indent + item_len);
-                }
-                _ => {
-                    Self::print_non_field_item(
+
+        // The leading run of plain accesses is the namespace path; it is
+        // atomic with the receiver and always stays on its line. When a call
+        // follows, the final access of the run is that call's method name and
+        // belongs to the call's group instead (`.new` stays glued to `()`).
+        let plain_run_len = rest
+            .iter()
+            .take_while(|item| Self::is_plain_access(item))
+            .count();
+        let path_len = if plain_run_len == rest.len() {
+            plain_run_len
+        } else {
+            rest[..plain_run_len]
+                .iter()
+                .rposition(|item| {
+                    matches!(
+                        item,
+                        PrintChainItem::FieldAccess(..) | PrintChainItem::OptionalFieldAccess(..)
+                    )
+                })
+                .unwrap_or(plain_run_len)
+        };
+        for item in &rest[..path_len] {
+            Self::print_plain_item(item, printer);
+        }
+        rest = &rest[path_len..];
+        line_remaining_width = printer.current_line_remaining_width();
+
+        // Split the remaining items into groups: each group is a run of
+        // plain accesses (the method name) followed by its calls/indexes.
+        let mut is_first_group = true;
+        while !rest.is_empty() {
+            let group_plain = rest
+                .iter()
+                .take_while(|item| Self::is_plain_access(item))
+                .count();
+            let group_callish = rest[group_plain..]
+                .iter()
+                .take_while(|item| !Self::is_plain_access(item))
+                .count();
+            let (group, tail) = rest.split_at(group_plain + group_callish);
+            rest = tail;
+
+            // A group can only start with a call/index when the path had no
+            // field access to serve as its name; such a group cannot move to
+            // its own line. Otherwise, the first call group stays glued to
+            // the receiver line when it fits; later groups always break.
+            let glue = if group_plain == 0 {
+                true
+            } else if is_first_group && first_single_line {
+                Self::group_single_line_width(group, printer)
+                    .is_some_and(|width| width <= line_remaining_width)
+            } else {
+                false
+            };
+            if !glue {
+                printer.print_newline();
+                printer.print_spaces(chain_indent);
+                line_remaining_width = printer.config.line_width.saturating_sub(chain_indent);
+                multi_lined = true;
+            }
+            for item in group {
+                if Self::is_plain_access(item) {
+                    Self::print_plain_item(item, printer);
+                    line_remaining_width = printer.current_line_remaining_width();
+                } else {
+                    multi_lined |= Self::print_non_field_item(
                         item,
                         chain_indent,
                         &mut line_remaining_width,
@@ -5384,14 +5401,28 @@ impl PrintMultiLine for PrintChain<'_> {
                     );
                 }
             }
+            is_first_group = false;
         }
 
-        PrintInfo::default_multi_lined()
+        PrintInfo { multi_lined }
     }
 }
 
 impl PrintChain<'_> {
-    fn print_field_access_item(item: &PrintChainItem<'_>, printer: &mut Printer) {
+    /// Plain (non-call) chain items: member accesses and generic type
+    /// segments. These are atomic with their receiver and never move to
+    /// their own line.
+    const fn is_plain_access(item: &PrintChainItem<'_>) -> bool {
+        matches!(
+            item,
+            PrintChainItem::FieldAccess(..)
+                | PrintChainItem::OptionalFieldAccess(..)
+                | PrintChainItem::GenericArgs(..)
+        )
+    }
+
+    /// Prints a plain access glued to whatever precedes it on the line.
+    fn print_plain_item(item: &PrintChainItem<'_>, printer: &mut Printer) {
         match *item {
             PrintChainItem::FieldAccess(dot, word) => {
                 printer.print_raw_token(dot);
@@ -5401,25 +5432,66 @@ impl PrintChain<'_> {
                 printer.print_raw_token(qd);
                 printer.print_raw_token(word);
             }
-            _ => unreachable!("print_field_access_item called with non-field-access item"),
+            PrintChainItem::GenericArgs(generic_args) => {
+                printer.print(generic_args, Shape::unlimited_single_line());
+            }
+            _ => unreachable!("print_plain_item called with a call/index item"),
         }
     }
 
+    /// Returns the single-line width of one chain item, or `None` if it can
+    /// never be single-lined.
+    fn item_single_line_width(item: &PrintChainItem<'_>, printer: &Printer<'_>) -> Option<usize> {
+        match item {
+            PrintChainItem::FieldAccess(dot, word) => {
+                Some(usize::from(dot.span().len() + word.span().len()))
+            }
+            PrintChainItem::OptionalFieldAccess(qd, word) => {
+                Some(usize::from(qd.span().len() + word.span().len()))
+            }
+            PrintChainItem::Index(index_args) => index_args.single_line_width(printer),
+            PrintChainItem::OptionalIndex(qd, index_args) => {
+                Some(usize::from(qd.span().len()) + index_args.single_line_width(printer)?)
+            }
+            PrintChainItem::Call(call_args) => call_args.single_line_width(printer),
+            PrintChainItem::OptionalCall(qd, call_args) => {
+                Some(usize::from(qd.span().len()) + call_args.single_line_width(printer)?)
+            }
+            PrintChainItem::GenericArgs(generic_args) => {
+                Some(generic_args.formatted_single_line_width())
+            }
+        }
+    }
+
+    /// Returns the single-line width of a group of chain items, or `None` if
+    /// any of them can never be single-lined.
+    fn group_single_line_width(
+        group: &[PrintChainItem<'_>],
+        printer: &Printer<'_>,
+    ) -> Option<usize> {
+        group
+            .iter()
+            .map(|item| Self::item_single_line_width(item, printer))
+            .sum()
+    }
+
+    /// Prints a call/index item on the current line. Its arguments may wrap.
+    ///
+    /// Returns whether the printed item spanned multiple lines.
     fn print_non_field_item(
         item: &PrintChainItem<'_>,
         chain_indent: usize,
         line_remaining_width: &mut usize,
         printer: &mut Printer,
-    ) {
-        match item {
+    ) -> bool {
+        let multi_lined = match item {
             PrintChainItem::Index(index_args) => {
                 let index_shape = Shape {
                     width: *line_remaining_width,
                     indent: chain_indent,
                     first_line_offset: printer.current_line_len().saturating_sub(chain_indent),
                 };
-                printer.print(index_args, index_shape);
-                *line_remaining_width = printer.current_line_remaining_width();
+                printer.print(index_args, index_shape).multi_lined
             }
             PrintChainItem::OptionalIndex(qd, index_args) => {
                 printer.print_raw_token(*qd);
@@ -5428,8 +5500,7 @@ impl PrintChain<'_> {
                     indent: chain_indent,
                     first_line_offset: printer.current_line_len().saturating_sub(chain_indent),
                 };
-                printer.print(index_args, index_shape);
-                *line_remaining_width = printer.current_line_remaining_width();
+                printer.print(index_args, index_shape).multi_lined
             }
             &PrintChainItem::Call(call_args) => {
                 let call_shape = Shape {
@@ -5437,8 +5508,7 @@ impl PrintChain<'_> {
                     indent: chain_indent,
                     first_line_offset: printer.current_line_len().saturating_sub(chain_indent),
                 };
-                printer.print(call_args, call_shape);
-                *line_remaining_width = printer.current_line_remaining_width();
+                printer.print(call_args, call_shape).multi_lined
             }
             &PrintChainItem::OptionalCall(qd, call_args) => {
                 printer.print_raw_token(qd);
@@ -5447,20 +5517,12 @@ impl PrintChain<'_> {
                     indent: chain_indent,
                     first_line_offset: printer.current_line_len().saturating_sub(chain_indent),
                 };
-                printer.print(call_args, call_shape);
-                *line_remaining_width = printer.current_line_remaining_width();
+                printer.print(call_args, call_shape).multi_lined
             }
-            &PrintChainItem::GenericArgs(generic_args) => {
-                let ga_shape = Shape {
-                    width: *line_remaining_width,
-                    indent: chain_indent,
-                    first_line_offset: printer.current_line_len().saturating_sub(chain_indent),
-                };
-                printer.print(generic_args, ga_shape);
-                *line_remaining_width = printer.current_line_remaining_width();
-            }
-            _ => unreachable!("print_non_field_item called with field-access item"),
-        }
+            _ => unreachable!("print_non_field_item called with a plain access item"),
+        };
+        *line_remaining_width = printer.current_line_remaining_width();
+        multi_lined
     }
 
     /// Prints `first` followed by `members` in single-line form. Returns
@@ -5593,6 +5655,54 @@ impl PrintChain<'_> {
         };
         call_args.try_print_hug(&hug_shape, printer)
     }
+
+    /// Tail-broken layout: the receiver, the namespace path, and every
+    /// intermediate call stay on one line, and only the final call/index
+    /// wraps its arguments:
+    ///
+    /// ```baml
+    /// root.ai.Agent<Itinerary>.new().run(
+    ///     plan_trip_spec(...),
+    /// );
+    /// ```
+    ///
+    /// Applies when the whole prefix up to the final call fits the line.
+    /// Should be passed a sub-printer to avoid printing partial output in
+    /// the event that the layout does not apply.
+    fn try_print_tail_call_broken(&self, shape: &Shape, printer: &mut Printer) -> Option<PrintInfo> {
+        let (last, prefix) = self.chain_members.split_last()?;
+        let question_dot = match last {
+            PrintChainItem::Call(_) | PrintChainItem::Index(_) => None,
+            PrintChainItem::OptionalCall(qd, _) | PrintChainItem::OptionalIndex(qd, _) => {
+                Some(*qd)
+            }
+            PrintChainItem::FieldAccess(..)
+            | PrintChainItem::OptionalFieldAccess(..)
+            | PrintChainItem::GenericArgs(..) => return None,
+        };
+        self.try_print_members_single_line(prefix, shape, printer)?;
+        if let Some(qd) = question_dot {
+            printer.print_raw_token(qd);
+        }
+        if printer.output.len() > shape.width {
+            return None;
+        }
+        let args_shape = Shape {
+            width: shape.width.saturating_sub(printer.output.len()),
+            indent: shape.indent,
+            first_line_offset: shape.first_line_offset + printer.output.len(),
+        };
+        let info = match last {
+            PrintChainItem::Call(call_args) | PrintChainItem::OptionalCall(_, call_args) => {
+                printer.print(*call_args, args_shape)
+            }
+            PrintChainItem::Index(index_args) | PrintChainItem::OptionalIndex(_, index_args) => {
+                printer.print(index_args, args_shape)
+            }
+            _ => unreachable!("checked above"),
+        };
+        Some(info)
+    }
 }
 
 impl Printable for PrintChain<'_> {
@@ -5600,6 +5710,7 @@ impl Printable for PrintChain<'_> {
         printer
             .try_sub_printer(|p| self.try_print_single_line(&shape, p))
             .or_else(|| printer.try_sub_printer(|p| self.try_print_hug(&shape, p)))
+            .or_else(|| printer.try_sub_printer(|p| self.try_print_tail_call_broken(&shape, p)))
             .unwrap_or_else(|| self.print_multi_line(shape, printer))
     }
     fn leftmost_token(&self) -> TextRange {

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -1567,4 +1567,34 @@ mod member_chain_layout_tests {
         let expected = "function f() -> int {\n    let x = builder.configure(a_pretty_long_argument_name, another_pretty_long_argument_name)\n        .result.field.value;\n    x\n}\n";
         assert_formats_to(source, expected);
     }
+
+    /// A long chain ending in an optional call (`?.(…)`) uses the tail-broken
+    /// layout: the path stays glued, `?.` stays attached to the opening paren,
+    /// and only the arguments wrap.
+    #[test]
+    fn test_optional_call_tail_breaks_args_only() {
+        let source = "function f() -> int {\n    let result = root.ai.handlers.maybe_factory?.(the_first_long_argument_name, the_second_long_argument_name, the_third_long_argument_name);\n    result\n}\n";
+        let expected = "function f() -> int {\n    let result = root.ai.handlers.maybe_factory?.(\n        the_first_long_argument_name,\n        the_second_long_argument_name,\n        the_third_long_argument_name,\n    );\n    result\n}\n";
+        assert_formats_to(source, expected);
+    }
+
+    /// A chain whose final member is a long index `[…]` uses the tail-broken
+    /// layout too: the path stays glued and the index expression wraps inside
+    /// the brackets.
+    #[test]
+    fn test_final_long_index_breaks_inside_brackets() {
+        let source = "function f() -> int {\n    let x = the_data_table.rows_by_category[compute_the_category_key(the_first_component_value, the_second_component_value)];\n    x\n}\n";
+        let expected = "function f() -> int {\n    let x = the_data_table.rows_by_category[\n        compute_the_category_key(the_first_component_value, the_second_component_value)\n    ];\n    x\n}\n";
+        assert_formats_to(source, expected);
+    }
+
+    /// An optional call applied directly to the receiver (`base?.(x).field`)
+    /// cannot break away from it: it stays glued to the receiver's line while
+    /// later call groups break normally.
+    #[test]
+    fn test_leading_optional_call_stays_glued_to_receiver() {
+        let source = "function f() -> int {\n    let out = fetch_handler?.(the_request_value).response.payload.decode_as_structured(schema_registry_value).validate_against(validation_rules_value);\n    out\n}\n";
+        let expected = "function f() -> int {\n    let out = fetch_handler?.(the_request_value).response.payload\n        .decode_as_structured(schema_registry_value)\n        .validate_against(validation_rules_value);\n    out\n}\n";
+        assert_formats_to(source, expected);
+    }
 }

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -1475,3 +1475,96 @@ mod return_comment_tests {
         assert_formats_to(source, expected);
     }
 }
+
+#[cfg(test)]
+mod member_chain_layout_tests {
+    //! Regression tests for member-chain layout. `baml fmt` used to explode
+    //! dotted namespace paths one segment per line (`root\n.ai\n.Agent<T>\n…`)
+    //! whenever the full expression overflowed the line width. The rule is now
+    //! the standard prettier/rustfmt member-chain rule: plain accesses
+    //! (namespace segments, field accesses, generic type segments) are atomic
+    //! with their receiver, and the chain breaks only at method-call
+    //! boundaries — and only when the line overflows.
+
+    use super::*;
+
+    fn assert_formats_to(source: &str, expected: &str) {
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("formatter should succeed");
+        assert_eq!(
+            formatted, expected,
+            "formatter output didn't match expected\n--- got ---\n{formatted}\n--- want ---\n{expected}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    /// The headline case: the namespace path and both calls stay glued on the
+    /// receiver line; only the final call's arguments wrap.
+    #[test]
+    fn test_namespace_chain_stays_glued_only_args_wrap() {
+        let source = "function f() -> int {\n    let result = root.ai.Agent<Itinerary>.new().run(plan_trip_spec(\"plan a weekend trip to yosemite with plenty of hiking\", root.anthropic.AnthropicClient.new()));\n    result\n}\n";
+        let expected = "function f() -> int {\n    let result = root.ai.Agent<Itinerary>.new().run(\n        plan_trip_spec(\n            \"plan a weekend trip to yosemite with plenty of hiking\",\n            root.anthropic.AnthropicClient.new(),\n        ),\n    );\n    result\n}\n";
+        assert_formats_to(source, expected);
+    }
+
+    /// An already-exploded chain (the old formatter's output) collapses back
+    /// to the glued layout.
+    #[test]
+    fn test_exploded_chain_collapses() {
+        let source = "function f() -> int {\n    let result = root\n        .ai\n        .Agent<Itinerary>\n        .new()\n        .run(\n            plan_trip_spec(\n                \"plan a weekend trip to yosemite with plenty of hiking\",\n                root.anthropic.AnthropicClient.new(),\n            ),\n        );\n    result\n}\n";
+        let expected = "function f() -> int {\n    let result = root.ai.Agent<Itinerary>.new().run(\n        plan_trip_spec(\n            \"plan a weekend trip to yosemite with plenty of hiking\",\n            root.anthropic.AnthropicClient.new(),\n        ),\n    );\n    result\n}\n";
+        assert_formats_to(source, expected);
+    }
+
+    /// A single call at the end of a namespace path keeps the whole path and
+    /// the call glued; the long array argument wraps inside the parens.
+    #[test]
+    fn test_namespace_call_with_long_array_arg() {
+        let source = "function f() -> int {\n    let c = root.ai.ScriptedClient.new([\"the first canned response text\", \"the second canned response text\", \"the third canned response text\"]);\n    c\n}\n";
+        let expected = "function f() -> int {\n    let c = root.ai.ScriptedClient.new(\n        [\n            \"the first canned response text\",\n            \"the second canned response text\",\n            \"the third canned response text\",\n        ],\n    );\n    c\n}\n";
+        assert_formats_to(source, expected);
+    }
+
+    /// A chain too long to keep every call on the receiver line breaks at
+    /// method-call boundaries. The namespace path never breaks, and the first
+    /// call (`.new()`) stays attached to the path because it fits.
+    #[test]
+    fn test_long_chain_breaks_at_calls_only() {
+        let source = "function f() -> int {\n    let result = root.ai.Agent<Itinerary>.new().with_client(root.anthropic.AnthropicClient.new()).with_options(the_default_options).run(the_spec_value);\n    result\n}\n";
+        let expected = "function f() -> int {\n    let result = root.ai.Agent<Itinerary>.new()\n        .with_client(root.anthropic.AnthropicClient.new())\n        .with_options(the_default_options)\n        .run(the_spec_value);\n    result\n}\n";
+        assert_formats_to(source, expected);
+    }
+
+    /// A dotted path of plain accesses never breaks internally, even past the
+    /// line width.
+    #[test]
+    fn test_plain_access_path_is_atomic() {
+        let source = "function f() -> int {\n    let value = root.some_namespace.another_namespace.deeply.nested.module.SomeVeryLongTypeName.CONSTANT_VALUE;\n    value\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    /// Enum-member paths in match arms (patterns and arm values) stay on one
+    /// line.
+    #[test]
+    fn test_enum_member_paths_in_match_arms() {
+        let source = "function f(r: StopReason) -> int {\n    match (r) {\n        StopReason.Complete => 1,\n        StopReason.MaxTokens => 2,\n        _ => root.some.namespaced.StopReason.Complete.value(),\n    }\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    /// A short chain that fits stays on one line.
+    #[test]
+    fn test_short_chain_stays_single_line() {
+        let source = "function f() -> int {\n    let result = root.ai.Agent<Itinerary>.new().run(spec);\n    result\n}\n";
+        assert_formats_to(source, source);
+    }
+
+    /// Plain accesses trailing a broken call group stay glued to each other
+    /// on the group's line.
+    #[test]
+    fn test_trailing_plain_accesses_stay_glued() {
+        let source = "function f() -> int {\n    let x = builder.configure(a_pretty_long_argument_name, another_pretty_long_argument_name).result.field.value;\n    x\n}\n";
+        let expected = "function f() -> int {\n    let x = builder.configure(a_pretty_long_argument_name, another_pretty_long_argument_name)\n        .result.field.value;\n    x\n}\n";
+        assert_formats_to(source, expected);
+    }
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__10_formatter__chain_expr.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__10_formatter__chain_expr.snap
@@ -73,21 +73,19 @@ function ChainExprs(user: ChainUser, items: ChainItem[], m: map<string, int>) ->
 
     // ===== Trivia in call (line comments) =====
     // 1 callee leading
-    items
-        .get( // 7 open paren trailing
-            // 8 arg leading
-            0, // 9 arg trailing
-            // 10 close paren leading
-        );
+    items.get( // 7 open paren trailing
+        // 8 arg leading
+        0, // 9 arg trailing
+        // 10 close paren leading
+    );
 
     // ===== Trivia in call (block comments) =====
     /* 1 callee leading */
-    items
-        .get( /* 7 open paren trailing */
-            /* 8 arg leading */
-            0, /* 9 arg trailing */
-            /* 10 close paren leading */
-        )/* 11 close paren trailing */;
+    items.get( /* 7 open paren trailing */
+        /* 8 arg leading */
+        0, /* 9 arg trailing */
+        /* 10 close paren leading */
+    )/* 11 close paren trailing */;
 
     // ===== Index access =====
     items[0];
@@ -115,11 +113,7 @@ function ChainExprs(user: ChainUser, items: ChainItem[], m: map<string, int>) ->
     user.name.len().to_string();
 
     // ===== Long chain exceeding limit: many field accesses =====
-    user.profile
-        .settings
-        .preferences
-        .color
-        .len()
+    user.profile.settings.preferences.color.len()
         .to_string()
         .len()
         .to_string()
@@ -132,8 +126,7 @@ function ChainExprs(user: ChainUser, items: ChainItem[], m: map<string, int>) ->
     user.profile.items[0].metadata.tags[0].len().to_string().len().to_string().len().to_string();
 
     // ===== Long call args exceeding limit =====
-    user.profile
-        .items
+    user.profile.items
         .get(
             user.profile.items.len()
                 - 1
@@ -145,16 +138,15 @@ function ChainExprs(user: ChainUser, items: ChainItem[], m: map<string, int>) ->
         .label;
 
     // ===== Call with many args exceeding limit =====
-    user.profile
-        .items
-        .slice(0, user.profile.items.len() - 1, user.profile.settings.preferences.size);
+    user.profile.items.slice(
+        0,
+        user.profile.items.len() - 1,
+        user.profile.settings.preferences.size,
+    );
 
     // ===== Trivia in long wrapping chain (line comments) =====
     // 1 leading
-    user.profile
-        .settings
-        .preferences
-        .color
+    user.profile.settings.preferences.color
         .len( // 18 trailing
         )
         .to_string( // 23 trailing
@@ -164,18 +156,13 @@ function ChainExprs(user: ChainUser, items: ChainItem[], m: map<string, int>) ->
 
     // ===== Trivia in long wrapping chain (block comments) =====
     /* 1 leading */
-    user.profile
-        .settings
-        .preferences
-        .color
-        .len(/* 18 trailing */)
+    user.profile.settings.preferences.color.len(/* 18 trailing */)
         .to_string(/* 23 trailing */)
         .len(/* 28 trailing */)/* 29 trailing */;
 
     // ===== Trivia in call with long args (line comments) =====
     // 1 leading
-    user.profile
-        .items
+    user.profile.items
         .get( // 12 trailing
             // 13 leading
             user.profile.items.len() - 1 + user.profile.items.len() - 2, // 14 trailing


### PR DESCRIPTION
## Problem

`baml fmt` exploded dotted namespace paths one segment per line whenever the full expression overflowed the line width:

```baml
let result = root
    .ai
    .Agent<Itinerary>
    .new()
    .run(
        plan_trip_spec(
            "...",
            root.anthropic.AnthropicClient.new(),
        ),
    );
```

## Fix

The chain printer (`PrintChain` in `baml_fmt`) now follows the standard prettier/rustfmt member-chain rule: plain accesses glue to their receiver; call sites are the break points.

1. **Plain-access paths are atomic.** Namespace segments, field accesses, and generic type segments (`root.ai.Agent<Itinerary>`, `StopReason.Complete`) never break internally, regardless of length.
2. **Tail-broken layout (new).** When everything up to the final call fits on the line, only the final call's arguments wrap:

```baml
let result = root.ai.Agent<Itinerary>.new().run(
    plan_trip_spec(
        "...",
        root.anthropic.AnthropicClient.new(),
    ),
);
```

3. **Break at call boundaries only.** When the chain itself is too long, it breaks before the `.name` of each call group, keeping the leading path — plus the first call when it fits — glued to the receiver line:

```baml
let result = root.ai.Agent<Itinerary>.new()
    .with_client(root.anthropic.AnthropicClient.new())
    .with_options(the_default_options)
    .run(the_spec_value);
```

## Verification

- All 102 pre-existing `baml_fmt` tests pass unchanged (including the 1024-case scenario matrix with idempotency checks) — zero churn in existing formatter behavior outside chains.
- 8 new regression tests in `member_chain_layout_tests` (glued namespace chain, exploded-input collapse, long array arg, chain that must break, atomic long path, `StopReason.Complete` in match arms, short chain single-line, trailing plain accesses); each asserts idempotency.
- `cargo clippy -p baml_fmt --all-targets` clean; `baml_tests` formatter-dependent suites (`backtick_fmt_value_preservation`, `interfaces_associated_types`) pass.
- Ran the patched `baml-cli fmt` against a copy of the `_planv2` BAML sources and diffed against a canary-baseline CLI run: all 12 changed files show only the intended chain-layout improvements (e.g. `live/anthropic.baml` collapses to exactly the desired form above).

Note: kept out of scope per the in-flight `KW_CLIENT` formatter fix — no changes to keyword-as-identifier handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the formatter’s layout logic and snapshots; they do not affect parsing, type-checking, or runtime behavior.
> 
> **Overview**
> **`baml fmt` no longer splits long dotted paths one segment per line.** `PrintChain` now uses a prettier/rustfmt-style rule: field accesses, namespace segments, and generic type args stay glued to their receiver; line breaks happen only at method-call/index groups (with width-based “glue” for the first group when it fits).
> 
> A new **`try_print_tail_call_broken`** layout runs before the multi-line fallback so when the prefix fits on one line, only the **final** call or index wraps its arguments (including optional `?.(...)` chains).
> 
> Multi-line printing was rewritten around **call groups** (method name + following calls/indexes), leading optional calls on the receiver, and accurate **`multi_lined`** reporting. **`GenericArgs`** are formatted as plain chain segments instead of separate breakable items.
> 
> Regression coverage adds **`member_chain_layout_tests`** and updates the **`chain_expr`** formatter snapshot to match the new output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63da78ca89f5261dba6ff70a272ca9a221c69fe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting for chained expressions, keeping related member and namespace paths together.
  * Added more consistent line breaks around method calls, indexing, and generic arguments.
  * Preserved compact layouts for short chains while wrapping long call or index arguments cleanly.
  * Fixed formatting for enum-member paths and trailing field accesses after wrapped calls.

* **Tests**
  * Added regression coverage for chained-expression formatting and argument wrapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->