### PR TITLE
Math ops for `baml.time.*`

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_time/duration.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_time/duration.baml
@@ -99,3 +99,75 @@ class Duration {
         self._nanoseconds / 3600000000000
     }
 }
+
+implement root.ops.Add<Duration> for Duration {
+    type Output = Duration
+    function add(self, other: Duration) -> Duration throws never {
+        Duration {
+            _nanoseconds: self._nanoseconds + other._nanoseconds,
+        }
+    }
+}
+
+implement root.ops.Subtract<Duration> for Duration {
+    type Output = Duration
+    function sub(self, other: Duration) -> Duration throws never {
+        Duration {
+            _nanoseconds: self._nanoseconds - other._nanoseconds,
+        }
+    }
+}
+
+implement root.ops.Multiply<int> for Duration {
+    type Output = Duration
+    function mul(self, other: int) -> Duration throws never {
+        Duration {
+            _nanoseconds: self._nanoseconds * other,
+        }
+    }
+}
+
+implement root.ops.Multiply<bigint> for Duration {
+    type Output = Duration
+    function mul(self, other: bigint) -> Duration throws never {
+        Duration {
+            _nanoseconds: self._nanoseconds * other,
+        }
+    }
+}
+
+implement root.ops.Divide<int> for Duration {
+    type Output = Duration
+    function div(self, other: int) -> Duration throws never {
+        Duration {
+            _nanoseconds: self._nanoseconds / other,
+        }
+    }
+}
+
+implement root.ops.Divide<bigint> for Duration {
+    type Output = Duration
+    function div(self, other: bigint) -> Duration throws never {
+        Duration {
+            _nanoseconds: self._nanoseconds / other,
+        }
+    }
+}
+
+implement root.ops.Remainder<Duration> for Duration {
+    type Output = Duration
+    function rem(self, other: Duration) -> Duration throws never {
+        Duration {
+            _nanoseconds: self._nanoseconds % other._nanoseconds,
+        }
+    }
+}
+
+implement root.ops.Negate for Duration {
+    type Output = Duration
+    function neg(self) -> Duration throws never {
+        Duration {
+            _nanoseconds: -self._nanoseconds
+        }
+    }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_time/instant.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_time/instant.baml
@@ -176,3 +176,30 @@ class Instant {
         Instant { _nanoseconds: 0n }
     }
 }
+
+implement root.ops.Add<Duration> for Instant {
+    type Output = Instant
+    function add(self, other: Duration) -> Instant {
+        Instant {
+            _nanoseconds: self._nanoseconds + other._nanoseconds
+        }
+    }
+}
+
+implement root.ops.Subtract<Duration> for Instant {
+    type Output = Instant
+    function sub(self, other: Duration) -> Instant {
+        Instant {
+            _nanoseconds: self._nanoseconds - other._nanoseconds
+        }
+    }
+}
+
+implement root.ops.Subtract<Instant> for Instant {
+    type Output = Duration
+    function sub(self, other: Instant) -> Duration {
+        Duration {
+            _nanoseconds: self._nanoseconds - other._nanoseconds
+        }
+    }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_time/plaindatetime.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_time/plaindatetime.baml
@@ -228,3 +228,30 @@ class PlainDateTime {
         }
     }
 }
+
+implement root.ops.Add<Duration> for PlainDateTime {
+    type Output = PlainDateTime
+    function add(self, other: Duration) -> PlainDateTime {
+        PlainDateTime {
+            _nanoseconds: self._nanoseconds + other._nanoseconds
+        }
+    }
+}
+
+implement root.ops.Subtract<Duration> for PlainDateTime {
+    type Output = PlainDateTime
+    function sub(self, other: Duration) -> PlainDateTime {
+        PlainDateTime {
+            _nanoseconds: self._nanoseconds - other._nanoseconds
+        }
+    }
+}
+
+implement root.ops.Subtract<PlainDateTime> for PlainDateTime {
+    type Output = Duration
+    function sub(self, other: PlainDateTime) -> Duration {
+        Duration {
+            _nanoseconds: self._nanoseconds - other._nanoseconds
+        }
+    }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_time/plaintime.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_time/plaintime.baml
@@ -100,3 +100,52 @@ class PlainTime {
         }
     }
 }
+
+/// Adding a `Duration` wraps around midnight: a `PlainTime` has no date to
+/// carry into, so `23:00 + 2h` is `01:00`, not a next-day value.
+implement root.ops.Add<Duration> for PlainTime {
+    type Output = PlainTime
+    function add(self, other: Duration) -> PlainTime {
+        PlainTime {
+            _nanoseconds: _wrap_into_day(self._nanoseconds + other._nanoseconds),
+        }
+    }
+}
+
+/// Wraps like [`Add`]: `01:00 - 2h` is `23:00`.
+implement root.ops.Subtract<Duration> for PlainTime {
+    type Output = PlainTime
+    function sub(self, other: Duration) -> PlainTime {
+        PlainTime {
+            _nanoseconds: _wrap_into_day(self._nanoseconds - other._nanoseconds),
+        }
+    }
+}
+
+/// The signed gap between two wall-clock times, which does *not* wrap: the
+/// result is negative when `other` is later in the day than `self`.
+implement root.ops.Subtract<PlainTime> for PlainTime {
+    type Output = Duration
+    function sub(self, other: PlainTime) -> Duration {
+        Duration {
+            _nanoseconds: 0n + (self._nanoseconds - other._nanoseconds),
+        }
+    }
+}
+
+/// Internal: reduce `total_ns` to nanoseconds-since-midnight in `[0, 24h)`.
+///
+/// Written `((n % day) + day) % day` rather than `n % day` because `%` keeps
+/// the sign of the left operand, so a negative `total_ns` would otherwise stay
+/// negative and break `PlainTime`'s range invariant.
+function _wrap_into_day(total_ns: bigint) -> int throws never {
+    let day_ns = 86400000000000n;
+    let wrapped = ((total_ns % day_ns) + day_ns) % day_ns;
+    // `wrapped` is in `[0, 24h)`, i.e. under 2^47 ns, so it always fits an int.
+    {
+        wrapped.to_int()
+    } catch (e) {
+        root.errors.InvalidArgument => baml.sys
+            .panic("unreachable: nanoseconds wrapped into [0, 24h) exceed int range")
+    }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_time/zoneddatetime.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_time/zoneddatetime.baml
@@ -268,3 +268,34 @@ function _format_zoned(
 ) -> string throws root.errors.InvalidArgument {
     $rust_function
 }
+
+implement root.ops.Add<Duration> for ZonedDateTime {
+    type Output = ZonedDateTime
+    function add(self, other: Duration) -> ZonedDateTime {
+        ZonedDateTime {
+            _nanoseconds: self._nanoseconds + other._nanoseconds,
+            _offset_ns: self._offset_ns,
+            _iana: self._iana,
+        }
+    }
+}
+
+implement root.ops.Subtract<Duration> for ZonedDateTime {
+    type Output = ZonedDateTime
+    function sub(self, other: Duration) -> ZonedDateTime {
+        ZonedDateTime {
+            _nanoseconds: self._nanoseconds - other._nanoseconds,
+            _offset_ns: self._offset_ns,
+            _iana: self._iana,
+        }
+    }
+}
+
+implement root.ops.Subtract<ZonedDateTime> for ZonedDateTime {
+    type Output = Duration
+    function sub(self, other: ZonedDateTime) -> Duration {
+        Duration {
+            _nanoseconds: self._nanoseconds - other._nanoseconds,
+        }
+    }
+}

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -272,6 +272,7 @@ class            baml.time.Instant                <builtin>/baml/ns_time/instant
 class            baml.time.PlainDate              <builtin>/baml/ns_time/plaindate.baml:5
 class            baml.time.PlainDateTime          <builtin>/baml/ns_time/plaindatetime.baml:7
 class            baml.time.PlainTime              <builtin>/baml/ns_time/plaintime.baml:4
+function         baml.time._wrap_into_day         <builtin>/baml/ns_time/plaintime.baml:141
 type             baml.time.Disambiguation         <builtin>/baml/ns_time/timezone.baml:5
 class            baml.time.UnknownTimezoneError   <builtin>/baml/ns_time/timezone.baml:9
 class            baml.time.AmbiguousTimeError     <builtin>/baml/ns_time/timezone.baml:15

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_render__tests__renders_builtin_class_with_impls.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_render__tests__renders_builtin_class_with_impls.snap
@@ -25,6 +25,14 @@ methods:
       Returns the number of minutes in `self`.
   function to_hours(self) -> bigint
       Returns the number of hours in `self`.
+  function add(self, other: baml.time.Duration) -> baml.time.Duration
+  function sub(self, other: baml.time.Duration) -> baml.time.Duration
+  function mul(self, other: int) -> baml.time.Duration
+  function mul(self, other: bigint) -> baml.time.Duration
+  function div(self, other: int) -> baml.time.Duration
+  function div(self, other: bigint) -> baml.time.Duration
+  function rem(self, other: baml.time.Duration) -> baml.time.Duration
+  function neg(self) -> baml.time.Duration
 
 static methods:
   function from_nanoseconds(ns: int | bigint) -> baml.time.Duration
@@ -39,6 +47,32 @@ static methods:
       Creates a new duration of `m` minutes.
   function from_hours(h: int | bigint) -> baml.time.Duration
       Creates a new duration of `h` hours.
+
+implements:
+  implements baml.ops.Add for baml.time.Duration   (<builtin>/baml/ns_time/duration.baml:103)
+    type Output = baml.time.Duration
+    function add(self, other: baml.time.Duration) -> baml.time.Duration
+  implements baml.ops.Divide for baml.time.Duration   (<builtin>/baml/ns_time/duration.baml:139)
+    type Output = baml.time.Duration
+    function div(self, other: int) -> baml.time.Duration
+  implements baml.ops.Divide for baml.time.Duration   (<builtin>/baml/ns_time/duration.baml:148)
+    type Output = baml.time.Duration
+    function div(self, other: bigint) -> baml.time.Duration
+  implements baml.ops.Multiply for baml.time.Duration   (<builtin>/baml/ns_time/duration.baml:121)
+    type Output = baml.time.Duration
+    function mul(self, other: int) -> baml.time.Duration
+  implements baml.ops.Multiply for baml.time.Duration   (<builtin>/baml/ns_time/duration.baml:130)
+    type Output = baml.time.Duration
+    function mul(self, other: bigint) -> baml.time.Duration
+  implements baml.ops.Negate for baml.time.Duration   (<builtin>/baml/ns_time/duration.baml:166)
+    type Output = baml.time.Duration
+    function neg(self) -> baml.time.Duration
+  implements baml.ops.Remainder for baml.time.Duration   (<builtin>/baml/ns_time/duration.baml:157)
+    type Output = baml.time.Duration
+    function rem(self, other: baml.time.Duration) -> baml.time.Duration
+  implements baml.ops.Subtract for baml.time.Duration   (<builtin>/baml/ns_time/duration.baml:112)
+    type Output = baml.time.Duration
+    function sub(self, other: baml.time.Duration) -> baml.time.Duration
 
 blanket implementations:
   baml.Concrete   (<builtin>/baml/core.baml:13)

--- a/baml_language/crates/baml_project/src/client_codegen.rs
+++ b/baml_language/crates/baml_project/src/client_codegen.rs
@@ -203,6 +203,29 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
                     continue;
                 }
 
+                // Interface-impl methods are not part of the generated surface.
+                // Interfaces themselves are never emitted — host languages differ
+                // too much on trait/protocol/interface semantics — so a method
+                // that only exists to satisfy one has nothing to attach to.
+                //
+                // Emitting them is not merely redundant but unsound: the
+                // generated name is the bare method name, so a type implementing
+                // one interface at several instantiations (`Multiply<int>` and
+                // `Multiply<bigint>` for `baml.time.Duration`) or two interfaces
+                // sharing a method name (`Subtract<Duration>` and
+                // `Subtract<Instant>` for `baml.time.Instant`) collides with
+                // itself. The runtime path it invokes (`baml.time.Duration.mul`)
+                // is ambiguous for the same reason.
+                //
+                // `class.methods` is flat: in-body `implements I { … }` and a
+                // non-generic out-of-body `implement I for C` merged onto `C`
+                // (`lower_cst`) both land here, so the interface target — not the
+                // declaration site — is what identifies them.
+                if baml_compiler2_ppir::item_data::method_interface_target(db, method_loc).is_some()
+                {
+                    continue;
+                }
+
                 if matches!(
                     baml_compiler2_ppir::function_body(db, method_loc).as_ref(),
                     baml_compiler2_hir::body::FunctionBody::Builtin(ast::BuiltinKind::Intrinsic)

--- a/baml_language/crates/baml_tests/baml_src/ns_time/time.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_time/time.baml
@@ -104,3 +104,240 @@ test "duration_since_is_nonnegative_for_past_instant" {
         baml.time.Instant.parse("1970-01-01T00:00:00Z").elapsed().to_nanoseconds() > 0n
     )
 }
