### PR TITLE
Add local SQLite query engine with hydration

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -130,6 +130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "version_check",
@@ -305,6 +306,230 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "arrow"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cfdd0833e32a9874d2b55089333ad310c0be208aafa277385ce2461dec90be3"
+dependencies = [
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a41203398f0eaa6f7ec8e62c0da742a21abf282c148fc157f6c35c90e29981a"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae33dad492b7df00a217563a7b0ef2874df68a0deea1b1a3acf628152f7f7a69"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "chrono-tz",
+ "half",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9552f96391c005e6ab449fa941420935e7e062489b12b8b1b08879b2163f5b5"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a8a327c9649f30d8406995f27642b68df354713cca3baaaf100f076f18d5f34"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "atoi",
+ "base64",
+ "chrono",
+ "comfy-table",
+ "half",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-csv"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af0dd6d90d1955e9f9a014c1e563ee8aeffc21909085d25623e1da44d96eca26"
+dependencies = [
+ "arrow-array",
+ "arrow-cast",
+ "arrow-schema",
+ "chrono",
+ "csv",
+ "csv-core",
+ "regex",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b24852db04738907e06c04ea61e42fe7fda962a34513022dc0d0e754fb7976b"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a908a11fcfb3fb2f6730f4ac15e367bc644e419155e96238f68cf3adde572b"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+ "lz4_flex",
+ "zstd",
+]
+
+[[package]]
+name = "arrow-json"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8a96aed3931c076adee39ec2a40d8219fc7f09e79bcdaca1df16272993e1e14"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
+ "chrono",
+ "half",
+ "indexmap",
+ "itoa",
+ "lexical-core",
+ "memchr",
+ "num-traits",
+ "ryu",
+ "serde_core",
+ "serde_json",
+ "simdutf8",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63a083ec750f5c043f02946b4baf05fcdbb55f4560a3277055caca5cc99f3eb0"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+]
+
+[[package]]
+name = "arrow-row"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "514ba0ef0d4c5896202dae736251ce415abb43a950bed570fb7981b8716c0e4c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "half",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
+dependencies = [
+ "serde_core",
+ "serde_json",
+]
+
+[[package]]
+name = "arrow-select"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c58da39eb3d8350ad4a549e5c2bc49284dac554016c69829310350f1731b0aad"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-string"
+version = "58.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6789b388467525e3271326b6b4915666ecfdf5142aef09779445c954b67543c"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax 0.8.10",
+]
 
 [[package]]
 name = "as-raw-xcb-connection"
@@ -502,6 +727,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1135,6 +1369,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "baml_query"
+version = "0.0.0-beta"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "codspeed-divan-compat-walltime",
+ "datafusion",
+ "futures",
+ "parking_lot",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "uuid",
+]
+
+[[package]]
 name = "baml_release"
 version = "0.0.0-beta"
 dependencies = [
@@ -1515,6 +1770,19 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -2053,6 +2321,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2209,6 +2487,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "compact_str"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,6 +2552,26 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "convert_case"
@@ -2419,6 +2727,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde_core",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "ctor"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2464,10 +2793,627 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6096b38fb382be19435f7c2fc912577c16916c81174173ca1aab5a1c0acdd8b"
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "datafusion"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ef4e8f073922a26f5b23133b9db4829342362b09be0bc94309cf261c2f098"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "async-trait",
+ "chrono",
+ "datafusion-catalog",
+ "datafusion-catalog-listing",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-datasource-arrow",
+ "datafusion-datasource-csv",
+ "datafusion-datasource-json",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-nested",
+ "datafusion-functions-table",
+ "datafusion-functions-window",
+ "datafusion-optimizer",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-optimizer",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "datafusion-sql",
+ "futures",
+ "indexmap",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "sqlparser",
+ "tempfile",
+ "tokio",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion-catalog"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06afd1e38dd27bbb1258685a1fc6524df6aff4e07b25b393a47de59635178d99"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-catalog-listing"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0668fb32c12065ec242be0e5b4bc62bd7a06a0be3ecd83791ef877e4be67e02"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+]
+
+[[package]]
+name = "datafusion-common"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca43b263cdff57042cfa8fb817fb3469f4878933380dccff25f5e793580abbf9"
+dependencies = [
+ "arrow",
+ "arrow-ipc",
+ "arrow-schema",
+ "chrono",
+ "foldhash 0.2.0",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "libc",
+ "log",
+ "object_store",
+ "sqlparser",
+ "tokio",
+ "uuid",
+ "web-time",
+]
+
+[[package]]
+name = "datafusion-common-runtime"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f0ba2b864792bdca4d76c59a1de0ab6e1b61946596b9936888dbd6360035f2"
+dependencies = [
+ "futures",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b840a8bce0bcbf5afad02946d438591e7c373f7afccaf3d874c04485772514dd"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "chrono",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "glob",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "rand 0.9.4",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "datafusion-datasource-arrow"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a24cc0b9cf6e367f27f27406eff13abf48a11b72446aaa40b3105c0ded5c17d9"
+dependencies = [
+ "arrow",
+ "arrow-ipc",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "object_store",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-csv"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1abe56b2a7a2d1d6de5117dd1a203181e267f28529faa5da546947621b697d7"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "object_store",
+ "regex",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-datasource-json"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3e467f0611ad7bdd5aad17c63c9bb6182d04e5282e5496d897ea2b49c024ba"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-session",
+ "futures",
+ "object_store",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "datafusion-doc"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69bb69d8769e34f76839c960dbde24c1ac0c885a79b6c3c2287bdc56ec67891"
+
+[[package]]
+name = "datafusion-execution"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eac0a09bc8d263f52025cad9e001da4d8138d633fa288edda4d06b1772eae6"
+dependencies = [
+ "arrow",
+ "arrow-buffer",
+ "async-trait",
+ "dashmap",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr-common",
+ "futures",
+ "log",
+ "object_store",
+ "parking_lot",
+ "rand 0.9.4",
+ "tempfile",
+ "url",
+]
+
+[[package]]
+name = "datafusion-expr"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeb14d374767ee0fc62dc79a5ba8bcf8a63c14e993c7d992d0e63adfa23d77d3"
+dependencies = [
+ "arrow",
+ "arrow-schema",
+ "async-trait",
+ "chrono",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr-common",
+ "indexmap",
+ "itertools 0.14.0",
+ "serde_json",
+ "sqlparser",
+]
+
+[[package]]
+name = "datafusion-expr-common"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b19a8c95522bee8cbb313d74263b85e355d2b52f42e67ef5694bf5de9e9356"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "indexmap",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-functions"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f64c983bbbdcb729d921a2b2ac3375598719b5cc0c30345ad664936f3176fc7"
+dependencies = [
+ "arrow",
+ "arrow-buffer",
+ "base64",
+ "chrono",
+ "chrono-tz",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-macros",
+ "datafusion-physical-expr-common",
+ "hex",
+ "itertools 0.14.0",
+ "log",
+ "memchr",
+ "num-traits",
+ "rand 0.9.4",
+ "regex",
+ "uuid",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89bc17041e424a47ed062f43df24d84aab8b57c4c3221e5c1a5eef46d6c5718b"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "foldhash 0.2.0",
+ "half",
+ "log",
+ "num-traits",
+]
+
+[[package]]
+name = "datafusion-functions-aggregate-common"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97dd2a9e865c6108059f5b37b77934f84b50bfb108f837bd0e5c9536e03f0545"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "datafusion-physical-expr-common",
+]
+
+[[package]]
+name = "datafusion-functions-nested"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f0bdfeef16d96417b9632ef855645376b242e9006a126dfd0bedfc54a93f5f"
+dependencies = [
+ "arrow",
+ "arrow-ord",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr-common",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
+ "itoa",
+ "log",
+ "memchr",
+]
+
+[[package]]
+name = "datafusion-functions-table"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4e4941673c917819616877e9993da4503e4f4739812be0bc32c5356184c6383"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-expr",
+ "datafusion-physical-plan",
+ "parking_lot",
+]
+
+[[package]]
+name = "datafusion-functions-window"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12dd2e16c12b84b6f6b41b19f55b366dd1c46876bb35b86896c6349067379e8d"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-expr",
+ "datafusion-functions-window-common",
+ "datafusion-macros",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "log",
+]
+
+[[package]]
+name = "datafusion-functions-window-common"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cdc5e4b6f8b6ef823cc1c761f85088ad4c884fe8df64df3cbcc6b2b84698441"
+dependencies = [
+ "datafusion-common",
+ "datafusion-physical-expr-common",
+]
+
+[[package]]
+name = "datafusion-macros"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a3614234dd93578c92428cb4f408e020874f0d2b7e6c90c928d9d28b5df2ceb"
+dependencies = [
+ "datafusion-doc",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "datafusion-optimizer"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0635620b050b81bb92764e99250868f654e2cd5ad1bece413283b3f73c83179"
+dependencies = [
+ "arrow",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "indexmap",
+ "itertools 0.14.0",
+ "log",
+ "regex",
+ "regex-syntax 0.8.10",
+]
+
+[[package]]
+name = "datafusion-physical-expr"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cabf7a86eb70b816729e33c81bf7767c936ee1226f607a114f5dac2decac8d0"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr-common",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "parking_lot",
+ "petgraph 0.8.3",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-physical-expr-adapter"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de222e04f7e6744501555a54ab0abe26bfdfebee380af79a9bdc175704246859"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-expr-common"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72d0d0057fc5a502d45c870cb6d47c66eb7bdd5edb1bd71ad6f3f724975ac2a8"
+dependencies = [
+ "arrow",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr-common",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "parking_lot",
+ "pin-project",
+]
+
+[[package]]
+name = "datafusion-physical-optimizer"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86046eed10950c5f9aaed9acfd148e9bd2e1dfdfe4f9aef607d1447b271e4183"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-pruning",
+ "itertools 0.14.0",
+]
+
+[[package]]
+name = "datafusion-physical-plan"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bc84da934c903407ba297971ebcc020c4c1a38aafd765d6c144c76eff3fa6a1"
+dependencies = [
+ "arrow",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-schema",
+ "async-trait",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions",
+ "datafusion-functions-aggregate-common",
+ "datafusion-functions-window-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "futures",
+ "half",
+ "hashbrown 0.17.1",
+ "indexmap",
+ "itertools 0.14.0",
+ "log",
+ "num-traits",
+ "parking_lot",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-pruning"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb63eeac6de19be40f487b65dd84e546195f783c5a9928618e0c4f2a3569b0d7"
+dependencies = [
+ "arrow",
+ "datafusion-common",
+ "datafusion-datasource",
+ "datafusion-expr-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "log",
+]
+
+[[package]]
+name = "datafusion-session"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f961d209177f91bd014db5cbb2c33b7d28a2597b9003e77f17aeb712964315a"
+dependencies = [
+ "async-trait",
+ "datafusion-common",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-physical-plan",
+ "parking_lot",
+]
+
+[[package]]
+name = "datafusion-sql"
+version = "54.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d71cb454da682b2af7488e1fc1ddd72ee1b28f19297b8ccad73f0a21ee9a69"
+dependencies = [
+ "arrow",
+ "bigdecimal",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions-nested",
+ "indexmap",
+ "log",
+ "regex",
+ "sqlparser",
+]
 
 [[package]]
 name = "deadpool"
@@ -2886,6 +3832,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2933,6 +3891,16 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustc_version",
+]
 
 [[package]]
 name = "flate2"
@@ -3536,6 +4504,15 @@ dependencies = [
 
 [[package]]
 name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
@@ -3632,6 +4609,12 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humantime"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hyper"
@@ -4250,6 +5233,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "lexical-core"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8d125a277f807e55a77304455eb7b1cb52f2b18c143b60e766c120bd64a594"
+dependencies = [
+ "lexical-parse-float",
+ "lexical-parse-integer",
+ "lexical-util",
+ "lexical-write-float",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
+name = "lexical-write-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50c438c87c013188d415fbabbb1dceb44249ab81664efbd31b14ae55dabb6361"
+dependencies = [
+ "lexical-util",
+ "lexical-write-integer",
+]
+
+[[package]]
+name = "lexical-write-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "409851a618475d2d5796377cad353802345cba92c867d9fbcde9cf4eac4e14df"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4300,6 +5340,17 @@ dependencies = [
  "libc",
  "plain",
  "redox_syscall 0.8.0",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4463,6 +5514,15 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
+]
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+dependencies = [
+ "twox-hash",
 ]
 
 [[package]]
@@ -5233,6 +6293,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "humantime",
+ "itertools 0.14.0",
+ "parking_lot",
+ "percent-encoding",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5475,6 +6561,7 @@ dependencies = [
  "fixedbitset 0.5.7",
  "hashbrown 0.15.5",
  "indexmap",
+ "serde",
 ]
 
 [[package]]
@@ -5483,7 +6570,16 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -5493,7 +6589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -5502,7 +6598,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.6",
 ]
 
@@ -5511,6 +6607,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]
@@ -5730,7 +6835,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",
@@ -6318,6 +7423,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink 0.9.1",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6481,7 +7600,7 @@ dependencies = [
  "log",
  "num-bigint",
  "num-traits",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
  "rustc-hash 1.1.0",
  "rustpython-ast",
