### PR TITLE
More stdlib matrix fixes

### DIFF
--- a/.github/workflows/stdlib-matrix.yml
+++ b/.github/workflows/stdlib-matrix.yml
@@ -55,7 +55,7 @@ jobs:
     # subprocess lookups between them, eight sessions at a time. An incremental
     # run is minutes; this bound is for the cold one.
     timeout-minutes: 120
-    # Holds ANTHROPIC_API_KEY. Pages needs its own environment, which is why
+    # Holds OPENAI_API_KEY. Pages needs its own environment, which is why
     # deploying is a separate job — a job may name only one.
     #
     # -prod rather than -dev: the key in -dev was rejected on every one of 199
@@ -171,7 +171,7 @@ jobs:
       - name: "Build the matrix"
         if: steps.ratchet.outputs.changed == 'true'
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           set -euo pipefail
           # Two independent questions, which were one flag until a forced

--- a/.github/workflows/stdlib-matrix.yml
+++ b/.github/workflows/stdlib-matrix.yml
@@ -141,14 +141,21 @@ jobs:
           FORCED: ${{ github.event_name == 'workflow_dispatch' && inputs.force }}
         run: |
           set -euo pipefail
+          # `extracted` is reported separately from `changed`, because the build
+          # below needs to know something different: whether data/ exists yet.
+          # Both paths out of this step set it, and the early ones set it false
+          # — a forced dispatch skips the comparison, and skipping the
+          # comparison means skipping the extraction that comes with it.
           if [[ "${{ steps.previous.outputs.have }}" != "true" || "${FORCED}" == "true" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "extracted=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           # This run does the extraction; the build below reuses its data/, so
           # the decision and the report it gates are made from the same bytes.
           if tools/stdlib-matrix/run --check --baseline previous.json; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "extracted=true" >> "$GITHUB_OUTPUT"
             echo "The deployed report was built from these inputs; nothing to publish."
           else
             status=$?
@@ -158,6 +165,7 @@ jobs:
               exit "${status}"
             fi
             echo "changed=true" >> "$GITHUB_OUTPUT"
+            echo "extracted=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: "Build the matrix"
@@ -166,10 +174,17 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
           set -euo pipefail
+          # Two independent questions, which were one flag until a forced
+          # dispatch told them apart: whether there is a report to carry
+          # forward, and whether data/ has already been built. A forced run has
+          # the first and not the second, and claiming otherwise made the tool
+          # refuse with "--skip-extract passed but data/ is incomplete".
           args=()
           if [[ "${{ steps.previous.outputs.have }}" == "true" ]]; then
-            # The ratchet step already extracted; reuse exactly what it judged.
-            args=(--skip-extract --previous "${GITHUB_WORKSPACE}/previous.json")
+            args+=(--previous "${GITHUB_WORKSPACE}/previous.json")
+          fi
+          if [[ "${{ steps.ratchet.outputs.extracted }}" == "true" ]]; then
+            args+=(--skip-extract)
           fi
           # Written straight into the site's public directory rather than copied
           # there afterwards. `run` creates the destination directory, and that

--- a/baml_language/crates/baml_cli/src/describe_command.rs
+++ b/baml_language/crates/baml_cli/src/describe_command.rs
@@ -38,7 +38,7 @@ Examples:
     baml describe match
 
   Search for something by what it does:
-    baml describe --search 'run a subprocess'")]
+    baml describe --search 'read a file'")]
 pub struct DescribeArgs {
     #[command(flatten)]
     pub compiler: crate::commands::CompilerArgs,
@@ -66,20 +66,24 @@ pub struct DescribeArgs {
     ///
     /// `describe` answers "what is this called"; `--search` answers "what does
     /// this", which is the question you have when you know the job and not the
-    /// name. `baml describe subprocess` finds nothing — nothing is called that
-    /// — while `baml describe --search subprocess` finds `baml.sys.exec`.
-    /// Matching is on whole words, best first.
+    /// name: `baml describe --search 'read a file'`. Matching is on whole words
+    /// — of names and of docstrings — best first, so it finds a symbol whose
+    /// documentation uses your words even when its name does not.
     #[arg(long, help_heading = "Output options")]
     pub search: bool,
 
-    /// Most results to return from `--search`.
+    /// Most results to return from `--search`. At least 1.
+    ///
+    /// Bounded below because `--limit 0` truncated a full result set to nothing
+    /// and then reported "no symbol matches", which is a different answer.
     #[arg(
         long,
         default_value_t = 30,
         value_name = "N",
+        value_parser = clap::value_parser!(u16).range(1..),
         help_heading = "Output options"
     )]
-    pub limit: usize,
+    pub limit: u16,
 
     /// Export a whole package's surface as one versioned JSON document
     /// (NAME must be a package: `baml`, `user`, …). Cross-package references
@@ -340,7 +344,7 @@ impl DescribeArgs {
 
         // ── --search: names and docstrings, rather than name resolution ─────
         if self.search {
-            let hits = crate::describe_search::search(&db, name, self.limit);
+            let hits = crate::describe_search::search(&db, name, usize::from(self.limit));
             if self.json {
                 println!(
                     "{}",

--- a/baml_language/crates/baml_cli/src/describe_search.rs
+++ b/baml_language/crates/baml_cli/src/describe_search.rs
@@ -14,7 +14,7 @@
 //! only finds a symbol that shares a *word* with its name or its prose.
 //! `subprocess` finds nothing, because no symbol and no docstring in the
 //! standard library uses that word — `baml.sys.exec` says "Runs `program`".
-//! Reaching that needs an index this is not.
+//! Reaching that needs a semantic index, which this search is not.
 //!
 //! Matching is on whole words, not substrings. Substrings are how a search
 //! becomes noise — `run` is inside `trunc`, so a substring search for "run a
@@ -52,14 +52,48 @@ const STOP_WORDS: &[&str] = &[
 /// name — and `CAFÉ` lowercased to `cafÉ` on one side and `café` on the other.
 ///
 /// One- and two-character tokens, and the stop words above, match nearly
-/// everything and are dropped.
-fn query_tokens(query: &str) -> Vec<String> {
-    haystack(query)
+/// everything, so they are dropped from `relevance` — but not from `names`,
+/// because a symbol may simply *be* called `get`.
+fn query_tokens(query: &str) -> Query {
+    let words: Vec<String> = haystack(query)
         .split_whitespace()
-        .filter(|token| token.chars().count() > 2 && !STOP_WORDS.contains(token))
         .map(str::to_string)
         .take(8)
-        .collect()
+        .collect();
+    Query {
+        relevance: words
+            .iter()
+            .filter(|token| token.chars().count() > 2 && !STOP_WORDS.contains(&token.as_str()))
+            .cloned()
+            .collect(),
+        // Single characters stay out of both: camelCase splitting turns `toA`
+        // into ` to a `, so a stray `a` in a query would match on nothing but
+        // an artefact of the tokenizer.
+        names: words
+            .into_iter()
+            .filter(|token| token.chars().count() > 1)
+            .collect(),
+    }
+}
+
+/// A tokenized query, split by what each half may be matched against.
+///
+/// Two lists rather than one because filtering serves ranking and defeats
+/// lookup. `get` is too common to rank a docstring by and is exactly the right
+/// thing to match a name against, and a single list has to choose.
+#[derive(Debug)]
+struct Query {
+    /// Tokens that discriminate: prose and owner are ranked on these.
+    relevance: Vec<String>,
+    /// Tokens that might be a symbol's name, whole-word.
+    names: Vec<String>,
+}
+
+impl Query {
+    /// Nothing to look for on either axis.
+    fn is_empty(&self) -> bool {
+        self.relevance.is_empty() && self.names.is_empty()
+    }
 }
 
 /// A name or docstring reduced to whole words, space-delimited at both ends so
@@ -103,14 +137,25 @@ fn haystack(text: &str) -> String {
 /// A prefix still scores, so `run` finds "Runs" — English inflection is not
 /// worth a stemmer here, but ignoring it entirely would lose the most natural
 /// way to ask.
-fn score(leaf: &str, owner: &str, docs: &str, tokens: &[String]) -> u32 {
+fn score(leaf: &str, owner: &str, docs: &str, query: &Query) -> u32 {
     let mut total = 0;
-    for token in tokens {
+    // A name is matched on every token, including the ones too common to rank
+    // prose by. Symbols really are called `get`, `set` and `id`, and filtering
+    // those out of the name test made each one unfindable by typing it.
+    for token in &query.names {
+        if leaf.contains(&format!(" {token} ")) {
+            total += 20;
+        }
+    }
+    // Everything else is ranked on the discriminating tokens only. A stop word
+    // appears in most docstrings in the library, so scoring prose by it ranks
+    // the whole surface equally, which is the same as not ranking at all.
+    for token in &query.relevance {
         let exact = format!(" {token} ");
         let prefix = format!(" {token}");
-        if leaf.contains(&exact) {
+        if !query.names.contains(token) && leaf.contains(&exact) {
             total += 20;
-        } else if leaf.contains(&prefix) {
+        } else if leaf.contains(&prefix) && !leaf.contains(&exact) {
             total += 10;
         }
         if docs.contains(&exact) {
@@ -142,6 +187,18 @@ struct Candidate {
     docstring: Option<String>,
 }
 
+/// The prefix `describe` accepts for a package.
+///
+/// The user package is called `user` internally and addressed as `root`:
+/// `resolve` maps a leading `root.` onto it, and reads a leading `user.` as an
+/// item *named* `user`, which is nothing. So a hit printed as `user.Judgement`
+/// was a path the reader could not paste back into `describe` — and pasting it
+/// back is the entire reason a path is printed. This mirrors the `root` the
+/// search walk already pushes for the same reason.
+fn addressable_package(package: &str) -> &str {
+    if package == "user" { "root" } else { package }
+}
+
 /// Everything in a package that a search can land on.
 ///
 /// The match over `ItemDetail` is exhaustive on purpose: a kind that gains
@@ -158,7 +215,7 @@ fn candidates(export: &PackageExport) -> Vec<Candidate> {
         // The package is not part of `item.namespace`, and without it a result
         // reads `sys.exec`: ambiguous across packages, and not the name the id
         // beside it uses or the one `describe` accepts.
-        let mut segments: Vec<&str> = vec![export.package.as_str()];
+        let mut segments: Vec<&str> = vec![addressable_package(&export.package)];
         segments.extend(item.namespace.iter().map(String::as_str));
         segments.push(&item.name);
         let path = segments.join(".");
@@ -264,8 +321,8 @@ fn candidates(export: &PackageExport) -> Vec<Candidate> {
 
 /// Search every package the project can see, best first.
 pub fn search(db: &ProjectDatabase, query: &str, limit: usize) -> Vec<Hit> {
-    let tokens = query_tokens(query);
-    if tokens.is_empty() {
+    let query = query_tokens(query);
+    if query.is_empty() {
         return Vec::new();
     }
 
@@ -299,7 +356,7 @@ pub fn search(db: &ProjectDatabase, query: &str, limit: usize) -> Vec<Hit> {
                 &haystack(&candidate.leaf),
                 &haystack(&owner),
                 &haystack(docs),
-                &tokens,
+                &query,
             );
             if score > 0 {
                 hits.push(Hit {
@@ -313,17 +370,20 @@ pub fn search(db: &ProjectDatabase, query: &str, limit: usize) -> Vec<Hit> {
         }
     }
 
-    // Best first, then by path, so equal scores come out in a stable order
-    // rather than in whichever order the packages were walked.
     // Best first, then path, then id: two impl blocks can provide the same
     // method name for the same receiver display, so path alone is not a total
-    // order and the tie would fall to the walk order.
+    // order and the tie would fall to whichever order the packages were walked.
     hits.sort_by(|a, b| {
         b.score
             .cmp(&a.score)
             .then_with(|| a.path.cmp(&b.path))
             .then_with(|| a.id.cmp(&b.id))
     });
+    // One symbol, one row. A method written in a class body's `implements`
+    // block is listed by the export both as a method of the class and as a
+    // method of the block; both now carry the same id, so a search for `id`
+    // printed `ai.clients.Fallback.id` twice, character for character.
+    hits.dedup_by(|a, b| a.id == b.id);
     hits.truncate(limit);
     hits
 }
@@ -337,7 +397,7 @@ mod tests {
         // The bug this scoring exists to prevent: `run` is a substring of
         // `trunc`, and a substring search buries the answer under arithmetic.
         let tokens = query_tokens("run a subprocess");
-        assert_eq!(tokens, ["run", "subprocess"]);
+        assert_eq!(tokens.relevance, ["run", "subprocess"]);
         assert_eq!(
             score(
                 &haystack("trunc"),
@@ -419,9 +479,60 @@ mod tests {
     fn stop_words_are_dropped() {
         // `the` scores against essentially every docstring in the library.
         assert_eq!(
-            query_tokens("read the file from disk"),
+            query_tokens("read the file from disk").relevance,
             ["read", "file", "disk"]
         );
+    }
+
+    #[test]
+    fn a_name_that_is_a_stop_word_is_still_findable() {
+        // `get`, `set` and `id` are all filtered out of relevance ranking —
+        // two of them are stop words and one is two characters — and every
+        // symbol actually called that became unreachable by typing its name.
+        for name in ["get", "set", "id", "all", "any", "use"] {
+            let query = query_tokens(name);
+            assert!(
+                query.relevance.is_empty(),
+                "{name} is filtered from ranking, which is the premise"
+            );
+            assert!(
+                score(
+                    &haystack(name),
+                    &haystack("baml.env"),
+                    &haystack(""),
+                    &query
+                ) > 0,
+                "{name} still scores against a symbol of that exact name"
+            );
+        }
+
+        // Still filtered where it was noise: a stop word must not pull in
+        // every docstring that happens to contain it.
+        let query = query_tokens("get");
+        assert_eq!(
+            score(
+                &haystack("read"),
+                &haystack("baml.fs"),
+                &haystack("Get the contents of a file"),
+                &query
+            ),
+            0,
+            "a stop word scores no prose"
+        );
+
+        // And a single character stays out of both: camelCase splitting turns
+        // `toA` into ` to a `, so a stray `a` would match a tokenizer artefact.
+        let query = query_tokens("a");
+        assert!(query.is_empty());
+    }
+
+    #[test]
+    fn a_user_symbol_is_printed_as_a_path_describe_accepts() {
+        // The resolver maps a leading `root.` to the user package and reads a
+        // leading `user.` as an item *named* `user`. Printing `user.Foo` gave
+        // the reader a path that `describe` then rejected.
+        assert_eq!(addressable_package("user"), "root");
+        assert_eq!(addressable_package("baml"), "baml");
     }
 
     #[test]
@@ -437,8 +548,16 @@ mod tests {
     fn short_tokens_are_dropped() {
         // `a` and `of` match nearly every docstring in the standard library —
         // and so did `the`, which this test used to assert *survives*.
-        assert_eq!(query_tokens("a list of the"), ["list"]);
+        assert_eq!(query_tokens("a list of the").relevance, ["list"]);
         assert!(query_tokens("").is_empty());
-        assert!(query_tokens("the and for").is_empty());
+
+        // Dropped from ranking but kept for names, deliberately: `all` and
+        // `any` are stop words *and* real methods, so a query of nothing but
+        // stop words still has somewhere to look. Only the empty query, and
+        // one made of single characters, has nothing.
+        let stops = query_tokens("the and for");
+        assert!(stops.relevance.is_empty(), "none of them rank prose");
+        assert_eq!(stops.names, ["the", "and", "for"]);
+        assert!(query_tokens("a b c").is_empty());
     }
 }

--- a/baml_language/crates/baml_cli/src/describe_search.rs
+++ b/baml_language/crates/baml_cli/src/describe_search.rs
@@ -7,8 +7,14 @@
 //! and not what it is *called* has nothing to type.
 //!
 //! This searches docstrings as well as names, which is where that knowledge
-//! lives: `baml.sys.exec` never says "subprocess", but it does say "Runs
-//! `program` with the given `args`".
+//! often lives: `baml.fs.read` is findable by "read a file" because its
+//! documentation says so.
+//!
+//! It is lexical, not semantic, and the limit is worth stating plainly: a query
+//! only finds a symbol that shares a *word* with its name or its prose.
+//! `subprocess` finds nothing, because no symbol and no docstring in the
+//! standard library uses that word — `baml.sys.exec` says "Runs `program`".
+//! Reaching that needs an index this is not.
 //!
 //! Matching is on whole words, not substrings. Substrings are how a search
 //! becomes noise — `run` is inside `trunc`, so a substring search for "run a
@@ -30,13 +36,28 @@ pub struct Hit {
     pub score: u32,
 }
 
-/// The words a query is looking for: lowercased, and long enough to mean
-/// something. One- and two-character tokens match nearly everything.
+/// Words so common that scoring them is noise rather than signal.
+const STOP_WORDS: &[&str] = &[
+    "the", "and", "for", "from", "into", "with", "that", "this", "there", "then", "when", "how",
+    "does", "using", "use", "get", "set", "all", "any", "not",
+];
+
+/// The words a query is looking for.
+///
+/// Tokenized through `haystack`, the same way the text being searched is. They
+/// used to diverge: the haystack split camelCase and lowercased with full
+/// Unicode, while the query did neither. So `ZonedDateTime` became the single
+/// token `zoneddatetime` and could not match ` zoned date time ` — every
+/// PascalCase type in the standard library was unfindable by typing its own
+/// name — and `CAFÉ` lowercased to `cafÉ` on one side and `café` on the other.
+///
+/// One- and two-character tokens, and the stop words above, match nearly
+/// everything and are dropped.
 fn query_tokens(query: &str) -> Vec<String> {
-    query
-        .split(|c: char| !c.is_alphanumeric())
-        .filter(|t| t.chars().count() > 2)
-        .map(str::to_ascii_lowercase)
+    haystack(query)
+        .split_whitespace()
+        .filter(|token| token.chars().count() > 2 && !STOP_WORDS.contains(token))
+        .map(str::to_string)
         .take(8)
         .collect()
 }
@@ -218,6 +239,15 @@ fn candidates(export: &PackageExport) -> Vec<Candidate> {
     // search for "sort an array" could not reach `T[].sort`.
     for block in &export.impls {
         for method in &block.methods {
+            // An inherited default is re-listed by every implementor — 13 impls
+            // inherit `baml.iter.Iterator.chain`, and 198 of 324 impl entries
+            // are re-listings. The declaration itself is already a candidate,
+            // through the interface's `default_methods`, so keeping these spent
+            // half a result page on one method. An override is a distinct
+            // declaration and stays.
+            if method.from_default {
+                continue;
+            }
             out.push(Candidate {
                 id: method.id.clone(),
                 kind: "method",
@@ -242,7 +272,11 @@ pub fn search(db: &ProjectDatabase, query: &str, limit: usize) -> Vec<Hit> {
     let mut names: Vec<String> = baml_lsp2_actions::non_user_package_names(db)
         .into_iter()
         .collect();
-    names.push("user".to_string());
+    // `root`, not `user`: `resolve` maps `root` to the user package and treats a
+    // bare `user` as an item *named* `user` inside it, which is nothing. So this
+    // resolved to `None`, the `let … else` swallowed it, and the one package the
+    // reader actually wrote was the only one never searched.
+    names.push("root".to_string());
     // A stable walk order, so equal-scoring hits from different packages come
     // out the same way on every run.
     names.sort();
@@ -281,7 +315,15 @@ pub fn search(db: &ProjectDatabase, query: &str, limit: usize) -> Vec<Hit> {
 
     // Best first, then by path, so equal scores come out in a stable order
     // rather than in whichever order the packages were walked.
-    hits.sort_by(|a, b| b.score.cmp(&a.score).then_with(|| a.path.cmp(&b.path)));
+    // Best first, then path, then id: two impl blocks can provide the same
+    // method name for the same receiver display, so path alone is not a total
+    // order and the tie would fall to the walk order.
+    hits.sort_by(|a, b| {
+        b.score
+            .cmp(&a.score)
+            .then_with(|| a.path.cmp(&b.path))
+            .then_with(|| a.id.cmp(&b.id))
+    });
     hits.truncate(limit);
     hits
 }
@@ -351,6 +393,38 @@ mod tests {
     }
 
     #[test]
+    fn a_pascal_case_name_finds_itself() {
+        // The haystack split camelCase and the query did not, so every
+        // PascalCase type in the standard library was unfindable by typing its
+        // own name. Both sides go through `haystack` now.
+        for name in ["ZonedDateTime", "CsvReader", "ShellOutput", "TaskGroup"] {
+            let tokens = query_tokens(name);
+            let scored = score(&haystack(name), &haystack(""), &haystack(""), &tokens);
+            assert!(scored > 0, "{name} scored {scored} against itself");
+        }
+    }
+
+    #[test]
+    fn case_folding_agrees_on_both_sides() {
+        // The query lowercased with `to_ascii_lowercase` and the haystack with
+        // full Unicode, so any non-ASCII uppercase letter missed its own word.
+        for word in ["CAFÉ", "NAÏVE", "RÉSUMÉ"] {
+            let tokens = query_tokens(word);
+            let scored = score(&haystack(word), &haystack(""), &haystack(""), &tokens);
+            assert!(scored > 0, "{word} scored {scored} against itself");
+        }
+    }
+
+    #[test]
+    fn stop_words_are_dropped() {
+        // `the` scores against essentially every docstring in the library.
+        assert_eq!(
+            query_tokens("read the file from disk"),
+            ["read", "file", "disk"]
+        );
+    }
+
+    #[test]
     fn camel_case_splits_into_words() {
         // A query typed in snake_case has to find a name written in camelCase,
         // which is the whole reason names are split rather than compared.
@@ -361,8 +435,10 @@ mod tests {
 
     #[test]
     fn short_tokens_are_dropped() {
-        // `a` and `of` match nearly every docstring in the standard library.
-        assert_eq!(query_tokens("a list of the"), ["list", "the"]);
+        // `a` and `of` match nearly every docstring in the standard library —
+        // and so did `the`, which this test used to assert *survives*.
+        assert_eq!(query_tokens("a list of the"), ["list"]);
         assert!(query_tokens("").is_empty());
+        assert!(query_tokens("the and for").is_empty());
     }
 }

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__describe_detailed_help.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__describe_detailed_help.snap
@@ -30,7 +30,7 @@ Examples:
     baml describe match
 
   Search for something by what it does:
-    baml describe --search 'run a subprocess'
+    baml describe --search 'read a file'
 
 Arguments:
   [NAME]
@@ -58,12 +58,15 @@ Output options:
           Search names *and* docstrings for NAME, instead of resolving it.
 
           `describe` answers "what is this called"; `--search` answers "what does this", which is
-          the question you have when you know the job and not the name. `baml describe subprocess`
-          finds nothing — nothing is called that — while `baml describe --search subprocess` finds
-          `baml.sys.exec`. Matching is on whole words, best first.
+          the question you have when you know the job and not the name: `baml describe --search
+          'read a file'`. Matching is on whole words — of names and of docstrings — best first, so
+          it finds a symbol whose documentation uses your words even when its name does not.
 
       --limit <N>
-          Most results to return from `--search`
+          Most results to return from `--search`. At least 1.
+
+          Bounded below because `--limit 0` truncated a full result set to nothing and then reported
+          "no symbol matches", which is a different answer.
 
           [default: 30]
 

--- a/baml_language/crates/baml_surface/src/export.rs
+++ b/baml_language/crates/baml_surface/src/export.rs
@@ -76,9 +76,11 @@ impl TyRef {
             Some(TyHead::Nominal(qtn)) => Some(
                 SymbolId {
                     kind: crate::ids::IdKind::Type,
-                    package: qtn.package().to_string(),
-                    namespace: qtn.namespace().iter().map(ToString::to_string).collect(),
-                    name: qtn.name().to_string(),
+                    owner: crate::ids::Owner::Path {
+                        package: qtn.package().to_string(),
+                        namespace: qtn.namespace().iter().map(ToString::to_string).collect(),
+                        name: qtn.name().to_string(),
+                    },
                     member: None,
                 }
                 .to_string(),
@@ -363,13 +365,9 @@ struct ImplIndex<'db> {
 
 impl<'db> ImplIndex<'db> {
     fn build(db: &'db dyn Db) -> Self {
-        // Deterministic id assignment: file order (builtins first, then
-        // project files), `#n` suffixes for same-headed duplicates.
-        let mut seen_bases: std::collections::HashMap<String, u32> =
-            std::collections::HashMap::new();
         let mut exports = Vec::new();
         for imp in crate::handles::project_impls(db) {
-            let Some(export) = export_impl(db, imp, &mut seen_bases) else {
+            let Some(export) = export_impl(db, imp) else {
                 continue;
             };
             exports.push((imp, export));
@@ -531,25 +529,33 @@ fn required_method_export(
     }
 }
 
-fn export_impl(
-    db: &dyn Db,
-    imp: Impl<'_>,
-    seen_bases: &mut std::collections::HashMap<String, u32>,
-) -> Option<ImplExport> {
+/// The interface an impl names, with its arguments: `baml.ops.Add<bigint>`.
+///
+fn export_impl(db: &dyn Db, imp: Impl<'_>) -> Option<ImplExport> {
     let data = crate::facts::impl_data(db, imp.loc())?;
     let iface: crate::Interface<'_> = data.interface.into();
     let iface_qtn = iface.qualified_name(db);
     let pkg = baml_compiler2_hir::file_package::file_package(db, imp.file(db)).package;
 
     let for_ty = TyRef::of(&data.for_ty_pattern);
-    let base = format!(
-        "X:{pkg}.impl[{} for {}]",
-        iface_qtn.render_dotted(false),
-        for_ty.display
-    );
-    let n = seen_bases.entry(base.clone()).or_insert(0);
-    let id = if *n == 0 { base } else { format!("{base}#{n}") };
-    *n += 1;
+    // Destructured from the one renderer rather than rebuilt here, so a block's
+    // id and the ids of the methods it contributes can never disagree about
+    // what identifies it.
+    let crate::ids::Owner::Impl {
+        interface: iface_display,
+        ..
+    } = SymbolId::impl_owner(db, imp)?
+    else {
+        unreachable!("impl_owner always yields the impl form")
+    };
+    // No positional `#n` suffix. It used to disambiguate same-headed blocks,
+    // which meant twenty ids in `baml` alone were determined by declaration
+    // order — the one thing this module promises an id never depends on.
+    // Reordering two `impl Add for int` blocks silently rebound every consumer
+    // keyed on them. The arguments distinguish those blocks honestly, and if
+    // two blocks still collide they overlap, which coherence must reject
+    // rather than an id scheme paper over.
+    let id = format!("X:{pkg}.impl[{iface_display} for {}]", for_ty.display);
 
     let mut methods: Vec<FunctionExport> = imp
         .all_methods(db)
@@ -592,7 +598,12 @@ fn export_item<'db>(
 ) -> Option<ItemExport> {
     let id = SymbolId::of_symbol(db, symbol)?;
     let name = symbol.name(db)?;
-    let namespace = id.namespace.clone();
+    // An item always has a path owner; only impl-contributed methods do not,
+    // and those are not exported as items.
+    let namespace = match &id.owner {
+        crate::ids::Owner::Path { namespace, .. } => namespace.clone(),
+        crate::ids::Owner::Impl { .. } => Vec::new(),
+    };
 
     let detail = match symbol {
         Symbol::Class(class) => {

--- a/baml_language/crates/baml_surface/src/export.rs
+++ b/baml_language/crates/baml_surface/src/export.rs
@@ -162,14 +162,22 @@ pub struct SourceExport {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct FunctionExport {
-    /// Where this record lives, unique across the document. A method reached
-    /// through an impl block is addressed under that block, because the same
-    /// declaration can be re-listed by many of them.
+    /// Where this record lives. A method reached through an impl block is
+    /// addressed *through* it — `M:(int as baml.ops.Add<bigint>).add` — because
+    /// the same declaration can be re-listed by many blocks and each listing
+    /// needs its own address.
+    ///
+    /// One id may appear on two records when they are the same symbol seen two
+    /// ways: a method written in a class body's `implements` block is listed
+    /// both as a method of the class and as a method of the block. Two
+    /// *different* symbols never share one.
     pub id: String,
-    /// The declaring symbol's own id, when it has one — an inherited default
-    /// names the interface method it came from, and an override on a named type
-    /// names that type's member. Absent for a method declared only inside a
-    /// free impl block, which has no address other than [`id`](Self::id).
+    /// Where the code is written, when that is somewhere else — an inherited
+    /// default names the interface method it came from. Absent when [`id`]
+    /// already names the declaration, which is the case for every method a
+    /// block writes itself.
+    ///
+    /// [`id`]: Self::id
     #[serde(skip_serializing_if = "Option::is_none")]
     pub declared_by: Option<String>,
     pub name: String,
@@ -430,13 +438,34 @@ fn function_export(
     db: &dyn Db,
     function: Function<'_>,
     from_default: bool,
-    block: Option<&str>,
+    via: Option<Impl<'_>>,
 ) -> FunctionExport {
     let sig = function.signature(db);
     let name = function.name(db);
     let declared = SymbolId::of_symbol(db, Symbol::Function(function)).map(|id| id.to_string());
-    let (id, declared_by) = match block {
-        Some(block) => (format!("{block}::{name}"), declared),
+    let (id, declared_by) = match via {
+        // Reached through an impl block, so addressed through it, in the
+        // qualified path a caller would actually write. This used to be
+        // `<block id>::<name>`, which addressed the record perfectly well and
+        // was spelled in a language BAML is not: `::` appears nowhere in the
+        // grammar, and an id exists to be pasted back into a tool.
+        Some(imp) => {
+            let qualified = SymbolId::impl_owner(db, imp)
+                .map(|owner| {
+                    SymbolId {
+                        kind: crate::ids::IdKind::Method,
+                        owner,
+                        member: Some(name.to_string()),
+                    }
+                    .to_string()
+                })
+                .unwrap_or_default();
+            // `declared_by` is only worth stating when it differs — an
+            // inherited default lives on the interface, while a method the
+            // block writes itself is already named by `id`.
+            let declared_by = declared.filter(|declared| declared != &qualified);
+            (qualified, declared_by)
+        }
         // A method of a named type: its declaration is its address.
         None => (declared.unwrap_or_default(), None),
     };
@@ -560,7 +589,7 @@ fn export_impl(db: &dyn Db, imp: Impl<'_>) -> Option<ImplExport> {
     let mut methods: Vec<FunctionExport> = imp
         .all_methods(db)
         .into_iter()
-        .map(|m| function_export(db, m.function, m.from_default, Some(&id)))
+        .map(|m| function_export(db, m.function, m.from_default, Some(imp)))
         .collect();
     methods.sort_by(|a, b| a.name.cmp(&b.name));
 

--- a/baml_language/crates/baml_surface/src/export_tests.rs
+++ b/baml_language/crates/baml_surface/src/export_tests.rs
@@ -26,24 +26,39 @@ fn assert_package_exports_fully() {
     insta::assert_snapshot!(serde_json::to_string_pretty(&export).unwrap());
 }
 
-/// Every `id` in the document addresses exactly one record.
+/// Every `id` in the document addresses exactly one *symbol*.
 ///
 /// Consumers key on ids — a report diffs on them, a cache blesses on them — so
 /// a collision is not a cosmetic flaw but a wrong answer about a different
 /// symbol. The pressure is entirely on impl blocks: an inherited default is
-/// re-listed by every implementor (13 impls inherit `baml.iter.Iterator.chain`)
-/// and a method declared in a free impl has no symbol id at all, which is why
-/// an impl entry is addressed under its block and keeps the declaration in
-/// `declared_by`.
+/// re-listed by every implementor (13 impls inherit `baml.iter.Iterator.chain`),
+/// which is why an impl entry is addressed through its block and keeps the
+/// declaration in `declared_by`.
+///
+/// One symbol may legitimately appear twice, and the invariant is stated on
+/// records rather than on strings for that reason: a method written in a class
+/// body's `implements` block is both a method of the class and a method of the
+/// block, and both views list it. What must never happen is one id covering two
+/// *different* records, so equal ids are required to carry equal content.
 #[test]
 fn every_exported_id_is_unique() {
     let db = make_db();
     let json = serde_json::to_value(export_package(&db, Package::named(&db, "baml"))).unwrap();
 
     let mut ids: Vec<String> = Vec::new();
+    let mut records: std::collections::HashMap<String, serde_json::Value> =
+        std::collections::HashMap::new();
+    let mut conflicts: Vec<String> = Vec::new();
     let mut collect = |value: &serde_json::Value| {
         if let Some(id) = value.get("id").and_then(serde_json::Value::as_str) {
             ids.push(id.to_string());
+            match records.get(id) {
+                Some(existing) if existing != value => conflicts.push(id.to_string()),
+                Some(_) => {}
+                None => {
+                    records.insert(id.to_string(), value.clone());
+                }
+            }
         }
     };
     for item in json["items"].as_array().unwrap() {
@@ -77,21 +92,26 @@ fn every_exported_id_is_unique() {
     }
 
     assert!(ids.len() > 1000, "the census actually walked the document");
-    let mut sorted = ids.clone();
-    sorted.sort();
-    sorted.dedup();
-    if sorted.len() != ids.len() {
-        let mut seen = std::collections::HashSet::new();
-        let mut duplicates: Vec<&String> = ids.iter().filter(|id| !seen.insert(*id)).collect();
-        duplicates.sort();
-        duplicates.dedup();
-        panic!(
-            "{} of {} ids collide, e.g. {:?}",
-            ids.len() - sorted.len(),
-            ids.len(),
-            &duplicates[..duplicates.len().min(5)]
-        );
-    }
+    conflicts.sort();
+    conflicts.dedup();
+    assert!(
+        conflicts.is_empty(),
+        "{} id(s) cover more than one record, e.g. {:?}",
+        conflicts.len(),
+        &conflicts[..conflicts.len().min(5)]
+    );
+
+    // No `::` anywhere: it is Rust's path separator and appears nowhere in
+    // BAML's grammar, so an id containing one can be neither pasted into
+    // `describe` nor written in source. Impl entries were once addressed
+    // `<block id>::<name>`.
+    let rustish: Vec<&String> = ids.iter().filter(|id| id.contains("::")).collect();
+    assert!(
+        rustish.is_empty(),
+        "{} id(s) are spelled with `::`, e.g. {:?}",
+        rustish.len(),
+        &rustish[..rustish.len().min(5)]
+    );
 }
 
 #[test]

--- a/baml_language/crates/baml_surface/src/ids.rs
+++ b/baml_language/crates/baml_surface/src/ids.rs
@@ -337,9 +337,12 @@ impl SymbolId {
 }
 
 impl SymbolId {
-    /// The id of a named item or method. `None` for impls (unnamed — the
-    /// export layer identifies them structurally) and for free-impl methods
-    /// (their identity lives under that impl id).
+    /// The id of a named item or method.
+    ///
+    /// A method contributed by an `implements` block is addressed through that
+    /// block, free or in-body alike; an inherent method and an interface's own
+    /// default take the plain path form. `None` only for an impl block itself,
+    /// which is not a named item — the export layer gives it a structural id.
     pub fn of_symbol(db: &dyn Db, symbol: Symbol<'_>) -> Option<Self> {
         // A method's id nests under its owner type rather than the namespace.
         if let Symbol::Function(function) = symbol {
@@ -475,6 +478,18 @@ impl SymbolId {
                 let imp = crate::handles::project_impls(db)
                     .into_iter()
                     .find(|imp| Self::impl_owner(db, *imp).as_ref() == Some(&self.owner))?;
+                // `all_methods`, so the defaults a block inherits resolve too.
+                //
+                // For those, `of_symbol` gives back the *interface's* path id
+                // rather than this one, and that asymmetry is deliberate: the
+                // two answer different questions. `M:baml.iter.Iterator.chain`
+                // says where the code is written — once. `M:(T[] as
+                // baml.iter.Iterator).chain` says how it is reached, and
+                // thirteen implementors reach the same declaration. A
+                // declaration has one id; an access path has one per block,
+                // which is why the export carries both (`id`, `declared_by`).
+                // Rejecting the access path here would leave the record the
+                // export publishes unresolvable.
                 let method = imp
                     .all_methods(db)
                     .into_iter()

--- a/baml_language/crates/baml_surface/src/ids.rs
+++ b/baml_language/crates/baml_surface/src/ids.rs
@@ -25,8 +25,24 @@
 //! needed: the kind prefix decides the shape — for member kinds the last
 //! segment is the member and the one before it the containing type.
 //!
-//! Impl blocks are unnamed and get their identity from the export layer
-//! (interface head + for-type rendering), not from `SymbolId`.
+//! A method contributed by an `implements` block is addressed *through the
+//! block*, in BAML's own qualified-path syntax:
+//!
+//! ```text
+//! M:(int as baml.ops.Add<bigint>).add
+//! M:(baml.time.Instant as baml.ops.Subtract<baml.time.Duration>).sub
+//! ```
+//!
+//! The interface's arguments are load-bearing. One type may implement one
+//! interface at several instantiations — that is what multi-RHS operator
+//! overloading is — and each contributes a method under the same name, so
+//! `M:baml.time.Duration.mul` cannot name `Multiply<int>`'s and
+//! `Multiply<bigint>`'s both. Qualification is unconditional rather than
+//! applied on collision: an id that gained a qualifier the day some unrelated
+//! impl appeared would silently invalidate every cache keyed on it.
+//!
+//! This holds whether the block is free or written in a class body. An
+//! *inherent* method keeps the plain path form.
 //!
 //! [`resolve`] is the human-path front door (`"baml.time.Duration.abs"`,
 //! no prefixes); [`SymbolId::resolve`] is the precise, kind-directed one.
@@ -93,25 +109,72 @@ impl IdKind {
     }
 }
 
+/// What an id hangs off.
+///
+/// Two shapes, because two things can own a member. A named type is reached
+/// by path; a method contributed by an `implements` block is reached *through
+/// that block*, and the block is not a path — neither half of it need be
+/// addressable as an item. `int` is a primitive with no namespace, and the
+/// interface's arguments are types rather than names.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Owner {
+    /// A named item in a package's namespace: `baml.time.Duration`.
+    Path {
+        package: String,
+        namespace: Vec<String>,
+        /// The item's name; for a member id, the *containing type's* name.
+        name: String,
+    },
+    /// An impl block: `(int as baml.ops.Add<bigint>)`.
+    ///
+    /// This is BAML's own qualified-path syntax — the one that already writes
+    /// `(Self as baml.Comparable).CompareError` — so the id stays readable and
+    /// speakable, which is the point of a content-derived id.
+    ///
+    /// The interface's arguments are part of the identity, not decoration. A
+    /// type may implement one interface at several instantiations; that is
+    /// what multi-RHS operator overloading *is*, and `Add<int>` and
+    /// `Add<bigint>` contribute different methods under the same name.
+    Impl {
+        /// The implementing type, canonically rendered: `int`.
+        for_ty: String,
+        /// The interface with its arguments: `baml.ops.Add<bigint>`.
+        interface: String,
+    },
+}
+
+impl fmt::Display for Owner {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Path {
+                package,
+                namespace,
+                name,
+            } => {
+                write!(f, "{package}")?;
+                for seg in namespace {
+                    write!(f, ".{seg}")?;
+                }
+                write!(f, ".{name}")
+            }
+            Self::Impl { for_ty, interface } => write!(f, "({for_ty} as {interface})"),
+        }
+    }
+}
+
 /// A stable, content-derived symbol identity. See the module docs.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SymbolId {
     pub kind: IdKind,
-    pub package: String,
-    pub namespace: Vec<String>,
-    /// The item's name; for a member id, the *containing type's* name.
-    pub name: String,
+    pub owner: Owner,
     /// The member's name, for member kinds; `None` for item kinds.
     pub member: Option<String>,
 }
 
 impl fmt::Display for SymbolId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}", self.kind.prefix(), self.package)?;
-        for seg in &self.namespace {
-            write!(f, ".{seg}")?;
-        }
-        write!(f, ".{}", self.name)?;
+        write!(f, "{}:{}", self.kind.prefix(), self.owner)?;
         if let Some(member) = &self.member {
             write!(f, ".{member}")?;
         }
@@ -144,6 +207,10 @@ impl FromStr for SymbolId {
             .and_then(IdKind::from_prefix)
             .ok_or_else(invalid)?;
 
+        if rest.starts_with('(') {
+            return Self::parse_impl_owned(s, kind, rest);
+        }
+
         let mut segments: Vec<&str> = rest.split('.').collect();
         // Member ids need `pkg.Type.member`; item ids need `pkg.Name`.
         let min = if kind.is_member() { 3 } else { 2 };
@@ -157,9 +224,113 @@ impl FromStr for SymbolId {
         let package = segments.remove(0).to_string();
         Ok(Self {
             kind,
-            package,
-            namespace: segments.into_iter().map(str::to_string).collect(),
-            name,
+            owner: Owner::Path {
+                package,
+                namespace: segments.into_iter().map(str::to_string).collect(),
+                name,
+            },
+            member,
+        })
+    }
+}
+
+/// The impl block that contributes `function`, when one does.
+///
+/// A block written in a class body merges into the class, so the function's
+/// owner is the class and the block has to be found by looking for it. An
+/// inherent method belongs to no block and gets the plain path form.
+fn contributing_impl<'db>(
+    db: &'db dyn Db,
+    function: crate::handles::Function<'db>,
+) -> Option<crate::handles::Impl<'db>> {
+    match function.owner(db)? {
+        FunctionOwner::Impl(imp) => Some(imp),
+        FunctionOwner::Class(class) => class
+            .impls(db)
+            .into_iter()
+            .find(|imp| imp.methods(db).contains(&function)),
+        FunctionOwner::Interface(_) => None,
+    }
+}
+
+/// The byte index just past the `)` closing the parenthesis at index 0.
+///
+/// Counted rather than searched: a for-type may itself be parenthesized —
+/// `((Self as baml.Comparable).CompareError as baml.FromJson)` — so the first
+/// `)` is routinely the wrong one.
+fn matching_paren(text: &str) -> Option<usize> {
+    debug_assert!(text.starts_with('('));
+    let mut depth = 0usize;
+    for (index, ch) in text.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// The byte index of the ` as ` that separates the two halves, ignoring any
+/// nested inside a parenthesized projection.
+///
+/// Parens alone are enough to nest by: BAML's only other ` as ` is the
+/// qualified-path form, which is always parenthesized. Angle brackets need no
+/// tracking, which is just as well — `->` in a function type would break naive
+/// `<`/`>` counting.
+fn split_as(inner: &str) -> Option<usize> {
+    const AS: &str = " as ";
+    let mut depth = 0usize;
+    for (index, ch) in inner.char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => depth = depth.saturating_sub(1),
+            _ if depth == 0 && inner[index..].starts_with(AS) => return Some(index),
+            _ => {}
+        }
+    }
+    None
+}
+
+impl SymbolId {
+    /// Parse the impl-owned form: `(int as baml.ops.Add<bigint>).add`.
+    fn parse_impl_owned(whole: &str, kind: IdKind, rest: &str) -> Result<Self, InvalidSymbolId> {
+        let invalid = || InvalidSymbolId(whole.to_string());
+        let close = matching_paren(rest).ok_or_else(invalid)?;
+        let inner = &rest[1..close];
+        let at = split_as(inner).ok_or_else(invalid)?;
+        let for_ty = inner[..at].trim().to_string();
+        let interface = inner[at + " as ".len()..].trim().to_string();
+        if for_ty.is_empty() || interface.is_empty() {
+            return Err(invalid());
+        }
+
+        let tail = &rest[close + 1..];
+        // An impl block owns methods and nothing else: no fields, no variants,
+        // no associated types. A bare `(T as I)` with no member names the
+        // block itself, which is the impl record's own id.
+        let member = match (kind, tail) {
+            (IdKind::Method, _) if !tail.is_empty() => {
+                let name = tail.strip_prefix('.').ok_or_else(invalid)?;
+                if name.is_empty() || name.contains('.') {
+                    return Err(invalid());
+                }
+                Some(name.to_string())
+            }
+            (_, "") => None,
+            _ => return Err(invalid()),
+        };
+        if kind.is_member() && member.is_none() {
+            return Err(invalid());
+        }
+        Ok(Self {
+            kind,
+            owner: Owner::Impl { for_ty, interface },
             member,
         })
     }
@@ -172,6 +343,15 @@ impl SymbolId {
     pub fn of_symbol(db: &dyn Db, symbol: Symbol<'_>) -> Option<Self> {
         // A method's id nests under its owner type rather than the namespace.
         if let Symbol::Function(function) = symbol {
+            // An impl-contributed method is addressed through its block, even
+            // when the block is written in the class body and the method is
+            // therefore also a class method. Addressing it on the class alone
+            // is what collided: `Duration` implementing both `Multiply<int>`
+            // and `Multiply<bigint>` contributes two methods named `mul`, and
+            // `M:baml.time.Duration.mul` cannot name both.
+            if let Some(imp) = contributing_impl(db, function) {
+                return Self::impl_member_id(db, imp, &function.name(db));
+            }
             match function.owner(db) {
                 Some(FunctionOwner::Class(class)) => {
                     return Self::member_id(
@@ -189,8 +369,7 @@ impl SymbolId {
                         &function.name(db),
                     );
                 }
-                Some(FunctionOwner::Impl(_)) => return None,
-                None => {}
+                Some(FunctionOwner::Impl(_)) | None => {}
             }
         }
 
@@ -210,10 +389,43 @@ impl SymbolId {
         let pkg = baml_compiler2_hir::file_package::file_package(db, symbol.file(db));
         Some(Self {
             kind,
-            package: pkg.package.to_string(),
-            namespace: pkg.namespace_path.iter().map(ToString::to_string).collect(),
-            name: name.to_string(),
+            owner: Owner::Path {
+                package: pkg.package.to_string(),
+                namespace: pkg.namespace_path.iter().map(ToString::to_string).collect(),
+                name: name.to_string(),
+            },
             member: None,
+        })
+    }
+
+    /// How an impl block is written inside an id: `(int as baml.ops.Add<bigint>)`.
+    ///
+    /// The one renderer, shared with the export layer's block ids, so the two
+    /// can never disagree about what identifies an impl.
+    pub fn impl_owner(db: &dyn Db, imp: crate::handles::Impl<'_>) -> Option<Owner> {
+        let data = crate::facts::impl_data(db, imp.loc())?;
+        let iface: crate::Interface<'_> = data.interface.into();
+        let mut interface = iface.qualified_name(db).render_dotted(false);
+        if !data.interface_args.is_empty() {
+            let args: Vec<String> = data
+                .interface_args
+                .iter()
+                .map(|arg| crate::display::TyDisplayFormat::Canonical.render(arg))
+                .collect();
+            interface = format!("{interface}<{}>", args.join(", "));
+        }
+        Some(Owner::Impl {
+            for_ty: crate::display::TyDisplayFormat::Canonical.render(&data.for_ty_pattern),
+            interface,
+        })
+    }
+
+    /// The id of a method reached through `imp`.
+    fn impl_member_id(db: &dyn Db, imp: crate::handles::Impl<'_>, member: &Name) -> Option<Self> {
+        Some(Self {
+            kind: IdKind::Method,
+            owner: Self::impl_owner(db, imp)?,
+            member: Some(member.to_string()),
         })
     }
 
@@ -236,9 +448,11 @@ impl SymbolId {
         let pkg = baml_compiler2_hir::file_package::file_package(db, owner.file(db));
         Some(Self {
             kind,
-            package: pkg.package.to_string(),
-            namespace: pkg.namespace_path.iter().map(ToString::to_string).collect(),
-            name: owner_name.to_string(),
+            owner: Owner::Path {
+                package: pkg.package.to_string(),
+                namespace: pkg.namespace_path.iter().map(ToString::to_string).collect(),
+                name: owner_name.to_string(),
+            },
             member: Some(member.to_string()),
         })
     }
@@ -247,13 +461,37 @@ impl SymbolId {
     /// finds type-space items, a `V:` id only value-space items, and member
     /// ids look inside their containing type.
     pub fn resolve<'db>(&self, db: &'db dyn Db) -> Option<Resolved<'db>> {
-        let package = Package::named_checked(db, &self.package)?;
-        let namespace = package.namespace(db, &self.namespace)?;
+        let (package_name, namespace_path, name) = match &self.owner {
+            Owner::Path {
+                package,
+                namespace,
+                name,
+            } => (package, namespace, name),
+            // Impl-owned ids are found by matching the rendered block, since
+            // neither half is reachable through a namespace: the for-type may
+            // be a primitive and the interface arguments are types.
+            Owner::Impl { .. } => {
+                let member_name = self.member.as_deref()?;
+                let imp = crate::handles::project_impls(db)
+                    .into_iter()
+                    .find(|imp| Self::impl_owner(db, *imp).as_ref() == Some(&self.owner))?;
+                let method = imp
+                    .all_methods(db)
+                    .into_iter()
+                    .find(|m| m.function.name(db).as_str() == member_name)?;
+                return Some(Resolved::Member(
+                    Symbol::Impl(imp),
+                    Member::Method(method.function),
+                ));
+            }
+        };
+        let package = Package::named_checked(db, package_name)?;
+        let namespace = package.namespace(db, namespace_path)?;
         match self.kind {
-            IdKind::Type => namespace.type_named(db, &self.name).map(Resolved::Symbol),
-            IdKind::Value => namespace.value_named(db, &self.name).map(Resolved::Symbol),
+            IdKind::Type => namespace.type_named(db, name).map(Resolved::Symbol),
+            IdKind::Value => namespace.value_named(db, name).map(Resolved::Symbol),
             IdKind::Method | IdKind::Field | IdKind::Variant | IdKind::AssocType => {
-                let owner = namespace.type_named(db, &self.name)?;
+                let owner = namespace.type_named(db, name)?;
                 let member_name = self.member.as_deref()?;
                 let member = owner.member_named(db, member_name)?;
                 let matches = matches!(

--- a/baml_language/crates/baml_surface/src/ids_tests.rs
+++ b/baml_language/crates/baml_surface/src/ids_tests.rs
@@ -27,6 +27,101 @@ interface Encoder {
 function greet(name: string) -> string { name }
 "#;
 
+/// A class implementing one interface at two instantiations. This is the shape
+/// that broke: both blocks contribute a method named `scaled`, so addressing
+/// either on the class alone names both.
+const MULTI_IMPL_FIXTURE: &str = r#"
+interface Scale<By extends baml.Concrete> requires baml.Concrete {
+  function scaled(self, by: By) -> int
+}
+
+class Meters {
+  value int
+
+  implements Scale<int> {
+    function scaled(self, by: int) -> int { self.value * by }
+  }
+
+  implements Scale<string> {
+    function scaled(self, by: string) -> int { self.value * by.length() }
+  }
+}
+"#;
+
+/// Two instantiations of one interface contribute two distinct ids.
+///
+/// Before the impl-qualified form both were `M:user.Meters.scaled`, and the
+/// export document carried the same id on two different methods — a consumer
+/// keyed on it got a coin flip. Multi-RHS operator overloading is precisely
+/// what a parameterized interface is for, so this is not an exotic case.
+#[test]
+fn one_interface_at_two_instantiations_yields_two_ids() {
+    let mut db = make_db();
+    db.add_file("multi.baml", MULTI_IMPL_FIXTURE);
+
+    let Some(Resolved::Symbol(Symbol::Class(class))) = resolve(&db, "Meters") else {
+        panic!("Meters resolves to a class")
+    };
+    let ids: Vec<String> = class
+        .methods(&db)
+        .into_iter()
+        .filter(|f| f.name(&db).as_str() == "scaled")
+        .filter_map(|f| SymbolId::of_symbol(&db, Symbol::Function(f)))
+        .map(|id| id.to_string())
+        .collect();
+
+    assert_eq!(ids.len(), 2, "both blocks contribute a `scaled`: {ids:?}");
+    assert!(
+        ids.contains(&"M:(user.Meters as user.Scale<int>).scaled".to_string()),
+        "the int instantiation is named by its argument: {ids:?}"
+    );
+    assert!(
+        ids.contains(&"M:(user.Meters as user.Scale<string>).scaled".to_string()),
+        "the string instantiation is named by its argument: {ids:?}"
+    );
+
+    // And each id finds its own method back, rather than whichever the name
+    // lookup happened to reach first.
+    for id in &ids {
+        let parsed = SymbolId::from_str(id).expect("an emitted id parses");
+        assert_eq!(&parsed.to_string(), id, "round-trips verbatim");
+        let Some(Resolved::Member(Symbol::Impl(_), Member::Method(found))) = parsed.resolve(&db)
+        else {
+            panic!("{id} resolves to an impl method")
+        };
+        assert_eq!(found.name(&db).as_str(), "scaled");
+        assert_eq!(
+            SymbolId::of_symbol(&db, Symbol::Function(found)).map(|i| i.to_string()),
+            Some(id.clone()),
+            "resolution lands on the method the id names"
+        );
+    }
+}
+
+/// The parenthesized form survives a for-type that is itself parenthesized,
+/// and an interface argument carrying its own `as`.
+#[test]
+fn impl_owned_ids_parse_around_nested_projections() {
+    let id = "M:((Self as baml.Comparable).CompareError as baml.ops.Equals<int>).eq";
+    let parsed = SymbolId::from_str(id).expect("a nested projection parses");
+    let ids::Owner::Impl { for_ty, interface } = &parsed.owner else {
+        panic!("parsed as impl-owned")
+    };
+    assert_eq!(for_ty, "(Self as baml.Comparable).CompareError");
+    assert_eq!(interface, "baml.ops.Equals<int>");
+    assert_eq!(parsed.member.as_deref(), Some("eq"));
+    assert_eq!(parsed.to_string(), id, "round-trips verbatim");
+
+    // A function type's parens and arrow do not confuse the split either.
+    let arrowed = "M:(((int) -> string) as baml.ToString).to_string";
+    let parsed = SymbolId::from_str(arrowed).expect("a function for-type parses");
+    let ids::Owner::Impl { for_ty, .. } = &parsed.owner else {
+        panic!("parsed as impl-owned")
+    };
+    assert_eq!(for_ty, "((int) -> string)");
+    assert_eq!(parsed.to_string(), arrowed);
+}
+
 /// Every id round-trips: symbol → id → string → id → the same symbol.
 #[test]
 fn symbol_ids_round_trip_through_strings_and_resolution() {

--- a/baml_language/crates/baml_surface/src/ids_tests.rs
+++ b/baml_language/crates/baml_surface/src/ids_tests.rs
@@ -27,6 +27,21 @@ interface Encoder {
 function greet(name: string) -> string { name }
 "#;
 
+const DEFAULTED_FIXTURE: &str = r#"
+interface Greeter {
+  function greet(self) -> string
+  function shout(self) -> string { self.greet() }
+}
+
+class Widget {
+  name string
+
+  implements Greeter {
+    function greet(self) -> string { self.name }
+  }
+}
+"#;
+
 /// A class implementing one interface at two instantiations. This is the shape
 /// that broke: both blocks contribute a method named `scaled`, so addressing
 /// either on the class alone names both.
@@ -96,6 +111,43 @@ fn one_interface_at_two_instantiations_yields_two_ids() {
             "resolution lands on the method the id names"
         );
     }
+}
+
+/// An inherited default is reachable through every block that inherits it, and
+/// still names one declaration.
+///
+/// The two ids answer different questions and both are needed: the export
+/// publishes a record per block, so the access path must resolve, while
+/// `declared_by` carries the single place the code is written. Collapsing them
+/// would either make a published record unaddressable or claim thirteen
+/// implementors had thirteen `chain`s.
+#[test]
+fn an_inherited_default_is_reachable_through_the_block_and_declared_once() {
+    let mut db = make_db();
+    db.add_file("defaults.baml", DEFAULTED_FIXTURE);
+
+    // The override the block writes itself.
+    let overridden = SymbolId::from_str("M:(user.Widget as user.Greeter).greet")
+        .expect("the override's id parses");
+    assert!(
+        overridden.resolve(&db).is_some(),
+        "a method the block declares resolves through it"
+    );
+
+    // The default it inherits, reached through the same block.
+    let inherited = SymbolId::from_str("M:(user.Widget as user.Greeter).shout")
+        .expect("the access path parses");
+    let Some(Resolved::Member(Symbol::Impl(_), Member::Method(shout))) = inherited.resolve(&db)
+    else {
+        panic!("an inherited default resolves through the block that inherits it")
+    };
+
+    // And it is declared exactly once, on the interface.
+    assert_eq!(
+        SymbolId::of_symbol(&db, Symbol::Function(shout)).map(|id| id.to_string()),
+        Some("M:user.Greeter.shout".to_string()),
+        "the declaration keeps the interface's id, however it was reached"
+    );
 }
 
 /// The parenthesized form survives a for-type that is itself parenthesized,

--- a/tools/stdlib-matrix/README.md
+++ b/tools/stdlib-matrix/README.md
@@ -24,6 +24,19 @@ why.
 
 `--llm` needs `ANTHROPIC_API_KEY`; locally, `infisical run -- tools/stdlib-matrix/run --llm`.
 
+To check a key before spending a run on it — or before putting it in a CI
+environment — `check_client` makes one trial call and nothing else:
+
+```sh
+cd tools/stdlib-matrix && baml run check_client
+```
+
+It uses `AlignerProbe`, which is `Aligner` without the retry policy, because the
+orchestrator discards each attempt's error and reports only that all of them
+failed. Unretried, the provider's own message comes through: `invalid x-api-key`
+reads very differently from a model this account may not use, and a `--llm` run
+calls this first so it fails in seconds rather than at the end of a session.
+
 ## How it judges
 
 One session per TypeScript container — `(globals).Date`, `node:fs` — answering

--- a/tools/stdlib-matrix/README.md
+++ b/tools/stdlib-matrix/README.md
@@ -22,7 +22,7 @@ symbol comes out unjudged. Nothing pairs the two sides deterministically, by
 design — name agreement was tried and removed, and `build_symbol_matrix` says
 why.
 
-`--llm` needs `ANTHROPIC_API_KEY`; locally, `infisical run -- tools/stdlib-matrix/run --llm`.
+`--llm` needs `OPENAI_API_KEY`; locally, `infisical run -- tools/stdlib-matrix/run --llm`.
 
 To check a key before spending a run on it — or before putting it in a CI
 environment — `check_client` makes one trial call and nothing else:
@@ -31,11 +31,13 @@ environment — `check_client` makes one trial call and nothing else:
 cd tools/stdlib-matrix && baml run check_client
 ```
 
-It uses `AlignerProbe`, which is `Aligner` without the retry policy, because the
-orchestrator discards each attempt's error and reports only that all of them
-failed. Unretried, the provider's own message comes through: `invalid x-api-key`
-reads very differently from a model this account may not use, and a `--llm` run
-calls this first so it fails in seconds rather than at the end of a session.
+It goes through `Aligner`, the same client the sessions use, and still answers
+immediately: a rejected key arrives as `ai.errors.InvalidRequest`, which the
+retry wrapper's default judgment declines to retry, so the provider's own
+message comes through on the first attempt. That message is the point — a bad
+key and a model this account may not use need different fixes and are otherwise
+indistinguishable. A `--llm` run makes this call first, so it fails in seconds
+rather than after a session's worth of work.
 
 ## How it judges
 
@@ -135,7 +137,7 @@ Three things it needs, none of which live in this repo:
 
 1. **GitHub Pages enabled** for the repository, with the source set to *GitHub
    Actions*. Until then the deploy step fails.
-2. **`ANTHROPIC_API_KEY`** in the `boundary-tools-prod` environment.
+2. **`OPENAI_API_KEY`** in the `boundary-tools-prod` environment.
 3. Optionally **`STDLIB_MATRIX_URL`** as a repository variable, if the site is
    served anywhere other than `https://boundaryml.github.io/baml`. It is what the
    workflow fetches the previous report from; get it wrong and every run is a

--- a/tools/stdlib-matrix/baml_src/align.baml
+++ b/tools/stdlib-matrix/baml_src/align.baml
@@ -22,10 +22,13 @@
 // Reliability composes at the client boundary: the base client is wrapped
 // rather than configured with a `retry_policy` block, which is gone.
 //
-// No `temperature`: claude-sonnet-5 rejects it ("`temperature` is deprecated
-// for this model"). Run-to-run stability comes from `--previous` instead — an
-// unchanged symbol is never asked about twice.
-client AlignerBase = anthropic.AnthropicClient.new(model = "claude-sonnet-5");
+// No `temperature`, deliberately: the current reasoning models reject it
+// outright rather than ignoring it. Run-to-run stability comes from
+// `--previous` instead — an unchanged symbol is never asked about twice.
+//
+// No `api_key_env` either: `OPENAI_API_KEY` is what `OpenAiClient` falls back
+// to, so naming it would restate the default and invite the two to drift.
+client AlignerBase = openai.OpenAiClient.new(model = "gpt-5.5");
 
 // `max_attempts` counts attempts, where the old `max_retries: 3` counted
 // retries after the first, so four keeps the previous budget. The backoff
@@ -348,7 +351,7 @@ function check_client() -> null {
     let _ = preflight("Reply with one word: ready") catch_all (error) {
         _ => {
             throw baml.errors.InvalidArgument {
-                message: `the model client rejected a trial call, so every session would fail the same way.\n${error}\nCheck ANTHROPIC_API_KEY, and that this account may use the model named by the Aligner client.`,
+                message: `the model client rejected a trial call, so every session would fail the same way.\n${error}\nCheck OPENAI_API_KEY, and that this account may use the model the Aligner client names.`,
             };
         },
     };

--- a/tools/stdlib-matrix/baml_src/align.baml
+++ b/tools/stdlib-matrix/baml_src/align.baml
@@ -19,23 +19,28 @@
 // back is recorded as a failure — never as an empty verdict, which reads
 // exactly like an honest "found nothing".
 
-retry_policy AlignerRetry {
-    max_retries: 3,
-    backoff_multiplier: 2.0,
-    initial_delay_ms: 1000,
-}
-
+// Reliability composes at the client boundary: the base client is wrapped
+// rather than configured with a `retry_policy` block, which is gone.
+//
 // No `temperature`: claude-sonnet-5 rejects it ("`temperature` is deprecated
 // for this model"). Run-to-run stability comes from `--previous` instead — an
 // unchanged symbol is never asked about twice.
-client<llm> Aligner {
-    provider: anthropic,
-    retry_policy: AlignerRetry,
-    options: {
-        model: "claude-sonnet-5",
-        api_key: env.ANTHROPIC_API_KEY,
-    },
-}
+client AlignerBase = anthropic.AnthropicClient.new(model = "claude-sonnet-5");
+
+// `max_attempts` counts attempts, where the old `max_retries: 3` counted
+// retries after the first, so four keeps the previous budget. The backoff
+// matches too: one second, doubling.
+//
+// One client serves the sessions and the preflight both. A rejected key
+// arrives as `ai.errors.InvalidRequest`, which `default_retry_judgment`
+// declines to retry — a request the provider rejected does not become valid by
+// resending — so `check_client` gets the provider's own message on the first
+// attempt rather than after four rounds of backoff.
+client Aligner = ai.clients.Retry.new(
+    AlignerBase,
+    max_attempts = 4,
+    backoff = ai.clients.Backoff.new(initial_ms = 1000, multiplier = 2),
+);
 
 /// One turn of a conversation with the model.
 ///
@@ -65,14 +70,6 @@ function first_line(doc: string?) -> string {
     }
 }
 
-/// A BAML symbol as one line: how to name it, what it is, and enough of what it
-/// does to judge. Ids rather than displays, because a claim has to be checkable
-/// — displays collide, and matching them back was where the old pass leaked.
-function baml_line(symbol: BamlSymbol) -> string {
-    let signature = symbol.signature?.display ?? "";
-    `- [${symbol.id}] ${symbol.kind} ${symbol.display}${signature}${first_line(symbol.doc)}`
-}
-
 function ts_line(symbol: TsSymbol) -> string {
     `- [${symbol.id}] ${symbol.signature.lines().at(0) ?? ""}${first_line(symbol.doc)}`
 }
@@ -90,14 +87,6 @@ function prior_line(judgement: Judgement) -> string {
 
 // ── indexes ─────────────────────────────────────────────────────────────────
 
-function symbols_by_id(matrix: SymbolMatrix) -> map<string, BamlSymbol> {
-    let index: map<string, BamlSymbol> = {};
-    for (let symbol in matrix.baml) {
-        let _ = index.set(symbol.id, symbol);
-    }
-    index
-}
-
 function ts_by_id(matrix: SymbolMatrix) -> map<string, TsSymbol> {
     let index: map<string, TsSymbol> = {};
     for (let symbol in matrix.ts) {
@@ -110,7 +99,7 @@ function ts_by_id(matrix: SymbolMatrix) -> map<string, TsSymbol> {
 /// rather than against the order concurrent sessions happened to finish in.
 function sort_judgements(matrix: SymbolMatrix) -> null {
     matrix.judgements.sort_by_key((judgement) -> {
-        `${judgement.ts}\u{1f}${judgement.baml.join(",")}`
+        `${judgement.ts}${field_separator()}${judgement.baml.join(",")}`
     });
     null
 }
@@ -240,13 +229,23 @@ function session_rules() -> string {
         `Array.isArray` is not missing from BAML and has no counterpart: BAML checks
         types by pattern matching, so the question only comes up for a value in a union,
         and `foo is int[]` answers it there. Say that, rather than "none". The same goes
-        for anything the language answers instead of the library — `Object.freeze`
-        against immutable values, `typeof` against `match`.
+        for anything the language answers instead of the library — `typeof` against
+        `match`, `instanceof` against a type pattern.
+
+        Do not assume BAML's semantics; look them up. BAML values are mutable and arrays
+        are references, so anything you would justify with "values are immutable" is
+        probably wrong.
 
         Name TypeScript symbols by the id inside [ ], exactly as written. Name BAML
-        symbols by their full dotted path, the way the tools print it —
+        symbols by their full dotted path, the way `describe --search` prints it —
         `baml.time.Instant.now`, not `Instant.now`. A BAML path you have not seen in a
-        tool result does not exist; leave `baml` empty and say what you looked for.
+        tool result does not exist.
+
+        `match` and `divergent` must name at least one BAML symbol — they are claims
+        that something over there does this job, so they have to say what. If the answer
+        is syntax rather than a symbol — indexing, an operator, `.to_string()` — that is
+        `unnecessary`, with an example. If you could not find anything, that is `none`,
+        with a reason saying what you looked for.
 
         Prefer "none" over a strained pairing. TypeScript has plenty BAML has not, and
         saying so is a finding rather than a failure to try harder.
@@ -349,7 +348,7 @@ function check_client() -> null {
     let _ = preflight("Reply with one word: ready") catch_all (error) {
         _ => {
             throw baml.errors.InvalidArgument {
-                message: `the model client rejected a trial call, so every session would fail the same way: ${error}. Check that ANTHROPIC_API_KEY holds a working key.`,
+                message: `the model client rejected a trial call, so every session would fail the same way.\n${error}\nCheck ANTHROPIC_API_KEY, and that this account may use the model named by the Aligner client.`,
             };
         },
     };
@@ -391,7 +390,11 @@ function lookups_per_round() -> int {
 /// A session that will not answer is a failure, never an empty verdict: an
 /// `Answer` with no findings and a session that ran out of rounds are the same
 /// JSON, and they mean opposite things about the two libraries.
-function run_session(box: Toolbox, request: SessionRequest) -> SessionResult {
+function run_session(
+    box: Toolbox,
+    request: SessionRequest,
+    baml_names: map<string, string>,
+) -> SessionResult {
     let turns: Turn[] = [
         Turn { role: "system", text: session_system(box) },
         Turn { role: "user", text: session_user(request) },
@@ -403,22 +406,32 @@ function run_session(box: Toolbox, request: SessionRequest) -> SessionResult {
 
     let collected: Finding[] = [];
     let covered: map<string, bool> = {};
-    // Findings that arrived with an example that would not compile. Held back
-    // so the symbol is asked about again, but kept so that running out of
-    // attempts costs the example rather than the judgement.
+    // Findings that arrived with something wrong that the model can fix — an
+    // example that will not compile, a BAML name that does not resolve. Held
+    // back so the symbol is asked about again, but kept so that running out of
+    // attempts costs the flaw rather than the judgement.
     let held: map<string, Finding> = {};
 
+    // Rounds and attempts are counted apart. Sharing one counter meant an
+    // answer consumed a lookup round, so a session that used its lookup budget
+    // and then answered incompletely had its retry turn built and immediately
+    // discarded — the two further attempts `answer_attempts` promises were
+    // never reachable. `steps` is the backstop that keeps the loop finite.
     let round = 0;
     let attempts = 0;
+    let steps = 0;
+    let step_limit = lookup_rounds() + answer_attempts() + 1;
     let answered = false;
     let failure = `no answer after ${lookup_rounds()} rounds of lookups`;
 
-    while (!answered && round <= lookup_rounds()) {
+    while (!answered && steps < step_limit) {
+        steps += 1;
+        let final_round = round >= lookup_rounds();
         // The last round cannot look anything up: `session_final` returns an
         // answer and nothing else, so the shape of the call enforces what this
         // turn explains. Saying it as well is not redundant — a model handed a
         // schema it did not expect does better for being told why.
-        if (round == lookup_rounds()) {
+        if (final_round && attempts == 0) {
             turns.push(
                 Turn {
                     role: "user",
@@ -426,17 +439,29 @@ function run_session(box: Toolbox, request: SessionRequest) -> SessionResult {
                 },
             );
         }
-        let step: Step = if (round == lookup_rounds()) {
+        // A failed call ends the session but does not empty it. Returning here
+        // threw away everything already collected — a session that answered for
+        // 28 of 30 symbols and then hit a 529 recorded nothing, contradicting
+        // the accumulate-rather-than-replace rule this function is built on.
+        let attempt: Step? = if (final_round) {
             session_final(render_turns(turns))
         } else {
             session_step(render_turns(turns))
         } catch_all (error) {
             _ => {
-                return PassFailure { pass: "session", subject: request.subject, reason: `${error}` };
+                failure = `${error}`;
+                null
             },
+        };
+        let step = match (attempt) {
+            null => {
+                break;
+            },
+            let taken: Step => taken,
         };
         match (step) {
             let investigate: Investigate => {
+                round += 1;
                 turns.push(Turn { role: "assistant", text: render_lookups(investigate) });
                 turns.push(Turn { role: "tool", text: run_lookups(box, investigate) });
             },
@@ -457,16 +482,14 @@ function run_session(box: Toolbox, request: SessionRequest) -> SessionResult {
                         // Settled by an earlier attempt; the first answer wins.
                         continue;
                     }
-                    match (example_error(box, finding)) {
+                    match (finding_fault(box, finding, baml_names)) {
                         null => {
                             let _ = covered.set(finding.ts, true);
                             collected.push(finding);
                         },
-                        let error: string => {
+                        let fault: string => {
                             let _ = held.set(finding.ts, finding);
-                            complaints.push(
-                                `[${finding.ts}] this example does not compile:\n${finding.example?.baml ?? ""}\n\n${error}`,
-                            );
+                            complaints.push(fault);
                         },
                     }
                 }
@@ -477,13 +500,10 @@ function run_session(box: Toolbox, request: SessionRequest) -> SessionResult {
                         missing.push(id);
                     }
                 }
-                if (missing.length() == 0) {
+                if (missing.length() == 0 || attempts >= answer_attempts()) {
+                    // Complete, or out of attempts. What was held back is taken
+                    // below, on the way out.
                     answered = true;
-                } else if (attempts >= answer_attempts()) {
-                    // Out of attempts. What was held back for a broken example
-                    // is taken below, on the way out.
-                    answered = true;
-                    failure = "";
                 } else {
                     turns.push(Turn { role: "assistant", text: render_findings(answer) });
                     turns.push(
@@ -492,28 +512,115 @@ function run_session(box: Toolbox, request: SessionRequest) -> SessionResult {
                 }
             },
         }
-        round += 1;
     }
 
-    // Anything held back for an example that would not compile is taken without
-    // it: a judgement with no example is worth having, one with a broken
-    // example is not. Drained here rather than where the attempts run out,
-    // because the loop can also end by running out of *rounds* — and on that
-    // path the finding was being discarded entirely, which is the opposite of
-    // the rule it was meant to follow.
+    // Anything held back is taken without the part that was wrong: a judgement
+    // with no example is worth having, and one naming a symbol that does not
+    // exist is worth having without that name. Drained here rather than where
+    // the attempts run out, because the loop can also end by running out of
+    // rounds or by a failed call — and on those paths the finding was being
+    // discarded entirely, the opposite of the rule it was meant to follow.
     for (let id in request.ts_ids) {
         if (!covered.has(id)) {
             if let finding: Finding = held.get(id) {
-                collected.push(without_example(finding));
-                let _ = covered.set(id, true);
+                if let salvaged: Finding = without_faults(finding, baml_names) {
+                    collected.push(salvaged);
+                    let _ = covered.set(id, true);
+                }
             }
         }
     }
 
-    if (!answered && collected.length() == 0) {
+    // Nothing usable is a failure, never an empty answer. `Answer { findings:
+    // [] }` and a session that died are the same JSON and mean opposite things,
+    // and only a `PassFailure` reaches `matrix.failures`, the markdown, and the
+    // CI annotation.
+    if (collected.length() == 0) {
         PassFailure { pass: "session", subject: request.subject, reason: failure }
     } else {
         Answer { findings: collected }
+    }
+}
+
+/// What is wrong with a finding, or null when it can be accepted as it stands.
+///
+/// Both checks run here, inside the session, so the model can be told and can
+/// fix it. The name check used to run in `apply_findings` instead — after the
+/// session had closed — so a hallucinated path was dropped silently with unused
+/// attempts still on the table, and the README's claim that a session must
+/// satisfy it "before its answer is accepted" was not true of the one failure
+/// mode the design says matters most.
+function finding_fault(box: Toolbox, finding: Finding, baml_names: map<string, string>) -> string? {
+    let unknown: string[] = [];
+    for (let named in finding.baml) {
+        if (resolve_baml_name(baml_names, named) == null) {
+            unknown.push(named);
+        }
+    }
+    if (unknown.length() > 0) {
+        return `[${finding.ts}] these are not BAML symbols: ${unknown.join(", ")}. Look them up, or leave the baml list empty and say what you looked for.`;
+    }
+    // `divergent` is not a stronger `match`, it is the verdict that carries a
+    // caveat, and the caveat is the whole of what it adds. Thirteen shipped
+    // without one, rendering as a striped swatch whose tooltip had nothing to
+    // say. Either the difference can be stated or the verdict is `match`.
+    if (finding.verdict == "divergent" && (finding.divergence ?? "").trim().length() == 0) {
+        return `[${finding.ts}] you said divergent but did not say how they differ. Fill in divergence, or use match if they do not.`;
+    }
+    // The converse holds for the other three: a difference stated under a
+    // verdict that claims none is a contradiction, and the reader is shown the
+    // verdict. Asking is cheaper than guessing which half was meant.
+    if (finding.verdict != "divergent" && (finding.divergence ?? "").trim().length() > 0) {
+        return `[${finding.ts}] you gave a divergence but the verdict is ${finding.verdict}. Use divergent if they differ, or drop the divergence.`;
+    }
+    if let error: string = example_error(box, finding) {
+        // Clipped like a tool answer, and for the same reason: this goes into
+        // the transcript and stays there for every later round. A session with
+        // twenty broken examples, each with multi-diagnostic output, otherwise
+        // adds tens of kilobytes per attempt — and the snippet is the model's
+        // own text, so neither half is bounded by anything.
+        let snippet = clip(finding.example?.baml ?? "", complaint_budget());
+        return `[${finding.ts}] this example does not compile:\n${snippet}\n\n${clip(error, complaint_budget())}`;
+    }
+    null
+}
+
+/// The most one complaint may contribute to a transcript. Smaller than a tool
+/// answer's budget because a retry can carry one per finding.
+function complaint_budget() -> int {
+    1500
+}
+
+/// A held finding with whatever was wrong removed, or null if nothing is left
+/// worth keeping.
+///
+/// A pairing whose every counterpart was invented is dropped: recording it with
+/// an empty list would turn a hallucination into a confident "nothing in BAML
+/// does this".
+function without_faults(finding: Finding, baml_names: map<string, string>) -> Finding? {
+    let resolved: string[] = [];
+    for (let named in finding.baml) {
+        if let id: string = resolve_baml_name(baml_names, named) {
+            resolved.push(id);
+        }
+    }
+    if (resolved.length() == 0 && finding.baml.length() > 0 && finding.verdict != "none") {
+        return null;
+    }
+    // A `divergent` with no divergence text is *not* dropped here, though
+    // `finding_fault` refused it round after round. An absent caveat cannot be
+    // stripped the way a broken example can, so the choice is to keep an
+    // incomplete finding or discard a real one — and "these differ" is still
+    // what the session concluded. It renders as a difference nobody wrote down,
+    // which is worse than the sentence and better than silence.
+    Finding {
+        ts: finding.ts,
+        verdict: finding.verdict,
+        baml: resolved,
+        confidence: finding.confidence,
+        reason: finding.reason,
+        divergence: finding.divergence,
+        example: null,
     }
 }
 
@@ -546,7 +653,7 @@ function retry_turn(
         parts.push(complaints.join("\n\n"));
     }
     parts.push(
-        `You have not answered for these symbols:\n${missing.join("\n")}\n\nAnswer for exactly these. Everything else you said is kept — do not repeat it. If an example above would not compile, fix it or leave the example out; the finding matters, the example is optional.`,
+        `You have not answered for these symbols:\n${missing.join("\n")}\n\nAnswer for exactly these. Everything else you said is kept — do not repeat it. If something above would not compile or names a symbol that does not exist, fix it or leave it out; the finding matters, the example is optional.`,
     );
     parts.join("\n\n")
 }
@@ -558,18 +665,6 @@ function example_error(box: Toolbox, finding: Finding) -> string? {
         out = check_snippet(box, example.baml);
     }
     out
-}
-
-function without_example(finding: Finding) -> Finding {
-    Finding {
-        ts: finding.ts,
-        verdict: finding.verdict,
-        baml: finding.baml,
-        confidence: finding.confidence,
-        reason: finding.reason,
-        divergence: finding.divergence,
-        example: null,
-    }
 }
 
 /// An answer as the transcript should record it, so a retry can see what it
@@ -595,8 +690,9 @@ function render_lookups(investigate: Investigate) -> string {
 /// Every round's results stay in the transcript for every later round, so an
 /// unbounded tool is a transcript that grows unboundedly: four lookups of the
 /// `Interfaces` section of the type-system reference is 44KB in one round and
-/// 264KB by the sixth. Eight thousand characters holds any `describe` output
-/// whole and truncates only the two largest documentation sections.
+/// 264KB by the sixth. Eight thousand characters holds every `describe` output
+/// of a single symbol whole, and truncates the largest namespace listings and
+/// the two largest documentation sections.
 function lookup_budget() -> int {
     8000
 }
@@ -620,8 +716,11 @@ function run_lookups(box: Toolbox, investigate: Investigate) -> string {
     for (let lookup in investigate.lookups) {
         if (ran < lookups_per_round()) {
             ran += 1;
+            // The query is the model's own text and is echoed back, so it is
+            // bounded too — the answer was clipped and the label was not.
+            let asked = clip(lookup.query, complaint_budget());
             let answer = clip(run_tool(box, lookup.tool, lookup.query), lookup_budget());
-            blocks.push(`$ ${lookup.tool} ${lookup.query}\n${answer}`);
+            blocks.push(`$ ${lookup.tool} ${asked}\n${answer}`);
         }
     }
     if (investigate.lookups.length() > ran) {
@@ -778,12 +877,6 @@ function only_matching(requests: SessionRequest[], only: string) -> SessionReque
 /// them — and nothing outside this program knows about it or should have to.
 /// Demanding it rejected 39 correct answers in a row and, because a pairing
 /// with no surviving counterpart is dropped, left 20 symbols unjudged.
-///
-/// Dotted paths are unique and are recorded first. A display is recorded only
-/// if nothing has claimed it, and a display two symbols share is recorded as
-/// ambiguous rather than resolved: answering with whichever came first would
-/// silently attach a judgement to the wrong symbol, which is worse than
-/// refusing it.
 function baml_finding_names(matrix: SymbolMatrix) -> map<string, string> {
     let names: map<string, string> = {};
     for (let symbol in matrix.baml) {
@@ -839,12 +932,13 @@ function resolve_baml_name(names: map<string, string>, named: string) -> string?
     out
 }
 
-/// Folds a session's findings in, keeping only those that name real symbols.
+/// Folds a session's findings in.
 ///
-/// Every id is checked against the surface rather than trusted. A model that
-/// invents `baml.array.sort` is not obviously wrong to a reader — it is exactly
-/// what the answer should look like — so an unchecked claim is worse than no
-/// claim, and the count of refusals is how a drifting prompt becomes visible.
+/// Names are resolved again here rather than trusted. The session already
+/// refuses a finding whose names do not resolve, so this is the second line
+/// rather than the first — but a claim recorded without checking is a claim
+/// about two libraries that reads exactly like a verified one, and the count of
+/// refusals is how a drifting prompt becomes visible.
 function apply_findings(matrix: SymbolMatrix, results: SessionResult[]) -> AlignOutcome {
     let baml_names = baml_finding_names(matrix);
     let ts_index = ts_by_id(matrix);
@@ -884,10 +978,19 @@ function apply_findings(matrix: SymbolMatrix, results: SessionResult[]) -> Align
                             },
                         }
                     }
-                    // A pairing whose only counterpart was invented is not a
-                    // pairing. Recording it as one with an empty list would
-                    // turn a hallucination into a confident "no counterpart".
-                    if (invented && counterparts.length() == 0 && finding.verdict != "none") {
+                    // A pairing with nothing left to point at is not a pairing.
+                    // Recording it with an empty list would turn a hallucination
+                    // into a confident "no counterpart" — and a `match` that
+                    // named nothing to begin with is the same claim arrived at
+                    // by a different route, so both are refused here.
+                    if (counterparts.length() == 0 && judgement_pairs_verdict(finding.verdict)) {
+                        // Each invented name was already listed above; saying
+                        // so again would double-count the same mistake. What
+                        // needs its own line is the other route to an empty
+                        // list — a pairing verdict that named nothing at all.
+                        if (!invented) {
+                            rejected.push(`${finding.ts} claims a counterpart but names none`);
+                        }
                         continue;
                     }
                     let _ = judged.set(finding.ts, true);
@@ -915,10 +1018,15 @@ function apply_findings(matrix: SymbolMatrix, results: SessionResult[]) -> Align
     AlignOutcome { matrix: matrix, sessions: results.length(), judged: applied, rejected: rejected }
 }
 
-function run_sessions(box: Toolbox, requests: SessionRequest[], limit: int) -> SessionResult[] {
+function run_sessions(
+    box: Toolbox,
+    requests: SessionRequest[],
+    limit: int,
+    baml_names: map<string, string>,
+) -> SessionResult[] {
     let group = baml.spawn.TaskGroup.new(limit, name = "sessions");
     let pending = requests.map((request) -> {
-        spawn with baml.spawn.options(group = group) { run_session(box, request) }
+        spawn with baml.spawn.options(group = group) { run_session(box, request, baml_names) }
     });
     report_progress(`${requests.length()} sessions, ${limit} at a time`);
     let results: SessionResult[] = [];
@@ -947,7 +1055,7 @@ function align_matrix(
     for (let request in requests) {
         queued += request.ts_lines.length();
     }
-    let outcome = apply_findings(matrix, run_sessions(box, requests, limit));
+    let outcome = apply_findings(matrix, run_sessions(box, requests, limit, baml_finding_names(matrix)));
     report_progress(`${outcome.judged} of ${queued} judged, ${outcome.rejected.length()} claims refused`);
     // A session that answers for some of its symbols and not the rest leaves
     // exactly what a session that never ran leaves. Saying so is the only way

--- a/tools/stdlib-matrix/baml_src/align.baml
+++ b/tools/stdlib-matrix/baml_src/align.baml
@@ -563,6 +563,14 @@ function finding_fault(box: Toolbox, finding: Finding, baml_names: map<string, s
     if (unknown.length() > 0) {
         return `[${finding.ts}] these are not BAML symbols: ${unknown.join(", ")}. Look them up, or leave the baml list empty and say what you looked for.`;
     }
+    // A pairing verdict that names nothing is refused here, not only in
+    // `apply_findings`. That check runs after the session has ended, so the
+    // symbol was already marked covered: the model was never told, never spent
+    // a retry putting it right, and the symbol came out unjudged with the
+    // reason recorded somewhere the session could not see.
+    if (finding.baml.length() == 0 && judgement_pairs_verdict(finding.verdict)) {
+        return `[${finding.ts}] you said ${finding.verdict} but named no BAML symbol. Name what a developer would use, or say none if there is nothing.`;
+    }
     // `divergent` is not a stronger `match`, it is the verdict that carries a
     // caveat, and the caveat is the whole of what it adds. Thirteen shipped
     // without one, rendering as a striped swatch whose tooltip had nothing to

--- a/tools/stdlib-matrix/baml_src/entry.baml
+++ b/tools/stdlib-matrix/baml_src/entry.baml
@@ -196,10 +196,6 @@ function build_matrix_aligned(
     }
 }
 
-function main() -> MatrixResult {
-    build_matrix()
-}
-
 /// What the tools answer, without a model.
 ///
 /// Inspection only, and the point of it: a tool that answers badly is a session

--- a/tools/stdlib-matrix/baml_src/entry.baml
+++ b/tools/stdlib-matrix/baml_src/entry.baml
@@ -142,7 +142,7 @@ class AlignedMatrixResult {
 /// The full pass: the surfaces, then a session per TypeScript container over
 /// everything a previous revision did not already answer.
 ///
-/// Reads ANTHROPIC_API_KEY from the environment.
+/// Reads OPENAI_API_KEY from the environment.
 function build_matrix_aligned(
     baml_surface_file: string = "tools/stdlib-matrix/data/baml_surface.json",
     ts_surface_file: string = "tools/stdlib-matrix/data/ts_surface.json",

--- a/tools/stdlib-matrix/baml_src/models.baml
+++ b/tools/stdlib-matrix/baml_src/models.baml
@@ -128,13 +128,6 @@ class ExportImplMethod {
 /// parser rejects it in struct-literal position, so this class can only be
 /// built by JSON decoding — which is how it always arrives (tests build
 /// fixtures with `baml.json.from_string` for the same reason).
-///
-// BUG: `baml fmt` cannot format a file containing this declaration — it fails
-// with "Expected token/node of kind WORD, but found KW_INTERFACE" pointing at
-// the field below. The declaration is accepted by the compiler, so the parser
-// and the formatter disagree about whether `interface` is a legal field name.
-// This file and symbols.baml (which reads `impl_record.interface`) are the two
-// the formatter skips.
 class ExportImpl {
     id: string,
     interface: string,

--- a/tools/stdlib-matrix/baml_src/ratchet.baml
+++ b/tools/stdlib-matrix/baml_src/ratchet.baml
@@ -29,16 +29,14 @@ function short_sha(sha: string) -> string {
 function provenance_changes(before: MatrixProvenance, now: MatrixProvenance) -> string[] {
     let changes: string[] = [];
     if (before.baml_surface_sha256 != now.baml_surface_sha256) {
-        changes
-            .push(
-                `the BAML stdlib surface changed (${short_sha(before.baml_surface_sha256)} → ${short_sha(now.baml_surface_sha256)})`,
-            );
+        changes.push(
+            `the BAML stdlib surface changed (${short_sha(before.baml_surface_sha256)} → ${short_sha(now.baml_surface_sha256)})`,
+        );
     }
     if (before.export_format_version != now.export_format_version) {
-        changes
-            .push(
-                `the export format changed (v${before.export_format_version} → v${now.export_format_version})`,
-            );
+        changes.push(
+            `the export format changed (v${before.export_format_version} → v${now.export_format_version})`,
+        );
     }
     if (before.typescript_version != now.typescript_version) {
         changes.push(`TypeScript ${before.typescript_version} → ${now.typescript_version}`);
@@ -67,13 +65,13 @@ function count_changes(before: MatrixCounts, now: MatrixCounts) -> BaselineCompa
         neutral: [],
     };
     if (now.baml_symbols < before.baml_symbols) {
-        comparison
-            .regressions
-            .push(`the BAML surface shrank, ${before.baml_symbols} → ${now.baml_symbols} symbols`);
+        comparison.regressions.push(
+            `the BAML surface shrank, ${before.baml_symbols} → ${now.baml_symbols} symbols`,
+        );
     } else if (now.baml_symbols > before.baml_symbols) {
-        comparison
-            .improvements
-            .push(`the BAML surface grew, ${before.baml_symbols} → ${now.baml_symbols} symbols`);
+        comparison.improvements.push(
+            `the BAML surface grew, ${before.baml_symbols} → ${now.baml_symbols} symbols`,
+        );
     }
     if (now.matched < before.matched) {
         comparison.regressions.push(`counterparts lost, ${before.matched} → ${now.matched}`);
@@ -84,9 +82,9 @@ function count_changes(before: MatrixCounts, now: MatrixCounts) -> BaselineCompa
         comparison.neutral.push(`symbols awaiting judgement ${before.unjudged} → ${now.unjudged}`);
     }
     if (now.ts_symbols != before.ts_symbols) {
-        comparison
-            .neutral
-            .push(`TypeScript surface ${before.ts_symbols} → ${now.ts_symbols} symbols`);
+        comparison.neutral.push(
+            `TypeScript surface ${before.ts_symbols} → ${now.ts_symbols} symbols`,
+        );
     }
     comparison
 }

--- a/tools/stdlib-matrix/baml_src/references.baml
+++ b/tools/stdlib-matrix/baml_src/references.baml
@@ -173,11 +173,12 @@ function generic_param_bound(declared: string) -> string {
 // ── the BAML side ───────────────────────────────────────────────────────────
 
 /// The dotted path an id addresses, or the empty string when it addresses
-/// something no name can reach. An impl entry's id is a block address
-/// (`X:baml.impl[…]::compare`), which is not a path a signature could mention.
+/// something no name can reach. An impl entry is addressed through its block
+/// (`M:(baml.Foo as baml.Comparable).compare`), which is a way to *call* the
+/// method rather than a path a signature could mention.
 function id_path(id: string) -> string {
     let path = strip_kind_prefix(id);
-    if (path.includes("[") || path.includes("::")) {
+    if (path.includes("[") || path.starts_with("(")) {
         ""
     } else {
         path

--- a/tools/stdlib-matrix/baml_src/render.baml
+++ b/tools/stdlib-matrix/baml_src/render.baml
@@ -9,11 +9,10 @@
 // Keep the output deterministic: no timestamps, no environment.
 
 function escape_cell(value: string) -> string {
-    value
-        .replace_all("\\", "\\\\")
-        .replace_all("|", "\\|")
-        .replace_all("\r", "")
-        .replace_all("\n", "<br>")
+    value.replace_all("\\", "\\\\").replace_all("|", "\\|").replace_all("\r", "").replace_all(
+        "\n",
+        "<br>",
+    )
 }
 
 /// Stands in for a version the extractor could not determine. Shared with the
@@ -32,31 +31,7 @@ function render_inputs_section(provenance: MatrixProvenance) -> string {
         `- TypeScript: ${provenance.typescript_version}`,
         `- @types/node: ${provenance.types_node_version ?? provenance_absent()}`,
     ]
-    .join("\n")
-}
-
-/// The group a BAML symbol belongs to: its owner path, or the impl it arrives
-/// through. Mirrors `groupOf` in the web view.
-function baml_group_of(symbol: BamlSymbol) -> string {
-    let names: string[] = [];
-    let impl_group = "";
-    for (let step in symbol.symbol) {
-        match (step) {
-            let plain: string => {
-                names.push(plain);
-            },
-            let node: ImplStep => {
-                impl_group = `${node.base} as ${node.iface.join(".")}`;
-            },
-        }
-    }
-    if (impl_group.length() > 0) {
-        impl_group
-    } else if (names.length() > 1) {
-        names.slice(0, names.length() - 1).join(".")
-    } else {
-        names.at(0) ?? "(root)"
-    }
+        .join("\n")
 }
 
 /// One row: the symbol, what was concluded about it, and on what grounds.
@@ -100,7 +75,7 @@ function render_symbol_row(
         `| ${state} `,
         `| ${escape_cell(counterparts.join(", "))} |`,
     ]
-    .join("")
+        .join("")
 }
 
 function render_matrix_markdown(matrix: SymbolMatrix) -> string {
@@ -114,10 +89,13 @@ function render_matrix_markdown(matrix: SymbolMatrix) -> string {
         let bucket: Judgement[] = by_ts.get(judgement.ts) ?? [];
         bucket.push(judgement);
         let _ = by_ts.set(judgement.ts, bucket);
-        if (judgement_pairs(judgement)) {
-            for (let id in judgement.baml) {
-                let _ = baml_claimed.set(id, true);
-            }
+        // Every verdict claims what it names, matching `recount` — a symbol
+        // offered as the way to do something BAML makes unnecessary has still
+        // been pointed at. Gating on `judgement_pairs` here made the summary
+        // line and the table thirty lines below it disagree by eight rows,
+        // each listed under "no judgement names" while being counted as named.
+        for (let id in judgement.baml) {
+            let _ = baml_claimed.set(id, true);
         }
     }
     let baml_by_id: map<string, BamlSymbol> = {};

--- a/tools/stdlib-matrix/baml_src/report.baml
+++ b/tools/stdlib-matrix/baml_src/report.baml
@@ -142,7 +142,13 @@ class SymbolMatrix {
 /// A judgement that pairs this symbol with something, as opposed to one that
 /// records an absence.
 function judgement_pairs(judgement: Judgement) -> bool {
-    judgement.verdict == "match" || judgement.verdict == "divergent"
+    judgement_pairs_verdict(judgement.verdict)
+}
+
+/// The same test, on a verdict alone — for a finding, which is not yet a
+/// judgement.
+function judgement_pairs_verdict(verdict: string) -> bool {
+    verdict == "match" || verdict == "divergent"
 }
 
 /// The strongest thing said about a symbol, when more than one judgement speaks
@@ -284,18 +290,4 @@ function build_symbol_matrix(
     };
     matrix.counts = recount(matrix);
     matrix
-}
-
-/// Build the symbol matrix from the generated data files.
-function build_matrix_v2(
-    baml_surface_file: string = "tools/stdlib-matrix/data/baml_surface.json",
-    ts_surface_file: string = "tools/stdlib-matrix/data/ts_surface.json",
-    baml_surface_sha256: string = "",
-) -> SymbolMatrix {
-    if (baml_surface_sha256.length() == 0) {
-        throw baml.errors.InvalidArgument {
-            message: "baml_surface_sha256 is required — the run wrapper computes it",
-        };
-    }
-    build_symbol_matrix(load_baml_surface(baml_surface_file), load_ts_surface(ts_surface_file), baml_surface_sha256)
 }

--- a/tools/stdlib-matrix/baml_src/revision.baml
+++ b/tools/stdlib-matrix/baml_src/revision.baml
@@ -62,6 +62,20 @@ class Revision {
     judgements: map<string, Judgement[]>,
 }
 
+/// What separates the fields of a comparison key.
+///
+/// A vertical tab, because it cannot occur in a docstring or a printed
+/// signature and so keeps the key unambiguous — two symbols differing only in
+/// where a field boundary falls must not compare equal.
+///
+/// Not `\u{1f}`, which is what this was: BAML does not support that escape, so
+/// the separator was the six printable characters `\u{1f}` — ordinary text
+/// that content can contain, defeating the whole point. `\v` and `\f` are the
+/// control escapes the lexer does accept.
+function field_separator() -> string {
+    "\v"
+}
+
 /// The text a declaration is compared by.
 ///
 /// Everything that could change what a symbol *is*, and nothing that could not:
@@ -89,7 +103,7 @@ function declaration_text(
         signature,
         doc ?? "",
     ]
-    .join("\u{1f}")
+        .join(field_separator())
 }
 
 function baml_symbol_text(symbol: BamlSymbol) -> string {
@@ -124,7 +138,9 @@ function prior_symbol_text(symbol: PriorSymbol) -> string {
 /// TypeScript declares no error contract and its signature is printed text, so
 /// there is less to compare — but the shape of the question is the same.
 function ts_symbol_text(symbol: TsSymbol) -> string {
-    [symbol.origin, symbol.display, symbol.signature, symbol.doc ?? "", symbol.since].join("\u{1f}")
+    [symbol.origin, symbol.display, symbol.signature, symbol.doc ?? "", symbol.since].join(
+        field_separator(),
+    )
 }
 
 /// Reads a previous report. A file that cannot be decoded is an error, never a
@@ -257,9 +273,9 @@ function baml_surface_grew(matrix: SymbolMatrix, before: Revision) -> bool {
 
 /// Whether a judgement may be carried, given what has changed.
 ///
-/// A pairing survives when every BAML symbol it names reads as it did. A judged
-/// *absence* is a claim about the whole BAML surface rather than about any one
-/// symbol — "nothing in BAML does this job" — so it survives only while that
+/// A pairing survives when every BAML symbol it names — and everything each of
+/// those names in turn — reads as it did. A judged *absence* is a claim about
+/// the whole BAML surface rather than about any one symbol — "nothing in BAML does this job" — so it survives only while that
 /// surface could not have gained the thing it says is missing.
 ///
 /// `baml_grew` is that test, and it is deliberately a test for *additions*
@@ -279,20 +295,39 @@ function judgement_carries(
     now: map<string, string>,
     before: Revision,
     baml_grew: bool,
+    references: map<string, string[]>,
 ) -> bool {
-    // The counterpart list, not the verdict, decides which question to ask:
-    // it is what says whether there is anything to re-check.
-    if (judgement.baml.length() == 0) {
-        !baml_grew
-    } else {
-        let carries = true;
-        for (let id in judgement.baml) {
-            if (!before.texts.has(id) || before.texts.get(id) != now.get(id)) {
-                carries = false;
-            }
-        }
-        carries
+    // The verdict, not the counterpart list. A `match` that named nothing is
+    // still a pairing claim, and asking the absence question about it would
+    // cache it against "did BAML gain anything" — a rule written for a
+    // different claim entirely.
+    if (!judgement_pairs(judgement) && judgement.verdict != "unnecessary") {
+        return !baml_grew;
     }
+    let no_references: string[] = [];
+    let carries = true;
+    for (let id in judgement.baml) {
+        // `is_fresh`, not a bare text comparison: a judgement is only as stable
+        // as what the symbols it names are built from. This is the check the
+        // module header describes with `read(path) -> baml.fs.DirEntry[]`, and
+        // it ran on the TypeScript side alone — so retyping a field of
+        // `DirEntry` left every judgement about reading a directory carried,
+        // shipping reasoning written against the old type.
+        if (!is_fresh(id, references.get(id) ?? no_references, now, before)) {
+            carries = false;
+        }
+    }
+    carries
+}
+
+/// Every BAML symbol's references, by id — what `judgement_carries` needs in
+/// order to look one step past the symbols a judgement names.
+function baml_references(matrix: SymbolMatrix) -> map<string, string[]> {
+    let references: map<string, string[]> = {};
+    for (let symbol in matrix.baml) {
+        let _ = references.set(symbol.id, symbol.references);
+    }
+    references
 }
 
 /// Folds a previous revision into a fresh matrix.
@@ -303,6 +338,7 @@ function judgement_carries(
 function apply_revision(matrix: SymbolMatrix, before: Revision) -> CarryOutcome {
     let now = current_texts(matrix);
     let grew = baml_surface_grew(matrix, before);
+    let references = baml_references(matrix);
     let carried: Judgement[] = [];
     let carried_for: map<string, bool> = {};
     let queued = 0;
@@ -315,7 +351,7 @@ function apply_revision(matrix: SymbolMatrix, before: Revision) -> CarryOutcome 
         }
         let all_carry = true;
         for (let judgement in prior) {
-            if (!judgement_carries(judgement, now, before, grew)) {
+            if (!judgement_carries(judgement, now, before, grew, references)) {
                 all_carry = false;
             }
         }

--- a/tools/stdlib-matrix/baml_src/revision.baml
+++ b/tools/stdlib-matrix/baml_src/revision.baml
@@ -304,20 +304,69 @@ function judgement_carries(
     if (!judgement_pairs(judgement) && judgement.verdict != "unnecessary") {
         return !baml_grew;
     }
-    let no_references: string[] = [];
     let carries = true;
     for (let id in judgement.baml) {
-        // `is_fresh`, not a bare text comparison: a judgement is only as stable
-        // as what the symbols it names are built from. This is the check the
-        // module header describes with `read(path) -> baml.fs.DirEntry[]`, and
-        // it ran on the TypeScript side alone — so retyping a field of
-        // `DirEntry` left every judgement about reading a directory carried,
-        // shipping reasoning written against the old type.
-        if (!is_fresh(id, references.get(id) ?? no_references, now, before)) {
+        // Freshness of the whole reachable set, not a bare text comparison: a
+        // judgement is only as stable as what the symbols it names are built
+        // from. This is the check the module header describes with
+        // `read(path) -> baml.fs.DirEntry[]`, and it ran on the TypeScript
+        // side alone — so retyping a field of `DirEntry` left every judgement
+        // about reading a directory carried, shipping reasoning written
+        // against the old type.
+        if (!is_fresh_transitively(id, now, before, references)) {
             carries = false;
         }
     }
     carries
+}
+
+/// Whether `id`, and everything reachable from it, reads as it did.
+///
+/// Reachable rather than adjacent. The walk used to stop one step out, so a
+/// judgement naming `A` carried even when `A` referenced `B` and `B` had been
+/// built from a changed `C` — while the header above already promised
+/// "everything each of those names in turn". The prose was right and the code
+/// was one hop short.
+///
+/// Measured on the shipped surface the full closure is barely wider than the
+/// neighbours — mean 3.0 symbols against 2.8, the same maximum of 17, and not
+/// one symbol reaching even a tenth of the surface — because references point
+/// at type declarations, which name nothing by existing. So the honest walk
+/// costs almost nothing in judgements needlessly expired, which is the cost
+/// this file exists to control.
+///
+/// Cycle-safe: `seen` gates every push, and a standard library is full of
+/// mutually referential types.
+function is_fresh_transitively(
+    root: string,
+    now: map<string, string>,
+    before: Revision,
+    references: map<string, string[]>,
+) -> bool {
+    let no_references: string[] = [];
+    let seen: map<string, bool> = {};
+    let pending: string[] = [root];
+    while (pending.length() > 0) {
+        let id = match (pending.pop()) {
+            null => {
+                break;
+            },
+            let popped: string => popped,
+        };
+        if (seen.has(id)) {
+            continue;
+        }
+        let _ = seen.set(id, true);
+        if (!before.texts.has(id) || before.texts.get(id) != now.get(id)) {
+            return false;
+        }
+        for (let reference in references.get(id) ?? no_references) {
+            if (!seen.has(reference)) {
+                pending.push(reference);
+            }
+        }
+    }
+    true
 }
 
 /// Every BAML symbol's references, by id — what `judgement_carries` needs in

--- a/tools/stdlib-matrix/baml_src/symbols.baml
+++ b/tools/stdlib-matrix/baml_src/symbols.baml
@@ -246,97 +246,93 @@ function extract_symbols(doc: PackageExportDoc) -> BamlSymbol[] {
         let owner_display = type_display_name(qualified);
 
         if (item.kind == "function") {
-            symbols
-                .push(
-                    BamlSymbol {
-                        id: item.id,
-                        declared_by: null,
-                        symbol: owner_path,
-                        display: qualified,
-                        kind: "function",
-                        origin: "free",
-                        generics: [],
-                        ty: null,
-                        resolved: null,
-                        default: null,
-                        signature: symbol_signature(item.signature),
-                        doc: item.docstring,
-                        references: [],
-                    },
-                );
-            continue;
-        }
-
-        symbols
-            .push(
+            symbols.push(
                 BamlSymbol {
                     id: item.id,
                     declared_by: null,
                     symbol: owner_path,
-                    display: owner_display,
-                    // `type_alias` is spelled `type` in source.
-                    kind: if (item.kind == "type_alias") {
-                        "type"
-                    } else {
-                        item.kind
-                    },
-                    origin: "type",
-                    generics: declared_generics(item.generics),
+                    display: qualified,
+                    kind: "function",
+                    origin: "free",
+                    generics: [],
                     ty: null,
-                    // Only an alias names a type; the other kinds declare one.
-                    resolved: normalize_optional_ty(item.resolved),
+                    resolved: null,
                     default: null,
-                    signature: null,
+                    signature: symbol_signature(item.signature),
                     doc: item.docstring,
                     references: [],
                 },
             );
+            continue;
+        }
+
+        symbols.push(
+            BamlSymbol {
+                id: item.id,
+                declared_by: null,
+                symbol: owner_path,
+                display: owner_display,
+                // `type_alias` is spelled `type` in source.
+                kind: if (item.kind == "type_alias") {
+                    "type"
+                } else {
+                    item.kind
+                },
+                origin: "type",
+                generics: declared_generics(item.generics),
+                ty: null,
+                // Only an alias names a type; the other kinds declare one.
+                resolved: normalize_optional_ty(item.resolved),
+                default: null,
+                signature: null,
+                doc: item.docstring,
+                references: [],
+            },
+        );
 
         let fields: ExportField[] = item.fields ?? [];
         for (let field in fields) {
             if (field.name.includes("$")) {
                 continue;
             }
-            symbols
-                .push(
-                    BamlSymbol {
-                        id: field.id,
-                        declared_by: null,
-                        symbol: member_steps(qualified, field.name),
-                        display: `${owner_display}.${field.name}`,
-                        kind: "field",
-                        origin: "field",
-                        generics: [],
-                        ty: normalize_optional_ty(field.ty),
-                        resolved: null,
-                        default: null,
-                        signature: null,
-                        doc: field.docstring,
-                        references: [],
-                    },
-                );
+            symbols.push(
+                BamlSymbol {
+                    id: field.id,
+                    declared_by: null,
+                    symbol: member_steps(qualified, field.name),
+                    display: `${owner_display}.${field.name}`,
+                    kind: "field",
+                    origin: "field",
+                    generics: [],
+                    ty: normalize_optional_ty(field.ty),
+                    resolved: null,
+                    default: null,
+                    signature: null,
+                    doc: field.docstring,
+                    references: [],
+                },
+            );
         }
 
         let variants: ExportVariant[] = item.variants ?? [];
         for (let variant in variants) {
-            symbols
-                .push(
-                    BamlSymbol {
-                        id: variant.id,
-                        declared_by: null,
-                        symbol: member_steps(qualified, variant.name),
-                        display: `${owner_display}.${variant.name}`,
-                        kind: "variant",
-                        origin: "variant",
-                        generics: [],
-                        ty: null,
-                        resolved: null,
-                        default: null,
-                        signature: null,
-                        doc: variant.docstring,
-                        references: [],
-                    },
-                );
+            symbols.push(
+                BamlSymbol {
+                    id: variant.id,
+                    declared_by: null,
+                    symbol: member_steps(qualified, variant.name),
+                    display: `${owner_display}.${variant.name}`,
+                    kind: "variant",
+                    origin: "variant",
+                    generics: [],
+                    ty: null,
+                    resolved: null,
+                    default: null,
+                    signature: null,
+                    doc: variant.docstring,
+                    references: [],
+                },
+            );
         }
 
         // An interface's associated types are members of it: `Sortable` is a
@@ -344,24 +340,23 @@ function extract_symbols(doc: PackageExportDoc) -> BamlSymbol[] {
         // looking like it has only the methods.
         let assoc_types: ExportAssocType[] = item.assoc_types ?? [];
         for (let assoc in assoc_types) {
-            symbols
-                .push(
-                    BamlSymbol {
-                        id: assoc.id,
-                        declared_by: null,
-                        symbol: member_steps(qualified, assoc.name),
-                        display: `${owner_display}.${assoc.name}`,
-                        kind: "associated type",
-                        origin: "assoc_type",
-                        generics: [],
-                        ty: null,
-                        resolved: null,
-                        default: normalize_optional_ty(assoc.default),
-                        signature: null,
-                        doc: null,
-                        references: [],
-                    },
-                );
+            symbols.push(
+                BamlSymbol {
+                    id: assoc.id,
+                    declared_by: null,
+                    symbol: member_steps(qualified, assoc.name),
+                    display: `${owner_display}.${assoc.name}`,
+                    kind: "associated type",
+                    origin: "assoc_type",
+                    generics: [],
+                    ty: null,
+                    resolved: null,
+                    default: normalize_optional_ty(assoc.default),
+                    signature: null,
+                    doc: null,
+                    references: [],
+                },
+            );
         }
 
         let methods: ExportMethod[] = item.methods ?? [];
@@ -371,24 +366,23 @@ function extract_symbols(doc: PackageExportDoc) -> BamlSymbol[] {
             if (method.name.includes("$")) {
                 continue;
             }
-            symbols
-                .push(
-                    BamlSymbol {
-                        id: method.id,
-                        declared_by: null,
-                        symbol: member_steps(qualified, method.name),
-                        display: `${owner_display}.${method.name}`,
-                        kind: "function",
-                        origin: origin_of_method(method.signature),
-                        generics: [],
-                        ty: null,
-                        resolved: null,
-                        default: null,
-                        signature: symbol_signature(method.signature),
-                        doc: method.docstring,
-                        references: [],
-                    },
-                );
+            symbols.push(
+                BamlSymbol {
+                    id: method.id,
+                    declared_by: null,
+                    symbol: member_steps(qualified, method.name),
+                    display: `${owner_display}.${method.name}`,
+                    kind: "function",
+                    origin: origin_of_method(method.signature),
+                    generics: [],
+                    ty: null,
+                    resolved: null,
+                    default: null,
+                    signature: symbol_signature(method.signature),
+                    doc: method.docstring,
+                    references: [],
+                },
+            );
         }
     }
 
@@ -400,24 +394,23 @@ function extract_symbols(doc: PackageExportDoc) -> BamlSymbol[] {
             }
             let impl_path: PathStep[] = [step];
             impl_path.push(method.name);
-            symbols
-                .push(
-                    BamlSymbol {
-                        id: method.id,
-                        declared_by: method.declared_by,
-                        symbol: impl_path,
-                        display: `(${impl_record.for_ty.display} as ${impl_record.interface}).${method.name}`,
-                        kind: "function",
-                        origin: "impl_method",
-                        generics: [],
-                        ty: null,
-                        resolved: null,
-                        default: null,
-                        signature: symbol_signature(method.signature),
-                        doc: method.docstring,
-                        references: [],
-                    },
-                );
+            symbols.push(
+                BamlSymbol {
+                    id: method.id,
+                    declared_by: method.declared_by,
+                    symbol: impl_path,
+                    display: `(${impl_record.for_ty.display} as ${impl_record.interface}).${method.name}`,
+                    kind: "function",
+                    origin: "impl_method",
+                    generics: [],
+                    ty: null,
+                    resolved: null,
+                    default: null,
+                    signature: symbol_signature(method.signature),
+                    doc: method.docstring,
+                    references: [],
+                },
+            );
         }
     }
 

--- a/tools/stdlib-matrix/baml_src/tests.baml
+++ b/tools/stdlib-matrix/baml_src/tests.baml
@@ -457,7 +457,10 @@ test "impl entries address themselves and name what they re-list" {
     }
     assert.equal(
         ids,
-        [ "X:baml.impl[baml.Comparable for baml.Foo]::compare", "X:baml.impl[baml.Comparable for baml.Foo]::index_of"],
+        [
+            "X:baml.impl[baml.Comparable for baml.Foo]::compare",
+            "X:baml.impl[baml.Comparable for baml.Foo]::index_of",
+        ],
     );
     // The re-listed one carries the declaration it came from; the override
     // declared only in the block has no other address.
@@ -1092,11 +1095,89 @@ test "an answer keeps its finding when only the example is bad" {
         divergence: null,
         example: CodeExample { typescript: "foo.only()", baml: "this does not compile", note: null },
     };
-    let stripped = without_example(finding);
-    assert.is_true(stripped.example == null);
-    assert.equal(stripped.verdict, finding.verdict);
-    assert.equal(stripped.baml, finding.baml);
-    assert.equal(stripped.reason, finding.reason);
+    let names: map<string, string> = { "M:baml.Foo.index_of": "M:baml.Foo.index_of" };
+    if let stripped: Finding = without_faults(finding, names) {
+        assert.is_true(stripped.example == null);
+        assert.equal(stripped.verdict, finding.verdict);
+        assert.equal(stripped.baml, finding.baml);
+        assert.equal(stripped.reason, finding.reason);
+    } else {
+        baml.sys.panic("a finding with a real counterpart was dropped");
+    }
+
+    // But a pairing whose every counterpart was invented has nothing left to
+    // salvage: keeping it with an empty list would turn a hallucination into a
+    // confident "nothing in BAML does this".
+    let invented = Finding {
+        ts: "Foo.prototype.only",
+        verdict: "match",
+        baml: ["baml.does_not_exist"],
+        confidence: "high",
+        reason: "fixture",
+        divergence: null,
+        example: null,
+    };
+    assert.is_true(without_faults(invented, names) == null);
+}
+
+/// A toolbox that can answer nothing. Enough for the checks that run before
+/// any tool is reached — a finding with no example never touches the compiler.
+function fixture_toolbox() -> Toolbox {
+    let headings: string[] = [];
+    let bodies: map<string, string> = {};
+    Toolbox {
+        skill: "",
+        doc_headings: headings,
+        doc_bodies: bodies,
+        repo_root: ".",
+        scratch_root: ".",
+        baml_bin: "baml-cli-that-is-never-run",
+    }
+}
+
+/// Built fresh per call, not aliased: class values are references, so mutating
+/// a `let` bound to one of these would edit the finding it was copied from.
+function fixture_divergence(
+    verdict: "match" | "divergent" | "unnecessary" | "none",
+    divergence: string?,
+) -> Finding {
+    Finding {
+        ts: "Foo.prototype.only",
+        verdict: verdict,
+        baml: ["M:baml.Foo.index_of"],
+        confidence: "high",
+        reason: "fixture",
+        divergence: divergence,
+        example: null,
+    }
+}
+
+test "a divergent verdict must say how they diverge" {
+    // Thirteen shipped without one. `divergent` is not a stronger `match`; the
+    // caveat is the entire difference between them, and a striped swatch whose
+    // tooltip is empty tells the reader nothing they can act on.
+    let box = fixture_toolbox();
+    let names: map<string, string> = { "M:baml.Foo.index_of": "M:baml.Foo.index_of" };
+
+    if let complaint: string = finding_fault(box, fixture_divergence("divergent", null), names) {
+        assert.is_true(complaint.includes("did not say how"));
+    } else {
+        baml.sys.panic("a divergent finding with no divergence was accepted");
+    }
+    // Whitespace is not a difference either.
+    assert.is_true(finding_fault(box, fixture_divergence("divergent", "   "), names) != null);
+
+    // And the converse: a difference written under a verdict that claims none.
+    let contradictory = fixture_divergence("match", "the argument order is reversed");
+    if let complaint: string = finding_fault(box, contradictory, names) {
+        assert.is_true(complaint.includes("the verdict is match"));
+    } else {
+        baml.sys.panic("a match carrying a divergence was accepted");
+    }
+
+    // Stated, it passes.
+    let stated = fixture_divergence("divergent", "BAML returns an optional rather than -1");
+    assert.is_true(finding_fault(box, stated, names) == null);
 }
 
 test "a long tool answer is cut, and says where" {
@@ -1124,13 +1205,135 @@ test "the last round cannot ask for another lookup" {
     // mechanism: it is what the model is shown. This has already been lost once
     // to a careless edit, leaving a comment describing a function that no
     // longer existed, so it is worth a test that costs nothing.
-    let step = baml.llm.render_output_format(baml.llm.get_return_type("session_step"));
-    let last = baml.llm.render_output_format(baml.llm.get_return_type("session_final"));
+    let step = baml.prompt.render_output_format(baml.prompt.get_return_type("session_step"));
+    let last = baml.prompt.render_output_format(baml.prompt.get_return_type("session_final"));
     assert.is_true(step.includes("any of these schemas"));
     assert.is_true(step.includes("lookups"));
     assert.is_true(!last.includes("any of these schemas"));
     assert.is_true(last.includes("findings"));
     assert.is_true(!last.includes("lookups"));
+}
+
+test "a judgement goes stale when a type its counterpart names changes" {
+    // The case revision.baml's own header describes and the code did not do:
+    // `read(path) -> baml.fs.DirEntry[]` means something new the moment
+    // `DirEntry` gains a field. `is_fresh` ran on the TypeScript side only, so
+    // retyping a field left every judgement about reading a directory carried,
+    // shipping reasoning written against the old type.
+    let before = fixture_revision(fixture_matrix("sha-a", "5.8.3-test"));
+    let matrix = fixture_matrix("sha-a", "5.8.3-test");
+    let baseline = apply_revision(fixture_matrix("sha-a", "5.8.3-test"), before);
+
+    // `M:baml.Foo.clone` returns `baml.Foo`, so it names a type. Nothing about
+    // the method itself moves — only the type it hands back.
+    let named: string[] = [];
+    for (let symbol in matrix.baml) {
+        if (symbol.id == "M:baml.Foo.clone") {
+            named = symbol.references;
+        }
+    }
+    assert.is_true(named.includes("T:baml.Foo"));
+    for (let symbol in matrix.baml) {
+        if (symbol.id == "T:baml.Foo") {
+            symbol.doc = "the type gained a field";
+        }
+    }
+
+    let outcome = apply_revision(matrix, before);
+    let now = current_texts(matrix);
+    // The methods themselves did not move — only the type they hand back and
+    // take as a receiver. That is the whole point: their own text compares
+    // equal, so a check that stopped at the named symbol would carry them.
+    assert.equal(now.get("M:baml.Foo.clone") ?? "", before.texts.get("M:baml.Foo.clone") ?? "");
+    assert.is_true((now.get("T:baml.Foo") ?? "") != (before.texts.get("T:baml.Foo") ?? ""));
+    assert.is_true(baseline.carried > 0);
+    assert.equal(outcome.carried, 0);
+}
+
+test "the field separator is one character that content cannot contain" {
+    // It was `\u{1f}`, which BAML does not parse as an escape — so the
+    // separator was six printable characters that a docstring could contain,
+    // and two symbols differing only in where a field boundary fell could
+    // compare equal.
+    assert.equal(field_separator().length(), 1);
+    assert.is_true(!field_separator().is_graphic());
+}
+
+test "a pairing that names nothing is refused, whatever the verdict says" {
+    // The shipped report had 11 of these: `match` and `divergent` findings with
+    // an empty counterpart list, because the guard only fired when a name had
+    // been *offered and refused*. They inflated `matched`, rendered a "BAML"
+    // section with nothing under it, and — since the freshness rule read the
+    // empty list as an absence — were cached against a rule for a different
+    // claim entirely.
+    let matrix = fixture_matrix("sha-e", "5.8.3-test");
+    let nothing: string[] = [];
+    let outcome = apply_findings(
+        matrix,
+        fixture_answers(
+            [
+                fixture_finding("Foo.prototype.only", "match", nothing),
+                fixture_finding("Foo.prototype.sortStuff", "divergent", nothing),
+            ],
+        ),
+    );
+    assert.equal(outcome.judged, 0);
+    assert.equal(outcome.rejected.length(), 2);
+    assert.is_true((outcome.rejected.at(0) ?? "").includes("names none"));
+
+    // An absence naming nothing is exactly right, and still lands.
+    let absence = apply_findings(
+        fixture_matrix("sha-e2", "5.8.3-test"),
+        fixture_answers([fixture_finding("Foo.prototype.only", "none", nothing)]),
+    );
+    assert.equal(absence.judged, 1);
+}
+
+test "the markdown summary and its table agree about what is claimed" {
+    // They disagreed by eight rows in the shipped report: `recount` counts a
+    // symbol as named whatever the verdict, while the renderer counted only
+    // `match`/`divergent`. Eight symbols were listed under "BAML symbols no
+    // judgement names" in the very table the summary line introduces.
+    let matrix = fixture_matrix("sha-md", "5.8.3-test");
+    let unnecessary_only: string[] = ["M:baml.Foo.sort_helper"];
+    matrix.judgements.push(
+        Judgement {
+            ts: "Foo.prototype.only",
+            baml: unnecessary_only,
+            verdict: "unnecessary",
+            basis: "model",
+            confidence: "high",
+            reason: "the language answers this",
+            divergence: null,
+            rejected: [],
+            verified: false,
+            example: null,
+        },
+    );
+    matrix.counts = recount(matrix);
+
+    let markdown = render_matrix_markdown(matrix);
+    // The one named only by an `unnecessary` judgement is claimed, so it is
+    // absent from the table of symbols nothing names.
+    let table = markdown.split("## BAML symbols no judgement names").at(1) ?? "";
+    assert.is_true(!table.includes("Foo.sort_helper"));
+    assert.is_true(
+        markdown.includes(`${matrix.counts.baml_symbols - matrix.counts.baml_unclaimed} of`),
+    );
+}
+
+test "an interstitial is not mistaken for the skill" {
+    // A captive portal or CDN error page returns 200 with HTML, and
+    // `response.ok()` is true for all of them. Accepting one told every session
+    // that BAML is that HTML, and overwrote the good cached copy on the way.
+    assert.is_true(
+        !looks_like_skill("<!DOCTYPE html><html><body>Sign in to continue</body></html>"),
+    );
+    assert.is_true(!looks_like_skill(""));
+    assert.is_true(!looks_like_skill("baml"));
+    // Long enough, not markup, and about BAML.
+    let real = `---\nname: baml-core\n---\n\n# baml\n\nBAML is a statically-typed language. ${"filler ".repeat(400)}`;
+    assert.is_true(looks_like_skill(real));
 }
 
 test "the concurrency cap falls back when nothing was asked for" {

--- a/tools/stdlib-matrix/baml_src/tests.baml
+++ b/tools/stdlib-matrix/baml_src/tests.baml
@@ -1152,6 +1152,81 @@ function fixture_divergence(
     }
 }
 
+test "a pairing verdict that names nothing is sent back" {
+    // `apply_findings` already refused these, but it runs after the session has
+    // ended: the symbol was marked covered, no retry was spent, and it came out
+    // unjudged with the reason recorded where the session could not read it.
+    let box = fixture_toolbox();
+    let names: map<string, string> = { "M:baml.Foo.index_of": "M:baml.Foo.index_of" };
+    let nothing: string[] = [];
+
+    let bare_match = Finding {
+        ts: "Foo.prototype.only",
+        verdict: "match",
+        baml: nothing,
+        confidence: "high",
+        reason: "fixture",
+        divergence: null,
+        example: null,
+    };
+    if let complaint: string = finding_fault(box, bare_match, names) {
+        assert.is_true(complaint.includes("named no BAML symbol"));
+    } else {
+        baml.sys.panic("a match naming nothing was accepted");
+    }
+
+    let bare_divergent = Finding {
+        ts: "Foo.prototype.only",
+        verdict: "divergent",
+        baml: nothing,
+        confidence: "high",
+        reason: "fixture",
+        divergence: "they differ",
+        example: null,
+    };
+    if let complaint: string = finding_fault(box, bare_divergent, names) {
+        assert.is_true(complaint.includes("named no BAML symbol"));
+    } else {
+        baml.sys.panic("a divergent naming nothing was accepted");
+    }
+
+    // The verdicts that legitimately name nothing are untouched.
+    let absent = Finding {
+        ts: "Foo.prototype.only",
+        verdict: "none",
+        baml: nothing,
+        confidence: "high",
+        reason: "fixture",
+        divergence: null,
+        example: null,
+    };
+    assert.is_true(finding_fault(box, absent, names) == null);
+}
+
+test "freshness follows references all the way, not one step" {
+    // A judgement naming A carried when A referenced B and B was built from a
+    // changed C. One hop short of what the module header already promised.
+    let seed = fixture_revision(fixture_matrix("sha-t", "5.8.3-test"));
+    let before = Revision {
+        provenance: seed.provenance,
+        texts: { "M:baml.a": "a", "T:baml.b": "b", "T:baml.c": "c" },
+        baml_ids: seed.baml_ids,
+        judgements: {},
+    };
+    let references: map<string, string[]> = { "M:baml.a": ["T:baml.b"], "T:baml.b": ["T:baml.c"] };
+    // C two hops out has been retyped.
+    let now: map<string, string> = { "M:baml.a": "a", "T:baml.b": "b", "T:baml.c": "changed" };
+    assert.is_true(!is_fresh_transitively("M:baml.a", now, before, references));
+
+    // Nothing moved: it carries.
+    let still: map<string, string> = { "M:baml.a": "a", "T:baml.b": "b", "T:baml.c": "c" };
+    assert.is_true(is_fresh_transitively("M:baml.a", still, before, references));
+
+    // A cycle terminates rather than spinning.
+    let cyclic: map<string, string[]> = { "M:baml.a": ["T:baml.b"], "T:baml.b": ["M:baml.a"] };
+    assert.is_true(is_fresh_transitively("M:baml.a", still, before, cyclic));
+}
+
 test "a divergent verdict must say how they diverge" {
     // Thirteen shipped without one. `divergent` is not a stronger `match`; the
     // caveat is the entire difference between them, and a striped swatch whose

--- a/tools/stdlib-matrix/baml_src/toolbox.baml
+++ b/tools/stdlib-matrix/baml_src/toolbox.baml
@@ -144,18 +144,11 @@ function strip_warnings(text: string) -> string {
 /// would turn the single most useful failure — a near miss with alternatives —
 /// into a bare error.
 function run_baml(box: Toolbox, args: string[]) -> string {
-    let result = baml
-        .sys
-        .exec(
-            box.baml_bin,
-            args,
-            baml.sys.ProcessOptions {
-                cwd: box.repo_root,
-                env: null,
-                timeout_ms: 30000,
-                stdin: null,
-            },
-        ) catch_all (error) {
+    let result = baml.sys.exec(
+        box.baml_bin,
+        args,
+        baml.sys.ProcessOptions { cwd: box.repo_root, env: null, timeout_ms: 30000, stdin: null },
+    ) catch_all (error) {
         _ => {
             return `could not run the compiler: ${error}`;
         },
@@ -203,18 +196,11 @@ function tool_examples(box: Toolbox, query: string) -> string {
     for (let path in examples_paths()) {
         args.push(path);
     }
-    let result = baml
-        .sys
-        .exec(
-            "git",
-            args,
-            baml.sys.ProcessOptions {
-                cwd: box.repo_root,
-                env: null,
-                timeout_ms: 20000,
-                stdin: null,
-            },
-        ) catch_all (error) {
+    let result = baml.sys.exec(
+        "git",
+        args,
+        baml.sys.ProcessOptions { cwd: box.repo_root, env: null, timeout_ms: 20000, stdin: null },
+    ) catch_all (error) {
         _ => {
             return `could not search for examples: ${error}`;
         },
@@ -357,7 +343,10 @@ function looks_like_skill(text: string) -> bool {
     let body = text.trim();
     // The real document is 22KB of markdown that opens with front matter and
     // names the language repeatedly. An interstitial satisfies none of that.
-    body.length() > 2000 && !body.to_lower_case().starts_with("<!doctype") && !body.to_lower_case().starts_with("<html") && body.to_lower_case().includes("baml")
+    body.length() > 2000
+        && !body.to_lower_case().starts_with("<!doctype")
+        && !body.to_lower_case().starts_with("<html")
+        && body.to_lower_case().includes("baml")
 }
 
 function load_skill(cache_file: string) -> string {
@@ -455,17 +444,15 @@ function check_snippet_in(
     baml.fs.mkdir(`${directory}/baml_src`, baml.fs.MkdirOptions { recursive: true });
     baml.fs.write(`${directory}/baml.toml`, "[package]\nname = \"snippet\"\n");
     baml.fs.write(`${directory}/baml_src/snippet.baml`, code);
-    let result = baml
-        .sys
-        .exec(
-            box.baml_bin,
-            ["check", "--color", "never", "--directory", directory],
-            // No `cwd`: `--directory` already says what to compile, and setting
-            // one would re-root the compiler's own path. `baml.sys.exec`
-            // resolves the program against the child's working directory, so a
-            // relative `baml_bin` plus a `cwd` is a spawn failure.
-            baml.sys.ProcessOptions { cwd: null, env: null, timeout_ms: 60000, stdin: null },
-        );
+    let result = baml.sys.exec(
+        box.baml_bin,
+        ["check", "--color", "never", "--directory", directory],
+        // No `cwd`: `--directory` already says what to compile, and setting
+        // one would re-root the compiler's own path. `baml.sys.exec`
+        // resolves the program against the child's working directory, so a
+        // relative `baml_bin` plus a `cwd` is a spawn failure.
+        baml.sys.ProcessOptions { cwd: null, env: null, timeout_ms: 60000, stdin: null },
+    );
     if (result.ok()) {
         return "";
     }

--- a/tools/stdlib-matrix/baml_src/toolbox.baml
+++ b/tools/stdlib-matrix/baml_src/toolbox.baml
@@ -346,9 +346,27 @@ function skill_url() -> string {
 /// fetch, fall back to the cache and say so, and fail if there is neither.
 /// Failing is the right outcome — the alternative is paying for a whole run to
 /// get answers nobody can tell are degraded.
+/// Whether a fetched body is plausibly the skill rather than something a
+/// network handed back with a 200.
+///
+/// A captive portal, a proxy interstitial or a CDN error page all return 200
+/// with HTML, and `response.ok()` is true for every one of them. Without this
+/// the run told two hundred sessions that BAML *is* that HTML — and, worse,
+/// wrote it over the cached copy, so the next run had no fallback either.
+function looks_like_skill(text: string) -> bool {
+    let body = text.trim();
+    // The real document is 22KB of markdown that opens with front matter and
+    // names the language repeatedly. An interstitial satisfies none of that.
+    body.length() > 2000 && !body.to_lower_case().starts_with("<!doctype") && !body.to_lower_case().starts_with("<html") && body.to_lower_case().includes("baml")
+}
+
 function load_skill(cache_file: string) -> string {
     let fetched = fetch_skill();
-    if (fetched.length() > 0) {
+    if (fetched.length() > 0 && !looks_like_skill(fetched)) {
+        // Fetched something, but not the skill. Fall through to the cache
+        // rather than trusting it, and leave the cache alone.
+        report_progress(`the skill URL returned ${fetched.length()} bytes that do not look like the skill`);
+    } else if (fetched.length() > 0) {
         let _ = baml.fs.write(cache_file, fetched) catch_all (_) {
             _ => null,
         };

--- a/tools/stdlib-matrix/baml_src/ts_symbols.baml
+++ b/tools/stdlib-matrix/baml_src/ts_symbols.baml
@@ -160,59 +160,56 @@ function extract_ts_symbols(doc: TsSurfaceDoc) -> TsSymbol[] {
     for (let module in doc.modules) {
         for (let container in module.containers) {
             let container_id = ts_container_id(module, container);
-            symbols
-                .push(
-                    TsSymbol {
-                        id: container_id,
-                        symbol: [module.name, container.name],
-                        display: ts_display_of(container_id),
-                        kind: container.kind,
-                        origin: "container",
-                        signature: ts_container_signature(container),
-                        doc: container.doc,
-                        since: container.since,
-                        references: [],
-                    },
-                );
+            symbols.push(
+                TsSymbol {
+                    id: container_id,
+                    symbol: [module.name, container.name],
+                    display: ts_display_of(container_id),
+                    kind: container.kind,
+                    origin: "container",
+                    signature: ts_container_signature(container),
+                    doc: container.doc,
+                    since: container.since,
+                    references: [],
+                },
+            );
             for (let member in container.members) {
                 let origin = ts_member_origin(member);
                 let member_id = ts_member_id(module, container, member);
-                symbols
-                    .push(
-                        TsSymbol {
-                            id: member_id,
-                            symbol: [module.name, container.name, member.name],
-                            display: ts_display_of(member_id),
-                            kind: ts_member_kind(origin),
-                            origin: origin,
-                            signature: ts_signature_of(member.signatures),
-                            doc: member.doc,
-                            since: member.since,
-                            references: [],
-                        },
-                    );
+                symbols.push(
+                    TsSymbol {
+                        id: member_id,
+                        symbol: [module.name, container.name, member.name],
+                        display: ts_display_of(member_id),
+                        kind: ts_member_kind(origin),
+                        origin: origin,
+                        signature: ts_signature_of(member.signatures),
+                        doc: member.doc,
+                        since: member.since,
+                        references: [],
+                    },
+                );
             }
         }
         for (let declared in module.functions) {
             let function_id = ts_function_id(module, declared);
-            symbols
-                .push(
-                    TsSymbol {
-                        id: function_id,
-                        symbol: [module.name, declared.name],
-                        display: ts_display_of(function_id),
-                        kind: if (ts_is_callable(declared.signatures)) {
-                            "function"
-                        } else {
-                            "property"
-                        },
-                        origin: "free",
-                        signature: ts_signature_of(declared.signatures),
-                        doc: declared.doc,
-                        since: declared.since,
-                        references: [],
+            symbols.push(
+                TsSymbol {
+                    id: function_id,
+                    symbol: [module.name, declared.name],
+                    display: ts_display_of(function_id),
+                    kind: if (ts_is_callable(declared.signatures)) {
+                        "function"
+                    } else {
+                        "property"
                     },
-                );
+                    origin: "free",
+                    signature: ts_signature_of(declared.signatures),
+                    doc: declared.doc,
+                    since: declared.since,
+                    references: [],
+                },
+            );
         }
     }
     attach_ts_references(symbols);

--- a/tools/stdlib-matrix/extractors/ts-surface.mjs
+++ b/tools/stdlib-matrix/extractors/ts-surface.mjs
@@ -380,6 +380,12 @@ function walkLibFile(filePath, isDom) {
           // literal, and only the first was ever recognized: every web class
           // came out an interface with none of its statics.
           if (!allowContainers.has(valueName)) continue;
+          // A namespace object's constructor is not a container of its own. The
+          // DOM declares `interface Performance`, `declare var Performance: {…}`
+          // *and* `declare var performance: Performance`; without this, the
+          // middle one minted a second container holding nothing but
+          // `prototype`, and `(web)` reported 34 containers for 33 names.
+          if (SINGLETONS.has(valueName)) continue;
           const container = containerFor(module, valueName, "class", since);
           for (const member of decl.type.members) {
             addMember(container, member, sourceFile, { since, isStatic: true });
@@ -414,13 +420,35 @@ function walkNodeModuleFile(filePath) {
   const text = fs.readFileSync(filePath, "utf8");
   const sourceFile = ts.createSourceFile(filePath, text, ts.ScriptTarget.Latest, false);
 
-  function visitModuleBody(bareName, body) {
+  function visitModuleBody(bareName, body, nested = false) {
     const module = moduleFor(`node:${bareName}`, "node");
     const containerInterfaces = NODE_CONTAINER_INTERFACES.get(bareName);
     const pooledInterfaces = NODE_MODULE_INTERFACES.get(bareName);
     for (const stmt of body.statements ?? []) {
       if (ts.isFunctionDeclaration(stmt) && stmt.name) {
-        addFunction(module, stmt, sourceFile, "node");
+        // Only at the module's own level. Node declares overload helpers as
+        // `export namespace readFile { function __promisify__(…) }`, 67 of them
+        // in `fs` alone — pooling those upward invented `fs.__promisify__` and
+        // `fs.native` as stdlib symbols (each judged by a model, at cost) while
+        // merging 56 unrelated declarations under one id, destroying the real
+        // `fs.readFile.__promisify__`.
+        if (!nested) addFunction(module, stmt, sourceFile, "node");
+      } else if (ts.isVariableStatement(stmt)) {
+        // `export const EOL: string`. Reached on the module exactly as its
+        // functions are, and dropped entirely until now — `os.EOL` and
+        // `os.devNull` were both absent.
+        //
+        // `os.constants` stays out: it is a `namespace` of nested namespaces,
+        // not a value, so there is no declaration to record. The comment that
+        // used to sit below claimed `os.constants.signals` was reachable
+        // through the module; it never was.
+        if (!nested) {
+          for (const decl of stmt.declarationList.declarations) {
+            if (ts.isIdentifier(decl.name)) {
+              addPooledMember(module, decl, sourceFile);
+            }
+          }
+        }
       } else if (ts.isClassDeclaration(stmt) && stmt.name) {
         const container = containerFor(module, stmt.name.text, "class", "node");
         container.doc ??= jsdocDescription(stmt, sourceFile);
@@ -450,10 +478,11 @@ function walkNodeModuleFile(filePath) {
           }
         }
       } else if (ts.isModuleDeclaration(stmt) && stmt.body && ts.isModuleBlock(stmt.body)) {
-        // `namespace fs { … }` inside `declare module "fs"`, and `declare
-        // namespace NodeJS`. Flattened into the module: a reader reaches
-        // `os.constants.signals` through `os`, not through a nested scope.
-        visitModuleBody(bareName, stmt.body);
+        // Descended into for the interfaces it may hold — `process`'s API lives
+        // in `declare namespace NodeJS { interface Process }` — but marked
+        // nested, so the functions and values inside stay where they are
+        // declared rather than being pooled onto the module.
+        visitModuleBody(bareName, stmt.body, true);
       }
     }
   }

--- a/tools/stdlib-matrix/run
+++ b/tools/stdlib-matrix/run
@@ -43,7 +43,7 @@ existing data/ files instead.
 developer would do instead, looking the answer up with `baml describe`,
 `baml describe --search`, the repository's own call sites, and the type system
 reference. Nothing else produces a judgement: without --llm every symbol comes
-out unjudged. Requires ANTHROPIC_API_KEY in the environment.
+out unjudged. Requires OPENAI_API_KEY in the environment.
 
 --previous PATH carries judgements forward from an earlier report. A symbol
 keeps its previous answer when it and every type it names are unchanged, so a
@@ -248,8 +248,8 @@ if ((check_only == 1)); then
     target="check_matrix"
     target_args+=(--baseline_file "${baseline_file}")
 elif ((use_llm == 1)); then
-    if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
-        echo "stdlib-matrix: --llm requires ANTHROPIC_API_KEY in the environment" >&2
+    if [[ -z "${OPENAI_API_KEY:-}" ]]; then
+        echo "stdlib-matrix: --llm requires OPENAI_API_KEY in the environment" >&2
         exit 2
     fi
     target="build_matrix_aligned"

--- a/typescript2/app-stdlib-matrix/src/components/matrix-app.ts
+++ b/typescript2/app-stdlib-matrix/src/components/matrix-app.ts
@@ -60,6 +60,12 @@ function legendFor(side: Side): ReadonlyArray<readonly [string, string]> {
 }
 
 /**
+ * The report shape this build understands. Bumped by the producer whenever the
+ * relation changes — v2 moved the judgement key to the TypeScript side.
+ */
+const REPORT_FORMAT = 2;
+
+/**
  * Which report to load, given whatever `?src=` said.
  *
  * A relative path only, resolved against this page. The parameter exists so one
@@ -71,12 +77,25 @@ function legendFor(side: Side): ReadonlyArray<readonly [string, string]> {
 export function reportSource(requested: string | null): string {
   const fallback = './matrix.json';
   if (requested === null || requested.length === 0) return fallback;
-  // Anything the URL parser accepts as absolute — including a scheme-relative
-  // `//host/x` — names an origin, and so is refused.
-  const resolved = new URL(requested, location.href);
-  return resolved.origin === location.origin
-    ? resolved.pathname + resolved.search
-    : fallback;
+  let resolved: URL;
+  try {
+    // Anything the URL parser accepts as absolute — including a scheme-relative
+    // `//host/x` — names an origin, and so is refused.
+    resolved = new URL(requested, location.href);
+  } catch {
+    // The parser rejects some inputs outright (`http://[`). Throwing here would
+    // escape `connectedCallback` and leave the page on "Loading…" forever,
+    // since the load's own error handling is downstream of this call.
+    return fallback;
+  }
+  if (resolved.origin !== location.origin) return fallback;
+  // The resolved URL, not a path rebuilt from its parts. Returning
+  // `pathname + search` passed the origin check and then threw the origin
+  // away: a `..` that pops past the root leaves a pathname beginning with
+  // `//`, and `fetch("//host/x")` is scheme-relative, not a path. So
+  // `?src=/..//evil.example/matrix.json` cleared the check and then fetched
+  // evil.example — the precise thing this function exists to prevent.
+  return resolved.href;
 }
 
 export class MatrixAppElement extends LitElement {
@@ -169,15 +188,33 @@ export class MatrixAppElement extends LitElement {
     this.target = { ...ref, nonce: this.#requests };
   }
 
-  /** `#<side>/<name>`, when the report knows that name. */
+  /**
+   * `#<side>/<name>`, when the report knows that name.
+   *
+   * Everything here is best-effort: the fragment is whatever was in the address
+   * bar, and a bad one must not cost the reader the report. It used to: this
+   * runs inside `#load`'s try, *after* the matrix is assigned, so a fragment
+   * like `#ts/%zz` made `decodeURIComponent` throw and the page reported
+   * "Could not load ./matrix.json — URI malformed" over a report that had
+   * loaded perfectly. Via `popstate` the same throw was uncaught entirely.
+   */
   #followHash() {
     const raw = location.hash.slice(1);
     const index = this.matrix ? SymbolIndex.for(this.matrix) : null;
     if (raw.length === 0 || !index) return;
     const cut = raw.indexOf('/');
+    // No separator means no name. `slice(0, -1)` would drop the last character
+    // and read `#tsX` as side `ts`, which is a different symbol's address.
+    if (cut < 0) return;
     const side = raw.slice(0, cut);
     if (side !== 'baml' && side !== 'ts') return;
-    const ref = index.resolve(side, decodeURIComponent(raw.slice(cut + 1)));
+    let name: string;
+    try {
+      name = decodeURIComponent(raw.slice(cut + 1));
+    } catch {
+      return;
+    }
+    const ref = index.resolve(side, name);
     if (ref) this.#focus(ref);
   }
 
@@ -187,6 +224,16 @@ export class MatrixAppElement extends LitElement {
       if (!response.ok)
         throw new Error(`${response.status} ${response.statusText}`);
       const matrix = (await response.json()) as SymbolMatrix;
+      // The producer refuses a report it cannot read, and so does the workflow;
+      // this is the third consumer and the only public one. Rendering a shape
+      // this build does not understand is worse than saying so — the fields it
+      // still recognises would draw a plausible page over the wrong data.
+      if (matrix.format_version !== REPORT_FORMAT) {
+        this.error =
+          `${source} is report format v${matrix.format_version}; this page reads ` +
+          `v${REPORT_FORMAT}. Rebuild it with tools/stdlib-matrix/run.`;
+        return;
+      }
       this.#links = new Links(matrix);
       this.matrix = matrix;
       this.#followHash();


### PR DESCRIPTION
- Various hardening passes
- Use an openai key since the anthropic one is dead
- Don't break on old client/retry policy syntax
- Identify impls as owners for interface methods instead of classes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added report format versioning with clear handling for unsupported versions.
  - Improved symbol search with whole-word matching, Unicode and camelCase support, filtering, and deterministic results.
  - Added safer navigation for malformed report links and fragments.

- **Bug Fixes**
  - Prevented duplicate or incorrectly promoted TypeScript declarations in generated reports.
  - Improved validation and recovery when loading skills and processing matrix findings.
  - Updated matrix analysis to use OpenAI with retry support.

- **Documentation**
  - Updated setup and usage guidance for OpenAI API key configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->