### PR TITLE
Show retained OTEL events in observability animation

### DIFF
--- a/typescript2/app-website/app/what-is-baml/_components/lost-events.tsx
+++ b/typescript2/app-website/app/what-is-baml/_components/lost-events.tsx
@@ -3,17 +3,17 @@
 import { useCallback, useRef, useState, useSyncExternalStore } from 'react';
 import { getDropped, getStartServer, subscribeDropped } from './dropped-store';
 
-// The observability pair. Two rows, same ripple field: under OTEL the field
-// forgets each ripple as it passes (and the code next to it is the sampler
-// you had to wire up). Under BAML every ripple leaves its light behind (and
-// the code next to it is just a function, because tracing is not code you
-// write). The full runnable example follows in the explorer below.
+// The observability pair. Two rows, same ripple field: under OTEL only the
+// sampled events keep their light after the ripple passes. Under BAML every
+// event keeps its light. The full runnable example follows in the explorer
+// below.
 
 const COLS = 18;
 const ROWS = 9;
 const CELLS = COLS * ROWS;
 const TICK_MS = 110;
-// One calm wavefront sweeping left to right, with a pause between passes.
+// One calm wavefront sweeping left to right. The extra span leaves about
+// 1.8 seconds of calm after the wave clears the slanted field.
 const SWEEP_SPEED = 0.45; // columns per tick
 const SWEEP_SPAN = COLS + 10;
 
@@ -21,10 +21,19 @@ const PURPLE = [109, 40, 217] as const;
 const RED = [180, 52, 43] as const;
 const BEIGE = [232, 227, 213] as const;
 
+function settledGlow(i: number, remember: boolean, pass = 0) {
+  if (remember) return 0.45;
+
+  // A scattered sample of roughly one in nine events. Each pass changes the
+  // offset so the next wave captures a different subset.
+  return (i * 73 + pass * 41 + 19) % 101 < 11 ? 0.6 : 0;
+}
+
 // One animated ripple field, pinned to a mode.
 function Field({ remember }: { remember: boolean }) {
   const [, setFrame] = useState(0);
   const tickRef = useRef(0);
+  const passRef = useRef(0);
   const memoryRef = useRef<Float32Array>(new Float32Array(CELLS));
   const flashRef = useRef<Float32Array>(new Float32Array(CELLS));
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -38,11 +47,7 @@ function Field({ remember }: { remember: boolean }) {
       if (reduced) {
         const memory = memoryRef.current;
         for (let i = 0; i < CELLS; i++) {
-          memory[i] = remember
-            ? ((i * 37) % 4) / 6
-            : (i * 37) % 9 === 0
-              ? 0.4
-              : 0;
+          memory[i] = settledGlow(i, remember);
         }
         setFrame((n) => n + 1);
         return undefined;
@@ -53,18 +58,24 @@ function Field({ remember }: { remember: boolean }) {
         const flash = flashRef.current;
         // A single soft wavefront, slightly slanted, sweeping left to right.
         const front = (t * SWEEP_SPEED) % SWEEP_SPAN;
+        const previousFront = ((t - 1) * SWEEP_SPEED) % SWEEP_SPAN;
+        // Start each pass empty so dots are only revealed after the wave
+        // reaches them. OTEL also selects a new sample for every pass.
+        if (front < previousFront) {
+          memory.fill(0);
+          if (!remember) passRef.current += 1;
+        }
         for (let i = 0; i < CELLS; i++) {
           const x = (i % COLS) + 0.5;
           const y = Math.floor(i / COLS) + 0.5;
           const d = Math.abs(x + y * 0.25 - front);
           const f = d < 1.6 ? 1 - d / 1.6 : 0;
           flash[i] = f * 0.7;
-          if (remember) {
-            // Settle to a calm lavender, a shade deeper on a sparse lattice.
-            const cap = (x + 2 * y) % 5 === 0 ? 0.75 : 0.45;
-            if (f > 0.4) memory[i] = Math.min(cap, memory[i] + 0.2);
-          } else {
-            memory[i] *= 0.95;
+          if (f > 0.4) {
+            // The wave reveals what was retained: every BAML event, but only
+            // the sampled OTEL events. OTEL holds this result through the
+            // pause, then clears it when the next pass starts.
+            memory[i] = settledGlow(i, remember, passRef.current);
           }
         }
         setFrame((n) => n + 1);
@@ -85,8 +96,8 @@ function Field({ remember }: { remember: boolean }) {
     <div
       aria-label={
         remember
-          ? 'A field of dots keeping the light of every passing ripple.'
-          : 'A field of dots forgetting each ripple as it passes.'
+          ? 'A field where every dot stays purple after the ripple passes.'
+          : 'A field where only sampled dots stay red after the ripple passes.'
       }
       className="lev-field"
       ref={rootRef}


### PR DESCRIPTION
## Summary

- reveal only a sampled subset of OTEL dots as each wave passes
- reveal every BAML dot as the same wave passes
- hold the completed comparison for about 1.8 seconds
- reset both fields to gray before the next pass
- select a different OTEL sample on each new pass
- match the reduced-motion state to the completed comparison

## Why

The previous animation faded every OTEL dot back to beige, so it showed loss without showing that OTEL still captures a sampled subset. Retained colors could also survive into the next pass, making events appear captured before the wave reached them.

Each pass now starts from gray, reveals the current results in order, pauses on the completed state, and then repeats with a new OTEL sample.

## Validation

- `git diff --check`
- visually verified the first pass, completed-state pause, reset, and second pass
- `pnpm --dir typescript2/app-website typecheck` *(blocked by existing errors in `TenetsAccordion.tsx` and `playground/baml-worker.ts`)*

## Screenshots

### Before
<img width="800" height="592" alt="CleanShot 2026-08-10 at 13 23 33" src="https://github.com/user-attachments/assets/fb961bc5-6080-44e8-8109-966ca3f5f065" />

### After
<img width="800" height="592" alt="CleanShot 2026-08-10 at 13 21 56" src="https://github.com/user-attachments/assets/0b85f230-ab9a-49f6-ac31-c16710d8e605" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the ripple visualization to retain all BAML events while displaying a consistent sample of OTEL events.
  * Each animation sweep now refreshes the sampled events for a clearer, more dynamic presentation.
  * Reduced-motion views now follow the same event-retention behavior.
  * Improved accessibility labels clarify which points are retained and which are sampled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->