@@ -6536,7 +7655,7 @@ dependencies = [
  "crossbeam-queue",
  "crossbeam-utils",
  "hashbrown 0.17.1",
- "hashlink",
+ "hashlink 0.10.0",
  "indexmap",
  "intrusive-collections",
  "inventory",
@@ -7205,6 +8324,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlparser"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c6d1b651dc4edf07eead2a0c6c78016ce971bc2c10da5266861b13f25e7cec"
+dependencies = [
+ "log",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7508,7 +8648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
@@ -7756,6 +8896,18 @@ checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -8102,6 +9254,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "twox-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
+
+[[package]]
 name = "type-map"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8248,7 +9406,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1673eca9782c84de5f81b82e4109dcfb3611c8ba0d52930ec4a9478f547b2dd"
 dependencies = [
- "phf",
+ "phf 0.11.3",
  "unicode_names2_generator",
 ]
 
@@ -9929,6 +11087,34 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -150,6 +150,7 @@ baml_workspace = { path = "crates/baml_workspace" }
 #  External dependencies
 anyhow = { version = "1" }
 async-trait = "0.1"
+datafusion = { version = "=54.1.0", default-features = false, features = [ "sql" ] }
 askama = { version = "0.14.0" }
 # Slim, reqwest/serde-based replacements for the AWS SDK + Google Cloud auth
 # crates, living in `forks/`. They cover only what BAML needs (Bedrock Converse,
@@ -264,6 +265,7 @@ tar = "0.4"
 zip = { version = "2", default-features = false, features = [ "deflate" ] }
 taplo = { version = "0.13" }
 tempfile = { version = "3" }
+rusqlite = { version = "=0.31.0", features = [ "bundled" ] }
 time = { version = "0.3", features = [ "formatting", "macros", "parsing" ] }
 text-size = { version = "1.1", features = [ "serde" ] }
 thiserror = { version = "2.0.0" }

--- a/baml_language/crates/baml_query/CLOUD_CLICKHOUSE_S3.md
+++ b/baml_language/crates/baml_query/CLOUD_CLICKHOUSE_S3.md
@@ -1,0 +1,144 @@
+# Cloud ClickHouse + S3 handoff
+
+This document records the decisions the local implementation makes so a
+future closed-source cloud implementation can be built independently. The
+cloud service does not need to reuse DataFusion or the SQLite provider.
+
+## Preserve the logical contract
+
+The cloud implementation should preserve these user-visible concepts:
+
+- Logical table and column names are separate from physical storage names.
+- Every queryable table has a project/tenant scope exposed logically as
+  `project_id`.
+- Relationship definitions use logical table and column names.
+- Resident columns are directly queryable values.
+- Hydrated columns are content-addressed values resolved through a value store.
+- `ValueId` values are 32-byte SHA-256 content IDs, represented as hex at API
+  boundaries and as binary values in storage.
+- Hydration may contain nested value references and must enforce depth, byte,
+  distinct-value, timeout, and cancellation budgets.
+- Portable functions such as `value_at`, `value_field`, `value_string`, and
+  `contains` should retain their logical behavior.
+
+The local implementation is the reference for semantics, not for physical
+execution. A cloud result should match the local result for the portable query
+corpus, including NULL handling, filtering, aggregation, and join cardinality.
+
+## Recommended ClickHouse shape
+
+Use a fact/dimension layout first:
+
+```text
+function_calls  -- very large fact table
+threads         -- small dimension table
+processes       -- small dimension table
+```
+
+`function_calls` should contain the keys needed for common filters directly:
+
+```text
+project_id
+thread_id
+process_id
+name
+captured_ts
+call_id
+args_value_id
+return_value_id
+error_value_id
+```
+
+This makes the common query join-free:
+
+```sql
+SELECT *
+FROM function_calls
+WHERE project_id = ?
+  AND thread_id = ?
+  AND process_id = ?
+  AND name = ?
+```
+
+Filtering calls by a small set of matching threads or processes can use a
+semi-join/`IN` shape. Enriching calls with thread or process attributes can use
+a regular join. The cloud planner may choose a ClickHouse join, semi-join,
+dictionary lookup, projection, or materialized view. Do not copy every large
+or mutable dimension field into every call row without a measured reason.
+
+Partitioning and sort keys must be chosen from measured query patterns. At a
+minimum, benchmark project, time-range, thread, process, and function-name
+filters against realistic data sizes. Do not treat the local SQLite indexes as
+an automatic ClickHouse schema prescription.
+
+## S3 value storage
+
+The local value store uses this logical layout:
+
+```text
+values/<lowercase-hex-value-id>.blob
+```
+
+The object body is UTF-8 JSON. A JSON value may contain a reference such as:
+
+```json
+{"$value_ref":"<value-id>"}
+```
+
+The cloud implementation may use S3 directly, a cached object service, or a
+ClickHouse-side value table, but it should preserve:
+
+- deterministic content-addressed object keys;
+- SHA-256 integrity verification;
+- missing-object and corrupt-object errors;
+- bounded recursive expansion;
+- bounded total downloaded/expanded bytes;
+- per-query deduplication and caching;
+- cancellation and request deadlines;
+- tenant authorization before object access.
+
+Hydration should normally happen in the cloud query service or a controlled
+value service, not by granting ClickHouse arbitrary S3 access to every object.
+The service should batch value requests and avoid downloading hydrated columns
+when the query projection does not use them.
+
+## Query/API boundary
+
+The default cloud API should accept the same logical SQL and parameters as the
+local engine for the portable subset. The service should parse, authorize,
+validate, and plan the request before issuing ClickHouse SQL. It must not trust
+`project_id` supplied by an untrusted caller as the sole authorization check;
+the tenant should come from authenticated request context and be applied to
+every table and value-store request.
+
+ClickHouse-specific features may be added as explicit cloud-only extensions:
+
+- dictionaries or direct key-value lookups;
+- `ANY`, `SEMI`, `ANTI`, or `ASOF` joins;
+- projections and materialized views;
+- ClickHouse-specific JSON, array, and date functions;
+- backend-specific settings and `EXPLAIN` output.
+
+Those features should be reported through capabilities or a clear
+cloud-only-query error. They should not silently change the meaning of a
+portable query.
+
+## Required cloud validation
+
+Before calling the cloud implementation production-ready, run a shared query
+corpus against local fixtures and representative ClickHouse data. Include:
+
+- project isolation across every table and hydrated object;
+- fact-to-dimension joins and semi-joins;
+- duplicate-key and NULL join behavior;
+- time-range filtering for “running yesterday” semantics;
+- resident and hydrated predicates;
+- `COUNT`, `COUNT(DISTINCT ...)`, `GROUP BY`, and `HAVING`;
+- missing and corrupt value objects;
+- query cancellation, timeouts, and memory/row budgets;
+- large fact-table performance and realistic concurrency.
+
+The local benchmark and metrics names are intended to provide the vocabulary
+for comparing SQLite, DataFusion, ClickHouse, and S3 phases. The numbers will
+not be directly comparable across backends, but the query shapes and outcome
+correctness should be.

--- a/baml_language/crates/baml_query/Cargo.toml
+++ b/baml_language/crates/baml_query/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "baml_query"
+version = { workspace = true }
+publish = false
+authors = { workspace = true }
+edition = { workspace = true }
+rust-version = { workspace = true }
+homepage = { workspace = true }
+documentation = { workspace = true }
+repository = { workspace = true }
+license = { workspace = true }
+description = "SQL queries over SQLite rows with transparently hydrated values"
+
+[lib]
+doctest = false
+
+[[bench]]
+name = "query_bench"
+harness = false
+
+[lints]
+workspace = true
+
+[dependencies]
+async-trait = { workspace = true }
+bytes = { workspace = true }
+datafusion = { workspace = true }
+futures = { workspace = true }
+parking_lot = { workspace = true }
+rusqlite = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = [ "fs", "macros", "rt-multi-thread", "sync" ] }
+tokio-util = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+divan = { package = "codspeed-divan-compat-walltime", version = "4.7.0" }
+tempfile = { workspace = true }

--- a/baml_language/crates/baml_query/EXAMPLE.md
+++ b/baml_language/crates/baml_query/EXAMPLE.md
@@ -1,0 +1,352 @@
+# Query examples
+
+This document shows the SQL currently supported by `baml_query`. The examples
+use the default logical tables:
+
+- `function_calls`: call-level fact data.
+- `threads`: thread metadata.
+- `processes`: process metadata.
+- `ccts`: call-context-tree metadata.
+
+The engine automatically scopes registered tables to the active project. The
+examples still include `project_id` where it makes the tenant boundary clear
+or where it is part of a join condition.
+
+The logical schema is configurable. If the physical database uses names such
+as `tenant_key`, `proc_uuid`, or `event_time`, map those physical columns to
+the logical names before running these queries.
+
+`captured_ts` is an `Int64`; replace the example values with the timestamp
+units used by the configured table definition. `args`, `return`, and `error`
+are hydrated JSON values exposed as `LargeBinary`. The value functions below
+operate on those hydrated values.
+
+## 1. Which calls failed recently?
+
+**Question:** “Did the `send_email` function start failing, and how many calls
+were affected during the incident window?”
+
+```sql
+SELECT
+    name,
+    status,
+    COUNT(*) AS call_count
+FROM function_calls
+WHERE name = 'send_email'
+  AND captured_ts >= 1720000000
+  AND captured_ts < 1720003600
+GROUP BY name, status
+ORDER BY call_count DESC;
+```
+
+This is a resident-only aggregation. It does not hydrate blobs and can be
+executed efficiently from SQLite-resident metadata.
+
+## 2. Which functions are failing most often?
+
+**Question:** “What are the top failing function names in the selected
+project?”
+
+```sql
+SELECT
+    name,
+    COUNT(*) AS failures
+FROM function_calls
+WHERE status = 'error'
+GROUP BY name
+ORDER BY failures DESC
+LIMIT 20;
+```
+
+This is useful for triage dashboards and regression detection. The provider’s
+project filter keeps the result scoped to the active project.
+
+## 3. Which calls belong to a particular process and thread?
+
+**Question:** “Show every call for one thread while debugging a specific
+process.”
+
+```sql
+SELECT
+    id,
+    captured_ts,
+    name,
+    status
+FROM function_calls
+WHERE thread_id = 'thread-42'
+  AND process_id = 'process-7'
+ORDER BY captured_ts;
+```
+
+This is the preferred shape when the caller already knows the stable IDs. It
+avoids a join entirely and lets the large `function_calls` table filter on its
+own resident keys.
+
+## 4. Which calls happened in a named thread?
+
+**Question:** “Find calls in threads named `checkout-worker`, including only
+threads associated with the expected process.”
+
+```sql
+SELECT
+    fc.id,
+    fc.captured_ts,
+    fc.name,
+    fc.status
+FROM function_calls AS fc
+JOIN threads AS t
+  ON t.project_id = fc.project_id
+ AND t.id = fc.thread_id
+WHERE t.name = 'checkout-worker'
+  AND fc.process_id = 'process-7'
+ORDER BY fc.captured_ts;
+```
+
+This is a fact-to-dimension join: the large table is `function_calls`, while
+`threads` is expected to be much smaller. The explicit project equality makes
+the tenant boundary visible in the query.
+
+## 5. Which calls ran in a process with a particular program name?
+
+**Question:** “Find errors produced by calls running in the `worker` process.”
+
+```sql
+SELECT
+    fc.id,
+    fc.name,
+    fc.status,
+    fc.captured_ts
+FROM function_calls AS fc
+JOIN processes AS p
+  ON p.project_id = fc.project_id
+ AND p.id = fc.process_id
+WHERE p.name = 'worker'
+  AND fc.status = 'error'
+ORDER BY fc.captured_ts DESC;
+```
+
+The process table supplies a human-readable filter, while the result remains
+call-level data. The same logical query can later be implemented as a
+ClickHouse join, semi-join, dictionary lookup, or materialized view.
+
+## 6. Filter calls by a small set of matching threads
+
+**Question:** “Which calls happened in threads that were named `checkout` or
+`payments`?”
+
+```sql
+SELECT
+    fc.id,
+    fc.thread_id,
+    fc.name,
+    fc.captured_ts
+FROM function_calls AS fc
+WHERE fc.project_id = 'project-1'
+  AND fc.thread_id IN (
+    SELECT t.id
+    FROM threads AS t
+    WHERE t.project_id = 'project-1'
+      AND t.name IN ('checkout', 'payments')
+)
+ORDER BY fc.captured_ts;
+```
+
+This is a semi-join: the subquery produces eligible thread IDs, but no thread
+columns are returned. It also avoids duplicating calls if the related table
+contains multiple matching records.
+
+## 7. What calls were active during a time window?
+
+**Question:** “Show the call timeline for yesterday’s incident window.”
+
+```sql
+SELECT
+    captured_ts,
+    name,
+    status,
+    thread_id,
+    process_id
+FROM function_calls
+WHERE captured_ts >= 1720000000
+  AND captured_ts < 1720086400
+ORDER BY captured_ts, id;
+```
+
+This filters on the event timestamp stored on the fact table. If “running
+yesterday” means that a thread’s lifetime overlapped yesterday, use the
+thread’s start/end columns in a relationship filter instead; that requires
+those columns to be included in the configured `threads` schema.
+
+## 8. Which argument field was sent to a function?
+
+**Question:** “For calls with an argument object, what subject was sent to
+the function?”
+
+```sql
+SELECT
+    id,
+    name,
+    value_string(value_field(args, 'subject')) AS subject
+FROM function_calls
+WHERE name = 'send_email'
+  AND value_field(args, 'subject') IS NOT NULL
+ORDER BY captured_ts DESC;
+```
+
+`value_field` reads a field from hydrated JSON and `value_string` converts the
+field to a SQL string. Because this uses `args`, matching rows may require blob
+reads after resident filters have been applied.
+
+## 9. Find calls whose first argument contains a value
+
+**Question:** “Which calls passed `customer-123` anywhere in their first
+argument array?”
+
+```sql
+SELECT
+    id,
+    name,
+    captured_ts
+FROM function_calls
+WHERE contains(value_at(args, 0), 'customer-123')
+ORDER BY captured_ts DESC;
+```
+
+This assumes `args` is an array and that its first element is itself a value
+that `contains` can inspect. The exact JSON shape matters; malformed or
+missing value objects produce hydration errors rather than silently matching.
+
+## 10. Inspect a nested return value
+
+**Question:** “Which calls returned a response with `status = 'rejected'`?”
+
+```sql
+SELECT
+    id,
+    name,
+    value_string(value_field("return", 'status')) AS return_status
+FROM function_calls
+WHERE value_string(value_field("return", 'status')) = 'rejected'
+ORDER BY captured_ts DESC;
+```
+
+This is useful for debugging application-level failures that were recorded in
+the returned value rather than in the resident `status` column.
+
+## 11. How many calls did each process make?
+
+**Question:** “Which processes generated the most calls in the selected
+project?”
+
+```sql
+SELECT
+    process_id,
+    COUNT(*) AS call_count,
+    COUNT(DISTINCT thread_id) AS thread_count
+FROM function_calls
+GROUP BY process_id
+ORDER BY call_count DESC;
+```
+
+This aggregation stays entirely on resident columns. It is a useful baseline
+for comparing local SQLite/DataFusion performance with a future ClickHouse
+implementation.
+
+## 12. Which function names are used by each thread?
+
+**Question:** “What work did each thread perform during a debugging session?”
+
+```sql
+SELECT
+    thread_id,
+    name,
+    COUNT(*) AS call_count,
+    MIN(captured_ts) AS first_call_ts,
+    MAX(captured_ts) AS last_call_ts
+FROM function_calls
+WHERE captured_ts >= 1720000000
+  AND captured_ts < 1720086400
+GROUP BY thread_id, name
+ORDER BY thread_id, call_count DESC;
+```
+
+This produces a compact activity summary without reading any hydrated values.
+
+## 13. Which call-context trees contain errors?
+
+**Question:** “Which call-context-tree nodes contain failed calls, and what
+are their names?”
+
+```sql
+SELECT
+    c.id AS cct_id,
+    c.name AS cct_name,
+    COUNT(*) AS failed_calls
+FROM function_calls AS fc
+JOIN ccts AS c
+  ON c.project_id = fc.project_id
+ AND c.id = fc.cct_id
+WHERE fc.status = 'error'
+GROUP BY c.id, c.name
+ORDER BY failed_calls DESC;
+```
+
+This is another small-dimension-to-large-fact join. It is appropriate when
+the result needs dimension attributes such as the CCT name.
+
+## 14. Which argument categories have the highest failure rate?
+
+**Question:** “Is one input category causing a disproportionate number of
+failed calls?”
+
+```sql
+SELECT
+    value_string(value_field(args, 'category')) AS category,
+    COUNT(*) AS total_calls,
+    SUM(CASE WHEN status = 'error' THEN 1 ELSE 0 END) AS failed_calls
+FROM function_calls
+WHERE value_field(args, 'category') IS NOT NULL
+GROUP BY value_string(value_field(args, 'category'))
+HAVING COUNT(*) >= 10
+ORDER BY failed_calls DESC, total_calls DESC;
+```
+
+This combines resident aggregation with hydrated grouping. It is expressive,
+but can be memory-intensive locally because DataFusion groups serialized JSON
+values after hydration. It is a strong candidate for a future ClickHouse
+materialized view if it becomes a frequent dashboard query.
+
+## 15. Find calls with missing or present hydrated values
+
+**Question:** “Which calls have no recorded arguments, returns, or errors?”
+
+```sql
+SELECT
+    id,
+    name,
+    status,
+    args,
+    "return",
+    error
+FROM function_calls
+WHERE args IS NULL
+   OR "return" IS NULL
+   OR error IS NOT NULL
+ORDER BY captured_ts DESC;
+```
+
+This query checks whether the hydrated logical columns are present. Selecting
+the hydrated columns causes value loading; selecting only resident columns
+such as `id`, `name`, and `status` avoids blob reads.
+
+## Query design notes
+
+- Use direct `function_calls` predicates when the caller already knows IDs.
+- Use joins when related columns are needed in the result.
+- Use `IN`/semi-join patterns when a small dimension table only filters the
+  large fact table.
+- Keep `project_id` in relationship predicates when writing portable SQL,
+  even though the provider also applies project scoping automatically.
+- Apply resident filters before asking for hydrated values whenever possible.
+- Use `EXPLAIN` and `engine.metrics()` to see the plan, candidate rows,
+  hydration work, and serialization cost.

--- a/baml_language/crates/baml_query/EXAMPLE.md
+++ b/baml_language/crates/baml_query/EXAMPLE.md
@@ -3,10 +3,136 @@
 This document shows the SQL currently supported by `baml_query`. The examples
 use the default logical tables:
 
-- `function_calls`: call-level fact data.
-- `threads`: thread metadata.
-- `processes`: process metadata.
-- `ccts`: call-context-tree metadata.
+- `function_calls`: one row per function invocation.
+- `threads`: one row per execution thread or logical worker thread.
+- `processes`: one row per process, worker, or runtime instance.
+- `ccts`: one row per call-context-tree node or execution context.
+
+## Data model
+
+The default schema is shaped like a small star schema: `function_calls` is the
+large fact table, while `threads`, `processes`, and `ccts` are smaller metadata
+tables that explain or group those calls.
+
+### `function_calls`
+
+This is the primary event table. Each row represents one function invocation
+and is the table to start with when asking “what happened?” questions.
+
+| Column | Meaning | Typical use |
+| --- | --- | --- |
+| `id` | Stable identifier for the invocation | Trace a single call or deduplicate results |
+| `project_id` | Tenant/project scope | Isolate data and make portable joins safe |
+| `process_id` | Process or worker that executed the call | Filter by runtime instance or join to `processes` |
+| `thread_id` | Thread that executed the call | Inspect one thread or join to `threads` |
+| `cct_id` | Call-context-tree node for the call | Group calls by execution context |
+| `captured_ts` | Call capture timestamp as `Int64` | Time windows, timelines, and ordering |
+| `name` | Function name | Find a function, compare functions, or group by function |
+| `status` | Call outcome/status | Find failures, retries, and success rates |
+| `metadata` | Resident metadata text | Display or filter lightweight call metadata |
+| `metrics` | Resident metrics text | Inspect metrics stored with the call |
+| `args` | Hydrated JSON arguments | Debug inputs and filter on argument fields |
+| `return` | Hydrated JSON return value | Inspect outputs and application-level results |
+| `error` | Hydrated JSON error value | Inspect structured failures |
+
+The resident columns are cheap to scan compared with hydrated columns. A
+query that selects or filters on `args`, `return`, or `error` may read local
+value files. Start with resident predicates such as `name`, `status`, IDs, and
+`captured_ts` before applying hydrated predicates.
+
+`metadata` and `metrics` are currently exposed as resident text columns. They
+may contain JSON in an upstream schema, but this engine does not automatically
+treat them as hydrated `ValueId` columns. If they need structured hydration,
+define separate hydrated columns in the table specification.
+
+### `threads`
+
+This table describes the thread or logical worker associated with a call. It
+is usually much smaller than `function_calls` and is useful when users know a
+human-readable thread name rather than a thread ID.
+
+| Column | Meaning | Typical use |
+| --- | --- | --- |
+| `id` | Stable thread identifier | Join to `function_calls.thread_id` |
+| `project_id` | Tenant/project scope | Keep thread lookups within the project |
+| `process_id` | Owning process, when available | Join the thread to `processes` |
+| `name` | Human-readable thread or worker name | Find calls from a named thread |
+
+The default schema does not include `started_at`, `ended_at`, heartbeat, or
+last-activity columns. If “was this thread running yesterday?” is a required
+question, those fields must be added to the configured logical table schema or
+inferred from another event/activity table.
+
+### `processes`
+
+This table describes the process, worker, or runtime instance that produced
+calls. It is normally the smallest dimension table.
+
+| Column | Meaning | Typical use |
+| --- | --- | --- |
+| `id` | Stable process identifier | Join to `function_calls.process_id` or `threads.process_id` |
+| `project_id` | Tenant/project scope | Keep process lookups within the project |
+| `name` | Process/program/worker name | Filter calls by the runtime that produced them |
+
+Use this table for enrichment and human-readable filtering. Keep the stable
+`process_id` directly on `function_calls` so queries that already know the ID
+do not need a join.
+
+### `ccts`
+
+This table describes call-context-tree nodes. A CCT can represent a logical
+execution context, stack-like grouping, or another hierarchy supplied by the
+upstream system.
+
+| Column | Meaning | Typical use |
+| --- | --- | --- |
+| `id` | Stable context-node identifier | Join to `function_calls.cct_id` |
+| `project_id` | Tenant/project scope | Keep context lookups within the project |
+| `thread_id` | Thread containing the context, when available | Join the context to `threads` |
+| `name` | Human-readable context name | Group or filter calls by context |
+
+The default `ccts` table is intentionally small and descriptive. If the
+upstream CCT model has parent IDs, depths, source locations, or timestamps,
+those can be added as resident columns through a custom table specification.
+
+### Relationships
+
+The usual logical relationships are:
+
+```text
+function_calls.process_id  → processes.id
+function_calls.thread_id   → threads.id
+function_calls.cct_id      → ccts.id
+threads.process_id         → processes.id
+ccts.thread_id             → threads.id
+```
+
+These are generally many-to-one relationships: many calls can belong to one
+thread, process, or CCT. Every relationship is project-scoped in the default
+model, so portable joins should include the project equality:
+
+```sql
+ON related.project_id = calls.project_id
+AND related.id = calls.related_id
+```
+
+Use a regular join when you need columns from the related table. Use a
+semi-join or `IN` pattern when the related table only determines which calls
+are eligible. Because `function_calls` is expected to be much larger than the
+dimension tables, avoid joining it to another large event table unless the
+query is intentionally doing a broad event correlation.
+
+### Choosing a starting table
+
+| Question type | Start with | Why |
+| --- | --- | --- |
+| What calls happened? | `function_calls` | It contains the event rows and timestamps |
+| Which functions are failing? | `function_calls` | `name` and `status` are resident |
+| What did a call receive or return? | `function_calls` | `args`, `return`, and `error` are hydrated there |
+| Which calls came from a named worker? | `threads` or `processes`, then filter calls | The dimension contains the readable name |
+| How much work did each thread do? | `function_calls` grouped by `thread_id` | Avoids a join if only IDs are needed |
+| Which execution context contains failures? | `function_calls` joined to `ccts` | CCT supplies the readable context name |
+| Was a thread active during a time range? | `threads` plus lifecycle/activity columns | The default thread schema has no lifecycle timestamps |
 
 The engine automatically scopes registered tables to the active project. The
 examples still include `project_id` where it makes the tenant boundary clear

--- a/baml_language/crates/baml_query/README.md
+++ b/baml_language/crates/baml_query/README.md
@@ -1,0 +1,138 @@
+# baml_query
+
+`baml_query` is a local first SQL frontend for resident SQLite metadata with
+transparent hydration of content-addressed values from files. DataFusion owns
+SQL parsing, planning, joins, CTEs, residual predicates, limits, and UDF
+execution.
+
+## Storage contract
+
+The SQLite `function_calls` table keeps resident fields plus nullable
+`args_value_id`, `return_value_id`, and `error_value_id` columns. Each ID is a
+32-byte SHA-256 digest stored as a SQLite `BLOB`; the corresponding local file
+is `values/<lowercase-hex-id>.blob`. A blob is UTF-8 JSON and may contain a
+reference such as `{"$value_ref":"<id>"}`.
+
+The fixed-width digest is intentional: it has stable binary comparisons in
+SQLite, avoids UUID formatting ambiguity, and verifies blob integrity on read.
+`ValueId` is serialized as hex at API boundaries.
+
+## Example
+
+```rust,no_run
+use std::sync::Arc;
+
+use baml_query::{QueryEngine, SqliteFunctionCallsProvider};
+use rusqlite::Connection;
+
+# async fn example(connection: Connection) -> baml_query::Result<()> {
+let provider = SqliteFunctionCallsProvider::from_connection(
+    connection,
+    "/tmp/baml-values",
+    Arc::<str>::from("project-1"),
+)?
+.with_standard_resident_tables()?;
+let engine = QueryEngine::new(provider)?;
+let batches = engine
+    .execute("SELECT id FROM function_calls WHERE contains(value_at(args, 0), 'hi') LIMIT 100")
+    .await?;
+# let _ = batches;
+# Ok(())
+# }
+```
+
+When the physical schema is owned by another system, define the logical schema
+yourself and map each column to the external physical layout. The logical
+names, Arrow types, ID representation, and hydration behavior are all caller
+controlled:
+
+```rust,no_run
+use baml_query::{FunctionCallsTableSpec, SqliteFunctionCallsProvider};
+
+# fn configure(mut provider: SqliteFunctionCallsProvider) -> baml_query::Result<SqliteFunctionCallsProvider> {
+let calls = FunctionCallsTableSpec::new("trace_rows")?
+    .with_column("id", "call_uuid")?
+    .with_column("project_id", "tenant_key")?
+    .with_column("name", "fn_name")?
+    .with_column("args_value_id", "arg_cid")?;
+let provider = provider.with_function_calls_table(calls);
+# Ok(provider)
+# }
+```
+
+Use `SqliteTableSpec::from_columns` and `SqliteColumnSpec` for arbitrary tables.
+`SqliteColumnSpec::new` creates a resident column; use
+`SqliteColumnSpec::hydrated_value` when the physical column contains a
+content-addressed value ID:
+
+```rust,no_run
+use baml_query::{SqliteColumnSpec, SqliteTableSpec};
+use datafusion::arrow::datatypes::DataType;
+
+let events = SqliteTableSpec::from_columns(
+    "events",
+    "event_log",
+    vec![
+        SqliteColumnSpec::new("event_id", "event_key", DataType::UInt64, false),
+        SqliteColumnSpec::new("project_id", "tenant_key", DataType::Utf8, false),
+        SqliteColumnSpec::new("process_ref", "proc_uuid", DataType::Utf8, true),
+        SqliteColumnSpec::hydrated_value("payload", "payload_cid", true),
+    ],
+)?;
+let provider = provider.with_table(events)?;
+```
+
+`SqliteResidentTableSpec` remains as a compatibility name for
+`SqliteTableSpec`; the default constructors still map each logical name to an
+identically named physical column.
+
+Declare joinability separately from physical mappings. Relationships use the
+logical names and are validated against the registered table definitions:
+
+```rust,no_run
+use baml_query::{QueryEngine, RelationshipDefinition};
+
+let engine = QueryEngine::new(provider)?
+    .with_relationship(
+        RelationshipDefinition::many_to_one(
+            "events", "process_ref", "processes", "id",
+        )
+        .project_scoped(),
+    )?;
+```
+
+This metadata supports composite keys and cardinality validation. It does not
+change SQL syntax: queries still write explicit `JOIN ... ON ...` clauses.
+Project-scoped relationships require a project column on both tables, while
+each table provider independently applies the project filter.
+
+Use `register_udf` or `register_async_udf` to add allowlisted DataFusion
+functions. `with_budgets` controls candidate rows, recursive depth, expanded
+bytes, blob bytes, distinct values, and query duration. `explain` returns the
+DataFusion plan, including the lazy SQLite scan.
+
+After `execute` or `explain`, call `engine.metrics()` for the last query's
+candidate/output row counts, blob/cache counters, and phase timings. The
+repeatable benchmark fixture can be run with:
+
+```text
+cargo bench -p baml_query --bench query_bench
+```
+
+For a local wall-clock report with phase metrics, use the explicit baseline
+runner:
+
+```text
+BAML_QUERY_MANUAL_BENCH=1 cargo bench -p baml_query --bench query_bench
+```
+
+The provider intentionally does not push a final SQL `LIMIT` into SQLite when
+hydrated predicates may still reject rows. Lazy batches let DataFusion stop
+the scan once the final limit is satisfied.
+
+DataFusion also executes aggregates over the streamed batches, including
+`COUNT`, `COUNT(DISTINCT ...)`, `GROUP BY`, and `HAVING`. Resident filters are
+still pushed into SQLite first, but aggregate pushdown is not implemented yet;
+grouping therefore consumes the full candidate stream. Grouping hydrated JSON
+values can be memory-intensive because the current logical representation is
+serialized `LargeBinary` data.

--- a/baml_language/crates/baml_query/README.md
+++ b/baml_language/crates/baml_query/README.md
@@ -49,6 +49,9 @@ the upstream schema automatically.
 For the cloud handoff and the invariants the future ClickHouse/S3 service must
 preserve, see [CLOUD_CLICKHOUSE_S3.md](CLOUD_CLICKHOUSE_S3.md).
 
+For practical business and engineering/debugging queries, see
+[EXAMPLE.md](EXAMPLE.md).
+
 ## Example
 
 ```rust,no_run

--- a/baml_language/crates/baml_query/README.md
+++ b/baml_language/crates/baml_query/README.md
@@ -17,6 +17,38 @@ The fixed-width digest is intentional: it has stable binary comparisons in
 SQLite, avoids UUID formatting ambiguity, and verifies blob integrity on read.
 `ValueId` is serialized as hex at API boundaries.
 
+## Editing table schemas
+
+Table definitions are intentionally code-owned rather than inferred from the
+SQLite database. This keeps the SQL-facing schema stable while allowing the
+physical tables to be owned by another system.
+
+When an upstream table changes:
+
+1. Update the `SqliteTableSpec::from_columns` definition passed to
+   `with_table`.
+2. Keep the logical name used by SQL stable when possible; change only the
+   physical name when the upstream column was renamed.
+3. Use `SqliteColumnSpec::new` for resident values and
+   `SqliteColumnSpec::hydrated_value` for physical value-ID columns.
+4. Set the Arrow `DataType` and nullability to match the logical contract.
+5. Keep a logical `project_id` column on every registered table. Its physical
+   name can be `tenant_key`, `workspace_id`, or another valid SQLite identifier.
+6. Update relationship definitions if a join key or logical table changed.
+7. Add or update an integration test using the real physical column names.
+
+For new schemas, prefer `SqliteTableSpec` over
+`FunctionCallsTableSpec`. `FunctionCallsTableSpec` is a compatibility helper
+for the original fixed `function_calls` logical schema; it is not the general
+schema-definition mechanism.
+
+The mapping is explicit: the logical column name is what appears in SQL, while
+the physical name is what SQLite reads. The engine does not inspect or migrate
+the upstream schema automatically.
+
+For the cloud handoff and the invariants the future ClickHouse/S3 service must
+preserve, see [CLOUD_CLICKHOUSE_S3.md](CLOUD_CLICKHOUSE_S3.md).
+
 ## Example
 
 ```rust,no_run

--- a/baml_language/crates/baml_query/benches/query_bench.rs
+++ b/baml_language/crates/baml_query/benches/query_bench.rs
@@ -1,0 +1,241 @@
+use std::io::Write;
+use std::sync::{Arc, OnceLock};
+use std::time::Instant;
+
+use baml_query::{LocalBlobStore, QueryEngine, SqliteFunctionCallsProvider, ValueId};
+use divan::{Bencher, black_box};
+use rusqlite::Connection;
+use serde_json::json;
+use tempfile::TempDir;
+use tokio::runtime::Runtime;
+
+struct Fixture {
+    _temp_dir: TempDir,
+    engine: QueryEngine,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let temp_dir = tempfile::tempdir().expect("create benchmark temp directory");
+        let store = LocalBlobStore::new(temp_dir.path());
+        let hit_bytes = serde_json::to_vec(&json!(["needle"])).expect("encode hit value");
+        let miss_bytes = serde_json::to_vec(&json!(["other"])).expect("encode miss value");
+        let hit_id = ValueId::from_content(&hit_bytes);
+        let miss_id = ValueId::from_content(&miss_bytes);
+        std::fs::create_dir_all(temp_dir.path().join("values")).expect("create values directory");
+        std::fs::write(store.path_for(hit_id), hit_bytes).expect("write hit value");
+        std::fs::write(store.path_for(miss_id), miss_bytes).expect("write miss value");
+
+        let connection = Connection::open_in_memory().expect("open SQLite");
+        connection
+            .execute_batch(
+                "CREATE TABLE function_calls (
+                    id TEXT PRIMARY KEY,
+                    project_id TEXT NOT NULL,
+                    process_id TEXT,
+                    thread_id TEXT,
+                    cct_id TEXT,
+                    captured_ts INTEGER,
+                    name TEXT NOT NULL,
+                    status TEXT,
+                    metadata TEXT,
+                    metrics TEXT,
+                    args_value_id BLOB,
+                    return_value_id BLOB,
+                    error_value_id BLOB
+                );",
+            )
+            .expect("create benchmark table");
+        let transaction = connection
+            .unchecked_transaction()
+            .expect("start benchmark transaction");
+        for index in 0..10_000 {
+            let value_id = if index < 9_000 { miss_id } else { hit_id };
+            transaction
+                .execute(
+                    "INSERT INTO function_calls
+                     (id, project_id, name, args_value_id, captured_ts)
+                     VALUES (?1, 'benchmark-project', 'send_email', ?2, ?3)",
+                    rusqlite::params![
+                        format!("call-{index}"),
+                        value_id.as_bytes().to_vec(),
+                        i64::from(index),
+                    ],
+                )
+                .expect("insert benchmark row");
+        }
+        transaction.commit().expect("commit benchmark rows");
+
+        let provider = SqliteFunctionCallsProvider::from_connection(
+            connection,
+            temp_dir.path(),
+            Arc::<str>::from("benchmark-project"),
+        )
+        .expect("create provider");
+        Self {
+            _temp_dir: temp_dir,
+            engine: QueryEngine::new(provider).expect("create query engine"),
+        }
+    }
+}
+
+fn fixture() -> &'static Fixture {
+    static FIXTURE: OnceLock<Fixture> = OnceLock::new();
+    FIXTURE.get_or_init(Fixture::new)
+}
+
+fn runtime() -> &'static Runtime {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| Runtime::new().expect("create benchmark runtime"))
+}
+
+fn main() {
+    if cfg!(debug_assertions) {
+        return;
+    }
+    if std::env::var_os("BAML_QUERY_MANUAL_BENCH").is_some() {
+        manual_benchmark();
+        return;
+    }
+    divan::main();
+}
+
+fn manual_benchmark() {
+    let fixture = fixture();
+    let runtime = runtime();
+    benchmark_query(
+        fixture,
+        runtime,
+        "resident_filter",
+        "SELECT id FROM function_calls WHERE name = 'send_email'",
+    );
+    benchmark_query(
+        fixture,
+        runtime,
+        "hydrated_filter_with_final_limit",
+        "SELECT id FROM function_calls
+         WHERE contains(value_at(args, 0), 'needle')
+         LIMIT 100",
+    );
+    benchmark_query(
+        fixture,
+        runtime,
+        "hydrated_projection",
+        "SELECT args FROM function_calls WHERE id = 'call-9999'",
+    );
+    benchmark_query(
+        fixture,
+        runtime,
+        "resident_group_by",
+        "SELECT name, COUNT(*) FROM function_calls GROUP BY name",
+    );
+    benchmark_query(
+        fixture,
+        runtime,
+        "hydrated_group_by",
+        "SELECT value_string(value_at(args, 0)), COUNT(*)
+         FROM function_calls
+         GROUP BY value_string(value_at(args, 0))",
+    );
+}
+
+fn benchmark_query(fixture: &Fixture, runtime: &Runtime, name: &str, sql: &str) {
+    let mut samples = Vec::with_capacity(5);
+    for _ in 0..5 {
+        let started = Instant::now();
+        let batches = runtime
+            .block_on(fixture.engine.execute(sql))
+            .expect("benchmark query succeeds");
+        black_box(batches);
+        samples.push(started.elapsed().as_nanos());
+    }
+    let min = samples.iter().copied().min().unwrap_or_default();
+    let max = samples.iter().copied().max().unwrap_or_default();
+    let mean = samples.iter().sum::<u128>() / samples.len() as u128;
+    let metrics = fixture.engine.metrics();
+    write_line(&format!(
+        "{name}: min={}us mean={}us max={}us candidates={} output={} sqlite={}us hydration={}us blobs={} blob_bytes={} serialization={}us cache_hits={} cache_misses={}",
+        min / 1_000,
+        mean / 1_000,
+        max / 1_000,
+        metrics.input_rows,
+        metrics.output_rows,
+        metrics.sqlite_duration.as_nanos() / 1_000,
+        metrics.hydration_duration.as_nanos() / 1_000,
+        metrics.blob_requests,
+        metrics.blob_bytes,
+        metrics.serialization_duration.as_nanos() / 1_000,
+        metrics.cache_hits,
+        metrics.cache_misses,
+    ));
+}
+
+fn write_line(line: &str) {
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    let _ = writeln!(stdout, "{line}");
+}
+
+#[divan::bench]
+fn resident_filter(bencher: Bencher) {
+    let fixture = fixture();
+    let runtime = runtime();
+    bencher.bench(|| {
+        let batches = runtime.block_on(fixture.engine.execute(black_box(
+            "SELECT id FROM function_calls WHERE name = 'send_email'",
+        )));
+        black_box(batches)
+    });
+}
+
+#[divan::bench]
+fn hydrated_filter_with_final_limit(bencher: Bencher) {
+    let fixture = fixture();
+    let runtime = runtime();
+    bencher.bench(|| {
+        let batches = runtime.block_on(fixture.engine.execute(black_box(
+            "SELECT id FROM function_calls
+                 WHERE contains(value_at(args, 0), 'needle')
+                 LIMIT 100",
+        )));
+        black_box(batches)
+    });
+}
+
+#[divan::bench]
+fn hydrated_projection(bencher: Bencher) {
+    let fixture = fixture();
+    let runtime = runtime();
+    bencher.bench(|| {
+        let batches = runtime.block_on(fixture.engine.execute(black_box(
+            "SELECT args FROM function_calls WHERE id = 'call-9999'",
+        )));
+        black_box(batches)
+    });
+}
+
+#[divan::bench]
+fn resident_group_by(bencher: Bencher) {
+    let fixture = fixture();
+    let runtime = runtime();
+    bencher.bench(|| {
+        let batches = runtime.block_on(fixture.engine.execute(black_box(
+            "SELECT name, COUNT(*) FROM function_calls GROUP BY name",
+        )));
+        black_box(batches)
+    });
+}
+
+#[divan::bench]
+fn hydrated_group_by(bencher: Bencher) {
+    let fixture = fixture();
+    let runtime = runtime();
+    bencher.bench(|| {
+        let batches = runtime.block_on(fixture.engine.execute(black_box(
+            "SELECT value_string(value_at(args, 0)), COUNT(*)
+             FROM function_calls
+             GROUP BY value_string(value_at(args, 0))",
+        )));
+        black_box(batches)
+    });
+}

