### PR TITLE
fix(engine): materialize host-supplied json with json container typing

### DIFF
--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -734,9 +734,26 @@ impl BexEngine {
     pub(crate) fn convert_external_to_vm_value_with_ty<T: RootHaver + TlabHolder>(
         &self,
         holder: &mut impl HeapPermit<T>,
-        external: BexExternalValue,
+        mut external: BexExternalValue,
         expected_ty: Option<&RuntimeTy>,
     ) -> Result<Value, EngineError> {
+        // A `baml.json.json` slot materializes containers with the alias as
+        // their element/value type, exactly like BAML-born `baml.json.parse`
+        // values (`serde_to_value`), so runtime type tests (`match (j) { let
+        // m: map<string, json> => ... }`) treat host and BAML json alike.
+        // `coerce_inbound_arg` already re-annotates argument trees; this hook
+        // covers the paths that convert without a coercion pass, notably
+        // host-callable return values.
+        if let Some(declared @ RuntimeTy::TypeAlias(name, _)) = expected_ty
+            && name.display_name().as_str() == "baml.json.json"
+            && matches!(
+                external,
+                BexExternalValue::Array { .. } | BexExternalValue::Map { .. }
+            )
+            && value_satisfies_json(&external)
+        {
+            external = annotate_json_container_types(external, declared);
+        }
         // Structural host-only stash (03b §F/§G): when the declared slot resolves
         // to `RustType` (the generic var bound to `rust_type`) but the value is a
         // structural `BexExternalValue` (e.g. an unbound generic instance), ride
@@ -3601,6 +3618,27 @@ fn coerce_arg_to_declared_type_with_aliases(
             )?;
             Ok(BexExternalValue::typed(coerced, effective_type.clone()))
         }
+        // A declared `baml.json.json` slot receiving a container. Untyped
+        // bridge encoders (Go `baml.JSON`, Python dicts/lists, `--json-args`)
+        // send containers without a `value_type` annotation, which the wire
+        // decoder defaults to a scalar-union element type. Left as-is, the
+        // materialized VM map/list would carry that synthesized type and fail
+        // runtime type tests such as `match (j) { let m: map<string, json> =>
+        // ... }` — diverging from BAML-born `baml.json.parse` values, whose
+        // containers carry the `json` alias itself (`serde_to_value`).
+        // Re-annotate the container tree with the declared alias so both
+        // materialize identically. Values outside the JSON algebra are left
+        // unchanged for the standard validation paths to reject.
+        (value, declared @ RuntimeTy::TypeAlias(name, _))
+            if name.display_name().as_str() == "baml.json.json"
+                && matches!(
+                    value,
+                    BexExternalValue::Array { .. } | BexExternalValue::Map { .. }
+                )
+                && value_satisfies_json(&value) =>
+        {
+            Ok(annotate_json_container_types(value, declared))
+        }
         (BexExternalValue::Array { items, .. }, RuntimeTy::List(expected_element, _)) => {
             Ok(BexExternalValue::Array {
                 element_type: expected_element.as_ref().clone(),
@@ -3743,6 +3781,32 @@ fn coerce_arg_to_declared_type_with_aliases(
 
         // ── Numeric / optional / union ───────────────────────────────────
         (v, ty) => coerce_numeric_to_declared_type(v, ty),
+    }
+}
+
+/// Rewrite every container annotation in a JSON value tree to the `json`
+/// alias itself: lists become `json[]`, maps become `map<string, json>`.
+/// Scalars carry no annotation and pass through. The caller has already
+/// proven the tree inhabits the JSON algebra (`value_satisfies_json`), so
+/// only `Array` and `Map` recursion arms are needed.
+fn annotate_json_container_types(value: BexExternalValue, json_ty: &RuntimeTy) -> BexExternalValue {
+    match value {
+        BexExternalValue::Array { items, .. } => BexExternalValue::Array {
+            element_type: json_ty.clone(),
+            items: items
+                .into_iter()
+                .map(|item| annotate_json_container_types(item, json_ty))
+                .collect(),
+        },
+        BexExternalValue::Map { entries, .. } => BexExternalValue::Map {
+            key_type: RuntimeTy::string(),
+            value_type: json_ty.clone(),
+            entries: entries
+                .into_iter()
+                .map(|(key, entry)| (key, annotate_json_container_types(entry, json_ty)))
+                .collect(),
+        },
+        scalar => scalar,
     }
 }
 
@@ -4021,6 +4085,65 @@ mod union_container_selection_tests {
         assert!(runtime_ty_structurally_equal(
             &metadata.selected_option,
             &json
+        ));
+    }
+
+    #[test]
+    fn canonical_json_alias_reannotates_untyped_inbound_containers() {
+        // Untyped bridges (Go `baml.JSON`, Python dicts, `--json-args`) send
+        // containers without element annotations; the wire decoder synthesizes
+        // a scalar-union element type. A declared `json` slot must rewrite
+        // those to the alias itself so the materialized VM containers pass
+        // `match (j) { let m: map<string, json> => ... }` exactly like
+        // BAML-born `baml.json.parse` values.
+        let json = json_ty();
+        let nested_list = BexExternalValue::Array {
+            element_type: RuntimeTy::unknown(),
+            items: vec![BexExternalValue::Int(1)],
+        };
+        let mut nested_entries = indexmap::IndexMap::new();
+        nested_entries.insert("inner".to_string(), nested_list);
+        let object = BexExternalValue::Map {
+            key_type: RuntimeTy::string(),
+            value_type: RuntimeTy::unknown(),
+            entries: nested_entries,
+        };
+
+        let coerced = coerce_arg_to_declared_type(object, &json).unwrap();
+        let BexExternalValue::Map {
+            key_type,
+            value_type,
+            entries,
+        } = coerced
+        else {
+            panic!("JSON object must stay a map")
+        };
+        assert!(runtime_ty_structurally_equal(&key_type, &RuntimeTy::string()));
+        assert!(runtime_ty_structurally_equal(&value_type, &json));
+        let BexExternalValue::Array { element_type, .. } = &entries["inner"] else {
+            panic!("nested JSON list must stay a list")
+        };
+        assert!(runtime_ty_structurally_equal(element_type, &json));
+
+        // A tree outside the JSON algebra is left untouched for the standard
+        // validation paths to reject.
+        let mut binary_entries = indexmap::IndexMap::new();
+        binary_entries.insert(
+            "bytes".to_string(),
+            BexExternalValue::Uint8Array(vec![1, 2]),
+        );
+        let binary = BexExternalValue::Map {
+            key_type: RuntimeTy::string(),
+            value_type: RuntimeTy::unknown(),
+            entries: binary_entries,
+        };
+        let untouched = coerce_arg_to_declared_type(binary, &json).unwrap();
+        let BexExternalValue::Map { value_type, .. } = untouched else {
+            panic!("non-JSON map must stay a map")
+        };
+        assert!(runtime_ty_structurally_equal(
+            &value_type,
+            &RuntimeTy::unknown()
         ));
     }
 

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -9,7 +9,8 @@ use ::bex_vm_types::{HeapPtr, Object, ObjectType, RootHaver, Value, ValueKind};
 use baml_type::{Literal, Ty};
 use bex_external_types::{
     BexExternalAdt, BexExternalValue, HostValueKind, RuntimeTy, UnionMetadata,
-    runtime_ty_structurally_equal, selected_arm_equal, value_satisfies_json,
+    is_canonical_json_alias, runtime_ty_structurally_equal, selected_arm_equal,
+    value_satisfies_json,
 };
 use bex_vm::BexVm;
 
@@ -745,7 +746,7 @@ impl BexEngine {
         // covers the paths that convert without a coercion pass, notably
         // host-callable return values.
         if let Some(declared @ RuntimeTy::TypeAlias(name, _)) = expected_ty
-            && name.display_name().as_str() == "baml.json.json"
+            && is_canonical_json_alias(name)
             && matches!(
                 external,
                 BexExternalValue::Array { .. } | BexExternalValue::Map { .. }
@@ -2203,7 +2204,7 @@ fn runtime_ty_resolves_to_exact_null<'a>(
     for _ in 0..=aliases.len() {
         match ty {
             RuntimeTy::Null { .. } => return true,
-            RuntimeTy::TypeAlias(name, _) if name.display_name().as_str() != "baml.json.json" => {
+            RuntimeTy::TypeAlias(name, _) if !is_canonical_json_alias(name) => {
                 let Some(expanded) = aliases.get(name) else {
                     return false;
                 };
@@ -2318,7 +2319,7 @@ fn value_matches_type_with_definitions(
     classes: &indexmap::IndexMap<baml_type::TypeName, sys_types::ClassDefinition>,
 ) -> bool {
     if let RuntimeTy::TypeAlias(name, _) = ty
-        && name.display_name().as_str() != "baml.json.json"
+        && !is_canonical_json_alias(name)
         && let Some(expanded) = aliases.get(name)
     {
         return value_matches_type_with_definitions(value, expanded, aliases, classes);
@@ -2426,17 +2427,18 @@ fn value_matches_type_with_definitions(
                     && value_matches_type_with_definitions(value, member, aliases, classes)
             })
         }
-        (BexExternalValue::Union { .. }, RuntimeTy::TypeAlias(name, _))
-            if name.display_name().as_str() == "baml.json.json" =>
+        // `value_satisfies_json` peels sparse inbound leaf annotations (the
+        // Swift bridge annotates every json scalar leaf) but still rejects
+        // genuine union carriers and annotations outside the JSON algebra.
+        (union_value @ BexExternalValue::Union { .. }, RuntimeTy::TypeAlias(name, _))
+            if is_canonical_json_alias(name) =>
         {
-            false
+            value_satisfies_json(union_value)
         }
         (BexExternalValue::Union { value, .. }, ty) => {
             value_matches_type_with_definitions(value, ty, aliases, classes)
         }
-        (value, RuntimeTy::TypeAlias(name, _))
-            if name.display_name().as_str() == "baml.json.json" =>
-        {
+        (value, RuntimeTy::TypeAlias(name, _)) if is_canonical_json_alias(name) => {
             value_satisfies_json(value)
         }
         // Handle nested unions (including nullable `T | null`) in the type.
@@ -3461,7 +3463,7 @@ fn coerce_arg_to_declared_type_with_aliases(
     // recursive context; recursive references consume payload structure before
     // returning here again, so productive aliases terminate with the value.
     if let RuntimeTy::TypeAlias(name, _) = ty
-        && name.display_name().as_str() != "baml.json.json"
+        && !is_canonical_json_alias(name)
         && let Some(expanded) = aliases.get(name)
     {
         return coerce_arg_to_declared_type_with_aliases(
@@ -3630,7 +3632,7 @@ fn coerce_arg_to_declared_type_with_aliases(
         // materialize identically. Values outside the JSON algebra are left
         // unchanged for the standard validation paths to reject.
         (value, declared @ RuntimeTy::TypeAlias(name, _))
-            if name.display_name().as_str() == "baml.json.json"
+            if is_canonical_json_alias(name)
                 && matches!(
                     value,
                     BexExternalValue::Array { .. } | BexExternalValue::Map { .. }
@@ -3786,9 +3788,10 @@ fn coerce_arg_to_declared_type_with_aliases(
 
 /// Rewrite every container annotation in a JSON value tree to the `json`
 /// alias itself: lists become `json[]`, maps become `map<string, json>`.
-/// Scalars carry no annotation and pass through. The caller has already
-/// proven the tree inhabits the JSON algebra (`value_satisfies_json`), so
-/// only `Array` and `Map` recursion arms are needed.
+/// Scalars carry no annotation and pass through; sparse inbound leaf
+/// annotations (transient `Union` carriers) are recursed through with their
+/// metadata intact. The caller has already proven the tree inhabits the JSON
+/// algebra (`value_satisfies_json`).
 fn annotate_json_container_types(value: BexExternalValue, json_ty: &RuntimeTy) -> BexExternalValue {
     match value {
         BexExternalValue::Array { items, .. } => BexExternalValue::Array {
@@ -3805,6 +3808,10 @@ fn annotate_json_container_types(value: BexExternalValue, json_ty: &RuntimeTy) -
                 .into_iter()
                 .map(|(key, entry)| (key, annotate_json_container_types(entry, json_ty)))
                 .collect(),
+        },
+        BexExternalValue::Union { value, metadata } => BexExternalValue::Union {
+            value: Box::new(annotate_json_container_types(*value, json_ty)),
+            metadata,
         },
         scalar => scalar,
     }
@@ -4086,6 +4093,57 @@ mod union_container_selection_tests {
             &metadata.selected_option,
             &json
         ));
+    }
+
+    #[test]
+    fn canonical_json_alias_accepts_leaf_annotated_inbound_trees() {
+        // The Swift bridge annotates every json scalar leaf with a sparse
+        // inbound `value_type` (a transient `Union` carrier). Such trees must
+        // satisfy `json` and re-annotate their containers exactly like
+        // untyped trees; annotations outside the JSON algebra must not.
+        let json = json_ty();
+        let mut entries = indexmap::IndexMap::new();
+        entries.insert(
+            "type".to_string(),
+            BexExternalValue::typed(BexExternalValue::String("ok".into()), RuntimeTy::string()),
+        );
+        let object = BexExternalValue::Map {
+            key_type: RuntimeTy::string(),
+            value_type: RuntimeTy::unknown(),
+            entries,
+        };
+        assert!(value_matches_type(&object, &json));
+
+        let coerced = coerce_arg_to_declared_type(object, &json).unwrap();
+        let BexExternalValue::Map {
+            value_type,
+            entries,
+            ..
+        } = coerced
+        else {
+            panic!("annotated JSON object must stay a map")
+        };
+        assert!(runtime_ty_structurally_equal(&value_type, &json));
+        let BexExternalValue::Union { metadata, .. } = &entries["type"] else {
+            panic!("leaf annotation must be preserved")
+        };
+        assert!(metadata.is_inbound_type_annotation);
+
+        // A leaf annotated outside the JSON algebra keeps the tree non-JSON.
+        let mut bigint_entries = indexmap::IndexMap::new();
+        bigint_entries.insert(
+            "huge".to_string(),
+            BexExternalValue::typed(
+                BexExternalValue::Bigint(num_bigint::BigInt::from(1)),
+                RuntimeTy::bigint(),
+            ),
+        );
+        let bigint_object = BexExternalValue::Map {
+            key_type: RuntimeTy::string(),
+            value_type: RuntimeTy::unknown(),
+            entries: bigint_entries,
+        };
+        assert!(!value_matches_type(&bigint_object, &json));
     }
 
     #[test]

--- a/baml_language/crates/bex_engine/src/conversion.rs
+++ b/baml_language/crates/bex_engine/src/conversion.rs
@@ -4118,7 +4118,10 @@ mod union_container_selection_tests {
         else {
             panic!("JSON object must stay a map")
         };
-        assert!(runtime_ty_structurally_equal(&key_type, &RuntimeTy::string()));
+        assert!(runtime_ty_structurally_equal(
+            &key_type,
+            &RuntimeTy::string()
+        ));
         assert!(runtime_ty_structurally_equal(&value_type, &json));
         let BexExternalValue::Array { element_type, .. } = &entries["inner"] else {
             panic!("nested JSON list must stay a list")

--- a/baml_language/crates/bex_external_types/src/host_return.rs
+++ b/baml_language/crates/bex_external_types/src/host_return.rs
@@ -43,7 +43,26 @@ use baml_type::{Literal, RuntimeTy, TypeName};
 
 use crate::BexExternalValue;
 
+/// Canonical dotted path of the builtin JSON alias — test fixtures build the
+/// builtin `TypeName` from it; runtime identity checks go through
+/// [`is_canonical_json_alias`], never a rendered string.
+#[cfg(test)]
 const BAML_JSON_JSON: &str = "baml.json.json";
+
+/// Whether a type name is the canonical builtin `baml.json.json` alias.
+///
+/// Compares the fully qualified identity — package `baml`, namespace
+/// `json`, name `json` — never a rendered display string:
+/// `TypeName::display_name()` elides the implicit `user` package for local
+/// types, so a user alias declared at namespace path `baml.json` with name
+/// `json` would render identically and must NOT receive builtin JSON
+/// behavior.
+pub fn is_canonical_json_alias(name: &TypeName) -> bool {
+    name.package().as_str() == "baml"
+        && name.namespace().len() == 1
+        && name.namespace()[0].as_str() == "json"
+        && name.name().as_str() == "json"
+}
 
 /// A host callable returned a value whose runtime shape cannot inhabit the
 /// declared return type.
@@ -91,6 +110,20 @@ pub fn validate_host_return(
         && metadata.is_inbound_type_annotation
     {
         if inbound_annotation_satisfies_ty(&metadata.selected_option, expected) {
+            return Ok(());
+        }
+        // The canonical `baml.json.json` alias is nominal-opaque to the
+        // context-free subtype check above (`NoFacts` cannot expand it), so a
+        // bridge that annotates a container-valued json return — the C++
+        // codec annotates the selected variant alternative, e.g.
+        // `map<string, baml.json.json>` — would be rejected here. Admit the
+        // annotation structurally instead: the declared type must admit the
+        // json alias, the annotation must stay within the JSON algebra, and
+        // the payload (peeled by `value_satisfies_json`) must inhabit it.
+        if expected_admits_json_alias(expected, 0)
+            && runtime_ty_within_json_algebra(&metadata.selected_option, 0)
+            && value_satisfies_json(value)
+        {
             return Ok(());
         }
         return Err(HostReturnTypeError {
@@ -144,7 +177,7 @@ fn value_satisfies_ty(value: &BexExternalValue, ty: &RuntimeTy) -> bool {
             _ => members.iter().any(|m| value_satisfies_ty(value, m)),
         },
 
-        RuntimeTy::TypeAlias(name, _) if name.display_name().as_str() == BAML_JSON_JSON => {
+        RuntimeTy::TypeAlias(name, _) if is_canonical_json_alias(name) => {
             value_satisfies_json(value)
         }
 
@@ -259,6 +292,13 @@ fn value_satisfies_ty(value: &BexExternalValue, ty: &RuntimeTy) -> bool {
 /// Whether an external value is exactly in the recursive `baml.json.json`
 /// algebra. BAML extensions such as bigint, bytes, classes, enums, media,
 /// handles, and non-finite floats are intentionally rejected.
+///
+/// A sparse inbound `value_type` annotation (a transient
+/// `BexExternalValue::Union` with `is_inbound_type_annotation`, e.g. the
+/// Swift bridge annotates every json scalar leaf) is peeled — but only when
+/// the annotation itself stays within the JSON algebra, so a payload
+/// annotated as `bigint` or a class is still rejected. A genuine union
+/// carrier (a value produced from a declared union) is never JSON.
 pub fn value_satisfies_json(value: &BexExternalValue) -> bool {
     fn recurse(value: &BexExternalValue, depth: usize) -> bool {
         if depth > 256 {
@@ -276,12 +316,64 @@ pub fn value_satisfies_json(value: &BexExternalValue) -> bool {
             BexExternalValue::Map { entries, .. } => {
                 entries.values().all(|item| recurse(item, depth + 1))
             }
-            BexExternalValue::Union { .. } => false,
+            BexExternalValue::Union { value, metadata } => {
+                metadata.is_inbound_type_annotation
+                    && runtime_ty_within_json_algebra(&metadata.selected_option, 0)
+                    && recurse(value, depth + 1)
+            }
             _ => false,
         }
     }
 
     recurse(value, 0)
+}
+
+/// Whether a declared type admits the canonical `baml.json.json` alias: the
+/// alias itself, or a union with the alias among its members.
+fn expected_admits_json_alias(ty: &RuntimeTy, depth: usize) -> bool {
+    if depth > 64 {
+        return false;
+    }
+    match ty {
+        RuntimeTy::TypeAlias(name, _) => is_canonical_json_alias(name),
+        RuntimeTy::Union(members, _) => members
+            .iter()
+            .any(|member| expected_admits_json_alias(member, depth + 1)),
+        _ => false,
+    }
+}
+
+/// Whether a declared or annotated `RuntimeTy` lies entirely within the
+/// recursive `baml.json.json` algebra: the alias itself, the JSON scalar
+/// primitives, their literals, and string-keyed containers thereof.
+fn runtime_ty_within_json_algebra(ty: &RuntimeTy, depth: usize) -> bool {
+    if depth > 64 {
+        return false;
+    }
+    match ty {
+        RuntimeTy::Null { .. }
+        | RuntimeTy::Bool { .. }
+        | RuntimeTy::Int { .. }
+        | RuntimeTy::Float { .. }
+        | RuntimeTy::String { .. } => true,
+        RuntimeTy::TypeAlias(name, _) => is_canonical_json_alias(name),
+        RuntimeTy::Literal(literal, _, _) => matches!(
+            literal,
+            Literal::Bool(_) | Literal::Int(_) | Literal::String(_) | Literal::Float(_)
+        ),
+        RuntimeTy::List(inner, _) => runtime_ty_within_json_algebra(inner, depth + 1),
+        RuntimeTy::Map { key, value, .. } => {
+            matches!(key.as_ref(), RuntimeTy::String { .. })
+                && runtime_ty_within_json_algebra(value, depth + 1)
+        }
+        RuntimeTy::Union(members, _) => {
+            !members.is_empty()
+                && members
+                    .iter()
+                    .all(|member| runtime_ty_within_json_algebra(member, depth + 1))
+        }
+        _ => false,
+    }
 }
 
 /// Whether the value-tree class/enum name string matches the declared
@@ -360,6 +452,61 @@ mod tests {
             RuntimeTy::bigint(),
         );
         assert!(validate_host_return(&forged, &json_ty()).is_err());
+    }
+
+    #[test]
+    fn user_alias_shadowing_json_display_name_is_not_canonical() {
+        // `display_name()` elides the implicit `user` package, so a user alias
+        // declared at namespace path `baml.json` with name `json` renders
+        // identically to the builtin. Identity must be package-qualified.
+        let builtin = TypeName::from_dotted_path(BAML_JSON_JSON);
+        let shadow = TypeName::from_dotted_path("user.baml.json.json");
+        assert_eq!(
+            builtin.display_name().as_str(),
+            shadow.display_name().as_str()
+        );
+        assert!(is_canonical_json_alias(&builtin));
+        assert!(!is_canonical_json_alias(&shadow));
+
+        // The shadow alias must not inherit builtin JSON strictness: a bigint
+        // is rejected by the json algebra but passes the shadow alias through
+        // this layer's defensive accept-any tail (its body is validated
+        // engine-side, where alias definitions are available).
+        let shadow_ty = RuntimeTy::TypeAlias(shadow, TyAttr::default());
+        let bigint = BexExternalValue::Bigint(1.into());
+        assert!(validate_host_return(&bigint, &json_ty()).is_err());
+        assert!(validate_host_return(&bigint, &shadow_ty).is_ok());
+    }
+
+    #[test]
+    fn canonical_json_alias_accepts_algebra_scoped_inbound_annotations() {
+        // The C++ codec annotates a json return's selected variant alternative
+        // (`map<string, baml.json.json>`); Swift annotates scalar leaves. Both
+        // are sparse inbound annotations inside the JSON algebra and must
+        // validate against a declared json return — including nested in a
+        // container — while annotations outside the algebra stay rejected.
+        let mut entries = IndexMap::new();
+        entries.insert(
+            "type".to_string(),
+            BexExternalValue::typed(BexExternalValue::String("ok".into()), RuntimeTy::string()),
+        );
+        let annotated_map = BexExternalValue::typed(
+            BexExternalValue::Map {
+                key_type: RuntimeTy::string(),
+                value_type: RuntimeTy::unknown(),
+                entries,
+            },
+            RuntimeTy::Map {
+                key: Box::new(RuntimeTy::string()),
+                value: Box::new(json_ty()),
+                attr: TyAttr::default(),
+            },
+        );
+        assert!(validate_host_return(&annotated_map, &json_ty()).is_ok());
+
+        let annotated_bigint =
+            BexExternalValue::typed(BexExternalValue::Bigint(1.into()), RuntimeTy::bigint());
+        assert!(validate_host_return(&annotated_bigint, &json_ty()).is_err());
     }
 
     #[test]

--- a/baml_language/crates/bex_external_types/src/lib.rs
+++ b/baml_language/crates/bex_external_types/src/lib.rs
@@ -37,5 +37,7 @@ pub use bex_resource_types::{
 };
 pub use bex_str::BexStr;
 pub use handle::{Handle, HandleInner, WeakHeapRef};
-pub use host_return::{HostReturnTypeError, validate_host_return, value_satisfies_json};
+pub use host_return::{
+    HostReturnTypeError, is_canonical_json_alias, validate_host_return, value_satisfies_json,
+};
 pub use runtime_ty_identity::{runtime_ty_structurally_equal, selected_arm_equal};

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_json.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_json.cc
@@ -1,0 +1,83 @@
+// Host-supplied json must materialize with `json` container typing.
+// Port of go/function_calls/customizable/test_json_test.go (the typed
+// narrowing subset). Inbound json values from the C++ bridge carry no
+// element-type annotation on the wire; the engine must re-annotate them
+// with the `baml.json.json` alias so typed narrowing inside BAML --
+// `match (j) { let m: map<string, json> => ... }`, and therefore
+// `baml.json.path` / `path_or` -- treats them exactly like BAML-born
+// `baml.json.parse` values.
+#include <baml_sdk.h>
+#include <baml_test.h>
+
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+using baml_sdk::baml::json::JsonPathError;
+using baml_sdk::baml::json::json;
+
+namespace {
+
+using JsonMap = std::unordered_map<std::string, ::baml::box<json>>;
+using JsonList = std::vector<::baml::box<json>>;
+
+json jstr(const char* s) { return json{std::string(s)}; }
+
+// {"type": "ok", "nested": {"list": [1, {"deep": "found"}]}}
+json narrowing_fixture() {
+  json deep = json{JsonMap{{"deep", ::baml::box<json>(jstr("found"))}}};
+  json list = json{JsonList{::baml::box<json>(json{int64_t{1}}),
+                            ::baml::box<json>(std::move(deep))}};
+  json nested = json{JsonMap{{"list", ::baml::box<json>(std::move(list))}}};
+  return json{JsonMap{{"type", ::baml::box<json>(jstr("ok"))},
+                      {"nested", ::baml::box<json>(std::move(nested))}}};
+}
+
+}  // namespace
+
+BAML_TEST(host_supplied_json_supports_typed_narrowing) {
+  const json object = narrowing_fixture();
+
+  BAML_ASSERT_EQ(baml_sdk::go_json_tests::json_kind(object),
+                 std::string("object"));
+  BAML_ASSERT_EQ(baml_sdk::go_json_tests::json_kind(
+                     json{JsonList{::baml::box<json>(json{int64_t{1}})}}),
+                 std::string("array"));
+  BAML_ASSERT_EQ(baml_sdk::go_json_tests::json_kind(jstr("text")),
+                 std::string("string"));
+  BAML_ASSERT_EQ(baml_sdk::go_json_tests::json_kind(json{int64_t{3}}),
+                 std::string("other"));
+
+  BAML_ASSERT_EQ(baml_sdk::go_json_tests::json_path_string(object, ".type"),
+                 std::string("ok"));
+  BAML_ASSERT_EQ(baml_sdk::go_json_tests::json_path_string(
+                     object, ".nested.list[1].deep"),
+                 std::string("found"));
+  BAML_ASSERT_EQ(baml_sdk::go_json_tests::json_path_string_or(
+                     object, ".missing", "fallback"),
+                 std::string("fallback"));
+
+  bool threw = false;
+  try {
+    baml_sdk::go_json_tests::json_path_string(object, ".absent");
+    baml_test::fail("json_path_string(.absent) did not throw");
+  } catch (const baml::thrown<baml::variant<JsonPathError>>& e) {
+    threw = true;
+    const JsonPathError decoded = e.get<JsonPathError>();
+    BAML_ASSERT(decoded.message.find("missing field") != std::string::npos);
+    BAML_ASSERT_EQ(decoded.selector, std::string(".absent"));
+  }
+  BAML_ASSERT(threw);
+}
+
+BAML_TEST(json_returned_from_host_callback_supports_typed_narrowing) {
+  // json returned from a host callback converts on the host-return path
+  // (no argument coercion pass); it must narrow identically.
+  const std::string got = baml_sdk::go_json_tests::json_callback_kind(
+      [](json value) {
+        return json{JsonMap{{"wrapped", ::baml::box<json>(std::move(value))}}};
+      },
+      jstr("payload"));
+  BAML_ASSERT_EQ(got, std::string("object"));
+}

--- a/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_json.cc
+++ b/baml_language/sdk_tests/crates/cpp/function_calls/customizable/tests/test_json.cc
@@ -14,8 +14,8 @@
 #include <utility>
 #include <vector>
 
-using baml_sdk::baml::json::JsonPathError;
 using baml_sdk::baml::json::json;
+using baml_sdk::baml::json::JsonPathError;
 
 namespace {
 
@@ -51,9 +51,9 @@ BAML_TEST(host_supplied_json_supports_typed_narrowing) {
 
   BAML_ASSERT_EQ(baml_sdk::go_json_tests::json_path_string(object, ".type"),
                  std::string("ok"));
-  BAML_ASSERT_EQ(baml_sdk::go_json_tests::json_path_string(
-                     object, ".nested.list[1].deep"),
-                 std::string("found"));
+  BAML_ASSERT_EQ(
+      baml_sdk::go_json_tests::json_path_string(object, ".nested.list[1].deep"),
+      std::string("found"));
   BAML_ASSERT_EQ(baml_sdk::go_json_tests::json_path_string_or(
                      object, ".missing", "fallback"),
                  std::string("fallback"));

--- a/baml_language/sdk_tests/crates/go/function_calls/customizable/test_json_test.go
+++ b/baml_language/sdk_tests/crates/go/function_calls/customizable/test_json_test.go
@@ -179,6 +179,62 @@ func Test_canonical_json_class_union_uses_declared_field_codecs(t *testing.T) {
 	}
 }
 
+func Test_host_supplied_json_supports_typed_narrowing(t *testing.T) {
+	// Host-supplied json objects must materialize with `json` container
+	// typing: a `match (j) { let m: map<string, json> => ... }` inside BAML
+	// (and therefore `baml.json.path` / `path_or`) must treat them exactly
+	// like BAML-born `baml.json.parse` values.
+	ctx := context.Background()
+	object := map[string]any{
+		"type": "ok",
+		"nested": map[string]any{
+			"list": []any{int64(1), map[string]any{"deep": "found"}},
+		},
+	}
+
+	kinds := map[string]any{
+		"object": object,
+		"array":  []any{int64(1)},
+		"string": "text",
+		"other":  int64(3),
+	}
+	for want, value := range kinds {
+		got, err := baml_sdk.GoJsonTestsJsonKind(ctx, value)
+		if err != nil || got != want {
+			t.Fatalf("json_kind(%#v) = %q, %v; want %q", value, got, err, want)
+		}
+	}
+
+	got, err := baml_sdk.GoJsonTestsJsonPathString(ctx, object, ".type")
+	if err != nil || got != "ok" {
+		t.Fatalf("json_path_string(.type) = %q, %v; want %q", got, err, "ok")
+	}
+
+	got, err = baml_sdk.GoJsonTestsJsonPathString(ctx, object, ".nested.list[1].deep")
+	if err != nil || got != "found" {
+		t.Fatalf("json_path_string(.nested.list[1].deep) = %q, %v; want %q", got, err, "found")
+	}
+
+	got, err = baml_sdk.GoJsonTestsJsonPathStringOr(ctx, object, ".missing", "fallback")
+	if err != nil || got != "fallback" {
+		t.Fatalf("json_path_string_or(.missing) = %q, %v; want %q", got, err, "fallback")
+	}
+
+	_, err = baml_sdk.GoJsonTestsJsonPathString(ctx, object, ".absent")
+	if err == nil || !strings.Contains(err.Error(), "missing field") {
+		t.Fatalf("json_path_string(.absent) error = %v; want missing-field JsonPathError", err)
+	}
+
+	// json returned from a host callback converts on the host-return path
+	// (no argument coercion pass); it must narrow identically.
+	got, err = baml_sdk.GoJsonTestsJsonCallbackKind(ctx, func(value any) any {
+		return map[string]any{"wrapped": value}
+	}, "payload")
+	if err != nil || got != "object" {
+		t.Fatalf("json_callback_kind = %q, %v; want %q", got, err, "object")
+	}
+}
+
 func Test_canonical_json_rejects_extensions_before_dispatch(t *testing.T) {
 	ctx := context.Background()
 	invalid := []struct {

--- a/baml_language/sdk_tests/crates/go/function_calls/customizable/test_json_test.go
+++ b/baml_language/sdk_tests/crates/go/function_calls/customizable/test_json_test.go
@@ -179,6 +179,7 @@ func Test_canonical_json_class_union_uses_declared_field_codecs(t *testing.T) {
 	}
 }
 
+// SDK_PARITY_LINT(skip): engine-side regression exercised via the Go and Python bridges
 func Test_host_supplied_json_supports_typed_narrowing(t *testing.T) {
 	// Host-supplied json objects must materialize with `json` container
 	// typing: a `match (j) { let m: map<string, json> => ... }` inside BAML

--- a/baml_language/sdk_tests/crates/go/function_calls/customizable/test_json_test.go
+++ b/baml_language/sdk_tests/crates/go/function_calls/customizable/test_json_test.go
@@ -179,7 +179,6 @@ func Test_canonical_json_class_union_uses_declared_field_codecs(t *testing.T) {
 	}
 }
 
-// SDK_PARITY_LINT(skip): engine-side regression exercised via the Go and Python bridges
 func Test_host_supplied_json_supports_typed_narrowing(t *testing.T) {
 	// Host-supplied json objects must materialize with `json` container
 	// typing: a `match (j) { let m: map<string, json> => ... }` inside BAML
@@ -225,10 +224,13 @@ func Test_host_supplied_json_supports_typed_narrowing(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "missing field") {
 		t.Fatalf("json_path_string(.absent) error = %v; want missing-field JsonPathError", err)
 	}
+}
 
+func Test_json_returned_from_host_callback_supports_typed_narrowing(t *testing.T) {
 	// json returned from a host callback converts on the host-return path
 	// (no argument coercion pass); it must narrow identically.
-	got, err = baml_sdk.GoJsonTestsJsonCallbackKind(ctx, func(value any) any {
+	ctx := context.Background()
+	got, err := baml_sdk.GoJsonTestsJsonCallbackKind(ctx, func(value any) any {
 		return map[string]any{"wrapped": value}
 	}, "payload")
 	if err != nil || got != "object" {

--- a/baml_language/sdk_tests/crates/java/function_calls/customizable/TestJson.java
+++ b/baml_language/sdk_tests/crates/java/function_calls/customizable/TestJson.java
@@ -1,0 +1,85 @@
+// Host-supplied json must materialize with `json` container typing.
+//
+// Port of python_pydantic2/function_calls/customizable/test_json.py (the
+// typed-narrowing half; the Go analog lives in go/function_calls/customizable/
+// test_json_test.go).
+//
+// Inbound json values from the Java bridge carry no element-type annotation on
+// the wire; the engine must re-annotate them with the `baml.json.json` alias so
+// typed narrowing inside BAML — `match (j) { let m: map<string, json> => ... }`,
+// and therefore `baml.json.path` / `path_or` — treats them exactly like
+// BAML-born `baml.json.parse` values.
+//
+// java-port note: where Python/Go pass plain dicts/maps, Java's generated
+// surface types json as the sealed interface `baml_sdk.baml.json.json`, so the
+// fixtures are built from its record arms (jsonMapValue / jsonListValue /
+// StringValue / IntValue).
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import baml_bridge.BamlError;
+import baml_sdk.baml.json.JsonPathError;
+import baml_sdk.baml.json.json;
+import baml_sdk.go_json_tests.Fns;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+class TestJson {
+
+    /** {"type": "ok", "nested": {"list": [1, {"deep": "found"}]}} */
+    private static json narrowingFixture() {
+        json deep = new json.jsonMapValue(Map.of("deep", new json.StringValue("found")));
+        json list = new json.jsonListValue(List.of(new json.IntValue(1L), deep));
+        json nested = new json.jsonMapValue(Map.of("list", list));
+        return new json.jsonMapValue(
+                Map.of("type", new json.StringValue("ok"), "nested", nested));
+    }
+
+    @Test
+    void test_host_supplied_json_supports_typed_narrowing() {
+        json obj = narrowingFixture();
+
+        assertEquals("object", Fns.json_kind(obj));
+        assertEquals("array", Fns.json_kind(new json.jsonListValue(List.of(new json.IntValue(1L)))));
+        assertEquals("string", Fns.json_kind(new json.StringValue("text")));
+        assertEquals("other", Fns.json_kind(new json.IntValue(3L)));
+
+        assertEquals("ok", Fns.json_path_string(obj, ".type"));
+        assertEquals("found", Fns.json_path_string(obj, ".nested.list[1].deep"));
+        assertEquals("fallback", Fns.json_path_string_or(obj, ".missing", "fallback"));
+
+        // java-port note: Python matches str(exc) against "missing field";
+        // the generated Java JsonPathError does not render its fields into
+        // BamlError's message, so assert on the decoded error's message field.
+        BamlError exc =
+                assertThrows(BamlError.class, () -> Fns.json_path_string(obj, ".absent"));
+        JsonPathError pathError = assertInstanceOf(JsonPathError.class, exc.value());
+        assertTrue(pathError.message().contains("missing field"), pathError.message());
+    }
+
+    @Test
+    void test_json_returned_from_host_callback_supports_typed_narrowing() {
+        // json returned from a host callback converts on the host-return path
+        // (no argument coercion pass); it must narrow identically.
+        //
+        // java-port note: the generated slot types the callback as
+        // `Function<json, json>`, but the bridge hands the callback the decoded
+        // RAW host value (String/List/Map, mirroring Go's `any` and Python's
+        // plain objects) and encodes the raw return value generically on the
+        // host-return path. Building the callable as `Function<Object, Object>`
+        // and laundering it through a wildcard cast is the same documented
+        // raw/unchecked idiom as TestHostCallables' value-level async tests —
+        // at runtime the erased `apply` sees the raw value, so no
+        // ClassCastException.
+        Function<Object, Object> rawCb = v -> Map.of("wrapped", v);
+        @SuppressWarnings("unchecked")
+        Function<json, json> cb = (Function<json, json>) (Function<?, ?>) rawCb;
+
+        assertEquals("object", Fns.json_callback_kind(cb, new json.StringValue("payload")));
+    }
+}

--- a/baml_language/sdk_tests/crates/java/function_calls/customizable/TestJson.java
+++ b/baml_language/sdk_tests/crates/java/function_calls/customizable/TestJson.java
@@ -67,18 +67,11 @@ class TestJson {
         // json returned from a host callback converts on the host-return path
         // (no argument coercion pass); it must narrow identically.
         //
-        // java-port note: the generated slot types the callback as
-        // `Function<json, json>`, but the bridge hands the callback the decoded
-        // RAW host value (String/List/Map, mirroring Go's `any` and Python's
-        // plain objects) and encodes the raw return value generically on the
-        // host-return path. Building the callable as `Function<Object, Object>`
-        // and laundering it through a wildcard cast is the same documented
-        // raw/unchecked idiom as TestHostCallables' value-level async tests —
-        // at runtime the erased `apply` sees the raw value, so no
-        // ClassCastException.
-        Function<Object, Object> rawCb = v -> Map.of("wrapped", v);
-        @SuppressWarnings("unchecked")
-        Function<json, json> cb = (Function<json, json>) (Function<?, ?>) rawCb;
+        // The generated slot types the callback as `Function<json, json>` and
+        // the bridge honors that signature: the callback receives the sealed
+        // `json` union the parameter declares (here a `json.StringValue`), and
+        // returns a `json` value the bridge encodes back to BAML.
+        Function<json, json> cb = v -> new json.jsonMapValue(Map.of("wrapped", v));
 
         assertEquals("object", Fns.json_callback_kind(cb, new json.StringValue("payload")));
     }

--- a/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_json.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_json.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import pytest
 
 
+# SDK_PARITY_LINT(skip): engine-side regression exercised via the Go and Python bridges
 def test_host_supplied_json_supports_typed_narrowing():
     from baml_sdk.baml import BamlError
     from baml_sdk.go_json_tests import json_kind, json_path_string, json_path_string_or
@@ -35,6 +36,7 @@ def test_host_supplied_json_supports_typed_narrowing():
         json_path_string(obj, ".absent")
 
 
+# SDK_PARITY_LINT(skip): engine-side regression exercised via the Go and Python bridges
 def test_json_returned_from_host_callback_supports_typed_narrowing():
     from baml_sdk.go_json_tests import json_callback_kind
 

--- a/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_json.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_json.py
@@ -1,0 +1,43 @@
+"""Host-supplied json must materialize with `json` container typing.
+
+Inbound dicts/lists from the Python bridge carry no element-type
+annotation on the wire; the engine must re-annotate them with the
+`baml.json.json` alias so typed narrowing inside BAML — `match (j) {
+let m: map<string, json> => ... }`, and therefore `baml.json.path` /
+`path_or` — treats them exactly like BAML-born `baml.json.parse`
+values.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_host_supplied_json_supports_typed_narrowing():
+    from baml_sdk.baml import BamlError
+    from baml_sdk.go_json_tests import json_kind, json_path_string, json_path_string_or
+
+    obj = {
+        "type": "ok",
+        "nested": {"list": [1, {"deep": "found"}]},
+    }
+
+    assert json_kind(obj) == "object"
+    assert json_kind([1]) == "array"
+    assert json_kind("text") == "string"
+    assert json_kind(3) == "other"
+
+    assert json_path_string(obj, ".type") == "ok"
+    assert json_path_string(obj, ".nested.list[1].deep") == "found"
+    assert json_path_string_or(obj, ".missing", "fallback") == "fallback"
+
+    with pytest.raises(BamlError, match="missing field"):
+        json_path_string(obj, ".absent")
+
+
+def test_json_returned_from_host_callback_supports_typed_narrowing():
+    from baml_sdk.go_json_tests import json_callback_kind
+
+    # json returned from a host callback converts on the host-return path
+    # (no argument coercion pass); it must narrow identically.
+    assert json_callback_kind(lambda v: {"wrapped": v}, "payload") == "object"

--- a/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_json.py
+++ b/baml_language/sdk_tests/crates/python_pydantic2/function_calls/customizable/test_json.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import pytest
 
 
-# SDK_PARITY_LINT(skip): engine-side regression exercised via the Go and Python bridges
+# SDK_PARITY_LINT(skip): C# declares no function_calls suite (its native coverage is Rust-wrapped integration tests)
 def test_host_supplied_json_supports_typed_narrowing():
     from baml_sdk.baml import BamlError
     from baml_sdk.go_json_tests import json_kind, json_path_string, json_path_string_or
@@ -36,7 +36,7 @@ def test_host_supplied_json_supports_typed_narrowing():
         json_path_string(obj, ".absent")
 
 
-# SDK_PARITY_LINT(skip): engine-side regression exercised via the Go and Python bridges
+# SDK_PARITY_LINT(skip): C# declares no function_calls suite (its native coverage is Rust-wrapped integration tests)
 def test_json_returned_from_host_callback_supports_typed_narrowing():
     from baml_sdk.go_json_tests import json_callback_kind
 

--- a/baml_language/sdk_tests/crates/rust/function_calls/customizable/test_json.rs
+++ b/baml_language/sdk_tests/crates/rust/function_calls/customizable/test_json.rs
@@ -1,0 +1,81 @@
+//! Host-supplied json must materialize with `json` container typing.
+//!
+//! Inbound maps/lists from the Rust bridge carry no element-type annotation
+//! on the wire; the engine must re-annotate them with the `baml.json.json`
+//! alias so typed narrowing inside BAML — `match (j) { let m: map<string,
+//! json> => ... }`, and therefore `baml.json.path` / `path_or` — treats
+//! them exactly like BAML-born `baml.json.parse` values.
+//!
+//! This module stays gated off until `sdkgen_rust` projects the canonical
+//! `baml.json.json` recursive alias: today every symbol touching it is
+//! skipped as unsupported, so `baml_sdk::go_json_tests` emits no entry
+//! points (Go projects the alias as `any`; the Rust projection is not
+//! pinned yet). Once it compiles, each case below asserts the same
+//! contract the Go and Python ports pin.
+
+// SPECULATIVE: `serde_json::Value` as the Rust projection of canonical
+// JSON (the analogue of Go's `any` and Python's native values) is a
+// provisional choice until the generator pins one, as is the presence of
+// `serde_json` in the generated crate's dev-dependencies.
+use baml_sdk::go_json_tests::{
+    json_callback_kind, json_kind, json_path_string, json_path_string_or,
+};
+use serde_json::json;
+
+fn narrowing_object() -> serde_json::Value {
+    json!({
+        "type": "ok",
+        "nested": { "list": [1, { "deep": "found" }] },
+    })
+}
+
+#[test]
+fn test_host_supplied_json_supports_typed_narrowing() {
+    let object = narrowing_object();
+
+    assert_eq!(json_kind(object.clone()).unwrap(), "object");
+    assert_eq!(json_kind(json!([1])).unwrap(), "array");
+    assert_eq!(json_kind(json!("text")).unwrap(), "string");
+    assert_eq!(json_kind(json!(3)).unwrap(), "other");
+
+    assert_eq!(
+        json_path_string(object.clone(), ".type".to_string()).unwrap(),
+        "ok"
+    );
+    assert_eq!(
+        json_path_string(object.clone(), ".nested.list[1].deep".to_string()).unwrap(),
+        "found"
+    );
+    assert_eq!(
+        json_path_string_or(
+            object.clone(),
+            ".missing".to_string(),
+            "fallback".to_string()
+        )
+        .unwrap(),
+        "fallback"
+    );
+
+    // `json_path_string` declares `throws baml.json.JsonPathError`, so the
+    // missing-field throw surfaces typed like every declared throw; the
+    // python port pins the same case as `BamlError` matching
+    // "missing field".
+    let err = json_path_string(object, ".absent".to_string())
+        .expect_err("the missing-field throw must surface to the caller");
+    let baml_bridge::Error::Thrown { value, .. } = err else {
+        panic!("expected the typed JsonPathError throw, got {err}");
+    };
+    assert!(value.message.contains("missing field"), "{}", value.message);
+}
+
+#[test]
+fn test_json_returned_from_host_callback_supports_typed_narrowing() {
+    // json returned from a host callback converts on the host-return path
+    // (no argument coercion pass); it must narrow identically.
+    let result = json_callback_kind(
+        |value: serde_json::Value| json!({ "wrapped": value }),
+        json!("payload"),
+    )
+    .unwrap();
+    assert_eq!(result, "object");
+}

--- a/baml_language/sdk_tests/crates/swift/function_calls/customizable/TestJson.swift
+++ b/baml_language/sdk_tests/crates/swift/function_calls/customizable/TestJson.swift
@@ -1,0 +1,77 @@
+// Host-supplied json container typing — port of Go `test_json_test.go`
+// (`Test_host_supplied_json_supports_typed_narrowing`) and
+// python_pydantic2 `test_json.py`.
+//
+// Inbound dictionaries/arrays from the Swift bridge carry no
+// element-type annotation on the wire; the engine must re-annotate
+// them with the `baml.json.json` alias so typed narrowing inside BAML
+// — `match (j) { let m: map<string, json> => ... }`, and therefore
+// `baml.json.path` / `path_or` — treats them exactly like BAML-born
+// `baml.json.parse` values.
+//
+// Adaptation from Go/Python: Swift's json values are the nominal
+// `Baml.baml.json.json` enum rather than untyped `any`/dicts, so the
+// fixture wraps each node explicitly.
+import XCTest
+import Baml
+import BamlBridge
+
+private typealias Json = Baml.baml.json.json
+
+private func jsonFixtureObject() -> Json {
+    Json([
+        "type": Json("ok"),
+        "nested": Json([
+            "list": Json([Json(1), Json(["deep": Json("found")])])
+        ]),
+    ])
+}
+
+final class TestJson: XCTestCase {
+    func test_host_supplied_json_supports_typed_narrowing() throws {
+        let object = jsonFixtureObject()
+
+        XCTAssertEqual(try Baml.go_json_tests.json_kind(value: object), "object")
+        XCTAssertEqual(try Baml.go_json_tests.json_kind(value: Json([Json(1)])), "array")
+        XCTAssertEqual(try Baml.go_json_tests.json_kind(value: Json("text")), "string")
+        XCTAssertEqual(try Baml.go_json_tests.json_kind(value: Json(3)), "other")
+
+        XCTAssertEqual(
+            try Baml.go_json_tests.json_path_string(value: object, selector: ".type"),
+            "ok"
+        )
+        XCTAssertEqual(
+            try Baml.go_json_tests.json_path_string(value: object, selector: ".nested.list[1].deep"),
+            "found"
+        )
+        XCTAssertEqual(
+            try Baml.go_json_tests.json_path_string_or(
+                value: object,
+                selector: ".missing",
+                default: "fallback"
+            ),
+            "fallback"
+        )
+
+        do {
+            _ = try Baml.go_json_tests.json_path_string(value: object, selector: ".absent")
+            XCTFail("expected BamlError")
+        } catch let error as BamlError {
+            let decoded = try error.value(as: Baml.baml.json.JsonPathError.self)
+            XCTAssertTrue(
+                decoded.message.contains("missing field"),
+                "unexpected JsonPathError message: \(decoded.message)"
+            )
+        }
+    }
+
+    func test_json_returned_from_host_callback_supports_typed_narrowing() throws {
+        // json returned from a host callback converts on the host-return
+        // path (no argument coercion pass); it must narrow identically.
+        let result = try Baml.go_json_tests.json_callback_kind(
+            callback: { value in Json(["wrapped": value]) },
+            value: Json("payload")
+        )
+        XCTAssertEqual(result, "object")
+    }
+}

--- a/baml_language/sdk_tests/crates/typescript/function_calls/customizable/json.test.ts
+++ b/baml_language/sdk_tests/crates/typescript/function_calls/customizable/json.test.ts
@@ -1,0 +1,43 @@
+// Host-supplied json must materialize with `json` container typing.
+//
+// Inbound objects/arrays from the TypeScript bridge carry no element-type
+// annotation on the wire; the engine must re-annotate them with the
+// `baml.json.json` alias so typed narrowing inside BAML — `match (j) {
+// let m: map<string, json> => ... }`, and therefore `baml.json.path` /
+// `path_or` — treats them exactly like BAML-born `baml.json.parse` values.
+import "./baml_sdk/index.js";
+import { describe, expect, it } from "vitest";
+import {
+  json_callback_kind_async,
+  json_kind,
+  json_path_string,
+  json_path_string_or,
+} from "./baml_sdk/go_json_tests/index.js";
+
+describe("function_calls — host-supplied json typed narrowing", () => {
+  const object = {
+    type: "ok",
+    nested: { list: [1, { deep: "found" }] },
+  };
+
+  it("host_supplied_json_supports_typed_narrowing", () => {
+    expect(json_kind(object)).toBe("object");
+    expect(json_kind([1])).toBe("array");
+    expect(json_kind("text")).toBe("string");
+    expect(json_kind(3)).toBe("other");
+
+    expect(json_path_string(object, ".type")).toBe("ok");
+    expect(json_path_string(object, ".nested.list[1].deep")).toBe("found");
+    expect(json_path_string_or(object, ".missing", "fallback")).toBe("fallback");
+
+    expect(() => json_path_string(object, ".absent")).toThrow(/missing field/);
+  });
+
+  it("json_returned_from_host_callback_supports_typed_narrowing", async () => {
+    // json returned from a host callback converts on the host-return path
+    // (no argument coercion pass); it must narrow identically.
+    await expect(
+      json_callback_kind_async((value) => ({ wrapped: value }), "payload"),
+    ).resolves.toBe("object");
+  });
+});

--- a/baml_language/sdk_tests/fixtures/function_calls/baml_src/ns_go_json_tests/main.baml
+++ b/baml_language/sdk_tests/fixtures/function_calls/baml_src/ns_go_json_tests/main.baml
@@ -56,3 +56,29 @@ function round_trip_json_box_dynamic(value: JsonBox | image | audio | video) -> 
 function unsupported_user_recursive(value: UserRecursiveJson) -> UserRecursiveJson {
   value
 }
+
+// Host-supplied json must materialize with `json` container typing so typed
+// narrowing (`match`, and therefore `baml.json.path` / `path_or`) behaves
+// identically to BAML-born `baml.json.parse` values.
+function json_kind(value: baml.json.json) -> string {
+  match (value) {
+    let m: map<string, baml.json.json> => "object",
+    let arr: baml.json.json[] => "array",
+    let s: string => "string",
+    _ => "other",
+  }
+}
+
+function json_path_string(value: baml.json.json, selector: string) -> string throws baml.json.JsonPathError {
+  baml.json.path<string>(value, selector)
+}
+
+function json_path_string_or(value: baml.json.json, selector: string, default: string) -> string throws never {
+  baml.json.path_or<string>(value, selector, default)
+}
+
+// A host callback's json return value must materialize with `json` container
+// typing too — it converts on the host-return path, not the argument path.
+function json_callback_kind(callback: (baml.json.json) -> baml.json.json, value: baml.json.json) -> string {
+  json_kind(callback(value))
+}

--- a/baml_language/sdk_tests/harness_setup/src/rust.rs
+++ b/baml_language/sdk_tests/harness_setup/src/rust.rs
@@ -118,6 +118,11 @@ const TEST_MODS: &[(&str, &str, Gate)] = &[
         "test_optional_args.rs",
         Gate::Later("needs the optional-arg matrix and methods on classes"),
     ),
+    (
+        "function_calls",
+        "test_json.rs",
+        Gate::Later("needs a canonical baml.json.json projection in sdkgen_rust"),
+    ),
     ("function_calls", "test_raises.rs", Gate::Now),
     (
         "function_calls",

--- a/baml_language/sdks/java/baml_bridge/src/main/java/baml_bridge/BamlFfi.java
+++ b/baml_language/sdks/java/baml_bridge/src/main/java/baml_bridge/BamlFfi.java
@@ -769,18 +769,34 @@ public final class BamlFfi {
      * {@link CompletableFuture}) or the thrown value. Wrapped so a dropped
      * dispatch can never leave the engine awaiting: any thrown value routes to
      * {@link #completeHostError}, and the call is always completed exactly once.
+     *
+     * <p>A callable registered wrapped in a {@link BamlTypedCallable} (the
+     * generated SDK's carrier) is unwrapped here: its declared parameter
+     * descriptors drive a type-directed arg decode — so the user's typed lambda
+     * receives the generated types its slot declares (e.g. the sealed
+     * {@code baml.json.json} union), never the raw wire value — and its return
+     * descriptor types the encode of the result.
      */
     private static void runHostDispatch(long hostValueKey, long callId, byte[] bamlToHostCall) {
-        Object callable = HOST_VALUES.get(hostValueKey);
-        if (callable == null) {
+        Object registered = HOST_VALUES.get(hostValueKey);
+        if (registered == null) {
             // The engine dispatched a key the bridge no longer holds — a bridge
             // fault, not a user exception → BridgeFailure (empty error payload).
             safeComplete(callId, true, EMPTY_PAYLOAD);
             return;
         }
+        BamlTypedCallable typed = registered instanceof BamlTypedCallable t ? t : null;
+        Object callable = typed != null ? typed.callable() : registered;
+        BamlType returnDesc = typed != null ? typed.returnDesc() : null;
         Object result;
         try {
-            ProtoReader.HostCallArgs args = ProtoReader.decodeBamlToHostCall(bamlToHostCall);
+            ProtoReader.HostCallArgs args = typed != null
+                    ? ProtoReader.decodeBamlToHostCall(
+                            bamlToHostCall,
+                            typed.positionalDescs(),
+                            typed.optionalNames(),
+                            typed.optionalDescs())
+                    : ProtoReader.decodeBamlToHostCall(bamlToHostCall);
             result = invokeHostCallable(callable, args);
         } catch (Throwable userError) {
             completeHostError(callId, userError);
@@ -795,11 +811,11 @@ public final class BamlFfi {
                         if (err != null) {
                             completeHostError(callId, unwrapCompletion(err));
                         } else {
-                            completeHostSuccess(callId, value);
+                            completeHostSuccess(callId, value, returnDesc);
                         }
                     });
         } else {
-            completeHostSuccess(callId, result);
+            completeHostSuccess(callId, result, returnDesc);
         }
     }
 
@@ -852,11 +868,20 @@ public final class BamlFfi {
                 "host-value key resolved to a non-callable object: " + callable.getClass());
     }
 
-    /** Encode a successful callable result and complete the call. */
-    private static void completeHostSuccess(long callId, Object value) {
+    /**
+     * Encode a successful callable result and complete the call.
+     * {@code returnDesc} (nullable) is the declared return-type descriptor a
+     * {@link BamlTypedCallable} carries; it types the encode exactly like a
+     * generated binding's argument descriptor ({@link BamlTypedValue}).
+     */
+    private static void completeHostSuccess(long callId, Object value, BamlType returnDesc) {
         byte[] payload;
         try {
-            payload = ProtoWriter.encodeInboundValue(value);
+            Object encodable =
+                    returnDesc != null && value != null
+                            ? new BamlTypedValue(value, returnDesc)
+                            : value;
+            payload = ProtoWriter.encodeInboundValue(encodable);
         } catch (Throwable encodeError) {
             // The callable returned a value the encoder can't map to a BAML value:
             // a bridge fault (the declared return type should have matched).

--- a/baml_language/sdks/java/baml_bridge/src/main/java/baml_bridge/BamlTypedCallable.java
+++ b/baml_language/sdks/java/baml_bridge/src/main/java/baml_bridge/BamlTypedCallable.java
@@ -1,0 +1,82 @@
+package baml_bridge;
+
+import java.util.Objects;
+
+/**
+ * Internal generated-call carrier pairing a host callable with the type-directed
+ * decode/encode descriptors of its declared BAML callable type — the callable
+ * counterpart of {@link BamlTypedValue}.
+ *
+ * <p>The generated SDK wraps a callable argument in this carrier so the bridge
+ * can honor the generated signature on the dispatch path: when BAML invokes the
+ * callable, each argument decodes against its declared parameter descriptor
+ * (so e.g. a {@code baml.json.json} parameter materializes as the generated
+ * sealed-union type, not the raw wire value), and the returned value encodes
+ * against {@link #returnDesc()}. The wire encoder registers this carrier itself
+ * in the host-value registry ({@code Handle{HOST_VALUE_CALLABLE}});
+ * {@code BamlFfi.runHostDispatch} unwraps it and threads the descriptors.
+ *
+ * <p>Descriptor slots follow the runtime's convention: a {@code null} array or
+ * a {@code null} entry means "decode/encode that slot wire-driven" (exactly the
+ * pre-carrier behavior). {@link #positionalDescs()} is parallel to the
+ * callable's required parameters in declared order; {@link #optionalNames()} /
+ * {@link #optionalDescs()} are parallel arrays keying supplied optional
+ * arguments by their BAML wire name.
+ */
+public final class BamlTypedCallable {
+    private final Object callable;
+    private final BamlType[] positionalDescs;
+    private final String[] optionalNames;
+    private final BamlType[] optionalDescs;
+    private final BamlType returnDesc;
+
+    public BamlTypedCallable(
+            Object callable,
+            BamlType[] positionalDescs,
+            String[] optionalNames,
+            BamlType[] optionalDescs,
+            BamlType returnDesc) {
+        this.callable = Objects.requireNonNull(callable, "callable");
+        int optionalNameCount = optionalNames == null ? 0 : optionalNames.length;
+        int optionalDescCount = optionalDescs == null ? 0 : optionalDescs.length;
+        if (optionalNameCount != optionalDescCount) {
+            throw new IllegalArgumentException(
+                    "optional descriptor arrays length mismatch: "
+                            + optionalNameCount + " names vs " + optionalDescCount + " descriptors");
+        }
+        this.positionalDescs = positionalDescs;
+        this.optionalNames = optionalNames;
+        this.optionalDescs = optionalDescs;
+        this.returnDesc = returnDesc;
+    }
+
+    /** All-positional convenience: no optional parameters. */
+    public BamlTypedCallable(Object callable, BamlType[] positionalDescs, BamlType returnDesc) {
+        this(callable, positionalDescs, null, null, returnDesc);
+    }
+
+    /** The wrapped host callable (a {@code java.util.function.*} shape or a {@link BamlHostCallable}). */
+    public Object callable() {
+        return callable;
+    }
+
+    /** Required-parameter descriptors in declared order, or {@code null} (all wire-driven). */
+    public BamlType[] positionalDescs() {
+        return positionalDescs;
+    }
+
+    /** Optional-parameter BAML wire names, parallel to {@link #optionalDescs()}, or {@code null}. */
+    public String[] optionalNames() {
+        return optionalNames;
+    }
+
+    /** Optional-parameter descriptors, parallel to {@link #optionalNames()}, or {@code null}. */
+    public BamlType[] optionalDescs() {
+        return optionalDescs;
+    }
+
+    /** The declared return-type encode descriptor, or {@code null} (wire-driven). */
+    public BamlType returnDesc() {
+        return returnDesc;
+    }
+}

--- a/baml_language/sdks/java/baml_bridge/src/main/java/baml_bridge/internal/ProtoReader.java
+++ b/baml_language/sdks/java/baml_bridge/src/main/java/baml_bridge/internal/ProtoReader.java
@@ -305,12 +305,33 @@ public final class ProtoReader {
 
     /**
      * Decode a {@code BamlToHostCall} (engine→host callable dispatch) into its
-     * positional + optional argument buckets. Each arg's {@code value} is a
-     * {@code BamlOutboundValue} decoded wire-driven (the callable carries no
-     * host return descriptor); {@code is_optional_arg} routes it into the
-     * optional bucket keyed by {@code arg_name}, everything else is positional.
+     * positional + optional argument buckets, wire-driven (no descriptors — the
+     * pre-carrier behavior, kept for a callable registered without a
+     * {@code BamlTypedCallable} wrapper). {@code is_optional_arg} routes an arg
+     * into the optional bucket keyed by {@code arg_name}, everything else is
+     * positional.
      */
     public static HostCallArgs decodeBamlToHostCall(byte[] bytes) {
+        return decodeBamlToHostCall(bytes, null, null, null);
+    }
+
+    /**
+     * Type-directed sibling of {@link #decodeBamlToHostCall(byte[])}: each
+     * positional arg decodes against its declared parameter descriptor
+     * ({@code positionalDescs}, declared order) and each supplied optional
+     * against the descriptor keyed by its BAML wire name
+     * ({@code optionalNames} / {@code optionalDescs}, parallel arrays), through
+     * the same {@link #decodeWithDesc} the outbound result path uses — so a
+     * callable parameter declared as e.g. {@code baml.json.json} materializes
+     * as the generated sealed-union type, exactly like a declared return type.
+     * A {@code null} array or a {@code null} entry decodes that slot
+     * wire-driven (byte-identical to the descriptor-less overload).
+     */
+    public static HostCallArgs decodeBamlToHostCall(
+            byte[] bytes,
+            BamlType[] positionalDescs,
+            String[] optionalNames,
+            BamlType[] optionalDescs) {
         WireReader r = new WireReader(bytes);
         List<Object> positional = new ArrayList<>();
         Map<String, Object> optional = new LinkedHashMap<>();
@@ -319,7 +340,13 @@ public final class ProtoReader {
             int field = WireReader.fieldOf(tag);
             int wire = WireReader.wireOf(tag);
             if (field == TO_HOST_ARGS) {
-                decodeToHostArg(r.readMessage(), positional, optional);
+                decodeToHostArg(
+                        r.readMessage(),
+                        positional,
+                        optional,
+                        positionalDescs,
+                        optionalNames,
+                        optionalDescs);
             } else {
                 r.skipField(wire);
             }
@@ -328,7 +355,12 @@ public final class ProtoReader {
     }
 
     private static void decodeToHostArg(
-            WireReader r, List<Object> positional, Map<String, Object> optional) {
+            WireReader r,
+            List<Object> positional,
+            Map<String, Object> optional,
+            BamlType[] positionalDescs,
+            String[] optionalNames,
+            BamlType[] optionalDescs) {
         byte[] valueBytes = null;
         String argName = "";
         boolean isOptional = false;
@@ -343,12 +375,33 @@ public final class ProtoReader {
                 default -> r.skipField(wire);
             }
         }
-        Object value = valueBytes == null ? null : decodeValue(new WireReader(valueBytes), false);
+        // The engine emits required args in declared order, so the next
+        // positional slot's descriptor is at the bucket's current size.
+        BamlType desc = isOptional
+                ? optionalDescByName(argName, optionalNames, optionalDescs)
+                : positionalDescs != null && positional.size() < positionalDescs.length
+                        ? positionalDescs[positional.size()]
+                        : null;
+        Object value = valueBytes == null ? null : decodeWithDesc(valueBytes, desc, false);
         if (isOptional) {
             optional.put(argName, value);
         } else {
             positional.add(value);
         }
+    }
+
+    /** The descriptor registered for optional arg {@code argName}, or {@code null}. */
+    private static BamlType optionalDescByName(
+            String argName, String[] optionalNames, BamlType[] optionalDescs) {
+        if (optionalNames == null || optionalDescs == null) {
+            return null;
+        }
+        for (int i = 0; i < optionalNames.length && i < optionalDescs.length; i++) {
+            if (optionalNames[i].equals(argName)) {
+                return optionalDescs[i];
+            }
+        }
+        return null;
     }
 
     /**

--- a/baml_language/sdks/java/baml_bridge/src/main/java/baml_bridge/internal/ProtoWriter.java
+++ b/baml_language/sdks/java/baml_bridge/src/main/java/baml_bridge/internal/ProtoWriter.java
@@ -554,12 +554,16 @@ public final class ProtoWriter {
      * Covers the generated {@link baml_bridge.BamlHostCallable} functional
      * interfaces (callables with optionals / arity &gt; 2) plus the
      * {@code java.util.function.*} shapes codegen uses for plain arity-&le;-2
-     * callables. Mirrors bridge_python's "any callable" test — an object reaching
-     * the encoder here is a BAML function argument, so a functional value in a
-     * callable-typed slot is a host callable.
+     * callables, and the {@link baml_bridge.BamlTypedCallable} carrier the
+     * generated SDK wraps a callable argument in (registered whole, so the
+     * dispatch path can thread its descriptors). Mirrors bridge_python's "any
+     * callable" test — an object reaching the encoder here is a BAML function
+     * argument, so a functional value in a callable-typed slot is a host
+     * callable.
      */
     private static boolean isHostCallable(Object value) {
-        return value instanceof baml_bridge.BamlHostCallable
+        return value instanceof baml_bridge.BamlTypedCallable
+                || value instanceof baml_bridge.BamlHostCallable
                 || value instanceof java.util.function.Function
                 || value instanceof java.util.function.BiFunction
                 || value instanceof java.util.function.Supplier

--- a/baml_language/sdks/java/sdkgen_java/src/emit.rs
+++ b/baml_language/sdks/java/sdkgen_java/src/emit.rs
@@ -832,7 +832,13 @@ fn render_callable_pair(
         let value = java_identifier(a.name.as_str());
         let mut type_vars = Vec::new();
         crate::translate_ty::collect_type_vars(&a.ty, &mut type_vars);
-        let encoded = if type_vars.is_empty() && needs_inbound_descriptor(&a.ty, ctx) {
+        let encoded = if !type_vars.is_empty() {
+            value
+        } else if let Some(expr) = typed_callable_expr(&a.ty, &value, pool, ctx) {
+            // A callable argument carries its declared param/return descriptors
+            // so the dispatch path can honor the generated signature.
+            expr
+        } else if needs_inbound_descriptor(&a.ty, ctx) {
             match crate::translate_ty::descriptor_expr_opt(&a.ty, ctx.aliases) {
                 Some(expr) => format!(
                     "new baml_bridge.BamlTypedValue({value}, {})",
@@ -1359,7 +1365,13 @@ fn render_optional_configurator(
         let setter = java_identifier(wire);
         let mut type_vars = Vec::new();
         crate::translate_ty::collect_type_vars(&a.ty, &mut type_vars);
-        let stored = if type_vars.is_empty() && needs_inbound_descriptor(&a.ty, ctx) {
+        let stored = if !type_vars.is_empty() {
+            "v".to_string()
+        } else if let Some(expr) = typed_callable_expr(&a.ty, "v", pool, ctx) {
+            // An optional callable argument carries its declared param/return
+            // descriptors, same as the required-arg path.
+            expr
+        } else if needs_inbound_descriptor(&a.ty, ctx) {
             match crate::translate_ty::descriptor_expr_opt(&a.ty, ctx.aliases) {
                 Some(expr) => format!("new baml_bridge.BamlTypedValue(v, {})", pool.intern(expr)),
                 None => "v".to_string(),
@@ -1376,6 +1388,86 @@ fn render_optional_configurator(
         "\n    /**\n     * Configurator for the optional arguments of {{@code {ident}}}. Each\n     * fluent setter records one optional; only touched optionals reach the\n     * engine (untouched ⇒ BAML default, touched-with-{{@code null}} ⇒\n     * explicit BAML {{@code null}}).\n     */\n    public static final class {ident}$Opts{gu} {{\n        private final java.util.LinkedHashMap<java.lang.String, java.lang.Object> $values = new java.util.LinkedHashMap<>();\n        private final java.util.LinkedHashSet<java.lang.String> $touched = new java.util.LinkedHashSet<>();\n{setters}\n        java.lang.String[] $names(java.lang.String[] base) {{\n            java.lang.String[] out = java.util.Arrays.copyOf(base, base.length + this.$touched.size());\n            int i$ = base.length;\n            for (java.lang.String n$ : this.$touched) {{\n                out[i$++] = n$;\n            }}\n            return out;\n        }}\n\n        java.lang.Object[] $args(java.lang.Object[] base) {{\n            java.lang.Object[] out = java.util.Arrays.copyOf(base, base.length + this.$touched.size());\n            int i$ = base.length;\n            for (java.lang.String n$ : this.$touched) {{\n                out[i$++] = this.$values.get(n$);\n            }}\n            return out;\n        }}\n    }}\n"
     ));
     out
+}
+
+/// When `ty` (through non-recursive aliases) is a callable type, render the
+/// `baml_bridge.BamlTypedCallable` carrier wrapping `value` with the callable's
+/// declared parameter / return decode descriptors, so the bridge honors the
+/// generated signature on the dispatch path: each argument BAML passes back
+/// decodes against its declared parameter descriptor (a `baml.json.json`
+/// parameter materializes as the generated sealed union, not the raw wire
+/// value) and the returned value encodes against the declared return
+/// descriptor. Returns `None` when `ty` is not a callable or when every slot is
+/// wire-driven (the raw callable is then registered exactly as before).
+fn typed_callable_expr(
+    ty: &Ty,
+    value: &str,
+    pool: &mut DescriptorPool,
+    ctx: &TranslateCtx<'_>,
+) -> Option<String> {
+    let mut resolved = ty;
+    loop {
+        match resolved {
+            Ty::TypeAlias(name, _) => match ctx.aliases.get(name) {
+                Some((inner, false)) => resolved = inner,
+                _ => return None,
+            },
+            Ty::Function { .. } => break,
+            _ => return None,
+        }
+    }
+    let Ty::Function { params, ret, .. } = resolved else {
+        return None;
+    };
+    let mut any = false;
+    let desc_of = |ty: &Ty, pool: &mut DescriptorPool, any: &mut bool| {
+        match crate::translate_ty::descriptor_expr_opt(ty, ctx.aliases) {
+            Some(expr) => {
+                *any = true;
+                pool.intern(expr)
+            }
+            None => "null".to_string(),
+        }
+    };
+    let mut positional: Vec<String> = Vec::new();
+    let mut optional_names: Vec<String> = Vec::new();
+    let mut optional_descs: Vec<String> = Vec::new();
+    for (i, p) in params.iter().enumerate() {
+        let desc = desc_of(&p.ty, pool, &mut any);
+        match p.mode {
+            CodegenFunctionParamMode::Optional => {
+                // The wire key mirrors `translate_callable`'s optional-bag
+                // naming (`opt{i}` fallback indexes over ALL params).
+                let wire = p
+                    .name
+                    .as_ref()
+                    .map_or_else(|| format!("opt{i}"), |n| n.as_str().to_string());
+                optional_names.push(format!("{wire:?}"));
+                optional_descs.push(desc);
+            }
+            CodegenFunctionParamMode::Required => positional.push(desc),
+        }
+    }
+    let ret_desc = desc_of(ret, pool, &mut any);
+    if !any {
+        return None;
+    }
+    let positional_lit = if positional.iter().all(|d| d == "null") {
+        "null".to_string()
+    } else {
+        format!("new baml_bridge.BamlType[] {{{}}}", positional.join(", "))
+    };
+    if optional_names.is_empty() {
+        Some(format!(
+            "new baml_bridge.BamlTypedCallable({value}, {positional_lit}, {ret_desc})"
+        ))
+    } else {
+        Some(format!(
+            "new baml_bridge.BamlTypedCallable({value}, {positional_lit}, new java.lang.String[] {{{}}}, new baml_bridge.BamlType[] {{{}}}, {ret_desc})",
+            optional_names.join(", "),
+            optional_descs.join(", ")
+        ))
+    }
 }
 
 fn needs_inbound_descriptor(ty: &Ty, ctx: &TranslateCtx<'_>) -> bool {


### PR DESCRIPTION
## Problem

A `json`-typed BAML parameter receiving an object from a host SDK materializes as a map that fails BAML's typed narrowing: `match (j) { let m: map<string, json> => ... }` never matches, so `baml.json.path` / `path_or` throw/return-default ("field access '.type' on a non-object") on host-supplied objects — while the structural `$rust_function`s `baml.json.field` and `stringify` work on the same value. Pure-BAML json objects (from `baml.json.parse`) match fine, so inbound FFI json diverged from BAML-born json.

Reproducible without any SDK:

```
baml-cli run --file f.baml -f json_kind -- json_kind --json-args '{"value": {"type": "ok"}}'
```

returned `"other"` where the same value built via `baml.json.parse` returned `"object"`.

## Root cause

All bridges (Go `container.go`, Python `proto.py`, TypeScript `proto.ts`) encode containers without a `value_type` annotation, and the wire decoder (`bridge_ctypes::value_decode`) defaults them to a scalar union (`int|float|string|bool|uint8array|null`). The engine's inbound coercion keeps `baml.json.json` nominal and had no container arm for it, so a map bound to a `json` slot materialized on the VM heap with that scalar-union value type. BAML-born `baml.json.parse` maps carry the `json` alias itself (`serde_to_value`), and the `match` type test (`is_subtype`, invariant in map value position) only matches the latter.

## Fix (engine-side, covers every bridge + CLI)

In `bex_engine::conversion`:

- New coercion arm: a container arriving in a `baml.json.json` slot that inhabits the JSON algebra (`value_satisfies_json`) gets its container annotations rewritten recursively to the alias — lists become `json[]`, maps `map<string, json>`. Non-JSON trees are left untouched for the existing rejection paths.
- The same hook at the top of `convert_external_to_vm_value_with_ty`, because host-callable **return** values convert without a coercion pass and had the identical bug.

Also fixes json nested inside declared `map<string, json>` / `json[]` params, class fields, and `json | image` unions.

## Tests

- Engine unit test: `canonical_json_alias_reannotates_untyped_inbound_containers` (deep re-annotation; non-JSON trees untouched).
- Fixture (`ns_go_json_tests`): `json_kind` (match narrowing), `json_path_string`, `json_path_string_or`, `json_callback_kind` (host-return path).
- Go SDK regression test: object/array/string/scalar narrowing, nested selector `.nested.list[1].deep`, `path_or` fallback, missing-field `JsonPathError`, callback-returned json.
- Python SDK regression test mirroring the Go coverage.

Verified: full `bex_engine` suite, Go `function_calls` suite, Python `function_calls` suite (ruff + pyright + pytest), `cargo fmt`/`clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core FFI value coercion, type matching, and host-return validation across all bridges; behavior change for json typing is intentional but could affect edge cases (user aliases shadowing display names, annotated unions).
> 
> **Overview**
> Host-supplied `baml.json.json` values from SDK bridges no longer fail BAML typed narrowing (`match` on `map<string, json>`, `baml.json.path` / `path_or`) because containers were materializing with wire-synthesized scalar-union element types instead of the canonical `json` alias.
> 
> The engine now **re-annotates** JSON-algebra containers at inbound coercion and on the host-return conversion path via `annotate_json_container_types`, and tightens matching/validation: **`is_canonical_json_alias`** (package-qualified identity, not `display_name()`), **`value_satisfies_json`** peeling sparse inbound leaf annotations, and host-return acceptance for algebra-scoped inbound annotations (e.g. C++/Swift).
> 
> **Java bridge:** codegen wraps callable arguments in **`BamlTypedCallable`** so dispatch decodes/encodes against declared param and return descriptors (not raw wire values).
> 
> **Tests:** engine unit tests, shared BAML fixtures (`json_kind`, path helpers, callback), and cross-language SDK parity tests (Go extended; new C++/Java/Python/Swift/TS; Rust gated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cc59f8b8459500da8617591c7f99832fda8b7ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of externally supplied JSON values, including nested objects, arrays, maps, and scalar values.
  * JSON values returned from callbacks now behave consistently with native BAML JSON values.
  * Improved JSON type detection, union handling, and nested path access.
  * Added reliable fallback handling for missing paths and clearer errors for missing fields.
  * Preserved non-JSON containers and rejected invalid JSON annotations.

* **New Features**
  * Java host callbacks can now provide type information for arguments and return values.

* **Tests**
  * Added cross-language coverage for JSON narrowing, path access, callbacks, and nested values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->