### PR TITLE
Fix stdlib matrix report CI output

### DIFF
--- a/.github/workflows/stdlib-matrix.yml
+++ b/.github/workflows/stdlib-matrix.yml
@@ -168,7 +168,14 @@ jobs:
             # The ratchet step already extracted; reuse exactly what it judged.
             args=(--skip-extract --previous "${GITHUB_WORKSPACE}/previous.json")
           fi
-          tools/stdlib-matrix/run --llm "${args[@]}"
+          # Written straight into the site's public directory rather than copied
+          # there afterwards. `run` creates the destination directory, and that
+          # directory is one git cannot supply: it holds nothing but the report,
+          # which is gitignored, so a fresh checkout has no `public/` at all and
+          # the copy that used to follow failed on it.
+          tools/stdlib-matrix/run --llm \
+            --json-output typescript2/app-stdlib-matrix/public/matrix.json \
+            "${args[@]}"
 
       # A session that did not come back leaves symbols unjudged, which in the
       # published report is indistinguishable from symbols nothing reached — so
@@ -186,7 +193,7 @@ jobs:
         if: steps.ratchet.outputs.changed == 'true'
         run: |
           set -euo pipefail
-          report=tools/stdlib-matrix/report/matrix.json
+          report=typescript2/app-stdlib-matrix/public/matrix.json
           failures="$(jq -er '.failures | length' "${report}")"
           if ((failures > 0)); then
             echo "::warning::${failures} sessions did not come back; their symbols are unjudged" >&2
@@ -211,7 +218,8 @@ jobs:
         working-directory: typescript2/app-stdlib-matrix
         run: |
           set -euo pipefail
-          cp "${GITHUB_WORKSPACE}/tools/stdlib-matrix/report/matrix.json" public/matrix.json
+          # No copy: the report was written here directly, which is also what
+          # created this directory.
           pnpm exec tsc -b --noEmit
           pnpm exec vite build
           cp "${GITHUB_WORKSPACE}/tools/stdlib-matrix/report/matrix.md" dist/matrix.md


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated coverage report generation and validation to use the web app’s public location.
  * Removed outdated report-copying behavior from the site build process.
  * Ensured coverage data is available to the web app as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->