--- a/baml_language/crates/baml_query/src/catalog.rs
+++ b/baml_language/crates/baml_query/src/catalog.rs
@@ -1,0 +1,229 @@
+use std::collections::HashMap;
+
+use datafusion::arrow::datatypes::SchemaRef;
+
+use crate::resident::SqliteResidentTableSpec;
+use crate::{QueryError, Result};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RelationshipCardinality {
+    OneToOne,
+    OneToMany,
+    ManyToOne,
+    ManyToMany,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RelationshipDefinition {
+    pub from_table: String,
+    pub from_columns: Vec<String>,
+    pub to_table: String,
+    pub to_columns: Vec<String>,
+    pub cardinality: RelationshipCardinality,
+    pub project_scoped: bool,
+}
+
+impl RelationshipDefinition {
+    pub fn new(
+        from_table: impl Into<String>,
+        from_columns: Vec<String>,
+        to_table: impl Into<String>,
+        to_columns: Vec<String>,
+        cardinality: RelationshipCardinality,
+    ) -> Self {
+        Self {
+            from_table: from_table.into(),
+            from_columns,
+            to_table: to_table.into(),
+            to_columns,
+            cardinality,
+            project_scoped: false,
+        }
+    }
+
+    pub fn many_to_one(
+        from_table: impl Into<String>,
+        from_column: impl Into<String>,
+        to_table: impl Into<String>,
+        to_column: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            from_table,
+            vec![from_column.into()],
+            to_table,
+            vec![to_column.into()],
+            RelationshipCardinality::ManyToOne,
+        )
+    }
+
+    pub fn one_to_many(
+        from_table: impl Into<String>,
+        from_column: impl Into<String>,
+        to_table: impl Into<String>,
+        to_column: impl Into<String>,
+    ) -> Self {
+        Self::new(
+            from_table,
+            vec![from_column.into()],
+            to_table,
+            vec![to_column.into()],
+            RelationshipCardinality::OneToMany,
+        )
+    }
+
+    #[must_use]
+    pub fn project_scoped(mut self) -> Self {
+        self.project_scoped = true;
+        self
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TableDefinition {
+    pub name: String,
+    pub schema: SchemaRef,
+    pub project_column: Option<String>,
+    hydrated_columns: Vec<String>,
+}
+
+impl TableDefinition {
+    pub fn new(name: impl Into<String>, schema: SchemaRef) -> Result<Self> {
+        let name = name.into();
+        if name.is_empty() {
+            return Err(QueryError::Internal(
+                "table name cannot be empty".to_owned(),
+            ));
+        }
+        Ok(Self {
+            name,
+            schema,
+            project_column: None,
+            hydrated_columns: Vec::new(),
+        })
+    }
+
+    #[must_use]
+    pub fn project_column(mut self, column: impl Into<String>) -> Self {
+        self.project_column = Some(column.into());
+        self
+    }
+
+    #[must_use]
+    pub fn hydrated_column(mut self, column: impl Into<String>) -> Self {
+        self.hydrated_columns.push(column.into());
+        self
+    }
+
+    fn has_column(&self, column: &str) -> bool {
+        self.schema.field_with_name(column).is_ok()
+    }
+
+    fn is_hydrated(&self, column: &str) -> bool {
+        self.hydrated_columns.iter().any(|name| name == column)
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct QueryCatalog {
+    tables: HashMap<String, TableDefinition>,
+    relationships: Vec<RelationshipDefinition>,
+}
+
+impl QueryCatalog {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn register_table(&mut self, table: TableDefinition) -> Result<()> {
+        if self.tables.contains_key(&table.name) {
+            return Err(QueryError::Internal(
+                "duplicate query catalog table".to_owned(),
+            ));
+        }
+        if let Some(project_column) = &table.project_column {
+            if !table.has_column(project_column) {
+                return Err(QueryError::Internal(format!(
+                    "project column does not exist: {}.{}",
+                    table.name, project_column
+                )));
+            }
+        }
+        self.tables.insert(table.name.clone(), table);
+        Ok(())
+    }
+
+    pub fn register_sqlite_table(&mut self, table: &SqliteResidentTableSpec) -> Result<()> {
+        self.register_table(table.table_definition())
+    }
+
+    pub fn register_relationship(&mut self, relationship: RelationshipDefinition) -> Result<()> {
+        let from = self.table(&relationship.from_table)?;
+        let to = self.table(&relationship.to_table)?;
+        if relationship.from_columns.is_empty()
+            || relationship.from_columns.len() != relationship.to_columns.len()
+        {
+            return Err(QueryError::Internal(
+                "relationship sides must have the same non-zero number of columns".to_owned(),
+            ));
+        }
+        for (from_column, to_column) in relationship
+            .from_columns
+            .iter()
+            .zip(&relationship.to_columns)
+        {
+            let from_field = from.schema.field_with_name(from_column).map_err(|_| {
+                QueryError::Internal(format!(
+                    "relationship column does not exist: {}.{}",
+                    relationship.from_table, from_column
+                ))
+            })?;
+            let to_field = to.schema.field_with_name(to_column).map_err(|_| {
+                QueryError::Internal(format!(
+                    "relationship column does not exist: {}.{}",
+                    relationship.to_table, to_column
+                ))
+            })?;
+            if from_field.data_type() != to_field.data_type() {
+                return Err(QueryError::Internal(format!(
+                    "relationship column types differ: {}.{} ({}) and {}.{} ({})",
+                    relationship.from_table,
+                    from_column,
+                    from_field.data_type(),
+                    relationship.to_table,
+                    to_column,
+                    to_field.data_type()
+                )));
+            }
+            if from.is_hydrated(from_column) || to.is_hydrated(to_column) {
+                return Err(QueryError::Internal(
+                    "hydrated value columns cannot be relationship keys".to_owned(),
+                ));
+            }
+        }
+        if relationship.project_scoped
+            && (from.project_column.is_none() || to.project_column.is_none())
+        {
+            return Err(QueryError::Internal(
+                "project-scoped relationships require project columns on both tables".to_owned(),
+            ));
+        }
+        self.relationships.push(relationship);
+        Ok(())
+    }
+
+    pub fn table(&self, name: &str) -> Result<&TableDefinition> {
+        self.tables
+            .get(name)
+            .ok_or_else(|| QueryError::Internal(format!("unknown query catalog table: {name}")))
+    }
+
+    pub fn tables(&self) -> impl Iterator<Item = &TableDefinition> {
+        self.tables.values()
+    }
+
+    #[must_use]
+    pub fn relationships(&self) -> &[RelationshipDefinition] {
+        &self.relationships
+    }
+}

--- a/baml_language/crates/baml_query/src/context.rs
+++ b/baml_language/crates/baml_query/src/context.rs
@@ -1,0 +1,180 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+use tokio_util::sync::CancellationToken;
+use uuid::Uuid;
+
+use crate::{QueryError, Result, ValueId};
+
+#[derive(Clone, Debug)]
+pub struct QueryBudgets {
+    pub max_candidate_rows: usize,
+    pub max_value_depth: usize,
+    pub max_expanded_bytes: usize,
+    pub max_blob_bytes: usize,
+    pub max_distinct_values: usize,
+    pub max_query_duration: Duration,
+}
+
+#[derive(Default)]
+pub struct QueryMetrics {
+    pub batches: AtomicUsize,
+    pub input_rows: AtomicUsize,
+    pub output_rows: AtomicUsize,
+    pub distinct_root_ids: AtomicUsize,
+    pub cache_hits: AtomicUsize,
+    pub cache_misses: AtomicUsize,
+    pub blob_requests: AtomicUsize,
+    pub blob_bytes: AtomicUsize,
+    query_duration_ns: AtomicU64,
+    sqlite_duration_ns: AtomicU64,
+    hydration_duration_ns: AtomicU64,
+    blob_read_duration_ns: AtomicU64,
+    serialization_duration_ns: AtomicU64,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct QueryMetricsSnapshot {
+    pub batches: usize,
+    pub input_rows: usize,
+    pub output_rows: usize,
+    pub distinct_root_ids: usize,
+    pub cache_hits: usize,
+    pub cache_misses: usize,
+    pub blob_requests: usize,
+    pub blob_bytes: usize,
+    pub query_duration: Duration,
+    pub sqlite_duration: Duration,
+    pub hydration_duration: Duration,
+    pub blob_read_duration: Duration,
+    pub serialization_duration: Duration,
+}
+
+impl QueryMetrics {
+    pub fn snapshot(&self) -> QueryMetricsSnapshot {
+        QueryMetricsSnapshot {
+            batches: self.batches.load(Ordering::Relaxed),
+            input_rows: self.input_rows.load(Ordering::Relaxed),
+            output_rows: self.output_rows.load(Ordering::Relaxed),
+            distinct_root_ids: self.distinct_root_ids.load(Ordering::Relaxed),
+            cache_hits: self.cache_hits.load(Ordering::Relaxed),
+            cache_misses: self.cache_misses.load(Ordering::Relaxed),
+            blob_requests: self.blob_requests.load(Ordering::Relaxed),
+            blob_bytes: self.blob_bytes.load(Ordering::Relaxed),
+            query_duration: Duration::from_nanos(self.query_duration_ns.load(Ordering::Relaxed)),
+            sqlite_duration: Duration::from_nanos(self.sqlite_duration_ns.load(Ordering::Relaxed)),
+            hydration_duration: Duration::from_nanos(
+                self.hydration_duration_ns.load(Ordering::Relaxed),
+            ),
+            blob_read_duration: Duration::from_nanos(
+                self.blob_read_duration_ns.load(Ordering::Relaxed),
+            ),
+            serialization_duration: Duration::from_nanos(
+                self.serialization_duration_ns.load(Ordering::Relaxed),
+            ),
+        }
+    }
+
+    pub(crate) fn record_query_duration(&self, duration: Duration) {
+        self.query_duration_ns
+            .fetch_add(duration_nanos(duration), Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_sqlite_duration(&self, duration: Duration) {
+        self.sqlite_duration_ns
+            .fetch_add(duration_nanos(duration), Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_hydration_duration(&self, duration: Duration) {
+        self.hydration_duration_ns
+            .fetch_add(duration_nanos(duration), Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_blob_read_duration(&self, duration: Duration) {
+        self.blob_read_duration_ns
+            .fetch_add(duration_nanos(duration), Ordering::Relaxed);
+    }
+
+    pub(crate) fn record_serialization_duration(&self, duration: Duration) {
+        self.serialization_duration_ns
+            .fetch_add(duration_nanos(duration), Ordering::Relaxed);
+    }
+}
+
+fn duration_nanos(duration: Duration) -> u64 {
+    u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
+}
+
+impl Default for QueryBudgets {
+    fn default() -> Self {
+        Self {
+            max_candidate_rows: 1_000_000,
+            max_value_depth: 64,
+            max_expanded_bytes: 64 * 1024 * 1024,
+            max_blob_bytes: 256 * 1024 * 1024,
+            max_distinct_values: 100_000,
+            max_query_duration: Duration::from_secs(60),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct QueryContext {
+    pub query_id: Uuid,
+    pub project_id: Arc<str>,
+    pub cancellation: CancellationToken,
+    pub deadline: Instant,
+    pub budgets: QueryBudgets,
+    pub metrics: Arc<QueryMetrics>,
+    hydrated_values: Arc<parking_lot::Mutex<std::collections::HashMap<ValueId, serde_json::Value>>>,
+}
+
+impl QueryContext {
+    pub fn new(project_id: impl Into<Arc<str>>) -> Self {
+        let budgets = QueryBudgets::default();
+        Self {
+            query_id: Uuid::new_v4(),
+            project_id: project_id.into(),
+            cancellation: CancellationToken::new(),
+            deadline: Instant::now() + budgets.max_query_duration,
+            budgets,
+            metrics: Arc::new(QueryMetrics::default()),
+            hydrated_values: Arc::new(parking_lot::Mutex::new(std::collections::HashMap::new())),
+        }
+    }
+
+    pub fn metrics_snapshot(&self) -> QueryMetricsSnapshot {
+        self.metrics.snapshot()
+    }
+
+    pub(crate) fn fresh(&self) -> Self {
+        let mut context = Self::new(self.project_id.clone()).with_budgets(self.budgets.clone());
+        context.cancellation = self.cancellation.clone();
+        context
+    }
+
+    #[must_use]
+    pub fn with_budgets(mut self, budgets: QueryBudgets) -> Self {
+        self.deadline = Instant::now() + budgets.max_query_duration;
+        self.budgets = budgets;
+        self
+    }
+
+    pub fn check_cancelled(&self) -> Result<()> {
+        if self.cancellation.is_cancelled() || Instant::now() >= self.deadline {
+            return Err(QueryError::Cancelled {
+                query_id: self.query_id,
+            });
+        }
+        Ok(())
+    }
+
+    pub(crate) fn cached_value(&self, id: &ValueId) -> Option<serde_json::Value> {
+        self.hydrated_values.lock().get(id).cloned()
+    }
+
+    pub(crate) fn cache_value(&self, id: ValueId, value: serde_json::Value) {
+        self.hydrated_values.lock().insert(id, value);
+    }
+}

--- a/baml_language/crates/baml_query/src/error.rs
+++ b/baml_language/crates/baml_query/src/error.rs
@@ -1,0 +1,50 @@
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+pub type Result<T> = std::result::Result<T, QueryError>;
+
+#[derive(Debug, Error)]
+pub enum QueryError {
+    #[error("query {query_id} was cancelled")]
+    Cancelled { query_id: uuid::Uuid },
+
+    #[error("query is not read-only: {0}")]
+    NotReadOnly(String),
+
+    #[error("value {value_id} is missing at {path}")]
+    MissingValue { value_id: String, path: PathBuf },
+
+    #[error("value {value_id} is corrupt: {message}")]
+    CorruptValue { value_id: String, message: String },
+
+    #[error("value expansion exceeded the configured limit")]
+    ValueLimit,
+
+    #[error("value reference cycle detected at {0}")]
+    ValueCycle(String),
+
+    #[error("invalid value ID: {0}")]
+    InvalidValueId(String),
+
+    #[error("SQLite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("DataFusion error: {0}")]
+    DataFusion(String),
+
+    #[error("internal error: {0}")]
+    Internal(String),
+}
+
+impl From<datafusion::error::DataFusionError> for QueryError {
+    fn from(error: datafusion::error::DataFusionError) -> Self {
+        Self::DataFusion(error.to_string())
+    }
+}

--- a/baml_language/crates/baml_query/src/functions.rs
+++ b/baml_language/crates/baml_query/src/functions.rs
@@ -1,0 +1,280 @@
+use std::sync::Arc;
+
+use datafusion::arrow::array::{
+    Array, BooleanBuilder, LargeBinaryArray, LargeBinaryBuilder, StringBuilder,
+};
+use datafusion::arrow::datatypes::DataType;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::logical_expr::{
+    ColumnarValue, ScalarFunctionArgs, ScalarUDF, ScalarUDFImpl, Signature, Volatility,
+};
+use datafusion::scalar::ScalarValue;
+use serde_json::Value;
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+struct ValueAt {
+    signature: Signature,
+}
+
+impl ScalarUDFImpl for ValueAt {
+    fn name(&self) -> &'static str {
+        "value_at"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+    fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+        Ok(DataType::LargeBinary)
+    }
+    fn invoke_with_args(
+        &self,
+        function_args: ScalarFunctionArgs,
+    ) -> DataFusionResult<ColumnarValue> {
+        let args = function_args.args;
+        let values = match args.first() {
+            Some(ColumnarValue::Array(array)) => array
+                .as_any()
+                .downcast_ref::<LargeBinaryArray>()
+                .ok_or_else(|| {
+                    DataFusionError::Execution("value_at expects BamlValue bytes".to_owned())
+                })?,
+            _ => {
+                return Err(DataFusionError::Execution(
+                    "value_at expects an array value".to_owned(),
+                ));
+            }
+        };
+        let index = match args.get(1) {
+            Some(ColumnarValue::Scalar(ScalarValue::Int64(Some(index)))) if *index >= 0 => {
+                usize::try_from(*index).map_err(|_| {
+                    DataFusionError::Execution("value_at index is too large".to_owned())
+                })?
+            }
+            Some(ColumnarValue::Scalar(ScalarValue::Int32(Some(index)))) if *index >= 0 => {
+                usize::try_from(*index).map_err(|_| {
+                    DataFusionError::Execution("value_at index is too large".to_owned())
+                })?
+            }
+            _ => {
+                return Err(DataFusionError::Execution(
+                    "value_at expects a non-negative integer index".to_owned(),
+                ));
+            }
+        };
+        let mut output = LargeBinaryBuilder::new();
+        for row in 0..values.len() {
+            if values.is_null(row) {
+                output.append_null();
+                continue;
+            }
+            let value: Value = serde_json::from_slice(values.value(row))
+                .map_err(|error| DataFusionError::Execution(error.to_string()))?;
+            match value.get(index) {
+                Some(value) => output.append_value(
+                    serde_json::to_vec(value)
+                        .map_err(|error| DataFusionError::Execution(error.to_string()))?,
+                ),
+                None => output.append_null(),
+            }
+        }
+        Ok(ColumnarValue::Array(Arc::new(output.finish())))
+    }
+}
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+struct Contains {
+    signature: Signature,
+}
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+struct ValueField {
+    signature: Signature,
+}
+
+impl ScalarUDFImpl for ValueField {
+    fn name(&self) -> &'static str {
+        "value_field"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+        Ok(DataType::LargeBinary)
+    }
+
+    fn invoke_with_args(
+        &self,
+        function_args: ScalarFunctionArgs,
+    ) -> DataFusionResult<ColumnarValue> {
+        let values = binary_argument(&function_args.args, "value_field")?;
+        let field = string_argument(&function_args.args, 1, "value_field")?;
+        let mut output = LargeBinaryBuilder::new();
+        for row in 0..values.len() {
+            if values.is_null(row) {
+                output.append_null();
+                continue;
+            }
+            let value: Value = serde_json::from_slice(values.value(row))
+                .map_err(|error| DataFusionError::Execution(error.to_string()))?;
+            match value.get(field) {
+                Some(value) => output.append_value(
+                    serde_json::to_vec(value)
+                        .map_err(|error| DataFusionError::Execution(error.to_string()))?,
+                ),
+                None => output.append_null(),
+            }
+        }
+        Ok(ColumnarValue::Array(Arc::new(output.finish())))
+    }
+}
+
+#[derive(Debug, Eq, Hash, PartialEq)]
+struct ValueString {
+    signature: Signature,
+}
+
+impl ScalarUDFImpl for ValueString {
+    fn name(&self) -> &'static str {
+        "value_string"
+    }
+
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+
+    fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+        Ok(DataType::Utf8)
+    }
+
+    fn invoke_with_args(
+        &self,
+        function_args: ScalarFunctionArgs,
+    ) -> DataFusionResult<ColumnarValue> {
+        let values = binary_argument(&function_args.args, "value_string")?;
+        let mut output = StringBuilder::new();
+        for row in 0..values.len() {
+            if values.is_null(row) {
+                output.append_null();
+                continue;
+            }
+            let value: Value = serde_json::from_slice(values.value(row))
+                .map_err(|error| DataFusionError::Execution(error.to_string()))?;
+            match value.as_str() {
+                Some(value) => output.append_value(value),
+                None => output.append_null(),
+            }
+        }
+        Ok(ColumnarValue::Array(Arc::new(output.finish())))
+    }
+}
+
+impl ScalarUDFImpl for Contains {
+    fn name(&self) -> &'static str {
+        "contains"
+    }
+    fn signature(&self) -> &Signature {
+        &self.signature
+    }
+    fn return_type(&self, _arg_types: &[DataType]) -> DataFusionResult<DataType> {
+        Ok(DataType::Boolean)
+    }
+    fn invoke_with_args(
+        &self,
+        function_args: ScalarFunctionArgs,
+    ) -> DataFusionResult<ColumnarValue> {
+        let args = function_args.args;
+        let values = match args.first() {
+            Some(ColumnarValue::Array(array)) => array
+                .as_any()
+                .downcast_ref::<LargeBinaryArray>()
+                .ok_or_else(|| {
+                    DataFusionError::Execution("contains expects BamlValue bytes".to_owned())
+                })?,
+            _ => {
+                return Err(DataFusionError::Execution(
+                    "contains expects an array value".to_owned(),
+                ));
+            }
+        };
+        let needle = match args.get(1) {
+            Some(ColumnarValue::Scalar(ScalarValue::Utf8(Some(value)))) => value.as_str(),
+            Some(ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(value)))) => value.as_str(),
+            _ => {
+                return Err(DataFusionError::Execution(
+                    "contains expects a string literal".to_owned(),
+                ));
+            }
+        };
+        let mut output = BooleanBuilder::new();
+        for row in 0..values.len() {
+            if values.is_null(row) {
+                output.append_null();
+                continue;
+            }
+            let value: Value = serde_json::from_slice(values.value(row))
+                .map_err(|error| DataFusionError::Execution(error.to_string()))?;
+            match value.as_str() {
+                Some(value) => output.append_value(value.contains(needle)),
+                None => output.append_null(),
+            }
+        }
+        Ok(ColumnarValue::Array(Arc::new(output.finish())))
+    }
+}
+
+pub fn register_builtin_functions(ctx: &datafusion::execution::context::SessionContext) {
+    ctx.register_udf(ScalarUDF::new_from_impl(ValueAt {
+        signature: Signature::exact(
+            vec![DataType::LargeBinary, DataType::Int64],
+            Volatility::Immutable,
+        ),
+    }));
+    ctx.register_udf(ScalarUDF::new_from_impl(Contains {
+        signature: Signature::exact(
+            vec![DataType::LargeBinary, DataType::Utf8],
+            Volatility::Immutable,
+        ),
+    }));
+    ctx.register_udf(ScalarUDF::new_from_impl(ValueField {
+        signature: Signature::exact(
+            vec![DataType::LargeBinary, DataType::Utf8],
+            Volatility::Immutable,
+        ),
+    }));
+    ctx.register_udf(ScalarUDF::new_from_impl(ValueString {
+        signature: Signature::exact(vec![DataType::LargeBinary], Volatility::Immutable),
+    }));
+}
+
+fn binary_argument<'a>(
+    args: &'a [ColumnarValue],
+    function_name: &str,
+) -> DataFusionResult<&'a LargeBinaryArray> {
+    match args.first() {
+        Some(ColumnarValue::Array(array)) => array
+            .as_any()
+            .downcast_ref::<LargeBinaryArray>()
+            .ok_or_else(|| {
+                DataFusionError::Execution(format!("{function_name} expects BamlValue bytes"))
+            }),
+        _ => Err(DataFusionError::Execution(format!(
+            "{function_name} expects an array value"
+        ))),
+    }
+}
+
+fn string_argument<'a>(
+    args: &'a [ColumnarValue],
+    index: usize,
+    function_name: &str,
+) -> DataFusionResult<&'a str> {
+    match args.get(index) {
+        Some(ColumnarValue::Scalar(ScalarValue::Utf8(Some(value)))) => Ok(value),
+        Some(ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(value)))) => Ok(value),
+        _ => Err(DataFusionError::Execution(format!(
+            "{function_name} expects a string literal"
+        ))),
+    }
+}

--- a/baml_language/crates/baml_query/src/hydrator.rs
+++ b/baml_language/crates/baml_query/src/hydrator.rs
@@ -1,0 +1,244 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use serde_json::{Map, Value};
+
+use crate::{QueryContext, QueryError, Result, ValueId, ValueStore};
+
+pub type HydratedValue = Value;
+
+/// A value file may contain this object to refer to another content-addressed
+/// value. The marker is deliberately explicit so ordinary JSON strings are not
+/// mistaken for references.
+pub(crate) const VALUE_REFERENCE_KEY: &str = "$value_ref";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValueReference(pub ValueId);
+
+#[async_trait]
+pub trait Hydrator: Send + Sync {
+    async fn hydrate_many(
+        &self,
+        roots: &[ValueId],
+        context: &QueryContext,
+    ) -> Result<HashMap<ValueId, HydratedValue>>;
+}
+
+pub struct RecursiveHydrator {
+    store: Arc<dyn ValueStore>,
+}
+
+impl RecursiveHydrator {
+    pub fn new(store: Arc<dyn ValueStore>) -> Self {
+        Self { store }
+    }
+
+    async fn load_graph(
+        &self,
+        roots: &[ValueId],
+        context: &QueryContext,
+    ) -> Result<HashMap<ValueId, Value>> {
+        let mut pending: Vec<ValueId> = roots.to_vec();
+        let mut loaded = HashMap::new();
+        let mut seen = HashSet::new();
+
+        while !pending.is_empty() {
+            context.check_cancelled()?;
+            let mut request = Vec::new();
+            for id in pending.drain(..) {
+                if seen.insert(id) {
+                    if let Some(value) = context.cached_value(&id) {
+                        context
+                            .metrics
+                            .cache_hits
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        loaded.insert(id, value);
+                    } else {
+                        context
+                            .metrics
+                            .cache_misses
+                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        request.push(id);
+                    }
+                }
+            }
+            if request.len() + loaded.len() > context.budgets.max_distinct_values {
+                return Err(QueryError::ValueLimit);
+            }
+            let blobs = self.store.get_many(&request, context).await?;
+            for id in request {
+                let bytes = blobs.get(&id).ok_or_else(|| QueryError::MissingValue {
+                    value_id: id.to_string(),
+                    path: std::path::PathBuf::new(),
+                })?;
+                let value: Value =
+                    serde_json::from_slice(bytes).map_err(|error| QueryError::CorruptValue {
+                        value_id: id.to_string(),
+                        message: error.to_string(),
+                    })?;
+                if ValueId::from_content(bytes) != id {
+                    return Err(QueryError::CorruptValue {
+                        value_id: id.to_string(),
+                        message: "content hash does not match the requested ID".to_owned(),
+                    });
+                }
+                collect_references(&value, &mut pending)?;
+                loaded.insert(id, value);
+            }
+        }
+        Ok(loaded)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn resolve(
+        &self,
+        id: ValueId,
+        value: &Value,
+        graph: &HashMap<ValueId, Value>,
+        active: &mut HashSet<ValueId>,
+        depth: usize,
+        expanded_bytes: &mut usize,
+        context: &QueryContext,
+    ) -> Result<Value> {
+        if depth > context.budgets.max_value_depth {
+            return Err(QueryError::ValueLimit);
+        }
+        if !active.insert(id) {
+            return Err(QueryError::ValueCycle(id.to_string()));
+        }
+        let result = self.resolve_value(value, graph, active, depth, expanded_bytes, context);
+        active.remove(&id);
+        result
+    }
+
+    fn resolve_value(
+        &self,
+        value: &Value,
+        graph: &HashMap<ValueId, Value>,
+        active: &mut HashSet<ValueId>,
+        depth: usize,
+        expanded_bytes: &mut usize,
+        context: &QueryContext,
+    ) -> Result<Value> {
+        let result = match value {
+            Value::Object(object)
+                if object.len() == 1 && object.contains_key(VALUE_REFERENCE_KEY) =>
+            {
+                let reference = object
+                    .get(VALUE_REFERENCE_KEY)
+                    .and_then(Value::as_str)
+                    .ok_or_else(|| QueryError::CorruptValue {
+                        value_id: "inline".to_owned(),
+                        message: "reference must be a string".to_owned(),
+                    })?;
+                let id = ValueId::from_hex(reference)?;
+                let child = graph.get(&id).ok_or_else(|| QueryError::MissingValue {
+                    value_id: id.to_string(),
+                    path: std::path::PathBuf::new(),
+                })?;
+                self.resolve(id, child, graph, active, depth + 1, expanded_bytes, context)?
+            }
+            Value::Array(values) => Value::Array(
+                values
+                    .iter()
+                    .map(|value| {
+                        self.resolve_value(value, graph, active, depth + 1, expanded_bytes, context)
+                    })
+                    .collect::<Result<_>>()?,
+            ),
+            Value::Object(object) => {
+                let mut output = Map::new();
+                for (key, value) in object {
+                    output.insert(
+                        key.clone(),
+                        self.resolve_value(
+                            value,
+                            graph,
+                            active,
+                            depth + 1,
+                            expanded_bytes,
+                            context,
+                        )?,
+                    );
+                }
+                Value::Object(output)
+            }
+            primitive => primitive.clone(),
+        };
+        *expanded_bytes += serde_json::to_vec(&result)?.len();
+        if *expanded_bytes > context.budgets.max_expanded_bytes {
+            return Err(QueryError::ValueLimit);
+        }
+        Ok(result)
+    }
+}
+
+#[async_trait]
+impl Hydrator for RecursiveHydrator {
+    async fn hydrate_many(
+        &self,
+        roots: &[ValueId],
+        context: &QueryContext,
+    ) -> Result<HashMap<ValueId, HydratedValue>> {
+        let graph = self.load_graph(roots, context).await?;
+        context.metrics.distinct_root_ids.fetch_add(
+            roots.iter().copied().collect::<HashSet<_>>().len(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        let mut resolved_graph = HashMap::with_capacity(graph.len());
+        for (id, value) in &graph {
+            let mut expanded_bytes = 0;
+            let resolved = self.resolve(
+                *id,
+                value,
+                &graph,
+                &mut HashSet::new(),
+                0,
+                &mut expanded_bytes,
+                context,
+            )?;
+            context.cache_value(*id, resolved.clone());
+            resolved_graph.insert(*id, resolved);
+        }
+        let mut output = HashMap::new();
+        for id in roots.iter().copied() {
+            let value = resolved_graph
+                .get(&id)
+                .ok_or_else(|| QueryError::MissingValue {
+                    value_id: id.to_string(),
+                    path: std::path::PathBuf::new(),
+                })?
+                .clone();
+            output.insert(id, value);
+        }
+        Ok(output)
+    }
+}
+
+fn collect_references(value: &Value, output: &mut Vec<ValueId>) -> Result<()> {
+    match value {
+        Value::Object(object) if object.len() == 1 && object.contains_key(VALUE_REFERENCE_KEY) => {
+            let value = object
+                .get(VALUE_REFERENCE_KEY)
+                .and_then(Value::as_str)
+                .ok_or_else(|| QueryError::CorruptValue {
+                    value_id: "inline".to_owned(),
+                    message: "reference must be a string".to_owned(),
+                })?;
+            output.push(ValueId::from_hex(value)?);
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_references(value, output)?;
+            }
+        }
+        Value::Object(object) => {
+            for value in object.values() {
+                collect_references(value, output)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}

--- a/baml_language/crates/baml_query/src/lib.rs
+++ b/baml_language/crates/baml_query/src/lib.rs
@@ -1,0 +1,906 @@
+//! SQL over resident `SQLite` columns with transparent value-file hydration.
+//!
+//! The crate deliberately keeps the physical representation separate from the
+//! SQL-facing schema. A query sees `args`, `return`, and `error`; `SQLite` stores
+//! nullable content IDs and the value store resolves those IDs on demand.
+
+mod catalog;
+mod context;
+mod error;
+mod functions;
+mod hydrator;
+mod provider;
+mod pushdown;
+mod resident;
+mod store;
+mod value_id;
+
+pub use catalog::{QueryCatalog, RelationshipCardinality, RelationshipDefinition, TableDefinition};
+pub use context::{QueryBudgets, QueryContext, QueryMetricsSnapshot};
+pub use error::{QueryError, Result};
+pub use functions::register_builtin_functions;
+pub use hydrator::{HydratedValue, Hydrator, RecursiveHydrator, ValueReference};
+pub use provider::{FunctionCallsTableSpec, QueryEngine, SqliteFunctionCallsProvider};
+pub use resident::SqliteColumnSpec;
+pub use resident::{
+    SqliteResidentTableSpec, SqliteTableProvider, SqliteTableSpec, standard_resident_table_specs,
+};
+pub use store::{LocalBlobStore, ValueStore};
+pub use value_id::ValueId;
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::array::{
+        Array, BooleanBuilder, Int64Array, LargeBinaryArray, StringArray, UInt64Array,
+    };
+    use datafusion::arrow::datatypes::DataType;
+    use datafusion::error::DataFusionError;
+    use datafusion::logical_expr::async_udf::AsyncScalarUDFImpl;
+    use datafusion::logical_expr::{
+        ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+    };
+    use rusqlite::Connection;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    use super::*;
+
+    fn create_database() -> Connection {
+        let connection = Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE function_calls (
+                id TEXT PRIMARY KEY,
+                project_id TEXT NOT NULL,
+                process_id TEXT,
+                thread_id TEXT,
+                cct_id TEXT,
+                captured_ts INTEGER,
+                name TEXT NOT NULL,
+                status TEXT,
+                metadata TEXT,
+                metrics TEXT,
+                args_value_id BLOB,
+                return_value_id BLOB,
+                error_value_id BLOB
+            );",
+            )
+            .unwrap();
+        connection
+    }
+
+    fn insert_call(connection: &Connection, id: &str, project_id: &str, args_id: Option<ValueId>) {
+        connection.execute(
+            "INSERT INTO function_calls (id, project_id, name, args_value_id) VALUES (?1, ?2, 'send_email', ?3)",
+            rusqlite::params![id, project_id, args_id.map(|id| id.as_bytes().to_vec())],
+        ).unwrap();
+    }
+
+    #[derive(Debug, Eq, Hash, PartialEq)]
+    struct IsSendEmail {
+        signature: Signature,
+    }
+
+    impl ScalarUDFImpl for IsSendEmail {
+        fn name(&self) -> &'static str {
+            "is_send_email"
+        }
+
+        fn signature(&self) -> &Signature {
+            &self.signature
+        }
+
+        fn return_type(&self, _arg_types: &[DataType]) -> datafusion::error::Result<DataType> {
+            Ok(DataType::Boolean)
+        }
+
+        fn invoke_with_args(
+            &self,
+            _args: ScalarFunctionArgs,
+        ) -> datafusion::error::Result<ColumnarValue> {
+            Err(DataFusionError::Execution(
+                "is_send_email must execute asynchronously".to_owned(),
+            ))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AsyncScalarUDFImpl for IsSendEmail {
+        async fn invoke_async_with_args(
+            &self,
+            function_args: ScalarFunctionArgs,
+        ) -> datafusion::error::Result<ColumnarValue> {
+            let values = match function_args.args.first() {
+                Some(ColumnarValue::Array(array)) => array
+                    .as_any()
+                    .downcast_ref::<StringArray>()
+                    .ok_or_else(|| {
+                    DataFusionError::Execution("expected string input".to_owned())
+                })?,
+                _ => {
+                    return Err(DataFusionError::Execution(
+                        "expected array input".to_owned(),
+                    ));
+                }
+            };
+            let mut output = BooleanBuilder::new();
+            for row in 0..values.len() {
+                output.append_value(!values.is_null(row) && values.value(row) == "send_email");
+            }
+            Ok(ColumnarValue::Array(Arc::new(output.finish())))
+        }
+    }
+
+    fn engine_for(connection: Connection, temp_dir: &TempDir) -> QueryEngine {
+        QueryEngine::new(
+            SqliteFunctionCallsProvider::from_connection(
+                connection,
+                temp_dir.path(),
+                Arc::<str>::from("p1"),
+            )
+            .unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn hydrates_nested_value_references() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = LocalBlobStore::new(temp_dir.path());
+        let child_bytes = serde_json::to_vec(&json!("hello")).unwrap();
+        let child_id = ValueId::from_content(&child_bytes);
+        store.put(child_id, &child_bytes).await.unwrap();
+
+        let root_value = json!([{"$value_ref": child_id.to_hex()}]);
+        let root_bytes = serde_json::to_vec(&root_value).unwrap();
+        let root_id = ValueId::from_content(&root_bytes);
+        store.put(root_id, &root_bytes).await.unwrap();
+
+        let connection = create_database();
+        insert_call(&connection, "call-1", "p1", Some(root_id));
+        let engine = engine_for(connection, &temp_dir);
+        let batches = engine
+            .execute("SELECT id FROM function_calls WHERE contains(value_at(args, 0), 'hello')")
+            .await
+            .unwrap();
+
+        let ids = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(ids.value(0), "call-1");
+    }
+
+    #[tokio::test]
+    async fn final_limit_is_applied_after_hydrated_filter() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = LocalBlobStore::new(temp_dir.path());
+        let miss_bytes = serde_json::to_vec(&json!(["nope"])).unwrap();
+        let miss_id = ValueId::from_content(&miss_bytes);
+        store.put(miss_id, &miss_bytes).await.unwrap();
+        let hit_bytes = serde_json::to_vec(&json!(["hi"])).unwrap();
+        let hit_id = ValueId::from_content(&hit_bytes);
+        store.put(hit_id, &hit_bytes).await.unwrap();
+
+        let connection = create_database();
+        for index in 0..500 {
+            insert_call(&connection, &format!("miss-{index}"), "p1", Some(miss_id));
+        }
+        for index in 0..100 {
+            insert_call(&connection, &format!("hit-{index}"), "p1", Some(hit_id));
+        }
+        let engine = engine_for(connection, &temp_dir);
+        let batches = engine
+            .execute(
+                "SELECT id FROM function_calls WHERE contains(value_at(args, 0), 'hi') LIMIT 100",
+            )
+            .await
+            .unwrap();
+
+        let ids = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(ids.len(), 100);
+        assert!(ids.value(0).starts_with("hit-"));
+    }
+
+    #[tokio::test]
+    async fn selecting_resident_columns_does_not_require_blob_files() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let connection = create_database();
+        insert_call(&connection, "call-1", "p1", None);
+        let engine = engine_for(connection, &temp_dir);
+        let batches = engine
+            .execute("SELECT id, name FROM function_calls")
+            .await
+            .unwrap();
+
+        assert_eq!(batches[0].num_rows(), 1);
+        assert_eq!(batches[0].schema().field(0).name(), "id");
+    }
+
+    #[tokio::test]
+    async fn projection_prunes_unrequested_hydrated_columns() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = LocalBlobStore::new(temp_dir.path());
+        let args_bytes = serde_json::to_vec(&json!(["args"])).unwrap();
+        let args_id = ValueId::from_content(&args_bytes);
+        store.put(args_id, &args_bytes).await.unwrap();
+        let connection = create_database();
+        insert_call(&connection, "call-1", "p1", Some(args_id));
+        let engine = engine_for(connection, &temp_dir);
+
+        let batches = engine
+            .execute("SELECT args FROM function_calls")
+            .await
+            .unwrap();
+        let values = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeBinaryArray>()
+            .unwrap();
+        assert_eq!(values.value(0), args_bytes.as_slice());
+    }
+
+    #[tokio::test]
+    async fn hydrated_columns_are_available_as_json_bytes() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = LocalBlobStore::new(temp_dir.path());
+        let bytes = serde_json::to_vec(&json!({"subject": "hello"})).unwrap();
+        let id = ValueId::from_content(&bytes);
+        store.put(id, &bytes).await.unwrap();
+        let connection = create_database();
+        insert_call(&connection, "call-1", "p1", Some(id));
+        let engine = engine_for(connection, &temp_dir);
+        let batches = engine
+            .execute("SELECT args FROM function_calls")
+            .await
+            .unwrap();
+
+        let values = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<LargeBinaryArray>()
+            .unwrap();
+        assert_eq!(values.value(0), bytes.as_slice());
+    }
+
+    #[tokio::test]
+    async fn value_field_and_value_string_compose_in_sql() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = LocalBlobStore::new(temp_dir.path());
+        let bytes = serde_json::to_vec(&json!({"subject": "hello"})).unwrap();
+        let id = ValueId::from_content(&bytes);
+        store.put(id, &bytes).await.unwrap();
+        let connection = create_database();
+        insert_call(&connection, "call-1", "p1", Some(id));
+        let engine = engine_for(connection, &temp_dir);
+
+        let batches = engine
+            .execute("SELECT id FROM function_calls WHERE value_string(value_field(args, 'subject')) = 'hello'")
+            .await
+            .unwrap();
+        let ids = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(ids.value(0), "call-1");
+    }
+
+    #[tokio::test]
+    async fn ctes_keep_resident_and_hydrated_filters_correct() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = LocalBlobStore::new(temp_dir.path());
+        let bytes = serde_json::to_vec(&json!(["hello"])).unwrap();
+        let id = ValueId::from_content(&bytes);
+        store.put(id, &bytes).await.unwrap();
+        let connection = create_database();
+        insert_call(&connection, "call-1", "p1", Some(id));
+        let engine = engine_for(connection, &temp_dir);
+
+        let batches = engine
+            .execute(
+                "WITH recent AS (SELECT * FROM function_calls WHERE name = 'send_email')
+                 SELECT id FROM recent
+                 WHERE contains(value_at(args, 0), 'hello')",
+            )
+            .await
+            .unwrap();
+        let ids = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(ids.value(0), "call-1");
+    }
+
+    #[tokio::test]
+    async fn mixed_or_predicates_are_not_partially_pushed() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = LocalBlobStore::new(temp_dir.path());
+        let hi_bytes = serde_json::to_vec(&json!(["hi"])).unwrap();
+        let hi_id = ValueId::from_content(&hi_bytes);
+        store.put(hi_id, &hi_bytes).await.unwrap();
+        let no_bytes = serde_json::to_vec(&json!(["no"])).unwrap();
+        let no_id = ValueId::from_content(&no_bytes);
+        store.put(no_id, &no_bytes).await.unwrap();
+        let connection = create_database();
+        connection
+            .execute(
+                "INSERT INTO function_calls (id, project_id, name, args_value_id) VALUES ('call-other', 'p1', 'other', ?1)",
+                rusqlite::params![hi_id.as_bytes().to_vec()],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO function_calls (id, project_id, name, args_value_id) VALUES ('call-send', 'p1', 'send_email', ?1)",
+                rusqlite::params![no_id.as_bytes().to_vec()],
+            )
+            .unwrap();
+        let engine = engine_for(connection, &temp_dir);
+
+        let batches = engine
+            .execute("SELECT id FROM function_calls WHERE name = 'send_email' OR contains(value_at(args, 0), 'hi') ORDER BY id")
+            .await
+            .unwrap();
+        let ids = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(ids.len(), 2);
+        assert_eq!(ids.value(0), "call-other");
+        assert_eq!(ids.value(1), "call-send");
+    }
+
+    #[tokio::test]
+    async fn resident_filters_are_pushed_before_hydration() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let connection = create_database();
+        let missing_id = ValueId::from_content(b"missing");
+        connection
+            .execute(
+                "INSERT INTO function_calls (id, project_id, name, args_value_id) VALUES ('call-1', 'p1', 'other', ?1)",
+                rusqlite::params![missing_id.as_bytes().to_vec()],
+            )
+            .unwrap();
+        let engine = engine_for(connection, &temp_dir);
+
+        let batches = engine
+            .execute("SELECT args FROM function_calls WHERE name = 'send_email'")
+            .await
+            .unwrap();
+        assert_eq!(
+            batches
+                .iter()
+                .map(datafusion::arrow::record_batch::RecordBatch::num_rows)
+                .sum::<usize>(),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn async_udfs_can_be_registered_and_used_in_filters() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let connection = create_database();
+        insert_call(&connection, "call-1", "p1", None);
+        let engine = engine_for(connection, &temp_dir);
+        engine.register_async_udf(Arc::new(IsSendEmail {
+            signature: Signature::exact(vec![DataType::Utf8], Volatility::Immutable),
+        }));
+
+        let batches = engine
+            .execute("SELECT id FROM function_calls WHERE is_send_email(name)")
+            .await
+            .unwrap();
+        let ids = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(ids.value(0), "call-1");
+    }
+
+    #[tokio::test]
+    async fn cancellation_stops_lazy_scan() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let connection = create_database();
+        insert_call(&connection, "call-1", "p1", None);
+        let engine = engine_for(connection, &temp_dir);
+        engine.cancel();
+
+        let error = engine
+            .execute("SELECT id FROM function_calls")
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("cancelled"));
+    }
+
+    #[tokio::test]
+    async fn standard_resident_tables_support_project_scoped_joins() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let connection = create_database();
+        connection
+            .execute_batch(
+                "CREATE TABLE processes (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, name TEXT);
+                 CREATE TABLE threads (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, process_id TEXT, name TEXT);
+                 CREATE TABLE ccts (id TEXT PRIMARY KEY, project_id TEXT NOT NULL, thread_id TEXT, name TEXT);
+                 INSERT INTO processes VALUES ('process-1', 'p1', 'worker');
+                 INSERT INTO threads VALUES ('thread-1', 'p1', 'process-1', 'thread');
+                 INSERT INTO ccts VALUES ('cct-1', 'p1', 'thread-1', 'root');",
+            )
+            .unwrap();
+        insert_call(&connection, "call-1", "p1", None);
+        connection
+            .execute(
+                "UPDATE function_calls SET process_id = 'process-1', thread_id = 'thread-1', cct_id = 'cct-1'
+                 WHERE id = 'call-1'",
+                [],
+            )
+            .unwrap();
+        let provider = SqliteFunctionCallsProvider::from_connection(
+            connection,
+            temp_dir.path(),
+            Arc::<str>::from("p1"),
+        )
+        .unwrap()
+        .with_standard_resident_tables()
+        .unwrap();
+        let engine = QueryEngine::new(provider).unwrap();
+
+        let batches = engine
+            .execute(
+                "SELECT f.id, p.name, t.name, c.name
+                 FROM function_calls f
+                 JOIN processes p ON p.id = f.process_id
+                 JOIN threads t ON t.id = f.thread_id
+                 JOIN ccts c ON c.id = f.cct_id
+                 WHERE f.name = 'send_email'",
+            )
+            .await
+            .unwrap();
+        assert_eq!(batches[0].num_rows(), 1);
+        let id = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let process_name = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(id.value(0), "call-1");
+        assert_eq!(process_name.value(0), "worker");
+    }
+
+    #[tokio::test]
+    async fn explain_exposes_the_sqlite_scan() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let connection = create_database();
+        insert_call(&connection, "call-1", "p1", None);
+        let engine = engine_for(connection, &temp_dir);
+        let batches = engine
+            .explain("SELECT id FROM function_calls WHERE name = 'send_email'")
+            .await
+            .unwrap();
+        assert!(!batches.is_empty());
+        let plan = batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .columns()
+                    .iter()
+                    .filter_map(|column| column.as_any().downcast_ref::<StringArray>())
+                    .flat_map(|column| (0..column.len()).map(|row| column.value(row).to_owned()))
+                    .collect::<Vec<_>>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(plan.contains("SQLite function_calls"));
+    }
+
+    #[tokio::test]
+    async fn candidate_row_budget_is_enforced() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let connection = create_database();
+        insert_call(&connection, "call-1", "p1", None);
+        let provider = SqliteFunctionCallsProvider::from_connection(
+            connection,
+            temp_dir.path(),
+            Arc::<str>::from("p1"),
+        )
+        .unwrap()
+        .with_budgets(QueryBudgets {
+            max_candidate_rows: 0,
+            ..QueryBudgets::default()
+        });
+        let engine = QueryEngine::new(provider).unwrap();
+        let error = engine
+            .execute("SELECT id FROM function_calls")
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("limit"));
+    }
+
+    #[tokio::test]
+    async fn metrics_capture_query_work_and_phase_timings() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let connection = create_database();
+        insert_call(&connection, "call-1", "p1", None);
+        let engine = engine_for(connection, &temp_dir);
+
+        engine
+            .execute("SELECT id FROM function_calls WHERE name = 'send_email'")
+            .await
+            .unwrap();
+
+        let metrics = engine.metrics();
+        assert_eq!(metrics.input_rows, 1);
+        assert_eq!(metrics.output_rows, 1);
+        assert_eq!(metrics.batches, 1);
+        assert!(metrics.query_duration > std::time::Duration::ZERO);
+        assert!(metrics.sqlite_duration > std::time::Duration::ZERO);
+    }
+
+    #[tokio::test]
+    async fn externally_defined_physical_layouts_are_mapped_to_logical_sql() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = LocalBlobStore::new(temp_dir.path());
+        let args_bytes = serde_json::to_vec(&json!(["hi"])).unwrap();
+        let args_id = ValueId::from_content(&args_bytes);
+        store.put(args_id, &args_bytes).await.unwrap();
+
+        let connection = Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE trace_rows (
+                    call_uuid TEXT PRIMARY KEY,
+                    tenant_key TEXT NOT NULL,
+                    proc_ref TEXT,
+                    thread_ref TEXT,
+                    cct_ref TEXT,
+                    event_time INTEGER,
+                    fn_name TEXT NOT NULL,
+                    state TEXT,
+                    meta_json TEXT,
+                    metric_json TEXT,
+                    arg_cid BLOB,
+                    ret_cid BLOB,
+                    err_cid BLOB
+                );
+                 CREATE TABLE process_catalog (
+                    process_key TEXT PRIMARY KEY,
+                    tenant_key TEXT NOT NULL,
+                    program_name TEXT
+                 );
+                 INSERT INTO process_catalog VALUES ('process-1', 'p1', 'worker');",
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO trace_rows
+                 (call_uuid, tenant_key, proc_ref, fn_name, arg_cid)
+                 VALUES ('call-1', 'p1', 'process-1', 'send_email', ?1)",
+                rusqlite::params![args_id.as_bytes().to_vec()],
+            )
+            .unwrap();
+
+        let function_calls = FunctionCallsTableSpec::new("trace_rows")
+            .unwrap()
+            .with_column("id", "call_uuid")
+            .unwrap()
+            .with_column("project_id", "tenant_key")
+            .unwrap()
+            .with_column("process_id", "proc_ref")
+            .unwrap()
+            .with_column("thread_id", "thread_ref")
+            .unwrap()
+            .with_column("cct_id", "cct_ref")
+            .unwrap()
+            .with_column("captured_ts", "event_time")
+            .unwrap()
+            .with_column("name", "fn_name")
+            .unwrap()
+            .with_column("status", "state")
+            .unwrap()
+            .with_column("metadata", "meta_json")
+            .unwrap()
+            .with_column("metrics", "metric_json")
+            .unwrap()
+            .with_column("args_value_id", "arg_cid")
+            .unwrap()
+            .with_column("return_value_id", "ret_cid")
+            .unwrap()
+            .with_column("error_value_id", "err_cid")
+            .unwrap();
+        let process_table = SqliteResidentTableSpec::from_columns(
+            "processes",
+            "process_catalog",
+            vec![
+                SqliteColumnSpec::new("id", "process_key", DataType::Utf8, false),
+                SqliteColumnSpec::new("project_id", "tenant_key", DataType::Utf8, false),
+                SqliteColumnSpec::new("name", "program_name", DataType::Utf8, true),
+            ],
+        )
+        .unwrap();
+        let provider = SqliteFunctionCallsProvider::from_connection(
+            connection,
+            temp_dir.path(),
+            Arc::<str>::from("p1"),
+        )
+        .unwrap()
+        .with_function_calls_table(function_calls)
+        .with_resident_table(process_table)
+        .unwrap();
+        let engine = QueryEngine::new(provider).unwrap();
+
+        let batches = engine
+            .execute(
+                "SELECT f.id, p.name
+                 FROM function_calls f
+                 JOIN processes p ON p.id = f.process_id
+                 WHERE f.name = 'send_email'
+                   AND contains(value_at(f.args, 0), 'hi')",
+            )
+            .await
+            .unwrap();
+        let ids = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let names = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(ids.value(0), "call-1");
+        assert_eq!(names.value(0), "worker");
+    }
+
+    #[tokio::test]
+    async fn arbitrary_table_specs_support_hydration_and_declared_relationships() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = LocalBlobStore::new(temp_dir.path());
+        let value_bytes = serde_json::to_vec(&json!("hello")).unwrap();
+        let value_id = ValueId::from_content(&value_bytes);
+        store.put(value_id, &value_bytes).await.unwrap();
+
+        let connection = Connection::open_in_memory().unwrap();
+        connection
+            .execute_batch(
+                "CREATE TABLE event_log (
+                    event_key INTEGER PRIMARY KEY,
+                    tenant_key TEXT NOT NULL,
+                    process_ref INTEGER,
+                    payload_cid BLOB
+                 );
+                 CREATE TABLE process_catalog (
+                    process_key INTEGER PRIMARY KEY,
+                    tenant_key TEXT NOT NULL,
+                    program_name TEXT
+                 );
+                 INSERT INTO process_catalog VALUES (7, 'p1', 'worker');
+                 INSERT INTO event_log VALUES (42, 'p1', 7, NULL);",
+            )
+            .unwrap();
+        connection
+            .execute(
+                "UPDATE event_log SET payload_cid = ?1 WHERE event_key = 42",
+                rusqlite::params![value_id.as_bytes().to_vec()],
+            )
+            .unwrap();
+
+        let events = SqliteTableSpec::from_columns(
+            "events",
+            "event_log",
+            vec![
+                SqliteColumnSpec::new("event_id", "event_key", DataType::UInt64, false),
+                SqliteColumnSpec::new("project_id", "tenant_key", DataType::Utf8, false),
+                SqliteColumnSpec::new("process_ref", "process_ref", DataType::UInt64, true),
+                SqliteColumnSpec::hydrated_value("payload", "payload_cid", true),
+            ],
+        )
+        .unwrap();
+        let processes = SqliteTableSpec::from_columns(
+            "processes",
+            "process_catalog",
+            vec![
+                SqliteColumnSpec::new("id", "process_key", DataType::UInt64, false),
+                SqliteColumnSpec::new("project_id", "tenant_key", DataType::Utf8, false),
+                SqliteColumnSpec::new("name", "program_name", DataType::Utf8, true),
+            ],
+        )
+        .unwrap();
+        let provider = SqliteFunctionCallsProvider::from_connection(
+            connection,
+            temp_dir.path(),
+            Arc::<str>::from("p1"),
+        )
+        .unwrap()
+        .with_table(events)
+        .unwrap()
+        .with_table(processes)
+        .unwrap();
+        let engine = QueryEngine::new(provider)
+            .unwrap()
+            .with_relationship(
+                RelationshipDefinition::many_to_one("events", "process_ref", "processes", "id")
+                    .project_scoped(),
+            )
+            .unwrap();
+
+        assert_eq!(engine.catalog().relationships().len(), 1);
+        let batches = engine
+            .execute(
+                "SELECT e.event_id
+                 FROM events e
+                 JOIN processes p ON p.id = e.process_ref
+                 WHERE p.name = 'worker' AND value_string(e.payload) = 'hello'",
+            )
+            .await
+            .unwrap();
+        let ids = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap();
+        assert_eq!(ids.value(0), 42);
+    }
+
+    #[tokio::test]
+    async fn resident_aggregations_work_without_hydration() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let connection = create_database();
+        connection
+            .execute(
+                "INSERT INTO function_calls (id, project_id, name, status) VALUES ('call-1', 'p1', 'send_email', 'ok')",
+                [],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO function_calls (id, project_id, name, status) VALUES ('call-2', 'p1', 'send_email', 'ok')",
+                [],
+            )
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO function_calls (id, project_id, name, status) VALUES ('call-3', 'p1', 'refund', 'error')",
+                [],
+            )
+            .unwrap();
+        let engine = engine_for(connection, &temp_dir);
+
+        let batches = engine
+            .execute(
+                "SELECT name, COUNT(*) AS count
+                 FROM function_calls
+                 GROUP BY name
+                 ORDER BY name",
+            )
+            .await
+            .unwrap();
+        assert_eq!(batches.len(), 1);
+        let names = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let counts = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(names.value(0), "refund");
+        assert_eq!(names.value(1), "send_email");
+        assert_eq!(counts.values(), &[1, 2]);
+        assert_eq!(engine.metrics().blob_requests, 0);
+
+        let distinct_batches = engine
+            .execute(
+                "SELECT COUNT(DISTINCT name) AS distinct_names
+                 FROM function_calls
+                 HAVING COUNT(*) = 3",
+            )
+            .await
+            .unwrap();
+        let distinct_names = distinct_batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(distinct_names.value(0), 2);
+    }
+
+    #[tokio::test]
+    async fn hydrated_scalar_aggregations_work() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = LocalBlobStore::new(temp_dir.path());
+        let make_value = |category: &str| {
+            let bytes = serde_json::to_vec(&json!({"category": category})).unwrap();
+            let id = ValueId::from_content(&bytes);
+            (id, bytes)
+        };
+        let (alpha_id, alpha_bytes) = make_value("alpha");
+        let (beta_id, beta_bytes) = make_value("beta");
+        store.put(alpha_id, &alpha_bytes).await.unwrap();
+        store.put(beta_id, &beta_bytes).await.unwrap();
+        let connection = create_database();
+        insert_call(&connection, "call-1", "p1", Some(alpha_id));
+        insert_call(&connection, "call-2", "p1", Some(alpha_id));
+        insert_call(&connection, "call-3", "p1", Some(beta_id));
+        let engine = engine_for(connection, &temp_dir);
+
+        let batches = engine
+            .execute(
+                "SELECT value_string(value_field(args, 'category')) AS category, COUNT(*) AS count
+                 FROM function_calls
+                 GROUP BY category
+                 ORDER BY category",
+            )
+            .await
+            .unwrap();
+        let categories = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let counts = batches[0]
+            .column(1)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(categories.value(0), "alpha");
+        assert_eq!(categories.value(1), "beta");
+        assert_eq!(counts.values(), &[2, 1]);
+        assert_eq!(engine.metrics().blob_requests, 2);
+    }
+
+    #[tokio::test]
+    async fn aggregation_after_hydrated_filter_counts_all_survivors() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let store = LocalBlobStore::new(temp_dir.path());
+        let make_value = |value: &str| {
+            let bytes = serde_json::to_vec(&json!([value])).unwrap();
+            let id = ValueId::from_content(&bytes);
+            (id, bytes)
+        };
+        let (hit_id, hit_bytes) = make_value("hit");
+        let (miss_id, miss_bytes) = make_value("miss");
+        store.put(hit_id, &hit_bytes).await.unwrap();
+        store.put(miss_id, &miss_bytes).await.unwrap();
+        let connection = create_database();
+        for index in 0..5 {
+            insert_call(&connection, &format!("hit-{index}"), "p1", Some(hit_id));
+        }
+        for index in 0..7 {
+            insert_call(&connection, &format!("miss-{index}"), "p1", Some(miss_id));
+        }
+        let engine = engine_for(connection, &temp_dir);
+
+        let batches = engine
+            .execute(
+                "SELECT COUNT(*) AS count
+                 FROM function_calls
+                 WHERE contains(value_at(args, 0), 'hit')",
+            )
+            .await
+            .unwrap();
+        let counts = batches[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+        assert_eq!(counts.value(0), 5);
+        assert_eq!(engine.metrics().input_rows, 12);
+        assert_eq!(engine.metrics().output_rows, 1);
+    }
+}

