### PR TITLE
fix(release): stamp C++ verifier version

### DIFF
--- a/.github/workflows/verify-cpp-sdk.reusable.yaml
+++ b/.github/workflows/verify-cpp-sdk.reusable.yaml
@@ -86,12 +86,13 @@ jobs:
           name: bridge-cffi-${{ matrix.target }}
           path: runtime-dist
 
-      - name: Resolve expected version
+      - name: Stamp release plan
         env:
           RELEASE_PLAN_JSON: ${{ inputs.release_plan_json }}
         run: |
           set -euo pipefail
           printf '%s\n' "$RELEASE_PLAN_JSON" > release-plan.json
+          scripts/baml-language-version stamp --plan release-plan.json
           expected="$(jq -r .canonical_version release-plan.json)"
           echo "BAML_EXPECTED_VERSION=$expected" >> "$GITHUB_ENV"
 

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -47,6 +47,9 @@ PACK_E2E = (
 CFFI_BUILDER = (
     ROOT / ".github" / "workflows" / "build2-bridge-cffi.reusable.yaml"
 )
+CPP_VERIFIER = (
+    ROOT / ".github" / "workflows" / "verify-cpp-sdk.reusable.yaml"
+)
 PACK_PRODUCT = (
     ROOT
     / "baml_language"
@@ -657,6 +660,24 @@ def step_inputs(step: str) -> dict[str, str]:
 
 
 class WorkflowGraphTests(unittest.TestCase):
+    def test_cpp_verifier_stamps_the_frozen_release_plan(self) -> None:
+        workflow = CPP_VERIFIER.read_text(encoding="utf-8")
+        verify = job_block(workflow, "verify")
+        stamp = step_block(verify, "Stamp release plan")
+
+        self.assertIn(
+            "scripts/baml-language-version stamp --plan release-plan.json",
+            stamp,
+        )
+        self.assertLess(
+            stamp.index("printf '%s\\n' \"$RELEASE_PLAN_JSON\""),
+            stamp.index("scripts/baml-language-version stamp"),
+        )
+        self.assertLess(
+            workflow.index("scripts/baml-language-version stamp"),
+            workflow.index("cmake -S baml_language/sdks/cpp/bridge_cpp/tests"),
+        )
+
     def test_cargo_jobs_name_targets_and_run_pack_e2e_on_musl(self) -> None:
         workflow = CARGO_TESTS.read_text(encoding="utf-8")
         for target in (


### PR DESCRIPTION
## Issue Reference

Failed release job: https://github.com/BoundaryML/baml/actions/runs/31158395652/job/92807446666

## Changes

- Stamp the frozen release plan before compiling the C++ consumer verifier.
- Add a workflow contract test that preserves the ordering between plan materialization, stamping, and CMake compilation.

The native runtime was stamped as 0.15.1-nightly.20260806.a, but the checked-out C++ headers still identified the bridge and required toolchain as 0.15.0.

## Testing

- [x] Unit tests added/updated
- [x] python3 -m unittest scripts.tests.test_release_pipeline_contract
- [x] mise exec -- ruff check scripts/tests/test_release_pipeline_contract.py
- [x] mise exec -- actionlint .github/workflows/verify-cpp-sdk.reusable.yaml

## Screenshots

Not applicable.

## PR Checklist

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

## Additional Notes

No data structures or runtime behavior changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved C++ release verification by stamping the release plan before version checks and test builds.
  * Helps ensure C++ validation uses the correct frozen release information.

* **Tests**
  * Added coverage to verify the release workflow stamps the plan at the correct stage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->