### PR TITLE
fmt: accept struct-update spread in object literals (B-900)

### DIFF
--- a/baml_language/crates/baml_fmt/src/ast/expressions.rs
+++ b/baml_language/crates/baml_fmt/src/ast/expressions.rs
@@ -3745,7 +3745,9 @@ impl Printable for ArrayInitializer {
 pub struct ObjectInitializer {
     pub name: PathExpr,
     pub open_brace: t::LBrace,
-    pub fields: Vec<(ObjectField, Option<t::Comma>)>,
+    /// Fields and `...spread` members, in source order. Order is significant:
+    /// later members win at runtime, so it must be preserved verbatim.
+    pub fields: Vec<(ObjectMember, Option<t::Comma>)>,
     pub close_brace: t::RBrace,
 }
 
@@ -3771,8 +3773,8 @@ impl FromCST for ObjectInitializer {
                 SyntaxKind::R_BRACE => {
                     break t::RBrace::from_cst(elem)?;
                 }
-                SyntaxKind::OBJECT_FIELD => {
-                    let field = ObjectField::from_cst(elem)?;
+                SyntaxKind::OBJECT_FIELD | SyntaxKind::SPREAD_ELEMENT => {
+                    let field = ObjectMember::from_cst(elem)?;
                     let comma = it
                         .next_if_kind(SyntaxKind::COMMA)
                         .map(t::Comma::from_cst)
@@ -3781,7 +3783,7 @@ impl FromCST for ObjectInitializer {
                 }
                 _ => {
                     return Err(StrongAstError::UnexpectedKindDesc {
-                        expected_desc: "OBJECT_FIELD or R_BRACE".into(),
+                        expected_desc: "OBJECT_FIELD, SPREAD_ELEMENT, or R_BRACE".into(),
                         found: elem.kind(),
                         at: elem.text_range(),
                     });
@@ -4300,6 +4302,132 @@ impl Printable for ObjectField {
             .as_ref()
             .map(Printable::rightmost_token)
             .unwrap_or_else(|| self.name.rightmost_token())
+    }
+}
+
+/// A member of an [`ObjectInitializer`]: either a `name: value` field or a
+/// `...expr` spread element.
+///
+/// Only [`SyntaxKind::OBJECT_LITERAL`] admits spreads; map literals and array
+/// literals keep using [`ObjectField`] directly.
+#[derive(Debug)]
+pub enum ObjectMember {
+    Field(ObjectField),
+    Spread(SpreadElement),
+}
+
+impl FromCST for ObjectMember {
+    fn from_cst(elem: SyntaxElement) -> Result<Self, StrongAstError> {
+        match elem.kind() {
+            SyntaxKind::OBJECT_FIELD => Ok(ObjectMember::Field(ObjectField::from_cst(elem)?)),
+            SyntaxKind::SPREAD_ELEMENT => Ok(ObjectMember::Spread(SpreadElement::from_cst(elem)?)),
+            _ => Err(StrongAstError::UnexpectedKindDesc {
+                expected_desc: "OBJECT_FIELD or SPREAD_ELEMENT".into(),
+                found: elem.kind(),
+                at: elem.text_range(),
+            }),
+        }
+    }
+}
+
+impl ObjectMember {
+    /// Returns the width of the member if it fits on a single line.
+    /// Returns `None` if it can never be single-lined.
+    pub(crate) fn single_line_width(&self, input: &Printer<'_>) -> Option<usize> {
+        match self {
+            ObjectMember::Field(field) => field.single_line_width(input),
+            ObjectMember::Spread(spread) => spread.single_line_width(input),
+        }
+    }
+}
+
+impl Printable for ObjectMember {
+    fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        match self {
+            ObjectMember::Field(field) => field.print(shape, printer),
+            ObjectMember::Spread(spread) => spread.print(shape, printer),
+        }
+    }
+    fn leftmost_token(&self) -> TextRange {
+        match self {
+            ObjectMember::Field(field) => field.leftmost_token(),
+            ObjectMember::Spread(spread) => spread.leftmost_token(),
+        }
+    }
+    fn rightmost_token(&self) -> TextRange {
+        match self {
+            ObjectMember::Field(field) => field.rightmost_token(),
+            ObjectMember::Spread(spread) => spread.rightmost_token(),
+        }
+    }
+}
+
+/// Corresponds to a [`SyntaxKind::SPREAD_ELEMENT`] node.
+///
+/// Struct-update spread inside an object literal: `Type { ...base, field: v }`.
+#[derive(Debug)]
+pub struct SpreadElement {
+    pub dot_dot_dot: t::DotDotDot,
+    pub value: Expression,
+}
+
+impl FromCST for SpreadElement {
+    fn from_cst(elem: SyntaxElement) -> Result<Self, StrongAstError> {
+        let node = StrongAstError::assert_is_node(elem)?;
+        StrongAstError::assert_kind_node(&node, SyntaxKind::SPREAD_ELEMENT)?;
+
+        let mut it = SyntaxNodeIter::new(&node);
+
+        let dot_dot_dot = it.expect_parse()?;
+        let value = it.expect_next("spread value")?;
+        let value = Expression::from_cst(value)?;
+
+        it.expect_end()?;
+
+        Ok(SpreadElement { dot_dot_dot, value })
+    }
+}
+
+impl KnownKind for SpreadElement {
+    fn kind() -> SyntaxKind {
+        SyntaxKind::SPREAD_ELEMENT
+    }
+}
+
+impl SpreadElement {
+    /// Returns the width of the expression if it fits on a single line.
+    /// Returns `None` if it can never be single-lined.
+    pub(crate) fn single_line_width(&self, input: &Printer<'_>) -> Option<usize> {
+        // Must match the trivia handled by `print`: dots_trailing + value_leading.
+        let mut trivia_len = 0usize;
+        let (_, dots_trailing) = input.trivia.get_for_range_split(self.dot_dot_dot.span());
+        for t in dots_trailing {
+            trivia_len += t.single_line_len(input.input)?;
+        }
+        let value_leading = input.trivia.get_leading_for_element(&self.value);
+        for t in value_leading {
+            trivia_len += t.single_line_len(input.input)?;
+        }
+        let value_width = self.value.single_line_width(input)?;
+        Some(const { "...".len() } + value_width + trivia_len)
+    }
+}
+
+impl Printable for SpreadElement {
+    fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        // No space after `...` — it binds tightly to its operand.
+        printer.print_raw_token(&self.dot_dot_dot);
+        let (_, dots_trailing) = printer.trivia.get_for_range_split(self.dot_dot_dot.span());
+        printer.print_trivia_squished(dots_trailing);
+        let value_leading = printer.trivia.get_leading_for_element(&self.value);
+        printer.print_trivia_squished(value_leading);
+        printer.print(&self.value, shape)
+    }
+    fn leftmost_token(&self) -> TextRange {
+        self.dot_dot_dot.span()
+    }
+    fn rightmost_token(&self) -> TextRange {
+        self.value.rightmost_token()
     }
 }
 

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -196,7 +196,7 @@ mod object_spread_tests {
 
     /// Struct-update spread (`Type { ...base, field: v }`) compiles, but the
     /// object printer used to reject it outright: "Expected token/node
-    /// OBJECT_FIELD or R_BRACE, but found SPREAD_ELEMENT".
+    /// `OBJECT_FIELD` or `R_BRACE`, but found `SPREAD_ELEMENT`".
     #[test]
     fn test_spread_formats_and_is_idempotent() {
         let source = concat!(

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -191,6 +191,133 @@ mod llm_tools_field_tests {
 }
 
 #[cfg(test)]
+mod object_spread_tests {
+    use super::*;
+
+    /// Struct-update spread (`Type { ...base, field: v }`) compiles, but the
+    /// object printer used to reject it outright: "Expected token/node
+    /// OBJECT_FIELD or R_BRACE, but found SPREAD_ELEMENT".
+    #[test]
+    fn test_spread_formats_and_is_idempotent() {
+        let source = concat!(
+            "class P {\n",
+            "    name: string,\n",
+            "    score: int,\n",
+            "}\n",
+            "\n",
+            "function f(p: P) -> P {\n",
+            "    P { ...p, score: 1 }\n",
+            "}\n",
+        );
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("class spread should format");
+        assert!(
+            formatted.contains("P { ...p, score: 1 }"),
+            "spread preserved without a space after `...`: {formatted}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    /// Member order is semantic — later members win at runtime, so
+    /// `P { score: 9, ...p }` and `P { ...p, score: 9 }` evaluate differently.
+    /// The formatter must never reorder them, and must keep multiple spreads.
+    #[test]
+    fn test_spread_and_field_order_is_preserved() {
+        let options = FormatOptions::default();
+        for (source_expr, expected) in [
+            ("P { ...p, score: 9 }", "P { ...p, score: 9 }"),
+            ("P { score: 9, ...p }", "P { score: 9, ...p }"),
+            ("P { ...a, ...b }", "P { ...a, ...b }"),
+            ("P { ...a, score: 1, ...b }", "P { ...a, score: 1, ...b }"),
+        ] {
+            let source = format!(
+                concat!(
+                    "class P {{\n",
+                    "    name: string,\n",
+                    "    score: int,\n",
+                    "}}\n",
+                    "\n",
+                    "function f(p: P, a: P, b: P) -> P {{\n",
+                    "    {source_expr}\n",
+                    "}}\n",
+                ),
+                source_expr = source_expr
+            );
+            let formatted = format(&source, &options)
+                .unwrap_or_else(|e| panic!("`{source_expr}` should format: {e:?}"));
+            assert!(
+                formatted.contains(expected),
+                "order preserved for `{source_expr}`, got: {formatted}"
+            );
+            let second = format(&formatted, &options).expect("formatter should be idempotent");
+            assert_eq!(formatted, second, "idempotent for `{source_expr}`");
+        }
+    }
+
+    /// A spread wide enough to break must survive the multi-line path too,
+    /// and comments attached to a spread member must not be dropped.
+    #[test]
+    fn test_spread_multi_line_and_comments() {
+        let source = concat!(
+            "class Config {\n",
+            "    alpha: string,\n",
+            "    beta: string,\n",
+            "    gamma: string,\n",
+            "}\n",
+            "\n",
+            "function f(base: Config) -> Config {\n",
+            "    Config {\n",
+            "        // inherit everything from the base configuration first\n",
+            "        ...base,\n",
+            "        alpha: \"a much longer override value to force the multi-line path\",\n",
+            "        beta: \"another fairly long override value so this cannot fit\",\n",
+            "    }\n",
+            "}\n",
+        );
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("multi-line spread should format");
+        assert!(
+            formatted.contains("...base,"),
+            "spread member preserved on its own line: {formatted}"
+        );
+        assert!(
+            formatted.contains("// inherit everything from the base configuration first"),
+            "comment above the spread preserved: {formatted}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+
+    /// The spread operand is an arbitrary expression, not just a name.
+    #[test]
+    fn test_spread_of_call_expression() {
+        let source = concat!(
+            "class P {\n",
+            "    name: string,\n",
+            "    score: int,\n",
+            "}\n",
+            "\n",
+            "function base() -> P {\n",
+            "    P { name: \"b\", score: 0 }\n",
+            "}\n",
+            "\n",
+            "function f() -> P {\n",
+            "    P { ...base(), score: 1 }\n",
+            "}\n",
+        );
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("spread of a call should format");
+        assert!(
+            formatted.contains("P { ...base(), score: 1 }"),
+            "call operand preserved: {formatted}"
+        );
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+    }
+}
+
+#[cfg(test)]
 mod contextual_keyword_identifier_tests {
     use super::*;
 


### PR DESCRIPTION
Fixes [B-900](https://linear.app/boundaryml2/issue/B-900/baml-fmt-rejects-valid-typed-class-spread-expressions-spread-element).

## Problem

`baml fmt` rejected any object literal containing a `...spread` member:

```
error: while formatting: Expected token/node OBJECT_FIELD or R_BRACE, but found SPREAD_ELEMENT
```

The syntax parses and type-checks, so `baml check` and `baml test` passed on files `baml fmt` refused to format at all. Two-line repro:

```baml
class P { name: string, score: int }
function f(p: P) -> P { P { ...p, score: 1 } }
```

## Cause

`ObjectInitializer::from_cst` in `baml_fmt` only admitted `OBJECT_FIELD` nodes, so a `SPREAD_ELEMENT` sibling fell through to the catch-all error arm.

## Fix

Added an `ObjectMember` enum (`Field | Spread`) and a `SpreadElement` strong-AST node, and widened the object-literal member list to hold either.

Members stay in one ordered list rather than being split into "spreads" and "fields", because **order is semantic** — later members win at runtime, so `P { score: 9, ...p }` evaluates to `1` while `P { ...p, score: 9 }` evaluates to `9`. Splitting them would silently change program behavior. `...` prints tight against its operand.

The change is scoped to `OBJECT_LITERAL`, the only node where the parser emits `SPREAD_ELEMENT` (`parse_object_literal_body` is its sole caller). Map and array literals reject spread at parse time, so they keep using `ObjectField` directly.

## Tests

Four regression tests in `object_spread_tests`, each asserting idempotency:

- single-line spread round-trips as `P { ...p, score: 1 }`
- order preserved across `...p, score`, `score, ...p`, `...a, ...b`, and `...a, score, ...b`
- multi-line path with a comment above the spread member
- spread of a call expression (`...base()`), not just a bare name

Full suite: **124 passed, 0 failed** — 120 pre-existing plus these 4, including the 1024-case `formatter_scenario_matrix`.

## Verification

Formatting a messy input now produces stable output, and a second pass is a no-op:

```baml
function tight(p: Config) -> Config {
    Config { ...p, alpha: "x" }
}

function wide(base: Config) -> Config {
    Config {
        // inherit everything from base first
        ...base,
        alpha: "a much longer override value that forces the multi-line path here",
    }
}
```

Also confirmed against the case that surfaced this: Example 2 of `plugins/baml/skills/core/SKILL.md` in the `baml-skill` repo now passes `baml fmt`, `baml check`, and `baml test`. That example demonstrates spread while the same skill instructs agents to run `baml fmt`, so the guidance was self-contradicting until this landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WeFQbEGpSJjzM79LHJ8du

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Formatter-only change scoped to object-literal AST/printing; no language semantics, auth, or data-handling paths are modified.
> 
> **Overview**
> **`baml fmt` now formats object literals that contain `...spread` members**, which previously failed with an unexpected `SPREAD_ELEMENT` error even though the syntax already parsed and type-checked.
> 
> `ObjectInitializer` members are modeled as an ordered `ObjectMember` list (`Field | Spread`) so field/spread order is preserved — later members win at runtime. Spreads print tight against their operand (`...expr`), including call expressions, on both single- and multi-line layouts.
> 
> Adds regression tests covering order preservation, multi-line comments, call operands, and formatter idempotency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9058c10eabe9f686617bcd50b46894fc86bd32f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for object spread syntax (`...expression`) in object initializers.
  * Preserved the original order of fields, spread elements, and comments when formatting.
  * Supported spreads across single-line and multi-line object formatting.
  * Enabled arbitrary spread expressions, including function calls.

* **Bug Fixes**
  * Improved validation messages for object initializer members.
  * Ensured formatting remains consistent when run repeatedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->