--- a/baml_language/crates/baml_query/src/provider.rs
+++ b/baml_language/crates/baml_query/src/provider.rs
@@ -1,0 +1,888 @@
+use std::any::Any;
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use datafusion::arrow::array::{ArrayRef, Int64Builder, LargeBinaryBuilder, StringBuilder};
+use datafusion::arrow::datatypes::{DataType, Field, Schema, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::catalog::Session;
+use datafusion::datasource::TableProvider;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::execution::context::SessionContext;
+use datafusion::logical_expr::async_udf::{AsyncScalarUDF, AsyncScalarUDFImpl};
+use datafusion::logical_expr::{Expr, ScalarUDF, TableProviderFilterPushDown, TableType};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::execution_plan::Boundedness;
+use datafusion::physical_plan::memory::{LazyBatchGenerator, LazyMemoryExec};
+use parking_lot::RwLock;
+use rusqlite::Connection;
+
+use crate::pushdown::SqlPredicate;
+use crate::resident::{SqliteColumnSpec, SqliteResidentTableSpec, SqliteTableProvider};
+use crate::{
+    Hydrator, QueryContext, QueryError, RecursiveHydrator, Result, ValueId, ValueStore,
+    register_builtin_functions,
+};
+
+const ARGS: usize = 10;
+const RETURN: usize = 11;
+const ERROR: usize = 12;
+const DEFAULT_BATCH_SIZE: usize = 2048;
+
+const FUNCTION_CALL_COLUMNS: [&str; 13] = [
+    "id",
+    "project_id",
+    "process_id",
+    "thread_id",
+    "cct_id",
+    "captured_ts",
+    "name",
+    "status",
+    "metadata",
+    "metrics",
+    "args_value_id",
+    "return_value_id",
+    "error_value_id",
+];
+
+#[derive(Clone, Debug)]
+pub struct FunctionCallsTableSpec {
+    pub physical_name: String,
+    columns: HashMap<String, String>,
+}
+
+impl FunctionCallsTableSpec {
+    pub fn new(physical_name: impl Into<String>) -> Result<Self> {
+        let physical_name = physical_name.into();
+        validate_identifier(&physical_name)?;
+        Ok(Self {
+            physical_name,
+            columns: FUNCTION_CALL_COLUMNS
+                .into_iter()
+                .map(|column| (column.to_owned(), column.to_owned()))
+                .collect(),
+        })
+    }
+
+    pub fn with_column(
+        mut self,
+        logical_name: impl Into<String>,
+        physical_name: impl Into<String>,
+    ) -> Result<Self> {
+        let logical_name = logical_name.into();
+        let physical_name = physical_name.into();
+        if !FUNCTION_CALL_COLUMNS.contains(&logical_name.as_str()) {
+            return Err(QueryError::Internal(format!(
+                "unknown function_calls logical column: {logical_name}"
+            )));
+        }
+        validate_identifier(&physical_name)?;
+        self.columns.insert(logical_name, physical_name);
+        Ok(self)
+    }
+
+    pub(crate) fn physical_column(&self, logical_name: &str) -> &str {
+        self.columns
+            .get(logical_name)
+            .map(String::as_str)
+            .expect("function_calls spec contains every logical column")
+    }
+
+    pub(crate) fn resident_mapping(&self) -> HashMap<String, String> {
+        FUNCTION_CALL_COLUMNS[..10]
+            .iter()
+            .map(|logical_name| {
+                (
+                    (*logical_name).to_owned(),
+                    quote_identifier(self.physical_column(logical_name)),
+                )
+            })
+            .collect()
+    }
+
+    pub(crate) fn sqlite_table_spec(&self) -> Result<SqliteResidentTableSpec> {
+        let columns = vec![
+            SqliteColumnSpec::new("id", self.physical_column("id"), DataType::Utf8, false),
+            SqliteColumnSpec::new(
+                "project_id",
+                self.physical_column("project_id"),
+                DataType::Utf8,
+                false,
+            ),
+            SqliteColumnSpec::new(
+                "process_id",
+                self.physical_column("process_id"),
+                DataType::Utf8,
+                true,
+            ),
+            SqliteColumnSpec::new(
+                "thread_id",
+                self.physical_column("thread_id"),
+                DataType::Utf8,
+                true,
+            ),
+            SqliteColumnSpec::new(
+                "cct_id",
+                self.physical_column("cct_id"),
+                DataType::Utf8,
+                true,
+            ),
+            SqliteColumnSpec::new(
+                "captured_ts",
+                self.physical_column("captured_ts"),
+                DataType::Int64,
+                true,
+            ),
+            SqliteColumnSpec::new("name", self.physical_column("name"), DataType::Utf8, false),
+            SqliteColumnSpec::new(
+                "status",
+                self.physical_column("status"),
+                DataType::Utf8,
+                true,
+            ),
+            SqliteColumnSpec::new(
+                "metadata",
+                self.physical_column("metadata"),
+                DataType::Utf8,
+                true,
+            ),
+            SqliteColumnSpec::new(
+                "metrics",
+                self.physical_column("metrics"),
+                DataType::Utf8,
+                true,
+            ),
+            SqliteColumnSpec::hydrated_value("args", self.physical_column("args_value_id"), true),
+            SqliteColumnSpec::hydrated_value(
+                "return",
+                self.physical_column("return_value_id"),
+                true,
+            ),
+            SqliteColumnSpec::hydrated_value("error", self.physical_column("error_value_id"), true),
+        ];
+        SqliteResidentTableSpec::from_columns("function_calls", self.physical_name.clone(), columns)
+    }
+}
+
+#[derive(Clone)]
+pub struct SqliteFunctionCallsProvider {
+    connection: Arc<Mutex<Connection>>,
+    schema: SchemaRef,
+    table_spec: FunctionCallsTableSpec,
+    hydrator: Arc<dyn Hydrator>,
+    query_context: QueryContext,
+    batch_size: usize,
+    resident_tables: Vec<SqliteResidentTableSpec>,
+}
+
+impl SqliteFunctionCallsProvider {
+    pub fn open(
+        path: impl AsRef<std::path::Path>,
+        blob_root: impl AsRef<std::path::Path>,
+        project_id: impl Into<Arc<str>>,
+    ) -> Result<Self> {
+        let connection = Connection::open(path)?;
+        connection.pragma_update(None, "query_only", true)?;
+        Self::from_connection(connection, blob_root, project_id)
+    }
+
+    pub fn from_connection(
+        connection: Connection,
+        blob_root: impl AsRef<std::path::Path>,
+        project_id: impl Into<Arc<str>>,
+    ) -> Result<Self> {
+        connection.pragma_update(None, "query_only", true)?;
+        let store: Arc<dyn ValueStore> =
+            Arc::new(crate::LocalBlobStore::new(blob_root.as_ref().to_path_buf()));
+        Self::with_store(connection, store, project_id)
+    }
+
+    pub fn with_store(
+        connection: Connection,
+        store: Arc<dyn ValueStore>,
+        project_id: impl Into<Arc<str>>,
+    ) -> Result<Self> {
+        Ok(Self {
+            connection: Arc::new(Mutex::new(connection)),
+            schema: logical_schema(),
+            table_spec: FunctionCallsTableSpec::new("function_calls")?,
+            hydrator: Arc::new(RecursiveHydrator::new(store)),
+            query_context: QueryContext::new(project_id),
+            batch_size: DEFAULT_BATCH_SIZE,
+            resident_tables: Vec::new(),
+        })
+    }
+
+    #[must_use]
+    pub fn with_batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = batch_size.max(1);
+        self
+    }
+
+    #[must_use]
+    pub fn with_budgets(mut self, budgets: crate::QueryBudgets) -> Self {
+        self.query_context = self.query_context.with_budgets(budgets);
+        self
+    }
+
+    #[must_use]
+    pub fn with_function_calls_table(mut self, table_spec: FunctionCallsTableSpec) -> Self {
+        self.table_spec = table_spec;
+        self
+    }
+
+    pub fn with_resident_table(mut self, spec: SqliteResidentTableSpec) -> Result<Self> {
+        if spec.name == "function_calls" {
+            return Err(QueryError::Internal(
+                "function_calls is already registered".to_owned(),
+            ));
+        }
+        self.resident_tables.push(spec);
+        Ok(self)
+    }
+
+    pub fn with_table(self, spec: SqliteResidentTableSpec) -> Result<Self> {
+        self.with_resident_table(spec)
+    }
+
+    pub fn with_standard_resident_tables(mut self) -> Result<Self> {
+        for spec in crate::standard_resident_table_specs()? {
+            self = self.with_resident_table(spec)?;
+        }
+        Ok(self)
+    }
+
+    pub fn query_context(&self) -> QueryContext {
+        self.query_context.clone()
+    }
+
+    fn for_query(&self) -> Self {
+        let mut provider = self.clone();
+        provider.query_context = self.query_context.fresh();
+        provider
+    }
+
+    pub fn metrics(&self) -> crate::QueryMetricsSnapshot {
+        self.query_context.metrics_snapshot()
+    }
+}
+
+impl fmt::Debug for SqliteFunctionCallsProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SqliteFunctionCallsProvider")
+            .field("schema", &self.schema)
+            .field("table_spec", &self.table_spec)
+            .field("project_id", &self.query_context.project_id)
+            .field("batch_size", &self.batch_size)
+            .field("resident_tables", &self.resident_tables)
+            .finish_non_exhaustive()
+    }
+}
+
+#[async_trait::async_trait]
+impl TableProvider for SqliteFunctionCallsProvider {
+    fn schema(&self) -> SchemaRef {
+        self.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        let columns = self.table_spec.resident_mapping();
+        Ok(filters
+            .iter()
+            .map(|filter| {
+                if crate::pushdown::to_sql_for_columns(filter, &columns).is_some() {
+                    TableProviderFilterPushDown::Exact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            })
+            .collect())
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let needs_values = projection
+            .map(|projection| {
+                [
+                    projection.contains(&ARGS),
+                    projection.contains(&RETURN),
+                    projection.contains(&ERROR),
+                ]
+            })
+            .unwrap_or([true; 3]);
+        let generator = SqliteBatchGenerator {
+            connection: Arc::clone(&self.connection),
+            schema: self.schema.clone(),
+            table_spec: self.table_spec.clone(),
+            hydrator: Arc::clone(&self.hydrator),
+            query_context: self.query_context.clone(),
+            predicates: {
+                let columns = self.table_spec.resident_mapping();
+                filters
+                    .iter()
+                    .filter_map(|filter| crate::pushdown::to_sql_for_columns(filter, &columns))
+                    .collect()
+            },
+            needs_values,
+            batch_size: self.batch_size,
+            offset: 0,
+        };
+        let exec = LazyMemoryExec::try_new(self.schema(), vec![Arc::new(RwLock::new(generator))])?
+            .with_projection(projection.cloned());
+        Ok(Arc::new(exec))
+    }
+}
+
+struct SqliteBatchGenerator {
+    connection: Arc<Mutex<Connection>>,
+    schema: SchemaRef,
+    table_spec: FunctionCallsTableSpec,
+    hydrator: Arc<dyn Hydrator>,
+    query_context: QueryContext,
+    predicates: Vec<SqlPredicate>,
+    needs_values: [bool; 3],
+    batch_size: usize,
+    offset: usize,
+}
+
+impl fmt::Debug for SqliteBatchGenerator {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SqliteBatchGenerator")
+            .field("batch_size", &self.batch_size)
+            .field("offset", &self.offset)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for SqliteBatchGenerator {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let predicates = self
+            .predicates
+            .iter()
+            .map(|predicate| predicate.sql.as_str())
+            .collect::<Vec<_>>()
+            .join(" AND ");
+        write!(
+            formatter,
+            "SQLite function_calls batch_size={} offset={} predicates={}",
+            self.batch_size, self.offset, predicates
+        )
+    }
+}
+
+impl LazyBatchGenerator for SqliteBatchGenerator {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn boundedness(&self) -> Boundedness {
+        Boundedness::Bounded
+    }
+
+    fn generate_next_batch(&mut self) -> datafusion::error::Result<Option<RecordBatch>> {
+        self.query_batch()
+            .map_err(|error| DataFusionError::Execution(error.to_string()))
+    }
+
+    fn reset_state(&self) -> Arc<RwLock<dyn LazyBatchGenerator>> {
+        Arc::new(RwLock::new(Self {
+            connection: Arc::clone(&self.connection),
+            schema: self.schema.clone(),
+            table_spec: self.table_spec.clone(),
+            hydrator: Arc::clone(&self.hydrator),
+            query_context: self.query_context.clone(),
+            predicates: self.predicates.clone(),
+            needs_values: self.needs_values,
+            batch_size: self.batch_size,
+            offset: 0,
+        }))
+    }
+}
+
+impl SqliteBatchGenerator {
+    fn query_batch(&mut self) -> Result<Option<RecordBatch>> {
+        self.query_context.check_cancelled()?;
+        let sqlite_started = std::time::Instant::now();
+        let candidate_result = (|| -> Result<_> {
+            let physical = |logical_name: &str| {
+                quote_identifier(self.table_spec.physical_column(logical_name))
+            };
+            let (
+                ids,
+                project_ids,
+                process_ids,
+                thread_ids,
+                cct_ids,
+                captured_ts,
+                names,
+                statuses,
+                metadata,
+                metrics,
+                args_ids,
+                return_ids,
+                error_ids,
+            ) = {
+                let connection = self
+                    .connection
+                    .lock()
+                    .map_err(|_| QueryError::Internal("SQLite mutex poisoned".to_owned()))?;
+                let mut sql = format!(
+                    "SELECT {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}, {}
+                         FROM {} WHERE {} = ?",
+                    physical("id"),
+                    physical("project_id"),
+                    physical("process_id"),
+                    physical("thread_id"),
+                    physical("cct_id"),
+                    physical("captured_ts"),
+                    physical("name"),
+                    physical("status"),
+                    physical("metadata"),
+                    physical("metrics"),
+                    physical("args_value_id"),
+                    physical("return_value_id"),
+                    physical("error_value_id"),
+                    quote_identifier(&self.table_spec.physical_name),
+                    physical("project_id"),
+                );
+                let mut params = vec![rusqlite::types::Value::Text(
+                    self.query_context.project_id.to_string(),
+                )];
+                for predicate in &self.predicates {
+                    sql.push_str(" AND ");
+                    sql.push_str(&predicate.sql);
+                    params.extend(predicate.params.iter().cloned());
+                }
+                sql.push_str(" ORDER BY rowid LIMIT ? OFFSET ?");
+                params.push(rusqlite::types::Value::Integer(
+                    i64::try_from(self.batch_size).map_err(|_| QueryError::ValueLimit)?,
+                ));
+                params.push(rusqlite::types::Value::Integer(
+                    i64::try_from(self.offset).map_err(|_| QueryError::ValueLimit)?,
+                ));
+                let mut statement = connection.prepare(&sql)?;
+                let mut rows = statement.query(rusqlite::params_from_iter(params.iter()))?;
+                let mut ids = Vec::new();
+                let mut project_ids = Vec::new();
+                let mut process_ids = Vec::new();
+                let mut thread_ids = Vec::new();
+                let mut cct_ids = Vec::new();
+                let mut captured_ts = Vec::new();
+                let mut names = Vec::new();
+                let mut statuses = Vec::new();
+                let mut metadata = Vec::new();
+                let mut metrics = Vec::new();
+                let mut args_ids = Vec::new();
+                let mut return_ids = Vec::new();
+                let mut error_ids = Vec::new();
+                while let Some(row) = rows.next()? {
+                    ids.push(row.get::<_, String>(0)?);
+                    project_ids.push(row.get::<_, String>(1)?);
+                    process_ids.push(row.get::<_, Option<String>>(2)?);
+                    thread_ids.push(row.get::<_, Option<String>>(3)?);
+                    cct_ids.push(row.get::<_, Option<String>>(4)?);
+                    captured_ts.push(row.get::<_, Option<i64>>(5)?);
+                    names.push(row.get::<_, String>(6)?);
+                    statuses.push(row.get::<_, Option<String>>(7)?);
+                    metadata.push(row.get::<_, Option<String>>(8)?);
+                    metrics.push(row.get::<_, Option<String>>(9)?);
+                    args_ids.push(read_id(row, 10)?);
+                    return_ids.push(read_id(row, 11)?);
+                    error_ids.push(read_id(row, 12)?);
+                }
+                (
+                    ids,
+                    project_ids,
+                    process_ids,
+                    thread_ids,
+                    cct_ids,
+                    captured_ts,
+                    names,
+                    statuses,
+                    metadata,
+                    metrics,
+                    args_ids,
+                    return_ids,
+                    error_ids,
+                )
+            };
+            Ok((
+                ids,
+                project_ids,
+                process_ids,
+                thread_ids,
+                cct_ids,
+                captured_ts,
+                names,
+                statuses,
+                metadata,
+                metrics,
+                args_ids,
+                return_ids,
+                error_ids,
+            ))
+        })();
+        self.query_context
+            .metrics
+            .record_sqlite_duration(sqlite_started.elapsed());
+        let (
+            ids,
+            project_ids,
+            process_ids,
+            thread_ids,
+            cct_ids,
+            captured_ts,
+            names,
+            statuses,
+            metadata,
+            metrics,
+            args_ids,
+            return_ids,
+            error_ids,
+        ) = candidate_result?;
+
+        if ids.is_empty() {
+            return Ok(None);
+        }
+        if self.offset.saturating_add(ids.len()) > self.query_context.budgets.max_candidate_rows {
+            return Err(QueryError::ValueLimit);
+        }
+        self.offset += ids.len();
+        self.query_context
+            .metrics
+            .batches
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.query_context
+            .metrics
+            .input_rows
+            .fetch_add(ids.len(), std::sync::atomic::Ordering::Relaxed);
+        let args = self.hydrate_column(&args_ids, self.needs_values[0])?;
+        let returns = self.hydrate_column(&return_ids, self.needs_values[1])?;
+        let errors = self.hydrate_column(&error_ids, self.needs_values[2])?;
+        let arrays: Vec<ArrayRef> = vec![
+            strings(ids),
+            strings(project_ids),
+            optional_strings(process_ids),
+            optional_strings(thread_ids),
+            optional_strings(cct_ids),
+            optional_ints(captured_ts),
+            strings(names),
+            optional_strings(statuses),
+            optional_strings(metadata),
+            optional_strings(metrics),
+            binaries(args),
+            binaries(returns),
+            binaries(errors),
+        ];
+        Ok(Some(
+            RecordBatch::try_new(self.schema.clone(), arrays)
+                .map_err(|error| QueryError::Internal(error.to_string()))?,
+        ))
+    }
+
+    fn hydrate_column(
+        &self,
+        ids: &[Option<ValueId>],
+        needed: bool,
+    ) -> Result<Vec<Option<Vec<u8>>>> {
+        if !needed {
+            return Ok(vec![None; ids.len()]);
+        }
+        let roots: Vec<ValueId> = ids.iter().flatten().copied().collect();
+        if roots.is_empty() {
+            return Ok(vec![None; ids.len()]);
+        }
+        let hydration_started = std::time::Instant::now();
+        let values =
+            futures::executor::block_on(self.hydrator.hydrate_many(&roots, &self.query_context))?;
+        self.query_context
+            .metrics
+            .record_hydration_duration(hydration_started.elapsed());
+        let serialization_started = std::time::Instant::now();
+        let result = ids
+            .iter()
+            .map(|id| match id {
+                None => Ok(None),
+                Some(id) => {
+                    let value = values.get(id).ok_or_else(|| QueryError::MissingValue {
+                        value_id: id.to_string(),
+                        path: std::path::PathBuf::new(),
+                    })?;
+                    Ok(Some(serde_json::to_vec(value)?))
+                }
+            })
+            .collect();
+        self.query_context
+            .metrics
+            .record_serialization_duration(serialization_started.elapsed());
+        result
+    }
+}
+
+pub struct QueryEngine {
+    provider: SqliteFunctionCallsProvider,
+    catalog: crate::QueryCatalog,
+    udfs: parking_lot::Mutex<Vec<ScalarUDF>>,
+    last_metrics: parking_lot::Mutex<crate::QueryMetricsSnapshot>,
+}
+
+impl QueryEngine {
+    pub fn new(provider: SqliteFunctionCallsProvider) -> Result<Self> {
+        let mut catalog = crate::QueryCatalog::new();
+        catalog.register_sqlite_table(&provider.table_spec.sqlite_table_spec()?)?;
+        for spec in &provider.resident_tables {
+            catalog.register_sqlite_table(spec)?;
+        }
+        Ok(Self {
+            provider,
+            catalog,
+            udfs: parking_lot::Mutex::new(Vec::new()),
+            last_metrics: parking_lot::Mutex::new(crate::QueryMetricsSnapshot::default()),
+        })
+    }
+
+    fn new_context(&self) -> Result<(SessionContext, QueryContext)> {
+        let provider = self.provider.for_query();
+        let query_context = provider.query_context();
+        let context = SessionContext::new();
+        context.register_table(
+            "function_calls",
+            Arc::new(SqliteTableProvider::new(
+                Arc::clone(&provider.connection),
+                provider.table_spec.sqlite_table_spec()?,
+                Arc::clone(&provider.hydrator),
+                query_context.clone(),
+                provider.batch_size,
+            )),
+        )?;
+        for spec in &self.provider.resident_tables {
+            context.register_table(
+                spec.name.clone(),
+                Arc::new(SqliteTableProvider::new(
+                    Arc::clone(&self.provider.connection),
+                    spec.clone(),
+                    Arc::clone(&self.provider.hydrator),
+                    query_context.clone(),
+                    self.provider.batch_size,
+                )),
+            )?;
+        }
+        register_builtin_functions(&context);
+        for udf in self.udfs.lock().iter().cloned() {
+            context.register_udf(udf);
+        }
+        Ok((context, query_context))
+    }
+
+    pub fn with_relationship(
+        mut self,
+        relationship: crate::RelationshipDefinition,
+    ) -> Result<Self> {
+        self.catalog.register_relationship(relationship)?;
+        Ok(self)
+    }
+
+    #[must_use]
+    pub fn catalog(&self) -> &crate::QueryCatalog {
+        &self.catalog
+    }
+
+    /// Registers an allowlisted `DataFusion` scalar UDF for subsequent queries.
+    /// Async UDFs can be wrapped with `DataFusion`'s `AsyncScalarUDF` adapter.
+    pub fn register_udf(&self, udf: ScalarUDF) {
+        self.udfs.lock().push(udf);
+    }
+
+    /// Registers a batch-oriented asynchronous UDF implementation.
+    pub fn register_async_udf(&self, udf: Arc<dyn AsyncScalarUDFImpl>) {
+        self.register_udf(AsyncScalarUDF::new(udf).into_scalar_udf());
+    }
+
+    pub fn query_context(&self) -> QueryContext {
+        self.provider.query_context()
+    }
+
+    pub fn metrics(&self) -> crate::QueryMetricsSnapshot {
+        self.last_metrics.lock().clone()
+    }
+
+    pub fn cancel(&self) {
+        self.provider.query_context().cancellation.cancel();
+    }
+
+    pub async fn execute(&self, sql: &str) -> Result<Vec<RecordBatch>> {
+        validate_read_only(sql)?;
+        let (context, query_context) = self.new_context()?;
+        let started = std::time::Instant::now();
+        let result = match context.sql(sql).await {
+            Ok(dataframe) => dataframe.collect().await,
+            Err(error) => Err(error),
+        };
+        query_context
+            .metrics
+            .record_query_duration(started.elapsed());
+        let batches = result?;
+        query_context.metrics.output_rows.fetch_add(
+            batches.iter().map(RecordBatch::num_rows).sum(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        *self.last_metrics.lock() = query_context.metrics_snapshot();
+        Ok(batches)
+    }
+
+    pub async fn explain(&self, sql: &str) -> Result<Vec<RecordBatch>> {
+        validate_read_only(sql)?;
+        let (context, query_context) = self.new_context()?;
+        let started = std::time::Instant::now();
+        let result = match context.sql(&format!("EXPLAIN {sql}")).await {
+            Ok(dataframe) => dataframe.collect().await,
+            Err(error) => Err(error),
+        };
+        query_context
+            .metrics
+            .record_query_duration(started.elapsed());
+        let batches = result?;
+        query_context.metrics.output_rows.fetch_add(
+            batches.iter().map(RecordBatch::num_rows).sum(),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        *self.last_metrics.lock() = query_context.metrics_snapshot();
+        Ok(batches)
+    }
+}
+
+fn logical_schema() -> SchemaRef {
+    let baml_metadata = HashMap::from([
+        (
+            "ARROW:extension:name".to_owned(),
+            "boundary.baml_value".to_owned(),
+        ),
+        ("ARROW:extension:metadata".to_owned(), "v1".to_owned()),
+    ]);
+    Arc::new(Schema::new(vec![
+        Field::new("id", DataType::Utf8, false),
+        Field::new("project_id", DataType::Utf8, false),
+        Field::new("process_id", DataType::Utf8, true),
+        Field::new("thread_id", DataType::Utf8, true),
+        Field::new("cct_id", DataType::Utf8, true),
+        Field::new("captured_ts", DataType::Int64, true),
+        Field::new("name", DataType::Utf8, false),
+        Field::new("status", DataType::Utf8, true),
+        Field::new("metadata", DataType::Utf8, true),
+        Field::new("metrics", DataType::Utf8, true),
+        Field::new("args", DataType::LargeBinary, true).with_metadata(baml_metadata.clone()),
+        Field::new("return", DataType::LargeBinary, true).with_metadata(baml_metadata.clone()),
+        Field::new("error", DataType::LargeBinary, true).with_metadata(baml_metadata),
+    ]))
+}
+
+fn read_id(row: &rusqlite::Row<'_>, index: usize) -> Result<Option<ValueId>> {
+    let bytes: Option<Vec<u8>> = row.get(index)?;
+    match bytes {
+        None => Ok(None),
+        Some(bytes) if bytes.len() == ValueId::LEN => {
+            Ok(Some(ValueId::from_bytes(bytes.try_into().map_err(
+                |_| QueryError::InvalidValueId("wrong byte length".to_owned()),
+            )?)))
+        }
+        Some(bytes) => Err(QueryError::InvalidValueId(format!(
+            "expected 32 bytes, got {}",
+            bytes.len()
+        ))),
+    }
+}
+
+fn strings(values: Vec<String>) -> ArrayRef {
+    let mut builder = StringBuilder::new();
+    for value in values {
+        builder.append_value(value);
+    }
+    Arc::new(builder.finish())
+}
+
+fn optional_strings(values: Vec<Option<String>>) -> ArrayRef {
+    let mut builder = StringBuilder::new();
+    for value in values {
+        match value {
+            Some(value) => builder.append_value(value),
+            None => builder.append_null(),
+        }
+    }
+    Arc::new(builder.finish())
+}
+
+fn optional_ints(values: Vec<Option<i64>>) -> ArrayRef {
+    let mut builder = Int64Builder::new();
+    for value in values {
+        match value {
+            Some(value) => builder.append_value(value),
+            None => builder.append_null(),
+        }
+    }
+    Arc::new(builder.finish())
+}
+
+fn binaries(values: Vec<Option<Vec<u8>>>) -> ArrayRef {
+    let mut builder = LargeBinaryBuilder::new();
+    for value in values {
+        match value {
+            Some(value) => builder.append_value(value),
+            None => builder.append_null(),
+        }
+    }
+    Arc::new(builder.finish())
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+fn validate_identifier(identifier: &str) -> Result<()> {
+    if identifier.is_empty()
+        || !identifier
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+    {
+        return Err(QueryError::Internal(format!(
+            "invalid SQLite identifier: {identifier}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_read_only(sql: &str) -> Result<()> {
+    let statements = sql
+        .split(';')
+        .map(str::trim)
+        .filter(|statement| !statement.is_empty())
+        .collect::<Vec<_>>();
+    if statements.len() != 1 {
+        return Err(QueryError::NotReadOnly(
+            "multiple statements are not allowed".to_owned(),
+        ));
+    }
+    let normalized = statements[0].to_ascii_lowercase();
+    if !(normalized.starts_with("select ")
+        || normalized == "select"
+        || normalized.starts_with("with ")
+        || normalized.starts_with("explain "))
+    {
+        return Err(QueryError::NotReadOnly(statements[0].to_owned()));
+    }
+    Ok(())
+}

--- a/baml_language/crates/baml_query/src/pushdown.rs
+++ b/baml_language/crates/baml_query/src/pushdown.rs
@@ -1,0 +1,103 @@
+use datafusion::logical_expr::{Expr, Operator};
+use datafusion::scalar::ScalarValue;
+use rusqlite::types::Value;
+use std::collections::HashMap;
+
+#[derive(Clone, Debug)]
+pub(crate) struct SqlPredicate {
+    pub sql: String,
+    pub params: Vec<Value>,
+}
+
+pub(crate) fn to_sql_for_columns(
+    expr: &Expr,
+    resident_columns: &HashMap<String, String>,
+) -> Option<SqlPredicate> {
+    let mut params = Vec::new();
+    let sql = build(expr, &mut params, resident_columns)?;
+    Some(SqlPredicate { sql, params })
+}
+
+fn build(
+    expr: &Expr,
+    params: &mut Vec<Value>,
+    resident_columns: &HashMap<String, String>,
+) -> Option<String> {
+    match expr {
+        Expr::Alias(alias) => build(alias.expr.as_ref(), params, resident_columns),
+        Expr::Column(column) => resident_columns.get(&column.name).cloned(),
+        Expr::Literal(value, _) => {
+            scalar_to_sqlite(value, params)?;
+            Some("?".to_owned())
+        }
+        Expr::BinaryExpr(binary) => {
+            let operator = match binary.op {
+                Operator::Eq => "=",
+                Operator::NotEq => "<>",
+                Operator::LtEq => "<=",
+                Operator::Lt => "<",
+                Operator::GtEq => ">=",
+                Operator::Gt => ">",
+                Operator::And => "AND",
+                Operator::Or => "OR",
+                _ => return None,
+            };
+            let left = build(binary.left.as_ref(), params, resident_columns)?;
+            let right = build(binary.right.as_ref(), params, resident_columns)?;
+            Some(format!("({left} {operator} {right})"))
+        }
+        Expr::IsNull(value) => Some(format!(
+            "({} IS NULL)",
+            resident_operand(value, resident_columns)?
+        )),
+        Expr::IsNotNull(value) => Some(format!(
+            "({} IS NOT NULL)",
+            resident_operand(value, resident_columns)?
+        )),
+        Expr::InList(list) => {
+            let expr = resident_operand(list.expr.as_ref(), resident_columns)?;
+            if list.list.is_empty() {
+                return None;
+            }
+            let values = list
+                .list
+                .iter()
+                .map(|value| build(value, params, resident_columns))
+                .collect::<Option<Vec<_>>>()?;
+            let operator = if list.negated { "NOT IN" } else { "IN" };
+            Some(format!("({expr} {operator} ({}))", values.join(", ")))
+        }
+        _ => None,
+    }
+}
+
+fn resident_operand(expr: &Expr, resident_columns: &HashMap<String, String>) -> Option<String> {
+    match expr {
+        Expr::Column(column) => resident_columns.get(&column.name).cloned(),
+        Expr::Alias(alias) => resident_operand(alias.expr.as_ref(), resident_columns),
+        _ => None,
+    }
+}
+
+fn scalar_to_sqlite(value: &ScalarValue, params: &mut Vec<Value>) -> Option<()> {
+    let value = match value {
+        ScalarValue::Null => Value::Null,
+        ScalarValue::Boolean(Some(value)) => Value::Integer(i64::from(*value)),
+        ScalarValue::Int8(Some(value)) => Value::Integer(i64::from(*value)),
+        ScalarValue::Int16(Some(value)) => Value::Integer(i64::from(*value)),
+        ScalarValue::Int32(Some(value)) => Value::Integer(i64::from(*value)),
+        ScalarValue::Int64(Some(value)) => Value::Integer(*value),
+        ScalarValue::UInt8(Some(value)) => Value::Integer(i64::from(*value)),
+        ScalarValue::UInt16(Some(value)) => Value::Integer(i64::from(*value)),
+        ScalarValue::UInt32(Some(value)) => Value::Integer(i64::from(*value)),
+        ScalarValue::UInt64(Some(value)) => Value::Integer(i64::try_from(*value).ok()?),
+        ScalarValue::Float32(Some(value)) => Value::Real(f64::from(*value)),
+        ScalarValue::Float64(Some(value)) => Value::Real(*value),
+        ScalarValue::Utf8(Some(value)) | ScalarValue::LargeUtf8(Some(value)) => {
+            Value::Text(value.clone())
+        }
+        _ => return None,
+    };
+    params.push(value);
+    Some(())
+}

--- a/baml_language/crates/baml_query/src/resident.rs
+++ b/baml_language/crates/baml_query/src/resident.rs
@@ -1,0 +1,983 @@
+use std::any::Any;
+use std::collections::HashMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use datafusion::arrow::array::{
+    ArrayRef, BooleanBuilder, Float64Builder, Int64Builder, LargeBinaryBuilder, LargeStringBuilder,
+    StringBuilder, UInt64Builder,
+};
+use datafusion::arrow::datatypes::{DataType, Field, SchemaRef};
+use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::catalog::Session;
+use datafusion::datasource::TableProvider;
+use datafusion::error::{DataFusionError, Result as DataFusionResult};
+use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::execution_plan::Boundedness;
+use datafusion::physical_plan::memory::{LazyBatchGenerator, LazyMemoryExec};
+use parking_lot::RwLock;
+use rusqlite::types::Value;
+use rusqlite::{Connection, Row};
+
+use crate::pushdown::SqlPredicate;
+use crate::{Hydrator, QueryContext, QueryError, Result, ValueId};
+
+#[derive(Clone, Debug)]
+pub struct SqliteColumnSpec {
+    pub logical_name: String,
+    pub physical_name: String,
+    pub data_type: DataType,
+    pub nullable: bool,
+    pub hydrated: bool,
+}
+
+impl SqliteColumnSpec {
+    pub fn new(
+        logical_name: impl Into<String>,
+        physical_name: impl Into<String>,
+        data_type: DataType,
+        nullable: bool,
+    ) -> Self {
+        Self {
+            logical_name: logical_name.into(),
+            physical_name: physical_name.into(),
+            data_type,
+            nullable,
+            hydrated: false,
+        }
+    }
+
+    #[must_use]
+    pub fn hydrated_value(
+        logical_name: impl Into<String>,
+        physical_name: impl Into<String>,
+        nullable: bool,
+    ) -> Self {
+        Self {
+            logical_name: logical_name.into(),
+            physical_name: physical_name.into(),
+            data_type: DataType::LargeBinary,
+            nullable,
+            hydrated: true,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SqliteResidentTableSpec {
+    pub name: String,
+    pub physical_name: String,
+    pub schema: SchemaRef,
+    pub columns: Vec<SqliteColumnSpec>,
+}
+
+/// Alias emphasizing that this specification can also contain hydrated value
+/// columns; `SqliteResidentTableSpec` is retained for compatibility.
+pub type SqliteTableSpec = SqliteResidentTableSpec;
+
+impl SqliteResidentTableSpec {
+    #[allow(clippy::needless_pass_by_value)]
+    pub fn new(
+        name: impl Into<String>,
+        physical_name: impl Into<String>,
+        schema: SchemaRef,
+    ) -> Result<Self> {
+        let name = name.into();
+        let physical_name = physical_name.into();
+        validate_identifier(&name)?;
+        validate_identifier(&physical_name)?;
+        let columns = schema
+            .fields()
+            .iter()
+            .map(|field| {
+                SqliteColumnSpec::new(
+                    field.name(),
+                    field.name(),
+                    field.data_type().clone(),
+                    field.is_nullable(),
+                )
+            })
+            .collect();
+        Self::from_columns(name, physical_name, columns)
+    }
+
+    pub fn from_columns(
+        name: impl Into<String>,
+        physical_name: impl Into<String>,
+        columns: Vec<SqliteColumnSpec>,
+    ) -> Result<Self> {
+        let name = name.into();
+        let physical_name = physical_name.into();
+        validate_identifier(&name)?;
+        validate_identifier(&physical_name)?;
+        if columns
+            .iter()
+            .all(|column| column.logical_name != "project_id")
+        {
+            return Err(QueryError::Internal(format!(
+                "resident table {name} must contain project_id"
+            )));
+        }
+        let mut logical_names = HashMap::new();
+        let fields = columns
+            .iter()
+            .map(|column| {
+                validate_identifier(&column.logical_name)?;
+                validate_identifier(&column.physical_name)?;
+                if logical_names
+                    .insert(column.logical_name.clone(), column.physical_name.clone())
+                    .is_some()
+                {
+                    return Err(QueryError::Internal(format!(
+                        "duplicate resident logical column: {}",
+                        column.logical_name
+                    )));
+                }
+                if column.hydrated && column.data_type != DataType::LargeBinary {
+                    return Err(QueryError::Internal(format!(
+                        "hydrated SQLite column must use LargeBinary: {}",
+                        column.logical_name
+                    )));
+                }
+                if !matches!(
+                    column.data_type,
+                    DataType::Utf8
+                        | DataType::LargeUtf8
+                        | DataType::Int64
+                        | DataType::UInt64
+                        | DataType::Float64
+                        | DataType::Boolean
+                        | DataType::Binary
+                        | DataType::LargeBinary
+                ) {
+                    return Err(QueryError::Internal(format!(
+                        "unsupported SQLite resident type for {}: {}",
+                        column.logical_name, column.data_type
+                    )));
+                }
+                let mut field = Field::new(
+                    &column.logical_name,
+                    column.data_type.clone(),
+                    column.nullable,
+                );
+                if column.hydrated {
+                    field = field.with_metadata(HashMap::from([
+                        (
+                            "ARROW:extension:name".to_owned(),
+                            "boundary.baml_value".to_owned(),
+                        ),
+                        ("ARROW:extension:metadata".to_owned(), "v1".to_owned()),
+                    ]));
+                }
+                Ok(field)
+            })
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Self {
+            name,
+            physical_name,
+            schema: Arc::new(datafusion::arrow::datatypes::Schema::new(fields)),
+            columns,
+        })
+    }
+
+    pub(crate) fn physical_column(&self, logical_name: &str) -> Option<&str> {
+        self.columns
+            .iter()
+            .find(|column| column.logical_name == logical_name)
+            .map(|column| column.physical_name.as_str())
+    }
+
+    pub(crate) fn column_mapping(&self) -> HashMap<String, String> {
+        self.columns
+            .iter()
+            .filter(|column| !column.hydrated)
+            .map(|column| {
+                (
+                    column.logical_name.clone(),
+                    quote_identifier(&column.physical_name),
+                )
+            })
+            .collect()
+    }
+
+    pub(crate) fn table_definition(&self) -> crate::TableDefinition {
+        let mut definition = crate::TableDefinition::new(&self.name, self.schema.clone())
+            .expect("validated SQLite table specification");
+        if self.physical_column("project_id").is_some() {
+            definition = definition.project_column("project_id");
+        }
+        for column in &self.columns {
+            if column.hydrated {
+                definition = definition.hydrated_column(&column.logical_name);
+            }
+        }
+        definition
+    }
+}
+
+pub fn standard_resident_table_specs() -> Result<Vec<SqliteResidentTableSpec>> {
+    Ok(vec![
+        SqliteResidentTableSpec::new(
+            "processes",
+            "processes",
+            Arc::new(datafusion::arrow::datatypes::Schema::new(vec![
+                datafusion::arrow::datatypes::Field::new("id", DataType::Utf8, false),
+                datafusion::arrow::datatypes::Field::new("project_id", DataType::Utf8, false),
+                datafusion::arrow::datatypes::Field::new("name", DataType::Utf8, true),
+            ])),
+        )?,
+        SqliteResidentTableSpec::new(
+            "threads",
+            "threads",
+            Arc::new(datafusion::arrow::datatypes::Schema::new(vec![
+                datafusion::arrow::datatypes::Field::new("id", DataType::Utf8, false),
+                datafusion::arrow::datatypes::Field::new("project_id", DataType::Utf8, false),
+                datafusion::arrow::datatypes::Field::new("process_id", DataType::Utf8, true),
+                datafusion::arrow::datatypes::Field::new("name", DataType::Utf8, true),
+            ])),
+        )?,
+        SqliteResidentTableSpec::new(
+            "ccts",
+            "ccts",
+            Arc::new(datafusion::arrow::datatypes::Schema::new(vec![
+                datafusion::arrow::datatypes::Field::new("id", DataType::Utf8, false),
+                datafusion::arrow::datatypes::Field::new("project_id", DataType::Utf8, false),
+                datafusion::arrow::datatypes::Field::new("thread_id", DataType::Utf8, true),
+                datafusion::arrow::datatypes::Field::new("name", DataType::Utf8, true),
+            ])),
+        )?,
+    ])
+}
+
+/// A SQLite-backed table whose logical schema is supplied by the caller.
+///
+/// A column marked with [`SqliteColumnSpec::hydrated_value`] is read as a
+/// `ValueId` from `SQLite` and exposed to `DataFusion` as hydrated JSON bytes.
+#[derive(Clone)]
+pub struct SqliteTableProvider {
+    connection: Arc<Mutex<Connection>>,
+    spec: SqliteResidentTableSpec,
+    hydrator: Arc<dyn Hydrator>,
+    query_context: QueryContext,
+    batch_size: usize,
+}
+
+impl fmt::Debug for SqliteTableProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SqliteTableProvider")
+            .field("table", &self.spec.name)
+            .field("batch_size", &self.batch_size)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SqliteTableProvider {
+    pub fn new(
+        connection: Arc<Mutex<Connection>>,
+        spec: SqliteResidentTableSpec,
+        hydrator: Arc<dyn Hydrator>,
+        query_context: QueryContext,
+        batch_size: usize,
+    ) -> Self {
+        Self {
+            connection,
+            spec,
+            hydrator,
+            query_context,
+            batch_size: batch_size.max(1),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TableProvider for SqliteTableProvider {
+    fn schema(&self) -> SchemaRef {
+        self.spec.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        let columns = self.spec.column_mapping();
+        Ok(filters
+            .iter()
+            .map(|filter| {
+                if crate::pushdown::to_sql_for_columns(filter, &columns).is_some() {
+                    TableProviderFilterPushDown::Exact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            })
+            .collect())
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let needs_values = self
+            .spec
+            .columns
+            .iter()
+            .enumerate()
+            .map(|(index, column)| {
+                column.hydrated
+                    && projection
+                        .map(|projection| projection.contains(&index))
+                        .unwrap_or(true)
+            })
+            .collect();
+        let columns = self.spec.column_mapping();
+        let generator = GenericBatchGenerator {
+            connection: Arc::clone(&self.connection),
+            spec: self.spec.clone(),
+            hydrator: Arc::clone(&self.hydrator),
+            query_context: self.query_context.clone(),
+            predicates: filters
+                .iter()
+                .filter_map(|filter| crate::pushdown::to_sql_for_columns(filter, &columns))
+                .collect(),
+            needs_values,
+            batch_size: self.batch_size,
+            offset: 0,
+        };
+        let exec = LazyMemoryExec::try_new(self.schema(), vec![Arc::new(RwLock::new(generator))])?
+            .with_projection(projection.cloned());
+        Ok(Arc::new(exec))
+    }
+}
+
+struct GenericBatchGenerator {
+    connection: Arc<Mutex<Connection>>,
+    spec: SqliteResidentTableSpec,
+    hydrator: Arc<dyn Hydrator>,
+    query_context: QueryContext,
+    predicates: Vec<SqlPredicate>,
+    needs_values: Vec<bool>,
+    batch_size: usize,
+    offset: usize,
+}
+
+impl fmt::Debug for GenericBatchGenerator {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("GenericBatchGenerator")
+            .field("table", &self.spec.name)
+            .field("batch_size", &self.batch_size)
+            .field("offset", &self.offset)
+            .finish_non_exhaustive()
+    }
+}
+
+impl fmt::Display for GenericBatchGenerator {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let predicates = self
+            .predicates
+            .iter()
+            .map(|predicate| predicate.sql.as_str())
+            .collect::<Vec<_>>()
+            .join(" AND ");
+        write!(
+            formatter,
+            "SQLite {} batch_size={} offset={} predicates={predicates}",
+            self.spec.name, self.batch_size, self.offset
+        )
+    }
+}
+
+impl LazyBatchGenerator for GenericBatchGenerator {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn boundedness(&self) -> Boundedness {
+        Boundedness::Bounded
+    }
+
+    fn generate_next_batch(&mut self) -> datafusion::error::Result<Option<RecordBatch>> {
+        self.query_batch()
+            .map_err(|error| DataFusionError::Execution(error.to_string()))
+    }
+
+    fn reset_state(&self) -> Arc<RwLock<dyn LazyBatchGenerator>> {
+        Arc::new(RwLock::new(Self {
+            connection: Arc::clone(&self.connection),
+            spec: self.spec.clone(),
+            hydrator: Arc::clone(&self.hydrator),
+            query_context: self.query_context.clone(),
+            predicates: self.predicates.clone(),
+            needs_values: self.needs_values.clone(),
+            batch_size: self.batch_size,
+            offset: 0,
+        }))
+    }
+}
+
+impl GenericBatchGenerator {
+    fn query_batch(&mut self) -> Result<Option<RecordBatch>> {
+        self.query_context.check_cancelled()?;
+        let sqlite_started = std::time::Instant::now();
+        let fields = self.spec.schema.fields();
+        let select_list = self
+            .spec
+            .columns
+            .iter()
+            .map(|column| quote_identifier(&column.physical_name))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let project_id = self
+            .spec
+            .physical_column("project_id")
+            .ok_or_else(|| QueryError::Internal("table lacks project_id".to_owned()))?;
+        let mut sql = format!(
+            "SELECT {select_list} FROM {} WHERE {} = ?",
+            quote_identifier(&self.spec.physical_name),
+            quote_identifier(project_id),
+        );
+        let mut params = vec![Value::Text(self.query_context.project_id.to_string())];
+        for predicate in &self.predicates {
+            sql.push_str(" AND ");
+            sql.push_str(&predicate.sql);
+            params.extend(predicate.params.iter().cloned());
+        }
+        sql.push_str(" ORDER BY rowid LIMIT ? OFFSET ?");
+        params.push(Value::Integer(
+            i64::try_from(self.batch_size).map_err(|_| QueryError::ValueLimit)?,
+        ));
+        params.push(Value::Integer(
+            i64::try_from(self.offset).map_err(|_| QueryError::ValueLimit)?,
+        ));
+
+        let (resident_columns, value_id_columns) = {
+            let connection = self
+                .connection
+                .lock()
+                .map_err(|_| QueryError::Internal("SQLite mutex poisoned".to_owned()))?;
+            let mut statement = connection.prepare(&sql)?;
+            let mut rows = statement.query(rusqlite::params_from_iter(params.iter()))?;
+            let mut resident_columns = (0..fields.len())
+                .map(|_| Vec::new())
+                .collect::<Vec<Vec<Cell>>>();
+            let mut value_id_columns = (0..fields.len())
+                .map(|_| Vec::new())
+                .collect::<Vec<Vec<Option<ValueId>>>>();
+            while let Some(row) = rows.next()? {
+                for (index, column) in self.spec.columns.iter().enumerate() {
+                    if column.hydrated {
+                        value_id_columns[index].push(read_value_id(row, index)?);
+                    } else {
+                        resident_columns[index].push(read_cell(
+                            row,
+                            index,
+                            fields[index].data_type(),
+                        )?);
+                    }
+                }
+            }
+            (resident_columns, value_id_columns)
+        };
+        self.query_context
+            .metrics
+            .record_sqlite_duration(sqlite_started.elapsed());
+        let row_count = resident_columns
+            .iter()
+            .map(Vec::len)
+            .chain(value_id_columns.iter().map(Vec::len))
+            .max()
+            .unwrap_or(0);
+        if row_count == 0 {
+            return Ok(None);
+        }
+        if self.offset.saturating_add(row_count) > self.query_context.budgets.max_candidate_rows {
+            return Err(QueryError::ValueLimit);
+        }
+        self.offset += row_count;
+        self.query_context
+            .metrics
+            .batches
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.query_context
+            .metrics
+            .input_rows
+            .fetch_add(row_count, std::sync::atomic::Ordering::Relaxed);
+
+        let mut arrays = Vec::with_capacity(fields.len());
+        for (index, column) in self.spec.columns.iter().enumerate() {
+            if !column.hydrated {
+                arrays.push(build_array(
+                    fields[index].data_type(),
+                    &resident_columns[index],
+                )?);
+                continue;
+            }
+            let values = self.hydrate_column(&value_id_columns[index], self.needs_values[index])?;
+            let cells = values
+                .into_iter()
+                .map(|value| value.map_or(Cell::Null, Cell::Binary))
+                .collect::<Vec<_>>();
+            arrays.push(build_array(fields[index].data_type(), &cells)?);
+        }
+        Ok(Some(
+            RecordBatch::try_new(self.spec.schema.clone(), arrays)
+                .map_err(|error| QueryError::Internal(error.to_string()))?,
+        ))
+    }
+
+    fn hydrate_column(
+        &self,
+        ids: &[Option<ValueId>],
+        needed: bool,
+    ) -> Result<Vec<Option<Vec<u8>>>> {
+        if !needed {
+            return Ok(vec![None; ids.len()]);
+        }
+        let roots: Vec<ValueId> = ids.iter().flatten().copied().collect();
+        if roots.is_empty() {
+            return Ok(vec![None; ids.len()]);
+        }
+        let hydration_started = std::time::Instant::now();
+        let values =
+            futures::executor::block_on(self.hydrator.hydrate_many(&roots, &self.query_context))?;
+        self.query_context
+            .metrics
+            .record_hydration_duration(hydration_started.elapsed());
+        let serialization_started = std::time::Instant::now();
+        let result = ids
+            .iter()
+            .map(|id| match id {
+                None => Ok(None),
+                Some(id) => {
+                    let value = values.get(id).ok_or_else(|| QueryError::MissingValue {
+                        value_id: id.to_string(),
+                        path: std::path::PathBuf::new(),
+                    })?;
+                    Ok(Some(serde_json::to_vec(value)?))
+                }
+            })
+            .collect();
+        self.query_context
+            .metrics
+            .record_serialization_duration(serialization_started.elapsed());
+        result
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Clone)]
+pub(crate) struct SqliteResidentTableProvider {
+    connection: Arc<Mutex<Connection>>,
+    spec: SqliteResidentTableSpec,
+    query_context: QueryContext,
+    batch_size: usize,
+}
+
+#[allow(dead_code)]
+impl fmt::Debug for SqliteResidentTableProvider {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SqliteResidentTableProvider")
+            .field("table", &self.spec.name)
+            .field("batch_size", &self.batch_size)
+            .finish_non_exhaustive()
+    }
+}
+
+#[allow(dead_code)]
+impl SqliteResidentTableProvider {
+    pub(crate) fn new(
+        connection: Arc<Mutex<Connection>>,
+        spec: SqliteResidentTableSpec,
+        query_context: QueryContext,
+        batch_size: usize,
+    ) -> Self {
+        Self {
+            connection,
+            spec,
+            query_context,
+            batch_size: batch_size.max(1),
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[async_trait::async_trait]
+impl TableProvider for SqliteResidentTableProvider {
+    fn schema(&self) -> SchemaRef {
+        self.spec.schema.clone()
+    }
+
+    fn table_type(&self) -> TableType {
+        TableType::Base
+    }
+
+    fn supports_filters_pushdown(
+        &self,
+        filters: &[&Expr],
+    ) -> DataFusionResult<Vec<TableProviderFilterPushDown>> {
+        let columns = self.spec.column_mapping();
+        Ok(filters
+            .iter()
+            .map(|filter| {
+                if crate::pushdown::to_sql_for_columns(filter, &columns).is_some() {
+                    TableProviderFilterPushDown::Exact
+                } else {
+                    TableProviderFilterPushDown::Unsupported
+                }
+            })
+            .collect())
+    }
+
+    async fn scan(
+        &self,
+        _state: &dyn Session,
+        projection: Option<&Vec<usize>>,
+        filters: &[Expr],
+        _limit: Option<usize>,
+    ) -> DataFusionResult<Arc<dyn ExecutionPlan>> {
+        let columns = self.spec.column_mapping();
+        let generator = ResidentBatchGenerator {
+            connection: Arc::clone(&self.connection),
+            spec: self.spec.clone(),
+            query_context: self.query_context.clone(),
+            predicates: filters
+                .iter()
+                .filter_map(|filter| crate::pushdown::to_sql_for_columns(filter, &columns))
+                .collect(),
+            batch_size: self.batch_size,
+            offset: 0,
+        };
+        let exec = LazyMemoryExec::try_new(self.schema(), vec![Arc::new(RwLock::new(generator))])?
+            .with_projection(projection.cloned());
+        Ok(Arc::new(exec))
+    }
+}
+
+#[allow(dead_code)]
+struct ResidentBatchGenerator {
+    connection: Arc<Mutex<Connection>>,
+    spec: SqliteResidentTableSpec,
+    query_context: QueryContext,
+    predicates: Vec<SqlPredicate>,
+    batch_size: usize,
+    offset: usize,
+}
+
+#[allow(dead_code)]
+impl fmt::Debug for ResidentBatchGenerator {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ResidentBatchGenerator")
+            .field("table", &self.spec.name)
+            .field("batch_size", &self.batch_size)
+            .field("offset", &self.offset)
+            .finish_non_exhaustive()
+    }
+}
+
+#[allow(dead_code)]
+impl fmt::Display for ResidentBatchGenerator {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let predicates = self
+            .predicates
+            .iter()
+            .map(|predicate| predicate.sql.as_str())
+            .collect::<Vec<_>>()
+            .join(" AND ");
+        write!(
+            formatter,
+            "SQLite {} batch_size={} offset={} predicates={predicates}",
+            self.spec.name, self.batch_size, self.offset
+        )
+    }
+}
+
+#[allow(dead_code)]
+impl LazyBatchGenerator for ResidentBatchGenerator {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn boundedness(&self) -> Boundedness {
+        Boundedness::Bounded
+    }
+
+    fn generate_next_batch(&mut self) -> datafusion::error::Result<Option<RecordBatch>> {
+        self.query_batch()
+            .map_err(|error| DataFusionError::Execution(error.to_string()))
+    }
+
+    fn reset_state(&self) -> Arc<RwLock<dyn LazyBatchGenerator>> {
+        Arc::new(RwLock::new(Self {
+            connection: Arc::clone(&self.connection),
+            spec: self.spec.clone(),
+            query_context: self.query_context.clone(),
+            predicates: self.predicates.clone(),
+            batch_size: self.batch_size,
+            offset: 0,
+        }))
+    }
+}
+
+#[allow(dead_code)]
+impl ResidentBatchGenerator {
+    fn query_batch(&mut self) -> Result<Option<RecordBatch>> {
+        self.query_context.check_cancelled()?;
+        let fields = self.spec.schema.fields();
+        let select_list = self
+            .spec
+            .columns
+            .iter()
+            .map(|column| quote_identifier(&column.physical_name))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let project_id = self
+            .spec
+            .physical_column("project_id")
+            .ok_or_else(|| QueryError::Internal("resident table lacks project_id".to_owned()))?;
+        let mut sql = format!(
+            "SELECT {select_list} FROM {} WHERE {} = ?",
+            quote_identifier(&self.spec.physical_name),
+            quote_identifier(project_id),
+        );
+        let mut params = vec![Value::Text(self.query_context.project_id.to_string())];
+        for predicate in &self.predicates {
+            sql.push_str(" AND ");
+            sql.push_str(&predicate.sql);
+            params.extend(predicate.params.iter().cloned());
+        }
+        sql.push_str(" ORDER BY rowid LIMIT ? OFFSET ?");
+        params.push(Value::Integer(
+            i64::try_from(self.batch_size).map_err(|_| QueryError::ValueLimit)?,
+        ));
+        params.push(Value::Integer(
+            i64::try_from(self.offset).map_err(|_| QueryError::ValueLimit)?,
+        ));
+
+        let columns = {
+            let connection = self
+                .connection
+                .lock()
+                .map_err(|_| QueryError::Internal("SQLite mutex poisoned".to_owned()))?;
+            let mut statement = connection.prepare(&sql)?;
+            let mut rows = statement.query(rusqlite::params_from_iter(params.iter()))?;
+            let mut columns = (0..fields.len()).map(|_| Vec::new()).collect::<Vec<_>>();
+            while let Some(row) = rows.next()? {
+                for (index, field) in fields.iter().enumerate() {
+                    columns[index].push(read_cell(row, index, field.data_type())?);
+                }
+            }
+            columns
+        };
+        let row_count = columns.first().map_or(0, Vec::len);
+        if row_count == 0 {
+            return Ok(None);
+        }
+        if self.offset.saturating_add(row_count) > self.query_context.budgets.max_candidate_rows {
+            return Err(QueryError::ValueLimit);
+        }
+        self.offset += row_count;
+        self.query_context
+            .metrics
+            .batches
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        self.query_context
+            .metrics
+            .input_rows
+            .fetch_add(row_count, std::sync::atomic::Ordering::Relaxed);
+        let arrays = fields
+            .iter()
+            .enumerate()
+            .map(|(index, field)| build_array(field.data_type(), &columns[index]))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(Some(
+            RecordBatch::try_new(self.spec.schema.clone(), arrays)
+                .map_err(|error| QueryError::Internal(error.to_string()))?,
+        ))
+    }
+}
+
+#[derive(Debug)]
+enum Cell {
+    Null,
+    Text(String),
+    Int64(i64),
+    UInt64(u64),
+    Float64(f64),
+    Boolean(bool),
+    Binary(Vec<u8>),
+}
+
+fn read_cell(row: &Row<'_>, index: usize, data_type: &DataType) -> Result<Cell> {
+    match data_type {
+        DataType::Utf8 => Ok(row
+            .get::<_, Option<String>>(index)?
+            .map_or(Cell::Null, Cell::Text)),
+        DataType::LargeUtf8 => Ok(row
+            .get::<_, Option<String>>(index)?
+            .map_or(Cell::Null, Cell::Text)),
+        DataType::Int64 => Ok(row
+            .get::<_, Option<i64>>(index)?
+            .map_or(Cell::Null, Cell::Int64)),
+        DataType::UInt64 => row
+            .get::<_, Option<i64>>(index)?
+            .map_or(Ok(Cell::Null), |value| {
+                u64::try_from(value)
+                    .map(Cell::UInt64)
+                    .map_err(|_| QueryError::InvalidValueId("negative UInt64".to_owned()))
+            }),
+        DataType::Float64 => Ok(row
+            .get::<_, Option<f64>>(index)?
+            .map_or(Cell::Null, Cell::Float64)),
+        DataType::Boolean => Ok(row
+            .get::<_, Option<bool>>(index)?
+            .map_or(Cell::Null, Cell::Boolean)),
+        DataType::Binary | DataType::LargeBinary => Ok(row
+            .get::<_, Option<Vec<u8>>>(index)?
+            .map_or(Cell::Null, Cell::Binary)),
+        other => Err(QueryError::Internal(format!(
+            "unsupported SQLite resident type: {other}"
+        ))),
+    }
+}
+
+fn read_value_id(row: &Row<'_>, index: usize) -> Result<Option<ValueId>> {
+    let bytes: Option<Vec<u8>> = row.get(index)?;
+    match bytes {
+        None => Ok(None),
+        Some(bytes) if bytes.len() == ValueId::LEN => {
+            Ok(Some(ValueId::from_bytes(bytes.try_into().map_err(
+                |_| QueryError::InvalidValueId("wrong byte length".to_owned()),
+            )?)))
+        }
+        Some(bytes) => Err(QueryError::InvalidValueId(format!(
+            "expected {} bytes, got {}",
+            ValueId::LEN,
+            bytes.len()
+        ))),
+    }
+}
+
+fn build_array(data_type: &DataType, values: &[Cell]) -> Result<ArrayRef> {
+    match data_type {
+        DataType::Utf8 => {
+            let mut builder = StringBuilder::new();
+            for value in values {
+                match value {
+                    Cell::Text(value) => builder.append_value(value),
+                    Cell::Null => builder.append_null(),
+                    _ => return Err(type_mismatch(data_type)),
+                }
+            }
+            Ok(Arc::new(builder.finish()))
+        }
+        DataType::LargeUtf8 => {
+            let mut builder = LargeStringBuilder::new();
+            for value in values {
+                match value {
+                    Cell::Text(value) => builder.append_value(value),
+                    Cell::Null => builder.append_null(),
+                    _ => return Err(type_mismatch(data_type)),
+                }
+            }
+            Ok(Arc::new(builder.finish()))
+        }
+        DataType::Int64 => {
+            let mut builder = Int64Builder::new();
+            for value in values {
+                match value {
+                    Cell::Int64(value) => builder.append_value(*value),
+                    Cell::Null => builder.append_null(),
+                    _ => return Err(type_mismatch(data_type)),
+                }
+            }
+            Ok(Arc::new(builder.finish()))
+        }
+        DataType::UInt64 => {
+            let mut builder = UInt64Builder::new();
+            for value in values {
+                match value {
+                    Cell::UInt64(value) => builder.append_value(*value),
+                    Cell::Null => builder.append_null(),
+                    _ => return Err(type_mismatch(data_type)),
+                }
+            }
+            Ok(Arc::new(builder.finish()))
+        }
+        DataType::Float64 => {
+            let mut builder = Float64Builder::new();
+            for value in values {
+                match value {
+                    Cell::Float64(value) => builder.append_value(*value),
+                    Cell::Null => builder.append_null(),
+                    _ => return Err(type_mismatch(data_type)),
+                }
+            }
+            Ok(Arc::new(builder.finish()))
+        }
+        DataType::Boolean => {
+            let mut builder = BooleanBuilder::new();
+            for value in values {
+                match value {
+                    Cell::Boolean(value) => builder.append_value(*value),
+                    Cell::Null => builder.append_null(),
+                    _ => return Err(type_mismatch(data_type)),
+                }
+            }
+            Ok(Arc::new(builder.finish()))
+        }
+        DataType::Binary => {
+            let mut builder = datafusion::arrow::array::BinaryBuilder::new();
+            for value in values {
+                match value {
+                    Cell::Binary(value) => builder.append_value(value),
+                    Cell::Null => builder.append_null(),
+                    _ => return Err(type_mismatch(data_type)),
+                }
+            }
+            Ok(Arc::new(builder.finish()))
+        }
+        DataType::LargeBinary => {
+            let mut builder = LargeBinaryBuilder::new();
+            for value in values {
+                match value {
+                    Cell::Binary(value) => builder.append_value(value),
+                    Cell::Null => builder.append_null(),
+                    _ => return Err(type_mismatch(data_type)),
+                }
+            }
+            Ok(Arc::new(builder.finish()))
+        }
+        _ => Err(type_mismatch(data_type)),
+    }
+}
+
+fn type_mismatch(data_type: &DataType) -> QueryError {
+    QueryError::Internal(format!("SQLite value did not match Arrow type {data_type}"))
+}
+
+fn quote_identifier(identifier: &str) -> String {
+    format!("\"{}\"", identifier.replace('"', "\"\""))
+}
+
+fn validate_identifier(identifier: &str) -> Result<()> {
+    if identifier.is_empty()
+        || !identifier
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+    {
+        return Err(QueryError::Internal(format!(
+            "invalid SQLite identifier: {identifier}"
+        )));
+    }
+    Ok(())
+}

--- a/baml_language/crates/baml_query/src/store.rs
+++ b/baml_language/crates/baml_query/src/store.rs
@@ -1,0 +1,93 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use crate::{QueryContext, QueryError, Result, ValueId};
+
+#[async_trait]
+pub trait ValueStore: Send + Sync {
+    async fn get_many(
+        &self,
+        ids: &[ValueId],
+        context: &QueryContext,
+    ) -> Result<HashMap<ValueId, Bytes>>;
+}
+
+#[derive(Clone)]
+pub struct LocalBlobStore {
+    root: Arc<Path>,
+}
+
+impl LocalBlobStore {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self {
+            root: Arc::from(root.into()),
+        }
+    }
+
+    pub fn path_for(&self, id: ValueId) -> PathBuf {
+        self.root
+            .join("values")
+            .join(format!("{}.blob", id.to_hex()))
+    }
+
+    pub async fn put(&self, id: ValueId, bytes: &[u8]) -> Result<()> {
+        let values_dir = self.root.join("values");
+        tokio::fs::create_dir_all(&values_dir).await?;
+        tokio::fs::write(self.path_for(id), bytes).await?;
+        Ok(())
+    }
+
+    pub fn root(&self) -> &Path {
+        self.root.as_ref()
+    }
+}
+
+#[async_trait]
+impl ValueStore for LocalBlobStore {
+    async fn get_many(
+        &self,
+        ids: &[ValueId],
+        context: &QueryContext,
+    ) -> Result<HashMap<ValueId, Bytes>> {
+        let started = Instant::now();
+        let mut output = HashMap::with_capacity(ids.len());
+        let mut total_bytes: usize = 0;
+        context
+            .metrics
+            .blob_requests
+            .fetch_add(ids.len(), std::sync::atomic::Ordering::Relaxed);
+        let result = (|| {
+            for id in ids.iter().copied() {
+                context.check_cancelled()?;
+                let path = self.path_for(id);
+                let bytes = std::fs::read(&path).map_err(|error| {
+                    if error.kind() == std::io::ErrorKind::NotFound {
+                        QueryError::MissingValue {
+                            value_id: id.to_string(),
+                            path: path.clone(),
+                        }
+                    } else {
+                        QueryError::Io(error)
+                    }
+                })?;
+                total_bytes = total_bytes.saturating_add(bytes.len());
+                context
+                    .metrics
+                    .blob_bytes
+                    .fetch_add(bytes.len(), std::sync::atomic::Ordering::Relaxed);
+                if total_bytes > context.budgets.max_blob_bytes {
+                    return Err(QueryError::ValueLimit);
+                }
+                output.insert(id, Bytes::from(bytes));
+            }
+            Ok(output)
+        })();
+        context.metrics.record_blob_read_duration(started.elapsed());
+        result
+    }
+}

--- a/baml_language/crates/baml_query/src/value_id.rs
+++ b/baml_language/crates/baml_query/src/value_id.rs
@@ -1,0 +1,82 @@
+use std::fmt;
+use std::fmt::Write;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use sha2::{Digest, Sha256};
+
+use crate::{QueryError, Result};
+
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ValueId([u8; 32]);
+
+impl ValueId {
+    pub const LEN: usize = 32;
+
+    pub fn from_bytes(bytes: [u8; Self::LEN]) -> Self {
+        Self(bytes)
+    }
+
+    pub fn as_bytes(&self) -> &[u8; Self::LEN] {
+        &self.0
+    }
+
+    pub fn from_content(bytes: &[u8]) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        Self(hasher.finalize().into())
+    }
+
+    pub fn from_hex(value: &str) -> Result<Self> {
+        if value.len() != Self::LEN * 2 {
+            return Err(QueryError::InvalidValueId(value.to_owned()));
+        }
+        let mut bytes = [0; Self::LEN];
+        for (index, byte) in bytes.iter_mut().enumerate() {
+            *byte = u8::from_str_radix(&value[index * 2..index * 2 + 2], 16)
+                .map_err(|_| QueryError::InvalidValueId(value.to_owned()))?;
+        }
+        Ok(Self(bytes))
+    }
+
+    pub fn to_hex(self) -> String {
+        let mut output = String::with_capacity(Self::LEN * 2);
+        for byte in self.0 {
+            write!(&mut output, "{byte:02x}").expect("writing to a String cannot fail");
+        }
+        output
+    }
+}
+
+impl fmt::Debug for ValueId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_tuple("ValueId")
+            .field(&self.to_hex())
+            .finish()
+    }
+}
+
+impl fmt::Display for ValueId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.to_hex())
+    }
+}
+
+impl Serialize for ValueId {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for ValueId {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::from_hex(&value).map_err(serde::de::Error::custom)
+    }
+}


### PR DESCRIPTION
## Summary

- Add the new baml_query local SQL engine backed by SQLite and DataFusion.
- Support transparent hydration of content-addressed value IDs from local blob storage.
- Add caller-defined logical table schemas with arbitrary physical column mappings.
- Add relationship metadata and validation for project-scoped joins.
- Add built-in and asynchronous UDF support.
- Add query budgets, cancellation, metrics, aggregation coverage, and repeatable benchmarks.
- Document schema mapping, hydration, relationships, and performance caveats.

## Validation

- cargo fmt --all -- --check
- cargo test -p baml_query --all-targets
- cargo clippy -p baml_query --all-targets -- -D warnings
- git diff --check

Cloud and ClickHouse execution are intentionally out of scope for this local-first crate.