### PR TITLE
fix(compiler): don't sink a panicking rvalue to its use site

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -1689,11 +1689,11 @@ fn is_pure_constant(rvalue: &Rvalue) -> bool {
 /// past that replay runs the defer body once on the way out and a second time
 /// in the unwind landing pad.
 ///
-/// Only arithmetic can fail. `/` and `%` reject a zero divisor for `int` and
-/// `float` alike. Add/sub/mul/shift and negation are range-checked on `int`
-/// only — `float` saturates to infinity, `bigint` grows, and `string + string`
-/// is concatenation — so those ask [`operand_could_be_int`]. Bitwise and/or/xor
-/// and the comparisons stay in range for every operand type.
+/// Only arithmetic can fail, and only `/` fails for every operand type. The
+/// rest are `int`-only failures — `float` saturates to infinity or NaN,
+/// `bigint` grows, and `string + string` is concatenation — so they ask
+/// [`operand_could_be_int`]. Bitwise and/or/xor and the comparisons stay in
+/// range whatever the operands are.
 ///
 /// Matched exhaustively on purpose. This is a soundness predicate, and a
 /// wrong `false` miscompiles silently — so a new `Rvalue` variant must fail to
@@ -1701,8 +1701,12 @@ fn is_pure_constant(rvalue: &Rvalue) -> bool {
 fn rvalue_can_panic(body: &MirFunctionBody, rvalue: &Rvalue) -> bool {
     match rvalue {
         Rvalue::BinaryOp { op, left, right } => match op {
-            BinOp::Div | BinOp::Mod => true,
-            BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Shl | BinOp::Shr => {
+            // `/` rejects a zero divisor on both numeric paths — BAML throws
+            // rather than yielding IEEE infinity (`OpCode::DivFloat`), so this
+            // holds whatever the operands are.
+            BinOp::Div => true,
+            // `%` is guarded on the `int` path only; the float path yields NaN.
+            BinOp::Mod | BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Shl | BinOp::Shr => {
                 operand_could_be_int(body, left) && operand_could_be_int(body, right)
             }
             BinOp::Eq

--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -19,6 +19,7 @@ use baml_compiler2_mir::{
     BinOp, BlockId, Constant, Local, MirFunctionBody, Operand, Place, Rvalue, StatementKind,
     Terminator, UnaryOp,
 };
+use baml_type::{Literal, RuntimeTy};
 
 use crate::stack_carry;
 
@@ -1452,7 +1453,7 @@ fn can_be_virtual(
         // The use site can also sit in a different exception region than the
         // def, which changes the handler and can double-run a `defer` body
         // (once inline on the way out, once in the unwind landing pad).
-        if rvalue_can_panic(&def.rvalue) {
+        if rvalue_can_panic(body, &def.rvalue) {
             return false;
         }
         //
@@ -1688,26 +1689,106 @@ fn is_pure_constant(rvalue: &Rvalue) -> bool {
 /// past that replay runs the defer body once on the way out and a second time
 /// in the unwind landing pad.
 ///
-/// Only arithmetic is listed: `int` add/sub/mul/shift are range-checked
-/// (`IntegerOverflow`), `/` and `%` reject a zero divisor (`DivisionByZero`),
-/// and negation overflows on `INT_MIN`. Bitwise and/or/xor and comparisons stay
-/// in range by construction. Reads through an index projection can also panic
-/// (`IndexOutOfBounds`); cross-block virtualization already rejects every rvalue
-/// with a projection read.
-fn rvalue_can_panic(rvalue: &Rvalue) -> bool {
+/// Only arithmetic can fail. `/` and `%` reject a zero divisor for `int` and
+/// `float` alike. Add/sub/mul/shift and negation are range-checked on `int`
+/// only — `float` saturates to infinity, `bigint` grows, and `string + string`
+/// is concatenation — so those ask [`operand_could_be_int`]. Bitwise and/or/xor
+/// and the comparisons stay in range for every operand type.
+///
+/// Matched exhaustively on purpose. This is a soundness predicate, and a
+/// wrong `false` miscompiles silently — so a new `Rvalue` variant must fail to
+/// compile here rather than default into the infallible group.
+fn rvalue_can_panic(body: &MirFunctionBody, rvalue: &Rvalue) -> bool {
     match rvalue {
-        Rvalue::BinaryOp { op, .. } => matches!(
-            op,
-            BinOp::Add
-                | BinOp::Sub
-                | BinOp::Mul
-                | BinOp::Div
-                | BinOp::Mod
-                | BinOp::Shl
-                | BinOp::Shr
-        ),
-        Rvalue::UnaryOp { op, .. } => matches!(op, UnaryOp::Neg),
-        _ => false,
+        Rvalue::BinaryOp { op, left, right } => match op {
+            BinOp::Div | BinOp::Mod => true,
+            BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Shl | BinOp::Shr => {
+                operand_could_be_int(body, left) && operand_could_be_int(body, right)
+            }
+            BinOp::Eq
+            | BinOp::Ne
+            | BinOp::Lt
+            | BinOp::Le
+            | BinOp::Gt
+            | BinOp::Ge
+            | BinOp::BitAnd
+            | BinOp::BitOr
+            | BinOp::BitXor => false,
+        },
+        Rvalue::UnaryOp { op, operand } => match op {
+            UnaryOp::Neg => operand_could_be_int(body, operand),
+            UnaryOp::Not => false,
+        },
+        // Allocation can report `AllocFailure`, but that is a host resource
+        // condition rather than a property of the program point, and treating
+        // every allocation as a barrier would disable virtualization outright.
+        //
+        // `Use` is the one entry here with a real failing case: reading through
+        // an index projection can raise `IndexOutOfBounds`. Every rvalue with a
+        // projection read is rejected a few lines above this predicate's only
+        // caller, on the same cross-block path, so it never reaches here.
+        Rvalue::Use(_)
+        | Rvalue::Array(..)
+        | Rvalue::Uint8Array(_)
+        | Rvalue::Map(..)
+        | Rvalue::Aggregate { .. }
+        | Rvalue::Discriminant(_)
+        | Rvalue::TypeTag(_)
+        | Rvalue::Len(_)
+        | Rvalue::IsType { .. }
+        | Rvalue::IsTypeTag { .. }
+        | Rvalue::MakeClosure { .. }
+        | Rvalue::MakeBoundMethod { .. }
+        | Rvalue::MakeVirtualBoundMethod { .. }
+        | Rvalue::VirtualFieldAccess { .. }
+        | Rvalue::MakeGenericFunction { .. }
+        | Rvalue::MakeGenericFunctionFromValue { .. }
+        | Rvalue::LoadType(_) => false,
+    }
+}
+
+/// Could this operand hold an `int` at runtime?
+///
+/// Deliberately answers `true` for anything whose runtime representation is not
+/// pinned down — a union, a type variable, a value read through a projection, a
+/// type family variant added later. Only a type that provably never holds an
+/// `int` answers `false`.
+fn operand_could_be_int(body: &MirFunctionBody, operand: &Operand) -> bool {
+    match operand {
+        Operand::Constant(c) => matches!(c, Constant::Int(_)),
+        Operand::Copy(place) | Operand::Move(place) => match place {
+            Place::Local(local) => ty_could_be_int(&body.local(*local).ty),
+            // A field / index / capture read carries no type here.
+            Place::Field { .. } | Place::Index { .. } | Place::Capture(_) => true,
+        },
+    }
+}
+
+/// See [`operand_could_be_int`]. The `_ => true` fallback keeps an unlisted or
+/// newly added variant on the conservative side.
+fn ty_could_be_int(ty: &RuntimeTy) -> bool {
+    match ty {
+        RuntimeTy::Int { .. } => true,
+        RuntimeTy::Literal(lit, ..) => matches!(lit, Literal::Int(_)),
+        RuntimeTy::Bigint { .. }
+        | RuntimeTy::Float { .. }
+        | RuntimeTy::String { .. }
+        | RuntimeTy::Bool { .. }
+        | RuntimeTy::Null { .. }
+        | RuntimeTy::Void { .. }
+        | RuntimeTy::Media(..)
+        | RuntimeTy::Class(..)
+        | RuntimeTy::Enum(..)
+        | RuntimeTy::EnumVariant(..)
+        | RuntimeTy::List(..)
+        | RuntimeTy::Map { .. }
+        | RuntimeTy::Function { .. }
+        | RuntimeTy::Future(..)
+        | RuntimeTy::RustType { .. }
+        | RuntimeTy::Type { .. }
+        | RuntimeTy::Resource { .. }
+        | RuntimeTy::PromptAst { .. } => false,
+        _ => true,
     }
 }
 

--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -16,7 +16,8 @@ use std::collections::{HashMap, HashSet};
 
 pub use baml_compiler2_mir::OptLevel;
 use baml_compiler2_mir::{
-    BlockId, Constant, Local, MirFunctionBody, Operand, Place, Rvalue, StatementKind, Terminator,
+    BinOp, BlockId, Constant, Local, MirFunctionBody, Operand, Place, Rvalue, StatementKind,
+    Terminator, UnaryOp,
 };
 
 use crate::stack_carry;
@@ -1445,6 +1446,15 @@ fn can_be_virtual(
         if rvalue_has_projection_reads(&def.rvalue) {
             return false;
         }
+        // A panicking evaluation is itself observable, and every path from the
+        // def block to the use block crosses at least the def block's
+        // terminator — a call, whose effects would then run before the panic.
+        // The use site can also sit in a different exception region than the
+        // def, which changes the handler and can double-run a `defer` body
+        // (once inline on the way out, once in the unwind landing pad).
+        if rvalue_can_panic(&def.rvalue) {
+            return false;
+        }
         //
         // Rather than walking all intermediate blocks (which requires full path
         // enumeration), we use a sound conservative check: if any local read by
@@ -1663,6 +1673,42 @@ fn has_side_effect(kind: &StatementKind, rvalue_reads: &HashSet<Local>) -> bool 
 /// so they can be re-emitted at every use site even with multiple uses.
 fn is_pure_constant(rvalue: &Rvalue) -> bool {
     matches!(rvalue, Rvalue::Use(Operand::Constant(_)))
+}
+
+/// Can evaluating this rvalue raise a catchable panic (`baml.panics.*`)?
+///
+/// Virtual emission *moves* an rvalue's evaluation from its definition to its
+/// use site. That is only sound when the evaluation cannot fail: a panicking
+/// evaluation is itself an observable event, so moving it past a call, a store,
+/// or an exception-region boundary changes which effects run before the panic
+/// and which handler receives it.
+///
+/// Concretely, a `defer` block's inline replay is emitted between the
+/// definition and the `return` that uses it. Sinking a panicking arithmetic op
+/// past that replay runs the defer body once on the way out and a second time
+/// in the unwind landing pad.
+///
+/// Only arithmetic is listed: `int` add/sub/mul/shift are range-checked
+/// (`IntegerOverflow`), `/` and `%` reject a zero divisor (`DivisionByZero`),
+/// and negation overflows on `INT_MIN`. Bitwise and/or/xor and comparisons stay
+/// in range by construction. Reads through an index projection can also panic
+/// (`IndexOutOfBounds`); cross-block virtualization already rejects every rvalue
+/// with a projection read.
+fn rvalue_can_panic(rvalue: &Rvalue) -> bool {
+    match rvalue {
+        Rvalue::BinaryOp { op, .. } => matches!(
+            op,
+            BinOp::Add
+                | BinOp::Sub
+                | BinOp::Mul
+                | BinOp::Div
+                | BinOp::Mod
+                | BinOp::Shl
+                | BinOp::Shr
+        ),
+        Rvalue::UnaryOp { op, .. } => matches!(op, UnaryOp::Neg),
+        _ => false,
+    }
 }
 
 /// Check if a local is a "call result immediate": defined by Call/Await/SysOp,

--- a/baml_language/crates/baml_tests/snapshots/baml_src/array_rest_binding.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/array_rest_binding.snap
@@ -181,14 +181,15 @@ function array_rest_binding.arb_grab(xs: int[]) -> int {
     load_const 1
     load_var _10
     call baml.Array.slice
-    container_len
-    store_var _14
     load_var xs
     load_const 0
     load_array_element
     load_const 10
     mul_int
-    load_var _14
+    store_var _12
+    container_len
+    store_var _14
+    load_var2 4 5
     add_int
 
   L2:
@@ -296,13 +297,14 @@ function array_rest_binding.arb_pushing_to_rest_does_not_mutate_source() -> int 
     load_var xs
     container_len
     store_var _13
-    load_var r
-    container_len
-    store_var _14
     load_var _13
     load_const 10
     mul_int
-    load_var _14
+    store_var _12
+    load_var r
+    container_len
+    store_var _14
+    load_var2 5 7
     add_int
 
   L2:
@@ -375,13 +377,14 @@ function array_rest_binding.arb_rest_bind_chain_aliases_same_slice() -> int {
     load_var r
     container_len
     store_var _8
-    load_var _2
-    container_len
-    store_var _9
     load_var _8
     load_const 10
     mul_int
-    load_var _9
+    store_var _7
+    load_var _2
+    container_len
+    store_var _9
+    load_var2 5 7
     add_int
     return
 }
@@ -394,17 +397,15 @@ function array_rest_binding.arb_rest_binding_generic_element_type() -> int {
     load_type string
     alloc_array 3
     call user.array_rest_binding.arb_tail_len
-    store_var _2
+    load_const 10
+    mul_int
+    store_var _1
     load_type bool
     load_const true
     load_type bool
     alloc_array 1
     call user.array_rest_binding.arb_tail_len
-    store_var _5
-    load_var _2
-    load_const 10
-    mul_int
-    load_var _5
+    load_var _1
     add_int
     return
 }
@@ -416,15 +417,13 @@ function array_rest_binding.arb_rest_binding_in_if_let() -> int {
     load_type int
     alloc_array 3
     call user.array_rest_binding.arb_grab
-    store_var _2
+    load_const 100
+    mul_int
+    store_var _1
     load_type int
     alloc_array 0
     call user.array_rest_binding.arb_grab
-    store_var _4
-    load_var _2
-    load_const 100
-    mul_int
-    load_var _4
+    load_var _1
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/classes.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/classes.snap
@@ -179,8 +179,7 @@ function classes.constructor_with_preceding_variables_fn() -> int {
     load_const 100
     load_const 200
     init_instance user.classes.MyClass .x, .y
-    store_var obj
-    load_var obj
+    store_var_load_var obj
     load_field .x
     load_var obj
     load_field .y
@@ -296,8 +295,7 @@ function classes.nested_constructor_with_preceding_variables_fn() -> int {
     init_instance user.classes.CInnerVal .val
     load_const 50
     init_instance user.classes.COuterXI .inner, .x
-    store_var obj
-    load_var obj
+    store_var_load_var obj
     load_field .inner
     load_field .val
     load_var obj

--- a/baml_language/crates/baml_tests/snapshots/baml_src/comparable_sort.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/comparable_sort.snap
@@ -592,15 +592,13 @@ function comparable_sort.is_primitive_probe_main() -> int {
     load_type int
     load_const 42
     call user.comparable_sort.probe
-    store_var _3
+    load_const 10
+    mul_int
+    store_var _2
     load_type string
     load_const "s"
     call user.comparable_sort.probe
-    store_var _6
-    load_var _3
-    load_const 10
-    mul_int
-    load_var _6
+    load_var _2
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/functions.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/functions.snap
@@ -104,8 +104,7 @@ function functions.call_twice(f: (int, int) -> int throws never, x: int, y: int)
     load_var2 2 3
     load_var f
     call_indirect
-    store_var _5
-    load_var2 4 5
+    load_var _4
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/interfaces_associated_types.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/interfaces_associated_types.snap
@@ -614,8 +614,7 @@ function interfaces_associated_types.rdf_main() -> int {
     load_const 9
     init_instance user.interfaces_associated_types.RdfIntSource .value
     call user.interfaces_associated_types.rdf_score
-    store_var _3
-    load_var2 1 2
+    load_var _1
     add_int
     return
 }
@@ -950,8 +949,7 @@ function interfaces_associated_types.rmf_main() -> int {
     load_const 7
     init_instance user.interfaces_associated_types.RmfIntSource .value
     call user.interfaces_associated_types.rmf_score
-    store_var _3
-    load_var2 1 2
+    load_var _1
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ints.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ints.snap
@@ -810,8 +810,7 @@ function ints.count_zeros_plus_ones(n: int) -> int {
     store_var _2
     load_var n
     call baml.Int.count_ones
-    store_var _3
-    load_var2 2 3
+    load_var _2
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
@@ -621,14 +621,14 @@ function lambdas.lambdas_issue_e_method_resolution_different_types() -> int {
     alloc_array 3
     container_len
     store_var arr_len
-    load_const "hello"
-    make_closure .<lambda(lambdas_issue_e_method_resolution_different_types, 0)>, 0
-    call_indirect
-    store_var _6
     load_var arr_len
     load_const 10
     mul_int
-    load_var _6
+    store_var _4
+    load_const "hello"
+    make_closure .<lambda(lambdas_issue_e_method_resolution_different_types, 0)>, 0
+    call_indirect
+    load_var _4
     add_int
     return
 }
@@ -647,15 +647,13 @@ function lambdas.lambdas_issue_f_shadowing_capture_correct_binding() -> int {
     load_var x
     make_closure .<lambda(lambdas_issue_f_shadowing_capture_correct_binding, 0)>, 1
     call_indirect
-    store_var _6
+    load_const 10
+    mul_int
+    store_var _5
     load_var x
     make_closure .<lambda(lambdas_issue_f_shadowing_capture_correct_binding, 1)>, 1
     call_indirect
-    store_var _8
-    load_var _6
-    load_const 10
-    mul_int
-    load_var _8
+    load_var _5
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
@@ -153,15 +153,13 @@ function lexical_scoping.capture_before_after_shadow() -> int {
     load_var x
     make_closure .<lambda(capture_before_after_shadow, 0)>, 1
     call_indirect
-    store_var _6
+    load_const 10
+    mul_int
+    store_var _5
     load_var x
     make_closure .<lambda(capture_before_after_shadow, 1)>, 1
     call_indirect
-    store_var _8
-    load_var _6
-    load_const 10
-    mul_int
-    load_var _8
+    load_var _5
     add_int
     return
 }
@@ -406,13 +404,14 @@ function lexical_scoping.match_and_catch_main() -> int {
     store_var _2
     call user.lexical_scoping.match_later_arm_uses_outer
     store_var _4
-    call user.lexical_scoping.catch_base_uses_outer_lambda
-    store_var _6
-    load_var2 1 2
+    load_var2 2 3
     load_const 100
     mul_int
     add_int
-    load_var _6
+    store_var _1
+    call user.lexical_scoping.catch_base_uses_outer_lambda
+    store_var _6
+    load_var2 1 4
     load_const 10000
     mul_int
     add_int

--- a/baml_language/crates/baml_tests/snapshots/baml_src/optional_function_parameters.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/optional_function_parameters.snap
@@ -124,15 +124,13 @@ function optional_function_parameters.ofp_mutable_default_array_is_fresh_per_cal
     load_const 1
     load_const <omitted>
     call user.optional_function_parameters.push_default
-    store_var _2
+    load_const 10
+    mul_int
+    store_var _1
     load_const 2
     load_const <omitted>
     call user.optional_function_parameters.push_default
-    store_var _3
-    load_var _2
-    load_const 10
-    mul_int
-    load_var _3
+    load_var _1
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
@@ -2718,14 +2718,15 @@ function patterns_new_runtime.score_rest_copy(xs: int[]) -> int {
 
   L1:
     load_var xs
-    container_len
-    store_var _12
-    load_var xs
     load_const 0
     load_array_element
     load_const 10
     mul_int
-    load_var _12
+    store_var _9
+    load_var xs
+    container_len
+    store_var _12
+    load_var2 3 4
     load_const 1
     sub_int
     add_int
@@ -3007,15 +3008,16 @@ function patterns_new_runtime.score_user_score(users: patterns_new_runtime.UserS
 
   L0:
     load_var users
-    container_len
-    store_var _12
-    load_var users
     load_const 0
     load_array_element
     load_field .score
     load_const 10
     mul_int
-    load_var _12
+    store_var _9
+    load_var users
+    container_len
+    store_var _12
+    load_var2 3 4
     load_const 1
     sub_int
     add_int
@@ -3226,16 +3228,14 @@ function patterns_new_runtime.test_empty_generic_covers_union() -> int {
     load_type string
     init_instance<1> user.patterns_new_runtime.BoxT .value
     call user.patterns_new_runtime.classify_box_either
-    store_var _4
+    load_const 10
+    mul_int
+    store_var _3
     load_const 3
     load_type int
     init_instance<1> user.patterns_new_runtime.BoxT .value
     call user.patterns_new_runtime.classify_box_either
-    store_var _6
-    load_var _4
-    load_const 10
-    mul_int
-    load_var _6
+    load_var _3
     add_int
     return
 }
@@ -3250,8 +3250,7 @@ function patterns_new_runtime.test_empty_generic_destruct_contextual() -> int {
     load_type string
     init_instance<1> user.patterns_new_runtime.BoxT .value
     call user.patterns_new_runtime.classify_box_string
-    store_var _5
-    load_var2 1 2
+    load_var _3
     add_int
     return
 }
@@ -3469,25 +3468,24 @@ function patterns_new_runtime.test_for_deep_class_capture_fresh() -> int {
     load_const 0
     load_array_element
     call_indirect
-    store_var _25
+    load_const 100
+    mul_int
+    store_var _24
     load_var funcs
     load_const 1
     load_array_element
     call_indirect
     store_var _30
+    load_var2 6 7
+    load_const 10
+    mul_int
+    add_int
+    store_var _23
     load_var funcs
     load_const 2
     load_array_element
     call_indirect
-    store_var _34
-    load_var _25
-    load_const 100
-    mul_int
-    load_var _30
-    load_const 10
-    mul_int
-    add_int
-    load_var _34
+    load_var _23
     add_int
     return
 }
@@ -3636,25 +3634,24 @@ function patterns_new_runtime.test_for_let_chain_alias_capture() -> int {
     load_const 0
     load_array_element
     call_indirect
-    store_var _13
+    load_const 100
+    mul_int
+    store_var _12
     load_var funcs
     load_const 1
     load_array_element
     call_indirect
     store_var _18
+    load_var2 8 9
+    load_const 10
+    mul_int
+    add_int
+    store_var _11
     load_var funcs
     load_const 2
     load_array_element
     call_indirect
-    store_var _22
-    load_var _13
-    load_const 100
-    mul_int
-    load_var _18
-    load_const 10
-    mul_int
-    add_int
-    load_var _22
+    load_var _11
     add_int
     return
 }
@@ -3734,10 +3731,7 @@ function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
     load_var row
     container_len
     store_var _13
-    load_var row
-    container_len
-    store_var _18
-    load_var2 1 5
+    load_var _13
     load_const 100
     mul_int
     load_var row
@@ -3746,6 +3740,11 @@ function patterns_new_runtime.test_for_let_chain_trailing_type() -> int {
     load_const 10
     mul_int
     add_int
+    store_var _11
+    load_var row
+    container_len
+    store_var _18
+    load_var2 1 5
     load_var _18
     add_int
     add_int
@@ -3924,25 +3923,24 @@ function patterns_new_runtime.test_for_rest_capture_fresh_cell() -> int {
     load_const 0
     load_array_element
     call_indirect
-    store_var _16
+    load_const 100
+    mul_int
+    store_var _15
     load_var funcs
     load_const 1
     load_array_element
     call_indirect
     store_var _21
+    load_var2 6 7
+    load_const 10
+    mul_int
+    add_int
+    store_var _14
     load_var funcs
     load_const 2
     load_array_element
     call_indirect
-    store_var _25
-    load_var _16
-    load_const 100
-    mul_int
-    load_var _21
-    load_const 10
-    mul_int
-    add_int
-    load_var _25
+    load_var _14
     add_int
     return
 }
@@ -4043,15 +4041,14 @@ function patterns_new_runtime.test_generic_backfills_wrapped() -> int {
     store_var _3
     load_var boxed
     call user.patterns_new_runtime.from_union_box
-    store_var _5
+    load_var _3
+    add_int
+    store_var _2
     load_var boxed
     load_type patterns_new_runtime.BoxT<int>
     alloc_array 1
     call user.patterns_new_runtime.from_array_boxes
-    store_var _7
-    load_var2 2 3
-    add_int
-    load_var _7
+    load_var _2
     add_int
     return
 }
@@ -4138,8 +4135,7 @@ function patterns_new_runtime.test_let_nested_same_field_names() -> int {
     load_const 1
     init_instance user.patterns_new_runtime.NestedOuter .field, .other
     load_field .field
-    store_var _3
-    load_var _3
+    store_var_load_var _3
     load_field .field
     load_var _3
     load_field .field
@@ -4505,16 +4501,14 @@ function patterns_new_runtime.test_match_generic_type_args_distinguish() -> int 
     load_type string
     init_instance<1> user.patterns_new_runtime.BoxT .value
     call user.patterns_new_runtime.classify_box_union_by_type
-    store_var _4
+    load_const 10
+    mul_int
+    store_var _3
     load_const 7
     load_type int
     init_instance<1> user.patterns_new_runtime.BoxT .value
     call user.patterns_new_runtime.classify_box_union_by_type
-    store_var _6
-    load_var _4
-    load_const 10
-    mul_int
-    load_var _6
+    load_var _3
     add_int
     return
 }
@@ -4524,16 +4518,14 @@ function patterns_new_runtime.test_match_generic_union_field() -> int {
     load_type string
     init_instance<1> user.patterns_new_runtime.BoxT .value
     call user.patterns_new_runtime.classify_box_union_by_field
-    store_var _4
+    load_const 10
+    mul_int
+    store_var _3
     load_const 9
     load_type int
     init_instance<1> user.patterns_new_runtime.BoxT .value
     call user.patterns_new_runtime.classify_box_union_by_field
-    store_var _6
-    load_var _4
-    load_const 10
-    mul_int
-    load_var _6
+    load_var _3
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/task_group.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/task_group.snap
@@ -141,20 +141,20 @@ function task_group.caps_active_and_queues_rest() -> int {
     pop 1
     load_var g
     call baml.spawn.TaskGroup.active_count
-    store_var _36
+    load_const 100
+    mul_int
+    store_var _35
     load_var g
     call baml.spawn.TaskGroup.queued_count
-    store_var _37
+    load_var _35
+    add_int
+    store_var snapshot
     load_var g
     load_const <omitted>
     load_const <omitted>
     call baml.spawn.TaskGroup.cancel
     pop 1
-    load_var _36
-    load_const 100
-    mul_int
-    load_var _37
-    add_int
+    load_var snapshot
     return
 }
 
@@ -347,23 +347,22 @@ function task_group.queues_excess_and_all_complete() -> int {
     store_var _50
     load_var _19
     await
-    store_var _52
+    load_var _50
+    add_int
+    store_var _49
     load_var _28
     await
-    store_var _54
+    load_var _49
+    add_int
+    store_var _48
     load_var _37
     await
-    store_var _56
+    load_var _48
+    add_int
+    store_var _47
     load_var _46
     await
-    store_var _58
-    load_var2 22 23
-    add_int
-    load_var _54
-    add_int
-    load_var _56
-    add_int
-    load_var _58
+    load_var _47
     add_int
     return
 }
@@ -382,8 +381,7 @@ function task_group.set_limit_updates_limit() -> int {
     pop 1
     load_var g
     call baml.spawn.TaskGroup.limit
-    store_var _5
-    load_var2 2 3
+    load_var before
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_fat_arrow/baml_tests__compiles__lambda_fat_arrow__06_codegen.snap
@@ -58,8 +58,7 @@ function user.test_mixed() -> int {
     load_const 0
     make_closure .<lambda(test_mixed, 1)>, 0
     call_indirect
-    store_var _5
-    load_var2 1 2
+    load_var _3
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lexical_scoping/baml_tests__compiles__lexical_scoping__06_codegen.snap
@@ -46,15 +46,13 @@ function user.capture_before_after_shadow() -> int {
     load_var x
     make_closure .<lambda(capture_before_after_shadow, 0)>, 1
     call_indirect
-    store_var _6
+    load_const 10
+    mul_int
+    store_var _5
     load_var x
     make_closure .<lambda(capture_before_after_shadow, 1)>, 1
     call_indirect
-    store_var _8
-    load_var _6
-    load_const 10
-    mul_int
-    load_var _8
+    load_var _5
     add_int
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/parser_statements/baml_tests__compiles__parser_statements__06_codegen.snap
@@ -281,8 +281,7 @@ function user.let_statements() -> int {
     load_const 1
     load_const 2
     init_instance user.Point .x, .y
-    store_var point
-    load_var point
+    store_var_load_var point
     load_field .x
     load_var point
     load_field .y

--- a/baml_language/crates/baml_tests/tests/defer.rs
+++ b/baml_language/crates/baml_tests/tests/defer.rs
@@ -347,3 +347,98 @@ function main() -> string[] {
         vec!["body", "awaited"]
     );
 }
+
+// ── Unwinding panics ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn defer_runs_once_when_a_panic_unwinds_through_it() {
+    // A panic reaches the defer through the unwind landing pad, exactly like a
+    // typed throw does. The emitter used to sink the panicking `10 / 0` past
+    // the `return`'s inline defer replay, so the body ran on the way out AND
+    // again in the pad.
+    let output = baml_test!(
+        r#"
+function risky(log: string[]) -> int throws unknown {
+  defer { log.push("D") }
+  return 10 / 0
+}
+
+function main() -> string[] {
+  let log: string[] = []
+  risky(log) catch (e) { baml.panics.DivisionByZero => -1 }
+  log
+}
+"#
+    );
+    assert_eq!(expect_strings(output.result.unwrap()), vec!["D"]);
+}
+
+#[tokio::test]
+async fn nested_defers_run_once_each_when_a_panic_unwinds() {
+    // The whole chain ran twice (`inner,outer,inner,outer`) for the same reason.
+    let output = baml_test!(
+        r#"
+function risky(log: string[]) -> int throws unknown {
+  defer { log.push("outer") }
+  defer { log.push("inner") }
+  return 10 / 0
+}
+
+function main() -> string[] {
+  let log: string[] = []
+  risky(log) catch (e) { baml.panics.DivisionByZero => -1 }
+  log
+}
+"#
+    );
+    assert_eq!(
+        expect_strings(output.result.unwrap()),
+        vec!["inner", "outer"]
+    );
+}
+
+#[tokio::test]
+async fn defer_runs_once_when_a_call_free_body_sees_a_panic() {
+    // Same shape with a defer body that compiles to statements rather than a
+    // call, so the replay lands in the returning block itself. Observed through
+    // a field write, which survives the unwind.
+    let output = baml_test!(
+        r#"
+class Counter { n: int }
+
+function risky(c: Counter) -> int throws unknown {
+  defer { c.n = c.n - 1 }
+  return 10 / 0
+}
+
+function main() -> int {
+  let c = Counter { n: 10 }
+  risky(c) catch (e) { baml.panics.DivisionByZero => -1 }
+  c.n
+}
+"#
+    );
+    assert_eq!(output.result.unwrap(), BexExternalValue::Int(9));
+}
+
+#[tokio::test]
+async fn a_panicking_binding_runs_before_later_side_effects() {
+    // The underlying emitter bug without any `defer`: `10 / 0` must panic where
+    // it is bound, before the `push` that follows it.
+    let output = baml_test!(
+        r#"
+function risky(log: string[]) -> int throws unknown {
+  let x = 10 / 0
+  log.push("after")
+  return x
+}
+
+function main() -> string[] {
+  let log: string[] = []
+  risky(log) catch (e) { baml.panics.DivisionByZero => -1 }
+  log
+}
+"#
+    );
+    assert!(expect_strings(output.result.unwrap()).is_empty());
+}


### PR DESCRIPTION
Fixes B-1184: `defer` runs twice when a panic unwinds through it.

## Root cause

Not in the VM unwinder — in the emitter. `can_be_virtual` (`baml_compiler2_emit/src/analysis.rs`) classifies a single-use local as `Virtual`, which drops the store at the definition and re-emits the rvalue at the use site. For a cross-block def-use that **moves the evaluation** past the def block's terminator (a call) and into a possibly different exception region.

MIR for the repro is correct:

```
bb1: { _0 = const 10 / const 0;
       _4 = call baml.Array.push(copy _1, const "D") -> [bb2]; }   // inline defer replay
bb2: { return; }
bb3: { _5 = call baml.Array.push(copy _1, const "D") -> [bb4]; }   // unwind landing pad
bb4: { rethrow copy _2; }
```

The emitted bytecode is not — `_0` is virtualized to the `return` in bb2, so the division lands *after* the replay:

```
0  load_var log; load_const "D"; call push; pop   <- inline defer replay
4  load_const 10; load_const 0; div_int           <- panics here
7  return
8  [pad] load_var log; load_const "D"; call push; pop
12 rethrow
```

The defer body runs once on the way out, the division then panics, and the landing pad runs it again. With nested defers the entire chain repeats.

Typed throws are unaffected because `throw` is its own terminator — there is nothing to sink past.

## The bug is not defer-specific

The same reorder is observable with no `defer` anywhere:

```baml
function risky(log: string[]) -> int throws unknown {
  let x = 10 / 0
  log.push("after")   // ran before the panic
  return x
}
```

## Fix

Reject cross-block virtualization when the rvalue can panic: `int` add/sub/mul/shift (range-checked → `IntegerOverflow`), `/` and `%` (zero divisor → `DivisionByZero`), and negation (`INT_MIN`). Bitwise and/or/xor and comparisons stay in range by construction. Index reads can panic too, but every rvalue with a projection read is already rejected cross-block.

Same-block virtualization is untouched: exception regions start and end on block boundaries, so the set of covering handlers is constant within a block, and the existing intervening-side-effect check still applies.

## Tests

Four new cases in `crates/baml_tests/tests/defer.rs`. Verified they fail on the parent commit with exactly the reported symptoms:

| test | before | after |
|---|---|---|
| `defer_runs_once_when_a_panic_unwinds_through_it` | `["D", "D"]` | `["D"]` |
| `nested_defers_run_once_each_when_a_panic_unwinds` | `["inner","outer","inner","outer"]` | `["inner","outer"]` |
| `defer_runs_once_when_a_call_free_body_sees_a_panic` | `8` | `9` |
| `a_panicking_binding_runs_before_later_side_effects` | `["after"]` | `[]` |

The third covers a defer body that compiles to statements rather than a call, so the replay lands in the returning block itself; the fourth is the underlying emitter bug with no `defer` involved.

Local run: `cargo test -p baml_tests --test defer` — 17 passed. Leaving the full suite to CI.

Draft pending a green CI run — the bytecode-snapshot tests are the ones worth watching, since this makes the emitter strictly less aggressive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018D2txzPqfLJXdUcTit3uqk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime behavior when arithmetic operations trigger panics, preventing unsafe evaluation changes across observable effects.
  * Ensured deferred actions execute exactly once during panic handling, in the correct last-in-first-out order and before subsequent side effects.
  * Division-by-zero panics are correctly surfaced and catchable.

* **Tests**
  * Added coverage for panic unwinding, deferred execution, non-call defer bodies, and division-by-zero handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->