+
+// ─── Operators ───────────────────────────────────────────────────────────────
+//
+// `baml.time` implements the `baml.ops` arithmetic interfaces, so `+` / `-` /
+// `*` / `/` / `%` / unary `-` work on these types. The shapes are:
+//
+//   Duration      ±  Duration      -> Duration      (also `%`, and unary `-`)
+//   Duration      */ int|bigint    -> Duration
+//   Instant       ±  Duration      -> Instant
+//   Instant       -  Instant       -> Duration
+//   PlainDateTime ±  Duration      -> PlainDateTime
+//   PlainDateTime -  PlainDateTime -> Duration
+//   PlainTime     ±  Duration      -> PlainTime     (wraps at midnight)
+//   PlainTime     -  PlainTime     -> Duration      (signed, does not wrap)
+//   ZonedDateTime ±  Duration      -> ZonedDateTime (timezone preserved)
+//   ZonedDateTime -  ZonedDateTime -> Duration
+//
+// `*` and `/` are covered for both `int` and `bigint` operands, since
+// `Duration` carries a separate impl for each.
+
+// ─── Duration arithmetic ─────────────────────────────────────────────────────
+
+test "duration_add" {
+    let sum = baml.time.Duration.from_seconds(10n) + baml.time.Duration.from_seconds(5n);
+    assert.equal(sum.to_seconds(), 15n)
+}
+
+test "duration_sub" {
+    let diff = baml.time.Duration.from_seconds(10n) - baml.time.Duration.from_seconds(4n);
+    assert.equal(diff.to_seconds(), 6n)
+}
+
+// Subtraction is signed: a larger subtrahend yields a negative duration.
+test "duration_sub_goes_negative" {
+    let diff = baml.time.Duration.from_seconds(4n) - baml.time.Duration.from_seconds(10n);
+    assert.equal(diff.to_seconds(), -6n)
+}
+
+test "duration_mul_by_int_and_bigint" {
+    assert.equal((baml.time.Duration.from_seconds(3n) * 4).to_seconds(), 12n);
+    assert.equal((baml.time.Duration.from_seconds(3n) * 4n).to_seconds(), 12n)
+}
+
+test "duration_mul_by_zero_is_zero" {
+    assert.equal((baml.time.Duration.from_hours(5n) * 0).to_nanoseconds(), 0n)
+}
+
+test "duration_div_by_int_and_bigint" {
+    assert.equal((baml.time.Duration.from_seconds(12n) / 4).to_seconds(), 3n);
+    assert.equal((baml.time.Duration.from_seconds(12n) / 4n).to_seconds(), 3n)
+}
+
+// Division is integer division on the nanosecond count, so it truncates rather
+// than rounding: 10ns / 4 is 2ns, not 2.5ns.
+test "duration_div_truncates" {
+    assert.equal((baml.time.Duration.from_nanoseconds(10n) / 4).to_nanoseconds(), 2n)
+}
+
+// `%` takes a `Duration` on the right, so it answers "what is left over after
+// whole intervals of `other`" — 10s in steps of 3s leaves 1s.
+test "duration_rem" {
+    let rem = baml.time.Duration.from_seconds(10n) % baml.time.Duration.from_seconds(3n);
+    assert.equal(rem.to_seconds(), 1n)
+}
+
+// The operands need not share a unit; both reduce to nanoseconds first.
+test "duration_rem_across_units" {
+    let rem = baml.time.Duration.from_milliseconds(1500n)
+        % baml.time.Duration.from_seconds(1n);
+    assert.equal(rem.to_milliseconds(), 500n)
+}
+
+test "duration_rem_divides_evenly_is_zero" {
+    let rem = baml.time.Duration.from_hours(2n) % baml.time.Duration.from_minutes(30n);
+    assert.equal(rem.to_nanoseconds(), 0n)
+}
+
+// `%` keeps the sign of the left operand, so a negative duration leaves a
+// negative remainder rather than wrapping up to a positive one.
+test "duration_rem_keeps_the_sign_of_the_left_operand" {
+    let rem = -baml.time.Duration.from_seconds(10n) % baml.time.Duration.from_seconds(3n);
+    assert.equal(rem.to_seconds(), -1n)
+}
+
+test "duration_negate" {
+    assert.equal((-baml.time.Duration.from_seconds(7n)).to_seconds(), -7n)
+}
+
+test "duration_negate_is_an_involution" {
+    assert.equal((-(-baml.time.Duration.from_seconds(7n))).to_seconds(), 7n)
+}
+
+// ─── Instant arithmetic ──────────────────────────────────────────────────────
+
+test "instant_add_duration" {
+    let t = baml.time.Instant.from_timestamp_seconds(1000n)
+        + baml.time.Duration.from_seconds(30n);
+    assert.equal(t.to_timestamp_seconds(), 1030n)
+}
+
+test "instant_sub_duration" {
+    let t = baml.time.Instant.from_timestamp_seconds(1000n)
+        - baml.time.Duration.from_seconds(30n);
+    assert.equal(t.to_timestamp_seconds(), 970n)
+}
+
+test "instant_sub_instant_is_a_duration" {
+    let gap = baml.time.Instant.from_timestamp_seconds(1000n)
+        - baml.time.Instant.from_timestamp_seconds(400n);
+    assert.equal(gap.to_seconds(), 600n)
+}
+
+// The gap is signed, so an earlier minuend gives a negative duration.
+test "instant_sub_later_instant_is_negative" {
+    let gap = baml.time.Instant.from_timestamp_seconds(400n)
+        - baml.time.Instant.from_timestamp_seconds(1000n);
+    assert.equal(gap.to_seconds(), -600n)
+}
+
+// `(t + d) - t == d` — adding then differencing recovers the duration.
+test "instant_add_then_sub_roundtrips" {
+    let base = baml.time.Instant.from_timestamp_seconds(1700000000n);
+    let step = baml.time.Duration.from_minutes(90n);
+    assert.equal(((base + step) - base).to_minutes(), 90n)
+}
+
+// ─── PlainDateTime arithmetic ────────────────────────────────────────────────
+
+test "plain_datetime_add_duration" {
+    let t = baml.time.PlainDateTime.from_components(2024, 3, 10, hour = 8)
+        + baml.time.Duration.from_hours(3n);
+    assert.equal(t.hour(), 11)
+}
+
+test "plain_datetime_sub_duration" {
+    let t = baml.time.PlainDateTime.from_components(2024, 3, 10, hour = 8)
+        - baml.time.Duration.from_hours(3n);
+    assert.equal(t.hour(), 5)
+}
+
+// Unlike `PlainTime`, a `PlainDateTime` carries a date, so crossing midnight
+// rolls the day rather than wrapping.
+test "plain_datetime_add_crosses_into_the_next_day" {
+    let t = baml.time.PlainDateTime.from_components(2024, 3, 10, hour = 23)
+        + baml.time.Duration.from_hours(2n);
+    assert.equal(t.day(), 11);
+    assert.equal(t.hour(), 1)
+}
+
+test "plain_datetime_sub_plain_datetime_is_a_duration" {
+    let gap = baml.time.PlainDateTime.from_components(2024, 3, 10, hour = 12)
+        - baml.time.PlainDateTime.from_components(2024, 3, 10, hour = 9);
+    assert.equal(gap.to_hours(), 3n)
+}
+
+// ─── PlainTime arithmetic (wraps at midnight) ────────────────────────────────
+
+test "plain_time_add_duration" {
+    let t = baml.time.PlainTime.from_components(7, minute = 30)
+        + baml.time.Duration.from_minutes(45n);
+    assert.equal(string.from(t), "08:15:00")
+}
+
+// No date to carry into, so 23:00 + 2h is 01:00.
+test "plain_time_add_wraps_past_midnight" {
+    let t = baml.time.PlainTime.from_components(23) + baml.time.Duration.from_hours(2n);
+    assert.equal(string.from(t), "01:00:00")
+}
+
+// Wrapping is modular, not saturating: a multi-day duration reduces mod 24h.
+test "plain_time_add_reduces_durations_longer_than_a_day" {
+    let t = baml.time.PlainTime.from_components(6)
+        + baml.time.Duration.from_hours(50n);
+    assert.equal(string.from(t), "08:00:00")
+}
+
+test "plain_time_sub_wraps_back_past_midnight" {
+    let t = baml.time.PlainTime.from_components(1) - baml.time.Duration.from_hours(2n);
+    assert.equal(string.from(t), "23:00:00")
+}
+
+// The `((n % day) + day) % day` wrap must land on 00:00:00, not a negative
+// value: subtracting exactly the current time-of-day is the boundary case.
+test "plain_time_sub_to_exact_midnight" {
+    let t = baml.time.PlainTime.from_components(5) - baml.time.Duration.from_hours(5n);
+    assert.equal(string.from(t), "00:00:00")
+}
+
+test "plain_time_sub_plain_time_is_a_duration" {
+    let gap = baml.time.PlainTime.from_components(9, minute = 30)
+        - baml.time.PlainTime.from_components(7);
+    assert.equal(gap.to_minutes(), 150n)
+}
+
+// The difference of two wall-clock times is signed and does NOT wrap — this is
+// the one `PlainTime` operator that can produce a negative result.
+test "plain_time_sub_plain_time_is_signed" {
+    let gap = baml.time.PlainTime.from_components(1)
+        - baml.time.PlainTime.from_components(23);
+    assert.equal(gap.to_hours(), -22n)
+}
+
+// ─── ZonedDateTime arithmetic ────────────────────────────────────────────────
+
+test "zoned_add_duration" {
+    let z = baml.time.ZonedDateTime.from_components("UTC", 2024, 3, 10, hour = 8)
+        + baml.time.Duration.from_hours(3n);
+    assert.equal(z.hour(), 11)
+}
+
+test "zoned_sub_duration" {
+    let z = baml.time.ZonedDateTime.from_components("UTC", 2024, 3, 10, hour = 8)
+        - baml.time.Duration.from_hours(3n);
+    assert.equal(z.hour(), 5)
+}
+
+// Arithmetic moves the absolute instant and leaves the timezone alone.
+test "zoned_arithmetic_preserves_the_timezone" {
+    let base = baml.time.ZonedDateTime.from_components("America/New_York", 2024, 3, 10, hour = 8);
+    let later = base + baml.time.Duration.from_hours(1n);
+    assert.equal(later.timezone(), "America/New_York");
+    assert.equal((later - base).to_hours(), 1n)
+}
+
+test "zoned_sub_zoned_is_a_duration" {
+    let gap = baml.time.ZonedDateTime.from_components("UTC", 2024, 3, 10, hour = 12)
+        - baml.time.ZonedDateTime.from_components("UTC", 2024, 3, 10, hour = 9);
+    assert.equal(gap.to_hours(), 3n)
+}
+
+// The gap is absolute, so two zoned times naming the same instant in different
+// timezones differ by zero.
+test "zoned_sub_across_timezones_measures_absolute_time" {
+    let utc = baml.time.ZonedDateTime.from_components("UTC", 2024, 3, 10, hour = 12);
+    let same = utc.with_timezone("Asia/Tokyo");
+    assert.equal((utc - same).to_nanoseconds(), 0n)
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/time.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/time.snap
@@ -280,6 +280,244 @@ function time.$init_test_ns_time_time(registry: testing.TestCollector) -> null {
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "duration_add"
+    make_closure .<lambda($init_test_ns_time_time, 12)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "duration_sub"
+    make_closure .<lambda($init_test_ns_time_time, 13)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "duration_sub_goes_negative"
+    make_closure .<lambda($init_test_ns_time_time, 14)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "duration_mul_by_int_and_bigint"
+    make_closure .<lambda($init_test_ns_time_time, 15)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "duration_mul_by_zero_is_zero"
+    make_closure .<lambda($init_test_ns_time_time, 16)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "duration_div_by_int_and_bigint"
+    make_closure .<lambda($init_test_ns_time_time, 17)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "duration_div_truncates"
+    make_closure .<lambda($init_test_ns_time_time, 18)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "duration_rem"
+    make_closure .<lambda($init_test_ns_time_time, 19)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "duration_rem_across_units"
+    make_closure .<lambda($init_test_ns_time_time, 20)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "duration_rem_divides_evenly_is_zero"
+    make_closure .<lambda($init_test_ns_time_time, 21)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "duration_rem_keeps_the_sign_of_the_left_operand"
+    make_closure .<lambda($init_test_ns_time_time, 22)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "duration_negate"
+    make_closure .<lambda($init_test_ns_time_time, 23)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "duration_negate_is_an_involution"
+    make_closure .<lambda($init_test_ns_time_time, 24)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "instant_add_duration"
+    make_closure .<lambda($init_test_ns_time_time, 25)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "instant_sub_duration"
+    make_closure .<lambda($init_test_ns_time_time, 26)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "instant_sub_instant_is_a_duration"
+    make_closure .<lambda($init_test_ns_time_time, 27)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "instant_sub_later_instant_is_negative"
+    make_closure .<lambda($init_test_ns_time_time, 28)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "instant_add_then_sub_roundtrips"
+    make_closure .<lambda($init_test_ns_time_time, 29)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "plain_datetime_add_duration"
+    make_closure .<lambda($init_test_ns_time_time, 30)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "plain_datetime_sub_duration"
+    make_closure .<lambda($init_test_ns_time_time, 31)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "plain_datetime_add_crosses_into_the_next_day"
+    make_closure .<lambda($init_test_ns_time_time, 32)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "plain_datetime_sub_plain_datetime_is_a_duration"
+    make_closure .<lambda($init_test_ns_time_time, 33)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "plain_time_add_duration"
+    make_closure .<lambda($init_test_ns_time_time, 34)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "plain_time_add_wraps_past_midnight"
+    make_closure .<lambda($init_test_ns_time_time, 35)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "plain_time_add_reduces_durations_longer_than_a_day"
+    make_closure .<lambda($init_test_ns_time_time, 36)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "plain_time_sub_wraps_back_past_midnight"
+    make_closure .<lambda($init_test_ns_time_time, 37)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "plain_time_sub_to_exact_midnight"
+    make_closure .<lambda($init_test_ns_time_time, 38)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "plain_time_sub_plain_time_is_a_duration"
+    make_closure .<lambda($init_test_ns_time_time, 39)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "plain_time_sub_plain_time_is_signed"
+    make_closure .<lambda($init_test_ns_time_time, 40)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "zoned_add_duration"
+    make_closure .<lambda($init_test_ns_time_time, 41)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "zoned_sub_duration"
+    make_closure .<lambda($init_test_ns_time_time, 42)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "zoned_arithmetic_preserves_the_timezone"
+    make_closure .<lambda($init_test_ns_time_time, 43)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "zoned_sub_zoned_is_a_duration"
+    make_closure .<lambda($init_test_ns_time_time, 44)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.time"
+    load_const "zoned_sub_across_timezones_measures_absolute_time"
+    make_closure .<lambda($init_test_ns_time_time, 45)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
     load_const null
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
@@ -1866,6 +1866,15 @@ class baml.time.Duration$stream {
 function baml.time.abs(self: ?) -> baml.time.Duration  [expr] {
   {  } baml.time.Duration { _nanoseconds: self._nanoseconds.abs() }
 }
+function baml.time.add(self: ?, other: baml.time.Duration) -> baml.time.Duration  [expr] {
+  {  } baml.time.Duration { _nanoseconds: self._nanoseconds Add other._nanoseconds }
+}
+function baml.time.div(self: ?, other: int) -> baml.time.Duration  [expr] {
+  {  } baml.time.Duration { _nanoseconds: self._nanoseconds Div other }
+}
+function baml.time.div(self: ?, other: bigint) -> baml.time.Duration  [expr] {
+  {  } baml.time.Duration { _nanoseconds: self._nanoseconds Div other }
+}
 function baml.time.from_hours(h: int | bigint) -> baml.time.Duration  [expr] {
   {  } baml.time.Duration { _nanoseconds: match (h) { value: bigint => value, value: int => 0n Add value } Mul 3600000000000n }
 }
@@ -1883,6 +1892,21 @@ function baml.time.from_nanoseconds(ns: int | bigint) -> baml.time.Duration  [ex
 }
 function baml.time.from_seconds(s: int | bigint) -> baml.time.Duration  [expr] {
   {  } baml.time.Duration { _nanoseconds: match (s) { value: bigint => value, value: int => 0n Add value } Mul 1000000000n }
+}
+function baml.time.mul(self: ?, other: int) -> baml.time.Duration  [expr] {
+  {  } baml.time.Duration { _nanoseconds: self._nanoseconds Mul other }
+}
+function baml.time.mul(self: ?, other: bigint) -> baml.time.Duration  [expr] {
+  {  } baml.time.Duration { _nanoseconds: self._nanoseconds Mul other }
+}
+function baml.time.neg(self: ?) -> baml.time.Duration  [expr] {
+  {  } baml.time.Duration { _nanoseconds: Neg self._nanoseconds }
+}
+function baml.time.rem(self: ?, other: baml.time.Duration) -> baml.time.Duration  [expr] {
+  {  } baml.time.Duration { _nanoseconds: self._nanoseconds Mod other._nanoseconds }
+}
+function baml.time.sub(self: ?, other: baml.time.Duration) -> baml.time.Duration  [expr] {
+  {  } baml.time.Duration { _nanoseconds: self._nanoseconds Sub other._nanoseconds }
 }
 function baml.time.to_hours(self: ?) -> bigint  [expr] {
   {  } self._nanoseconds Div 3600000000000
@@ -1914,6 +1938,9 @@ function baml.time._to_string_impl(self: ?) -> string  [builtin]
 function baml.time.abs_diff(self: ?, other: baml.time.Instant) -> Duration  [expr] {
   {  } Duration { _nanoseconds: self._nanoseconds Sub other._nanoseconds.abs() }
 }
+function baml.time.add(self: ?, other: Duration) -> baml.time.Instant  [expr] {
+  {  } baml.time.Instant { _nanoseconds: self._nanoseconds Add other._nanoseconds }
+}
 function baml.time.elapsed(self: ?) -> Duration  [expr] {
   {  } Duration { _nanoseconds: Instant.now()._nanoseconds Sub self._nanoseconds }
 }
@@ -1943,6 +1970,12 @@ function baml.time.min(self: ?, other: baml.time.Instant) -> baml.time.Instant  
 }
 function baml.time.now() -> baml.time.Instant  [builtin]
 function baml.time.parse(s: string) -> baml.time.Instant  [builtin]
+function baml.time.sub(self: ?, other: Duration) -> baml.time.Instant  [expr] {
+  {  } baml.time.Instant { _nanoseconds: self._nanoseconds Sub other._nanoseconds }
+}
+function baml.time.sub(self: ?, other: baml.time.Instant) -> Duration  [expr] {
+  {  } Duration { _nanoseconds: self._nanoseconds Sub other._nanoseconds }
+}
 function baml.time.to_json(self: ?) -> baml.json.json  [expr] {
   {  } self._to_string_impl() catch (_) { root.errors.InvalidArgument { message: message } => { throw baml.json.JsonSerializationError { message: message, path: "" } } }
 }
@@ -1998,6 +2031,9 @@ class baml.time.PlainDateTime$stream {
 }
 function baml.time._from_components(year: int, month: int, day: int, hour: int, minute: int, second: int, millisecond: int, microsecond: int, nanosecond: int) -> baml.time.PlainDateTime  [builtin]
 function baml.time._to_string_impl(self: ?) -> string  [builtin]
+function baml.time.add(self: ?, other: Duration) -> baml.time.PlainDateTime  [expr] {
+  {  } baml.time.PlainDateTime { _nanoseconds: self._nanoseconds Add other._nanoseconds }
+}
 function baml.time.day(self: ?) -> int  [builtin]
 function baml.time.from_components(year: int, month: int, day: int, hour: int = 0, minute: int = 0, second: int = 0, millisecond: int = 0, microsecond: int = 0, nanosecond: int = 0) -> baml.time.PlainDateTime  [expr] {
   {  } PlainDateTime._from_components(year, month, day, hour, minute, second, millisecond, microsecond, nanosecond)
@@ -2017,6 +2053,12 @@ function baml.time.minute(self: ?) -> int  [builtin]
 function baml.time.month(self: ?) -> int  [builtin]
 function baml.time.parse(s: string) -> baml.time.PlainDateTime  [builtin]
 function baml.time.second(self: ?) -> int  [builtin]
+function baml.time.sub(self: ?, other: Duration) -> baml.time.PlainDateTime  [expr] {
+  {  } baml.time.PlainDateTime { _nanoseconds: self._nanoseconds Sub other._nanoseconds }
+}
+function baml.time.sub(self: ?, other: baml.time.PlainDateTime) -> Duration  [expr] {
+  {  } Duration { _nanoseconds: self._nanoseconds Sub other._nanoseconds }
+}
 function baml.time.to_json(self: ?) -> baml.json.json  [expr] {
   {  } self._to_string_impl() catch (_) { root.errors.InvalidArgument { message: message } => { throw baml.json.JsonSerializationError { message: message, path: "" } } }
 }
@@ -2039,6 +2081,12 @@ class baml.time.PlainTime$stream {
 }
 function baml.time._from_components(hour: int, minute: int, second: int, millisecond: int, microsecond: int, nanosecond: int) -> baml.time.PlainTime  [builtin]
 function baml.time._to_string_impl(self: ?) -> string  [builtin]
+function baml.time._wrap_into_day(total_ns: bigint) -> int  [expr] {
+  { let day_ns = 86400000000000n; let wrapped = total_ns Mod day_ns Add day_ns Mod day_ns } {  } wrapped.to_int() catch (e) { root.errors.InvalidArgument => baml.sys.panic("unreachable: nano...") }
+}
+function baml.time.add(self: ?, other: Duration) -> baml.time.PlainTime  [expr] {
+  {  } baml.time.PlainTime { _nanoseconds: _wrap_into_day(self._nanoseconds Add other._nanoseconds) }
+}
 function baml.time.from_components(hour: int, minute: int = 0, second: int = 0, millisecond: int = 0, microsecond: int = 0, nanosecond: int = 0) -> baml.time.PlainTime  [expr] {
   {  } PlainTime._from_components(hour, minute, second, millisecond, microsecond, nanosecond)
 }
@@ -2057,6 +2105,12 @@ function baml.time.minute(self: ?) -> int  [expr] {
 function baml.time.parse(s: string) -> baml.time.PlainTime  [builtin]
 function baml.time.second(self: ?) -> int  [expr] {
   {  } self._nanoseconds Div 1000000000 Mod 60
+}
+function baml.time.sub(self: ?, other: Duration) -> baml.time.PlainTime  [expr] {
+  {  } baml.time.PlainTime { _nanoseconds: _wrap_into_day(self._nanoseconds Sub other._nanoseconds) }
+}
+function baml.time.sub(self: ?, other: baml.time.PlainTime) -> Duration  [expr] {
+  {  } Duration { _nanoseconds: 0n Add self._nanoseconds Sub other._nanoseconds }
 }
 function baml.time.to_json(self: ?) -> baml.json.json  [expr] {
   {  } baml.json.from(self.to_string())
@@ -2130,6 +2184,9 @@ function baml.time._format_zoned(epoch_ns: bigint, offset_ns: int, iana: string?
 function baml.time._to_string_impl(self: ?) -> string  [expr] {
   {  } _format_zoned(self._nanoseconds, self.timezone_offset()._nanoseconds, self._iana)
 }
+function baml.time.add(self: ?, other: Duration) -> baml.time.ZonedDateTime  [expr] {
+  {  } baml.time.ZonedDateTime { _nanoseconds: self._nanoseconds Add other._nanoseconds, _offset_ns: self._offset_ns, _iana: self._iana }
+}
 function baml.time.day(self: ?) -> int  [expr] {
   {  } self.to_plain().day()
 }
@@ -2169,6 +2226,12 @@ function baml.time.now_in(timezone: TimeZoneOffset | string) -> baml.time.ZonedD
 function baml.time.parse(s: string) -> baml.time.ZonedDateTime  [builtin]
 function baml.time.second(self: ?) -> int  [expr] {
   {  } self.to_plain().second()
+}
+function baml.time.sub(self: ?, other: Duration) -> baml.time.ZonedDateTime  [expr] {
+  {  } baml.time.ZonedDateTime { _nanoseconds: self._nanoseconds Sub other._nanoseconds, _offset_ns: self._offset_ns, _iana: self._iana }
+}
+function baml.time.sub(self: ?, other: baml.time.ZonedDateTime) -> Duration  [expr] {
+  {  } Duration { _nanoseconds: self._nanoseconds Sub other._nanoseconds }
 }
 function baml.time.timezone(self: ?) -> TimeZoneOffset | string  [expr] {
   {  } match (self._iana) { null => TimeZoneOffset { _nanoseconds: self._offset_ns NullCoalesce 0 }, iana => iana NullCoalesce "" }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -7527,6 +7527,171 @@ fn baml.time.Duration.to_hours(self: baml.time.Duration) -> bigint {
     }
 }
 
+fn baml.time.Duration.root.ops.Add<Duration>.add(self: baml.time.Duration, other: baml.time.Duration) -> baml.time.Duration {
+    // Locals:
+    let _0: baml.time.Duration // _0 // return
+    let _1: baml.time.Duration // self // param
+    let _2: baml.time.Duration // other // param
+    let _3: bigint
+    let _4: bigint
+    let _5: bigint
+
+    bb0: {
+        _4 = copy _1.0;
+        _5 = copy _2.0;
+        _3 = copy _4 + copy _5;
+        _0 = baml.time.Duration { copy _3 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.time.Duration.root.ops.Subtract<Duration>.sub(self: baml.time.Duration, other: baml.time.Duration) -> baml.time.Duration {
+    // Locals:
+    let _0: baml.time.Duration // _0 // return
+    let _1: baml.time.Duration // self // param
+    let _2: baml.time.Duration // other // param
+    let _3: bigint
+    let _4: bigint
+    let _5: bigint
+
+    bb0: {
+        _4 = copy _1.0;
+        _5 = copy _2.0;
+        _3 = copy _4 - copy _5;
+        _0 = baml.time.Duration { copy _3 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.time.Duration.root.ops.Multiply<int>.mul(self: baml.time.Duration, other: int) -> baml.time.Duration {
+    // Locals:
+    let _0: baml.time.Duration // _0 // return
+    let _1: baml.time.Duration // self // param
+    let _2: int // other // param
+    let _3: bigint
+    let _4: bigint
+
+    bb0: {
+        _4 = copy _1.0;
+        _3 = copy _4 * copy _2;
+        _0 = baml.time.Duration { copy _3 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.time.Duration.root.ops.Multiply<bigint>.mul(self: baml.time.Duration, other: bigint) -> baml.time.Duration {
+    // Locals:
+    let _0: baml.time.Duration // _0 // return
+    let _1: baml.time.Duration // self // param
+    let _2: bigint // other // param
+    let _3: bigint
+    let _4: bigint
+
+    bb0: {
+        _4 = copy _1.0;
+        _3 = copy _4 * copy _2;
+        _0 = baml.time.Duration { copy _3 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.time.Duration.root.ops.Divide<int>.div(self: baml.time.Duration, other: int) -> baml.time.Duration {
+    // Locals:
+    let _0: baml.time.Duration // _0 // return
+    let _1: baml.time.Duration // self // param
+    let _2: int // other // param
+    let _3: bigint
+    let _4: bigint
+
+    bb0: {
+        _4 = copy _1.0;
+        _3 = copy _4 / copy _2;
+        _0 = baml.time.Duration { copy _3 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.time.Duration.root.ops.Divide<bigint>.div(self: baml.time.Duration, other: bigint) -> baml.time.Duration {
+    // Locals:
+    let _0: baml.time.Duration // _0 // return
+    let _1: baml.time.Duration // self // param
+    let _2: bigint // other // param
+    let _3: bigint
+    let _4: bigint
+
+    bb0: {
+        _4 = copy _1.0;
+        _3 = copy _4 / copy _2;
+        _0 = baml.time.Duration { copy _3 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.time.Duration.root.ops.Remainder<Duration>.rem(self: baml.time.Duration, other: baml.time.Duration) -> baml.time.Duration {
+    // Locals:
+    let _0: baml.time.Duration // _0 // return
+    let _1: baml.time.Duration // self // param
+    let _2: baml.time.Duration // other // param
+    let _3: bigint
+    let _4: bigint
+    let _5: bigint
+
+    bb0: {
+        _4 = copy _1.0;
+        _5 = copy _2.0;
+        _3 = copy _4 % copy _5;
+        _0 = baml.time.Duration { copy _3 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.time.Duration.root.ops.Negate.neg(self: baml.time.Duration) -> baml.time.Duration {
+    // Locals:
+    let _0: baml.time.Duration // _0 // return
+    let _1: baml.time.Duration // self // param
+    let _2: bigint
+    let _3: bigint
+
+    bb0: {
+        _3 = copy _1.0;
+        _2 = -copy _3;
+        _0 = baml.time.Duration { copy _2 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
 fn baml.time.Instant.now = builtin(io)
 
 fn baml.time.Instant.elapsed(self: baml.time.Instant) -> baml.time.Duration {
@@ -7909,6 +8074,72 @@ fn baml.time.Instant.epoch() -> baml.time.Instant {
 
     bb0: {
         _0 = baml.time.Instant { const 0n };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.time.Instant.root.ops.Add<Duration>.add(self: baml.time.Instant, other: baml.time.Duration) -> baml.time.Instant {
+    // Locals:
+    let _0: baml.time.Instant // _0 // return
+    let _1: baml.time.Instant // self // param
+    let _2: baml.time.Duration // other // param
+    let _3: bigint
+    let _4: bigint
+    let _5: bigint
+
+    bb0: {
+        _4 = copy _1.0;
+        _5 = copy _2.0;
+        _3 = copy _4 + copy _5;
+        _0 = baml.time.Instant { copy _3 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.time.Instant.root.ops.Subtract<Duration>.sub(self: baml.time.Instant, other: baml.time.Duration) -> baml.time.Instant {
+    // Locals:
+    let _0: baml.time.Instant // _0 // return
+    let _1: baml.time.Instant // self // param
+    let _2: baml.time.Duration // other // param
+    let _3: bigint
+    let _4: bigint
+    let _5: bigint
+
+    bb0: {
+        _4 = copy _1.0;
+        _5 = copy _2.0;
+        _3 = copy _4 - copy _5;
+        _0 = baml.time.Instant { copy _3 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.time.Instant.root.ops.Subtract<Instant>.sub(self: baml.time.Instant, other: baml.time.Instant) -> baml.time.Duration {
+    // Locals:
+    let _0: baml.time.Duration // _0 // return
+    let _1: baml.time.Instant // self // param
+    let _2: baml.time.Instant // other // param
+    let _3: bigint
+    let _4: bigint
+    let _5: bigint
+
+    bb0: {
+        _4 = copy _1.0;
+        _5 = copy _2.0;
+        _3 = copy _4 - copy _5;
+        _0 = baml.time.Duration { copy _3 };
         goto -> bb1;
     }
 
@@ -8552,6 +8783,72 @@ fn baml.time.PlainDateTime.baml.ToJson.to_json(self: baml.time.PlainDateTime) ->
     }
 }
 
+fn baml.time.PlainDateTime.root.ops.Add<Duration>.add(self: baml.time.PlainDateTime, other: baml.time.Duration) -> baml.time.PlainDateTime {
+    // Locals:
+    let _0: baml.time.PlainDateTime // _0 // return
+    let _1: baml.time.PlainDateTime // self // param
+    let _2: baml.time.Duration // other // param
+    let _3: bigint
+    let _4: bigint
+    let _5: bigint
+
+    bb0: {
+        _4 = copy _1.0;
+        _5 = copy _2.0;
+        _3 = copy _4 + copy _5;
+        _0 = baml.time.PlainDateTime { copy _3 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.time.PlainDateTime.root.ops.Subtract<Duration>.sub(self: baml.time.PlainDateTime, other: baml.time.Duration) -> baml.time.PlainDateTime {
+    // Locals:
+    let _0: baml.time.PlainDateTime // _0 // return
+    let _1: baml.time.PlainDateTime // self // param
+    let _2: baml.time.Duration // other // param
+    let _3: bigint
+    let _4: bigint
+    let _5: bigint
+
+    bb0: {
+        _4 = copy _1.0;
+        _5 = copy _2.0;
+        _3 = copy _4 - copy _5;
+        _0 = baml.time.PlainDateTime { copy _3 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.time.PlainDateTime.root.ops.Subtract<PlainDateTime>.sub(self: baml.time.PlainDateTime, other: baml.time.PlainDateTime) -> baml.time.Duration {
+    // Locals:
+    let _0: baml.time.Duration // _0 // return
+    let _1: baml.time.PlainDateTime // self // param
+    let _2: baml.time.PlainDateTime // other // param
+    let _3: bigint
+    let _4: bigint
+    let _5: bigint
+
+    bb0: {
+        _4 = copy _1.0;
+        _5 = copy _2.0;
+        _3 = copy _4 - copy _5;
+        _0 = baml.time.Duration { copy _3 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
 fn baml.time.PlainTime.from_components(hour: int, minute: int, second: int, millisecond: int, microsecond: int, nanosecond: int) -> baml.time.PlainTime {
     // Locals:
     let _0: baml.time.PlainTime // _0 // return
@@ -8801,6 +9098,127 @@ fn baml.time.PlainTime.baml.ToJson.to_json(self: baml.time.PlainTime) -> int | f
     }
 
     bb2: {
+        return;
+    }
+}
+
+fn baml.time.PlainTime.root.ops.Add<Duration>.add(self: baml.time.PlainTime, other: baml.time.Duration) -> baml.time.PlainTime {
+    // Locals:
+    let _0: baml.time.PlainTime // _0 // return
+    let _1: baml.time.PlainTime // self // param
+    let _2: baml.time.Duration // other // param
+    let _3: int
+    let _4: bigint
+    let _5: int
+    let _6: bigint
+
+    bb0: {
+        _5 = copy _1.0;
+        _6 = copy _2.0;
+        _4 = copy _5 + copy _6;
+        _3 = call const fn baml.time._wrap_into_day(copy _4) -> [bb1];
+    }
+
+    bb1: {
+        _0 = baml.time.PlainTime { copy _3 };
+        goto -> bb2;
+    }
+
+    bb2: {
+        return;
+    }
+}
+
+fn baml.time.PlainTime.root.ops.Subtract<Duration>.sub(self: baml.time.PlainTime, other: baml.time.Duration) -> baml.time.PlainTime {
+    // Locals:
+    let _0: baml.time.PlainTime // _0 // return
+    let _1: baml.time.PlainTime // self // param
+    let _2: baml.time.Duration // other // param
+    let _3: int
+    let _4: bigint
+    let _5: int
+    let _6: bigint
+
+    bb0: {
+        _5 = copy _1.0;
+        _6 = copy _2.0;
+        _4 = copy _5 - copy _6;
+        _3 = call const fn baml.time._wrap_into_day(copy _4) -> [bb1];
+    }
+
+    bb1: {
+        _0 = baml.time.PlainTime { copy _3 };
+        goto -> bb2;
+    }
+
+    bb2: {
+        return;
+    }
+}
+
+fn baml.time.PlainTime.root.ops.Subtract<PlainTime>.sub(self: baml.time.PlainTime, other: baml.time.PlainTime) -> baml.time.Duration {
+    // Locals:
+    let _0: baml.time.Duration // _0 // return
+    let _1: baml.time.PlainTime // self // param
+    let _2: baml.time.PlainTime // other // param
+    let _3: bigint
+    let _4: int
+    let _5: int
+    let _6: int
+
+    bb0: {
+        _5 = copy _1.0;
+        _6 = copy _2.0;
+        _4 = copy _5 - copy _6;
+        _3 = const 0n + copy _4;
+        _0 = baml.time.Duration { copy _3 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.time._wrap_into_day(total_ns: bigint) -> int {
+    // Locals:
+    let _0: int // _0 // return
+    let _1: bigint // total_ns // param
+    let _2: bigint // day_ns
+    let _3: bigint // wrapped
+    let _4: bigint
+    let _5: bigint
+    let _6: bigint
+    let _7: bigint
+    let _8: bigint
+    let _9: unknown // e
+    let _10: bool
+
+    bb0: {
+        _2 = const 86400000000000n;
+        _6 = copy _2;
+        _5 = copy _1 % copy _6;
+        _7 = copy _2;
+        _4 = copy _5 + copy _7;
+        _8 = copy _2;
+        _3 = copy _4 % copy _8;
+        _0 = call const fn baml.Bigint.to_int(copy _3) -> [bb4, unwind: bb1];
+    }
+
+    bb1: {
+        _10 = is_type(copy _9, baml.errors.InvalidArgument);
+        branch copy _10 -> [bb3, bb2];
+    }
+
+    bb2: {
+        rethrow copy _9;
+    }
+
+    bb3: {
+        _0 = call const fn baml.sys.panic(const "unreachable: nanoseconds wrapped into [0, 24h) exceed int range") -> [bb4];
+    }
+
+    bb4: {
         return;
     }
 }
@@ -9826,6 +10244,80 @@ fn baml.time.ZonedDateTime.baml.ToJson.to_json(self: baml.time.ZonedDateTime) ->
 }
 
 fn baml.time._format_zoned = builtin(vm)
+
+fn baml.time.ZonedDateTime.root.ops.Add<Duration>.add(self: baml.time.ZonedDateTime, other: baml.time.Duration) -> baml.time.ZonedDateTime {
+    // Locals:
+    let _0: baml.time.ZonedDateTime // _0 // return
+    let _1: baml.time.ZonedDateTime // self // param
+    let _2: baml.time.Duration // other // param
+    let _3: bigint
+    let _4: bigint
+    let _5: bigint
+    let _6: int | null
+    let _7: string | null
+
+    bb0: {
+        _4 = copy _1.0;
+        _5 = copy _2.0;
+        _3 = copy _4 + copy _5;
+        _6 = copy _1.1;
+        _7 = copy _1.2;
+        _0 = baml.time.ZonedDateTime { copy _3, copy _6, copy _7 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.time.ZonedDateTime.root.ops.Subtract<Duration>.sub(self: baml.time.ZonedDateTime, other: baml.time.Duration) -> baml.time.ZonedDateTime {
+    // Locals:
+    let _0: baml.time.ZonedDateTime // _0 // return
+    let _1: baml.time.ZonedDateTime // self // param
+    let _2: baml.time.Duration // other // param
+    let _3: bigint
+    let _4: bigint
+    let _5: bigint
+    let _6: int | null
+    let _7: string | null
+
+    bb0: {
+        _4 = copy _1.0;
+        _5 = copy _2.0;
+        _3 = copy _4 - copy _5;
+        _6 = copy _1.1;
+        _7 = copy _1.2;
+        _0 = baml.time.ZonedDateTime { copy _3, copy _6, copy _7 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.time.ZonedDateTime.root.ops.Subtract<ZonedDateTime>.sub(self: baml.time.ZonedDateTime, other: baml.time.ZonedDateTime) -> baml.time.Duration {
+    // Locals:
+    let _0: baml.time.Duration // _0 // return
+    let _1: baml.time.ZonedDateTime // self // param
+    let _2: baml.time.ZonedDateTime // other // param
+    let _3: bigint
+    let _4: bigint
+    let _5: bigint
+
+    bb0: {
+        _4 = copy _1.0;
+        _5 = copy _2.0;
+        _3 = copy _4 - copy _5;
+        _0 = baml.time.Duration { copy _3 };
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
 
 fn baml.toml.Table.baml.ToJson.to_json(self: baml.toml.Table) -> int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> {
     // Locals:

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_tir.snap
@@ -2597,6 +2597,46 @@ function baml.time.Duration.to_hours(self: baml.time.Duration) -> bigint throws 
     self._nanoseconds / 3600000000000 : bigint
   }
 }
+function baml.time.Duration.add(self: baml.time.Duration, other: baml.time.Duration) -> baml.time.Duration throws never {
+  { : baml.time.Duration
+    Duration { _nanoseconds: self._nanoseconds + other._nanoseconds } : baml.time.Duration
+  }
+}
+function baml.time.Duration.sub(self: baml.time.Duration, other: baml.time.Duration) -> baml.time.Duration throws never {
+  { : baml.time.Duration
+    Duration { _nanoseconds: self._nanoseconds - other._nanoseconds } : baml.time.Duration
+  }
+}
+function baml.time.Duration.mul(self: baml.time.Duration, other: int) -> baml.time.Duration throws never {
+  { : baml.time.Duration
+    Duration { _nanoseconds: self._nanoseconds * other } : baml.time.Duration
+  }
+}
+function baml.time.Duration.mul(self: baml.time.Duration, other: bigint) -> baml.time.Duration throws never {
+  { : baml.time.Duration
+    Duration { _nanoseconds: self._nanoseconds * other } : baml.time.Duration
+  }
+}
+function baml.time.Duration.div(self: baml.time.Duration, other: int) -> baml.time.Duration throws never {
+  { : baml.time.Duration
+    Duration { _nanoseconds: self._nanoseconds / other } : baml.time.Duration
+  }
+}
+function baml.time.Duration.div(self: baml.time.Duration, other: bigint) -> baml.time.Duration throws never {
+  { : baml.time.Duration
+    Duration { _nanoseconds: self._nanoseconds / other } : baml.time.Duration
+  }
+}
+function baml.time.Duration.rem(self: baml.time.Duration, other: baml.time.Duration) -> baml.time.Duration throws never {
+  { : baml.time.Duration
+    Duration { _nanoseconds: self._nanoseconds % other._nanoseconds } : baml.time.Duration
+  }
+}
+function baml.time.Duration.neg(self: baml.time.Duration) -> baml.time.Duration throws never {
+  { : baml.time.Duration
+    Duration { _nanoseconds: Neg self._nanoseconds } : baml.time.Duration
+  }
+}
 class baml.time.Duration$stream {
   _nanoseconds: bigint | null
 }
@@ -2720,6 +2760,21 @@ function baml.time.Instant.to_json(self: baml.time.Instant) -> baml.json.json th
           { : never
             throw baml.json.JsonSerializationError { message: message, path: "" } : baml.json.JsonSerializationError
           }
+  }
+}
+function baml.time.Instant.add(self: baml.time.Instant, other: baml.time.Duration) -> baml.time.Instant throws never {
+  { : baml.time.Instant
+    Instant { _nanoseconds: self._nanoseconds + other._nanoseconds } : baml.time.Instant
+  }
+}
+function baml.time.Instant.sub(self: baml.time.Instant, other: baml.time.Duration) -> baml.time.Instant throws never {
+  { : baml.time.Instant
+    Instant { _nanoseconds: self._nanoseconds - other._nanoseconds } : baml.time.Instant
+  }
+}
+function baml.time.Instant.sub(self: baml.time.Instant, other: baml.time.Instant) -> baml.time.Duration throws never {
+  { : baml.time.Duration
+    Duration { _nanoseconds: self._nanoseconds - other._nanoseconds } : baml.time.Duration
   }
 }
 class baml.time.Instant$stream {
@@ -2893,6 +2948,21 @@ function baml.time.PlainDateTime.to_json(self: baml.time.PlainDateTime) -> baml.
           }
   }
 }
+function baml.time.PlainDateTime.add(self: baml.time.PlainDateTime, other: baml.time.Duration) -> baml.time.PlainDateTime throws never {
+  { : baml.time.PlainDateTime
+    PlainDateTime { _nanoseconds: self._nanoseconds + other._nanoseconds } : baml.time.PlainDateTime
+  }
+}
+function baml.time.PlainDateTime.sub(self: baml.time.PlainDateTime, other: baml.time.Duration) -> baml.time.PlainDateTime throws never {
+  { : baml.time.PlainDateTime
+    PlainDateTime { _nanoseconds: self._nanoseconds - other._nanoseconds } : baml.time.PlainDateTime
+  }
+}
+function baml.time.PlainDateTime.sub(self: baml.time.PlainDateTime, other: baml.time.PlainDateTime) -> baml.time.Duration throws never {
+  { : baml.time.Duration
+    Duration { _nanoseconds: self._nanoseconds - other._nanoseconds } : baml.time.Duration
+  }
+}
 class baml.time.PlainDateTime$stream {
   _nanoseconds: bigint | null
 }
@@ -2957,6 +3027,31 @@ function baml.time.PlainTime.from_json(j: baml.json.json) -> !error throws baml.
 function baml.time.PlainTime.to_json(self: baml.time.PlainTime) -> baml.json.json throws baml.json.JsonSerializationError {
   { : baml.json.json
     baml.json.from<T>(self.to_string()) : baml.json.json
+  }
+}
+function baml.time.PlainTime.add(self: baml.time.PlainTime, other: baml.time.Duration) -> baml.time.PlainTime throws never {
+  { : baml.time.PlainTime
+    PlainTime { _nanoseconds: _wrap_into_day(self._nanoseconds + other._nanoseconds) } : baml.time.PlainTime
+  }
+}
+function baml.time.PlainTime.sub(self: baml.time.PlainTime, other: baml.time.Duration) -> baml.time.PlainTime throws never {
+  { : baml.time.PlainTime
+    PlainTime { _nanoseconds: _wrap_into_day(self._nanoseconds - other._nanoseconds) } : baml.time.PlainTime
+  }
+}
+function baml.time.PlainTime.sub(self: baml.time.PlainTime, other: baml.time.PlainTime) -> baml.time.Duration throws never {
+  { : baml.time.Duration
+    Duration { _nanoseconds: 0n + self._nanoseconds - other._nanoseconds } : baml.time.Duration
+  }
+}
+function baml.time._wrap_into_day(total_ns: bigint) -> int throws never {
+  { : int
+    let day_ns = 86400000000000n : 86400000000000n -> bigint
+    let wrapped = total_ns % day_ns + day_ns % day_ns : bigint
+    catch ({ 0 stmts + tail } : int) : int
+      catch (e)
+        root.errors.InvalidArgument =>
+          baml.sys.panic("unreachable: nano...") : never
   }
 }
 class baml.time.PlainTime$stream {
@@ -3212,6 +3307,21 @@ function baml.time.ZonedDateTime.to_json(self: baml.time.ZonedDateTime) -> baml.
           { : never
             throw baml.json.JsonSerializationError { message: message, path: "" } : baml.json.JsonSerializationError
           }
+  }
+}
+function baml.time.ZonedDateTime.add(self: baml.time.ZonedDateTime, other: baml.time.Duration) -> baml.time.ZonedDateTime throws never {
+  { : baml.time.ZonedDateTime
+    ZonedDateTime { _nanoseconds: self._nanoseconds + other._nanoseconds, _offset_ns: self._offset_ns, _iana: self._iana } : baml.time.ZonedDateTime
+  }
+}
+function baml.time.ZonedDateTime.sub(self: baml.time.ZonedDateTime, other: baml.time.Duration) -> baml.time.ZonedDateTime throws never {
+  { : baml.time.ZonedDateTime
+    ZonedDateTime { _nanoseconds: self._nanoseconds - other._nanoseconds, _offset_ns: self._offset_ns, _iana: self._iana } : baml.time.ZonedDateTime
+  }
+}
+function baml.time.ZonedDateTime.sub(self: baml.time.ZonedDateTime, other: baml.time.ZonedDateTime) -> baml.time.Duration throws never {
+  { : baml.time.Duration
+    Duration { _nanoseconds: self._nanoseconds - other._nanoseconds } : baml.time.Duration
   }
 }
 class baml.time.ZonedDateTime$stream {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -5226,6 +5226,80 @@ function baml.time.Duration.from_seconds(s: int | bigint) -> baml.time.Duration 
     return
 }
 
+function baml.time.Duration.root.ops.Add<Duration>.add(self: baml.time.Duration, other: baml.time.Duration) -> baml.time.Duration {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    load_field ._nanoseconds
+    add_bigint
+    init_instance baml.time.Duration ._nanoseconds
+    return
+}
+
+function baml.time.Duration.root.ops.Divide<bigint>.div(self: baml.time.Duration, other: bigint) -> baml.time.Duration {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    div_bigint
+    init_instance baml.time.Duration ._nanoseconds
+    return
+}
+
+function baml.time.Duration.root.ops.Divide<int>.div(self: baml.time.Duration, other: int) -> baml.time.Duration {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    div_bigint
+    init_instance baml.time.Duration ._nanoseconds
+    return
+}
+
+function baml.time.Duration.root.ops.Multiply<bigint>.mul(self: baml.time.Duration, other: bigint) -> baml.time.Duration {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    mul_bigint
+    init_instance baml.time.Duration ._nanoseconds
+    return
+}
+
+function baml.time.Duration.root.ops.Multiply<int>.mul(self: baml.time.Duration, other: int) -> baml.time.Duration {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    mul_bigint
+    init_instance baml.time.Duration ._nanoseconds
+    return
+}
+
+function baml.time.Duration.root.ops.Negate.neg(self: baml.time.Duration) -> baml.time.Duration {
+    load_var self
+    load_field ._nanoseconds
+    unary_op -
+    init_instance baml.time.Duration ._nanoseconds
+    return
+}
+
+function baml.time.Duration.root.ops.Remainder<Duration>.rem(self: baml.time.Duration, other: baml.time.Duration) -> baml.time.Duration {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    load_field ._nanoseconds
+    mod_bigint
+    init_instance baml.time.Duration ._nanoseconds
+    return
+}
+
+function baml.time.Duration.root.ops.Subtract<Duration>.sub(self: baml.time.Duration, other: baml.time.Duration) -> baml.time.Duration {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    load_field ._nanoseconds
+    sub_bigint
+    init_instance baml.time.Duration ._nanoseconds
+    return
+}
+
 function baml.time.Duration.to_hours(self: baml.time.Duration) -> bigint {
     load_var self
     load_field ._nanoseconds
@@ -5463,6 +5537,36 @@ function baml.time.Instant.now() -> baml.time.Instant {
 }
 
 function baml.time.Instant.parse(s: string) -> baml.time.Instant {
+}
+
+function baml.time.Instant.root.ops.Add<Duration>.add(self: baml.time.Instant, other: baml.time.Duration) -> baml.time.Instant {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    load_field ._nanoseconds
+    add_bigint
+    init_instance baml.time.Instant ._nanoseconds
+    return
+}
+
+function baml.time.Instant.root.ops.Subtract<Duration>.sub(self: baml.time.Instant, other: baml.time.Duration) -> baml.time.Instant {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    load_field ._nanoseconds
+    sub_bigint
+    init_instance baml.time.Instant ._nanoseconds
+    return
+}
+
+function baml.time.Instant.root.ops.Subtract<Instant>.sub(self: baml.time.Instant, other: baml.time.Instant) -> baml.time.Duration {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    load_field ._nanoseconds
+    sub_bigint
+    init_instance baml.time.Duration ._nanoseconds
+    return
 }
 
 function baml.time.Instant.to_timestamp_microseconds(self: baml.time.Instant) -> bigint {
@@ -5822,6 +5926,36 @@ function baml.time.PlainDateTime.month(self: baml.time.PlainDateTime) -> int {
 function baml.time.PlainDateTime.parse(s: string) -> baml.time.PlainDateTime {
 }
 
+function baml.time.PlainDateTime.root.ops.Add<Duration>.add(self: baml.time.PlainDateTime, other: baml.time.Duration) -> baml.time.PlainDateTime {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    load_field ._nanoseconds
+    add_bigint
+    init_instance baml.time.PlainDateTime ._nanoseconds
+    return
+}
+
+function baml.time.PlainDateTime.root.ops.Subtract<Duration>.sub(self: baml.time.PlainDateTime, other: baml.time.Duration) -> baml.time.PlainDateTime {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    load_field ._nanoseconds
+    sub_bigint
+    init_instance baml.time.PlainDateTime ._nanoseconds
+    return
+}
+
+function baml.time.PlainDateTime.root.ops.Subtract<PlainDateTime>.sub(self: baml.time.PlainDateTime, other: baml.time.PlainDateTime) -> baml.time.Duration {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    load_field ._nanoseconds
+    sub_bigint
+    init_instance baml.time.Duration ._nanoseconds
+    return
+}
+
 function baml.time.PlainDateTime.second(self: baml.time.PlainDateTime) -> int {
 }
 
@@ -6111,6 +6245,40 @@ function baml.time.PlainTime.minute(self: baml.time.PlainTime) -> int {
 }
 
 function baml.time.PlainTime.parse(s: string) -> baml.time.PlainTime {
+}
+
+function baml.time.PlainTime.root.ops.Add<Duration>.add(self: baml.time.PlainTime, other: baml.time.Duration) -> baml.time.PlainTime {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    load_field ._nanoseconds
+    add_bigint
+    call baml.time._wrap_into_day
+    init_instance baml.time.PlainTime ._nanoseconds
+    return
+}
+
+function baml.time.PlainTime.root.ops.Subtract<Duration>.sub(self: baml.time.PlainTime, other: baml.time.Duration) -> baml.time.PlainTime {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    load_field ._nanoseconds
+    sub_bigint
+    call baml.time._wrap_into_day
+    init_instance baml.time.PlainTime ._nanoseconds
+    return
+}
+
+function baml.time.PlainTime.root.ops.Subtract<PlainTime>.sub(self: baml.time.PlainTime, other: baml.time.PlainTime) -> baml.time.Duration {
+    load_const 0n
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    load_field ._nanoseconds
+    sub_int
+    add_bigint
+    init_instance baml.time.Duration ._nanoseconds
+    return
 }
 
 function baml.time.PlainTime.second(self: baml.time.PlainTime) -> int {
@@ -6588,6 +6756,44 @@ function baml.time.ZonedDateTime.now_in(timezone: baml.time.TimeZoneOffset | str
 function baml.time.ZonedDateTime.parse(s: string) -> baml.time.ZonedDateTime {
 }
 
+function baml.time.ZonedDateTime.root.ops.Add<Duration>.add(self: baml.time.ZonedDateTime, other: baml.time.Duration) -> baml.time.ZonedDateTime {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    load_field ._nanoseconds
+    add_bigint
+    load_var self
+    load_field ._offset_ns
+    load_var self
+    load_field ._iana
+    init_instance baml.time.ZonedDateTime ._nanoseconds, ._offset_ns, ._iana
+    return
+}
+
+function baml.time.ZonedDateTime.root.ops.Subtract<Duration>.sub(self: baml.time.ZonedDateTime, other: baml.time.Duration) -> baml.time.ZonedDateTime {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    load_field ._nanoseconds
+    sub_bigint
+    load_var self
+    load_field ._offset_ns
+    load_var self
+    load_field ._iana
+    init_instance baml.time.ZonedDateTime ._nanoseconds, ._offset_ns, ._iana
+    return
+}
+
+function baml.time.ZonedDateTime.root.ops.Subtract<ZonedDateTime>.sub(self: baml.time.ZonedDateTime, other: baml.time.ZonedDateTime) -> baml.time.Duration {
+    load_var self
+    load_field ._nanoseconds
+    load_var other
+    load_field ._nanoseconds
+    sub_bigint
+    init_instance baml.time.Duration ._nanoseconds
+    return
+}
+
 function baml.time.ZonedDateTime.second(self: baml.time.ZonedDateTime) -> int {
     load_var self
     call baml.time.ZonedDateTime.to_plain
@@ -6772,6 +6978,33 @@ function baml.time._tz_offset_at(timezone: string, at_ns: bigint) -> int | null 
 }
 
 function baml.time._tz_to_instant(timezone: string, civil_ns: bigint, disambiguation: string) -> bigint | null {
+}
+
+function baml.time._wrap_into_day(total_ns: bigint) -> int {
+    load_var total_ns
+    load_const 86400000000000n
+    mod_bigint
+    load_const 86400000000000n
+    add_bigint
+    load_const 86400000000000n
+    mod_bigint
+    call baml.Bigint.to_int
+    jump L2
+    load_var e
+    is_type baml.errors.InvalidArgument
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var e
+    rethrow
+
+  L1:
+    load_const "unreachable: nanoseconds wrapped into [0, 24h) exceed int range"
+    call baml.sys.panic
+
+  L2:
+    return
 }
 
 function baml.time.system_timezone() -> string {

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -293,17 +293,18 @@ namespace baml.sys:
 namespace baml.time:
   class AmbiguousTimeError { methods: [] }
   type Disambiguation
-  class Duration { methods: [abs, from_nanoseconds, from_microseconds, from_milliseconds, from_seconds, from_minutes, from_hours, to_nanoseconds, to_microseconds, to_milliseconds, to_seconds, to_minutes, to_hours] }
-  class Instant { methods: [now, elapsed, parse, _to_string_impl, max, min, abs_diff, from_timestamp_nanoseconds, from_timestamp_microseconds, from_timestamp_milliseconds, from_timestamp_seconds, to_timestamp_nanoseconds, to_timestamp_microseconds, to_timestamp_milliseconds, to_timestamp_seconds, epoch, to_string, from_json, to_json] }
+  class Duration { methods: [abs, from_nanoseconds, from_microseconds, from_milliseconds, from_seconds, from_minutes, from_hours, to_nanoseconds, to_microseconds, to_milliseconds, to_seconds, to_minutes, to_hours, add, sub, mul, mul, div, div, rem, neg] }
+  class Instant { methods: [now, elapsed, parse, _to_string_impl, max, min, abs_diff, from_timestamp_nanoseconds, from_timestamp_microseconds, from_timestamp_milliseconds, from_timestamp_seconds, to_timestamp_nanoseconds, to_timestamp_microseconds, to_timestamp_milliseconds, to_timestamp_seconds, epoch, to_string, from_json, to_json, add, sub, sub] }
   class PlainDate { methods: [from_components, parse, _to_string_impl, to_plain_datetime, _to_plain_datetime, year, month, day, to_string, from_json, to_json] }
-  class PlainDateTime { methods: [from_components, _from_components, parse, _to_string_impl, to_zoned, max, min, to_plain_date, to_plain_time, year, month, day, hour, minute, second, millisecond, to_string, from_json, to_json] }
-  class PlainTime { methods: [from_components, _from_components, parse, _to_string_impl, to_plain_datetime, hour, minute, second, millisecond, to_string, from_json, to_json] }
+  class PlainDateTime { methods: [from_components, _from_components, parse, _to_string_impl, to_zoned, max, min, to_plain_date, to_plain_time, year, month, day, hour, minute, second, millisecond, to_string, from_json, to_json, add, sub, sub] }
+  class PlainTime { methods: [from_components, _from_components, parse, _to_string_impl, to_plain_datetime, hour, minute, second, millisecond, to_string, from_json, to_json, add, sub, sub] }
   class TimeZoneOffset { methods: [utc, new, from_timezone, local, from_duration, to_duration, hours, minutes] }
   class UnknownTimezoneError { methods: [] }
-  class ZonedDateTime { methods: [now, now_in, from_instant, to_instant, from_components, parse, _to_string_impl, max, min, with_timezone, timezone, timezone_offset, to_plain, year, month, day, hour, minute, second, millisecond, to_string, from_json, to_json] }
+  class ZonedDateTime { methods: [now, now_in, from_instant, to_instant, from_components, parse, _to_string_impl, max, min, with_timezone, timezone, timezone_offset, to_plain, year, month, day, hour, minute, second, millisecond, to_string, from_json, to_json, add, sub, sub] }
   function _format_zoned
   function _tz_offset_at
   function _tz_to_instant
+  function _wrap_into_day
   function system_timezone
 namespace baml.toml:
   type Item

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -30,14 +30,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   199   24    load_type 1                                
         25    load_deref 2                               
-        26    call 761 ntypeargs=1                       (ai.Journal.new)
+        26    call 782 ntypeargs=1                       (ai.Journal.new)
         27    store_deref 5                              
 
   200   28    load_type 1                                
         29    load_deref 1                               
         30    load_deref 5                               
         31    load_const 2                               (0)
-        32    call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        32    call 821 ntypeargs=1                       (ai.Agent._emit_from)
         33    store_var 6                                (seen)
 
   201   34    load_const 2                               (0)
@@ -73,7 +73,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         59    load_deref 5                               
         60    load_var 8                                 (total)
         61    load_const 5                               (2)
-        62    call 799 ntypeargs=1                       (ai.Agent._attempt_turn)
+        62    call 820 ntypeargs=1                       (ai.Agent._attempt_turn)
         63    store_var 10                               (turn)
 
   213   64    load_var 7                                 (steps)
@@ -85,11 +85,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         69    load_deref 1                               
         70    load_deref 5                               
         71    load_var 6                                 (seen)
-        72    call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        72    call 821 ntypeargs=1                       (ai.Agent._emit_from)
         73    store_var 6                                (seen)
 
   215   74    load_var 10                                (turn)
-        75    call 780 ntypeargs=0                       (ai.ModelTurn.tool_uses)
+        75    call 801 ntypeargs=0                       (ai.ModelTurn.tool_uses)
         76    store_var 11                               (calls)
 
   216   77    load_var 11                                (calls)
@@ -102,7 +102,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         84    jump +63                                   (to 147)
 
   251   85    load_var 10                                (turn)
-        86    call 779 ntypeargs=0                       (ai.ModelTurn.terminal_text)
+        86    call 800 ntypeargs=0                       (ai.ModelTurn.terminal_text)
         87    store_var 34                               (_96)
         88    load_var 34                                (_96)
         89    store_var 33                               (candidate)
@@ -156,14 +156,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         130   init_instance 4                            (ai.events.FinalProduced .value_json)
         131   load_type 11                               
         132   alloc_array 1                              
-        133   call 762 ntypeargs=0                       (ai.Journal.append_all)
+        133   call 783 ntypeargs=0                       (ai.Journal.append_all)
         134   pop 1                                      
 
   265   135   load_type 1                                
         136   load_deref 1                               
         137   load_deref 5                               
         138   load_var 6                                 (seen)
-        139   call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        139   call 821 ntypeargs=1                       (ai.Agent._emit_from)
         140   store_var 6                                (seen)
 
   266   141   load_var 35                                (value)
@@ -174,7 +174,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         146   return                                     
 
   217   147   load_deref 5                               
-        148   call 760 ntypeargs=0                       (ai.Journal.entries)
+        148   call 781 ntypeargs=0                       (ai.Journal.entries)
         149   container_len                              
         150   store_var 13                               (before)
 
@@ -185,7 +185,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         155   load_type 1                                
         156   load_var2 1 2                              
         157   load_var 5                                 (j)
-        158   make_closure 1676 captures=3 ntypeargs=1   
+        158   make_closure 1702 captures=3 ntypeargs=1   
         159   call 16 ntypeargs=3                        (baml.Array.map)
         160   store_var 14                               (futures)
 
@@ -200,11 +200,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         168   load_deref 1                               
         169   load_deref 5                               
         170   load_var 6                                 (seen)
-        171   call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        171   call 821 ntypeargs=1                       (ai.Agent._emit_from)
         172   store_var 6                                (seen)
 
   227   173   load_deref 5                               
-        174   call 760 ntypeargs=0                       (ai.Journal.entries)
+        174   call 781 ntypeargs=0                       (ai.Journal.entries)
         175   store_var 15                               (entries)
 
   228   176   load_var 13                                (before)
@@ -234,7 +234,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         197   load_var 11                                (calls)
         198   load_type 1                                
         199   load_var 20                                (f)
-        200   make_closure 1677 captures=1 ntypeargs=1   
+        200   make_closure 1703 captures=1 ntypeargs=1   
         201   call 19 ntypeargs=2                        (baml.Array.find)
 
   234   202   store_var 21                               (_58)
@@ -338,12 +338,12 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   126   3     load_type 0                        
         4     load_var 3                         (spec)
-        5     call 771 ntypeargs=1               (ai.FunctionSpec.tools)
+        5     call 792 ntypeargs=1               (ai.FunctionSpec.tools)
         6     store_var 9                        (_10)
 
   127   7     load_type 0                        
         8     load_var 3                         (spec)
-        9     call 769 ntypeargs=1               (ai.FunctionSpec.output_type)
+        9     call 790 ntypeargs=1               (ai.FunctionSpec.output_type)
         10    store_var 10                       (_12)
 
   122   11    load_var2 2 8                      
@@ -446,7 +446,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         99    store_var 21                       (batch)
 
   142   100   load_var 7                         (turn)
-        101   call 780 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        101   call 801 ntypeargs=0               (ai.ModelTurn.tool_uses)
         102   load_type 8                        
         103   load_const 9                       ("iter")
         104   virtual_call nargs=1 ntypeargs=0   
@@ -487,7 +487,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         135   pop 1                              
 
   148   136   load_var 7                         (turn)
-        137   call 779 ntypeargs=0               (ai.ModelTurn.terminal_text)
+        137   call 800 ntypeargs=0               (ai.ModelTurn.terminal_text)
         138   store_var 29                       (_54)
         139   load_var 29                        (_54)
         140   store_var 28                       (candidate)
@@ -499,7 +499,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         146   store_var 28                       (candidate)
 
   149   147   load_var 7                         (turn)
-        148   call 780 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        148   call 801 ntypeargs=0               (ai.ModelTurn.tool_uses)
         149   container_len                      
         150   store_var 30                       (_60)
         151   load_var 30                        (_60)
@@ -513,7 +513,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         158   load_field 1                       (stop_reason)
         159   load_const 14                      (ai.content.StopReason.MaxTokens)
         160   alloc_variant 436                  (ai.content.StopReason)
-        161   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        161   call 633 ntypeargs=0               (baml.ops.equals_equals)
 
   149   162   jump_if_false +2                   (to 164)
         163   jump +7                            (to 170)
@@ -523,7 +523,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         166   load_field 1                       (stop_reason)
         167   load_const 15                      (ai.content.StopReason.Refused)
         168   alloc_variant 436                  (ai.content.StopReason)
-        169   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        169   call 633 ntypeargs=0               (baml.ops.equals_equals)
 
   149   170   jump_if_false +2                   (to 172)
         171   jump +5                            (to 176)
@@ -531,7 +531,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   152   173   load_type 0                        
         174   load_var2 1 28                     
-        175   call 798 ntypeargs=1               (ai.Agent._parses)
+        175   call 819 ntypeargs=1               (ai.Agent._parses)
 
   153   176   pop_jump_if_false +2               (to 178)
         177   jump +33                           (to 210)
@@ -543,7 +543,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         182   jump +12                           (to 194)
 
   175   183   load_var2 4 21                     
-        184   call 762 ntypeargs=0               (ai.Journal.append_all)
+        184   call 783 ntypeargs=0               (ai.Journal.append_all)
         185   pop 1                              
 
   176   186   load_var 2                         (c)
@@ -563,7 +563,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         198   pop 1                              
 
   172   199   load_var2 4 21                     
-        200   call 762 ntypeargs=0               (ai.Journal.append_all)
+        200   call 783 ntypeargs=0               (ai.Journal.append_all)
         201   pop 1                              
 
   173   202   load_type 0                        
@@ -572,11 +572,11 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         205   load_var2 5 6                      
         206   load_const 16                      (1)
         207   sub_int                            
-        208   call 799 ntypeargs=1               (ai.Agent._attempt_turn)
+        208   call 820 ntypeargs=1               (ai.Agent._attempt_turn)
         209   jump +19                           (to 228)
 
   154   210   load_var2 4 21                     
-        211   call 762 ntypeargs=0               (ai.Journal.append_all)
+        211   call 783 ntypeargs=0               (ai.Journal.append_all)
         212   pop 1                              
 
   156   213   load_var 7                         (turn)
@@ -620,7 +620,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
 function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> int {
   182   0    load_var 2             (j)
-        1    call 760 ntypeargs=0   (ai.Journal.entries)
+        1    call 781 ntypeargs=0   (ai.Journal.entries)
         2    store_var 4            (entries)
 
   183   3    load_var 3             (seen)
@@ -708,7 +708,7 @@ function ai.Agent._parses(self: ai.Agent<#0>, candidate: string) -> bool {
 function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: ai.content.ToolUse, j: ai.Journal) -> null {
   56   0     load_var2 2 3          
        1     load_field 1           (name)
-       2     call 777 ntypeargs=0   (ai.tools.Toolbox.get)
+       2     call 798 ntypeargs=0   (ai.tools.Toolbox.get)
        3     store_var 5            (_7)
        4     load_var 5             (_7)
        5     narrow_bind 0 5        
@@ -733,7 +733,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        20    init_instance 0        (ai.events.ToolFailed .id, .message)
        21    load_type 3            
        22    alloc_array 1          
-       23    call 762 ntypeargs=0   (ai.Journal.append_all)
+       23    call 783 ntypeargs=0   (ai.Journal.append_all)
        24    pop 1                  
 
   94   25    load_const 4           (null)
@@ -744,7 +744,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
 
   58   29    load_var2 6 3          
        30    load_field 2           (args)
-       31    call 772 ntypeargs=0   (ai.tools.Tool.call)
+       31    call 793 ntypeargs=0   (ai.tools.Tool.call)
        32    store_var 7            (outcome)
        33    jump +63               (to 96)
        34    load_var 8             (e)
@@ -764,7 +764,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        45    init_instance 1        (ai.events.ToolFailed .id, .message)
        46    load_type 3            
        47    alloc_array 1          
-       48    call 762 ntypeargs=0   (ai.Journal.append_all)
+       48    call 783 ntypeargs=0   (ai.Journal.append_all)
        49    pop 1                  
 
   64   50    load_var 6             (t)
@@ -782,7 +782,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        62    load_var 11            (_19)
        63    load_const 6           (ai.tools.ErrorMode.Raise)
        64    alloc_variant 437      (ai.tools.ErrorMode)
-       65    call 612 ntypeargs=0   (baml.ops.equals_equals)
+       65    call 633 ntypeargs=0   (baml.ops.equals_equals)
        66    pop_jump_if_false +2   (to 68)
        67    jump +4                (to 71)
 
@@ -837,7 +837,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        104   init_instance 3        (ai.events.ToolCompleted .id, .output)
        105   load_type 3            
        106   alloc_array 1          
-       107   call 762 ntypeargs=0   (ai.Journal.append_all)
+       107   call 783 ntypeargs=0   (ai.Journal.append_all)
        108   pop 1                  
 
   83   109   load_const 4           (null)
@@ -883,7 +883,7 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
        30   pop_jump_if_false +4                       (to 34)
 
   41   31   load_type 4                                
-       32   make_closure 1658 captures=0 ntypeargs=1   
+       32   make_closure 1684 captures=0 ntypeargs=1   
        33   store_var 5                                (_9)
 
   35   34   load_var2 1 2                              
@@ -969,11 +969,11 @@ function ai.Journal.entries(self: ai.Journal) -> (ai.events.RunStarted | ai.even
 function ai.Journal.new(spec: ai.FunctionSpec<#0>) -> ai.Journal {
   21   0    load_type 0            
        1    load_var 1             (spec)
-       2    call 767 ntypeargs=1   (ai.FunctionSpec.name)
+       2    call 788 ntypeargs=1   (ai.FunctionSpec.name)
        3    store_var 2            (_4)
        4    load_type 0            
        5    load_var 1             (spec)
-       6    call 768 ntypeargs=1   (ai.FunctionSpec.arguments)
+       6    call 789 ntypeargs=1   (ai.FunctionSpec.arguments)
        7    store_var 3            (_6)
        8    load_var2 2 3          
        9    init_instance 0        (ai.events.RunStarted .spec_name, .arguments)
@@ -1056,7 +1056,7 @@ function ai.ModelTurn.tool_uses(self: ai.ModelTurn) -> ai.content.ToolUse[] {
 
 function ai.Prompt.baml.ToString.to_string(self: ai.Prompt) -> string {
   35   0   load_var 1             (self)
-       1   call 763 ntypeargs=0   (ai.Prompt.text)
+       1   call 784 ntypeargs=0   (ai.Prompt.text)
        2   return                 
 }
 
@@ -1214,7 +1214,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         47   load_var 10                        (_17)
         48   load_const 6                       (ai.errors.RetrySafety.Safe)
         49   alloc_variant 438                  (ai.errors.RetrySafety)
-        50   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        50   call 633 ntypeargs=0               (baml.ops.equals_equals)
 
   155   51   pop_jump_if_false +2               (to 53)
         52   jump +3                            (to 55)
@@ -1226,7 +1226,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         56   load_var 3                         (index)
         57   load_const 4                       (1)
         58   add_int                            
-        59   call 793 ntypeargs=0               (ai.clients.Fallback._try)
+        59   call 814 ntypeargs=0               (ai.clients.Fallback._try)
         60   return                             
 }
 
@@ -1258,13 +1258,13 @@ function ai.clients.Fallback.root.Client.id(self: ai.clients.Fallback) -> string
 function ai.clients.Fallback.root.Client.invoke(self: ai.clients.Fallback, input: ai.ModelTurnInput) -> ai.ModelTurn {
   185   0   load_var2 1 2          
         1   load_const 0           (0)
-        2   call 793 ntypeargs=0   (ai.clients.Fallback._try)
+        2   call 814 ntypeargs=0   (ai.clients.Fallback._try)
         3   jump +6                (to 9)
         4   load_var 3             (e)
         5   throw_if_panic         
 
   186   6   load_var 3             (e)
-        7   call 811 ntypeargs=0   (ai.errors.normalize)
+        7   call 832 ntypeargs=0   (ai.errors.normalize)
         8   throw                  
         9   return                 
 }
@@ -1306,7 +1306,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        29   load_var 7                         (_11)
        30   load_const 5                       (ai.errors.RetrySafety.Safe)
        31   alloc_variant 438                  (ai.errors.RetrySafety)
-       32   call 612 ntypeargs=0               (baml.ops.equals_equals)
+       32   call 633 ntypeargs=0               (baml.ops.equals_equals)
 
   74   33   jump_if_false +5                   (to 38)
        34   pop 1                              
@@ -1332,7 +1332,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        49   add_int                            
 
   80   50   load_var 6                         (f)
-       51   call 785 ntypeargs=0               (ai.clients.Backoff.delay_ms)
+       51   call 806 ntypeargs=0               (ai.clients.Backoff.delay_ms)
        52   call 502 ntypeargs=0               (baml.time.Duration.from_milliseconds)
 
   79   53   sys_op 255                         (baml.sys.sleep)
@@ -1345,7 +1345,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        59   load_var 3                         (remaining)
        60   load_const 3                       (1)
        61   sub_int                            
-       62   call 787 ntypeargs=0               (ai.clients.Retry._attempt)
+       62   call 808 ntypeargs=0               (ai.clients.Retry._attempt)
        63   return                             
 }
 
@@ -1390,7 +1390,7 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
        32   load_const 0           (<omitted>)
        33   load_const 0           (<omitted>)
        34   load_const 0           (<omitted>)
-       35   call 784 ntypeargs=0   (ai.clients.Backoff.new)
+       35   call 805 ntypeargs=0   (ai.clients.Backoff.new)
        36   store_var 6            (_10)
 
   61   37   load_var2 1 2          
@@ -1414,13 +1414,13 @@ function ai.clients.Retry.root.Client.invoke(self: ai.clients.Retry, input: ai.M
   99    0    load_var2 1 2          
         1    load_var 1             (self)
         2    load_field 1           (max_attempts)
-        3    call 787 ntypeargs=0   (ai.clients.Retry._attempt)
+        3    call 808 ntypeargs=0   (ai.clients.Retry._attempt)
         4    jump +6                (to 10)
         5    load_var 3             (e)
         6    throw_if_panic         
 
   100   7    load_var 3             (e)
-        8    call 811 ntypeargs=0   (ai.errors.normalize)
+        8    call 832 ntypeargs=0   (ai.errors.normalize)
         9    throw                  
         10   return                 
 }
@@ -1514,7 +1514,7 @@ function ai.clients.RoundRobin.root.Client.invoke(self: ai.clients.RoundRobin, i
         33   throw_if_panic                     
 
   141   34   load_var 4                         (e)
-        35   call 811 ntypeargs=0               (ai.errors.normalize)
+        35   call 832 ntypeargs=0               (ai.errors.normalize)
         36   throw                              
         37   load_var 3                         (_0)
         38   return                             
@@ -1690,7 +1690,7 @@ function ai.errors.normalize(error: unknown) -> ai.errors.Failure | baml.errors.
 
 function ai.internal._schema_for_signature(handler: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> map<string, unknown> {
   6    0    load_var 1                         (handler)
-       1    call 695 ntypeargs=0               (reflect.signature)
+       1    call 716 ntypeargs=0               (reflect.signature)
        2    store_var 2                        (sig)
 
   7    3    load_type 0                        
@@ -1770,10 +1770,10 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
 
   102   9     load_var2 4 2                      
         10    load_var 3                         (params)
-        11    call 881 ntypeargs=0               (ai.mcp.rpc_line)
+        11    call 902 ntypeargs=0               (ai.mcp.rpc_line)
         12    store_var 5                        (_6)
         13    load_var2 1 5                      
-        14    call 883 ntypeargs=0               (ai.mcp.McpConnection._send)
+        14    call 904 ntypeargs=0               (ai.mcp.McpConnection._send)
         15    pop 1                              
 
   103   16    load_const 1                       (true)
@@ -1907,7 +1907,7 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
 
   123   124   load_var 15                        (err)
         125   load_const 5                       (null)
-        126   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        126   call 633 ntypeargs=0               (baml.ops.equals_equals)
         127   unary_op !                         
         128   pop_jump_if_false +2               (to 130)
         129   jump +7                            (to 136)
@@ -2011,7 +2011,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         5    load_type 3                        
         6    load_type 4                        
         7    alloc_map 2                        
-        8    call 884 ntypeargs=0               (ai.mcp.McpConnection._request)
+        8    call 905 ntypeargs=0               (ai.mcp.McpConnection._request)
         9    store_var 4                        (result)
 
   185   10   load_type 3                        
@@ -2179,16 +2179,16 @@ function ai.mcp.McpConnection.connect(name: string, command: string, args: strin
        59   load_type 4            
        60   load_type 19           
        61   alloc_map 3            
-       62   call 884 ntypeargs=0   (ai.mcp.McpConnection._request)
+       62   call 905 ntypeargs=0   (ai.mcp.McpConnection._request)
        63   pop 1                  
 
   76   64   load_const 2           (null)
        65   load_const 20          ("notifications/initialized")
        66   load_const 2           (null)
-       67   call 881 ntypeargs=0   (ai.mcp.rpc_line)
+       67   call 902 ntypeargs=0   (ai.mcp.rpc_line)
        68   store_var 11           (_26)
        69   load_var2 10 11        
-       70   call 883 ntypeargs=0   (ai.mcp.McpConnection._send)
+       70   call 904 ntypeargs=0   (ai.mcp.McpConnection._send)
        71   pop 1                  
 
   77   72   load_var 10            (conn)
@@ -2201,7 +2201,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         2    load_type 1                        
         3    load_type 2                        
         4    alloc_map 0                        
-        5    call 884 ntypeargs=0               (ai.mcp.McpConnection._request)
+        5    call 905 ntypeargs=0               (ai.mcp.McpConnection._request)
         6    store_var 2                        (result)
 
   157   7    load_type 3                        
@@ -2270,13 +2270,13 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         63   store_var 13                       (_31)
 
   173   64   load_var2 1 7                      
-        65   call 880 ntypeargs=0               (ai.mcp._proxy)
+        65   call 901 ntypeargs=0               (ai.mcp._proxy)
         66   store_var 14                       (_32)
 
   170   67   load_var2 7 12                     
         68   load_var2 13 14                    
         69   load_const 18                      (<omitted>)
-        70   call 774 ntypeargs=0               (ai.tools.raw_tool)
+        70   call 795 ntypeargs=0               (ai.tools.raw_tool)
         71   store_var 11                       (_26)
 
   168   72   load_var2 3 11                     
@@ -2297,7 +2297,7 @@ function ai.mcp._proxy(conn: ai.mcp.McpConnection, name: string) -> (map<string,
        5   store_var 2           
 
   20   6   load_var2 1 2         
-       7   make_closure 2242 2   
+       7   make_closure 2268 2   
        8   return                
 }
 
@@ -2354,7 +2354,7 @@ function ai.prompt(body: ((string) -> baml.prompt.Role throws never, baml.prompt
        2   store_var 1           
 
   49   3   load_var 1            (body)
-       4   make_closure 1592 1   
+       4   make_closure 1618 1   
        5   return                
 }
 
@@ -2484,7 +2484,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         1    pop_jump_if_false +7   (to 8)
 
   216   2    load_var 1             (self)
-        3    call 806 ntypeargs=0   (ai.stream.TurnStream.next)
+        3    call 827 ntypeargs=0   (ai.stream.TurnStream.next)
         4    store_var 2            (_3)
         5    load_var 2             (_3)
         6    narrow_bind 1 2        
@@ -2493,7 +2493,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
   223   8    load_var 1             (self)
         9    load_field 8           (_input_tokens)
         10   load_const 2           (null)
-        11   call 612 ntypeargs=0   (baml.ops.equals_equals)
+        11   call 633 ntypeargs=0   (baml.ops.equals_equals)
         12   unary_op !             
         13   jump_if_false +2       (to 15)
         14   jump +7                (to 21)
@@ -2501,7 +2501,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         16   load_var 1             (self)
         17   load_field 9           (_output_tokens)
         18   load_const 2           (null)
-        19   call 612 ntypeargs=0   (baml.ops.equals_equals)
+        19   call 633 ntypeargs=0   (baml.ops.equals_equals)
         20   unary_op !             
         21   pop_jump_if_false +2   (to 23)
         22   jump +4                (to 26)
@@ -2649,7 +2649,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         38    jump +6                            (to 44)
 
   202   39    load_var 1                         (self)
-        40    call 805 ntypeargs=0               (ai.stream.TurnStream._finish)
+        40    call 826 ntypeargs=0               (ai.stream.TurnStream._finish)
         41    pop 1                              
 
   203   42    alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2727,7 +2727,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         102   jump -15                           (to 87)
 
   176   103   load_var 1                         (self)
-        104   call 805 ntypeargs=0               (ai.stream.TurnStream._finish)
+        104   call 826 ntypeargs=0               (ai.stream.TurnStream._finish)
         105   pop 1                              
 
   177   106   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2767,7 +2767,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         137   pop_jump_if_false -137             (to 0)
 
   165   138   load_var 1                         (self)
-        139   call 805 ntypeargs=0               (ai.stream.TurnStream._finish)
+        139   call 826 ntypeargs=0               (ai.stream.TurnStream._finish)
         140   pop 1                              
 
   166   141   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2856,8 +2856,8 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   306   9     load_type 2                                
         10    load_var 1                                 (spec)
-        11    call 771 ntypeargs=1                       (ai.FunctionSpec.tools)
-        12    call 778 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
+        11    call 792 ntypeargs=1                       (ai.FunctionSpec.tools)
+        12    call 799 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
         13    unary_op !                                 
         14    pop_jump_if_false +2                       (to 16)
         15    jump +71                                   (to 86)
@@ -2907,17 +2907,17 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   331   51    load_type 2                                
         52    load_var 1                                 (spec)
-        53    call 761 ntypeargs=1                       (ai.Journal.new)
+        53    call 782 ntypeargs=1                       (ai.Journal.new)
         54    store_var 12                               (_29)
 
   332   55    load_type 2                                
         56    load_var 1                                 (spec)
-        57    call 771 ntypeargs=1                       (ai.FunctionSpec.tools)
+        57    call 792 ntypeargs=1                       (ai.FunctionSpec.tools)
         58    store_var 13                               (_31)
 
   333   59    load_type 2                                
         60    load_var 1                                 (spec)
-        61    call 769 ntypeargs=1                       (ai.FunctionSpec.output_type)
+        61    call 790 ntypeargs=1                       (ai.FunctionSpec.output_type)
         62    store_var 14                               (_33)
 
   328   63    load_var2 5 11                             
@@ -2938,7 +2938,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
   340   75    load_type 8                                
         76    load_type 2                                
         77    load_var 10                                (turns)
-        78    make_closure 1698 captures=1 ntypeargs=2   
+        78    make_closure 1724 captures=1 ntypeargs=2   
         79    load_var 15                                (_36)
         80    load_const 9                               ("")
         81    load_const 10                              (false)
@@ -2949,7 +2949,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   308   86    load_type 2                                
         87    load_var 1                                 (spec)
-        88    call 767 ntypeargs=1                       (ai.FunctionSpec.name)
+        88    call 788 ntypeargs=1                       (ai.FunctionSpec.name)
         89    store_var 4                                (_12)
         90    load_type 11                               
         91    load_var 4                                 (_12)
@@ -2998,7 +2998,7 @@ function ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> 
        27   load_type 5            
 
   29   28   load_var2 4 2          
-       29   call 696 ntypeargs=2   (reflect.call_any)
+       29   call 717 ntypeargs=2   (reflect.call_any)
        30   store_var 5            (value)
        31   jump +33               (to 64)
 
@@ -3058,7 +3058,7 @@ function ai.tools.Toolbox.get(self: ai.tools.Toolbox, name: string) -> ai.tools.
         5    load_var 1            (self)
         6    load_field 0          (entries)
         7    load_var 2            (name)
-        8    make_closure 1618 1   
+        8    make_closure 1644 1   
         9    call 19 ntypeargs=2   (baml.Array.find)
         10   return                
 }
@@ -3182,7 +3182,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        17   store_var 4            (on_error)
 
   49   18   load_var 1             (handler)
-       19   call 695 ntypeargs=0   (reflect.signature)
+       19   call 716 ntypeargs=0   (reflect.signature)
        20   store_var 5            (sig)
 
   50   21   load_var 2             (name)
@@ -3233,7 +3233,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        61   store_var 9            (_17)
 
   58   62   load_var 1             (handler)
-       63   call 821 ntypeargs=0   (ai.internal._schema_for_signature)
+       63   call 842 ntypeargs=0   (ai.internal._schema_for_signature)
        64   store_var 11           (_21)
 
   56   65   load_var2 8 9          
@@ -3315,7 +3315,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
   27   48   load_var2 2 3          
        49   load_field 0           (status_code)
        50   load_var 7             (text)
-       51   call 820 ntypeargs=0   (ai.errors.classify_http)
+       51   call 841 ntypeargs=0   (ai.errors.classify_http)
        52   throw                  
 }
 
@@ -3333,20 +3333,20 @@ function anthropic.AnthropicClient.ai.Client.id(self: anthropic.AnthropicClient)
 
 function anthropic.AnthropicClient.ai.Client.invoke(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   32   0   load_var2 1 2          
-       1   call 848 ntypeargs=0   (anthropic.internal.invoke)
+       1   call 869 ntypeargs=0   (anthropic.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   33   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 832 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function anthropic.AnthropicClient.ai.stream.StreamingClient.invoke_stream(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   40   0   load_var2 1 2          
-       1   call 850 ntypeargs=0   (anthropic.internal.invoke_stream)
+       1   call 871 ntypeargs=0   (anthropic.internal.invoke_stream)
        2   return                 
 }
 
@@ -3508,7 +3508,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         2     store_var 2                        (out)
 
   349   3     load_var 1                         (batch)
-        4     call 802 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 823 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -3618,7 +3618,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         98    pop_jump_if_false +2               (to 100)
         99    jump +5                            (to 104)
         100   load_var 21                        (_65)
-        101   call 847 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+        101   call 868 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         102   store_var 20                       (stop)
         103   jump +3                            (to 106)
 
@@ -3778,7 +3778,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         2     store_var 2                        (msgs)
 
   132   3     load_var 1                         (j)
-        4     call 760 ntypeargs=0               (ai.Journal.entries)
+        4     call 781 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -3826,7 +3826,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         47    load_var 14                        (f)
         48    load_field 1                       (message)
         49    load_const 10                      (true)
-        50    call 843 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        50    call 864 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         51    pop 1                              
         52    jump -43                           (to 9)
 
@@ -3838,13 +3838,13 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         57    load_var 12                        (c)
         58    load_field 1                       (output)
         59    load_const 11                      (false)
-        60    call 843 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        60    call 864 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         61    pop 1                              
         62    jump -53                           (to 9)
 
   133   63    load_var 9                         (_24)
         64    load_field 0                       (content)
-        65    call 842 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
+        65    call 863 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
         66    store_var 10                       (_28)
 
   142   67    load_var 2                         (msgs)
@@ -3907,7 +3907,7 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
        5    store_var 3                        (messages)
 
   53   6    load_var 1                         (prompt)
-       7    call 764 ntypeargs=0               (ai.Prompt.messages)
+       7    call 785 ntypeargs=0               (ai.Prompt.messages)
        8    load_type 2                        
        9    load_const 3                       ("iter")
        10   virtual_call nargs=1 ntypeargs=0   
@@ -4145,11 +4145,11 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         2     store_var 4                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 782 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 803 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 4                         (_5)
         7     call_indirect                      
 
-  183   8     call 841 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
+  183   8     call 862 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
         9     store_var 5                        (prompt_parts)
 
   184   10    load_var 5                         (prompt_parts)
@@ -4162,7 +4162,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   186   16    load_var 2                         (input)
         17    load_field 1                       (journal)
-        18    call 844 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
+        18    call 865 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
         19    load_type 0                        
         20    load_const 1                       ("iter")
         21    virtual_call nargs=1 ntypeargs=0   
@@ -4263,7 +4263,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         107   pop 1                              
 
   210   108   load_var 7                         (lowered)
-        109   call 845 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        109   call 866 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         110   store_var 16                       (_60)
         111   load_type 5                        
         112   load_type 6                        
@@ -4285,7 +4285,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   201   126   load_var 7                         (lowered)
         127   call 7 ntypeargs=1                 (baml.Array.concat)
-        128   call 845 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        128   call 866 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         129   store_var 14                       (_45)
         130   load_type 5                        
         131   load_type 6                        
@@ -4297,7 +4297,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   213   137   load_var 2                         (input)
         138   load_field 2                       (toolbox)
-        139   call 778 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        139   call 799 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         140   unary_op !                         
         141   pop_jump_if_false +79              (to 220)
 
@@ -4307,7 +4307,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   215   145   load_var 2                         (input)
         146   load_field 2                       (toolbox)
-        147   call 776 ntypeargs=0               (ai.tools.Toolbox.list)
+        147   call 797 ntypeargs=0               (ai.tools.Toolbox.list)
         148   load_type 20                       
         149   load_const 21                      ("iter")
         150   virtual_call nargs=1 ntypeargs=0   
@@ -4496,13 +4496,13 @@ function anthropic.internal._anthropic_stop_reason(s: string) -> ai.content.Stop
 function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   266   0     load_var2 1 2                      
         1     load_const 0                       (false)
-        2     call 846 ntypeargs=0               (anthropic.internal._anthropic_request)
+        2     call 867 ntypeargs=0               (anthropic.internal._anthropic_request)
         3     store_var 3                        (req)
 
   267   4     load_type 1                        
         5     load_var 3                         (req)
         6     load_const 2                       ("anthropic")
-        7     call 781 ntypeargs=1               (ai.wire.send_as)
+        7     call 802 ntypeargs=1               (ai.wire.send_as)
         8     store_var 4                        (resp)
 
   269   9     load_type 3                        
@@ -4635,7 +4635,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         123   pop_jump_if_false +2               (to 125)
         124   jump +5                            (to 129)
         125   load_var 20                        (_43)
-        126   call 847 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+        126   call 868 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         127   store_var 19                       (stop)
         128   jump +4                            (to 132)
 
@@ -4676,7 +4676,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
 function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   415   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 846 ntypeargs=0   (anthropic.internal._anthropic_request)
+        2    call 867 ntypeargs=0   (anthropic.internal._anthropic_request)
 
   416   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -4702,7 +4702,7 @@ function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: a
         21   throw                  
 
   425   22   load_const 6           (anthropic.internal._anthropic_decode_batch)
-        23   call 803 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 824 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -4738,19 +4738,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 756 ntypeargs=0   (assert.format_operand)
+       26   call 777 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 756 ntypeargs=0   (assert.format_operand)
+       29   call 777 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 756 ntypeargs=0   (assert.format_operand)
+       32   call 777 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 756 ntypeargs=0   (assert.format_operand)
+       35   call 777 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -4794,7 +4794,7 @@ function assert.contains(haystack: string, needle: string) -> null {
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   50   0    load_var2 1 2          
-       1    call 612 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 633 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -4804,11 +4804,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 756 ntypeargs=0   (assert.format_operand)
+       8    call 777 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 756 ntypeargs=0   (assert.format_operand)
+       11   call 777 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -4847,7 +4847,7 @@ function assert.is_true(condition: bool) -> null {
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 612 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 633 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -4883,13 +4883,13 @@ function claude_code.ClaudeCodeClient.ai.Client.id(self: claude_code.ClaudeCodeC
 
 function claude_code.ClaudeCodeClient.ai.Client.invoke(self: claude_code.ClaudeCodeClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   44   0   load_var2 1 2          
-       1   call 879 ntypeargs=0   (claude_code.internal.invoke)
+       1   call 900 ntypeargs=0   (claude_code.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   45   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 832 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
@@ -5105,7 +5105,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         122   load_const 31                      (".thinking")
         123   load_const 32                      ("")
         124   call 340 ntypeargs=1               (baml.json.path_or)
-        125   call 875 ntypeargs=0               (claude_code.internal._preview)
+        125   call 896 ntypeargs=0               (claude_code.internal._preview)
         126   store_var 17                       (_55)
         127   load_type 0                        
         128   load_var 17                        (_55)
@@ -5126,7 +5126,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         140   load_const 34                      (".text")
         141   load_const 35                      ("")
         142   call 340 ntypeargs=1               (baml.json.path_or)
-        143   call 875 ntypeargs=0               (claude_code.internal._preview)
+        143   call 896 ntypeargs=0               (claude_code.internal._preview)
         144   store_var 15                       (_47)
         145   load_type 0                        
         146   load_var 15                        (_47)
@@ -5320,7 +5320,7 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         34   throw                              
 
   136   35   load_var 6                         (raw)
-        36   call 876 ntypeargs=0               (claude_code.internal._log_cc_event)
+        36   call 897 ntypeargs=0               (claude_code.internal._log_cc_event)
         37   pop 1                              
 
   137   38   load_type 8                        
@@ -5339,7 +5339,7 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
 
   144   49   load_var 2                         (result)
         50   load_const 0                       (null)
-        51   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        51   call 633 ntypeargs=0               (baml.ops.equals_equals)
         52   pop_jump_if_false +2               (to 54)
         53   jump +3                            (to 56)
 
@@ -5382,7 +5382,7 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
         8    load_type 2           
         9    load_var 3            (_3)
 
-  220   10   make_closure 2178 0   
+  220   10   make_closure 2204 0   
         11   call 16 ntypeargs=3   (baml.Array.map)
         12   store_var 2           (_2)
 
@@ -5415,7 +5415,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        16    store_var 5            (call_props)
 
   55   17    load_const 4           ("string")
-       18    call 872 ntypeargs=0   (claude_code.internal._type_schema)
+       18    call 893 ntypeargs=0   (claude_code.internal._type_schema)
        19    store_var 6            (_10)
        20    load_type 1            
        21    load_type 2            
@@ -5426,7 +5426,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        26    pop 1                  
 
   56   27    load_const 6           ("string")
-       28    call 872 ntypeargs=0   (claude_code.internal._type_schema)
+       28    call 893 ntypeargs=0   (claude_code.internal._type_schema)
        29    store_var 7            (_14)
        30    load_type 1            
        31    load_type 2            
@@ -5437,7 +5437,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        36    pop 1                  
 
   57   37    load_const 8           ("object")
-       38    call 872 ntypeargs=0   (claude_code.internal._type_schema)
+       38    call 893 ntypeargs=0   (claude_code.internal._type_schema)
        39    store_var 8            (_18)
        40    load_type 1            
        41    load_type 2            
@@ -5638,7 +5638,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
 
   82   212   load_var 4             (definitions)
        213   load_const 38          (null)
-       214   call 612 ntypeargs=0   (baml.ops.equals_equals)
+       214   call 633 ntypeargs=0   (baml.ops.equals_equals)
        215   unary_op !             
        216   pop_jump_if_false +8   (to 224)
 
@@ -5659,12 +5659,12 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         1     load_var 2                         (input)
         2     load_field 0                       (prompt)
         3     call_indirect                      
-        4     call 763 ntypeargs=0               (ai.Prompt.text)
+        4     call 784 ntypeargs=0               (ai.Prompt.text)
         5     store_var 4                        (instructions)
 
   234   6     load_var 2                         (input)
         7     load_field 2                       (toolbox)
-        8     call 778 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        8     call 799 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         9     unary_op !                         
         10    store_var_load_var 5               (has_tools)
 
@@ -5679,7 +5679,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 
   236   18    load_var 2                         (input)
         19    load_field 3                       (output_type)
-        20    call 871 ntypeargs=0               (claude_code.internal.envelope_schema)
+        20    call 892 ntypeargs=0               (claude_code.internal.envelope_schema)
         21    store_var 7                        (_11)
         22    load_type 1                        
         23    load_var 7                         (_11)
@@ -5696,7 +5696,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         32    store_var 14                       (_29)
         33    load_var 2                         (input)
         34    load_field 1                       (journal)
-        35    call 870 ntypeargs=0               (claude_code.internal.transcript_text)
+        35    call 891 ntypeargs=0               (claude_code.internal.transcript_text)
         36    store_var 16                       (_33)
         37    load_type 2                        
         38    load_var 16                        (_33)
@@ -5714,7 +5714,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         48    store_var 9                        (_18)
         49    load_var 2                         (input)
         50    load_field 1                       (journal)
-        51    call 870 ntypeargs=0               (claude_code.internal.transcript_text)
+        51    call 891 ntypeargs=0               (claude_code.internal.transcript_text)
         52    store_var 11                       (_22)
         53    load_type 2                        
         54    load_var 11                        (_22)
@@ -5722,7 +5722,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         56    store_var 10                       (_21)
         57    load_var 2                         (input)
         58    load_field 2                       (toolbox)
-        59    call 873 ntypeargs=0               (claude_code.internal.tool_protocol)
+        59    call 894 ntypeargs=0               (claude_code.internal.tool_protocol)
         60    store_var 13                       (_26)
         61    load_type 2                        
         62    load_var 13                        (_26)
@@ -5748,7 +5748,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         81    store_var 18                       (_44)
         82    load_var 2                         (input)
         83    load_field 2                       (toolbox)
-        84    call 776 ntypeargs=0               (ai.tools.Toolbox.list)
+        84    call 797 ntypeargs=0               (ai.tools.Toolbox.list)
         85    container_len                      
         86    store_var 21                       (_48)
         87    load_type 3                        
@@ -5844,7 +5844,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         162   pop 1                              
 
   267   163   load_var 1                         (c)
-        164   call 877 ntypeargs=0               (claude_code.internal.mcp_config_json)
+        164   call 898 ntypeargs=0               (claude_code.internal.mcp_config_json)
         165   store_var 24                       (_70)
         166   load_var 24                        (_70)
         167   narrow_bind 21 24                  
@@ -5867,7 +5867,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         181   pop 1                              
 
   271   182   load_var 1                         (c)
-        183   call 878 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
+        183   call 899 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
         184   store_var 27                       (_79)
         185   load_type 2                        
         186   load_var 27                        (_79)
@@ -5941,7 +5941,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         243   throw_if_panic                     
 
   299   244   load_var 29                        (p)
-        245   call 874 ntypeargs=0               (claude_code.internal._read_result)
+        245   call 895 ntypeargs=0               (claude_code.internal._read_result)
         246   store_var 36                       (result)
 
   300   247   load_var 29                        (p)
@@ -6159,7 +6159,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 
   359   432   load_var 2                         (input)
         433   load_field 1                       (journal)
-        434   call 760 ntypeargs=0               (ai.Journal.entries)
+        434   call 781 ntypeargs=0               (ai.Journal.entries)
         435   container_len                      
         436   store_var 67                       (_196)
         437   load_type 3                        
@@ -6329,7 +6329,7 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         2    store_var 2                        (catalog)
 
   100   3    load_var 1                         (tb)
-        4    call 776 ntypeargs=0               (ai.tools.Toolbox.list)
+        4    call 797 ntypeargs=0               (ai.tools.Toolbox.list)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -6410,7 +6410,7 @@ function claude_code.internal.transcript_text(j: ai.Journal) -> string {
        2     store_var 2                        (lines)
 
   8    3     load_var 1                         (j)
-       4     call 760 ntypeargs=0               (ai.Journal.entries)
+       4     call 781 ntypeargs=0               (ai.Journal.entries)
        5     load_type 1                        
        6     load_const 2                       ("iter")
        7     virtual_call nargs=1 ntypeargs=0   
@@ -6645,20 +6645,20 @@ function google.GoogleClient.ai.Client.id(self: google.GoogleClient) -> string {
 
 function google.GoogleClient.ai.Client.invoke(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   22   0   load_var2 1 2          
-       1   call 864 ntypeargs=0   (google.internal.invoke)
+       1   call 885 ntypeargs=0   (google.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   23   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 832 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function google.GoogleClient.ai.stream.StreamingClient.invoke_stream(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   30   0   load_var2 1 2          
-       1   call 866 ntypeargs=0   (google.internal.invoke_stream)
+       1   call 887 ntypeargs=0   (google.internal.invoke_stream)
        2   return                 
 }
 
@@ -6779,7 +6779,7 @@ function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string 
         1    store_var 3                        (name)
 
   110   2    load_var 1                         (j)
-        3    call 760 ntypeargs=0               (ai.Journal.entries)
+        3    call 781 ntypeargs=0               (ai.Journal.entries)
         4    load_type 1                        
         5    load_const 2                       ("iter")
         6    virtual_call nargs=1 ntypeargs=0   
@@ -6845,7 +6845,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         2     store_var 2                        (out)
 
   368   3     load_var 1                         (batch)
-        4     call 802 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 823 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -7011,7 +7011,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         153   jump +2                            (to 155)
         154   load_const 8                       (null)
         155   load_const 8                       (null)
-        156   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        156   call 633 ntypeargs=0               (baml.ops.equals_equals)
         157   store_var 21                       (_61)
 
   390   158   load_var 19                        (finish)
@@ -7082,14 +7082,14 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
 
   405   207   load_var 22                        (stop)
         208   load_const 8                       (null)
-        209   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        209   call 633 ntypeargs=0               (baml.ops.equals_equals)
         210   unary_op !                         
         211   jump_if_false +2                   (to 213)
         212   jump +6                            (to 218)
         213   pop 1                              
         214   load_var 23                        (usage)
         215   load_const 8                       (null)
-        216   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        216   call 633 ntypeargs=0               (baml.ops.equals_equals)
         217   unary_op !                         
         218   pop_jump_if_false -209             (to 9)
 
@@ -7138,11 +7138,11 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         2     store_var 4                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 782 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 803 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 4                         (_5)
         7     call_indirect                      
 
-  227   8     call 858 ntypeargs=0               (google.internal.google_lower_prompt)
+  227   8     call 879 ntypeargs=0               (google.internal.google_lower_prompt)
         9     store_var 5                        (prompt_parts)
 
   228   10    load_var 5                         (prompt_parts)
@@ -7151,7 +7151,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   229   13    load_var 2                         (input)
         14    load_field 1                       (journal)
-        15    call 860 ntypeargs=0               (google.internal.google_lower_journal)
+        15    call 881 ntypeargs=0               (google.internal.google_lower_journal)
         16    load_type 0                        
         17    load_const 1                       ("iter")
         18    virtual_call nargs=1 ntypeargs=0   
@@ -7229,7 +7229,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
   239   80    load_const 11                      ("user")
         81    load_var 5                         (prompt_parts)
         82    load_field 0                       (system_parts)
-        83    call 855 ntypeargs=0               (google.internal._gm_content)
+        83    call 876 ntypeargs=0               (google.internal._gm_content)
         84    store_var 11                       (_28)
         85    load_type 12                       
         86    load_var 11                        (_28)
@@ -7249,7 +7249,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   250   99    load_var 2                         (input)
         100   load_field 2                       (toolbox)
-        101   call 778 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        101   call 799 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         102   unary_op !                         
         103   pop_jump_if_false +103             (to 206)
 
@@ -7259,7 +7259,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   252   107   load_var 2                         (input)
         108   load_field 2                       (toolbox)
-        109   call 776 ntypeargs=0               (ai.tools.Toolbox.list)
+        109   call 797 ntypeargs=0               (ai.tools.Toolbox.list)
         110   load_type 14                       
         111   load_const 15                      ("iter")
         112   virtual_call nargs=1 ntypeargs=0   
@@ -7455,7 +7455,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         5     store_var 3                        (pending)
 
   141   6     load_var 1                         (j)
-        7     call 760 ntypeargs=0               (ai.Journal.entries)
+        7     call 781 ntypeargs=0               (ai.Journal.entries)
         8     load_type 1                        
         9     load_const 2                       ("iter")
         10    virtual_call nargs=1 ntypeargs=0   
@@ -7514,9 +7514,9 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   199   60    load_var2 1 34                     
         61    load_field 0                       (id)
-        62    call 859 ntypeargs=0               (google.internal._gm_tool_name_for)
+        62    call 880 ntypeargs=0               (google.internal._gm_tool_name_for)
         63    load_var 35                        (response)
-        64    call 857 ntypeargs=0               (google.internal._gm_function_response)
+        64    call 878 ntypeargs=0               (google.internal._gm_function_response)
         65    store_var 36                       (_84)
         66    load_var2 3 36                     
         67    call 4 ntypeargs=0                 (baml.Array.push)
@@ -7542,9 +7542,9 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   193   84    load_var2 1 30                     
         85    load_field 0                       (id)
-        86    call 859 ntypeargs=0               (google.internal._gm_tool_name_for)
+        86    call 880 ntypeargs=0               (google.internal._gm_tool_name_for)
         87    load_var 31                        (response)
-        88    call 857 ntypeargs=0               (google.internal._gm_function_response)
+        88    call 878 ntypeargs=0               (google.internal._gm_function_response)
         89    store_var 32                       (_72)
         90    load_var2 3 32                     
         91    call 4 ntypeargs=0                 (baml.Array.push)
@@ -7564,7 +7564,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   156   103   load_const 15                      ("user")
         104   load_var 3                         (pending)
-        105   call 855 ntypeargs=0               (google.internal._gm_content)
+        105   call 876 ntypeargs=0               (google.internal._gm_content)
         106   store_var 16                       (_27)
         107   load_var2 2 16                     
         108   call 4 ntypeargs=0                 (baml.Array.push)
@@ -7653,7 +7653,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   164   181   load_var 21                        (_36)
         182   load_field 0                       (text)
-        183   call 856 ntypeargs=0               (google.internal._gm_text_part)
+        183   call 877 ntypeargs=0               (google.internal._gm_text_part)
         184   store_var 22                       (_39)
 
   166   185   load_var2 17 22                    
@@ -7671,7 +7671,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   183   196   load_const 25                      ("model")
         197   load_var 17                        (parts)
-        198   call 855 ntypeargs=0               (google.internal._gm_content)
+        198   call 876 ntypeargs=0               (google.internal._gm_content)
         199   store_var 28                       (_62)
         200   load_var2 2 28                     
         201   call 4 ntypeargs=0                 (baml.Array.push)
@@ -7691,7 +7691,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   145   213   load_const 26                      ("user")
         214   load_var 3                         (pending)
-        215   call 855 ntypeargs=0               (google.internal._gm_content)
+        215   call 876 ntypeargs=0               (google.internal._gm_content)
         216   store_var 10                       (_15)
         217   load_var2 2 10                     
         218   call 4 ntypeargs=0                 (baml.Array.push)
@@ -7703,13 +7703,13 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   151   223   load_var 8                         (u)
         224   load_field 0                       (content)
-        225   call 856 ntypeargs=0               (google.internal._gm_text_part)
+        225   call 877 ntypeargs=0               (google.internal._gm_text_part)
         226   store_var 12                       (_20)
         227   load_const 27                      ("user")
         228   load_var 12                        (_20)
         229   load_type 0                        
         230   alloc_array 1                      
-        231   call 855 ntypeargs=0               (google.internal._gm_content)
+        231   call 876 ntypeargs=0               (google.internal._gm_content)
         232   store_var 11                       (_18)
         233   load_var2 2 11                     
         234   call 4 ntypeargs=0                 (baml.Array.push)
@@ -7726,7 +7726,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   206   244   load_const 28                      ("user")
         245   load_var 3                         (pending)
-        246   call 855 ntypeargs=0               (google.internal._gm_content)
+        246   call 876 ntypeargs=0               (google.internal._gm_content)
         247   store_var 38                       (_91)
         248   load_var2 2 38                     
         249   call 4 ntypeargs=0                 (baml.Array.push)
@@ -7749,7 +7749,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
         7    store_var 4                        (first_role)
 
   82    8    load_var 1                         (prompt)
-        9    call 764 ntypeargs=0               (ai.Prompt.messages)
+        9    call 785 ntypeargs=0               (ai.Prompt.messages)
         10   load_type 2                        
         11   load_const 3                       ("iter")
         12   virtual_call nargs=1 ntypeargs=0   
@@ -7767,7 +7767,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
         24   store_var_load_var 7               (message)
 
   83    25   load_field 1                       (content)
-        26   call 856 ntypeargs=0               (google.internal._gm_text_part)
+        26   call 877 ntypeargs=0               (google.internal._gm_text_part)
         27   store_var 8                        (part)
 
   84    28   load_var 7                         (message)
@@ -7803,7 +7803,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
   99    51   load_var2 9 8                      
         52   load_type 0                        
         53   alloc_array 1                      
-        54   call 855 ntypeargs=0               (google.internal._gm_content)
+        54   call 876 ntypeargs=0               (google.internal._gm_content)
         55   store_var 10                       (_23)
         56   load_var2 3 10                     
         57   call 4 ntypeargs=0                 (baml.Array.push)
@@ -8025,7 +8025,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         179   jump +2                            (to 181)
         180   load_const 3                       (null)
         181   load_const 3                       (null)
-        182   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        182   call 633 ntypeargs=0               (baml.ops.equals_equals)
         183   store_var 24                       (_71)
 
   324   184   load_var 4                         (has_call)
@@ -8138,35 +8138,35 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
 function google.internal.google_render(c: google.GoogleClient, input: ai.ModelTurnInput) -> baml.http.Request {
   216   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 862 ntypeargs=0   (google.internal._google_request)
+        2   call 883 ntypeargs=0   (google.internal._google_request)
         3   return                 
 }
 
 function google.internal.invoke(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   351   0    load_var 2             (input)
         1    load_field 1           (journal)
-        2    call 760 ntypeargs=0   (ai.Journal.entries)
+        2    call 781 ntypeargs=0   (ai.Journal.entries)
         3    container_len          
         4    store_var 3            (seq)
 
   352   5    load_var2 1 2          
-        6    call 861 ntypeargs=0   (google.internal.google_render)
+        6    call 882 ntypeargs=0   (google.internal.google_render)
         7    store_var 4            (req)
 
   353   8    load_type 0            
         9    load_var 4             (req)
         10   load_const 1           ("google")
-        11   call 781 ntypeargs=1   (ai.wire.send_as)
+        11   call 802 ntypeargs=1   (ai.wire.send_as)
 
   354   12   load_var 3             (seq)
-        13   call 863 ntypeargs=0   (google.internal.google_parse)
+        13   call 884 ntypeargs=0   (google.internal.google_parse)
         14   return                 
 }
 
 function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   432   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 862 ntypeargs=0   (google.internal._google_request)
+        2    call 883 ntypeargs=0   (google.internal._google_request)
 
   433   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -8192,7 +8192,7 @@ function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTu
         21   throw                  
 
   442   22   load_const 6           (google.internal._google_decode_batch)
-        23   call 803 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 824 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -8210,20 +8210,20 @@ function openai.OpenAiClient.ai.Client.id(self: openai.OpenAiClient) -> string {
 
 function openai.OpenAiClient.ai.Client.invoke(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   62   0   load_var2 1 2          
-       1   call 834 ntypeargs=0   (openai.internal.invoke)
+       1   call 855 ntypeargs=0   (openai.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   63   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 832 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function openai.OpenAiClient.ai.stream.StreamingClient.invoke_stream(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   70   0   load_var2 1 2          
-       1   call 836 ntypeargs=0   (openai.internal.invoke_stream)
+       1   call 857 ntypeargs=0   (openai.internal.invoke_stream)
        2   return                 
 }
 
@@ -8341,7 +8341,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         2     store_var 2                        (out)
 
   255   3     load_var 1                         (batch)
-        4     call 802 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 823 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -8433,7 +8433,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         83    narrow_bind 15 14                  
         84    pop_jump_if_false +38              (to 122)
         85    load_var 14                        (_38)
-        86    call 833 ntypeargs=0               (openai.internal.openai_parse)
+        86    call 854 ntypeargs=0               (openai.internal.openai_parse)
         87    store_var 15                       (turn)
 
   275   88    load_var 15                        (turn)
@@ -8505,16 +8505,16 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         2     store_var 4                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 782 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 803 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 4                         (_5)
         7     call_indirect                      
 
-  129   8     call 829 ntypeargs=0               (openai.internal.openai_lower_prompt)
+  129   8     call 850 ntypeargs=0               (openai.internal.openai_lower_prompt)
         9     store_var 5                        (items)
 
   130   10    load_var 2                         (input)
         11    load_field 1                       (journal)
-        12    call 830 ntypeargs=0               (openai.internal.openai_lower_journal)
+        12    call 851 ntypeargs=0               (openai.internal.openai_lower_journal)
         13    load_type 0                        
         14    load_const 1                       ("iter")
         15    virtual_call nargs=1 ntypeargs=0   
@@ -8567,7 +8567,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   137   56    load_var 2                         (input)
         57    load_field 2                       (toolbox)
-        58    call 778 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        58    call 799 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         59    unary_op !                         
         60    pop_jump_if_false +82              (to 142)
 
@@ -8577,7 +8577,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   139   64    load_var 2                         (input)
         65    load_field 2                       (toolbox)
-        66    call 776 ntypeargs=0               (ai.tools.Toolbox.list)
+        66    call 797 ntypeargs=0               (ai.tools.Toolbox.list)
         67    load_type 12                       
         68    load_const 13                      ("iter")
         69    virtual_call nargs=1 ntypeargs=0   
@@ -8675,7 +8675,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         150   pop 1                              
 
   162   151   load_var 1                         (c)
-        152   call 825 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
+        152   call 846 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
         153   store_var 16                       (_76)
         154   load_var 16                        (_76)
         155   store_var 15                       (_75)
@@ -8691,7 +8691,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         165   store_var 14                       (_74)
 
   163   166   load_var 1                         (c)
-        167   call 824 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
+        167   call 845 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
         168   store_var 18                       (_82)
         169   load_type 5                        
         170   load_var 18                        (_82)
@@ -8726,22 +8726,22 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
 function openai.internal.invoke(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   231   0   load_var2 1 2          
-        1   call 831 ntypeargs=0   (openai.internal.openai_render)
+        1   call 852 ntypeargs=0   (openai.internal.openai_render)
         2   store_var 3            (req)
 
   232   3   load_type 0            
         4   load_var 3             (req)
         5   load_const 1           ("openai")
-        6   call 781 ntypeargs=1   (ai.wire.send_as)
+        6   call 802 ntypeargs=1   (ai.wire.send_as)
 
-  233   7   call 833 ntypeargs=0   (openai.internal.openai_parse)
+  233   7   call 854 ntypeargs=0   (openai.internal.openai_parse)
         8   return                 
 }
 
 function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   304   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 832 ntypeargs=0   (openai.internal._openai_request)
+        2    call 853 ntypeargs=0   (openai.internal._openai_request)
 
   305   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -8767,7 +8767,7 @@ function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTu
         21   throw                  
 
   314   22   load_const 6           (openai.internal._openai_decode_batch)
-        23   call 803 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 824 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -8777,7 +8777,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         2     store_var 2                        (items)
 
   58    3     load_var 1                         (j)
-        4     call 760 ntypeargs=0               (ai.Journal.entries)
+        4     call 781 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -9066,7 +9066,7 @@ function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> map<string, u
        2    store_var 2                        (items)
 
   38   3    load_var 1                         (prompt)
-       4    call 764 ntypeargs=0               (ai.Prompt.messages)
+       4    call 785 ntypeargs=0               (ai.Prompt.messages)
        5    load_type 1                        
        6    load_const 2                       ("iter")
        7    virtual_call nargs=1 ntypeargs=0   
@@ -9413,7 +9413,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
 function openai.internal.openai_render(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> baml.http.Request {
   118   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 832 ntypeargs=0   (openai.internal._openai_request)
+        2   call 853 ntypeargs=0   (openai.internal._openai_request)
         3   return                 
 }
 
@@ -9430,7 +9430,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  104   0   make_closure 1559 0   
+  104   0   make_closure 1585 0   
         1   return                
 }
 
@@ -9455,7 +9455,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   76   16   load_var 1             (threshold)
-       17   make_closure 1554 1    
+       17   make_closure 1580 1    
        18   return                 
 }
 
@@ -9494,7 +9494,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1538 2    
+       29   make_closure 1564 2    
        30   return                 
 }
 
@@ -9513,12 +9513,12 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   42   10   load_var 1             (max_attempts)
-       11   make_closure 1548 1    
+       11   make_closure 1574 1    
        12   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  98   0   make_closure 1557 0   
+  98   0   make_closure 1583 0   
        1   return                
 }
 
@@ -9722,7 +9722,7 @@ function testing.TestCollector.register_test_at(self: testing.TestCollector, own
         4   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
         5   load_var2 3 4          
         6   load_var 5             (runner)
-        7   call 698 ntypeargs=0   (testing.TestCollector.register_test)
+        7   call 719 ntypeargs=0   (testing.TestCollector.register_test)
         8   return                 
 }
 
@@ -9851,7 +9851,7 @@ function testing.TestCollector.register_test_set_at(self: testing.TestCollector,
         4   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
         5   load_var2 3 4          
         6   load_var 5             (runner)
-        7   call 699 ntypeargs=0   (testing.TestCollector.register_test_set)
+        7   call 720 ntypeargs=0   (testing.TestCollector.register_test_set)
         8   return                 
 }
 
@@ -9881,11 +9881,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   290   22   load_var2 1 5                      
-        23   call 714 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 735 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   291   25   load_var 1                         (self)
-        26   call 706 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 727 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   295   28   load_type 5                        
@@ -9922,7 +9922,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   298   58   load_var2 9 2                      
-        59   call 713 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 734 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   301   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -9945,7 +9945,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         10   pop_jump_if_false +2   (to 12)
         11   jump +51               (to 62)
 
-  308   12   sys_op 512             (baml.time.Instant.now)
+  308   12   sys_op 520             (baml.time.Instant.now)
         13   store_var 4            (start)
 
   309   14   load_var 2             (ts)
@@ -9963,7 +9963,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         25   pop 1                  
 
   315   26   load_var 4             (start)
-        27   call 513 ntypeargs=0   (baml.time.Instant.elapsed)
+        27   call 521 ntypeargs=0   (baml.time.Instant.elapsed)
         28   call 508 ntypeargs=0   (baml.time.Duration.to_milliseconds)
         29   call 92 ntypeargs=0    (baml.Bigint.to_int)
         30   store_var 6            (elapsed)
@@ -10012,7 +10012,7 @@ function testing.TestRegistry.list_filtered(self: testing.TestRegistry, profile_
   281   0   load_var2 1 2          
         1   load_var2 3 4          
         2   load_var 5             (cli_exclude)
-        3   call 734 ntypeargs=0   (testing.select_names_layered)
+        3   call 755 ntypeargs=0   (testing.select_names_layered)
         4   return                 
 }
 
@@ -10028,9 +10028,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   237   0   load_var 1             (self)
-        1   call 715 ntypeargs=0   (testing.testset_children)
+        1   call 736 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 725 ntypeargs=0   (testing.run_testset)
+        3   call 746 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -10038,7 +10038,7 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
   259   0    load_var2 1 2          
         1    load_var2 3 4          
         2    load_var 5             (cli_exclude)
-        3    call 734 ntypeargs=0   (testing.select_names_layered)
+        3    call 755 ntypeargs=0   (testing.select_names_layered)
         4    store_var 6            (selected_names)
 
   261   5    load_var 2             (profile_include)
@@ -10081,22 +10081,22 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
         36   jump +4                (to 40)
 
   268   37   load_var2 1 6          
-        38   call 710 ntypeargs=0   (testing.TestRegistry.run_selected)
+        38   call 731 ntypeargs=0   (testing.TestRegistry.run_selected)
         39   jump +3                (to 42)
 
   266   40   load_var 1             (self)
-        41   call 709 ntypeargs=0   (testing.TestRegistry.run_all)
+        41   call 730 ntypeargs=0   (testing.TestRegistry.run_all)
 
   270   42   load_var 6             (selected_names)
-        43   call 740 ntypeargs=0   (testing.flatten_with_tolerated)
+        43   call 761 ntypeargs=0   (testing.flatten_with_tolerated)
         44   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   241   0   load_var2 1 2          
-        1   call 716 ntypeargs=0   (testing.testset_children_selected)
+        1   call 737 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 725 ntypeargs=0   (testing.run_testset)
+        3   call 746 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -10129,7 +10129,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 724 ntypeargs=0               (testing.run_test)
+        26   call 745 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   211   28   load_type 5                        
@@ -10166,7 +10166,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   215   58   load_var2 9 2                      
-        59   call 707 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 728 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   218   61   load_const 12                      ("Test not found: ")
@@ -10201,11 +10201,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   224   22   load_var2 1 5                      
-        23   call 714 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 715 ntypeargs=0               (testing.testset_children)
+        23   call 735 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 736 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 725 ntypeargs=0               (testing.run_testset)
+        27   call 746 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   227   29   load_type 5                        
@@ -10242,7 +10242,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   230   59   load_var2 9 2                      
-        60   call 708 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 729 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   233   62   load_const 12                      ("TestSet not found: ")
@@ -10333,7 +10333,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         69   store_var 10                       (_27)
 
   189   70   load_var 9                         (sub)
-        71   call 706 ntypeargs=0               (testing.TestRegistry.serialize)
+        71   call 727 ntypeargs=0               (testing.TestRegistry.serialize)
         72   store_var 11                       (_28)
 
   186   73   load_var2 2 10                     
@@ -10488,7 +10488,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   441   54    load_var 12                        (outcome)
         55    load_const 10                      ("pass")
-        56    call 612 ntypeargs=0               (baml.ops.equals_equals)
+        56    call 633 ntypeargs=0               (baml.ops.equals_equals)
         57    pop_jump_if_false +2               (to 59)
         58    jump +57                           (to 115)
 
@@ -10554,7 +10554,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   458   108   load_var 12                        (outcome)
         109   load_const 16                      ("error")
-        110   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        110   call 633 ntypeargs=0               (baml.ops.equals_equals)
         111   pop_jump_if_false -91              (to 20)
 
   459   112   load_const 17                      (true)
@@ -10629,7 +10629,7 @@ function testing.any_pattern_matches(pats: string[], canonical_id: string) -> bo
 
   608   14   load_var2 2 4                      
 
-  607   15   call 727 ntypeargs=0               (testing.glob_match)
+  607   15   call 748 ntypeargs=0               (testing.glob_match)
 
   608   16   pop_jump_if_false -11              (to 5)
 
@@ -10668,7 +10668,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         23   store_var_load_var 7               (name)
 
   949   24   load_var 3                         (all_failed_names)
-        25   call 743 ntypeargs=0               (testing.failure_matches_selected)
+        25   call 764 ntypeargs=0               (testing.failure_matches_selected)
         26   pop_jump_if_false +2               (to 28)
         27   jump +8                            (to 35)
 
@@ -10681,7 +10681,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         34   jump -21                           (to 13)
 
   950   35   load_var2 7 2                      
-        36   call 743 ntypeargs=0               (testing.failure_matches_selected)
+        36   call 764 ntypeargs=0               (testing.failure_matches_selected)
         37   pop_jump_if_false +2               (to 39)
         38   jump +8                            (to 46)
 
@@ -10725,7 +10725,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          16   store_var_load_var 5               (name)
 
   1050   17   load_var 2                         (out)
-         18   call 742 ntypeargs=0               (testing.name_in)
+         18   call 763 ntypeargs=0               (testing.name_in)
          19   unary_op !                         
          20   pop_jump_if_false -14              (to 6)
 
@@ -10756,7 +10756,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          43   pop_jump_if_false +2               (to 45)
          44   jump -13                           (to 31)
          45   load_var2 8 2                      
-         46   call 745 ntypeargs=0               (testing.collect_all_failed_names)
+         46   call 766 ntypeargs=0               (testing.collect_all_failed_names)
          47   pop 1                              
          48   jump -17                           (to 31)
 
@@ -10834,7 +10834,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
          57    load_var 14             (nested)
          58    load_field 0            (outcome)
          59    load_const 3            ("pass")
-         60    call 612 ntypeargs=0    (baml.ops.equals_equals)
+         60    call 633 ntypeargs=0    (baml.ops.equals_equals)
          61    store_var 15            (nested_tolerated)
 
   1015   62    load_var 14             (nested)
@@ -10859,7 +10859,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
          79    store_var_load_var 17   (sentinel)
 
   1024   80    load_var 3              (selected_names)
-         81    call 742 ntypeargs=0    (testing.name_in)
+         81    call 763 ntypeargs=0    (testing.name_in)
          82    pop_jump_if_false +2    (to 84)
          83    jump +21                (to 104)
 
@@ -10914,14 +10914,14 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
   1017   123   load_var2 14 15         
 
   1018   124   load_var2 3 4           
-         125   call 744 ntypeargs=0    (testing.collect_leaf_identities)
+         125   call 765 ntypeargs=0    (testing.collect_leaf_identities)
          126   pop 1                   
          127   jump +30                (to 157)
 
   1003   128   load_var 13             (_25)
          129   load_field 0            (outcome)
          130   load_const 7            ("pass")
-         131   call 612 ntypeargs=0    (baml.ops.equals_equals)
+         131   call 633 ntypeargs=0    (baml.ops.equals_equals)
 
   1005   132   pop_jump_if_false +2    (to 134)
          133   jump +18                (to 151)
@@ -10990,7 +10990,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
          22   load_var 5                         (r)
          23   load_field 5                       (results)
          24   load_var 2                         (out)
-         25   call 746 ntypeargs=0               (testing.collect_leaf_messages)
+         25   call 767 ntypeargs=0               (testing.collect_leaf_messages)
          26   pop 1                              
          27   jump -22                           (to 5)
          28   load_var 6                         (_8)
@@ -11014,7 +11014,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   1069   45   load_field 0                       (outcome)
          46   load_const 10                      ("pass")
-         47   call 612 ntypeargs=0               (baml.ops.equals_equals)
+         47   call 633 ntypeargs=0               (baml.ops.equals_equals)
          48   unary_op !                         
          49   pop_jump_if_false -15              (to 34)
 
@@ -11083,7 +11083,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
   749   40   load_var2 1 6                      
 
-  748   41   call 737 ntypeargs=0               (testing.collect_subtree_names)
+  748   41   call 758 ntypeargs=0               (testing.collect_subtree_names)
 
   749   42   load_type 10                       
         43   load_const 11                      ("iter")
@@ -11111,8 +11111,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   762   0    load_var2 1 2          
-        1    call 714 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 736 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 735 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 757 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +89               (to 92)
         4    load_var 3             (e)
         5    store_var 4            (_5)
@@ -11211,11 +11211,11 @@ function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testi
 
 function testing.collect_subtree_names_layered(registry: testing.TestRegistry, ts: testing.TestSetRegistration, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> string[] {
   778   0     load_var2 1 2           
-        1     call 714 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
+        1     call 735 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
 
   777   2     load_var2 3 4           
         3     load_var2 5 6           
-        4     call 734 ntypeargs=0    (testing.select_names_layered)
+        4     call 755 ntypeargs=0    (testing.select_names_layered)
         5     jump +109               (to 114)
         6     load_var 7              (e)
         7     store_var 8             (_9)
@@ -11298,7 +11298,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   805   83    load_var2 3 4           
         84    load_var2 5 6           
-        85    call 730 ntypeargs=0    (testing.leaf_selected_layered)
+        85    call 751 ntypeargs=0    (testing.leaf_selected_layered)
 
   803   86    pop_jump_if_false +2    (to 88)
         87    jump +4                 (to 91)
@@ -11322,7 +11322,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   789   100   load_var2 3 4           
         101   load_var2 5 6           
-        102   call 730 ntypeargs=0    (testing.leaf_selected_layered)
+        102   call 751 ntypeargs=0    (testing.leaf_selected_layered)
 
   787   103   pop_jump_if_false +2    (to 105)
         104   jump +4                 (to 108)
@@ -11390,7 +11390,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         37    load_var 12                        (tsr)
         38    load_field 0                       (outcome)
         39    load_const 7                       ("pass")
-        40    call 612 ntypeargs=0               (baml.ops.equals_equals)
+        40    call 633 ntypeargs=0               (baml.ops.equals_equals)
         41    store_var 13                       (ft)
 
   855   42    load_var 12                        (tsr)
@@ -11438,14 +11438,14 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   856   74    load_var 12                        (tsr)
         75    load_field 5                       (results)
         76    load_var 13                        (ft)
-        77    call 739 ntypeargs=0               (testing.count_leaves)
+        77    call 760 ntypeargs=0               (testing.count_leaves)
         78    store_var 10                       (delta)
         79    jump +30                           (to 109)
 
   843   80    load_var 11                        (_13)
         81    load_field 0                       (outcome)
         82    load_const 8                       ("pass")
-        83    call 612 ntypeargs=0               (baml.ops.equals_equals)
+        83    call 633 ntypeargs=0               (baml.ops.equals_equals)
 
   845   84    pop_jump_if_false +2               (to 86)
         85    jump +18                           (to 103)
@@ -11530,7 +11530,7 @@ function testing.expansion_error_report(name: string) -> testing.TestSetReport {
 
 function testing.failure_matches_selected(selected: string, failed_names: string[]) -> bool {
   972   0    load_var2 1 2                      
-        1    call 742 ntypeargs=0               (testing.name_in)
+        1    call 763 ntypeargs=0               (testing.name_in)
         2    pop_jump_if_false +2               (to 4)
         3    jump +40                           (to 43)
 
@@ -11592,7 +11592,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   887   0     load_var 1             (report)
         1     load_field 0           (outcome)
         2     load_const 0           ("pass")
-        3     call 612 ntypeargs=0   (baml.ops.equals_equals)
+        3     call 633 ntypeargs=0   (baml.ops.equals_equals)
         4     store_var 3            (top_tolerated)
 
   888   5     load_var 1             (report)
@@ -11640,7 +11640,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   889   37    load_var 1             (report)
         38    load_field 5           (results)
         39    load_var 3             (top_tolerated)
-        40    call 739 ntypeargs=0   (testing.count_leaves)
+        40    call 760 ntypeargs=0   (testing.count_leaves)
         41    store_var 4            (counts)
 
   905   42    load_type 2            
@@ -11650,7 +11650,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   906   45    load_var 1             (report)
         46    load_field 5           (results)
         47    load_var 6             (messages)
-        48    call 746 ntypeargs=0   (testing.collect_leaf_messages)
+        48    call 767 ntypeargs=0   (testing.collect_leaf_messages)
         49    pop 1                  
 
   907   50    load_type 2            
@@ -11658,7 +11658,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
         52    store_var 7            (all_failed_names)
 
   908   53    load_var2 1 7          
-        54    call 745 ntypeargs=0   (testing.collect_all_failed_names)
+        54    call 766 ntypeargs=0   (testing.collect_all_failed_names)
         55    pop 1                  
 
   909   56    load_type 2            
@@ -11672,7 +11672,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
 
   910   64    load_var2 1 3          
         65    load_var2 2 8          
-        66    call 744 ntypeargs=0   (testing.collect_leaf_identities)
+        66    call 765 ntypeargs=0   (testing.collect_leaf_identities)
         67    pop 1                  
 
   916   68    load_var 8             (executed)
@@ -11730,7 +11730,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   922   112   load_var2 2 1          
         113   load_field 4           (failed_names)
         114   load_var 7             (all_failed_names)
-        115   call 741 ntypeargs=0   (testing.classify_selected_names)
+        115   call 762 ntypeargs=0   (testing.classify_selected_names)
         116   store_var 9            (identities)
         117   jump +3                (to 120)
 
@@ -11890,14 +11890,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
   577   96    load_var2 1 2           
         97    call 155 ntypeargs=0    (baml.String.index_of)
         98    load_const 6            (null)
-        99    call 612 ntypeargs=0    (baml.ops.equals_equals)
+        99    call 633 ntypeargs=0    (baml.ops.equals_equals)
         100   unary_op !              
         101   return                  
 }
 
 function testing.leaf_selected(name: string, include: string[], exclude: string[]) -> bool {
   618   0    load_var2 3 1          
-        1    call 728 ntypeargs=0   (testing.any_pattern_matches)
+        1    call 749 ntypeargs=0   (testing.any_pattern_matches)
         2    pop_jump_if_false +2   (to 4)
         3    jump +14               (to 17)
 
@@ -11911,7 +11911,7 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
         11   jump +4                (to 15)
 
   624   12   load_var2 2 1          
-        13   call 728 ntypeargs=0   (testing.any_pattern_matches)
+        13   call 749 ntypeargs=0   (testing.any_pattern_matches)
         14   jump +4                (to 18)
 
   622   15   load_const 1           (true)
@@ -11924,13 +11924,13 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
 function testing.leaf_selected_layered(name: string, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> bool {
   637   0   load_var2 1 2          
         1   load_var 3             (profile_exclude)
-        2   call 729 ntypeargs=0   (testing.leaf_selected)
+        2   call 750 ntypeargs=0   (testing.leaf_selected)
         3   jump_if_false +5       (to 8)
         4   pop 1                  
 
   638   5   load_var2 1 4          
         6   load_var 5             (cli_exclude)
-        7   call 729 ntypeargs=0   (testing.leaf_selected)
+        7   call 750 ntypeargs=0   (testing.leaf_selected)
         8   return                 
 }
 
@@ -12026,7 +12026,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   486   25   load_var 5                         (child)
-        26   make_closure 1438 1                
+        26   make_closure 1464 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   load_type 7                        
@@ -12044,7 +12044,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         40   call 482 ntypeargs=2               (baml.future.all_complete)
         41   await                              
 
-  491   42   call 722 ntypeargs=0               (testing.aggregate_reports)
+  491   42   call 743 ntypeargs=0               (testing.aggregate_reports)
         43   return                             
 }
 
@@ -12100,16 +12100,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         43   pop 1                              
         44   load_var 8                         (outcome)
         45   load_const 7                       ("pass")
-        46   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        46   call 633 ntypeargs=0               (baml.ops.equals_equals)
         47   unary_op !                         
         48   pop_jump_if_false -40              (to 8)
 
   119   49   load_var 3                         (named_results)
-        50   call 722 ntypeargs=0               (testing.aggregate_reports)
+        50   call 743 ntypeargs=0               (testing.aggregate_reports)
         51   jump +3                            (to 54)
 
   124   52   load_var 3                         (named_results)
-        53   call 722 ntypeargs=0               (testing.aggregate_reports)
+        53   call 743 ntypeargs=0               (testing.aggregate_reports)
         54   return                             
 }
 
@@ -12119,7 +12119,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   496   3    load_var 1             (body)
-        4    make_closure 1450 1    
+        4    make_closure 1476 1    
         5    store_var 3            (base_run)
 
   527   6    load_var 2             (runner)
@@ -12151,7 +12151,7 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         7    jump +3                (to 10)
 
   539   8    load_var 1             (children)
-        9    call 723 ntypeargs=0   (testing.run_children_parallel)
+        9    call 744 ntypeargs=0   (testing.run_children_parallel)
         10   return                 
 }
 
@@ -12162,7 +12162,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         3   load_type 0            
         4   alloc_array 0          
         5   load_var2 2 3          
-        6   call 734 ntypeargs=0   (testing.select_names_layered)
+        6   call 755 ntypeargs=0   (testing.select_names_layered)
         7   return                 
 }
 
@@ -12193,7 +12193,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
   704   21   load_field 0                       (name)
         22   load_var2 2 3                      
         23   load_var2 4 5                      
-        24   call 730 ntypeargs=0               (testing.leaf_selected_layered)
+        24   call 751 ntypeargs=0               (testing.leaf_selected_layered)
 
   702   25   pop_jump_if_false -15              (to 10)
 
@@ -12224,14 +12224,14 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   718   49   load_field 0                       (name)
         50   load_var2 2 3                      
-        51   call 733 ntypeargs=0               (testing.subtree_may_be_selected)
+        51   call 754 ntypeargs=0               (testing.subtree_may_be_selected)
         52   jump_if_false +6                   (to 58)
         53   pop 1                              
 
   719   54   load_var 12                        (ts)
         55   load_field 0                       (name)
         56   load_var2 4 5                      
-        57   call 733 ntypeargs=0               (testing.subtree_may_be_selected)
+        57   call 754 ntypeargs=0               (testing.subtree_may_be_selected)
 
   717   58   pop_jump_if_false -20              (to 38)
 
@@ -12239,7 +12239,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   723   60   load_var2 2 3                      
         61   load_var2 4 5                      
-        62   call 738 ntypeargs=0               (testing.collect_subtree_names_layered)
+        62   call 759 ntypeargs=0               (testing.collect_subtree_names_layered)
 
   729   63   load_type 10                       
         64   load_const 11                      ("iter")
@@ -12292,13 +12292,13 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         21   load_const 6                       ("*")
         22   call 155 ntypeargs=0               (baml.String.index_of)
         23   load_const 7                       (null)
-        24   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        24   call 633 ntypeargs=0               (baml.ops.equals_equals)
         25   jump_if_false +7                   (to 32)
         26   pop 1                              
         27   load_var2 3 6                      
         28   call 155 ntypeargs=0               (baml.String.index_of)
         29   load_const 7                       (null)
-        30   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        30   call 633 ntypeargs=0               (baml.ops.equals_equals)
         31   unary_op !                         
         32   pop_jump_if_false +2               (to 34)
         33   jump +11                           (to 44)
@@ -12309,7 +12309,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         37   jump_if_false +4                   (to 41)
         38   pop 1                              
         39   load_var2 3 6                      
-        40   call 727 ntypeargs=0               (testing.glob_match)
+        40   call 748 ntypeargs=0               (testing.glob_match)
         41   pop_jump_if_false -32              (to 9)
 
   655   42   load_const 9                       (true)
@@ -12324,7 +12324,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
 
 function testing.subtree_may_be_selected(prefix: string, include: string[], exclude: string[]) -> bool {
   677   0    load_var2 1 3                      
-        1    call 731 ntypeargs=0               (testing.subtree_excluded)
+        1    call 752 ntypeargs=0               (testing.subtree_excluded)
         2    pop_jump_if_false +2               (to 4)
         3    jump +32                           (to 35)
 
@@ -12352,7 +12352,7 @@ function testing.subtree_may_be_selected(prefix: string, include: string[], excl
         24   pop_jump_if_false +2               (to 26)
         25   jump +6                            (to 31)
         26   load_var2 6 1                      
-        27   call 732 ntypeargs=0               (testing.pattern_may_match_descendant)
+        27   call 753 ntypeargs=0               (testing.pattern_may_match_descendant)
 
   684   28   pop_jump_if_false -11              (to 17)
 
@@ -12380,7 +12380,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   364   6    load_var2 1 2         
 
   366   7    load_var 3            (runner)
-        8    make_closure 1415 2   
+        8    make_closure 1441 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   return                
 }
@@ -12397,7 +12397,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   375   8    load_var2 1 2         
-        9    make_closure 1417 2   
+        9    make_closure 1443 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   return                
 }
@@ -12418,7 +12418,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   391   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1419 3   
+        13   make_closure 1445 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   return                
 }
@@ -12452,7 +12452,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 717 ntypeargs=0               (testing.test_child)
+        26   call 738 ntypeargs=0               (testing.test_child)
         27   store_var 6                        (_10)
         28   load_var2 2 6                      
         29   call 4 ntypeargs=0                 (baml.Array.push)
@@ -12478,7 +12478,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
 
   334   48   load_var2 1 8                      
 
-  333   49   call 718 ntypeargs=0               (testing.testset_child)
+  333   49   call 739 ntypeargs=0               (testing.testset_child)
         50   store_var 9                        (_21)
 
   334   51   load_var2 2 9                      
@@ -12516,7 +12516,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   342   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 720 ntypeargs=0               (testing._name_selected)
+        23   call 741 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   343   25   load_var 6                         (t)
@@ -12525,7 +12525,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 6                         (t)
         30   load_field 2                       (runner)
-        31   call 717 ntypeargs=0               (testing.test_child)
+        31   call 738 ntypeargs=0               (testing.test_child)
         32   store_var 7                        (_13)
         33   load_var2 3 7                      
         34   call 4 ntypeargs=0                 (baml.Array.push)
@@ -12553,12 +12553,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   354   55   load_field 0                       (name)
         56   load_var 2                         (names)
-        57   call 721 ntypeargs=0               (testing._has_selected_descendant)
+        57   call 742 ntypeargs=0               (testing._has_selected_descendant)
         58   pop_jump_if_false -14              (to 44)
 
   355   59   load_var2 1 10                     
         60   load_var 2                         (names)
-        61   call 719 ntypeargs=0               (testing.testset_child_selected)
+        61   call 740 ntypeargs=0               (testing.testset_child_selected)
         62   store_var 11                       (_26)
         63   load_var2 3 11                     
         64   call 4 ntypeargs=0                 (baml.Array.push)
@@ -12578,7 +12578,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 889 ntypeargs=0   (user.score)
+       7    call 910 ntypeargs=0   (user.score)
        8    store_var 3            (base)
 
   11   9    load_var 3             (base)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -30,14 +30,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   199   24    load_type 1                                
         25    load_deref 2                               
-        26    call 761 ntypeargs=1                       (ai.Journal.new)
+        26    call 782 ntypeargs=1                       (ai.Journal.new)
         27    store_deref 6                              
 
   200   28    load_type 1                                
         29    load_deref 1                               
         30    load_deref 6                               
         31    load_const 2                               (0)
-        32    call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        32    call 821 ntypeargs=1                       (ai.Agent._emit_from)
         33    store_var 7                                (seen)
 
   201   34    load_const 2                               (0)
@@ -73,7 +73,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         59    load_deref 6                               
         60    load_var 9                                 (total)
         61    load_const 5                               (2)
-        62    call 799 ntypeargs=1                       (ai.Agent._attempt_turn)
+        62    call 820 ntypeargs=1                       (ai.Agent._attempt_turn)
         63    store_var 11                               (turn)
 
   213   64    load_var 8                                 (steps)
@@ -85,11 +85,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         69    load_deref 1                               
         70    load_deref 6                               
         71    load_var 7                                 (seen)
-        72    call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        72    call 821 ntypeargs=1                       (ai.Agent._emit_from)
         73    store_var 7                                (seen)
 
   215   74    load_var 11                                (turn)
-        75    call 780 ntypeargs=0                       (ai.ModelTurn.tool_uses)
+        75    call 801 ntypeargs=0                       (ai.ModelTurn.tool_uses)
         76    store_var 12                               (calls)
 
   216   77    load_var 12                                (calls)
@@ -102,7 +102,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         84    jump +65                                   (to 149)
 
   251   85    load_var 11                                (turn)
-        86    call 779 ntypeargs=0                       (ai.ModelTurn.terminal_text)
+        86    call 800 ntypeargs=0                       (ai.ModelTurn.terminal_text)
         87    store_var 35                               (_96)
         88    load_var 35                                (_96)
         89    store_var 34                               (candidate)
@@ -156,14 +156,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         130   init_instance 4                            (ai.events.FinalProduced .value_json)
         131   load_type 11                               
         132   alloc_array 1                              
-        133   call 762 ntypeargs=0                       (ai.Journal.append_all)
+        133   call 783 ntypeargs=0                       (ai.Journal.append_all)
         134   pop 1                                      
 
   265   135   load_type 1                                
         136   load_deref 1                               
         137   load_deref 6                               
         138   load_var 7                                 (seen)
-        139   call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        139   call 821 ntypeargs=1                       (ai.Agent._emit_from)
         140   store_var 7                                (seen)
 
   266   141   load_var 36                                (value)
@@ -176,7 +176,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         148   return                                     
 
   217   149   load_deref 6                               
-        150   call 760 ntypeargs=0                       (ai.Journal.entries)
+        150   call 781 ntypeargs=0                       (ai.Journal.entries)
         151   container_len                              
         152   store_var 14                               (before)
 
@@ -187,7 +187,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         157   load_type 1                                
         158   load_var2 1 2                              
         159   load_var 6                                 (j)
-        160   make_closure 1675 captures=3 ntypeargs=1   
+        160   make_closure 1699 captures=3 ntypeargs=1   
         161   call 16 ntypeargs=3                        (baml.Array.map)
         162   store_var 15                               (futures)
 
@@ -202,11 +202,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         170   load_deref 1                               
         171   load_deref 6                               
         172   load_var 7                                 (seen)
-        173   call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        173   call 821 ntypeargs=1                       (ai.Agent._emit_from)
         174   store_var 7                                (seen)
 
   227   175   load_deref 6                               
-        176   call 760 ntypeargs=0                       (ai.Journal.entries)
+        176   call 781 ntypeargs=0                       (ai.Journal.entries)
         177   store_var 16                               (entries)
 
   228   178   load_var 14                                (before)
@@ -236,7 +236,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         199   load_var 12                                (calls)
         200   load_type 1                                
         201   load_var 21                                (f)
-        202   make_closure 1676 captures=1 ntypeargs=1   
+        202   make_closure 1700 captures=1 ntypeargs=1   
         203   call 19 ntypeargs=2                        (baml.Array.find)
 
   234   204   store_var 22                               (_58)
@@ -340,12 +340,12 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   126   3     load_type 0                        
         4     load_var 3                         (spec)
-        5     call 771 ntypeargs=1               (ai.FunctionSpec.tools)
+        5     call 792 ntypeargs=1               (ai.FunctionSpec.tools)
         6     store_var 9                        (_10)
 
   127   7     load_type 0                        
         8     load_var 3                         (spec)
-        9     call 769 ntypeargs=1               (ai.FunctionSpec.output_type)
+        9     call 790 ntypeargs=1               (ai.FunctionSpec.output_type)
         10    store_var 10                       (_12)
 
   122   11    load_var2 2 8                      
@@ -448,7 +448,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         99    store_var 21                       (batch)
 
   142   100   load_var 7                         (turn)
-        101   call 780 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        101   call 801 ntypeargs=0               (ai.ModelTurn.tool_uses)
         102   load_type 8                        
         103   load_const 9                       ("iter")
         104   virtual_call nargs=1 ntypeargs=0   
@@ -490,7 +490,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         137   pop 1                              
 
   148   138   load_var 7                         (turn)
-        139   call 779 ntypeargs=0               (ai.ModelTurn.terminal_text)
+        139   call 800 ntypeargs=0               (ai.ModelTurn.terminal_text)
         140   store_var 30                       (_54)
         141   load_var 30                        (_54)
         142   store_var 29                       (candidate)
@@ -502,7 +502,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         148   store_var 29                       (candidate)
 
   149   149   load_var 7                         (turn)
-        150   call 780 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        150   call 801 ntypeargs=0               (ai.ModelTurn.tool_uses)
         151   container_len                      
         152   store_var 31                       (_60)
         153   load_var 31                        (_60)
@@ -516,7 +516,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         160   load_field 1                       (stop_reason)
         161   load_const 14                      (ai.content.StopReason.MaxTokens)
         162   alloc_variant 436                  (ai.content.StopReason)
-        163   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        163   call 633 ntypeargs=0               (baml.ops.equals_equals)
 
   149   164   jump_if_false +2                   (to 166)
         165   jump +7                            (to 172)
@@ -526,7 +526,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         168   load_field 1                       (stop_reason)
         169   load_const 15                      (ai.content.StopReason.Refused)
         170   alloc_variant 436                  (ai.content.StopReason)
-        171   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        171   call 633 ntypeargs=0               (baml.ops.equals_equals)
 
   149   172   jump_if_false +2                   (to 174)
         173   jump +5                            (to 178)
@@ -534,7 +534,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   152   175   load_type 0                        
         176   load_var2 1 29                     
-        177   call 798 ntypeargs=1               (ai.Agent._parses)
+        177   call 819 ntypeargs=1               (ai.Agent._parses)
 
   153   178   pop_jump_if_false +2               (to 180)
         179   jump +33                           (to 212)
@@ -546,7 +546,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         184   jump +12                           (to 196)
 
   175   185   load_var2 4 21                     
-        186   call 762 ntypeargs=0               (ai.Journal.append_all)
+        186   call 783 ntypeargs=0               (ai.Journal.append_all)
         187   pop 1                              
 
   176   188   load_var 2                         (c)
@@ -566,7 +566,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         200   pop 1                              
 
   172   201   load_var2 4 21                     
-        202   call 762 ntypeargs=0               (ai.Journal.append_all)
+        202   call 783 ntypeargs=0               (ai.Journal.append_all)
         203   pop 1                              
 
   173   204   load_type 0                        
@@ -575,11 +575,11 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         207   load_var2 5 6                      
         208   load_const 16                      (1)
         209   sub_int                            
-        210   call 799 ntypeargs=1               (ai.Agent._attempt_turn)
+        210   call 820 ntypeargs=1               (ai.Agent._attempt_turn)
         211   jump +19                           (to 230)
 
   154   212   load_var2 4 21                     
-        213   call 762 ntypeargs=0               (ai.Journal.append_all)
+        213   call 783 ntypeargs=0               (ai.Journal.append_all)
         214   pop 1                              
 
   156   215   load_var 7                         (turn)
@@ -623,7 +623,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
 function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> int {
   182   0    load_var 2             (j)
-        1    call 760 ntypeargs=0   (ai.Journal.entries)
+        1    call 781 ntypeargs=0   (ai.Journal.entries)
         2    store_var 4            (entries)
 
   183   3    load_var 3             (seen)
@@ -713,7 +713,7 @@ function ai.Agent._parses(self: ai.Agent<#0>, candidate: string) -> bool {
 function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: ai.content.ToolUse, j: ai.Journal) -> null {
   56   0     load_var2 2 3           
        1     load_field 1            (name)
-       2     call 777 ntypeargs=0    (ai.tools.Toolbox.get)
+       2     call 798 ntypeargs=0    (ai.tools.Toolbox.get)
        3     store_var 5             (_7)
        4     load_var 5              (_7)
        5     narrow_bind 0 5         
@@ -738,7 +738,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        20    init_instance 0         (ai.events.ToolFailed .id, .message)
        21    load_type 3             
        22    alloc_array 1           
-       23    call 762 ntypeargs=0    (ai.Journal.append_all)
+       23    call 783 ntypeargs=0    (ai.Journal.append_all)
        24    pop 1                   
 
   94   25    load_const 4            (null)
@@ -749,7 +749,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
 
   58   29    load_var2 6 3           
        30    load_field 2            (args)
-       31    call 772 ntypeargs=0    (ai.tools.Tool.call)
+       31    call 793 ntypeargs=0    (ai.tools.Tool.call)
        32    store_var 7             (outcome)
        33    jump +65                (to 98)
        34    load_var 8              (e)
@@ -769,7 +769,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        45    init_instance 1         (ai.events.ToolFailed .id, .message)
        46    load_type 3             
        47    alloc_array 1           
-       48    call 762 ntypeargs=0    (ai.Journal.append_all)
+       48    call 783 ntypeargs=0    (ai.Journal.append_all)
        49    pop 1                   
 
   64   50    load_var 6              (t)
@@ -787,7 +787,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        62    load_var 11             (_19)
        63    load_const 6            (ai.tools.ErrorMode.Raise)
        64    alloc_variant 437       (ai.tools.ErrorMode)
-       65    call 612 ntypeargs=0    (baml.ops.equals_equals)
+       65    call 633 ntypeargs=0    (baml.ops.equals_equals)
        66    pop_jump_if_false +2    (to 68)
        67    jump +4                 (to 71)
 
@@ -846,7 +846,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        108   init_instance 3         (ai.events.ToolCompleted .id, .output)
        109   load_type 3             
        110   alloc_array 1           
-       111   call 762 ntypeargs=0    (ai.Journal.append_all)
+       111   call 783 ntypeargs=0    (ai.Journal.append_all)
        112   pop 1                   
 
   83   113   load_const 4            (null)
@@ -892,7 +892,7 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
        30   pop_jump_if_false +4                       (to 34)
 
   41   31   load_type 4                                
-       32   make_closure 1657 captures=0 ntypeargs=1   
+       32   make_closure 1681 captures=0 ntypeargs=1   
        33   store_var 5                                (_9)
 
   35   34   load_var2 1 2                              
@@ -983,11 +983,11 @@ function ai.Journal.entries(self: ai.Journal) -> (ai.events.RunStarted | ai.even
 function ai.Journal.new(spec: ai.FunctionSpec<#0>) -> ai.Journal {
   21   0    load_type 0            
        1    load_var 1             (spec)
-       2    call 767 ntypeargs=1   (ai.FunctionSpec.name)
+       2    call 788 ntypeargs=1   (ai.FunctionSpec.name)
        3    store_var 3            (_4)
        4    load_type 0            
        5    load_var 1             (spec)
-       6    call 768 ntypeargs=1   (ai.FunctionSpec.arguments)
+       6    call 789 ntypeargs=1   (ai.FunctionSpec.arguments)
        7    store_var 4            (_6)
        8    load_var2 3 4          
        9    init_instance 0        (ai.events.RunStarted .spec_name, .arguments)
@@ -1083,7 +1083,7 @@ function ai.ModelTurn.tool_uses(self: ai.ModelTurn) -> ai.content.ToolUse[] {
 
 function ai.Prompt.baml.ToString.to_string(self: ai.Prompt) -> string {
   35   0   load_var 1             (self)
-       1   call 763 ntypeargs=0   (ai.Prompt.text)
+       1   call 784 ntypeargs=0   (ai.Prompt.text)
        2   return                 
 }
 
@@ -1249,7 +1249,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         49   load_var 11                        (_17)
         50   load_const 6                       (ai.errors.RetrySafety.Safe)
         51   alloc_variant 438                  (ai.errors.RetrySafety)
-        52   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        52   call 633 ntypeargs=0               (baml.ops.equals_equals)
 
   155   53   pop_jump_if_false +2               (to 55)
         54   jump +3                            (to 57)
@@ -1261,7 +1261,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         58   load_var 3                         (index)
         59   load_const 4                       (1)
         60   add_int                            
-        61   call 793 ntypeargs=0               (ai.clients.Fallback._try)
+        61   call 814 ntypeargs=0               (ai.clients.Fallback._try)
         62   return                             
 }
 
@@ -1296,13 +1296,13 @@ function ai.clients.Fallback.root.Client.id(self: ai.clients.Fallback) -> string
 function ai.clients.Fallback.root.Client.invoke(self: ai.clients.Fallback, input: ai.ModelTurnInput) -> ai.ModelTurn {
   185   0   load_var2 1 2          
         1   load_const 0           (0)
-        2   call 793 ntypeargs=0   (ai.clients.Fallback._try)
+        2   call 814 ntypeargs=0   (ai.clients.Fallback._try)
         3   jump +6                (to 9)
         4   load_var 3             (e)
         5   throw_if_panic         
 
   186   6   load_var 3             (e)
-        7   call 811 ntypeargs=0   (ai.errors.normalize)
+        7   call 832 ntypeargs=0   (ai.errors.normalize)
         8   throw                  
         9   return                 
 }
@@ -1344,7 +1344,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        29   load_var 7                         (_11)
        30   load_const 5                       (ai.errors.RetrySafety.Safe)
        31   alloc_variant 438                  (ai.errors.RetrySafety)
-       32   call 612 ntypeargs=0               (baml.ops.equals_equals)
+       32   call 633 ntypeargs=0               (baml.ops.equals_equals)
 
   74   33   jump_if_false +5                   (to 38)
        34   pop 1                              
@@ -1370,7 +1370,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
   80   49   load_var 1                         (self)
        50   load_field 3                       (backoff)
        51   load_var2 8 6                      
-       52   call 785 ntypeargs=0               (ai.clients.Backoff.delay_ms)
+       52   call 806 ntypeargs=0               (ai.clients.Backoff.delay_ms)
        53   call 502 ntypeargs=0               (baml.time.Duration.from_milliseconds)
 
   79   54   sys_op 255                         (baml.sys.sleep)
@@ -1383,7 +1383,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        60   load_var 3                         (remaining)
        61   load_const 3                       (1)
        62   sub_int                            
-       63   call 787 ntypeargs=0               (ai.clients.Retry._attempt)
+       63   call 808 ntypeargs=0               (ai.clients.Retry._attempt)
        64   return                             
 }
 
@@ -1428,7 +1428,7 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
        32   load_const 0           (<omitted>)
        33   load_const 0           (<omitted>)
        34   load_const 0           (<omitted>)
-       35   call 784 ntypeargs=0   (ai.clients.Backoff.new)
+       35   call 805 ntypeargs=0   (ai.clients.Backoff.new)
        36   store_var 6            (_10)
 
   61   37   load_var2 1 2          
@@ -1452,13 +1452,13 @@ function ai.clients.Retry.root.Client.invoke(self: ai.clients.Retry, input: ai.M
   99    0    load_var2 1 2          
         1    load_var 1             (self)
         2    load_field 1           (max_attempts)
-        3    call 787 ntypeargs=0   (ai.clients.Retry._attempt)
+        3    call 808 ntypeargs=0   (ai.clients.Retry._attempt)
         4    jump +6                (to 10)
         5    load_var 3             (e)
         6    throw_if_panic         
 
   100   7    load_var 3             (e)
-        8    call 811 ntypeargs=0   (ai.errors.normalize)
+        8    call 832 ntypeargs=0   (ai.errors.normalize)
         9    throw                  
         10   return                 
 }
@@ -1560,7 +1560,7 @@ function ai.clients.RoundRobin.root.Client.invoke(self: ai.clients.RoundRobin, i
         37   throw_if_panic                     
 
   141   38   load_var 4                         (e)
-        39   call 811 ntypeargs=0               (ai.errors.normalize)
+        39   call 832 ntypeargs=0               (ai.errors.normalize)
         40   throw                              
         41   load_var 3                         (_0)
         42   return                             
@@ -1759,7 +1759,7 @@ function ai.errors.normalize(error: unknown) -> ai.errors.Failure | baml.errors.
 
 function ai.internal._schema_for_signature(handler: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> map<string, unknown> {
   6    0    load_var 1                         (handler)
-       1    call 695 ntypeargs=0               (reflect.signature)
+       1    call 716 ntypeargs=0               (reflect.signature)
        2    store_var 3                        (sig)
 
   7    3    load_type 0                        
@@ -1841,10 +1841,10 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
 
   102   9     load_var2 4 2                      
         10    load_var 3                         (params)
-        11    call 881 ntypeargs=0               (ai.mcp.rpc_line)
+        11    call 902 ntypeargs=0               (ai.mcp.rpc_line)
         12    store_var 5                        (_6)
         13    load_var2 1 5                      
-        14    call 883 ntypeargs=0               (ai.mcp.McpConnection._send)
+        14    call 904 ntypeargs=0               (ai.mcp.McpConnection._send)
         15    pop 1                              
 
   103   16    load_const 1                       (true)
@@ -1981,7 +1981,7 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
 
   123   126   load_var 16                        (err)
         127   load_const 5                       (null)
-        128   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        128   call 633 ntypeargs=0               (baml.ops.equals_equals)
         129   unary_op !                         
         130   pop_jump_if_false +2               (to 132)
         131   jump +7                            (to 138)
@@ -2089,7 +2089,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
   184   7    load_var 1                         (self)
         8    load_const 4                       ("tools/call")
         9    load_var 5                         (params)
-        10   call 884 ntypeargs=0               (ai.mcp.McpConnection._request)
+        10   call 905 ntypeargs=0               (ai.mcp.McpConnection._request)
         11   store_var 6                        (result)
 
   185   12   load_type 2                        
@@ -2261,16 +2261,16 @@ function ai.mcp.McpConnection.connect(name: string, command: string, args: strin
   75   61   load_var 11            (conn)
        62   load_const 19          ("initialize")
        63   load_var 12            (init)
-       64   call 884 ntypeargs=0   (ai.mcp.McpConnection._request)
+       64   call 905 ntypeargs=0   (ai.mcp.McpConnection._request)
        65   pop 1                  
 
   76   66   load_const 2           (null)
        67   load_const 20          ("notifications/initialized")
        68   load_const 2           (null)
-       69   call 881 ntypeargs=0   (ai.mcp.rpc_line)
+       69   call 902 ntypeargs=0   (ai.mcp.rpc_line)
        70   store_var 13           (_26)
        71   load_var2 11 13        
-       72   call 883 ntypeargs=0   (ai.mcp.McpConnection._send)
+       72   call 904 ntypeargs=0   (ai.mcp.McpConnection._send)
        73   pop 1                  
 
   77   74   load_var 11            (conn)
@@ -2285,7 +2285,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         2    load_type 1                        
         3    load_type 2                        
         4    alloc_map 0                        
-        5    call 884 ntypeargs=0               (ai.mcp.McpConnection._request)
+        5    call 905 ntypeargs=0               (ai.mcp.McpConnection._request)
         6    store_var 3                        (result)
 
   157   7    load_type 3                        
@@ -2357,13 +2357,13 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         65   store_var 15                       (_31)
 
   173   66   load_var2 1 8                      
-        67   call 880 ntypeargs=0               (ai.mcp._proxy)
+        67   call 901 ntypeargs=0               (ai.mcp._proxy)
         68   store_var 16                       (_32)
 
   170   69   load_var2 8 14                     
         70   load_var2 15 16                    
         71   load_const 18                      (<omitted>)
-        72   call 774 ntypeargs=0               (ai.tools.raw_tool)
+        72   call 795 ntypeargs=0               (ai.tools.raw_tool)
         73   store_var 13                       (_26)
 
   168   74   load_var2 4 13                     
@@ -2386,7 +2386,7 @@ function ai.mcp._proxy(conn: ai.mcp.McpConnection, name: string) -> (map<string,
        5    store_var 2           
 
   20   6    load_var2 1 2         
-       7    make_closure 2241 2   
+       7    make_closure 2265 2   
        8    store_var 3           (_0)
        9    load_var 3            (_0)
        10   return                
@@ -2447,7 +2447,7 @@ function ai.prompt(body: ((string) -> baml.prompt.Role throws never, baml.prompt
        2   store_var 1           
 
   49   3   load_var 1            (body)
-       4   make_closure 1591 1   
+       4   make_closure 1615 1   
        5   store_var 3           (render)
 
   53   6   load_var 3            (render)
@@ -2590,7 +2590,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         1    pop_jump_if_false +7   (to 8)
 
   216   2    load_var 1             (self)
-        3    call 806 ntypeargs=0   (ai.stream.TurnStream.next)
+        3    call 827 ntypeargs=0   (ai.stream.TurnStream.next)
         4    store_var 2            (_3)
         5    load_var 2             (_3)
         6    narrow_bind 1 2        
@@ -2599,7 +2599,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
   223   8    load_var 1             (self)
         9    load_field 8           (_input_tokens)
         10   load_const 2           (null)
-        11   call 612 ntypeargs=0   (baml.ops.equals_equals)
+        11   call 633 ntypeargs=0   (baml.ops.equals_equals)
         12   unary_op !             
         13   jump_if_false +2       (to 15)
         14   jump +7                (to 21)
@@ -2607,7 +2607,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         16   load_var 1             (self)
         17   load_field 9           (_output_tokens)
         18   load_const 2           (null)
-        19   call 612 ntypeargs=0   (baml.ops.equals_equals)
+        19   call 633 ntypeargs=0   (baml.ops.equals_equals)
         20   unary_op !             
         21   pop_jump_if_false +2   (to 23)
         22   jump +4                (to 26)
@@ -2759,7 +2759,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         38    jump +6                            (to 44)
 
   202   39    load_var 1                         (self)
-        40    call 805 ntypeargs=0               (ai.stream.TurnStream._finish)
+        40    call 826 ntypeargs=0               (ai.stream.TurnStream._finish)
         41    pop 1                              
 
   203   42    alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2842,7 +2842,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         110   jump -17                           (to 93)
 
   176   111   load_var 1                         (self)
-        112   call 805 ntypeargs=0               (ai.stream.TurnStream._finish)
+        112   call 826 ntypeargs=0               (ai.stream.TurnStream._finish)
         113   pop 1                              
 
   177   114   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2882,7 +2882,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         145   pop_jump_if_false -145             (to 0)
 
   165   146   load_var 1                         (self)
-        147   call 805 ntypeargs=0               (ai.stream.TurnStream._finish)
+        147   call 826 ntypeargs=0               (ai.stream.TurnStream._finish)
         148   pop 1                              
 
   166   149   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2975,8 +2975,8 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   306   9     load_type 2                                
         10    load_var 1                                 (spec)
-        11    call 771 ntypeargs=1                       (ai.FunctionSpec.tools)
-        12    call 778 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
+        11    call 792 ntypeargs=1                       (ai.FunctionSpec.tools)
+        12    call 799 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
         13    unary_op !                                 
         14    pop_jump_if_false +2                       (to 16)
         15    jump +79                                   (to 94)
@@ -3036,17 +3036,17 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   331   57    load_type 2                                
         58    load_var 1                                 (spec)
-        59    call 761 ntypeargs=1                       (ai.Journal.new)
+        59    call 782 ntypeargs=1                       (ai.Journal.new)
         60    store_var 16                               (_29)
 
   332   61    load_type 2                                
         62    load_var 1                                 (spec)
-        63    call 771 ntypeargs=1                       (ai.FunctionSpec.tools)
+        63    call 792 ntypeargs=1                       (ai.FunctionSpec.tools)
         64    store_var 17                               (_31)
 
   333   65    load_type 2                                
         66    load_var 1                                 (spec)
-        67    call 769 ntypeargs=1                       (ai.FunctionSpec.output_type)
+        67    call 790 ntypeargs=1                       (ai.FunctionSpec.output_type)
         68    store_var 18                               (_33)
 
   328   69    load_var2 6 15                             
@@ -3067,7 +3067,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
   340   81    load_type 8                                
         82    load_type 2                                
         83    load_var 14                                (turns)
-        84    make_closure 1697 captures=1 ntypeargs=2   
+        84    make_closure 1721 captures=1 ntypeargs=2   
         85    load_var 19                                (_36)
         86    load_const 9                               ("")
         87    load_const 10                              (false)
@@ -3080,7 +3080,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   308   94    load_type 2                                
         95    load_var 1                                 (spec)
-        96    call 767 ntypeargs=1                       (ai.FunctionSpec.name)
+        96    call 788 ntypeargs=1                       (ai.FunctionSpec.name)
         97    store_var 5                                (_12)
         98    load_type 11                               
         99    load_var 5                                 (_12)
@@ -3131,7 +3131,7 @@ function ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> 
   30   28   load_type 5            
        29   load_type 5            
        30   load_var2 6 2          
-       31   call 696 ntypeargs=2   (reflect.call_any)
+       31   call 717 ntypeargs=2   (reflect.call_any)
        32   store_var 7            (value)
        33   jump +33               (to 66)
        34   load_var 8             (e)
@@ -3192,7 +3192,7 @@ function ai.tools.Toolbox.get(self: ai.tools.Toolbox, name: string) -> ai.tools.
         5    load_var 1            (self)
         6    load_field 0          (entries)
         7    load_var 2            (name)
-        8    make_closure 1617 1   
+        8    make_closure 1641 1   
         9    call 19 ntypeargs=2   (baml.Array.find)
         10   return                
 }
@@ -3320,7 +3320,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        17   store_var 4            (on_error)
 
   49   18   load_var 1             (handler)
-       19   call 695 ntypeargs=0   (reflect.signature)
+       19   call 716 ntypeargs=0   (reflect.signature)
        20   store_var 5            (sig)
 
   50   21   load_var 2             (name)
@@ -3371,7 +3371,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        61   store_var 9            (_17)
 
   58   62   load_var 1             (handler)
-       63   call 821 ntypeargs=0   (ai.internal._schema_for_signature)
+       63   call 842 ntypeargs=0   (ai.internal._schema_for_signature)
        64   store_var 11           (_21)
 
   56   65   load_var2 8 9          
@@ -3453,7 +3453,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
   27   48   load_var2 2 3          
        49   load_field 0           (status_code)
        50   load_var 7             (text)
-       51   call 820 ntypeargs=0   (ai.errors.classify_http)
+       51   call 841 ntypeargs=0   (ai.errors.classify_http)
        52   throw                  
 }
 
@@ -3473,20 +3473,20 @@ function anthropic.AnthropicClient.ai.Client.id(self: anthropic.AnthropicClient)
 
 function anthropic.AnthropicClient.ai.Client.invoke(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   32   0   load_var2 1 2          
-       1   call 848 ntypeargs=0   (anthropic.internal.invoke)
+       1   call 869 ntypeargs=0   (anthropic.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   33   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 832 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function anthropic.AnthropicClient.ai.stream.StreamingClient.invoke_stream(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   40   0   load_var2 1 2          
-       1   call 850 ntypeargs=0   (anthropic.internal.invoke_stream)
+       1   call 871 ntypeargs=0   (anthropic.internal.invoke_stream)
        2   return                 
 }
 
@@ -3650,7 +3650,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         2     store_var 3                        (out)
 
   349   3     load_var 1                         (batch)
-        4     call 802 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 823 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -3762,7 +3762,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         102   load_var 24                        (_65)
         103   store_var_load_var 25              (s)
 
-  384   104   call 847 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+  384   104   call 868 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         105   store_var 23                       (stop)
         106   jump +3                            (to 109)
 
@@ -3925,7 +3925,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         2     store_var 3                        (msgs)
 
   132   3     load_var 1                         (j)
-        4     call 760 ntypeargs=0               (ai.Journal.entries)
+        4     call 781 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -3973,7 +3973,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         47    load_var 16                        (f)
         48    load_field 1                       (message)
         49    load_const 10                      (true)
-        50    call 843 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        50    call 864 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         51    pop 1                              
         52    jump -43                           (to 9)
 
@@ -3985,7 +3985,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         57    load_var 14                        (c)
         58    load_field 1                       (output)
         59    load_const 11                      (false)
-        60    call 843 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        60    call 864 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         61    pop 1                              
         62    jump -53                           (to 9)
 
@@ -3993,7 +3993,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         64    store_var_load_var 11              (m)
 
   146   65    load_field 0                       (content)
-        66    call 842 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
+        66    call 863 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
         67    store_var 12                       (_28)
 
   142   68    load_var 3                         (msgs)
@@ -4058,7 +4058,7 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
        5    store_var 4                        (messages)
 
   53   6    load_var 1                         (prompt)
-       7    call 764 ntypeargs=0               (ai.Prompt.messages)
+       7    call 785 ntypeargs=0               (ai.Prompt.messages)
        8    load_type 2                        
        9    load_const 3                       ("iter")
        10   virtual_call nargs=1 ntypeargs=0   
@@ -4300,11 +4300,11 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         2     store_var 5                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 782 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 803 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 5                         (_5)
         7     call_indirect                      
 
-  183   8     call 841 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
+  183   8     call 862 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
         9     store_var 6                        (prompt_parts)
 
   184   10    load_var 6                         (prompt_parts)
@@ -4317,7 +4317,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   186   16    load_var 2                         (input)
         17    load_field 1                       (journal)
-        18    call 844 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
+        18    call 865 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
         19    load_type 0                        
         20    load_const 1                       ("iter")
         21    virtual_call nargs=1 ntypeargs=0   
@@ -4419,7 +4419,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         109   pop 1                              
 
   210   110   load_var 8                         (lowered)
-        111   call 845 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        111   call 866 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         112   store_var 19                       (_60)
         113   load_type 5                        
         114   load_type 6                        
@@ -4442,7 +4442,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         129   alloc_array 1                      
         130   load_var 8                         (lowered)
         131   call 7 ntypeargs=1                 (baml.Array.concat)
-        132   call 845 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        132   call 866 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         133   store_var 17                       (_45)
         134   load_type 5                        
         135   load_type 6                        
@@ -4454,7 +4454,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   213   141   load_var 2                         (input)
         142   load_field 2                       (toolbox)
-        143   call 778 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        143   call 799 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         144   unary_op !                         
         145   pop_jump_if_false +79              (to 224)
 
@@ -4464,7 +4464,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   215   149   load_var 2                         (input)
         150   load_field 2                       (toolbox)
-        151   call 776 ntypeargs=0               (ai.tools.Toolbox.list)
+        151   call 797 ntypeargs=0               (ai.tools.Toolbox.list)
         152   load_type 20                       
         153   load_const 21                      ("iter")
         154   virtual_call nargs=1 ntypeargs=0   
@@ -4655,13 +4655,13 @@ function anthropic.internal._anthropic_stop_reason(s: string) -> ai.content.Stop
 function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   266   0     load_var2 1 2                      
         1     load_const 0                       (false)
-        2     call 846 ntypeargs=0               (anthropic.internal._anthropic_request)
+        2     call 867 ntypeargs=0               (anthropic.internal._anthropic_request)
         3     store_var 3                        (req)
 
   267   4     load_type 1                        
         5     load_var 3                         (req)
         6     load_const 2                       ("anthropic")
-        7     call 781 ntypeargs=1               (ai.wire.send_as)
+        7     call 802 ntypeargs=1               (ai.wire.send_as)
         8     store_var 4                        (resp)
 
   269   9     load_type 3                        
@@ -4798,7 +4798,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         127   load_var 21                        (_43)
         128   store_var_load_var 22              (s)
 
-  294   129   call 847 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+  294   129   call 868 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         130   store_var 20                       (stop)
         131   jump +4                            (to 135)
 
@@ -4839,7 +4839,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
 function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   415   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 846 ntypeargs=0   (anthropic.internal._anthropic_request)
+        2    call 867 ntypeargs=0   (anthropic.internal._anthropic_request)
 
   416   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -4865,7 +4865,7 @@ function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: a
         21   throw                  
 
   425   22   load_const 6           (anthropic.internal._anthropic_decode_batch)
-        23   call 803 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 824 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -4901,19 +4901,19 @@ function assert.approx_equal(actual: float, expected: float, eps: float) -> null
   81   24   jump +32               (to 56)
 
   84   25   load_var 4             (delta)
-       26   call 756 ntypeargs=0   (assert.format_operand)
+       26   call 777 ntypeargs=0   (assert.format_operand)
        27   store_var 5            (_18)
 
   86   28   load_var 3             (eps)
-       29   call 756 ntypeargs=0   (assert.format_operand)
+       29   call 777 ntypeargs=0   (assert.format_operand)
        30   store_var 6            (_20)
 
   88   31   load_var 1             (actual)
-       32   call 756 ntypeargs=0   (assert.format_operand)
+       32   call 777 ntypeargs=0   (assert.format_operand)
        33   store_var 7            (_21)
 
   90   34   load_var 2             (expected)
-       35   call 756 ntypeargs=0   (assert.format_operand)
+       35   call 777 ntypeargs=0   (assert.format_operand)
        36   store_var 8            (_22)
 
   84   37   load_const 2           ("assertion failed: |left - right| = ")
@@ -4957,7 +4957,7 @@ function assert.contains(haystack: string, needle: string) -> null {
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   50   0    load_var2 1 2          
-       1    call 612 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 633 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -4967,11 +4967,11 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   50   6    jump +15               (to 21)
 
   53   7    load_var 1             (actual)
-       8    call 756 ntypeargs=0   (assert.format_operand)
+       8    call 777 ntypeargs=0   (assert.format_operand)
        9    store_var 3            (_8)
 
   55   10   load_var 2             (expected)
-       11   call 756 ntypeargs=0   (assert.format_operand)
+       11   call 777 ntypeargs=0   (assert.format_operand)
        12   store_var 4            (_9)
 
   53   13   load_const 1           ("assertion failed: left = ")
@@ -5010,7 +5010,7 @@ function assert.is_true(condition: bool) -> null {
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 612 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 633 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -5048,13 +5048,13 @@ function claude_code.ClaudeCodeClient.ai.Client.id(self: claude_code.ClaudeCodeC
 
 function claude_code.ClaudeCodeClient.ai.Client.invoke(self: claude_code.ClaudeCodeClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   44   0   load_var2 1 2          
-       1   call 879 ntypeargs=0   (claude_code.internal.invoke)
+       1   call 900 ntypeargs=0   (claude_code.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   45   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 832 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
@@ -5272,7 +5272,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         122   load_const 31                      (".thinking")
         123   load_const 32                      ("")
         124   call 340 ntypeargs=1               (baml.json.path_or)
-        125   call 875 ntypeargs=0               (claude_code.internal._preview)
+        125   call 896 ntypeargs=0               (claude_code.internal._preview)
         126   store_var 18                       (_55)
         127   load_type 0                        
         128   load_var 18                        (_55)
@@ -5293,7 +5293,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         140   load_const 34                      (".text")
         141   load_const 35                      ("")
         142   call 340 ntypeargs=1               (baml.json.path_or)
-        143   call 875 ntypeargs=0               (claude_code.internal._preview)
+        143   call 896 ntypeargs=0               (claude_code.internal._preview)
         144   store_var 16                       (_47)
         145   load_type 0                        
         146   load_var 16                        (_47)
@@ -5492,7 +5492,7 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         36   throw                              
 
   136   37   load_var 7                         (raw)
-        38   call 876 ntypeargs=0               (claude_code.internal._log_cc_event)
+        38   call 897 ntypeargs=0               (claude_code.internal._log_cc_event)
         39   pop 1                              
 
   137   40   load_type 8                        
@@ -5511,7 +5511,7 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
 
   144   51   load_var 2                         (result)
         52   load_const 0                       (null)
-        53   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        53   call 633 ntypeargs=0               (baml.ops.equals_equals)
         54   pop_jump_if_false +2               (to 56)
         55   jump +3                            (to 58)
 
@@ -5556,7 +5556,7 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
         8    load_type 2           
         9    load_var 3            (_3)
 
-  220   10   make_closure 2177 0   
+  220   10   make_closure 2201 0   
         11   call 16 ntypeargs=3   (baml.Array.map)
         12   store_var 2           (_2)
 
@@ -5589,7 +5589,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        16    store_var 6            (call_props)
 
   55   17    load_const 4           ("string")
-       18    call 872 ntypeargs=0   (claude_code.internal._type_schema)
+       18    call 893 ntypeargs=0   (claude_code.internal._type_schema)
        19    store_var 7            (_10)
        20    load_type 1            
        21    load_type 2            
@@ -5600,7 +5600,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        26    pop 1                  
 
   56   27    load_const 6           ("string")
-       28    call 872 ntypeargs=0   (claude_code.internal._type_schema)
+       28    call 893 ntypeargs=0   (claude_code.internal._type_schema)
        29    store_var 8            (_14)
        30    load_type 1            
        31    load_type 2            
@@ -5611,7 +5611,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        36    pop 1                  
 
   57   37    load_const 8           ("object")
-       38    call 872 ntypeargs=0   (claude_code.internal._type_schema)
+       38    call 893 ntypeargs=0   (claude_code.internal._type_schema)
        39    store_var 9            (_18)
        40    load_type 1            
        41    load_type 2            
@@ -5812,7 +5812,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
 
   82   212   load_var 5             (definitions)
        213   load_const 38          (null)
-       214   call 612 ntypeargs=0   (baml.ops.equals_equals)
+       214   call 633 ntypeargs=0   (baml.ops.equals_equals)
        215   unary_op !             
        216   pop_jump_if_false +8   (to 224)
 
@@ -5835,12 +5835,12 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         1     load_var 2                         (input)
         2     load_field 0                       (prompt)
         3     call_indirect                      
-        4     call 763 ntypeargs=0               (ai.Prompt.text)
+        4     call 784 ntypeargs=0               (ai.Prompt.text)
         5     store_var 4                        (instructions)
 
   234   6     load_var 2                         (input)
         7     load_field 2                       (toolbox)
-        8     call 778 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        8     call 799 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         9     unary_op !                         
         10    store_var_load_var 5               (has_tools)
 
@@ -5855,7 +5855,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 
   236   18    load_var 2                         (input)
         19    load_field 3                       (output_type)
-        20    call 871 ntypeargs=0               (claude_code.internal.envelope_schema)
+        20    call 892 ntypeargs=0               (claude_code.internal.envelope_schema)
         21    store_var 7                        (_11)
         22    load_type 1                        
         23    load_var 7                         (_11)
@@ -5872,7 +5872,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         32    store_var 14                       (_29)
         33    load_var 2                         (input)
         34    load_field 1                       (journal)
-        35    call 870 ntypeargs=0               (claude_code.internal.transcript_text)
+        35    call 891 ntypeargs=0               (claude_code.internal.transcript_text)
         36    store_var 16                       (_33)
         37    load_type 2                        
         38    load_var 16                        (_33)
@@ -5890,7 +5890,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         48    store_var 9                        (_18)
         49    load_var 2                         (input)
         50    load_field 1                       (journal)
-        51    call 870 ntypeargs=0               (claude_code.internal.transcript_text)
+        51    call 891 ntypeargs=0               (claude_code.internal.transcript_text)
         52    store_var 11                       (_22)
         53    load_type 2                        
         54    load_var 11                        (_22)
@@ -5898,7 +5898,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         56    store_var 10                       (_21)
         57    load_var 2                         (input)
         58    load_field 2                       (toolbox)
-        59    call 873 ntypeargs=0               (claude_code.internal.tool_protocol)
+        59    call 894 ntypeargs=0               (claude_code.internal.tool_protocol)
         60    store_var 13                       (_26)
         61    load_type 2                        
         62    load_var 13                        (_26)
@@ -5924,7 +5924,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         81    store_var 18                       (_44)
         82    load_var 2                         (input)
         83    load_field 2                       (toolbox)
-        84    call 776 ntypeargs=0               (ai.tools.Toolbox.list)
+        84    call 797 ntypeargs=0               (ai.tools.Toolbox.list)
         85    container_len                      
         86    store_var 21                       (_48)
         87    load_type 3                        
@@ -6020,7 +6020,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         162   pop 1                              
 
   267   163   load_var 1                         (c)
-        164   call 877 ntypeargs=0               (claude_code.internal.mcp_config_json)
+        164   call 898 ntypeargs=0               (claude_code.internal.mcp_config_json)
         165   store_var 24                       (_70)
         166   load_var 24                        (_70)
         167   narrow_bind 21 24                  
@@ -6043,7 +6043,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         181   pop 1                              
 
   271   182   load_var 1                         (c)
-        183   call 878 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
+        183   call 899 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
         184   store_var 27                       (_79)
         185   load_type 2                        
         186   load_var 27                        (_79)
@@ -6117,7 +6117,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         243   throw_if_panic                     
 
   299   244   load_var 29                        (p)
-        245   call 874 ntypeargs=0               (claude_code.internal._read_result)
+        245   call 895 ntypeargs=0               (claude_code.internal._read_result)
         246   store_var 36                       (result)
 
   300   247   load_var 29                        (p)
@@ -6343,7 +6343,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 
   359   439   load_var 2                         (input)
         440   load_field 1                       (journal)
-        441   call 760 ntypeargs=0               (ai.Journal.entries)
+        441   call 781 ntypeargs=0               (ai.Journal.entries)
         442   container_len                      
         443   store_var 69                       (_196)
         444   load_type 3                        
@@ -6512,7 +6512,7 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         2    store_var 3                        (catalog)
 
   100   3    load_var 1                         (tb)
-        4    call 776 ntypeargs=0               (ai.tools.Toolbox.list)
+        4    call 797 ntypeargs=0               (ai.tools.Toolbox.list)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -6595,7 +6595,7 @@ function claude_code.internal.transcript_text(j: ai.Journal) -> string {
        2     store_var 2                        (lines)
 
   8    3     load_var 1                         (j)
-       4     call 760 ntypeargs=0               (ai.Journal.entries)
+       4     call 781 ntypeargs=0               (ai.Journal.entries)
        5     load_type 1                        
        6     load_const 2                       ("iter")
        7     virtual_call nargs=1 ntypeargs=0   
@@ -6835,20 +6835,20 @@ function google.GoogleClient.ai.Client.id(self: google.GoogleClient) -> string {
 
 function google.GoogleClient.ai.Client.invoke(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   22   0   load_var2 1 2          
-       1   call 864 ntypeargs=0   (google.internal.invoke)
+       1   call 885 ntypeargs=0   (google.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   23   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 832 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function google.GoogleClient.ai.stream.StreamingClient.invoke_stream(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   30   0   load_var2 1 2          
-       1   call 866 ntypeargs=0   (google.internal.invoke_stream)
+       1   call 887 ntypeargs=0   (google.internal.invoke_stream)
        2   return                 
 }
 
@@ -6975,7 +6975,7 @@ function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string 
         1    store_var 3                        (name)
 
   110   2    load_var 1                         (j)
-        3    call 760 ntypeargs=0               (ai.Journal.entries)
+        3    call 781 ntypeargs=0               (ai.Journal.entries)
         4    load_type 1                        
         5    load_const 2                       ("iter")
         6    virtual_call nargs=1 ntypeargs=0   
@@ -7046,7 +7046,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         2     store_var 3                        (out)
 
   368   3     load_var 1                         (batch)
-        4     call 802 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 823 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -7213,7 +7213,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         156   jump +2                            (to 158)
         157   load_const 8                       (null)
         158   load_const 8                       (null)
-        159   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        159   call 633 ntypeargs=0               (baml.ops.equals_equals)
         160   unary_op !                         
         161   store_var 24                       (blocked)
 
@@ -7284,14 +7284,14 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
 
   405   210   load_var 25                        (stop)
         211   load_const 8                       (null)
-        212   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        212   call 633 ntypeargs=0               (baml.ops.equals_equals)
         213   unary_op !                         
         214   jump_if_false +2                   (to 216)
         215   jump +6                            (to 221)
         216   pop 1                              
         217   load_var 26                        (usage)
         218   load_const 8                       (null)
-        219   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        219   call 633 ntypeargs=0               (baml.ops.equals_equals)
         220   unary_op !                         
         221   pop_jump_if_false -212             (to 9)
 
@@ -7342,11 +7342,11 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         2     store_var 5                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 782 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 803 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 5                         (_5)
         7     call_indirect                      
 
-  227   8     call 858 ntypeargs=0               (google.internal.google_lower_prompt)
+  227   8     call 879 ntypeargs=0               (google.internal.google_lower_prompt)
         9     store_var 6                        (prompt_parts)
 
   228   10    load_var 6                         (prompt_parts)
@@ -7355,7 +7355,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   229   13    load_var 2                         (input)
         14    load_field 1                       (journal)
-        15    call 860 ntypeargs=0               (google.internal.google_lower_journal)
+        15    call 881 ntypeargs=0               (google.internal.google_lower_journal)
         16    load_type 0                        
         17    load_const 1                       ("iter")
         18    virtual_call nargs=1 ntypeargs=0   
@@ -7435,7 +7435,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
   239   83    load_const 11                      ("user")
         84    load_var 6                         (prompt_parts)
         85    load_field 0                       (system_parts)
-        86    call 855 ntypeargs=0               (google.internal._gm_content)
+        86    call 876 ntypeargs=0               (google.internal._gm_content)
         87    store_var 14                       (_28)
         88    load_type 12                       
         89    load_var 14                        (_28)
@@ -7455,7 +7455,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   250   102   load_var 2                         (input)
         103   load_field 2                       (toolbox)
-        104   call 778 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        104   call 799 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         105   unary_op !                         
         106   pop_jump_if_false +103             (to 209)
 
@@ -7465,7 +7465,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   252   110   load_var 2                         (input)
         111   load_field 2                       (toolbox)
-        112   call 776 ntypeargs=0               (ai.tools.Toolbox.list)
+        112   call 797 ntypeargs=0               (ai.tools.Toolbox.list)
         113   load_type 14                       
         114   load_const 15                      ("iter")
         115   virtual_call nargs=1 ntypeargs=0   
@@ -7663,7 +7663,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         5     store_var 4                        (pending)
 
   141   6     load_var 1                         (j)
-        7     call 760 ntypeargs=0               (ai.Journal.entries)
+        7     call 781 ntypeargs=0               (ai.Journal.entries)
         8     load_type 1                        
         9     load_const 2                       ("iter")
         10    virtual_call nargs=1 ntypeargs=0   
@@ -7722,9 +7722,9 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   199   60    load_var2 1 36                     
         61    load_field 0                       (id)
-        62    call 859 ntypeargs=0               (google.internal._gm_tool_name_for)
+        62    call 880 ntypeargs=0               (google.internal._gm_tool_name_for)
         63    load_var 37                        (response)
-        64    call 857 ntypeargs=0               (google.internal._gm_function_response)
+        64    call 878 ntypeargs=0               (google.internal._gm_function_response)
         65    store_var 38                       (_84)
         66    load_var2 4 38                     
         67    call 4 ntypeargs=0                 (baml.Array.push)
@@ -7750,9 +7750,9 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   193   84    load_var2 1 32                     
         85    load_field 0                       (id)
-        86    call 859 ntypeargs=0               (google.internal._gm_tool_name_for)
+        86    call 880 ntypeargs=0               (google.internal._gm_tool_name_for)
         87    load_var 33                        (response)
-        88    call 857 ntypeargs=0               (google.internal._gm_function_response)
+        88    call 878 ntypeargs=0               (google.internal._gm_function_response)
         89    store_var 34                       (_72)
         90    load_var2 4 34                     
         91    call 4 ntypeargs=0                 (baml.Array.push)
@@ -7772,7 +7772,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   156   103   load_const 15                      ("user")
         104   load_var 4                         (pending)
-        105   call 855 ntypeargs=0               (google.internal._gm_content)
+        105   call 876 ntypeargs=0               (google.internal._gm_content)
         106   store_var 17                       (_27)
         107   load_var2 3 17                     
         108   call 4 ntypeargs=0                 (baml.Array.push)
@@ -7863,7 +7863,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         182   store_var_load_var 23              (t)
 
   166   183   load_field 0                       (text)
-        184   call 856 ntypeargs=0               (google.internal._gm_text_part)
+        184   call 877 ntypeargs=0               (google.internal._gm_text_part)
         185   store_var 24                       (_39)
         186   load_var2 18 24                    
         187   call 4 ntypeargs=0                 (baml.Array.push)
@@ -7880,7 +7880,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   183   197   load_const 25                      ("model")
         198   load_var 18                        (parts)
-        199   call 855 ntypeargs=0               (google.internal._gm_content)
+        199   call 876 ntypeargs=0               (google.internal._gm_content)
         200   store_var 30                       (_62)
         201   load_var2 3 30                     
         202   call 4 ntypeargs=0                 (baml.Array.push)
@@ -7900,7 +7900,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   145   214   load_const 26                      ("user")
         215   load_var 4                         (pending)
-        216   call 855 ntypeargs=0               (google.internal._gm_content)
+        216   call 876 ntypeargs=0               (google.internal._gm_content)
         217   store_var 11                       (_15)
         218   load_var2 3 11                     
         219   call 4 ntypeargs=0                 (baml.Array.push)
@@ -7912,13 +7912,13 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   151   224   load_var 9                         (u)
         225   load_field 0                       (content)
-        226   call 856 ntypeargs=0               (google.internal._gm_text_part)
+        226   call 877 ntypeargs=0               (google.internal._gm_text_part)
         227   store_var 13                       (_20)
         228   load_const 27                      ("user")
         229   load_var 13                        (_20)
         230   load_type 0                        
         231   alloc_array 1                      
-        232   call 855 ntypeargs=0               (google.internal._gm_content)
+        232   call 876 ntypeargs=0               (google.internal._gm_content)
         233   store_var 12                       (_18)
         234   load_var2 3 12                     
         235   call 4 ntypeargs=0                 (baml.Array.push)
@@ -7935,7 +7935,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   206   245   load_const 28                      ("user")
         246   load_var 4                         (pending)
-        247   call 855 ntypeargs=0               (google.internal._gm_content)
+        247   call 876 ntypeargs=0               (google.internal._gm_content)
         248   store_var 40                       (_91)
         249   load_var2 3 40                     
         250   call 4 ntypeargs=0                 (baml.Array.push)
@@ -7960,7 +7960,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
         7    store_var 4                        (first_role)
 
   82    8    load_var 1                         (prompt)
-        9    call 764 ntypeargs=0               (ai.Prompt.messages)
+        9    call 785 ntypeargs=0               (ai.Prompt.messages)
         10   load_type 2                        
         11   load_const 3                       ("iter")
         12   virtual_call nargs=1 ntypeargs=0   
@@ -7978,7 +7978,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
         24   store_var_load_var 7               (message)
 
   83    25   load_field 1                       (content)
-        26   call 856 ntypeargs=0               (google.internal._gm_text_part)
+        26   call 877 ntypeargs=0               (google.internal._gm_text_part)
         27   store_var 8                        (part)
 
   84    28   load_var 7                         (message)
@@ -8014,7 +8014,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
   99    51   load_var2 9 8                      
         52   load_type 0                        
         53   alloc_array 1                      
-        54   call 855 ntypeargs=0               (google.internal._gm_content)
+        54   call 876 ntypeargs=0               (google.internal._gm_content)
         55   store_var 10                       (_23)
         56   load_var2 3 10                     
         57   call 4 ntypeargs=0                 (baml.Array.push)
@@ -8239,7 +8239,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         181   jump +2                            (to 183)
         182   load_const 3                       (null)
         183   load_const 3                       (null)
-        184   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        184   call 633 ntypeargs=0               (baml.ops.equals_equals)
         185   unary_op !                         
         186   store_var 25                       (blocked)
 
@@ -8351,35 +8351,35 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
 function google.internal.google_render(c: google.GoogleClient, input: ai.ModelTurnInput) -> baml.http.Request {
   216   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 862 ntypeargs=0   (google.internal._google_request)
+        2   call 883 ntypeargs=0   (google.internal._google_request)
         3   return                 
 }
 
 function google.internal.invoke(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   351   0    load_var 2             (input)
         1    load_field 1           (journal)
-        2    call 760 ntypeargs=0   (ai.Journal.entries)
+        2    call 781 ntypeargs=0   (ai.Journal.entries)
         3    container_len          
         4    store_var 3            (seq)
 
   352   5    load_var2 1 2          
-        6    call 861 ntypeargs=0   (google.internal.google_render)
+        6    call 882 ntypeargs=0   (google.internal.google_render)
         7    store_var 4            (req)
 
   353   8    load_type 0            
         9    load_var 4             (req)
         10   load_const 1           ("google")
-        11   call 781 ntypeargs=1   (ai.wire.send_as)
+        11   call 802 ntypeargs=1   (ai.wire.send_as)
 
   354   12   load_var 3             (seq)
-        13   call 863 ntypeargs=0   (google.internal.google_parse)
+        13   call 884 ntypeargs=0   (google.internal.google_parse)
         14   return                 
 }
 
 function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   432   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 862 ntypeargs=0   (google.internal._google_request)
+        2    call 883 ntypeargs=0   (google.internal._google_request)
 
   433   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -8405,7 +8405,7 @@ function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTu
         21   throw                  
 
   442   22   load_const 6           (google.internal._google_decode_batch)
-        23   call 803 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 824 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -8425,20 +8425,20 @@ function openai.OpenAiClient.ai.Client.id(self: openai.OpenAiClient) -> string {
 
 function openai.OpenAiClient.ai.Client.invoke(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   62   0   load_var2 1 2          
-       1   call 834 ntypeargs=0   (openai.internal.invoke)
+       1   call 855 ntypeargs=0   (openai.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   63   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 832 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function openai.OpenAiClient.ai.stream.StreamingClient.invoke_stream(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   70   0   load_var2 1 2          
-       1   call 836 ntypeargs=0   (openai.internal.invoke_stream)
+       1   call 857 ntypeargs=0   (openai.internal.invoke_stream)
        2   return                 
 }
 
@@ -8567,7 +8567,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         2     store_var 3                        (out)
 
   255   3     load_var 1                         (batch)
-        4     call 802 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 823 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -8661,7 +8661,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         87    load_var 17                        (_38)
         88    store_var_load_var 18              (r)
 
-  272   89    call 833 ntypeargs=0               (openai.internal.openai_parse)
+  272   89    call 854 ntypeargs=0               (openai.internal.openai_parse)
         90    store_var 19                       (turn)
 
   275   91    load_var 19                        (turn)
@@ -8736,16 +8736,16 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         2     store_var 5                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 782 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 803 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 5                         (_5)
         7     call_indirect                      
 
-  129   8     call 829 ntypeargs=0               (openai.internal.openai_lower_prompt)
+  129   8     call 850 ntypeargs=0               (openai.internal.openai_lower_prompt)
         9     store_var 6                        (items)
 
   130   10    load_var 2                         (input)
         11    load_field 1                       (journal)
-        12    call 830 ntypeargs=0               (openai.internal.openai_lower_journal)
+        12    call 851 ntypeargs=0               (openai.internal.openai_lower_journal)
         13    load_type 0                        
         14    load_const 1                       ("iter")
         15    virtual_call nargs=1 ntypeargs=0   
@@ -8799,7 +8799,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   137   58    load_var 2                         (input)
         59    load_field 2                       (toolbox)
-        60    call 778 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        60    call 799 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         61    unary_op !                         
         62    pop_jump_if_false +82              (to 144)
 
@@ -8809,7 +8809,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   139   66    load_var 2                         (input)
         67    load_field 2                       (toolbox)
-        68    call 776 ntypeargs=0               (ai.tools.Toolbox.list)
+        68    call 797 ntypeargs=0               (ai.tools.Toolbox.list)
         69    load_type 12                       
         70    load_const 13                      ("iter")
         71    virtual_call nargs=1 ntypeargs=0   
@@ -8907,7 +8907,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         152   pop 1                              
 
   162   153   load_var 1                         (c)
-        154   call 825 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
+        154   call 846 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
         155   store_var 18                       (_76)
         156   load_var 18                        (_76)
         157   store_var 17                       (_75)
@@ -8923,7 +8923,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         167   store_var 16                       (_74)
 
   163   168   load_var 1                         (c)
-        169   call 824 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
+        169   call 845 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
         170   store_var 20                       (_82)
         171   load_type 5                        
         172   load_var 20                        (_82)
@@ -8960,22 +8960,22 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
 function openai.internal.invoke(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   231   0   load_var2 1 2          
-        1   call 831 ntypeargs=0   (openai.internal.openai_render)
+        1   call 852 ntypeargs=0   (openai.internal.openai_render)
         2   store_var 3            (req)
 
   232   3   load_type 0            
         4   load_var 3             (req)
         5   load_const 1           ("openai")
-        6   call 781 ntypeargs=1   (ai.wire.send_as)
+        6   call 802 ntypeargs=1   (ai.wire.send_as)
 
-  233   7   call 833 ntypeargs=0   (openai.internal.openai_parse)
+  233   7   call 854 ntypeargs=0   (openai.internal.openai_parse)
         8   return                 
 }
 
 function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   304   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 832 ntypeargs=0   (openai.internal._openai_request)
+        2    call 853 ntypeargs=0   (openai.internal._openai_request)
 
   305   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -9001,7 +9001,7 @@ function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTu
         21   throw                  
 
   314   22   load_const 6           (openai.internal._openai_decode_batch)
-        23   call 803 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 824 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -9011,7 +9011,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         2     store_var 3                        (items)
 
   58    3     load_var 1                         (j)
-        4     call 760 ntypeargs=0               (ai.Journal.entries)
+        4     call 781 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -9303,7 +9303,7 @@ function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> map<string, u
        2    store_var 3                        (items)
 
   38   3    load_var 1                         (prompt)
-       4    call 764 ntypeargs=0               (ai.Prompt.messages)
+       4    call 785 ntypeargs=0               (ai.Prompt.messages)
        5    load_type 1                        
        6    load_const 2                       ("iter")
        7    virtual_call nargs=1 ntypeargs=0   
@@ -9655,7 +9655,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
 function openai.internal.openai_render(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> baml.http.Request {
   118   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 832 ntypeargs=0   (openai.internal._openai_request)
+        2   call 853 ntypeargs=0   (openai.internal._openai_request)
         3   return                 
 }
 
@@ -9672,7 +9672,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  104   0   make_closure 1558 0   
+  104   0   make_closure 1582 0   
         1   store_var 1           (_0)
         2   load_var 1            (_0)
         3   return                
@@ -9699,7 +9699,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   76   16   load_var 1             (threshold)
-       17   make_closure 1553 1    
+       17   make_closure 1577 1    
        18   store_var 2            (_0)
        19   load_var 2             (_0)
        20   return                 
@@ -9740,7 +9740,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1537 2    
+       29   make_closure 1561 2    
        30   store_var 3            (_0)
        31   load_var 3             (_0)
        32   return                 
@@ -9761,14 +9761,14 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   42   10   load_var 1             (max_attempts)
-       11   make_closure 1547 1    
+       11   make_closure 1571 1    
        12   store_var 2            (_0)
        13   load_var 2             (_0)
        14   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  98   0   make_closure 1556 0   
+  98   0   make_closure 1580 0   
        1   store_var 1           (_0)
        2   load_var 1            (_0)
        3   return                
@@ -9984,7 +9984,7 @@ function testing.TestCollector.register_test_at(self: testing.TestCollector, own
 
   107   6   load_var2 6 3          
         7   load_var2 4 5          
-        8   call 698 ntypeargs=0   (testing.TestCollector.register_test)
+        8   call 719 ntypeargs=0   (testing.TestCollector.register_test)
         9   return                 
 }
 
@@ -10117,7 +10117,7 @@ function testing.TestCollector.register_test_set_at(self: testing.TestCollector,
 
   118   6   load_var2 6 3          
         7   load_var2 4 5          
-        8   call 699 ntypeargs=0   (testing.TestCollector.register_test_set)
+        8   call 720 ntypeargs=0   (testing.TestCollector.register_test_set)
         9   return                 
 }
 
@@ -10147,11 +10147,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   290   22   load_var2 1 5                      
-        23   call 714 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 735 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   291   25   load_var 1                         (self)
-        26   call 706 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 727 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   295   28   load_type 5                        
@@ -10188,7 +10188,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   298   58   load_var2 9 2                      
-        59   call 713 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 734 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   301   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -10211,7 +10211,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         10   pop_jump_if_false +2   (to 12)
         11   jump +53               (to 64)
 
-  308   12   sys_op 512             (baml.time.Instant.now)
+  308   12   sys_op 520             (baml.time.Instant.now)
         13   store_var 5            (start)
 
   309   14   load_var 2             (ts)
@@ -10229,7 +10229,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         25   pop 1                  
 
   315   26   load_var 5             (start)
-        27   call 513 ntypeargs=0   (baml.time.Instant.elapsed)
+        27   call 521 ntypeargs=0   (baml.time.Instant.elapsed)
         28   call 508 ntypeargs=0   (baml.time.Duration.to_milliseconds)
         29   call 92 ntypeargs=0    (baml.Bigint.to_int)
         30   store_var 7            (elapsed)
@@ -10282,7 +10282,7 @@ function testing.TestRegistry.list_filtered(self: testing.TestRegistry, profile_
   281   0   load_var2 1 2          
         1   load_var2 3 4          
         2   load_var 5             (cli_exclude)
-        3   call 734 ntypeargs=0   (testing.select_names_layered)
+        3   call 755 ntypeargs=0   (testing.select_names_layered)
         4   return                 
 }
 
@@ -10300,9 +10300,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   237   0   load_var 1             (self)
-        1   call 715 ntypeargs=0   (testing.testset_children)
+        1   call 736 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 725 ntypeargs=0   (testing.run_testset)
+        3   call 746 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -10310,7 +10310,7 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
   259   0    load_var2 1 2          
         1    load_var2 3 4          
         2    load_var 5             (cli_exclude)
-        3    call 734 ntypeargs=0   (testing.select_names_layered)
+        3    call 755 ntypeargs=0   (testing.select_names_layered)
         4    store_var 6            (selected_names)
 
   261   5    load_var 2             (profile_include)
@@ -10353,22 +10353,22 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
         36   jump +4                (to 40)
 
   268   37   load_var2 1 6          
-        38   call 710 ntypeargs=0   (testing.TestRegistry.run_selected)
+        38   call 731 ntypeargs=0   (testing.TestRegistry.run_selected)
         39   jump +3                (to 42)
 
   266   40   load_var 1             (self)
-        41   call 709 ntypeargs=0   (testing.TestRegistry.run_all)
+        41   call 730 ntypeargs=0   (testing.TestRegistry.run_all)
 
   270   42   load_var 6             (selected_names)
-        43   call 740 ntypeargs=0   (testing.flatten_with_tolerated)
+        43   call 761 ntypeargs=0   (testing.flatten_with_tolerated)
         44   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   241   0   load_var2 1 2          
-        1   call 716 ntypeargs=0   (testing.testset_children_selected)
+        1   call 737 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 725 ntypeargs=0   (testing.run_testset)
+        3   call 746 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -10401,7 +10401,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 724 ntypeargs=0               (testing.run_test)
+        26   call 745 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   211   28   load_type 5                        
@@ -10438,7 +10438,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   215   58   load_var2 9 2                      
-        59   call 707 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 728 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   218   61   load_const 12                      ("Test not found: ")
@@ -10473,11 +10473,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   224   22   load_var2 1 5                      
-        23   call 714 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 715 ntypeargs=0               (testing.testset_children)
+        23   call 735 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 736 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 725 ntypeargs=0               (testing.run_testset)
+        27   call 746 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   227   29   load_type 5                        
@@ -10514,7 +10514,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   230   59   load_var2 9 2                      
-        60   call 708 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 729 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   233   62   load_const 12                      ("TestSet not found: ")
@@ -10606,7 +10606,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         71   store_var 12                       (_27)
 
   189   72   load_var 11                        (sub)
-        73   call 706 ntypeargs=0               (testing.TestRegistry.serialize)
+        73   call 727 ntypeargs=0               (testing.TestRegistry.serialize)
         74   store_var 13                       (_28)
 
   186   75   load_var2 3 12                     
@@ -10777,7 +10777,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   441   58    load_var 13                        (outcome)
         59    load_const 10                      ("pass")
-        60    call 612 ntypeargs=0               (baml.ops.equals_equals)
+        60    call 633 ntypeargs=0               (baml.ops.equals_equals)
         61    pop_jump_if_false +2               (to 63)
         62    jump +59                           (to 121)
 
@@ -10844,7 +10844,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   458   114   load_var 13                        (outcome)
         115   load_const 16                      ("error")
-        116   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        116   call 633 ntypeargs=0               (baml.ops.equals_equals)
         117   pop_jump_if_false -97              (to 20)
 
   459   118   load_const 17                      (true)
@@ -10922,7 +10922,7 @@ function testing.any_pattern_matches(pats: string[], canonical_id: string) -> bo
         15   store_var 5                        (p)
 
   608   16   load_var2 2 5                      
-        17   call 727 ntypeargs=0               (testing.glob_match)
+        17   call 748 ntypeargs=0               (testing.glob_match)
         18   pop_jump_if_false -13              (to 5)
 
   609   19   load_const 5                       (true)
@@ -10960,7 +10960,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         23   store_var_load_var 8               (name)
 
   949   24   load_var 3                         (all_failed_names)
-        25   call 743 ntypeargs=0               (testing.failure_matches_selected)
+        25   call 764 ntypeargs=0               (testing.failure_matches_selected)
         26   pop_jump_if_false +2               (to 28)
         27   jump +8                            (to 35)
 
@@ -10973,7 +10973,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         34   jump -21                           (to 13)
 
   950   35   load_var2 8 2                      
-        36   call 743 ntypeargs=0               (testing.failure_matches_selected)
+        36   call 764 ntypeargs=0               (testing.failure_matches_selected)
         37   pop_jump_if_false +2               (to 39)
         38   jump +8                            (to 46)
 
@@ -11019,7 +11019,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          16   store_var_load_var 6               (name)
 
   1050   17   load_var 2                         (out)
-         18   call 742 ntypeargs=0               (testing.name_in)
+         18   call 763 ntypeargs=0               (testing.name_in)
          19   unary_op !                         
          20   pop_jump_if_false -14              (to 6)
 
@@ -11053,7 +11053,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          46   store_var_load_var 10              (nested)
 
   1057   47   load_var 2                         (out)
-         48   call 745 ntypeargs=0               (testing.collect_all_failed_names)
+         48   call 766 ntypeargs=0               (testing.collect_all_failed_names)
          49   pop 1                              
          50   jump -19                           (to 31)
 
@@ -11133,7 +11133,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
          57    load_var 15             (nested)
          58    load_field 0            (outcome)
          59    load_const 3            ("pass")
-         60    call 612 ntypeargs=0    (baml.ops.equals_equals)
+         60    call 633 ntypeargs=0    (baml.ops.equals_equals)
          61    store_var 16            (nested_tolerated)
 
   1015   62    load_var 15             (nested)
@@ -11158,7 +11158,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
          79    store_var_load_var 18   (sentinel)
 
   1024   80    load_var 3              (selected_names)
-         81    call 742 ntypeargs=0    (testing.name_in)
+         81    call 763 ntypeargs=0    (testing.name_in)
          82    pop_jump_if_false +2    (to 84)
          83    jump +21                (to 104)
 
@@ -11213,7 +11213,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
   1017   123   load_var2 15 16         
 
   1018   124   load_var2 3 4           
-         125   call 744 ntypeargs=0    (testing.collect_leaf_identities)
+         125   call 765 ntypeargs=0    (testing.collect_leaf_identities)
          126   pop 1                   
          127   jump +31                (to 158)
 
@@ -11222,7 +11222,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
 
   1005   130   load_field 0            (outcome)
          131   load_const 7            ("pass")
-         132   call 612 ntypeargs=0    (baml.ops.equals_equals)
+         132   call 633 ntypeargs=0    (baml.ops.equals_equals)
          133   pop_jump_if_false +2    (to 135)
          134   jump +18                (to 152)
 
@@ -11292,7 +11292,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   1077   24   load_field 5                       (results)
          25   load_var 2                         (out)
-         26   call 746 ntypeargs=0               (testing.collect_leaf_messages)
+         26   call 767 ntypeargs=0               (testing.collect_leaf_messages)
          27   pop 1                              
          28   jump -23                           (to 5)
 
@@ -11318,7 +11318,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   1069   47   load_field 0                       (outcome)
          48   load_const 10                      ("pass")
-         49   call 612 ntypeargs=0               (baml.ops.equals_equals)
+         49   call 633 ntypeargs=0               (baml.ops.equals_equals)
          50   unary_op !                         
          51   pop_jump_if_false -15              (to 36)
 
@@ -11392,7 +11392,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         43   store_var 9                        (ts)
 
   749   44   load_var2 1 9                      
-        45   call 737 ntypeargs=0               (testing.collect_subtree_names)
+        45   call 758 ntypeargs=0               (testing.collect_subtree_names)
         46   load_type 10                       
         47   load_const 11                      ("iter")
         48   virtual_call nargs=1 ntypeargs=0   
@@ -11422,8 +11422,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   762   0    load_var2 1 2          
-        1    call 714 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 736 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 735 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 757 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +91               (to 94)
         4    load_var 3             (e)
         5    store_var 4            (_5)
@@ -11525,11 +11525,11 @@ function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testi
 
 function testing.collect_subtree_names_layered(registry: testing.TestRegistry, ts: testing.TestSetRegistration, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> string[] {
   778   0     load_var2 1 2           
-        1     call 714 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
+        1     call 735 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
 
   777   2     load_var2 3 4           
         3     load_var2 5 6           
-        4     call 734 ntypeargs=0    (testing.select_names_layered)
+        4     call 755 ntypeargs=0    (testing.select_names_layered)
         5     jump +111               (to 116)
         6     load_var 7              (e)
         7     store_var 8             (_9)
@@ -11612,7 +11612,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   805   83    load_var2 3 4           
         84    load_var2 5 6           
-        85    call 730 ntypeargs=0    (testing.leaf_selected_layered)
+        85    call 751 ntypeargs=0    (testing.leaf_selected_layered)
 
   803   86    pop_jump_if_false +2    (to 88)
         87    jump +4                 (to 91)
@@ -11636,7 +11636,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   789   100   load_var2 3 4           
         101   load_var2 5 6           
-        102   call 730 ntypeargs=0    (testing.leaf_selected_layered)
+        102   call 751 ntypeargs=0    (testing.leaf_selected_layered)
 
   787   103   pop_jump_if_false +2    (to 105)
         104   jump +4                 (to 108)
@@ -11707,7 +11707,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         37    load_var 13                        (tsr)
         38    load_field 0                       (outcome)
         39    load_const 7                       ("pass")
-        40    call 612 ntypeargs=0               (baml.ops.equals_equals)
+        40    call 633 ntypeargs=0               (baml.ops.equals_equals)
         41    store_var 14                       (ft)
 
   855   42    load_var 13                        (tsr)
@@ -11755,7 +11755,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   856   74    load_var 13                        (tsr)
         75    load_field 5                       (results)
         76    load_var 14                        (ft)
-        77    call 739 ntypeargs=0               (testing.count_leaves)
+        77    call 760 ntypeargs=0               (testing.count_leaves)
         78    store_var 10                       (delta)
         79    jump +31                           (to 110)
 
@@ -11764,7 +11764,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
 
   845   82    load_field 0                       (outcome)
         83    load_const 8                       ("pass")
-        84    call 612 ntypeargs=0               (baml.ops.equals_equals)
+        84    call 633 ntypeargs=0               (baml.ops.equals_equals)
         85    pop_jump_if_false +2               (to 87)
         86    jump +18                           (to 104)
 
@@ -11850,7 +11850,7 @@ function testing.expansion_error_report(name: string) -> testing.TestSetReport {
 
 function testing.failure_matches_selected(selected: string, failed_names: string[]) -> bool {
   972   0    load_var2 1 2                      
-        1    call 742 ntypeargs=0               (testing.name_in)
+        1    call 763 ntypeargs=0               (testing.name_in)
         2    pop_jump_if_false +2               (to 4)
         3    jump +43                           (to 46)
 
@@ -11911,7 +11911,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   887   0     load_var 1             (report)
         1     load_field 0           (outcome)
         2     load_const 0           ("pass")
-        3     call 612 ntypeargs=0   (baml.ops.equals_equals)
+        3     call 633 ntypeargs=0   (baml.ops.equals_equals)
         4     store_var 3            (top_tolerated)
 
   888   5     load_var 1             (report)
@@ -11959,7 +11959,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   889   37    load_var 1             (report)
         38    load_field 5           (results)
         39    load_var 3             (top_tolerated)
-        40    call 739 ntypeargs=0   (testing.count_leaves)
+        40    call 760 ntypeargs=0   (testing.count_leaves)
         41    store_var 4            (counts)
 
   905   42    load_type 2            
@@ -11969,7 +11969,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   906   45    load_var 1             (report)
         46    load_field 5           (results)
         47    load_var 6             (messages)
-        48    call 746 ntypeargs=0   (testing.collect_leaf_messages)
+        48    call 767 ntypeargs=0   (testing.collect_leaf_messages)
         49    pop 1                  
 
   907   50    load_type 2            
@@ -11977,7 +11977,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
         52    store_var 7            (all_failed_names)
 
   908   53    load_var2 1 7          
-        54    call 745 ntypeargs=0   (testing.collect_all_failed_names)
+        54    call 766 ntypeargs=0   (testing.collect_all_failed_names)
         55    pop 1                  
 
   909   56    load_type 2            
@@ -11991,7 +11991,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
 
   910   64    load_var2 1 3          
         65    load_var2 2 8          
-        66    call 744 ntypeargs=0   (testing.collect_leaf_identities)
+        66    call 765 ntypeargs=0   (testing.collect_leaf_identities)
         67    pop 1                  
 
   916   68    load_var 8             (executed)
@@ -12049,7 +12049,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   922   112   load_var2 2 1          
         113   load_field 4           (failed_names)
         114   load_var 7             (all_failed_names)
-        115   call 741 ntypeargs=0   (testing.classify_selected_names)
+        115   call 762 ntypeargs=0   (testing.classify_selected_names)
         116   store_var 9            (identities)
         117   jump +3                (to 120)
 
@@ -12210,14 +12210,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
   577   98    load_var2 1 2           
         99    call 155 ntypeargs=0    (baml.String.index_of)
         100   load_const 6            (null)
-        101   call 612 ntypeargs=0    (baml.ops.equals_equals)
+        101   call 633 ntypeargs=0    (baml.ops.equals_equals)
         102   unary_op !              
         103   return                  
 }
 
 function testing.leaf_selected(name: string, include: string[], exclude: string[]) -> bool {
   618   0    load_var2 3 1          
-        1    call 728 ntypeargs=0   (testing.any_pattern_matches)
+        1    call 749 ntypeargs=0   (testing.any_pattern_matches)
         2    pop_jump_if_false +2   (to 4)
         3    jump +14               (to 17)
 
@@ -12231,7 +12231,7 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
         11   jump +4                (to 15)
 
   624   12   load_var2 2 1          
-        13   call 728 ntypeargs=0   (testing.any_pattern_matches)
+        13   call 749 ntypeargs=0   (testing.any_pattern_matches)
         14   jump +4                (to 18)
 
   622   15   load_const 1           (true)
@@ -12244,13 +12244,13 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
 function testing.leaf_selected_layered(name: string, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> bool {
   637   0   load_var2 1 2          
         1   load_var 3             (profile_exclude)
-        2   call 729 ntypeargs=0   (testing.leaf_selected)
+        2   call 750 ntypeargs=0   (testing.leaf_selected)
         3   jump_if_false +5       (to 8)
         4   pop 1                  
 
   638   5   load_var2 1 4          
         6   load_var 5             (cli_exclude)
-        7   call 729 ntypeargs=0   (testing.leaf_selected)
+        7   call 750 ntypeargs=0   (testing.leaf_selected)
         8   return                 
 }
 
@@ -12350,7 +12350,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   486   25   load_var 5                         (child)
-        26   make_closure 1438 1                
+        26   make_closure 1462 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   load_type 7                        
@@ -12368,7 +12368,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         40   call 482 ntypeargs=2               (baml.future.all_complete)
         41   await                              
 
-  491   42   call 722 ntypeargs=0               (testing.aggregate_reports)
+  491   42   call 743 ntypeargs=0               (testing.aggregate_reports)
         43   return                             
 }
 
@@ -12431,16 +12431,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         47   pop 1                              
         48   load_var 8                         (outcome)
         49   load_const 7                       ("pass")
-        50   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        50   call 633 ntypeargs=0               (baml.ops.equals_equals)
         51   unary_op !                         
         52   pop_jump_if_false -44              (to 8)
 
   119   53   load_var 3                         (named_results)
-        54   call 722 ntypeargs=0               (testing.aggregate_reports)
+        54   call 743 ntypeargs=0               (testing.aggregate_reports)
         55   jump +3                            (to 58)
 
   124   56   load_var 3                         (named_results)
-        57   call 722 ntypeargs=0               (testing.aggregate_reports)
+        57   call 743 ntypeargs=0               (testing.aggregate_reports)
         58   return                             
 }
 
@@ -12450,7 +12450,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   496   3    load_var 1             (body)
-        4    make_closure 1450 1    
+        4    make_closure 1474 1    
         5    store_var 3            (base_run)
 
   527   6    load_var 2             (runner)
@@ -12486,7 +12486,7 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         9    jump +3                (to 12)
 
   539   10   load_var 1             (children)
-        11   call 723 ntypeargs=0   (testing.run_children_parallel)
+        11   call 744 ntypeargs=0   (testing.run_children_parallel)
         12   return                 
 }
 
@@ -12497,7 +12497,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         3   load_type 0            
         4   alloc_array 0          
         5   load_var2 2 3          
-        6   call 734 ntypeargs=0   (testing.select_names_layered)
+        6   call 755 ntypeargs=0   (testing.select_names_layered)
         7   return                 
 }
 
@@ -12528,7 +12528,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
   704   21   load_field 0                       (name)
         22   load_var2 2 3                      
         23   load_var2 4 5                      
-        24   call 730 ntypeargs=0               (testing.leaf_selected_layered)
+        24   call 751 ntypeargs=0               (testing.leaf_selected_layered)
 
   702   25   pop_jump_if_false -15              (to 10)
 
@@ -12559,14 +12559,14 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   718   49   load_field 0                       (name)
         50   load_var2 2 3                      
-        51   call 733 ntypeargs=0               (testing.subtree_may_be_selected)
+        51   call 754 ntypeargs=0               (testing.subtree_may_be_selected)
         52   jump_if_false +6                   (to 58)
         53   pop 1                              
 
   719   54   load_var 13                        (ts)
         55   load_field 0                       (name)
         56   load_var2 4 5                      
-        57   call 733 ntypeargs=0               (testing.subtree_may_be_selected)
+        57   call 754 ntypeargs=0               (testing.subtree_may_be_selected)
 
   717   58   pop_jump_if_false -20              (to 38)
 
@@ -12574,7 +12574,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   723   60   load_var2 2 3                      
         61   load_var2 4 5                      
-        62   call 738 ntypeargs=0               (testing.collect_subtree_names_layered)
+        62   call 759 ntypeargs=0               (testing.collect_subtree_names_layered)
 
   729   63   load_type 10                       
         64   load_const 11                      ("iter")
@@ -12630,13 +12630,13 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         21   load_const 6                       ("*")
         22   call 155 ntypeargs=0               (baml.String.index_of)
         23   load_const 7                       (null)
-        24   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        24   call 633 ntypeargs=0               (baml.ops.equals_equals)
         25   jump_if_false +7                   (to 32)
         26   pop 1                              
         27   load_var2 3 6                      
         28   call 155 ntypeargs=0               (baml.String.index_of)
         29   load_const 7                       (null)
-        30   call 612 ntypeargs=0               (baml.ops.equals_equals)
+        30   call 633 ntypeargs=0               (baml.ops.equals_equals)
         31   unary_op !                         
         32   pop_jump_if_false +2               (to 34)
         33   jump +11                           (to 44)
@@ -12647,7 +12647,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         37   jump_if_false +4                   (to 41)
         38   pop 1                              
         39   load_var2 3 6                      
-        40   call 727 ntypeargs=0               (testing.glob_match)
+        40   call 748 ntypeargs=0               (testing.glob_match)
         41   pop_jump_if_false -32              (to 9)
 
   655   42   load_const 9                       (true)
@@ -12662,7 +12662,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
 
 function testing.subtree_may_be_selected(prefix: string, include: string[], exclude: string[]) -> bool {
   677   0    load_var2 1 3                      
-        1    call 731 ntypeargs=0               (testing.subtree_excluded)
+        1    call 752 ntypeargs=0               (testing.subtree_excluded)
         2    pop_jump_if_false +2               (to 4)
         3    jump +34                           (to 37)
 
@@ -12693,7 +12693,7 @@ function testing.subtree_may_be_selected(prefix: string, include: string[], excl
         27   store_var_load_var 7               (pattern)
 
   684   28   load_var 1                         (prefix)
-        29   call 732 ntypeargs=0               (testing.pattern_may_match_descendant)
+        29   call 753 ntypeargs=0               (testing.pattern_may_match_descendant)
         30   pop_jump_if_false -13              (to 17)
 
   685   31   load_const 6                       (true)
@@ -12720,7 +12720,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   364   6    load_var2 1 2         
 
   366   7    load_var 3            (runner)
-        8    make_closure 1415 2   
+        8    make_closure 1439 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   store_var 4           (_0)
         11   load_var 4            (_0)
@@ -12739,7 +12739,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   375   8    load_var2 1 2         
-        9    make_closure 1417 2   
+        9    make_closure 1441 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   store_var 3           (_0)
         12   load_var 3            (_0)
@@ -12762,7 +12762,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   391   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1419 3   
+        13   make_closure 1443 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   store_var 4           (_0)
         16   load_var 4            (_0)
@@ -12798,7 +12798,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 6                         (t)
         25   load_field 2                       (runner)
-        26   call 717 ntypeargs=0               (testing.test_child)
+        26   call 738 ntypeargs=0               (testing.test_child)
         27   store_var 7                        (_10)
         28   load_var2 3 7                      
         29   call 4 ntypeargs=0                 (baml.Array.push)
@@ -12825,7 +12825,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         49   store_var 10                       (ts)
 
   334   50   load_var2 1 10                     
-        51   call 718 ntypeargs=0               (testing.testset_child)
+        51   call 739 ntypeargs=0               (testing.testset_child)
         52   store_var 11                       (_21)
         53   load_var2 3 11                     
         54   call 4 ntypeargs=0                 (baml.Array.push)
@@ -12864,7 +12864,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   342   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 720 ntypeargs=0               (testing._name_selected)
+        23   call 741 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   343   25   load_var 7                         (t)
@@ -12873,7 +12873,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 7                         (t)
         30   load_field 2                       (runner)
-        31   call 717 ntypeargs=0               (testing.test_child)
+        31   call 738 ntypeargs=0               (testing.test_child)
         32   store_var 8                        (_13)
         33   load_var2 4 8                      
         34   call 4 ntypeargs=0                 (baml.Array.push)
@@ -12901,12 +12901,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   354   55   load_field 0                       (name)
         56   load_var 2                         (names)
-        57   call 721 ntypeargs=0               (testing._has_selected_descendant)
+        57   call 742 ntypeargs=0               (testing._has_selected_descendant)
         58   pop_jump_if_false -14              (to 44)
 
   355   59   load_var2 1 11                     
         60   load_var 2                         (names)
-        61   call 719 ntypeargs=0               (testing.testset_child_selected)
+        61   call 740 ntypeargs=0               (testing.testset_child_selected)
         62   store_var 12                       (_26)
         63   load_var2 4 12                     
         64   call 4 ntypeargs=0                 (baml.Array.push)
@@ -12928,7 +12928,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 889 ntypeargs=0   (user.score)
+       7    call 910 ntypeargs=0   (user.score)
        8    store_var 4            (base)
 
   11   9    load_var 4             (base)

--- a/baml_language/sdk_tests/harness_setup/src/csharp.rs
+++ b/baml_language/sdk_tests/harness_setup/src/csharp.rs
@@ -448,10 +448,6 @@ fn verify_phase12_surface(fixture: &std::path::Path) {
         (
             "Csv/CsvReader.g.cs",
             vec![
-                " Iter(",
-                " IterAsync(",
-                " Next(",
-                " NextAsync(",
                 " Headers(",
                 " HeadersAsync(",
                 " Rows<T>(",
@@ -467,14 +463,11 @@ fn verify_phase12_surface(fixture: &std::path::Path) {
             ],
         ),
         (
+            // `iter` / `next` come from `implements root.iter.Iterable` /
+            // `Iterator`; interface-impl methods are not generated, so the
+            // reader handle is the whole surface here.
             "Csv/CsvRows.g.cs",
-            vec![
-                " Reader { get; }",
-                " Iter(",
-                " IterAsync(",
-                " Next(",
-                " NextAsync(",
-            ],
+            vec![" Reader { get; }"],
         ),
         (
             "Csv/CsvWriter.g.cs",


### PR DESCRIPTION
- Adding and subtracting `Duration` from time quantities
- Multiply and dividing `Duration` by `int` or `bigint`
- Remainder of `Duration` by `Duration`
- Negation of a `Duration`
- Difference between two points in time produces a `Duration`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added arithmetic support for durations, including addition, subtraction, multiplication, division, remainder, and negation.
  - Added date and time arithmetic for instants, plain dates and times, and zoned date-times.
  - Plain times now wrap correctly across midnight when adding or subtracting durations.
  - Subtracting compatible date or time values now returns the elapsed duration.
  - Zoned date-time calculations preserve timezone information.

- **Bug Fixes**
  - Improved generated client output by excluding interface-provided methods from class method collections.

- **Tests**
  - Added comprehensive coverage for time arithmetic, wrapping, signed differences, timezone preservation, and integer operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->