### PR TITLE
Support media inputs in stdlib LLM clients

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/ai/ns_wire/wire.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/ns_wire/wire.baml
@@ -36,3 +36,156 @@ function send_as<T>(req: baml.http.Request, provider: string) -> T {
 function render_output_format(t: type) -> string {
     baml.prompt.render_output_format(t)
 }
+
+/// Provider-neutral media payload after resolving local files and, when
+/// requested, ordinary HTTP(S) URLs. Google Cloud `gs://` URLs remain URLs.
+class ResolvedMedia {
+    url: string?,
+    base64: string?,
+    mime_type: string,
+}
+
+function _media_mime_type(explicit: string?, source_value: string, kind: string) -> string {
+    if let supplied: string = explicit {
+        return supplied;
+    }
+    let source = source_value.to_lower_case();
+    if (source.includes(".jpg") || source.includes(".jpeg")) {
+        "image/jpeg"
+    } else if (source.includes(".png")) {
+        "image/png"
+    } else if (source.includes(".webp")) {
+        "image/webp"
+    } else if (source.includes(".gif")) {
+        "image/gif"
+    } else if (source.includes(".svg")) {
+        "image/svg+xml"
+    } else if (source.includes(".wav")) {
+        "audio/wav"
+    } else if (source.includes(".mp3")) {
+        "audio/mpeg"
+    } else if (source.includes(".flac")) {
+        "audio/flac"
+    } else if (source.includes(".ogg")) {
+        "audio/ogg"
+    } else if (source.includes(".webm")) {
+        if (kind == "audio") {
+            "audio/webm"
+        } else {
+            "video/webm"
+        }
+    } else if (source.includes(".mov")) {
+        "video/quicktime"
+    } else if (source.includes(".mp4")) {
+        "video/mp4"
+    } else if (source.includes(".avi")) {
+        "video/x-msvideo"
+    } else if (source.includes(".mkv")) {
+        "video/x-matroska"
+    } else if (source.includes(".pdf")) {
+        "application/pdf"
+    } else if (kind == "audio") {
+        "audio/mpeg"
+    } else if (kind == "video") {
+        "video/mp4"
+    } else if (kind == "pdf") {
+        "application/pdf"
+    } else {
+        "image/png"
+    }
+}
+
+function _resolve_media_content(
+    url: string?,
+    file: string?,
+    inline: string,
+    mime: string,
+    fetch_url: bool,
+) -> ResolvedMedia {
+    if let path: string = file {
+        let handle = baml.fs.open(path, "r");
+        let data = handle.bytes().to_base64();
+        handle.close();
+        return ResolvedMedia { url: null, base64: data, mime_type: mime };
+    }
+    if (inline != "") {
+        return ResolvedMedia { url: null, base64: inline, mime_type: mime };
+    }
+    if let media_url: string = url {
+        if (media_url.starts_with("data:")) {
+            if let separator: int = media_url.index_of(";base64,") {
+                return ResolvedMedia {
+                    url: null,
+                    base64: media_url.substring(separator + 8, media_url.length()),
+                    mime_type: media_url.substring(5, separator),
+                };
+            }
+        }
+        if (!fetch_url || media_url.starts_with("gs://")) {
+            return ResolvedMedia { url: media_url, base64: null, mime_type: mime };
+        }
+        let response = baml.http.fetch(media_url);
+        if (!response.ok()) {
+            throw root.errors.NetworkFailure {
+                provider: "media",
+                detail: `media URL ${media_url} returned HTTP ${response.status_code}`,
+                raw_body: null,
+            }
+        }
+        let response_mime = response.headers.get("content-type") ?? mime;
+        return ResolvedMedia {
+            url: null,
+            base64: response.bytes().to_base64(),
+            mime_type: response_mime.split(";").at(0) ?? mime,
+        };
+    }
+    throw baml.errors.InvalidArgument { message: "media has no URL, file, or base64 content" }
+}
+
+/// Resolve BAML media for provider request lowering. This mirrors the media
+/// resolution pass in `sys_llm`: local files become base64, existing base64 is
+/// retained, and URL fetching is selected by the provider.
+function resolve_media(media: ai.MediaPart, fetch_url: bool) -> ResolvedMedia {
+    match (media) {
+        let image: baml.media.Image => {
+            let source = image.file() ?? image.url() ?? "";
+            _resolve_media_content(
+                image.url(),
+                image.file(),
+                image.base64(),
+                _media_mime_type(image.mime_type(), source, "image"),
+                fetch_url,
+            )
+        },
+        let audio: baml.media.Audio => {
+            let source = audio.file() ?? audio.url() ?? "";
+            _resolve_media_content(
+                audio.url(),
+                audio.file(),
+                audio.base64(),
+                _media_mime_type(audio.mime_type(), source, "audio"),
+                fetch_url,
+            )
+        },
+        let video: baml.media.Video => {
+            let source = video.file() ?? video.url() ?? "";
+            _resolve_media_content(
+                video.url(),
+                video.file(),
+                video.base64(),
+                _media_mime_type(video.mime_type(), source, "video"),
+                fetch_url,
+            )
+        },
+        let pdf: baml.media.Pdf => {
+            let source = pdf.file() ?? pdf.url() ?? "";
+            _resolve_media_content(
+                pdf.url(),
+                pdf.file(),
+                pdf.base64(),
+                _media_mime_type(pdf.mime_type(), source, "pdf"),
+                fetch_url,
+            )
+        },
+    }
+}

--- a/baml_language/crates/baml_builtins2/baml_std/ai/spec.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/ai/spec.baml
@@ -3,6 +3,12 @@
 // No journal, no conversation, no wire state.
 // Mirrors _planv2/pages/02_guides/02_specs_and_runners/01_specs.md.
 
+/// Provider-neutral media retained inside a rendered prompt.
+type MediaPart = baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf;
+
+/// One structural part of a rendered prompt message.
+type PromptPart = string | MediaPart;
+
 /// A single chat message in a rendered prompt.
 class PromptMessage {
     /// The chat role, e.g. "system", "user", or "assistant". Empty for
@@ -10,6 +16,9 @@ class PromptMessage {
     role: string,
     /// The message's rendered text. Media parts use a readable placeholder.
     content: string,
+    /// Ordered structural content. Provider clients use this instead of the
+    /// readable `content` projection so media survives prompt rendering.
+    parts: PromptPart[],
 }
 
 /// The rendered, provider-neutral prompt passed to clients. Roles split the

--- a/baml_language/crates/baml_builtins2/baml_std/anthropic/ns_internal/messages.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/anthropic/ns_internal/messages.baml
@@ -47,15 +47,84 @@ class AnthropicPrompt {
     messages: AnthropicMessage[],
 }
 
+function _anthropic_media_block(media: ai.MediaPart, block_type: string) -> map<string, unknown> {
+    let resolved = ai.wire.resolve_media(media, false);
+    let source: map<string, unknown> = {};
+    if let url: string = resolved.url {
+        let _ = source.set("type", "url");
+        let _ = source.set("url", url);
+        null
+    } else {
+        let _ = source.set("type", "base64");
+        let _ = source.set("media_type", resolved.mime_type);
+        let _ = source.set("data", resolved.base64 ?? "");
+        null
+    };
+    let block: map<string, unknown> = {};
+    let _ = block.set("type", block_type);
+    let _ = block.set("source", source);
+    block
+}
+
+function _anthropic_prompt_blocks(
+    message: ai.PromptMessage,
+    role: string,
+) -> map<string, unknown>[] {
+    let blocks: map<string, unknown>[] = [];
+    for (let part in message.parts) {
+        match (part) {
+            let text: string => {
+                let block: map<string, unknown> = {};
+                let _ = block.set("type", "text");
+                let _ = block.set("text", text);
+                blocks.push(block);
+                null
+            },
+            let image: baml.media.Image => {
+                if (role != "user") {
+                    throw baml.errors.InvalidArgument {
+                        message: `Anthropic only supports image input in user messages, found ${role}`,
+                    }
+                }
+                blocks.push(_anthropic_media_block(image, "image"));
+                null
+            },
+            let audio: baml.media.Audio => {
+                if (role != "user") {
+                    throw baml.errors.InvalidArgument {
+                        message: `Anthropic only supports audio input in user messages, found ${role}`,
+                    }
+                }
+                blocks.push(_anthropic_media_block(audio, "input_audio"));
+                null
+            },
+            let pdf: baml.media.Pdf => {
+                if (role != "user") {
+                    throw baml.errors.InvalidArgument {
+                        message: `Anthropic only supports PDF input in user messages, found ${role}`,
+                    }
+                }
+                blocks.push(_anthropic_media_block(pdf, "document"));
+                null
+            },
+            let video: baml.media.Video => {
+                throw baml.errors.InvalidArgument {
+                    message: "Anthropic does not support video prompt input",
+                }
+            },
+        };
+    }
+    blocks
+}
+
 function _anthropic_lower_prompt(prompt: ai.Prompt) -> AnthropicPrompt {
     let system: map<string, unknown>[] = [];
     let messages: AnthropicMessage[] = [];
     for (let message in prompt.messages()) {
-        let block: map<string, unknown> = {};
-        let _ = block.set("type", "text");
-        let _ = block.set("text", message.content);
         if (message.role == "system") {
-            system.push(block);
+            for (let block in _anthropic_prompt_blocks(message, "system")) {
+                system.push(block);
+            }
             null
         } else {
             let role = if (message.role == "assistant") {
@@ -63,7 +132,13 @@ function _anthropic_lower_prompt(prompt: ai.Prompt) -> AnthropicPrompt {
             } else {
                 "user"
             };
-            messages.push(AnthropicMessage { role: role, tool_results: false, blocks: [block] });
+            messages.push(
+                AnthropicMessage {
+                    role: role,
+                    tool_results: false,
+                    blocks: _anthropic_prompt_blocks(message, role),
+                },
+            );
             null
         };
     }

--- a/baml_language/crates/baml_builtins2/baml_std/google/ns_internal/gemini.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/google/ns_internal/gemini.baml
@@ -54,6 +54,54 @@ function _gm_text_part(text: string) -> map<string, unknown> {
     p
 }
 
+function _gm_media_part(media: ai.MediaPart) -> map<string, unknown> {
+    let resolved = ai.wire.resolve_media(media, true);
+    let media_part: map<string, unknown> = {};
+    if let url: string = resolved.url {
+        let file_data: map<string, unknown> = {};
+        let _ = file_data.set("mimeType", resolved.mime_type);
+        let _ = file_data.set("fileUri", url);
+        let _ = media_part.set("fileData", file_data);
+        null
+    } else {
+        let inline_data: map<string, unknown> = {};
+        let _ = inline_data.set("mimeType", resolved.mime_type);
+        let _ = inline_data.set("data", resolved.base64 ?? "");
+        let _ = media_part.set("inlineData", inline_data);
+        null
+    };
+    media_part
+}
+
+function _gm_prompt_parts(message: ai.PromptMessage) -> map<string, unknown>[] {
+    let parts: map<string, unknown>[] = [];
+    for (let part in message.parts) {
+        match (part) {
+            let text: string => {
+                parts.push(_gm_text_part(text));
+                null
+            },
+            let image: baml.media.Image => {
+                parts.push(_gm_media_part(image));
+                null
+            },
+            let audio: baml.media.Audio => {
+                parts.push(_gm_media_part(audio));
+                null
+            },
+            let video: baml.media.Video => {
+                parts.push(_gm_media_part(video));
+                null
+            },
+            let pdf: baml.media.Pdf => {
+                parts.push(_gm_media_part(pdf));
+                null
+            },
+        };
+    }
+    parts
+}
+
 // One {functionResponse: {name, response}} part.
 function _gm_function_response(
     name: string,
@@ -80,9 +128,11 @@ function google_lower_prompt(prompt: ai.Prompt) -> GooglePrompt {
     let contents: map<string, unknown>[] = [];
     let first_role = "";
     for (let message in prompt.messages()) {
-        let part = _gm_text_part(message.content);
+        let parts = _gm_prompt_parts(message);
         if (message.role == "system") {
-            system_parts.push(part);
+            for (let part in parts) {
+                system_parts.push(part);
+            }
             null
         } else {
             let role = if (message.role == "assistant") {
@@ -96,7 +146,7 @@ function google_lower_prompt(prompt: ai.Prompt) -> GooglePrompt {
             } else {
                 null
             };
-            contents.push(_gm_content(role, [part]));
+            contents.push(_gm_content(role, parts));
             null
         };
     }

--- a/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/responses.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/openai/ns_internal/responses.baml
@@ -33,6 +33,89 @@ class OaResponse {
 // content uses the ordinary user role; `tool` is not a valid
 // free-standing Responses message role, so authored tool context is user
 // content (actual tool outputs come from the journal path below).
+function _openai_prompt_content(message: ai.PromptMessage, role: string) -> map<string, unknown>[] {
+    let content: map<string, unknown>[] = [];
+    for (let part in message.parts) {
+        match (part) {
+            let text: string => {
+                let item: map<string, unknown> = {};
+                let _ = item.set(
+                    "type",
+                    if (role == "assistant") {
+                        "output_text"
+                    } else {
+                        "input_text"
+                    },
+                );
+                let _ = item.set("text", text);
+                content.push(item);
+                null
+            },
+            let image: baml.media.Image => {
+                if (role != "user") {
+                    throw baml.errors.InvalidArgument {
+                        message: `OpenAI Responses only supports image input in user messages, found ${role}`,
+                    }
+                }
+                let resolved = ai.wire.resolve_media(image, false);
+                let image_url = resolved.url ?? `data:${resolved.mime_type};base64,${resolved.base64 ?? ""}`;
+                let item: map<string, unknown> = {};
+                let _ = item.set("type", "input_image");
+                let _ = item.set("image_url", image_url);
+                content.push(item);
+                null
+            },
+            let audio: baml.media.Audio => {
+                if (role != "user") {
+                    throw baml.errors.InvalidArgument {
+                        message: `OpenAI Responses only supports audio input in user messages, found ${role}`,
+                    }
+                }
+                let resolved = ai.wire.resolve_media(audio, true);
+                let format = if (resolved.mime_type == "audio/wav" || resolved.mime_type == "audio/x-wav") {
+                    "wav"
+                } else if (resolved.mime_type == "audio/mpeg" || resolved.mime_type == "audio/mp3") {
+                    "mp3"
+                } else if (resolved.mime_type == "audio/flac" || resolved.mime_type == "audio/x-flac") {
+                    "flac"
+                } else if (resolved.mime_type == "audio/ogg") {
+                    "ogg"
+                } else if (resolved.mime_type == "audio/webm") {
+                    "webm"
+                } else {
+                    resolved.mime_type
+                };
+                let item: map<string, unknown> = {};
+                let _ = item.set("type", "input_audio");
+                let _ = item.set("data", resolved.base64 ?? "");
+                let _ = item.set("format", format);
+                content.push(item);
+                null
+            },
+            let pdf: baml.media.Pdf => {
+                if (role != "user") {
+                    throw baml.errors.InvalidArgument {
+                        message: `OpenAI Responses only supports PDF input in user messages, found ${role}`,
+                    }
+                }
+                let resolved = ai.wire.resolve_media(pdf, false);
+                let file_data = resolved.url ?? `data:${resolved.mime_type};base64,${resolved.base64 ?? ""}`;
+                let item: map<string, unknown> = {};
+                let _ = item.set("type", "input_file");
+                let _ = item.set("file_data", file_data);
+                content.push(item);
+                null
+            },
+            let video: baml.media.Video => {
+                throw baml.errors.InvalidArgument {
+                    message: "OpenAI Responses does not support video prompt input",
+                }
+            },
+        };
+    }
+    content
+}
+
 function openai_lower_prompt(prompt: ai.Prompt) -> map<string, unknown>[] {
     let items: map<string, unknown>[] = [];
     for (let message in prompt.messages()) {
@@ -45,7 +128,7 @@ function openai_lower_prompt(prompt: ai.Prompt) -> map<string, unknown>[] {
         };
         let item: map<string, unknown> = {};
         let _ = item.set("role", role);
-        let _ = item.set("content", message.content);
+        let _ = item.set("content", _openai_prompt_content(message, role));
         items.push(item);
     }
     items

--- a/baml_language/crates/baml_builtins2/src/adt.rs
+++ b/baml_language/crates/baml_builtins2/src/adt.rs
@@ -82,28 +82,38 @@ impl PromptAst {
         }
     }
 
-    /// Flatten this prompt into an ordered list of `(role, content)` chat
-    /// messages. A `Message` node contributes its role; a role-less `Simple`
-    /// node contributes an empty role; nested `Vec` nodes are flattened in
-    /// document order. Backs the stdlib `PromptAst.messages()` accessor.
-    pub fn to_messages(&self) -> Vec<(String, String)> {
+    /// Flatten this prompt into an ordered list of structural chat messages.
+    /// A `Message` node contributes its role; a role-less `Simple` node
+    /// contributes an empty role; nested `Vec` nodes are flattened in document
+    /// order. The content stays structural so stdlib clients can lower media to
+    /// their provider-specific wire representation.
+    pub fn to_structured_messages(&self) -> Vec<(String, Arc<PromptAstSimple>)> {
         let mut out = Vec::new();
-        self.collect_messages(&mut out);
+        self.collect_structured_messages(&mut out);
         out
     }
 
-    fn collect_messages(&self, out: &mut Vec<(String, String)>) {
+    fn collect_structured_messages(&self, out: &mut Vec<(String, Arc<PromptAstSimple>)>) {
         match self {
-            PromptAst::Simple(content) => out.push((String::new(), content.to_text())),
+            PromptAst::Simple(content) => out.push((String::new(), content.clone())),
             PromptAst::Message { role, content, .. } => {
-                out.push((role.clone(), content.to_text()));
+                out.push((role.clone(), content.clone()));
             }
             PromptAst::Vec(items) => {
                 for item in items {
-                    item.collect_messages(out);
+                    item.collect_structured_messages(out);
                 }
             }
         }
+    }
+
+    /// Readable projection of [`Self::to_structured_messages`]. Media becomes
+    /// a placeholder here, but remains structural in the underlying prompt.
+    pub fn to_messages(&self) -> Vec<(String, String)> {
+        self.to_structured_messages()
+            .into_iter()
+            .map(|(role, content)| (role, content.to_text()))
+            .collect()
     }
 
     /// Render this prompt as readable plain text: each chat message as a

--- a/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____03_ppir.snap
@@ -510,8 +510,27 @@ function ai.tools.tool(handler: baml.AnyFunction, name: string? = null, descript
 lambda (t) in get: captures [name]
 
 --- <builtin>/ai/ns_wire/wire.baml ---
+class ai.wire.ResolvedMedia {
+  url: string?
+  base64: string?
+  mime_type: string
+}
+class ai.wire.ResolvedMedia$stream {
+  url: string | null
+  base64: string | null
+  mime_type: string | null
+}
+function ai.wire._media_mime_type(explicit: string?, source_value: string, kind: string) -> string  [expr] {
+  { if let supplied: string = explicit { return supplied }; let source = source_value.to_lower_case() } if (source.includes(".jpg") Or source.includes(".jpeg")) {  } "image/jpeg" else if (source.includes(".png")) {  } "image/png" else if (source.includes(".webp")) {  } "image/webp" else if (source.includes(".gif")) {  } "image/gif" else if (source.includes(".svg")) {  } "image/svg+xml" else if (source.includes(".wav")) {  } "audio/wav" else if (source.includes(".mp3")) {  } "audio/mpeg" else if (source.includes(".flac")) {  } "audio/flac" else if (source.includes(".ogg")) {  } "audio/ogg" else if (source.includes(".webm")) {  } if (kind Eq "audio") {  } "audio/webm" else {  } "video/webm" else if (source.includes(".mov")) {  } "video/quicktime" else if (source.includes(".mp4")) {  } "video/mp4" else if (source.includes(".avi")) {  } "video/x-msvideo" else if (source.includes(".mkv")) {  } "video/x-matroska" else if (source.includes(".pdf")) {  } "application/pdf" else if (kind Eq "audio") {  } "audio/mpeg" else if (kind Eq "video") {  } "video/mp4" else if (kind Eq "pdf") {  } "application/pdf" else {  } "image/png"
+}
+function ai.wire._resolve_media_content(url: string?, file: string?, inline: string, mime: string, fetch_url: bool) -> ai.wire.ResolvedMedia  [expr] {
+  { if let path: string = file { let handle = baml.fs.open(path, "r"); let data = handle.bytes().to_base64(); handle.close(); return ai.wire.ResolvedMedia { url: null, base64: data, mime_type: mime } }; if (inline Ne "") { return ai.wire.ResolvedMedia { url: null, base64: inline, mime_type: mime } }; if let media_url: string = url { if (media_url.starts_with("data:")) {  } if let separator: int = media_url.index_of(";base64,") { return ai.wire.ResolvedMedia { url: null, base64: media_url.substring(separator Add 8, media_url.length()), mime_type: media_url.substring(5, separator) } }; if (Not fetch_url Or media_url.starts_with("gs://")) { return ai.wire.ResolvedMedia { url: media_url, base64: null, mime_type: mime } }; let response = baml.http.fetch(media_url); if (Not response.ok()) { throw root.errors.NetworkFailure { provider: "media", detail: `...`, raw_body: null } }; let response_mime = response.headers.get("content-type") NullCoalesce mime; return ai.wire.ResolvedMedia { url: null, base64: response.bytes().to_base64(), mime_type: response_mime.split(";").at(0) NullCoalesce mime } }; throw baml.errors.InvalidArgument { message: "media has no URL,..." } }
+}
 function ai.wire.render_output_format(t: type) -> string  [expr] {
   {  } baml.prompt.render_output_format(t)
+}
+function ai.wire.resolve_media(media: ai.MediaPart, fetch_url: bool) -> ai.wire.ResolvedMedia  [expr] {
+  {  } match (media) { image: baml.media.Image => { let source = image.file() NullCoalesce image.url() NullCoalesce "" } _resolve_media_content(image.url(), image.file(), image.base64(), _media_mime_type(image.mime_type(), source, "image"), fetch_url), audio: baml.media.Audio => { let source = audio.file() NullCoalesce audio.url() NullCoalesce "" } _resolve_media_content(audio.url(), audio.file(), audio.base64(), _media_mime_type(audio.mime_type(), source, "audio"), fetch_url), video: baml.media.Video => { let source = video.file() NullCoalesce video.url() NullCoalesce "" } _resolve_media_content(video.url(), video.file(), video.base64(), _media_mime_type(video.mime_type(), source, "video"), fetch_url), pdf: baml.media.Pdf => { let source = pdf.file() NullCoalesce pdf.url() NullCoalesce "" } _resolve_media_content(pdf.url(), pdf.file(), pdf.base64(), _media_mime_type(pdf.mime_type(), source, "pdf"), fetch_url) }
 }
 function ai.wire.send_as(req: baml.http.Request, provider: string) -> T  [expr] {
   { let resp = baml.http.send(req) catch_all (e) { _ => { throw root.errors.NetworkFailure { provider: provider, detail: `...`, raw_body: null } } }; let text = resp.text() catch_all (e) { _ => { throw root.errors.NetworkFailure { provider: provider, detail: "the response body...", raw_body: null } } }; if (Not resp.ok()) { throw root.errors.classify_http(provider, resp.status_code, text) } } baml.json.from_string(text) catch_all (e) { _ => throw root.errors.ParseFailed { provider: provider, raw_output: text } }
@@ -587,11 +606,17 @@ class ai.Prompt$stream {
 class ai.PromptMessage {
   role: string
   content: string
+  parts: ai.PromptPart[]
 }
 class ai.PromptMessage$stream {
   role: string | null
   content: string | null
+  parts: ai.PromptPart$stream[]
 }
+type ai.MediaPart = baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf
+type ai.MediaPart$stream = baml.media.Image$stream | baml.media.Audio$stream | baml.media.Video$stream | baml.media.Pdf$stream
+type ai.PromptPart = string | ai.MediaPart
+type ai.PromptPart$stream = string | ai.MediaPart$stream
 function ai.arguments(self: ?) -> map<string, unknown>  [expr] {
   {  } self.args
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____04_5_mir.snap
@@ -3378,6 +3378,843 @@ fn ai.wire.render_output_format(t: type) -> string {
     }
 }
 
+fn ai.wire._media_mime_type(explicit: string | null, source_value: string, kind: string) -> string {
+    // Locals:
+    let _0: string // _0 // return
+    let _1: string | null // explicit // param
+    let _2: string // source_value // param
+    let _3: string // kind // param
+    let _4: string | null
+    let _5: string // supplied
+    let _6: string // source
+    let _7: bool
+    let _8: bool
+    let _9: bool
+    let _10: bool
+    let _11: bool
+    let _12: bool
+    let _13: bool
+    let _14: bool
+    let _15: bool
+    let _16: bool
+    let _17: bool
+    let _18: bool
+    let _19: bool
+    let _20: bool
+    let _21: bool
+    let _22: bool
+    let _23: bool
+    let _24: bool
+    let _25: bool
+    let _26: bool
+
+    bb0: {
+        _4 = copy _1;
+        _4 = narrow_bind copy _4 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb58, bb1];
+    }
+
+    bb1: {
+        _6 = call const fn baml.String.to_lower_case(copy _2) -> [bb2];
+    }
+
+    bb2: {
+        _8 = call const fn baml.String.includes(copy _6, const ".jpg") -> [bb3];
+    }
+
+    bb3: {
+        _7 = short_circuit(||) copy _8 -> [eval: bb4, join: bb5];
+    }
+
+    bb4: {
+        _7 = call const fn baml.String.includes(copy _6, const ".jpeg") -> [bb5];
+    }
+
+    bb5: {
+        branch copy _7 -> [bb57, bb6];
+    }
+
+    bb6: {
+        _9 = call const fn baml.String.includes(copy _6, const ".png") -> [bb7];
+    }
+
+    bb7: {
+        branch copy _9 -> [bb56, bb8];
+    }
+
+    bb8: {
+        _10 = call const fn baml.String.includes(copy _6, const ".webp") -> [bb9];
+    }
+
+    bb9: {
+        branch copy _10 -> [bb55, bb10];
+    }
+
+    bb10: {
+        _11 = call const fn baml.String.includes(copy _6, const ".gif") -> [bb11];
+    }
+
+    bb11: {
+        branch copy _11 -> [bb54, bb12];
+    }
+
+    bb12: {
+        _12 = call const fn baml.String.includes(copy _6, const ".svg") -> [bb13];
+    }
+
+    bb13: {
+        branch copy _12 -> [bb53, bb14];
+    }
+
+    bb14: {
+        _13 = call const fn baml.String.includes(copy _6, const ".wav") -> [bb15];
+    }
+
+    bb15: {
+        branch copy _13 -> [bb52, bb16];
+    }
+
+    bb16: {
+        _14 = call const fn baml.String.includes(copy _6, const ".mp3") -> [bb17];
+    }
+
+    bb17: {
+        branch copy _14 -> [bb51, bb18];
+    }
+
+    bb18: {
+        _15 = call const fn baml.String.includes(copy _6, const ".flac") -> [bb19];
+    }
+
+    bb19: {
+        branch copy _15 -> [bb50, bb20];
+    }
+
+    bb20: {
+        _16 = call const fn baml.String.includes(copy _6, const ".ogg") -> [bb21];
+    }
+
+    bb21: {
+        branch copy _16 -> [bb49, bb22];
+    }
+
+    bb22: {
+        _17 = call const fn baml.String.includes(copy _6, const ".webm") -> [bb23];
+    }
+
+    bb23: {
+        branch copy _17 -> [bb46, bb24];
+    }
+
+    bb24: {
+        _19 = call const fn baml.String.includes(copy _6, const ".mov") -> [bb25];
+    }
+
+    bb25: {
+        branch copy _19 -> [bb45, bb26];
+    }
+
+    bb26: {
+        _20 = call const fn baml.String.includes(copy _6, const ".mp4") -> [bb27];
+    }
+
+    bb27: {
+        branch copy _20 -> [bb44, bb28];
+    }
+
+    bb28: {
+        _21 = call const fn baml.String.includes(copy _6, const ".avi") -> [bb29];
+    }
+
+    bb29: {
+        branch copy _21 -> [bb43, bb30];
+    }
+
+    bb30: {
+        _22 = call const fn baml.String.includes(copy _6, const ".mkv") -> [bb31];
+    }
+
+    bb31: {
+        branch copy _22 -> [bb42, bb32];
+    }
+
+    bb32: {
+        _23 = call const fn baml.String.includes(copy _6, const ".pdf") -> [bb33];
+    }
+
+    bb33: {
+        branch copy _23 -> [bb41, bb34];
+    }
+
+    bb34: {
+        _24 = copy _3 == const "audio";
+        branch copy _24 -> [bb40, bb35];
+    }
+
+    bb35: {
+        _25 = copy _3 == const "video";
+        branch copy _25 -> [bb39, bb36];
+    }
+
+    bb36: {
+        _26 = copy _3 == const "pdf";
+        branch copy _26 -> [bb38, bb37];
+    }
+
+    bb37: {
+        _0 = const "image/png";
+        goto -> bb59;
+    }
+
+    bb38: {
+        _0 = const "application/pdf";
+        goto -> bb59;
+    }
+
+    bb39: {
+        _0 = const "video/mp4";
+        goto -> bb59;
+    }
+
+    bb40: {
+        _0 = const "audio/mpeg";
+        goto -> bb59;
+    }
+
+    bb41: {
+        _0 = const "application/pdf";
+        goto -> bb59;
+    }
+
+    bb42: {
+        _0 = const "video/x-matroska";
+        goto -> bb59;
+    }
+
+    bb43: {
+        _0 = const "video/x-msvideo";
+        goto -> bb59;
+    }
+
+    bb44: {
+        _0 = const "video/mp4";
+        goto -> bb59;
+    }
+
+    bb45: {
+        _0 = const "video/quicktime";
+        goto -> bb59;
+    }
+
+    bb46: {
+        _18 = copy _3 == const "audio";
+        branch copy _18 -> [bb48, bb47];
+    }
+
+    bb47: {
+        _0 = const "video/webm";
+        goto -> bb59;
+    }
+
+    bb48: {
+        _0 = const "audio/webm";
+        goto -> bb59;
+    }
+
+    bb49: {
+        _0 = const "audio/ogg";
+        goto -> bb59;
+    }
+
+    bb50: {
+        _0 = const "audio/flac";
+        goto -> bb59;
+    }
+
+    bb51: {
+        _0 = const "audio/mpeg";
+        goto -> bb59;
+    }
+
+    bb52: {
+        _0 = const "audio/wav";
+        goto -> bb59;
+    }
+
+    bb53: {
+        _0 = const "image/svg+xml";
+        goto -> bb59;
+    }
+
+    bb54: {
+        _0 = const "image/gif";
+        goto -> bb59;
+    }
+
+    bb55: {
+        _0 = const "image/webp";
+        goto -> bb59;
+    }
+
+    bb56: {
+        _0 = const "image/png";
+        goto -> bb59;
+    }
+
+    bb57: {
+        _0 = const "image/jpeg";
+        goto -> bb59;
+    }
+
+    bb58: {
+        _5 = copy _4;
+        _0 = copy _5;
+        goto -> bb59;
+    }
+
+    bb59: {
+        return;
+    }
+}
+
+fn ai.wire._resolve_media_content(url: string | null, file: string | null, inline: string, mime: string, fetch_url: bool) -> ai.wire.ResolvedMedia {
+    // Locals:
+    let _0: ai.wire.ResolvedMedia // _0 // return
+    let _1: string | null // url // param
+    let _2: string | null // file // param
+    let _3: string // inline // param
+    let _4: string // mime // param
+    let _5: bool // fetch_url // param
+    let _6: string | null
+    let _7: string // path
+    let _8: baml.fs.File // handle
+    let _9: string
+    let _10: string // data
+    let _11: uint8array
+    let _12: null
+    let _13: string
+    let _14: bool
+    let _15: string | null
+    let _16: string // media_url
+    let _17: bool
+    let _18: int | null
+    let _19: int | null
+    let _20: int // separator
+    let _21: string
+    let _22: int
+    let _23: int
+    let _24: int
+    let _25: string
+    let _26: int
+    let _27: bool
+    let _28: bool
+    let _29: string
+    let _30: baml.http.Response // response
+    let _31: string
+    let _32: bool
+    let _33: bool
+    let _34: ai.errors.NetworkFailure
+    let _35: string
+    let _36: string
+    let _37: string
+    let _38: string
+    let _39: string
+    let _40: type
+    let _41: string
+    let _42: int
+    let _43: type
+    let _44: string // response_mime
+    let _45: string | null
+    let _46: (map<string, string>, string) -> string | null throws never
+    let _47: type
+    let _48: type
+    let _49: bool
+    let _50: string
+    let _51: uint8array
+    let _52: string
+    let _53: string | null
+    let _54: string[]
+    let _55: type
+    let _56: bool
+    let _57: baml.errors.InvalidArgument
+
+    bb0: {
+        _6 = copy _2;
+        _6 = narrow_bind copy _6 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb33, bb1];
+    }
+
+    bb1: {
+        _14 = copy _3 != const "";
+        branch copy _14 -> [bb32, bb2];
+    }
+
+    bb2: {
+        _15 = copy _1;
+        _15 = narrow_bind copy _15 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb4, bb3];
+    }
+
+    bb3: {
+        _57 = baml.errors.InvalidArgument { const "media has no URL, file, or base64 content" };
+        throw copy _57;
+    }
+
+    bb4: {
+        _16 = copy _15;
+        _17 = call const fn baml.String.starts_with(copy _16, const "data:") -> [bb5];
+    }
+
+    bb5: {
+        branch copy _17 -> [bb6, bb8];
+    }
+
+    bb6: {
+        _18 = call const fn baml.String.index_of(copy _16, const ";base64,") -> [bb7];
+    }
+
+    bb7: {
+        _19 = copy _18;
+        _19 = narrow_bind copy _19 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb28, bb8];
+    }
+
+    bb8: {
+        _28 = !copy _5;
+        _27 = short_circuit(||) copy _28 -> [eval: bb9, join: bb10];
+    }
+
+    bb9: {
+        _27 = call const fn baml.String.starts_with(copy _16, const "gs://") -> [bb10];
+    }
+
+    bb10: {
+        branch copy _27 -> [bb27, bb11];
+    }
+
+    bb11: {
+        _31 = copy _16;
+        _30 = call const fn baml.http.fetch(copy _31, const <omitted>) -> [bb12];
+    }
+
+    bb12: {
+        _33 = call const fn baml.http.Response.ok(copy _30) -> [bb13];
+    }
+
+    bb13: {
+        _32 = !copy _33;
+        branch copy _32 -> [bb24, bb14];
+    }
+
+    bb14: {
+        _46 = copy _30.1;
+        _47 = load_type(string);
+        _48 = load_type(string);
+        _45 = call const fn baml.Map.get<copy _47, copy _48>(copy _46, const "content-type") -> [bb15];
+    }
+
+    bb15: {
+        _44 = copy _45;
+        _49 = copy _45 == const null;
+        branch copy _49 -> [bb16, bb17];
+    }
+
+    bb16: {
+        _44 = copy _4;
+        goto -> bb17;
+    }
+
+    bb17: {
+        _51 = sys_op const fn baml.http.Response.bytes(copy _30) -> bb18;
+    }
+
+    bb18: {
+        _50 = call const fn baml.Uint8Array.to_base64(copy _51) -> [bb19];
+    }
+
+    bb19: {
+        _54 = call const fn baml.String.split(copy _44, const ";") -> [bb20];
+    }
+
+    bb20: {
+        _55 = load_type(string);
+        _53 = call const fn baml.Array.at<copy _55>(copy _54, const 0_i64) -> [bb21];
+    }
+
+    bb21: {
+        _52 = copy _53;
+        _56 = copy _53 == const null;
+        branch copy _56 -> [bb22, bb23];
+    }
+
+    bb22: {
+        _52 = copy _4;
+        goto -> bb23;
+    }
+
+    bb23: {
+        _0 = ai.wire.ResolvedMedia { const null, copy _50, copy _52 };
+        goto -> bb38;
+    }
+
+    bb24: {
+        _39 = copy _16;
+        _40 = load_type(string);
+        _38 = call const fn baml.String.from<copy _40>(copy _39) -> [bb25];
+    }
+
+    bb25: {
+        _37 = const "media URL " + copy _38;
+        _36 = copy _37 + const " returned HTTP ";
+        _42 = copy _30.0;
+        _43 = load_type(int);
+        _41 = call const fn baml.String.from<copy _43>(copy _42) -> [bb26];
+    }
+
+    bb26: {
+        _35 = copy _36 + copy _41;
+        _34 = ai.errors.NetworkFailure { const "media", copy _35, const null };
+        throw copy _34;
+    }
+
+    bb27: {
+        _29 = copy _16;
+        _0 = ai.wire.ResolvedMedia { copy _29, const null, copy _4 };
+        goto -> bb38;
+    }
+
+    bb28: {
+        _20 = copy _19;
+        _23 = copy _20;
+        _22 = copy _23 + const 8_i64;
+        _24 = call const fn baml.String.length(copy _16) -> [bb29];
+    }
+
+    bb29: {
+        _21 = call const fn baml.String.substring(copy _16, copy _22, copy _24) -> [bb30];
+    }
+
+    bb30: {
+        _26 = copy _20;
+        _25 = call const fn baml.String.substring(copy _16, const 5_i64, copy _26) -> [bb31];
+    }
+
+    bb31: {
+        _0 = ai.wire.ResolvedMedia { const null, copy _21, copy _25 };
+        goto -> bb38;
+    }
+
+    bb32: {
+        _0 = ai.wire.ResolvedMedia { const null, copy _3, copy _4 };
+        goto -> bb38;
+    }
+
+    bb33: {
+        _7 = copy _6;
+        _9 = copy _7;
+        _8 = sys_op const fn baml.fs.open(copy _9, const "r") -> bb34;
+    }
+
+    bb34: {
+        _11 = sys_op const fn baml.fs.File.bytes(copy _8) -> bb35;
+    }
+
+    bb35: {
+        _10 = call const fn baml.Uint8Array.to_base64(copy _11) -> [bb36];
+    }
+
+    bb36: {
+        _12 = sys_op const fn baml.fs.File.close(copy _8) -> bb37;
+    }
+
+    bb37: {
+        _13 = copy _10;
+        _0 = ai.wire.ResolvedMedia { const null, copy _13, copy _4 };
+        goto -> bb38;
+    }
+
+    bb38: {
+        return;
+    }
+}
+
+fn ai.wire.resolve_media(media: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video, fetch_url: bool) -> ai.wire.ResolvedMedia {
+    // Locals:
+    let _0: ai.wire.ResolvedMedia // _0 // return
+    let _1: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video // media // param
+    let _2: bool // fetch_url // param
+    let _3: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _4: baml.media.Image // image
+    let _5: string // source
+    let _6: string | null
+    let _7: string | null
+    let _8: bool
+    let _9: bool
+    let _10: string | null
+    let _11: string | null
+    let _12: string
+    let _13: string
+    let _14: string | null
+    let _15: string
+    let _16: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _17: baml.media.Audio // audio
+    let _18: string // source
+    let _19: string | null
+    let _20: string | null
+    let _21: bool
+    let _22: bool
+    let _23: string | null
+    let _24: string | null
+    let _25: string
+    let _26: string
+    let _27: string | null
+    let _28: string
+    let _29: baml.media.Audio | baml.media.Image | baml.media.Pdf | baml.media.Video
+    let _30: baml.media.Video // video
+    let _31: string // source
+    let _32: string | null
+    let _33: string | null
+    let _34: bool
+    let _35: bool
+    let _36: string | null
+    let _37: string | null
+    let _38: string
+    let _39: string
+    let _40: string | null
+    let _41: string
+    let _42: baml.media.Pdf // pdf
+    let _43: string // source
+    let _44: string | null
+    let _45: string | null
+    let _46: bool
+    let _47: bool
+    let _48: string | null
+    let _49: string | null
+    let _50: string
+    let _51: string
+    let _52: string | null
+    let _53: string
+
+    bb0: {
+        _3 = copy _1;
+        _3 = narrow_bind copy _3 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Image" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb36, bb1];
+    }
+
+    bb1: {
+        _16 = copy _1;
+        _16 = narrow_bind copy _16 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Audio" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb25, bb2];
+    }
+
+    bb2: {
+        _29 = copy _1;
+        _29 = narrow_bind copy _29 as Class(QualifiedTypeName { pkg: Dep("baml"), namespace: ["media"], name: "Video" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb14, bb3];
+    }
+
+    bb3: {
+        _42 = copy _1;
+        _45 = call const fn baml.media.Pdf.file(copy _42) -> [bb4];
+    }
+
+    bb4: {
+        _44 = copy _45;
+        _46 = copy _45 == const null;
+        branch copy _46 -> [bb5, bb6];
+    }
+
+    bb5: {
+        _44 = call const fn baml.media.Pdf.url(copy _42) -> [bb6];
+    }
+
+    bb6: {
+        _43 = copy _44;
+        _47 = copy _44 == const null;
+        branch copy _47 -> [bb7, bb8];
+    }
+
+    bb7: {
+        _43 = const "";
+        goto -> bb8;
+    }
+
+    bb8: {
+        _48 = call const fn baml.media.Pdf.url(copy _42) -> [bb9];
+    }
+
+    bb9: {
+        _49 = call const fn baml.media.Pdf.file(copy _42) -> [bb10];
+    }
+
+    bb10: {
+        _50 = call const fn baml.media.Pdf.base64(copy _42) -> [bb11];
+    }
+
+    bb11: {
+        _52 = call const fn baml.media.Pdf.mime_type(copy _42) -> [bb12];
+    }
+
+    bb12: {
+        _53 = copy _43;
+        _51 = call const fn ai.wire._media_mime_type(copy _52, copy _53, const "pdf") -> [bb13];
+    }
+
+    bb13: {
+        _0 = call const fn ai.wire._resolve_media_content(copy _48, copy _49, copy _50, copy _51, copy _2) -> [bb47];
+    }
+
+    bb14: {
+        _30 = copy _29;
+        _33 = call const fn baml.media.Video.file(copy _30) -> [bb15];
+    }
+
+    bb15: {
+        _32 = copy _33;
+        _34 = copy _33 == const null;
+        branch copy _34 -> [bb16, bb17];
+    }
+
+    bb16: {
+        _32 = call const fn baml.media.Video.url(copy _30) -> [bb17];
+    }
+
+    bb17: {
+        _31 = copy _32;
+        _35 = copy _32 == const null;
+        branch copy _35 -> [bb18, bb19];
+    }
+
+    bb18: {
+        _31 = const "";
+        goto -> bb19;
+    }
+
+    bb19: {
+        _36 = call const fn baml.media.Video.url(copy _30) -> [bb20];
+    }
+
+    bb20: {
+        _37 = call const fn baml.media.Video.file(copy _30) -> [bb21];
+    }
+
+    bb21: {
+        _38 = call const fn baml.media.Video.base64(copy _30) -> [bb22];
+    }
+
+    bb22: {
+        _40 = call const fn baml.media.Video.mime_type(copy _30) -> [bb23];
+    }
+
+    bb23: {
+        _41 = copy _31;
+        _39 = call const fn ai.wire._media_mime_type(copy _40, copy _41, const "video") -> [bb24];
+    }
+
+    bb24: {
+        _0 = call const fn ai.wire._resolve_media_content(copy _36, copy _37, copy _38, copy _39, copy _2) -> [bb47];
+    }
+
+    bb25: {
+        _17 = copy _16;
+        _20 = call const fn baml.media.Audio.file(copy _17) -> [bb26];
+    }
+
+    bb26: {
+        _19 = copy _20;
+        _21 = copy _20 == const null;
+        branch copy _21 -> [bb27, bb28];
+    }
+
+    bb27: {
+        _19 = call const fn baml.media.Audio.url(copy _17) -> [bb28];
+    }
+
+    bb28: {
+        _18 = copy _19;
+        _22 = copy _19 == const null;
+        branch copy _22 -> [bb29, bb30];
+    }
+
+    bb29: {
+        _18 = const "";
+        goto -> bb30;
+    }
+
+    bb30: {
+        _23 = call const fn baml.media.Audio.url(copy _17) -> [bb31];
+    }
+
+    bb31: {
+        _24 = call const fn baml.media.Audio.file(copy _17) -> [bb32];
+    }
+
+    bb32: {
+        _25 = call const fn baml.media.Audio.base64(copy _17) -> [bb33];
+    }
+
+    bb33: {
+        _27 = call const fn baml.media.Audio.mime_type(copy _17) -> [bb34];
+    }
+
+    bb34: {
+        _28 = copy _18;
+        _26 = call const fn ai.wire._media_mime_type(copy _27, copy _28, const "audio") -> [bb35];
+    }
+
+    bb35: {
+        _0 = call const fn ai.wire._resolve_media_content(copy _23, copy _24, copy _25, copy _26, copy _2) -> [bb47];
+    }
+
+    bb36: {
+        _4 = copy _3;
+        _7 = call const fn baml.media.Image.file(copy _4) -> [bb37];
+    }
+
+    bb37: {
+        _6 = copy _7;
+        _8 = copy _7 == const null;
+        branch copy _8 -> [bb38, bb39];
+    }
+
+    bb38: {
+        _6 = call const fn baml.media.Image.url(copy _4) -> [bb39];
+    }
+
+    bb39: {
+        _5 = copy _6;
+        _9 = copy _6 == const null;
+        branch copy _9 -> [bb40, bb41];
+    }
+
+    bb40: {
+        _5 = const "";
+        goto -> bb41;
+    }
+
+    bb41: {
+        _10 = call const fn baml.media.Image.url(copy _4) -> [bb42];
+    }
+
+    bb42: {
+        _11 = call const fn baml.media.Image.file(copy _4) -> [bb43];
+    }
+
+    bb43: {
+        _12 = call const fn baml.media.Image.base64(copy _4) -> [bb44];
+    }
+
+    bb44: {
+        _14 = call const fn baml.media.Image.mime_type(copy _4) -> [bb45];
+    }
+
+    bb45: {
+        _15 = copy _5;
+        _13 = call const fn ai.wire._media_mime_type(copy _14, copy _15, const "image") -> [bb46];
+    }
+
+    bb46: {
+        _0 = call const fn ai.wire._resolve_media_content(copy _10, copy _11, copy _12, copy _13, copy _2) -> [bb47];
+    }
+
+    bb47: {
+        return;
+    }
+}
+
 fn ai.Agent.new(max_steps: int, client: null | ai.Client, tool_errors: ai.tools.ErrorMode, on_event: null | ((ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> null throws never)) -> ai.Agent<Out> {
     // Locals:
     let _0: ai.Agent<Out> // _0 // return

--- a/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____04_tir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____04_tir.snap
@@ -997,6 +997,158 @@ function ai.wire.render_output_format(t: type) -> string throws never {
     baml.prompt.render_output_format(t) : string
   }
 }
+class ai.wire.ResolvedMedia {
+  url: string | null
+  base64: string | null
+  mime_type: string
+}
+function ai.wire._media_mime_type(explicit: string | null, source_value: string, kind: string) -> string throws never {
+  { : "image/jpeg" | "image/png" | "image/webp" | "image/gif" | "image/svg+xml" | "audio/wav" | "audio/mpeg" | "audio/flac" | "audio/ogg" | "audio/webm" | "video/webm" | "video/quicktime" | "video/mp4" | "video/x-msvideo" | "video/x-matroska" | "application/pdf"
+    if let <pat> = explicit { 1 stmts } : void
+    let source = source_value.to_lower_case() : string
+    if (source.includes(".jpg") || source.includes(".jpeg") : bool) : "image/jpeg" | "image/png" | "image/webp" | "image/gif" | "image/svg+xml" | "audio/wav" | "audio/mpeg" | "audio/flac" | "audio/ogg" | "audio/webm" | "video/webm" | "video/quicktime" | "video/mp4" | "video/x-msvideo" | "video/x-matroska" | "application/pdf"
+      { : "image/jpeg"
+        "image/jpeg" : "image/jpeg"
+      }
+    else
+      if (source.includes(".png") : bool) : "image/png" | "image/webp" | "image/gif" | "image/svg+xml" | "audio/wav" | "audio/mpeg" | "audio/flac" | "audio/ogg" | "audio/webm" | "video/webm" | "video/quicktime" | "video/mp4" | "video/x-msvideo" | "video/x-matroska" | "application/pdf"
+        { : "image/png"
+          "image/png" : "image/png"
+        }
+      else
+        if (source.includes(".webp") : bool) : "image/webp" | "image/gif" | "image/svg+xml" | "audio/wav" | "audio/mpeg" | "audio/flac" | "audio/ogg" | "audio/webm" | "video/webm" | "video/quicktime" | "video/mp4" | "video/x-msvideo" | "video/x-matroska" | "application/pdf" | "image/png"
+          { : "image/webp"
+            "image/webp" : "image/webp"
+          }
+        else
+          if (source.includes(".gif") : bool) : "image/gif" | "image/svg+xml" | "audio/wav" | "audio/mpeg" | "audio/flac" | "audio/ogg" | "audio/webm" | "video/webm" | "video/quicktime" | "video/mp4" | "video/x-msvideo" | "video/x-matroska" | "application/pdf" | "image/png"
+            { : "image/gif"
+              "image/gif" : "image/gif"
+            }
+          else
+            if (source.includes(".svg") : bool) : "image/svg+xml" | "audio/wav" | "audio/mpeg" | "audio/flac" | "audio/ogg" | "audio/webm" | "video/webm" | "video/quicktime" | "video/mp4" | "video/x-msvideo" | "video/x-matroska" | "application/pdf" | "image/png"
+              { : "image/svg+xml"
+                "image/svg+xml" : "image/svg+xml"
+              }
+            else
+              if (source.includes(".wav") : bool) : "audio/wav" | "audio/mpeg" | "audio/flac" | "audio/ogg" | "audio/webm" | "video/webm" | "video/quicktime" | "video/mp4" | "video/x-msvideo" | "video/x-matroska" | "application/pdf" | "image/png"
+                { : "audio/wav"
+                  "audio/wav" : "audio/wav"
+                }
+              else
+                if (source.includes(".mp3") : bool) : "audio/mpeg" | "audio/flac" | "audio/ogg" | "audio/webm" | "video/webm" | "video/quicktime" | "video/mp4" | "video/x-msvideo" | "video/x-matroska" | "application/pdf" | "image/png"
+                  { : "audio/mpeg"
+                    "audio/mpeg" : "audio/mpeg"
+                  }
+                else
+                  if (source.includes(".flac") : bool) : "audio/flac" | "audio/ogg" | "audio/webm" | "video/webm" | "video/quicktime" | "video/mp4" | "video/x-msvideo" | "video/x-matroska" | "application/pdf" | "audio/mpeg" | "image/png"
+                    { : "audio/flac"
+                      "audio/flac" : "audio/flac"
+                    }
+                  else
+                    if (source.includes(".ogg") : bool) : "audio/ogg" | "audio/webm" | "video/webm" | "video/quicktime" | "video/mp4" | "video/x-msvideo" | "video/x-matroska" | "application/pdf" | "audio/mpeg" | "image/png"
+                      { : "audio/ogg"
+                        "audio/ogg" : "audio/ogg"
+                      }
+                    else
+                      if (source.includes(".webm") : bool) : "audio/webm" | "video/webm" | "video/quicktime" | "video/mp4" | "video/x-msvideo" | "video/x-matroska" | "application/pdf" | "audio/mpeg" | "image/png"
+                        { : "audio/webm" | "video/webm"
+                          if (kind == "audio" : bool) : "audio/webm" | "video/webm"
+                            { : "audio/webm"
+                              "audio/webm" : "audio/webm"
+                            }
+                          else
+                            { : "video/webm"
+                              "video/webm" : "video/webm"
+                            }
+                        }
+                      else
+                        if (source.includes(".mov") : bool) : "video/quicktime" | "video/mp4" | "video/x-msvideo" | "video/x-matroska" | "application/pdf" | "audio/mpeg" | "image/png"
+                          { : "video/quicktime"
+                            "video/quicktime" : "video/quicktime"
+                          }
+                        else
+                          if (source.includes(".mp4") : bool) : "video/mp4" | "video/x-msvideo" | "video/x-matroska" | "application/pdf" | "audio/mpeg" | "image/png"
+                            { : "video/mp4"
+                              "video/mp4" : "video/mp4"
+                            }
+                          else
+                            if (source.includes(".avi") : bool) : "video/x-msvideo" | "video/x-matroska" | "application/pdf" | "audio/mpeg" | "video/mp4" | "image/png"
+                              { : "video/x-msvideo"
+                                "video/x-msvideo" : "video/x-msvideo"
+                              }
+                            else
+                              if (source.includes(".mkv") : bool) : "video/x-matroska" | "application/pdf" | "audio/mpeg" | "video/mp4" | "image/png"
+                                { : "video/x-matroska"
+                                  "video/x-matroska" : "video/x-matroska"
+                                }
+                              else
+                                if (source.includes(".pdf") : bool) : "application/pdf" | "audio/mpeg" | "video/mp4" | "image/png"
+                                  { : "application/pdf"
+                                    "application/pdf" : "application/pdf"
+                                  }
+                                else
+                                  if (kind == "audio" : bool) : "audio/mpeg" | "video/mp4" | "application/pdf" | "image/png"
+                                    { : "audio/mpeg"
+                                      "audio/mpeg" : "audio/mpeg"
+                                    }
+                                  else
+                                    if (kind == "video" : bool) : "video/mp4" | "application/pdf" | "image/png"
+                                      { : "video/mp4"
+                                        "video/mp4" : "video/mp4"
+                                      }
+                                    else
+                                      if (kind == "pdf" : bool) : "application/pdf" | "image/png"
+                                        { : "application/pdf"
+                                          "application/pdf" : "application/pdf"
+                                        }
+                                      else
+                                        { : "image/png"
+                                          "image/png" : "image/png"
+                                        }
+  }
+}
+function ai.wire._resolve_media_content(url: string | null, file: string | null, inline: string, mime: string, fetch_url: bool) -> ai.wire.ResolvedMedia throws never {
+  { : never
+    if let <pat> = file { 4 stmts } : void
+    if (inline != "" : bool) : void
+      { : never
+        return ResolvedMedia { url: null, base64: inline, mime_type: mime } : ai.wire.ResolvedMedia
+      }
+    if let <pat> = url { 6 stmts } : void
+    throw baml.errors.InvalidArgument { message: "media has no URL,..." } : baml.errors.InvalidArgument
+  }
+}
+function ai.wire.resolve_media(media: ai.MediaPart, fetch_url: bool) -> ai.wire.ResolvedMedia throws never {
+  { : ai.wire.ResolvedMedia
+    match (media : ai.MediaPart) : ai.wire.ResolvedMedia
+      image: baml.media.Image =>
+        { : ai.wire.ResolvedMedia
+          let source = image.file() ?? image.url() ?? "" : string
+          _resolve_media_content(image.url(), image.file(), image.base64(), _media_mime_type(image.mime_type(), source, "image"), fetch_url) : ai.wire.ResolvedMedia
+        }
+      audio: baml.media.Audio =>
+        { : ai.wire.ResolvedMedia
+          let source = audio.file() ?? audio.url() ?? "" : string
+          _resolve_media_content(audio.url(), audio.file(), audio.base64(), _media_mime_type(audio.mime_type(), source, "audio"), fetch_url) : ai.wire.ResolvedMedia
+        }
+      video: baml.media.Video =>
+        { : ai.wire.ResolvedMedia
+          let source = video.file() ?? video.url() ?? "" : string
+          _resolve_media_content(video.url(), video.file(), video.base64(), _media_mime_type(video.mime_type(), source, "video"), fetch_url) : ai.wire.ResolvedMedia
+        }
+      pdf: baml.media.Pdf =>
+        { : ai.wire.ResolvedMedia
+          let source = pdf.file() ?? pdf.url() ?? "" : string
+          _resolve_media_content(pdf.url(), pdf.file(), pdf.base64(), _media_mime_type(pdf.mime_type(), source, "pdf"), fetch_url) : ai.wire.ResolvedMedia
+        }
+  }
+}
+class ai.wire.ResolvedMedia$stream {
+  url: string | null
+  base64: string | null
+  mime_type: string | null
+}
 
 --- <builtin>/ai/runner.baml ---
 class ai.RunResult {
@@ -1191,9 +1343,12 @@ class ai.Agent$stream {
 }
 
 --- <builtin>/ai/spec.baml ---
+type ai.MediaPart = baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf
+type ai.PromptPart = string | ai.MediaPart
 class ai.PromptMessage {
   role: string
   content: string
+  parts: ai.PromptPart[]
 }
 class ai.Prompt {
   _data: $rust_type
@@ -1248,9 +1403,12 @@ function ai.FunctionSpec.tools(self: ai.FunctionSpec<Out>) -> ai.tools.Toolbox t
     self.toolbox : ai.tools.Toolbox
   }
 }
+type ai.MediaPart$stream = baml.media.Image$stream | baml.media.Audio$stream | baml.media.Video$stream | baml.media.Pdf$stream
+type ai.PromptPart$stream = string | ai.MediaPart$stream
 class ai.PromptMessage$stream {
   role: string | null
   content: string | null
+  parts: ai.PromptPart$stream[]
 }
 class ai.Prompt$stream {
   _data: $rust_type

--- a/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____06_codegen.snap
@@ -3325,9 +3325,662 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
     throw
 }
 
+function ai.wire._media_mime_type(explicit: string | null, source_value: string, kind: string) -> string {
+    load_var explicit
+    store_var _4
+    load_var _4
+    narrow_bind string, slot=4
+    pop_jump_if_false L0
+    jump L41
+
+  L0:
+    load_var source_value
+    call baml.String.to_lower_case
+    store_var source
+    load_var source
+    load_const ".jpg"
+    call baml.String.includes
+    jump_if_false L1
+    jump L2
+
+  L1:
+    pop 1
+    load_var source
+    load_const ".jpeg"
+    call baml.String.includes
+
+  L2:
+    pop_jump_if_false L3
+    jump L40
+
+  L3:
+    load_var source
+    load_const ".png"
+    call baml.String.includes
+    pop_jump_if_false L4
+    jump L39
+
+  L4:
+    load_var source
+    load_const ".webp"
+    call baml.String.includes
+    pop_jump_if_false L5
+    jump L38
+
+  L5:
+    load_var source
+    load_const ".gif"
+    call baml.String.includes
+    pop_jump_if_false L6
+    jump L37
+
+  L6:
+    load_var source
+    load_const ".svg"
+    call baml.String.includes
+    pop_jump_if_false L7
+    jump L36
+
+  L7:
+    load_var source
+    load_const ".wav"
+    call baml.String.includes
+    pop_jump_if_false L8
+    jump L35
+
+  L8:
+    load_var source
+    load_const ".mp3"
+    call baml.String.includes
+    pop_jump_if_false L9
+    jump L34
+
+  L9:
+    load_var source
+    load_const ".flac"
+    call baml.String.includes
+    pop_jump_if_false L10
+    jump L33
+
+  L10:
+    load_var source
+    load_const ".ogg"
+    call baml.String.includes
+    pop_jump_if_false L11
+    jump L32
+
+  L11:
+    load_var source
+    load_const ".webm"
+    call baml.String.includes
+    pop_jump_if_false L12
+    jump L29
+
+  L12:
+    load_var source
+    load_const ".mov"
+    call baml.String.includes
+    pop_jump_if_false L13
+    jump L28
+
+  L13:
+    load_var source
+    load_const ".mp4"
+    call baml.String.includes
+    pop_jump_if_false L14
+    jump L27
+
+  L14:
+    load_var source
+    load_const ".avi"
+    call baml.String.includes
+    pop_jump_if_false L15
+    jump L26
+
+  L15:
+    load_var source
+    load_const ".mkv"
+    call baml.String.includes
+    pop_jump_if_false L16
+    jump L25
+
+  L16:
+    load_var source
+    load_const ".pdf"
+    call baml.String.includes
+    pop_jump_if_false L17
+    jump L24
+
+  L17:
+    load_var kind
+    load_const "audio"
+    cmp_op ==
+    pop_jump_if_false L18
+    jump L23
+
+  L18:
+    load_var kind
+    load_const "video"
+    cmp_op ==
+    pop_jump_if_false L19
+    jump L22
+
+  L19:
+    load_var kind
+    load_const "pdf"
+    cmp_op ==
+    pop_jump_if_false L20
+    jump L21
+
+  L20:
+    load_const "image/png"
+    jump L42
+
+  L21:
+    load_const "application/pdf"
+    jump L42
+
+  L22:
+    load_const "video/mp4"
+    jump L42
+
+  L23:
+    load_const "audio/mpeg"
+    jump L42
+
+  L24:
+    load_const "application/pdf"
+    jump L42
+
+  L25:
+    load_const "video/x-matroska"
+    jump L42
+
+  L26:
+    load_const "video/x-msvideo"
+    jump L42
+
+  L27:
+    load_const "video/mp4"
+    jump L42
+
+  L28:
+    load_const "video/quicktime"
+    jump L42
+
+  L29:
+    load_var kind
+    load_const "audio"
+    cmp_op ==
+    pop_jump_if_false L30
+    jump L31
+
+  L30:
+    load_const "video/webm"
+    jump L42
+
+  L31:
+    load_const "audio/webm"
+    jump L42
+
+  L32:
+    load_const "audio/ogg"
+    jump L42
+
+  L33:
+    load_const "audio/flac"
+    jump L42
+
+  L34:
+    load_const "audio/mpeg"
+    jump L42
+
+  L35:
+    load_const "audio/wav"
+    jump L42
+
+  L36:
+    load_const "image/svg+xml"
+    jump L42
+
+  L37:
+    load_const "image/gif"
+    jump L42
+
+  L38:
+    load_const "image/webp"
+    jump L42
+
+  L39:
+    load_const "image/png"
+    jump L42
+
+  L40:
+    load_const "image/jpeg"
+    jump L42
+
+  L41:
+    load_var _4
+
+  L42:
+    return
+}
+
+function ai.wire._resolve_media_content(url: string | null, file: string | null, inline: string, mime: string, fetch_url: bool) -> ai.wire.ResolvedMedia {
+    load_var file
+    store_var _6
+    load_var _6
+    narrow_bind string, slot=6
+    pop_jump_if_false L0
+    jump L15
+
+  L0:
+    load_var inline
+    load_const ""
+    cmp_op !=
+    pop_jump_if_false L1
+    jump L14
+
+  L1:
+    load_var url
+    store_var _15
+    load_var _15
+    narrow_bind string, slot=9
+    pop_jump_if_false L2
+    jump L3
+
+  L2:
+    load_const "media has no URL, file, or base64 content"
+    init_instance baml.errors.InvalidArgument .message
+    throw
+
+  L3:
+    load_var _15
+    store_var media_url
+    load_var media_url
+    load_const "data:"
+    call baml.String.starts_with
+    pop_jump_if_false L4
+    load_var media_url
+    load_const ";base64,"
+    call baml.String.index_of
+    store_var _19
+    load_var _19
+    narrow_bind int, slot=11
+    pop_jump_if_false L4
+    jump L13
+
+  L4:
+    load_var fetch_url
+    unary_op !
+    jump_if_false L5
+    jump L6
+
+  L5:
+    pop 1
+    load_var media_url
+    load_const "gs://"
+    call baml.String.starts_with
+
+  L6:
+    pop_jump_if_false L7
+    jump L12
+
+  L7:
+    load_var media_url
+    load_const <omitted>
+    call baml.http.fetch
+    store_var response
+    load_var response
+    call baml.http.Response.ok
+    unary_op !
+    pop_jump_if_false L8
+    jump L11
+
+  L8:
+    load_type string
+    load_type string
+    load_var response
+    load_field .headers
+    load_const "content-type"
+    call baml.Map.get
+    store_var _45
+    load_var _45
+    store_var response_mime
+    load_var _45
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L9
+    load_var mime
+    store_var response_mime
+
+  L9:
+    load_var response
+    sys_op baml.http.Response.bytes
+    call baml.Uint8Array.to_base64
+    store_var _50
+    load_var response_mime
+    load_const ";"
+    call baml.String.split
+    store_var _54
+    load_type string
+    load_var _54
+    load_const 0
+    call baml.Array.at
+    store_var _53
+    load_var _53
+    store_var _52
+    load_var _53
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L10
+    load_var mime
+    store_var _52
+
+  L10:
+    load_const null
+    load_var2 22 23
+    init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
+    jump L16
+
+  L11:
+    load_type string
+    load_var media_url
+    call baml.String.from
+    store_var _38
+    load_type int
+    load_var response
+    load_field .status_code
+    call baml.String.from
+    store_var _41
+    load_const "media"
+    load_const "media URL "
+    load_var _38
+    bin_op +
+    load_const " returned HTTP "
+    bin_op +
+    load_var _41
+    bin_op +
+    load_const null
+    init_instance ai.errors.NetworkFailure .provider, .detail, .raw_body
+    throw
+
+  L12:
+    load_var media_url
+    load_const null
+    load_var mime
+    init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
+    jump L16
+
+  L13:
+    load_var _19
+    store_var_load_var separator
+    load_const 8
+    add_int
+    store_var _22
+    load_var media_url
+    call baml.String.length
+    store_var _24
+    load_var2 10 14
+    load_var _24
+    call baml.String.substring
+    store_var _21
+    load_var media_url
+    load_const 5
+    load_var separator
+    call baml.String.substring
+    store_var _25
+    load_const null
+    load_var2 13 16
+    init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
+    jump L16
+
+  L14:
+    load_const null
+    load_var2 3 4
+    init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
+    jump L16
+
+  L15:
+    load_var _6
+    load_const "r"
+    sys_op baml.fs.open
+    store_var handle
+    load_var handle
+    sys_op baml.fs.File.bytes
+    call baml.Uint8Array.to_base64
+    store_var data
+    load_var handle
+    sys_op baml.fs.File.close
+    pop 1
+    load_const null
+    load_var2 8 4
+    init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
+
+  L16:
+    return
+}
+
 function ai.wire.render_output_format(t: type) -> string {
     load_var t
     sys_op baml.prompt.render_output_format
+    return
+}
+
+function ai.wire.resolve_media(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf, fetch_url: bool) -> ai.wire.ResolvedMedia {
+    load_var media
+    store_var _3
+    load_var _3
+    narrow_bind baml.media.Image, slot=3
+    pop_jump_if_false L0
+    jump L11
+
+  L0:
+    load_var media
+    store_var _16
+    load_var _16
+    narrow_bind baml.media.Audio, slot=12
+    pop_jump_if_false L1
+    jump L8
+
+  L1:
+    load_var media
+    store_var _29
+    load_var _29
+    narrow_bind baml.media.Video, slot=21
+    pop_jump_if_false L2
+    jump L5
+
+  L2:
+    load_var media
+    call baml.media.Pdf.file
+    store_var _45
+    load_var _45
+    store_var _44
+    load_var _45
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L3
+    load_var media
+    call baml.media.Pdf.url
+    store_var _44
+
+  L3:
+    load_var _44
+    store_var source
+    load_var _44
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L4
+    load_const ""
+    store_var source
+
+  L4:
+    load_var media
+    call baml.media.Pdf.url
+    store_var _48
+    load_var media
+    call baml.media.Pdf.file
+    store_var _49
+    load_var media
+    call baml.media.Pdf.base64
+    store_var _50
+    load_var media
+    call baml.media.Pdf.mime_type
+    load_var source
+    load_const "pdf"
+    call ai.wire._media_mime_type
+    store_var _51
+    load_var2 33 34
+    load_var2 35 36
+    load_var fetch_url
+    call ai.wire._resolve_media_content
+    jump L14
+
+  L5:
+    load_var _29
+    store_var video
+    load_var video
+    call baml.media.Video.file
+    store_var _33
+    load_var _33
+    store_var _32
+    load_var _33
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L6
+    load_var video
+    call baml.media.Video.url
+    store_var _32
+
+  L6:
+    load_var _32
+    store_var source
+    load_var _32
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L7
+    load_const ""
+    store_var source
+
+  L7:
+    load_var video
+    call baml.media.Video.url
+    store_var _36
+    load_var video
+    call baml.media.Video.file
+    store_var _37
+    load_var video
+    call baml.media.Video.base64
+    store_var _38
+    load_var video
+    call baml.media.Video.mime_type
+    load_var source
+    load_const "video"
+    call ai.wire._media_mime_type
+    store_var _39
+    load_var2 26 27
+    load_var2 28 29
+    load_var fetch_url
+    call ai.wire._resolve_media_content
+    jump L14
+
+  L8:
+    load_var _16
+    store_var audio
+    load_var audio
+    call baml.media.Audio.file
+    store_var _20
+    load_var _20
+    store_var _19
+    load_var _20
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L9
+    load_var audio
+    call baml.media.Audio.url
+    store_var _19
+
+  L9:
+    load_var _19
+    store_var source
+    load_var _19
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L10
+    load_const ""
+    store_var source
+
+  L10:
+    load_var audio
+    call baml.media.Audio.url
+    store_var _23
+    load_var audio
+    call baml.media.Audio.file
+    store_var _24
+    load_var audio
+    call baml.media.Audio.base64
+    store_var _25
+    load_var audio
+    call baml.media.Audio.mime_type
+    load_var source
+    load_const "audio"
+    call ai.wire._media_mime_type
+    store_var _26
+    load_var2 17 18
+    load_var2 19 20
+    load_var fetch_url
+    call ai.wire._resolve_media_content
+    jump L14
+
+  L11:
+    load_var _3
+    store_var image
+    load_var image
+    call baml.media.Image.file
+    store_var _7
+    load_var _7
+    store_var _6
+    load_var _7
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L12
+    load_var image
+    call baml.media.Image.url
+    store_var _6
+
+  L12:
+    load_var _6
+    store_var source
+    load_var _6
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L13
+    load_const ""
+    store_var source
+
+  L13:
+    load_var image
+    call baml.media.Image.url
+    store_var _10
+    load_var image
+    call baml.media.Image.file
+    store_var _11
+    load_var image
+    call baml.media.Image.base64
+    store_var _12
+    load_var image
+    call baml.media.Image.mime_type
+    load_var source
+    load_const "image"
+    call ai.wire._media_mime_type
+    store_var _13
+    load_var2 8 9
+    load_var2 10 11
+    load_var fetch_url
+    call ai.wire._resolve_media_content
+
+  L14:
     return
 }
 

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -37,7 +37,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         29    load_deref 1                               
         30    load_deref 5                               
         31    load_const 2                               (0)
-        32    call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        32    call 803 ntypeargs=1                       (ai.Agent._emit_from)
         33    store_var 6                                (seen)
 
   201   34    load_const 2                               (0)
@@ -73,7 +73,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         59    load_deref 5                               
         60    load_var 8                                 (total)
         61    load_const 5                               (2)
-        62    call 799 ntypeargs=1                       (ai.Agent._attempt_turn)
+        62    call 802 ntypeargs=1                       (ai.Agent._attempt_turn)
         63    store_var 10                               (turn)
 
   213   64    load_var 7                                 (steps)
@@ -85,7 +85,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         69    load_deref 1                               
         70    load_deref 5                               
         71    load_var 6                                 (seen)
-        72    call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        72    call 803 ntypeargs=1                       (ai.Agent._emit_from)
         73    store_var 6                                (seen)
 
   215   74    load_var 10                                (turn)
@@ -163,7 +163,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         136   load_deref 1                               
         137   load_deref 5                               
         138   load_var 6                                 (seen)
-        139   call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        139   call 803 ntypeargs=1                       (ai.Agent._emit_from)
         140   store_var 6                                (seen)
 
   266   141   load_var 35                                (value)
@@ -185,7 +185,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         155   load_type 1                                
         156   load_var2 1 2                              
         157   load_var 5                                 (j)
-        158   make_closure 1676 captures=3 ntypeargs=1   
+        158   make_closure 1740 captures=3 ntypeargs=1   
         159   call 16 ntypeargs=3                        (baml.Array.map)
         160   store_var 14                               (futures)
 
@@ -200,7 +200,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         168   load_deref 1                               
         169   load_deref 5                               
         170   load_var 6                                 (seen)
-        171   call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        171   call 803 ntypeargs=1                       (ai.Agent._emit_from)
         172   store_var 6                                (seen)
 
   227   173   load_deref 5                               
@@ -234,7 +234,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         197   load_var 11                                (calls)
         198   load_type 1                                
         199   load_var 20                                (f)
-        200   make_closure 1677 captures=1 ntypeargs=1   
+        200   make_closure 1741 captures=1 ntypeargs=1   
         201   call 19 ntypeargs=2                        (baml.Array.find)
 
   234   202   store_var 21                               (_58)
@@ -512,7 +512,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
   150   157   load_var 7                         (turn)
         158   load_field 1                       (stop_reason)
         159   load_const 14                      (ai.content.StopReason.MaxTokens)
-        160   alloc_variant 436                  (ai.content.StopReason)
+        160   alloc_variant 438                  (ai.content.StopReason)
         161   call 612 ntypeargs=0               (baml.ops.equals_equals)
 
   149   162   jump_if_false +2                   (to 164)
@@ -522,7 +522,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
   151   165   load_var 7                         (turn)
         166   load_field 1                       (stop_reason)
         167   load_const 15                      (ai.content.StopReason.Refused)
-        168   alloc_variant 436                  (ai.content.StopReason)
+        168   alloc_variant 438                  (ai.content.StopReason)
         169   call 612 ntypeargs=0               (baml.ops.equals_equals)
 
   149   170   jump_if_false +2                   (to 172)
@@ -531,7 +531,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   152   173   load_type 0                        
         174   load_var2 1 28                     
-        175   call 798 ntypeargs=1               (ai.Agent._parses)
+        175   call 801 ntypeargs=1               (ai.Agent._parses)
 
   153   176   pop_jump_if_false +2               (to 178)
         177   jump +33                           (to 210)
@@ -572,7 +572,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         205   load_var2 5 6                      
         206   load_const 16                      (1)
         207   sub_int                            
-        208   call 799 ntypeargs=1               (ai.Agent._attempt_turn)
+        208   call 802 ntypeargs=1               (ai.Agent._attempt_turn)
         209   jump +19                           (to 228)
 
   154   210   load_var2 4 21                     
@@ -781,7 +781,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        61    store_var 11           (_19)
        62    load_var 11            (_19)
        63    load_const 6           (ai.tools.ErrorMode.Raise)
-       64    alloc_variant 437      (ai.tools.ErrorMode)
+       64    alloc_variant 439      (ai.tools.ErrorMode)
        65    call 612 ntypeargs=0   (baml.ops.equals_equals)
        66    pop_jump_if_false +2   (to 68)
        67    jump +4                (to 71)
@@ -865,7 +865,7 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
        15   pop_jump_if_false +4                       (to 19)
 
   32   16   load_const 3                               (ai.tools.ErrorMode.Report)
-       17   alloc_variant 437                          (ai.tools.ErrorMode)
+       17   alloc_variant 439                          (ai.tools.ErrorMode)
        18   store_var 3                                (tool_errors)
        19   load_var 4                                 (on_event)
        20   load_const 0                               (<omitted>)
@@ -883,7 +883,7 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
        30   pop_jump_if_false +4                       (to 34)
 
   41   31   load_type 4                                
-       32   make_closure 1658 captures=0 ntypeargs=1   
+       32   make_closure 1722 captures=0 ntypeargs=1   
        33   store_var 5                                (_9)
 
   35   34   load_var2 1 2                              
@@ -894,19 +894,19 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
 }
 
 function ai.FunctionSpec.arguments(self: ai.FunctionSpec<#0>) -> map<string, unknown> {
-  73   0   load_var 1     (self)
+  82   0   load_var 1     (self)
        1   load_field 1   (args)
        2   return         
 }
 
 function ai.FunctionSpec.name(self: ai.FunctionSpec<#0>) -> string {
-  69   0   load_var 1     (self)
+  78   0   load_var 1     (self)
        1   load_field 0   (spec_name)
        2   return         
 }
 
 function ai.FunctionSpec.output_type(self: ai.FunctionSpec<#0>) -> type {
-  77   0   load_type 0   
+  86   0   load_type 0   
        1   return        
 }
 
@@ -916,17 +916,17 @@ function ai.FunctionSpec.prompt(self: ai.FunctionSpec<#0>, output_format: string
        2   cmp_op ==              
        3   pop_jump_if_false +3   (to 6)
 
-  80   4   load_const 1           ("")
+  89   4   load_const 1           ("")
        5   store_var 2            (output_format)
 
-  81   6   load_var2 2 1          
+  90   6   load_var2 2 1          
        7   load_field 2           (prompt_template)
        8   call_indirect          
        9   return                 
 }
 
 function ai.FunctionSpec.tools(self: ai.FunctionSpec<#0>) -> ai.tools.Toolbox {
-  85   0   load_var 1     (self)
+  94   0   load_var 1     (self)
        1   load_field 3   (toolbox)
        2   return         
 }
@@ -1055,7 +1055,7 @@ function ai.ModelTurn.tool_uses(self: ai.ModelTurn) -> ai.content.ToolUse[] {
 }
 
 function ai.Prompt.baml.ToString.to_string(self: ai.Prompt) -> string {
-  35   0   load_var 1             (self)
+  44   0   load_var 1             (self)
        1   call 763 ntypeargs=0   (ai.Prompt.text)
        2   return                 
 }
@@ -1213,7 +1213,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         46   store_var 10                       (_17)
         47   load_var 10                        (_17)
         48   load_const 6                       (ai.errors.RetrySafety.Safe)
-        49   alloc_variant 438                  (ai.errors.RetrySafety)
+        49   alloc_variant 440                  (ai.errors.RetrySafety)
         50   call 612 ntypeargs=0               (baml.ops.equals_equals)
 
   155   51   pop_jump_if_false +2               (to 53)
@@ -1226,7 +1226,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         56   load_var 3                         (index)
         57   load_const 4                       (1)
         58   add_int                            
-        59   call 793 ntypeargs=0               (ai.clients.Fallback._try)
+        59   call 796 ntypeargs=0               (ai.clients.Fallback._try)
         60   return                             
 }
 
@@ -1258,13 +1258,13 @@ function ai.clients.Fallback.root.Client.id(self: ai.clients.Fallback) -> string
 function ai.clients.Fallback.root.Client.invoke(self: ai.clients.Fallback, input: ai.ModelTurnInput) -> ai.ModelTurn {
   185   0   load_var2 1 2          
         1   load_const 0           (0)
-        2   call 793 ntypeargs=0   (ai.clients.Fallback._try)
+        2   call 796 ntypeargs=0   (ai.clients.Fallback._try)
         3   jump +6                (to 9)
         4   load_var 3             (e)
         5   throw_if_panic         
 
   186   6   load_var 3             (e)
-        7   call 811 ntypeargs=0   (ai.errors.normalize)
+        7   call 814 ntypeargs=0   (ai.errors.normalize)
         8   throw                  
         9   return                 
 }
@@ -1305,7 +1305,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        28   store_var 7                        (_11)
        29   load_var 7                         (_11)
        30   load_const 5                       (ai.errors.RetrySafety.Safe)
-       31   alloc_variant 438                  (ai.errors.RetrySafety)
+       31   alloc_variant 440                  (ai.errors.RetrySafety)
        32   call 612 ntypeargs=0               (baml.ops.equals_equals)
 
   74   33   jump_if_false +5                   (to 38)
@@ -1332,7 +1332,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        49   add_int                            
 
   80   50   load_var 6                         (f)
-       51   call 785 ntypeargs=0               (ai.clients.Backoff.delay_ms)
+       51   call 788 ntypeargs=0               (ai.clients.Backoff.delay_ms)
        52   call 502 ntypeargs=0               (baml.time.Duration.from_milliseconds)
 
   79   53   sys_op 255                         (baml.sys.sleep)
@@ -1345,7 +1345,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        59   load_var 3                         (remaining)
        60   load_const 3                       (1)
        61   sub_int                            
-       62   call 787 ntypeargs=0               (ai.clients.Retry._attempt)
+       62   call 790 ntypeargs=0               (ai.clients.Retry._attempt)
        63   return                             
 }
 
@@ -1390,7 +1390,7 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
        32   load_const 0           (<omitted>)
        33   load_const 0           (<omitted>)
        34   load_const 0           (<omitted>)
-       35   call 784 ntypeargs=0   (ai.clients.Backoff.new)
+       35   call 787 ntypeargs=0   (ai.clients.Backoff.new)
        36   store_var 6            (_10)
 
   61   37   load_var2 1 2          
@@ -1414,13 +1414,13 @@ function ai.clients.Retry.root.Client.invoke(self: ai.clients.Retry, input: ai.M
   99    0    load_var2 1 2          
         1    load_var 1             (self)
         2    load_field 1           (max_attempts)
-        3    call 787 ntypeargs=0   (ai.clients.Retry._attempt)
+        3    call 790 ntypeargs=0   (ai.clients.Retry._attempt)
         4    jump +6                (to 10)
         5    load_var 3             (e)
         6    throw_if_panic         
 
   100   7    load_var 3             (e)
-        8    call 811 ntypeargs=0   (ai.errors.normalize)
+        8    call 814 ntypeargs=0   (ai.errors.normalize)
         9    throw                  
         10   return                 
 }
@@ -1514,7 +1514,7 @@ function ai.clients.RoundRobin.root.Client.invoke(self: ai.clients.RoundRobin, i
         33   throw_if_panic                     
 
   141   34   load_var 4                         (e)
-        35   call 811 ntypeargs=0               (ai.errors.normalize)
+        35   call 814 ntypeargs=0               (ai.errors.normalize)
         36   throw                              
         37   load_var 3                         (_0)
         38   return                             
@@ -1558,49 +1558,49 @@ function ai.clients.default_retry_judgment(f: ai.errors.Failure) -> bool {
 
 function ai.errors.InvalidRequest.Failure.retry_safety(self: ai.errors.InvalidRequest) -> ai.errors.RetrySafety {
   54   0   load_const 0        (ai.errors.RetrySafety.Safe)
-       1   alloc_variant 438   (ai.errors.RetrySafety)
+       1   alloc_variant 440   (ai.errors.RetrySafety)
        2   return              
 }
 
 function ai.errors.NetworkFailure.Failure.retry_safety(self: ai.errors.NetworkFailure) -> ai.errors.RetrySafety {
   42   0   load_const 0        (ai.errors.RetrySafety.Safe)
-       1   alloc_variant 438   (ai.errors.RetrySafety)
+       1   alloc_variant 440   (ai.errors.RetrySafety)
        2   return              
 }
 
 function ai.errors.ParseFailed.Failure.retry_safety(self: ai.errors.ParseFailed) -> ai.errors.RetrySafety {
   75   0   load_const 0        (ai.errors.RetrySafety.Safe)
-       1   alloc_variant 438   (ai.errors.RetrySafety)
+       1   alloc_variant 440   (ai.errors.RetrySafety)
        2   return              
 }
 
 function ai.errors.RateLimited.Failure.retry_safety(self: ai.errors.RateLimited) -> ai.errors.RetrySafety {
   31   0   load_const 0        (ai.errors.RetrySafety.Safe)
-       1   alloc_variant 438   (ai.errors.RetrySafety)
+       1   alloc_variant 440   (ai.errors.RetrySafety)
        2   return              
 }
 
 function ai.errors.Refused.Failure.retry_safety(self: ai.errors.Refused) -> ai.errors.RetrySafety {
   65   0   load_const 0        (ai.errors.RetrySafety.Safe)
-       1   alloc_variant 438   (ai.errors.RetrySafety)
+       1   alloc_variant 440   (ai.errors.RetrySafety)
        2   return              
 }
 
 function ai.errors.StepBudgetExceeded.Failure.retry_safety(self: ai.errors.StepBudgetExceeded) -> ai.errors.RetrySafety {
   88   0   load_const 0        (ai.errors.RetrySafety.Unsafe)
-       1   alloc_variant 438   (ai.errors.RetrySafety)
+       1   alloc_variant 440   (ai.errors.RetrySafety)
        2   return              
 }
 
 function ai.errors.StreamingUnsupported.Failure.retry_safety(self: ai.errors.StreamingUnsupported) -> ai.errors.RetrySafety {
   117   0   load_const 0        (ai.errors.RetrySafety.Safe)
-        1   alloc_variant 438   (ai.errors.RetrySafety)
+        1   alloc_variant 440   (ai.errors.RetrySafety)
         2   return              
 }
 
 function ai.errors.ToolFailedError.Failure.retry_safety(self: ai.errors.ToolFailedError) -> ai.errors.RetrySafety {
   104   0   load_const 0        (ai.errors.RetrySafety.Unsafe)
-        1   alloc_variant 438   (ai.errors.RetrySafety)
+        1   alloc_variant 440   (ai.errors.RetrySafety)
         2   return              
 }
 
@@ -1770,10 +1770,10 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
 
   102   9     load_var2 4 2                      
         10    load_var 3                         (params)
-        11    call 881 ntypeargs=0               (ai.mcp.rpc_line)
+        11    call 889 ntypeargs=0               (ai.mcp.rpc_line)
         12    store_var 5                        (_6)
         13    load_var2 1 5                      
-        14    call 883 ntypeargs=0               (ai.mcp.McpConnection._send)
+        14    call 891 ntypeargs=0               (ai.mcp.McpConnection._send)
         15    pop 1                              
 
   103   16    load_const 1                       (true)
@@ -2011,7 +2011,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         5    load_type 3                        
         6    load_type 4                        
         7    alloc_map 2                        
-        8    call 884 ntypeargs=0               (ai.mcp.McpConnection._request)
+        8    call 892 ntypeargs=0               (ai.mcp.McpConnection._request)
         9    store_var 4                        (result)
 
   185   10   load_type 3                        
@@ -2179,16 +2179,16 @@ function ai.mcp.McpConnection.connect(name: string, command: string, args: strin
        59   load_type 4            
        60   load_type 19           
        61   alloc_map 3            
-       62   call 884 ntypeargs=0   (ai.mcp.McpConnection._request)
+       62   call 892 ntypeargs=0   (ai.mcp.McpConnection._request)
        63   pop 1                  
 
   76   64   load_const 2           (null)
        65   load_const 20          ("notifications/initialized")
        66   load_const 2           (null)
-       67   call 881 ntypeargs=0   (ai.mcp.rpc_line)
+       67   call 889 ntypeargs=0   (ai.mcp.rpc_line)
        68   store_var 11           (_26)
        69   load_var2 10 11        
-       70   call 883 ntypeargs=0   (ai.mcp.McpConnection._send)
+       70   call 891 ntypeargs=0   (ai.mcp.McpConnection._send)
        71   pop 1                  
 
   77   72   load_var 10            (conn)
@@ -2201,7 +2201,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         2    load_type 1                        
         3    load_type 2                        
         4    alloc_map 0                        
-        5    call 884 ntypeargs=0               (ai.mcp.McpConnection._request)
+        5    call 892 ntypeargs=0               (ai.mcp.McpConnection._request)
         6    store_var 2                        (result)
 
   157   7    load_type 3                        
@@ -2270,7 +2270,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         63   store_var 13                       (_31)
 
   173   64   load_var2 1 7                      
-        65   call 880 ntypeargs=0               (ai.mcp._proxy)
+        65   call 888 ntypeargs=0               (ai.mcp._proxy)
         66   store_var 14                       (_32)
 
   170   67   load_var2 7 12                     
@@ -2297,7 +2297,7 @@ function ai.mcp._proxy(conn: ai.mcp.McpConnection, name: string) -> (map<string,
        5   store_var 2           
 
   20   6   load_var2 1 2         
-       7   make_closure 2242 2   
+       7   make_closure 2391 2   
        8   return                
 }
 
@@ -2353,8 +2353,8 @@ function ai.prompt(body: ((string) -> baml.prompt.Role throws never, baml.prompt
        1   make_cell             
        2   store_var 1           
 
-  49   3   load_var 1            (body)
-       4   make_closure 1592 1   
+  58   3   load_var 1            (body)
+       4   make_closure 1594 1   
        5   return                
 }
 
@@ -2451,10 +2451,10 @@ function ai.stream.Stream.next(self: ai.stream.Stream<#0, #1>) -> #0 | ai.stream
         39   load_const 0                     (true)
         40   store_field 3                    (_finished)
 
-  259   41   alloc_instance 359 ntypeargs=0   (ai.stream.Done)
+  259   41   alloc_instance 361 ntypeargs=0   (ai.stream.Done)
         42   jump +2                          (to 44)
 
-  254   43   alloc_instance 359 ntypeargs=0   (ai.stream.Done)
+  254   43   alloc_instance 361 ntypeargs=0   (ai.stream.Done)
         44   return                           
 }
 
@@ -2484,7 +2484,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         1    pop_jump_if_false +7   (to 8)
 
   216   2    load_var 1             (self)
-        3    call 806 ntypeargs=0   (ai.stream.TurnStream.next)
+        3    call 809 ntypeargs=0   (ai.stream.TurnStream.next)
         4    store_var 2            (_3)
         5    load_var 2             (_3)
         6    narrow_bind 1 2        
@@ -2551,7 +2551,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         60   cmp_op ==              
         61   pop_jump_if_false +4   (to 65)
         62   load_const 3           (ai.content.StopReason.Complete)
-        63   alloc_variant 436      (ai.content.StopReason)
+        63   alloc_variant 438      (ai.content.StopReason)
         64   store_var 8            (_20)
 
   234   65   load_var 1             (self)
@@ -2649,10 +2649,10 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         38    jump +6                            (to 44)
 
   202   39    load_var 1                         (self)
-        40    call 805 ntypeargs=0               (ai.stream.TurnStream._finish)
+        40    call 808 ntypeargs=0               (ai.stream.TurnStream._finish)
         41    pop 1                              
 
-  203   42    alloc_instance 359 ntypeargs=0     (ai.stream.Done)
+  203   42    alloc_instance 361 ntypeargs=0     (ai.stream.Done)
         43    jump +146                          (to 189)
 
   195   44    load_var 20                        (_58)
@@ -2727,10 +2727,10 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         102   jump -15                           (to 87)
 
   176   103   load_var 1                         (self)
-        104   call 805 ntypeargs=0               (ai.stream.TurnStream._finish)
+        104   call 808 ntypeargs=0               (ai.stream.TurnStream._finish)
         105   pop 1                              
 
-  177   106   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
+  177   106   alloc_instance 361 ntypeargs=0     (ai.stream.Done)
         107   jump +82                           (to 189)
 
   145   108   load_type 12                       
@@ -2767,10 +2767,10 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         137   pop_jump_if_false -137             (to 0)
 
   165   138   load_var 1                         (self)
-        139   call 805 ntypeargs=0               (ai.stream.TurnStream._finish)
+        139   call 808 ntypeargs=0               (ai.stream.TurnStream._finish)
         140   pop 1                              
 
-  166   141   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
+  166   141   alloc_instance 361 ntypeargs=0     (ai.stream.Done)
         142   jump +47                           (to 189)
 
   147   143   load_var 9                         (_19)
@@ -2831,7 +2831,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         186   load_field 0                       (text)
         187   jump +2                            (to 189)
 
-  141   188   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
+  141   188   alloc_instance 361 ntypeargs=0     (ai.stream.Done)
         189   return                             
 }
 
@@ -2938,7 +2938,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
   340   75    load_type 8                                
         76    load_type 2                                
         77    load_var 10                                (turns)
-        78    make_closure 1698 captures=1 ntypeargs=2   
+        78    make_closure 1762 captures=1 ntypeargs=2   
         79    load_var 15                                (_36)
         80    load_const 9                               ("")
         81    load_const 10                              (false)
@@ -3058,7 +3058,7 @@ function ai.tools.Toolbox.get(self: ai.tools.Toolbox, name: string) -> ai.tools.
         5    load_var 1            (self)
         6    load_field 0          (entries)
         7    load_var 2            (name)
-        8    make_closure 1618 1   
+        8    make_closure 1620 1   
         9    call 19 ntypeargs=2   (baml.Array.find)
         10   return                
 }
@@ -3233,7 +3233,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        61   store_var 9            (_17)
 
   58   62   load_var 1             (handler)
-       63   call 821 ntypeargs=0   (ai.internal._schema_for_signature)
+       63   call 824 ntypeargs=0   (ai.internal._schema_for_signature)
        64   store_var 11           (_21)
 
   56   65   load_var2 8 9          
@@ -3248,10 +3248,627 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        73   throw                  
 }
 
+function ai.wire._media_mime_type(explicit: string | null, source_value: string, kind: string) -> string {
+  49   0     load_var 1             (explicit)
+       1     store_var 4            (_4)
+       2     load_var 4             (_4)
+       3     narrow_bind 0 4        
+       4     pop_jump_if_false +2   (to 6)
+       5     jump +145              (to 150)
+
+  52   6     load_var 2             (source_value)
+       7     call 142 ntypeargs=0   (baml.String.to_lower_case)
+       8     store_var 5            (source)
+
+  53   9     load_var 5             (source)
+       10    load_const 1           (".jpg")
+       11    call 147 ntypeargs=0   (baml.String.includes)
+       12    jump_if_false +2       (to 14)
+       13    jump +5                (to 18)
+       14    pop 1                  
+       15    load_var 5             (source)
+       16    load_const 2           (".jpeg")
+       17    call 147 ntypeargs=0   (baml.String.includes)
+       18    pop_jump_if_false +2   (to 20)
+       19    jump +129              (to 148)
+
+  55   20    load_var 5             (source)
+       21    load_const 3           (".png")
+       22    call 147 ntypeargs=0   (baml.String.includes)
+       23    pop_jump_if_false +2   (to 25)
+       24    jump +122              (to 146)
+
+  57   25    load_var 5             (source)
+       26    load_const 4           (".webp")
+       27    call 147 ntypeargs=0   (baml.String.includes)
+       28    pop_jump_if_false +2   (to 30)
+       29    jump +115              (to 144)
+
+  59   30    load_var 5             (source)
+       31    load_const 5           (".gif")
+       32    call 147 ntypeargs=0   (baml.String.includes)
+       33    pop_jump_if_false +2   (to 35)
+       34    jump +108              (to 142)
+
+  61   35    load_var 5             (source)
+       36    load_const 6           (".svg")
+       37    call 147 ntypeargs=0   (baml.String.includes)
+       38    pop_jump_if_false +2   (to 40)
+       39    jump +101              (to 140)
+
+  63   40    load_var 5             (source)
+       41    load_const 7           (".wav")
+       42    call 147 ntypeargs=0   (baml.String.includes)
+       43    pop_jump_if_false +2   (to 45)
+       44    jump +94               (to 138)
+
+  65   45    load_var 5             (source)
+       46    load_const 8           (".mp3")
+       47    call 147 ntypeargs=0   (baml.String.includes)
+       48    pop_jump_if_false +2   (to 50)
+       49    jump +87               (to 136)
+
+  67   50    load_var 5             (source)
+       51    load_const 9           (".flac")
+       52    call 147 ntypeargs=0   (baml.String.includes)
+       53    pop_jump_if_false +2   (to 55)
+       54    jump +80               (to 134)
+
+  69   55    load_var 5             (source)
+       56    load_const 10          (".ogg")
+       57    call 147 ntypeargs=0   (baml.String.includes)
+       58    pop_jump_if_false +2   (to 60)
+       59    jump +73               (to 132)
+
+  71   60    load_var 5             (source)
+       61    load_const 11          (".webm")
+       62    call 147 ntypeargs=0   (baml.String.includes)
+       63    pop_jump_if_false +2   (to 65)
+       64    jump +59               (to 123)
+
+  77   65    load_var 5             (source)
+       66    load_const 12          (".mov")
+       67    call 147 ntypeargs=0   (baml.String.includes)
+       68    pop_jump_if_false +2   (to 70)
+       69    jump +52               (to 121)
+
+  79   70    load_var 5             (source)
+       71    load_const 13          (".mp4")
+       72    call 147 ntypeargs=0   (baml.String.includes)
+       73    pop_jump_if_false +2   (to 75)
+       74    jump +45               (to 119)
+
+  81   75    load_var 5             (source)
+       76    load_const 14          (".avi")
+       77    call 147 ntypeargs=0   (baml.String.includes)
+       78    pop_jump_if_false +2   (to 80)
+       79    jump +38               (to 117)
+
+  83   80    load_var 5             (source)
+       81    load_const 15          (".mkv")
+       82    call 147 ntypeargs=0   (baml.String.includes)
+       83    pop_jump_if_false +2   (to 85)
+       84    jump +31               (to 115)
+
+  85   85    load_var 5             (source)
+       86    load_const 16          (".pdf")
+       87    call 147 ntypeargs=0   (baml.String.includes)
+       88    pop_jump_if_false +2   (to 90)
+       89    jump +24               (to 113)
+
+  87   90    load_var 3             (kind)
+       91    load_const 17          ("audio")
+       92    cmp_op ==              
+       93    pop_jump_if_false +2   (to 95)
+       94    jump +17               (to 111)
+
+  89   95    load_var 3             (kind)
+       96    load_const 18          ("video")
+       97    cmp_op ==              
+       98    pop_jump_if_false +2   (to 100)
+       99    jump +10               (to 109)
+
+  91   100   load_var 3             (kind)
+       101   load_const 19          ("pdf")
+       102   cmp_op ==              
+       103   pop_jump_if_false +2   (to 105)
+       104   jump +3                (to 107)
+
+  94   105   load_const 20          ("image/png")
+
+  91   106   jump +45               (to 151)
+
+  92   107   load_const 21          ("application/pdf")
+
+  91   108   jump +43               (to 151)
+
+  90   109   load_const 22          ("video/mp4")
+
+  89   110   jump +41               (to 151)
+
+  88   111   load_const 23          ("audio/mpeg")
+
+  87   112   jump +39               (to 151)
+
+  86   113   load_const 24          ("application/pdf")
+
+  85   114   jump +37               (to 151)
+
+  84   115   load_const 25          ("video/x-matroska")
+
+  83   116   jump +35               (to 151)
+
+  82   117   load_const 26          ("video/x-msvideo")
+
+  81   118   jump +33               (to 151)
+
+  80   119   load_const 27          ("video/mp4")
+
+  79   120   jump +31               (to 151)
+
+  78   121   load_const 28          ("video/quicktime")
+
+  77   122   jump +29               (to 151)
+
+  72   123   load_var 3             (kind)
+       124   load_const 29          ("audio")
+       125   cmp_op ==              
+       126   pop_jump_if_false +2   (to 128)
+       127   jump +3                (to 130)
+
+  75   128   load_const 30          ("video/webm")
+
+  72   129   jump +22               (to 151)
+
+  73   130   load_const 31          ("audio/webm")
+
+  72   131   jump +20               (to 151)
+
+  70   132   load_const 32          ("audio/ogg")
+
+  69   133   jump +18               (to 151)
+
+  68   134   load_const 33          ("audio/flac")
+
+  67   135   jump +16               (to 151)
+
+  66   136   load_const 34          ("audio/mpeg")
+
+  65   137   jump +14               (to 151)
+
+  64   138   load_const 35          ("audio/wav")
+
+  63   139   jump +12               (to 151)
+
+  62   140   load_const 36          ("image/svg+xml")
+
+  61   141   jump +10               (to 151)
+
+  60   142   load_const 37          ("image/gif")
+
+  59   143   jump +8                (to 151)
+
+  58   144   load_const 38          ("image/webp")
+
+  57   145   jump +6                (to 151)
+
+  56   146   load_const 39          ("image/png")
+
+  55   147   jump +4                (to 151)
+
+  54   148   load_const 40          ("image/jpeg")
+
+  53   149   jump +2                (to 151)
+
+  49   150   load_var 4             (_4)
+       151   return                 
+}
+
+function ai.wire._resolve_media_content(url: string | null, file: string | null, inline: string, mime: string, fetch_url: bool) -> ai.wire.ResolvedMedia {
+  105   0     load_var 2              (file)
+        1     store_var 6             (_6)
+        2     load_var 6              (_6)
+        3     narrow_bind 0 6         
+        4     pop_jump_if_false +2    (to 6)
+        5     jump +138               (to 143)
+
+  111   6     load_var 3              (inline)
+        7     load_const 1            ("")
+        8     cmp_op !=               
+        9     pop_jump_if_false +2    (to 11)
+        10    jump +129               (to 139)
+
+  114   11    load_var 1              (url)
+        12    store_var 9             (_15)
+        13    load_var 9              (_15)
+        14    narrow_bind 0 9         
+        15    pop_jump_if_false +2    (to 17)
+        16    jump +4                 (to 20)
+
+  142   17    load_const 2            ("media has no URL, file, or base64 content")
+        18    init_instance 0         (baml.errors.InvalidArgument .message)
+        19    throw                   
+
+  114   20    load_var 9              (_15)
+        21    store_var 10            (media_url)
+
+  115   22    load_var 10             (media_url)
+        23    load_const 3            ("data:")
+        24    call 148 ntypeargs=0    (baml.String.starts_with)
+        25    pop_jump_if_false +9    (to 34)
+
+  116   26    load_var 10             (media_url)
+        27    load_const 4            (";base64,")
+        28    call 155 ntypeargs=0    (baml.String.index_of)
+        29    store_var 11            (_19)
+        30    load_var 11             (_19)
+        31    narrow_bind 5 11        
+        32    pop_jump_if_false +2    (to 34)
+        33    jump +85                (to 118)
+
+  124   34    load_var 5              (fetch_url)
+        35    unary_op !              
+        36    jump_if_false +2        (to 38)
+        37    jump +5                 (to 42)
+        38    pop 1                   
+        39    load_var 10             (media_url)
+        40    load_const 6            ("gs://")
+        41    call 148 ntypeargs=0    (baml.String.starts_with)
+        42    pop_jump_if_false +2    (to 44)
+        43    jump +70                (to 113)
+
+  127   44    load_var 10             (media_url)
+        45    load_const 7            (<omitted>)
+        46    call 228 ntypeargs=0    (baml.http.fetch)
+        47    store_var 17            (response)
+
+  128   48    load_var 17             (response)
+        49    call 220 ntypeargs=0    (baml.http.Response.ok)
+        50    unary_op !              
+        51    pop_jump_if_false +2    (to 53)
+        52    jump +41                (to 93)
+
+  135   53    load_type 8             
+        54    load_type 8             
+        55    load_var 17             (response)
+        56    load_field 1            (headers)
+        57    load_const 9            ("content-type")
+        58    call 38 ntypeargs=2     (baml.Map.get)
+        59    store_var 21            (_45)
+        60    load_var 21             (_45)
+        61    store_var 20            (response_mime)
+        62    load_var 21             (_45)
+        63    load_const 10           (null)
+        64    cmp_op ==               
+        65    pop_jump_if_false +3    (to 68)
+        66    load_var 4              (mime)
+        67    store_var 20            (response_mime)
+
+  138   68    load_var 17             (response)
+        69    sys_op 219              (baml.http.Response.bytes)
+        70    call 197 ntypeargs=0    (baml.Uint8Array.to_base64)
+        71    store_var 22            (_50)
+
+  139   72    load_var 20             (response_mime)
+        73    load_const 11           (";")
+        74    call 150 ntypeargs=0    (baml.String.split)
+        75    store_var 25            (_54)
+        76    load_type 8             
+        77    load_var 25             (_54)
+        78    load_const 5            (0)
+        79    call 3 ntypeargs=1      (baml.Array.at)
+        80    store_var 24            (_53)
+        81    load_var 24             (_53)
+        82    store_var 23            (_52)
+        83    load_var 24             (_53)
+        84    load_const 10           (null)
+        85    cmp_op ==               
+        86    pop_jump_if_false +3    (to 89)
+        87    load_var 4              (mime)
+        88    store_var 23            (_52)
+
+  136   89    load_const 10           (null)
+        90    load_var2 22 23         
+        91    init_instance 1         (ai.wire.ResolvedMedia .url, .base64, .mime_type)
+        92    jump +65                (to 157)
+
+  131   93    load_type 8             
+        94    load_var 10             (media_url)
+        95    call 138 ntypeargs=1    (baml.String.from)
+        96    store_var 18            (_38)
+        97    load_type 12            
+        98    load_var 17             (response)
+        99    load_field 0            (status_code)
+        100   call 138 ntypeargs=1    (baml.String.from)
+        101   store_var 19            (_41)
+
+  129   102   load_const 13           ("media")
+
+  131   103   load_const 14           ("media URL ")
+        104   load_var 18             (_38)
+        105   bin_op +                
+        106   load_const 15           (" returned HTTP ")
+        107   bin_op +                
+        108   load_var 19             (_41)
+        109   bin_op +                
+        110   load_const 10           (null)
+        111   init_instance 2         (ai.errors.NetworkFailure .provider, .detail, .raw_body)
+        112   throw                   
+
+  125   113   load_var 10             (media_url)
+        114   load_const 10           (null)
+        115   load_var 4              (mime)
+        116   init_instance 3         (ai.wire.ResolvedMedia .url, .base64, .mime_type)
+        117   jump +40                (to 157)
+
+  116   118   load_var 11             (_19)
+        119   store_var_load_var 12   (separator)
+
+  119   120   load_const 16           (8)
+        121   add_int                 
+        122   store_var 14            (_22)
+        123   load_var 10             (media_url)
+        124   call 139 ntypeargs=0    (baml.String.length)
+        125   store_var 15            (_24)
+        126   load_var2 10 14         
+        127   load_var 15             (_24)
+        128   call 153 ntypeargs=0    (baml.String.substring)
+        129   store_var 13            (_21)
+
+  120   130   load_var 10             (media_url)
+        131   load_const 17           (5)
+        132   load_var 12             (separator)
+        133   call 153 ntypeargs=0    (baml.String.substring)
+        134   store_var 16            (_25)
+
+  117   135   load_const 10           (null)
+        136   load_var2 13 16         
+        137   init_instance 4         (ai.wire.ResolvedMedia .url, .base64, .mime_type)
+        138   jump +19                (to 157)
+
+  112   139   load_const 10           (null)
+        140   load_var2 3 4           
+        141   init_instance 5         (ai.wire.ResolvedMedia .url, .base64, .mime_type)
+        142   jump +15                (to 157)
+
+  105   143   load_var 6              (_6)
+        144   load_const 18           ("r")
+        145   sys_op 268              (baml.fs.open)
+        146   store_var 7             (handle)
+
+  107   147   load_var 7              (handle)
+        148   sys_op 261              (baml.fs.File.bytes)
+        149   call 197 ntypeargs=0    (baml.Uint8Array.to_base64)
+        150   store_var 8             (data)
+
+  108   151   load_var 7              (handle)
+        152   sys_op 264              (baml.fs.File.close)
+        153   pop 1                   
+
+  109   154   load_const 10           (null)
+        155   load_var2 8 4           
+        156   init_instance 6         (ai.wire.ResolvedMedia .url, .base64, .mime_type)
+        157   return                  
+}
+
 function ai.wire.render_output_format(t: type) -> string {
   37   0   load_var 1   (t)
        1   sys_op 418   (baml.prompt.render_output_format)
        2   return       
+}
+
+function ai.wire.resolve_media(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf, fetch_url: bool) -> ai.wire.ResolvedMedia {
+  149   0     load_var 1             (media)
+        1     store_var 3            (_3)
+        2     load_var 3             (_3)
+        3     narrow_bind 0 3        
+        4     pop_jump_if_false +2   (to 6)
+        5     jump +137              (to 142)
+        6     load_var 1             (media)
+        7     store_var 12           (_16)
+        8     load_var 12            (_16)
+        9     narrow_bind 1 12       
+        10    pop_jump_if_false +2   (to 12)
+        11    jump +89               (to 100)
+        12    load_var 1             (media)
+        13    store_var 21           (_29)
+        14    load_var 21            (_29)
+        15    narrow_bind 2 21       
+        16    pop_jump_if_false +2   (to 18)
+        17    jump +41               (to 58)
+
+  181   18    load_var 1             (media)
+        19    call 300 ntypeargs=0   (baml.media.Pdf.file)
+        20    store_var 32           (_45)
+        21    load_var 32            (_45)
+        22    store_var 31           (_44)
+        23    load_var 32            (_45)
+        24    load_const 3           (null)
+        25    cmp_op ==              
+        26    pop_jump_if_false +4   (to 30)
+        27    load_var 1             (media)
+        28    call 299 ntypeargs=0   (baml.media.Pdf.url)
+        29    store_var 31           (_44)
+        30    load_var 31            (_44)
+        31    store_var 30           (source)
+        32    load_var 31            (_44)
+        33    load_const 3           (null)
+        34    cmp_op ==              
+        35    pop_jump_if_false +3   (to 38)
+        36    load_const 4           ("")
+        37    store_var 30           (source)
+
+  183   38    load_var 1             (media)
+        39    call 299 ntypeargs=0   (baml.media.Pdf.url)
+        40    store_var 33           (_48)
+
+  184   41    load_var 1             (media)
+        42    call 300 ntypeargs=0   (baml.media.Pdf.file)
+        43    store_var 34           (_49)
+
+  185   44    load_var 1             (media)
+        45    call 301 ntypeargs=0   (baml.media.Pdf.base64)
+        46    store_var 35           (_50)
+
+  186   47    load_var 1             (media)
+        48    call 302 ntypeargs=0   (baml.media.Pdf.mime_type)
+        49    load_var 30            (source)
+        50    load_const 5           ("pdf")
+        51    call 783 ntypeargs=0   (ai.wire._media_mime_type)
+        52    store_var 36           (_51)
+
+  182   53    load_var2 33 34        
+        54    load_var2 35 36        
+        55    load_var 2             (fetch_url)
+        56    call 784 ntypeargs=0   (ai.wire._resolve_media_content)
+        57    jump +126              (to 183)
+
+  149   58    load_var 21            (_29)
+        59    store_var 22           (video)
+
+  171   60    load_var 22            (video)
+        61    call 314 ntypeargs=0   (baml.media.Video.file)
+        62    store_var 25           (_33)
+        63    load_var 25            (_33)
+        64    store_var 24           (_32)
+        65    load_var 25            (_33)
+        66    load_const 3           (null)
+        67    cmp_op ==              
+        68    pop_jump_if_false +4   (to 72)
+        69    load_var 22            (video)
+        70    call 313 ntypeargs=0   (baml.media.Video.url)
+        71    store_var 24           (_32)
+        72    load_var 24            (_32)
+        73    store_var 23           (source)
+        74    load_var 24            (_32)
+        75    load_const 3           (null)
+        76    cmp_op ==              
+        77    pop_jump_if_false +3   (to 80)
+        78    load_const 6           ("")
+        79    store_var 23           (source)
+
+  173   80    load_var 22            (video)
+        81    call 313 ntypeargs=0   (baml.media.Video.url)
+        82    store_var 26           (_36)
+
+  174   83    load_var 22            (video)
+        84    call 314 ntypeargs=0   (baml.media.Video.file)
+        85    store_var 27           (_37)
+
+  175   86    load_var 22            (video)
+        87    call 315 ntypeargs=0   (baml.media.Video.base64)
+        88    store_var 28           (_38)
+
+  176   89    load_var 22            (video)
+        90    call 316 ntypeargs=0   (baml.media.Video.mime_type)
+        91    load_var 23            (source)
+        92    load_const 7           ("video")
+        93    call 783 ntypeargs=0   (ai.wire._media_mime_type)
+        94    store_var 29           (_39)
+
+  172   95    load_var2 26 27        
+        96    load_var2 28 29        
+        97    load_var 2             (fetch_url)
+        98    call 784 ntypeargs=0   (ai.wire._resolve_media_content)
+        99    jump +84               (to 183)
+
+  149   100   load_var 12            (_16)
+        101   store_var 13           (audio)
+
+  161   102   load_var 13            (audio)
+        103   call 307 ntypeargs=0   (baml.media.Audio.file)
+        104   store_var 16           (_20)
+        105   load_var 16            (_20)
+        106   store_var 15           (_19)
+        107   load_var 16            (_20)
+        108   load_const 3           (null)
+        109   cmp_op ==              
+        110   pop_jump_if_false +4   (to 114)
+        111   load_var 13            (audio)
+        112   call 306 ntypeargs=0   (baml.media.Audio.url)
+        113   store_var 15           (_19)
+        114   load_var 15            (_19)
+        115   store_var 14           (source)
+        116   load_var 15            (_19)
+        117   load_const 3           (null)
+        118   cmp_op ==              
+        119   pop_jump_if_false +3   (to 122)
+        120   load_const 8           ("")
+        121   store_var 14           (source)
+
+  163   122   load_var 13            (audio)
+        123   call 306 ntypeargs=0   (baml.media.Audio.url)
+        124   store_var 17           (_23)
+
+  164   125   load_var 13            (audio)
+        126   call 307 ntypeargs=0   (baml.media.Audio.file)
+        127   store_var 18           (_24)
+
+  165   128   load_var 13            (audio)
+        129   call 308 ntypeargs=0   (baml.media.Audio.base64)
+        130   store_var 19           (_25)
+
+  166   131   load_var 13            (audio)
+        132   call 309 ntypeargs=0   (baml.media.Audio.mime_type)
+        133   load_var 14            (source)
+        134   load_const 9           ("audio")
+        135   call 783 ntypeargs=0   (ai.wire._media_mime_type)
+        136   store_var 20           (_26)
+
+  162   137   load_var2 17 18        
+        138   load_var2 19 20        
+        139   load_var 2             (fetch_url)
+        140   call 784 ntypeargs=0   (ai.wire._resolve_media_content)
+        141   jump +42               (to 183)
+
+  149   142   load_var 3             (_3)
+        143   store_var 4            (image)
+
+  151   144   load_var 4             (image)
+        145   call 321 ntypeargs=0   (baml.media.Image.file)
+        146   store_var 7            (_7)
+        147   load_var 7             (_7)
+        148   store_var 6            (_6)
+        149   load_var 7             (_7)
+        150   load_const 3           (null)
+        151   cmp_op ==              
+        152   pop_jump_if_false +4   (to 156)
+        153   load_var 4             (image)
+        154   call 320 ntypeargs=0   (baml.media.Image.url)
+        155   store_var 6            (_6)
+        156   load_var 6             (_6)
+        157   store_var 5            (source)
+        158   load_var 6             (_6)
+        159   load_const 3           (null)
+        160   cmp_op ==              
+        161   pop_jump_if_false +3   (to 164)
+        162   load_const 10          ("")
+        163   store_var 5            (source)
+
+  153   164   load_var 4             (image)
+        165   call 320 ntypeargs=0   (baml.media.Image.url)
+        166   store_var 8            (_10)
+
+  154   167   load_var 4             (image)
+        168   call 321 ntypeargs=0   (baml.media.Image.file)
+        169   store_var 9            (_11)
+
+  155   170   load_var 4             (image)
+        171   call 322 ntypeargs=0   (baml.media.Image.base64)
+        172   store_var 10           (_12)
+
+  156   173   load_var 4             (image)
+        174   call 323 ntypeargs=0   (baml.media.Image.mime_type)
+        175   load_var 5             (source)
+        176   load_const 11          ("image")
+        177   call 783 ntypeargs=0   (ai.wire._media_mime_type)
+        178   store_var 11           (_13)
+
+  152   179   load_var2 8 9          
+        180   load_var2 10 11        
+        181   load_var 2             (fetch_url)
+        182   call 784 ntypeargs=0   (ai.wire._resolve_media_content)
+        183   return                 
 }
 
 function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
@@ -3315,7 +3932,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
   27   48   load_var2 2 3          
        49   load_field 0           (status_code)
        50   load_var 7             (text)
-       51   call 820 ntypeargs=0   (ai.errors.classify_http)
+       51   call 823 ntypeargs=0   (ai.errors.classify_http)
        52   throw                  
 }
 
@@ -3333,20 +3950,20 @@ function anthropic.AnthropicClient.ai.Client.id(self: anthropic.AnthropicClient)
 
 function anthropic.AnthropicClient.ai.Client.invoke(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   32   0   load_var2 1 2          
-       1   call 848 ntypeargs=0   (anthropic.internal.invoke)
+       1   call 854 ntypeargs=0   (anthropic.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   33   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 814 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function anthropic.AnthropicClient.ai.stream.StreamingClient.invoke_stream(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   40   0   load_var2 1 2          
-       1   call 850 ntypeargs=0   (anthropic.internal.invoke_stream)
+       1   call 856 ntypeargs=0   (anthropic.internal.invoke_stream)
        2   return                 
 }
 
@@ -3387,128 +4004,128 @@ function anthropic.AnthropicClient.new(model: string, api_key: string | null, ba
 }
 
 function anthropic.internal._anthropic_assistant_blocks(content: (ai.content.Text | ai.content.Reasoning | ai.content.ToolUse)[]) -> map<string, unknown>[] {
-  74   0    load_type 0                        
-       1    alloc_array 0                      
-       2    store_var 2                        (out)
+  149   0    load_type 0                        
+        1    alloc_array 0                      
+        2    store_var 2                        (out)
 
-  75   3    load_var 1                         (content)
-       4    load_type 1                        
-       5    load_const 2                       ("iter")
-       6    virtual_call nargs=1 ntypeargs=0   
-       7    store_var 3                        (_3)
-       8    load_var 3                         (_3)
-       9    load_type 3                        
-       10   load_const 4                       ("next")
-       11   virtual_call nargs=1 ntypeargs=0   
-       12   store_var 4                        (_4)
-       13   load_var 4                         (_4)
-       14   is_type 5                          
-       15   pop_jump_if_false +2               (to 17)
-       16   jump +81                           (to 97)
-       17   load_var 4                         (_4)
-       18   store_var 5                        (b)
+  150   3    load_var 1                         (content)
+        4    load_type 1                        
+        5    load_const 2                       ("iter")
+        6    virtual_call nargs=1 ntypeargs=0   
+        7    store_var 3                        (_3)
+        8    load_var 3                         (_3)
+        9    load_type 3                        
+        10   load_const 4                       ("next")
+        11   virtual_call nargs=1 ntypeargs=0   
+        12   store_var 4                        (_4)
+        13   load_var 4                         (_4)
+        14   is_type 5                          
+        15   pop_jump_if_false +2               (to 17)
+        16   jump +81                           (to 97)
+        17   load_var 4                         (_4)
+        18   store_var 5                        (b)
 
-  76   19   load_var 5                         (b)
-       20   store_var 6                        (_8)
-       21   load_var 6                         (_8)
-       22   narrow_bind 6 6                    
-       23   pop_jump_if_false +2               (to 25)
-       24   jump +48                           (to 72)
-       25   load_var 5                         (b)
-       26   store_var 9                        (_20)
-       27   load_var 9                         (_20)
-       28   narrow_bind 7 9                    
-       29   pop_jump_if_false +2               (to 31)
-       30   jump -22                           (to 8)
-       31   load_var 5                         (b)
-       32   store_var 10                       (u)
+  151   19   load_var 5                         (b)
+        20   store_var 6                        (_8)
+        21   load_var 6                         (_8)
+        22   narrow_bind 6 6                    
+        23   pop_jump_if_false +2               (to 25)
+        24   jump +48                           (to 72)
+        25   load_var 5                         (b)
+        26   store_var 9                        (_20)
+        27   load_var 9                         (_20)
+        28   narrow_bind 7 9                    
+        29   pop_jump_if_false +2               (to 31)
+        30   jump -22                           (to 8)
+        31   load_var 5                         (b)
+        32   store_var 10                       (u)
 
-  88   33   load_type 8                        
-       34   load_type 9                        
-       35   alloc_map 0                        
-       36   store_var 11                       (bb)
+  163   33   load_type 8                        
+        34   load_type 9                        
+        35   alloc_map 0                        
+        36   store_var 11                       (bb)
 
-  89   37   load_type 8                        
-       38   load_type 9                        
-       39   load_var 11                        (bb)
-       40   load_const 10                      ("type")
-       41   load_const 11                      ("tool_use")
-       42   call 37 ntypeargs=2                (baml.Map.set)
-       43   pop 1                              
+  164   37   load_type 8                        
+        38   load_type 9                        
+        39   load_var 11                        (bb)
+        40   load_const 10                      ("type")
+        41   load_const 11                      ("tool_use")
+        42   call 37 ntypeargs=2                (baml.Map.set)
+        43   pop 1                              
 
-  90   44   load_type 8                        
-       45   load_type 9                        
-       46   load_var 11                        (bb)
-       47   load_const 12                      ("id")
-       48   load_var 10                        (u)
-       49   load_field 0                       (id)
-       50   call 37 ntypeargs=2                (baml.Map.set)
-       51   pop 1                              
+  165   44   load_type 8                        
+        45   load_type 9                        
+        46   load_var 11                        (bb)
+        47   load_const 12                      ("id")
+        48   load_var 10                        (u)
+        49   load_field 0                       (id)
+        50   call 37 ntypeargs=2                (baml.Map.set)
+        51   pop 1                              
 
-  91   52   load_type 8                        
-       53   load_type 9                        
-       54   load_var 11                        (bb)
-       55   load_const 13                      ("name")
-       56   load_var 10                        (u)
-       57   load_field 1                       (name)
-       58   call 37 ntypeargs=2                (baml.Map.set)
-       59   pop 1                              
+  166   52   load_type 8                        
+        53   load_type 9                        
+        54   load_var 11                        (bb)
+        55   load_const 13                      ("name")
+        56   load_var 10                        (u)
+        57   load_field 1                       (name)
+        58   call 37 ntypeargs=2                (baml.Map.set)
+        59   pop 1                              
 
-  92   60   load_type 8                        
-       61   load_type 9                        
-       62   load_var 11                        (bb)
-       63   load_const 14                      ("input")
-       64   load_var 10                        (u)
-       65   load_field 2                       (args)
-       66   call 37 ntypeargs=2                (baml.Map.set)
-       67   pop 1                              
+  167   60   load_type 8                        
+        61   load_type 9                        
+        62   load_var 11                        (bb)
+        63   load_const 14                      ("input")
+        64   load_var 10                        (u)
+        65   load_field 2                       (args)
+        66   call 37 ntypeargs=2                (baml.Map.set)
+        67   pop 1                              
 
-  93   68   load_var2 2 11                     
-       69   call 4 ntypeargs=0                 (baml.Array.push)
-       70   pop 1                              
-       71   jump -63                           (to 8)
+  168   68   load_var2 2 11                     
+        69   call 4 ntypeargs=0                 (baml.Array.push)
+        70   pop 1                              
+        71   jump -63                           (to 8)
 
-  76   72   load_var 6                         (_8)
-       73   store_var 7                        (t)
+  151   72   load_var 6                         (_8)
+        73   store_var 7                        (t)
 
-  78   74   load_type 8                        
-       75   load_type 9                        
-       76   alloc_map 0                        
-       77   store_var 8                        (bb)
+  153   74   load_type 8                        
+        75   load_type 9                        
+        76   alloc_map 0                        
+        77   store_var 8                        (bb)
 
-  79   78   load_type 8                        
-       79   load_type 9                        
-       80   load_var 8                         (bb)
-       81   load_const 15                      ("type")
-       82   load_const 16                      ("text")
-       83   call 37 ntypeargs=2                (baml.Map.set)
-       84   pop 1                              
+  154   78   load_type 8                        
+        79   load_type 9                        
+        80   load_var 8                         (bb)
+        81   load_const 15                      ("type")
+        82   load_const 16                      ("text")
+        83   call 37 ntypeargs=2                (baml.Map.set)
+        84   pop 1                              
 
-  80   85   load_type 8                        
-       86   load_type 9                        
-       87   load_var 8                         (bb)
-       88   load_const 17                      ("text")
-       89   load_var 7                         (t)
-       90   load_field 0                       (text)
-       91   call 37 ntypeargs=2                (baml.Map.set)
-       92   pop 1                              
+  155   85   load_type 8                        
+        86   load_type 9                        
+        87   load_var 8                         (bb)
+        88   load_const 17                      ("text")
+        89   load_var 7                         (t)
+        90   load_field 0                       (text)
+        91   call 37 ntypeargs=2                (baml.Map.set)
+        92   pop 1                              
 
-  81   93   load_var2 2 8                      
-       94   call 4 ntypeargs=0                 (baml.Array.push)
-       95   pop 1                              
-       96   jump -88                           (to 8)
+  156   93   load_var2 2 8                      
+        94   call 4 ntypeargs=0                 (baml.Array.push)
+        95   pop 1                              
+        96   jump -88                           (to 8)
 
-  98   97   load_var 2                         (out)
-       98   return                             
+  173   97   load_var 2                         (out)
+        98   return                             
 }
 
 function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone)[] {
-  348   0     load_type 0                        
+  423   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 2                        (out)
 
-  349   3     load_var 1                         (batch)
-        4     call 802 ntypeargs=0               (ai.stream.decode_sse_batch)
+  424   3     load_var 1                         (batch)
+        4     call 805 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -3525,31 +4142,31 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         18    load_var 4                         (_5)
         19    store_var_load_var 5               (raw)
 
-  350   20    load_field 1                       (data)
+  425   20    load_field 1                       (data)
         21    store_var 6                        (_10)
         22    load_var 6                         (_10)
         23    narrow_bind 6 6                    
         24    pop_jump_if_false -15              (to 9)
 
-  351   25    load_type 7                        
+  426   25    load_type 7                        
 
-  350   26    load_var 6                         (_10)
+  425   26    load_var 6                         (_10)
         27    call 333 ntypeargs=1               (baml.json.from_string)
         28    jump +4                            (to 32)
 
-  351   29    load_var 7                         (e)
+  426   29    load_var 7                         (e)
         30    throw_if_panic                     
 
-  352   31    load_const 8                       (null)
+  427   31    load_const 8                       (null)
 
-  354   32    store_var 8                        (_16)
+  429   32    store_var 8                        (_16)
         33    load_var 8                         (_16)
         34    narrow_bind 9 8                    
         35    pop_jump_if_false -26              (to 9)
         36    load_var 8                         (_16)
         37    store_var 9                        (event)
 
-  355   38    load_var 9                         (event)
+  430   38    load_var 9                         (event)
         39    load_field 0                       (type)
         40    store_var 12                       (_20)
         41    load_var 12                        (_20)
@@ -3570,36 +4187,36 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         56    load_const 10                      ("")
         57    store_var 10                       (t)
 
-  356   58    load_var 10                        (t)
+  431   58    load_var 10                        (t)
         59    load_const 11                      ("content_block_delta")
         60    cmp_op ==                          
         61    pop_jump_if_false +2               (to 63)
         62    jump +139                          (to 201)
 
-  372   63    load_var 10                        (t)
+  447   63    load_var 10                        (t)
         64    load_const 12                      ("message_start")
         65    cmp_op ==                          
         66    pop_jump_if_false +2               (to 68)
         67    jump +73                           (to 140)
 
-  381   68    load_var 10                        (t)
+  456   68    load_var 10                        (t)
         69    load_const 13                      ("message_delta")
         70    cmp_op ==                          
         71    pop_jump_if_false +2               (to 73)
         72    jump +10                           (to 82)
 
-  394   73    load_var 10                        (t)
+  469   73    load_var 10                        (t)
         74    load_const 14                      ("message_stop")
         75    cmp_op ==                          
         76    pop_jump_if_false -67              (to 9)
 
-  395   77    load_var 2                         (out)
-        78    alloc_instance 358 ntypeargs=0     (ai.stream.TurnDone)
+  470   77    load_var 2                         (out)
+        78    alloc_instance 360 ntypeargs=0     (ai.stream.TurnDone)
         79    call 4 ntypeargs=0                 (baml.Array.push)
         80    pop 1                              
         81    jump -72                           (to 9)
 
-  382   82    load_var 9                         (event)
+  457   82    load_var 9                         (event)
         83    load_field 1                       (delta)
         84    load_const 8                       (null)
         85    cmp_op ==                          
@@ -3618,17 +4235,17 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         98    pop_jump_if_false +2               (to 100)
         99    jump +5                            (to 104)
         100   load_var 21                        (_65)
-        101   call 847 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+        101   call 853 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         102   store_var 20                       (stop)
         103   jump +3                            (to 106)
 
-  383   104   load_const 8                       (null)
+  458   104   load_const 8                       (null)
         105   store_var 20                       (stop)
 
-  388   106   load_var 20                        (stop)
+  463   106   load_var 20                        (stop)
         107   store_var 22                       (_74)
 
-  389   108   load_var 9                         (event)
+  464   108   load_var 9                         (event)
         109   load_field 3                       (usage)
         110   load_const 8                       (null)
         111   cmp_op ==                          
@@ -3642,7 +4259,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         119   load_const 8                       (null)
         120   store_var 23                       (_75)
 
-  390   121   load_var 9                         (event)
+  465   121   load_var 9                         (event)
         122   load_field 3                       (usage)
         123   load_const 8                       (null)
         124   cmp_op ==                          
@@ -3656,15 +4273,15 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         132   load_const 8                       (null)
         133   store_var 24                       (_79)
 
-  386   134   load_var2 2 22                     
+  461   134   load_var2 2 22                     
 
-  387   135   load_var2 23 24                    
+  462   135   load_var2 23 24                    
         136   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
         137   call 4 ntypeargs=0                 (baml.Array.push)
         138   pop 1                              
         139   jump -130                          (to 9)
 
-  376   140   load_var 9                         (event)
+  451   140   load_var 9                         (event)
         141   load_field 2                       (message)
         142   load_const 8                       (null)
         143   cmp_op ==                          
@@ -3692,7 +4309,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         165   load_const 8                       (null)
         166   store_var 18                       (_42)
 
-  377   167   load_var 9                         (event)
+  452   167   load_var 9                         (event)
         168   load_field 2                       (message)
         169   load_const 8                       (null)
         170   cmp_op ==                          
@@ -3720,16 +4337,16 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         192   load_const 8                       (null)
         193   store_var 19                       (_52)
 
-  373   194   load_var 2                         (out)
+  448   194   load_var 2                         (out)
 
-  374   195   load_const 8                       (null)
+  449   195   load_const 8                       (null)
         196   load_var2 18 19                    
         197   init_instance 1                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
         198   call 4 ntypeargs=0                 (baml.Array.push)
         199   pop 1                              
         200   jump -191                          (to 9)
 
-  357   201   load_var 9                         (event)
+  432   201   load_var 9                         (event)
         202   load_field 1                       (delta)
         203   store_var 13                       (_26)
         204   load_var 13                        (_26)
@@ -3738,7 +4355,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         207   load_var 13                        (_26)
         208   store_var 14                       (d)
 
-  358   209   load_var 14                        (d)
+  433   209   load_var 14                        (d)
         210   load_field 0                       (type)
         211   store_var 16                       (_30)
         212   load_var 16                        (_30)
@@ -3754,30 +4371,30 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         222   cmp_op ==                          
         223   pop_jump_if_false -214             (to 9)
 
-  359   224   load_var 14                        (d)
+  434   224   load_var 14                        (d)
         225   load_field 1                       (text)
         226   store_var 17                       (_33)
         227   load_var 17                        (_33)
         228   narrow_bind 6 17                   
         229   pop_jump_if_false -220             (to 9)
 
-  360   230   load_var2 2 17                     
+  435   230   load_var2 2 17                     
 
-  359   231   init_instance 2                    (ai.stream.TextDelta .text)
+  434   231   init_instance 2                    (ai.stream.TextDelta .text)
         232   call 4 ntypeargs=0                 (baml.Array.push)
         233   pop 1                              
         234   jump -225                          (to 9)
 
-  409   235   load_var 2                         (out)
+  484   235   load_var 2                         (out)
         236   return                             
 }
 
 function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic.internal.AnthropicMessage[] {
-  131   0     load_type 0                        
+  206   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 2                        (msgs)
 
-  132   3     load_var 1                         (j)
+  207   3     load_var 1                         (j)
         4     call 760 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
@@ -3795,7 +4412,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         18    load_var 4                         (_5)
         19    store_var 5                        (e)
 
-  133   20    load_var 5                         (e)
+  208   20    load_var 5                         (e)
         21    store_var 6                        (_10)
         22    load_var 6                         (_10)
         23    narrow_bind 6 6                    
@@ -3821,35 +4438,35 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         43    load_var 13                        (_35)
         44    store_var 14                       (f)
 
-  154   45    load_var2 2 14                     
+  229   45    load_var2 2 14                     
         46    load_field 0                       (id)
         47    load_var 14                        (f)
         48    load_field 1                       (message)
         49    load_const 10                      (true)
-        50    call 843 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        50    call 849 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         51    pop 1                              
         52    jump -43                           (to 9)
 
-  133   53    load_var 11                        (_30)
+  208   53    load_var 11                        (_30)
         54    store_var 12                       (c)
 
-  152   55    load_var2 2 12                     
+  227   55    load_var2 2 12                     
         56    load_field 0                       (id)
         57    load_var 12                        (c)
         58    load_field 1                       (output)
         59    load_const 11                      (false)
-        60    call 843 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        60    call 849 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         61    pop 1                              
         62    jump -53                           (to 9)
 
-  133   63    load_var 9                         (_24)
+  208   63    load_var 9                         (_24)
         64    load_field 0                       (content)
-        65    call 842 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
+        65    call 848 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
         66    store_var 10                       (_28)
 
-  142   67    load_var 2                         (msgs)
+  217   67    load_var 2                         (msgs)
 
-  143   68    load_const 12                      ("assistant")
+  218   68    load_const 12                      ("assistant")
         69    load_const 11                      (false)
         70    load_var 10                        (_28)
         71    init_instance 0                    (anthropic.internal.AnthropicMessage .role, .tool_results, .blocks)
@@ -3857,15 +4474,15 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         73    pop 1                              
         74    jump -65                           (to 9)
 
-  133   75    load_var 6                         (_10)
+  208   75    load_var 6                         (_10)
         76    store_var 7                        (m)
 
-  135   77    load_type 13                       
+  210   77    load_type 13                       
         78    load_type 14                       
         79    alloc_map 0                        
         80    store_var 8                        (block)
 
-  136   81    load_type 13                       
+  211   81    load_type 13                       
         82    load_type 14                       
         83    load_var 8                         (block)
         84    load_const 15                      ("type")
@@ -3873,7 +4490,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         86    call 37 ntypeargs=2                (baml.Map.set)
         87    pop 1                              
 
-  137   88    load_type 13                       
+  212   88    load_type 13                       
         89    load_type 14                       
         90    load_var 8                         (block)
         91    load_const 17                      ("text")
@@ -3882,7 +4499,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         94    call 37 ntypeargs=2                (baml.Map.set)
         95    pop 1                              
 
-  138   96    load_var 2                         (msgs)
+  213   96    load_var 2                         (msgs)
         97    load_const 18                      ("user")
         98    load_const 11                      (false)
         99    load_var 8                         (block)
@@ -3893,108 +4510,378 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         104   pop 1                              
         105   jump -96                           (to 9)
 
-  158   106   load_var 2                         (msgs)
+  233   106   load_var 2                         (msgs)
         107   return                             
 }
 
 function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthropic.internal.AnthropicPrompt {
-  51   0    load_type 0                        
-       1    alloc_array 0                      
-       2    store_var 2                        (system)
+  121   0    load_type 0                        
+        1    alloc_array 0                      
+        2    store_var 2                        (system)
 
-  52   3    load_type 1                        
-       4    alloc_array 0                      
-       5    store_var 3                        (messages)
+  122   3    load_type 1                        
+        4    alloc_array 0                      
+        5    store_var 3                        (messages)
 
-  53   6    load_var 1                         (prompt)
-       7    call 764 ntypeargs=0               (ai.Prompt.messages)
-       8    load_type 2                        
-       9    load_const 3                       ("iter")
-       10   virtual_call nargs=1 ntypeargs=0   
-       11   store_var 4                        (_5)
-       12   load_var 4                         (_5)
-       13   load_type 4                        
-       14   load_const 5                       ("next")
-       15   virtual_call nargs=1 ntypeargs=0   
-       16   store_var 5                        (_6)
-       17   load_var 5                         (_6)
-       18   is_type 6                          
-       19   pop_jump_if_false +2               (to 21)
-       20   jump +52                           (to 72)
-       21   load_var 5                         (_6)
-       22   store_var 6                        (message)
+  123   6    load_var 1                         (prompt)
+        7    call 764 ntypeargs=0               (ai.Prompt.messages)
+        8    load_type 2                        
+        9    load_const 3                       ("iter")
+        10   virtual_call nargs=1 ntypeargs=0   
+        11   store_var 4                        (_5)
+        12   load_var 4                         (_5)
+        13   load_type 4                        
+        14   load_const 5                       ("next")
+        15   virtual_call nargs=1 ntypeargs=0   
+        16   store_var 5                        (_6)
+        17   load_var 5                         (_6)
+        18   is_type 6                          
+        19   pop_jump_if_false +2               (to 21)
+        20   jump +51                           (to 71)
+        21   load_var 5                         (_6)
+        22   store_var_load_var 6               (message)
 
-  54   23   load_type 7                        
-       24   load_type 8                        
-       25   alloc_map 0                        
-       26   store_var 7                        (block)
+  124   23   load_field 0                       (role)
+        24   load_const 7                       ("system")
+        25   cmp_op ==                          
+        26   pop_jump_if_false +2               (to 28)
+        27   jump +24                           (to 51)
 
-  55   27   load_type 7                        
-       28   load_type 8                        
-       29   load_var 7                         (block)
-       30   load_const 9                       ("type")
-       31   load_const 10                      ("text")
-       32   call 37 ntypeargs=2                (baml.Map.set)
-       33   pop 1                              
+  130   28   load_var 6                         (message)
+        29   load_field 0                       (role)
+        30   load_const 8                       ("assistant")
+        31   cmp_op ==                          
+        32   pop_jump_if_false +2               (to 34)
+        33   jump +4                            (to 37)
 
-  56   34   load_type 7                        
-       35   load_type 8                        
-       36   load_var 7                         (block)
-       37   load_const 11                      ("text")
-       38   load_var 6                         (message)
-       39   load_field 1                       (content)
-       40   call 37 ntypeargs=2                (baml.Map.set)
-       41   pop 1                              
+  133   34   load_const 9                       ("user")
+        35   store_var 9                        (role)
 
-  57   42   load_var 6                         (message)
-       43   load_field 0                       (role)
-       44   load_const 12                      ("system")
-       45   cmp_op ==                          
-       46   pop_jump_if_false +2               (to 48)
-       47   jump +21                           (to 68)
+  130   36   jump +3                            (to 39)
 
-  61   48   load_var 6                         (message)
-       49   load_field 0                       (role)
-       50   load_const 13                      ("assistant")
-       51   cmp_op ==                          
-       52   pop_jump_if_false +2               (to 54)
-       53   jump +4                            (to 57)
+  131   37   load_const 10                      ("assistant")
+        38   store_var 9                        (role)
 
-  64   54   load_const 14                      ("user")
-       55   store_var 8                        (role)
+  137   39   load_var 9                         (role)
+        40   store_var 10                       (_26)
 
-  61   56   jump +3                            (to 59)
+  139   41   load_var2 6 9                      
+        42   call 846 ntypeargs=0               (anthropic.internal._anthropic_prompt_blocks)
+        43   store_var 11                       (_27)
 
-  62   57   load_const 15                      ("assistant")
-       58   store_var 8                        (role)
+  135   44   load_var2 3 10                     
 
-  66   59   load_var2 3 8                      
-       60   load_const 16                      (false)
-       61   load_var 7                         (block)
-       62   load_type 0                        
-       63   alloc_array 1                      
-       64   init_instance 0                    (anthropic.internal.AnthropicMessage .role, .tool_results, .blocks)
-       65   call 4 ntypeargs=0                 (baml.Array.push)
-       66   pop 1                              
-       67   jump -55                           (to 12)
+  136   45   load_const 11                      (false)
+        46   load_var 11                        (_27)
+        47   init_instance 0                    (anthropic.internal.AnthropicMessage .role, .tool_results, .blocks)
+        48   call 4 ntypeargs=0                 (baml.Array.push)
+        49   pop 1                              
+        50   jump -38                           (to 12)
 
-  58   68   load_var2 2 7                      
-       69   call 4 ntypeargs=0                 (baml.Array.push)
-       70   pop 1                              
-       71   jump -59                           (to 12)
+  125   51   load_var 6                         (message)
+        52   load_const 12                      ("system")
+        53   call 846 ntypeargs=0               (anthropic.internal._anthropic_prompt_blocks)
+        54   load_type 13                       
+        55   load_const 14                      ("iter")
+        56   virtual_call nargs=1 ntypeargs=0   
+        57   store_var 7                        (_14)
+        58   load_var 7                         (_14)
+        59   load_type 15                       
+        60   load_const 16                      ("next")
+        61   virtual_call nargs=1 ntypeargs=0   
+        62   store_var 8                        (_15)
+        63   load_var 8                         (_15)
+        64   is_type 6                          
+        65   pop_jump_if_false +2               (to 67)
+        66   jump -54                           (to 12)
 
-  70   72   load_var2 2 3                      
-       73   init_instance 1                    (anthropic.internal.AnthropicPrompt .system, .messages)
-       74   return                             
+  126   67   load_var2 2 8                      
+
+  125   68   call 4 ntypeargs=0                 (baml.Array.push)
+        69   pop 1                              
+        70   jump -12                           (to 58)
+
+  145   71   load_var2 2 3                      
+        72   init_instance 1                    (anthropic.internal.AnthropicPrompt .system, .messages)
+        73   return                             
+}
+
+function anthropic.internal._anthropic_media_block(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf, block_type: string) -> map<string, unknown> {
+  51   0    load_var 1             (media)
+       1    load_const 0           (false)
+       2    call 785 ntypeargs=0   (ai.wire.resolve_media)
+       3    store_var 3            (resolved)
+
+  52   4    load_type 1            
+       5    load_type 2            
+       6    alloc_map 0            
+       7    store_var 4            (source)
+
+  53   8    load_var 3             (resolved)
+       9    load_field 0           (url)
+       10   store_var 5            (_6)
+       11   load_var 5             (_6)
+       12   narrow_bind 3 5        
+       13   pop_jump_if_false +2   (to 15)
+       14   jump +35               (to 49)
+
+  58   15   load_type 1            
+       16   load_type 2            
+       17   load_var 4             (source)
+       18   load_const 4           ("type")
+       19   load_const 5           ("base64")
+       20   call 37 ntypeargs=2    (baml.Map.set)
+       21   pop 1                  
+
+  59   22   load_type 1            
+       23   load_type 2            
+       24   load_var 4             (source)
+       25   load_const 6           ("media_type")
+       26   load_var 3             (resolved)
+       27   load_field 2           (mime_type)
+       28   call 37 ntypeargs=2    (baml.Map.set)
+       29   pop 1                  
+
+  60   30   load_var 3             (resolved)
+       31   load_field 1           (base64)
+       32   store_var 8            (_24)
+       33   load_var 8             (_24)
+       34   store_var 7            (_23)
+       35   load_var 8             (_24)
+       36   load_const 7           (null)
+       37   cmp_op ==              
+       38   pop_jump_if_false +3   (to 41)
+       39   load_const 8           ("")
+       40   store_var 7            (_23)
+       41   load_type 1            
+       42   load_type 2            
+       43   load_var 4             (source)
+       44   load_const 9           ("data")
+       45   load_var 7             (_23)
+       46   call 37 ntypeargs=2    (baml.Map.set)
+       47   pop 1                  
+       48   jump +17               (to 65)
+
+  53   49   load_var 5             (_6)
+       50   store_var 6            (url)
+
+  54   51   load_type 1            
+       52   load_type 2            
+       53   load_var 4             (source)
+       54   load_const 10          ("type")
+       55   load_const 11          ("url")
+       56   call 37 ntypeargs=2    (baml.Map.set)
+       57   pop 1                  
+
+  55   58   load_type 1            
+       59   load_type 2            
+       60   load_var 4             (source)
+       61   load_const 12          ("url")
+       62   load_var 6             (url)
+       63   call 37 ntypeargs=2    (baml.Map.set)
+       64   pop 1                  
+
+  63   65   load_type 1            
+       66   load_type 2            
+       67   alloc_map 0            
+       68   store_var 9            (block)
+
+  64   69   load_type 1            
+       70   load_type 2            
+       71   load_var 9             (block)
+       72   load_const 13          ("type")
+       73   load_var 2             (block_type)
+       74   call 37 ntypeargs=2    (baml.Map.set)
+       75   pop 1                  
+
+  65   76   load_type 1            
+       77   load_type 2            
+       78   load_var 9             (block)
+       79   load_const 14          ("source")
+       80   load_var 4             (source)
+       81   call 37 ntypeargs=2    (baml.Map.set)
+       82   pop 1                  
+
+  66   83   load_var 9             (block)
+       84   return                 
+}
+
+function anthropic.internal._anthropic_prompt_blocks(message: ai.PromptMessage, role: string) -> map<string, unknown>[] {
+  73    0     load_type 0                        
+        1     alloc_array 0                      
+        2     store_var 3                        (blocks)
+
+  74    3     load_var 1                         (message)
+        4     load_field 2                       (parts)
+        5     load_type 1                        
+        6     load_const 2                       ("iter")
+        7     virtual_call nargs=1 ntypeargs=0   
+        8     store_var 4                        (_5)
+        9     load_var 4                         (_5)
+        10    load_type 3                        
+        11    load_const 4                       ("next")
+        12    virtual_call nargs=1 ntypeargs=0   
+        13    store_var 5                        (_6)
+        14    load_var 5                         (_6)
+        15    is_type 5                          
+        16    pop_jump_if_false +2               (to 18)
+        17    jump +126                          (to 143)
+        18    load_var 5                         (_6)
+        19    store_var 6                        (part)
+
+  75    20    load_var 6                         (part)
+        21    store_var 7                        (_10)
+        22    load_var 7                         (_10)
+        23    narrow_bind 6 7                    
+        24    pop_jump_if_false +2               (to 26)
+        25    jump +94                           (to 119)
+        26    load_var 6                         (part)
+        27    store_var 10                       (_22)
+        28    load_var 10                        (_22)
+        29    narrow_bind 7 10                   
+        30    pop_jump_if_false +2               (to 32)
+        31    jump +64                           (to 95)
+        32    load_var 6                         (part)
+        33    store_var 14                       (_32)
+        34    load_var 14                        (_32)
+        35    narrow_bind 8 14                   
+        36    pop_jump_if_false +2               (to 38)
+        37    jump +34                           (to 71)
+        38    load_var 6                         (part)
+        39    store_var 18                       (_42)
+        40    load_var 18                        (_42)
+        41    narrow_bind 9 18                   
+        42    pop_jump_if_false +2               (to 44)
+        43    jump +4                            (to 47)
+
+  111   44    load_const 10                      ("Anthropic does not support video prompt input")
+        45    init_instance 0                    (baml.errors.InvalidArgument .message)
+        46    throw                              
+
+  75    47    load_var 18                        (_42)
+        48    store_var 19                       (pdf)
+
+  102   49    load_var 2                         (role)
+        50    load_const 11                      ("user")
+        51    cmp_op !=                          
+        52    pop_jump_if_false +2               (to 54)
+        53    jump +9                            (to 62)
+
+  107   54    load_var 19                        (pdf)
+        55    load_const 12                      ("document")
+        56    call 845 ntypeargs=0               (anthropic.internal._anthropic_media_block)
+        57    store_var 21                       (_50)
+        58    load_var2 3 21                     
+        59    call 4 ntypeargs=0                 (baml.Array.push)
+        60    pop 1                              
+        61    jump -52                           (to 9)
+
+  104   62    load_type 13                       
+        63    load_var 2                         (role)
+        64    call 138 ntypeargs=1               (baml.String.from)
+        65    store_var 20                       (_47)
+        66    load_const 14                      ("Anthropic only supports PDF input in user messages, found ")
+        67    load_var 20                        (_47)
+        68    bin_op +                           
+        69    init_instance 1                    (baml.errors.InvalidArgument .message)
+        70    throw                              
+
+  75    71    load_var 14                        (_32)
+        72    store_var 15                       (audio)
+
+  93    73    load_var 2                         (role)
+        74    load_const 15                      ("user")
+        75    cmp_op !=                          
+        76    pop_jump_if_false +2               (to 78)
+        77    jump +9                            (to 86)
+
+  98    78    load_var 15                        (audio)
+        79    load_const 16                      ("input_audio")
+        80    call 845 ntypeargs=0               (anthropic.internal._anthropic_media_block)
+        81    store_var 17                       (_40)
+        82    load_var2 3 17                     
+        83    call 4 ntypeargs=0                 (baml.Array.push)
+        84    pop 1                              
+        85    jump -76                           (to 9)
+
+  95    86    load_type 13                       
+        87    load_var 2                         (role)
+        88    call 138 ntypeargs=1               (baml.String.from)
+        89    store_var 16                       (_37)
+        90    load_const 17                      ("Anthropic only supports audio input in user messages, found ")
+        91    load_var 16                        (_37)
+        92    bin_op +                           
+        93    init_instance 2                    (baml.errors.InvalidArgument .message)
+        94    throw                              
+
+  75    95    load_var 10                        (_22)
+        96    store_var 11                       (image)
+
+  84    97    load_var 2                         (role)
+        98    load_const 18                      ("user")
+        99    cmp_op !=                          
+        100   pop_jump_if_false +2               (to 102)
+        101   jump +9                            (to 110)
+
+  89    102   load_var 11                        (image)
+        103   load_const 19                      ("image")
+        104   call 845 ntypeargs=0               (anthropic.internal._anthropic_media_block)
+        105   store_var 13                       (_30)
+        106   load_var2 3 13                     
+        107   call 4 ntypeargs=0                 (baml.Array.push)
+        108   pop 1                              
+        109   jump -100                          (to 9)
+
+  86    110   load_type 13                       
+        111   load_var 2                         (role)
+        112   call 138 ntypeargs=1               (baml.String.from)
+        113   store_var 12                       (_27)
+        114   load_const 20                      ("Anthropic only supports image input in user messages, found ")
+        115   load_var 12                        (_27)
+        116   bin_op +                           
+        117   init_instance 3                    (baml.errors.InvalidArgument .message)
+        118   throw                              
+
+  75    119   load_var 7                         (_10)
+        120   store_var 8                        (text)
+
+  77    121   load_type 13                       
+        122   load_type 21                       
+        123   alloc_map 0                        
+        124   store_var 9                        (block)
+
+  78    125   load_type 13                       
+        126   load_type 21                       
+        127   load_var 9                         (block)
+        128   load_const 22                      ("type")
+        129   load_const 23                      ("text")
+        130   call 37 ntypeargs=2                (baml.Map.set)
+        131   pop 1                              
+
+  79    132   load_type 13                       
+        133   load_type 21                       
+        134   load_var 9                         (block)
+        135   load_const 24                      ("text")
+        136   load_var 8                         (text)
+        137   call 37 ntypeargs=2                (baml.Map.set)
+        138   pop 1                              
+
+  80    139   load_var2 3 9                      
+        140   call 4 ntypeargs=0                 (baml.Array.push)
+        141   pop 1                              
+        142   jump -133                          (to 9)
+
+  117   143   load_var 3                         (blocks)
+        144   return                             
 }
 
 function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal.AnthropicMessage[], id: string, content: string, is_error: bool) -> null {
-  108   0    load_type 0            
+  183   0    load_type 0            
         1    load_type 1            
         2    alloc_map 0            
         3    store_var 5            (block)
 
-  109   4    load_type 0            
+  184   4    load_type 0            
         5    load_type 1            
         6    load_var 5             (block)
         7    load_const 2           ("type")
@@ -4002,7 +4889,7 @@ function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal
         9    call 37 ntypeargs=2    (baml.Map.set)
         10   pop 1                  
 
-  110   11   load_type 0            
+  185   11   load_type 0            
         12   load_type 1            
         13   load_var 5             (block)
         14   load_const 4           ("tool_use_id")
@@ -4010,7 +4897,7 @@ function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal
         16   call 37 ntypeargs=2    (baml.Map.set)
         17   pop 1                  
 
-  111   18   load_type 0            
+  186   18   load_type 0            
         19   load_type 1            
         20   load_var 5             (block)
         21   load_const 5           ("content")
@@ -4018,7 +4905,7 @@ function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal
         23   call 37 ntypeargs=2    (baml.Map.set)
         24   pop 1                  
 
-  112   25   load_type 0            
+  187   25   load_type 0            
         26   load_type 1            
         27   load_var 5             (block)
         28   load_const 6           ("is_error")
@@ -4026,7 +4913,7 @@ function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal
         30   call 37 ntypeargs=2    (baml.Map.set)
         31   pop 1                  
 
-  114   32   load_var 1             (msgs)
+  189   32   load_var 1             (msgs)
         33   container_len          
         34   store_var 6            (_20)
         35   load_type 7            
@@ -4040,7 +4927,7 @@ function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal
         43   pop_jump_if_false +2   (to 45)
         44   jump +12               (to 56)
 
-  123   45   load_var 1             (msgs)
+  198   45   load_var 1             (msgs)
         46   load_const 10          ("user")
         47   load_const 11          (true)
         48   load_var 5             (block)
@@ -4050,17 +4937,17 @@ function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal
         52   call 4 ntypeargs=0     (baml.Array.push)
         53   pop 1                  
 
-  124   54   load_const 13          (null)
+  199   54   load_const 13          (null)
 
-  114   55   jump +24               (to 79)
+  189   55   jump +24               (to 79)
         56   load_var 7             (_22)
         57   store_var_load_var 8   (m)
 
-  115   58   load_field 1           (tool_results)
+  190   58   load_field 1           (tool_results)
         59   pop_jump_if_false +2   (to 61)
         60   jump +12               (to 72)
 
-  119   61   load_var 1             (msgs)
+  194   61   load_var 1             (msgs)
         62   load_const 14          ("user")
         63   load_const 11          (true)
         64   load_var 5             (block)
@@ -4070,27 +4957,27 @@ function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal
         68   call 4 ntypeargs=0     (baml.Array.push)
         69   pop 1                  
 
-  120   70   load_const 13          (null)
+  195   70   load_const 13          (null)
 
-  115   71   jump +8                (to 79)
+  190   71   jump +8                (to 79)
 
-  116   72   load_type 12           
+  191   72   load_type 12           
         73   load_var 8             (m)
         74   load_field 2           (blocks)
         75   load_var 5             (block)
         76   call 4 ntypeargs=1     (baml.Array.push)
         77   pop 1                  
 
-  117   78   load_const 13          (null)
+  192   78   load_const 13          (null)
         79   return                 
 }
 
 function anthropic.internal._anthropic_render_messages(msgs: anthropic.internal.AnthropicMessage[]) -> map<string, unknown>[] {
-  162   0    load_type 0                        
+  237   0    load_type 0                        
         1    alloc_array 0                      
         2    store_var 2                        (out)
 
-  163   3    load_var 1                         (msgs)
+  238   3    load_var 1                         (msgs)
         4    load_type 1                        
         5    load_const 2                       ("iter")
         6    virtual_call nargs=1 ntypeargs=0   
@@ -4107,12 +4994,12 @@ function anthropic.internal._anthropic_render_messages(msgs: anthropic.internal.
         17   load_var 4                         (_4)
         18   store_var 5                        (m)
 
-  164   19   load_type 6                        
+  239   19   load_type 6                        
         20   load_type 7                        
         21   alloc_map 0                        
         22   store_var 6                        (mm)
 
-  165   23   load_type 6                        
+  240   23   load_type 6                        
         24   load_type 7                        
         25   load_var 6                         (mm)
         26   load_const 8                       ("role")
@@ -4121,7 +5008,7 @@ function anthropic.internal._anthropic_render_messages(msgs: anthropic.internal.
         29   call 37 ntypeargs=2                (baml.Map.set)
         30   pop 1                              
 
-  166   31   load_type 6                        
+  241   31   load_type 6                        
         32   load_type 7                        
         33   load_var 6                         (mm)
         34   load_const 9                       ("content")
@@ -4130,17 +5017,17 @@ function anthropic.internal._anthropic_render_messages(msgs: anthropic.internal.
         37   call 37 ntypeargs=2                (baml.Map.set)
         38   pop 1                              
 
-  167   39   load_var2 2 6                      
+  242   39   load_var2 2 6                      
         40   call 4 ntypeargs=0                 (baml.Array.push)
         41   pop 1                              
         42   jump -34                           (to 8)
 
-  169   43   load_var 2                         (out)
+  244   43   load_var 2                         (out)
         44   return                             
 }
 
 function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
-  182   0     load_var 2                         (input)
+  257   0     load_var 2                         (input)
         1     load_field 0                       (prompt)
         2     store_var 4                        (_5)
         3     load_var 2                         (input)
@@ -4149,20 +5036,20 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         6     load_var 4                         (_5)
         7     call_indirect                      
 
-  183   8     call 841 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
+  258   8     call 847 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
         9     store_var 5                        (prompt_parts)
 
-  184   10    load_var 5                         (prompt_parts)
+  259   10    load_var 5                         (prompt_parts)
         11    load_field 0                       (system)
         12    store_var 6                        (system)
 
-  185   13    load_var 5                         (prompt_parts)
+  260   13    load_var 5                         (prompt_parts)
         14    load_field 1                       (messages)
         15    store_var 7                        (lowered)
 
-  186   16    load_var 2                         (input)
+  261   16    load_var 2                         (input)
         17    load_field 1                       (journal)
-        18    call 844 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
+        18    call 850 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
         19    load_type 0                        
         20    load_const 1                       ("iter")
         21    virtual_call nargs=1 ntypeargs=0   
@@ -4177,18 +5064,18 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         30    pop_jump_if_false +2               (to 32)
         31    jump +5                            (to 36)
 
-  187   32    load_var2 7 9                      
+  262   32    load_var2 7 9                      
 
-  186   33    call 4 ntypeargs=0                 (baml.Array.push)
+  261   33    call 4 ntypeargs=0                 (baml.Array.push)
         34    pop 1                              
         35    jump -12                           (to 23)
 
-  190   36    load_type 5                        
+  265   36    load_type 5                        
         37    load_type 6                        
         38    alloc_map 0                        
         39    store_var 10                       (body)
 
-  191   40    load_type 5                        
+  266   40    load_type 5                        
         41    load_type 6                        
         42    load_var 10                        (body)
         43    load_const 7                       ("model")
@@ -4197,7 +5084,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         46    call 37 ntypeargs=2                (baml.Map.set)
         47    pop 1                              
 
-  192   48    load_type 5                        
+  267   48    load_type 5                        
         49    load_type 6                        
         50    load_var 10                        (body)
         51    load_const 8                       ("max_tokens")
@@ -4206,7 +5093,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         54    call 37 ntypeargs=2                (baml.Map.set)
         55    pop 1                              
 
-  198   56    load_type 9                        
+  273   56    load_type 9                        
         57    load_var 7                         (lowered)
         58    load_const 10                      (0)
         59    call 3 ntypeargs=1                 (baml.Array.at)
@@ -4232,7 +5119,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         79    load_const 12                      ("")
         80    store_var 11                       (first_role)
 
-  199   81    load_var 11                        (first_role)
+  274   81    load_var 11                        (first_role)
         82    load_const 13                      ("user")
         83    cmp_op !=                          
         84    jump_if_false +8                   (to 92)
@@ -4246,7 +5133,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         92    pop_jump_if_false +2               (to 94)
         93    jump +26                           (to 119)
 
-  204   94    load_var 6                         (system)
+  279   94    load_var 6                         (system)
         95    container_len                      
         96    store_var 15                       (_54)
         97    load_var 15                        (_54)
@@ -4254,7 +5141,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         99    cmp_int_op >                       
         100   pop_jump_if_false +8               (to 108)
 
-  205   101   load_type 5                        
+  280   101   load_type 5                        
         102   load_type 6                        
         103   load_var 10                        (body)
         104   load_const 14                      ("system")
@@ -4262,8 +5149,8 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         106   call 37 ntypeargs=2                (baml.Map.set)
         107   pop 1                              
 
-  210   108   load_var 7                         (lowered)
-        109   call 845 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+  285   108   load_var 7                         (lowered)
+        109   call 851 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         110   store_var 16                       (_60)
         111   load_type 5                        
         112   load_type 6                        
@@ -4274,18 +5161,18 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         117   pop 1                              
         118   jump +19                           (to 137)
 
-  201   119   load_type 9                        
+  276   119   load_type 9                        
 
-  200   120   load_const 16                      ("user")
+  275   120   load_const 16                      ("user")
         121   load_const 17                      (false)
         122   load_var 6                         (system)
         123   init_instance 0                    (anthropic.internal.AnthropicMessage .role, .tool_results, .blocks)
         124   load_type 9                        
         125   alloc_array 1                      
 
-  201   126   load_var 7                         (lowered)
+  276   126   load_var 7                         (lowered)
         127   call 7 ntypeargs=1                 (baml.Array.concat)
-        128   call 845 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        128   call 851 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         129   store_var 14                       (_45)
         130   load_type 5                        
         131   load_type 6                        
@@ -4295,17 +5182,17 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         135   call 37 ntypeargs=2                (baml.Map.set)
         136   pop 1                              
 
-  213   137   load_var 2                         (input)
+  288   137   load_var 2                         (input)
         138   load_field 2                       (toolbox)
         139   call 778 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         140   unary_op !                         
         141   pop_jump_if_false +79              (to 220)
 
-  214   142   load_type 19                       
+  289   142   load_type 19                       
         143   alloc_array 0                      
         144   store_var 17                       (tools)
 
-  215   145   load_var 2                         (input)
+  290   145   load_var 2                         (input)
         146   load_field 2                       (toolbox)
         147   call 776 ntypeargs=0               (ai.tools.Toolbox.list)
         148   load_type 20                       
@@ -4324,12 +5211,12 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         161   load_var 19                        (_71)
         162   store_var 20                       (t)
 
-  216   163   load_type 5                        
+  291   163   load_type 5                        
         164   load_type 6                        
         165   alloc_map 0                        
         166   store_var 21                       (tw)
 
-  217   167   load_type 5                        
+  292   167   load_type 5                        
         168   load_type 6                        
         169   load_var 21                        (tw)
         170   load_const 24                      ("name")
@@ -4338,7 +5225,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         173   call 37 ntypeargs=2                (baml.Map.set)
         174   pop 1                              
 
-  218   175   load_type 5                        
+  293   175   load_type 5                        
         176   load_type 6                        
         177   load_var 21                        (tw)
         178   load_const 25                      ("description")
@@ -4347,7 +5234,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         181   call 37 ntypeargs=2                (baml.Map.set)
         182   pop 1                              
 
-  219   183   load_type 5                        
+  294   183   load_type 5                        
         184   load_type 6                        
         185   load_var 21                        (tw)
         186   load_const 26                      ("input_schema")
@@ -4356,17 +5243,17 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         189   call 37 ntypeargs=2                (baml.Map.set)
         190   pop 1                              
 
-  220   191   load_var2 17 21                    
+  295   191   load_var2 17 21                    
         192   call 4 ntypeargs=0                 (baml.Array.push)
         193   pop 1                              
         194   jump -42                           (to 152)
 
-  222   195   load_type 5                        
+  297   195   load_type 5                        
         196   load_type 6                        
         197   alloc_map 0                        
         198   store_var 22                       (tc)
 
-  223   199   load_type 5                        
+  298   199   load_type 5                        
         200   load_type 6                        
         201   load_var 22                        (tc)
         202   load_const 27                      ("type")
@@ -4374,7 +5261,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         204   call 37 ntypeargs=2                (baml.Map.set)
         205   pop 1                              
 
-  224   206   load_type 5                        
+  299   206   load_type 5                        
         207   load_type 6                        
         208   load_var 10                        (body)
         209   load_const 29                      ("tools")
@@ -4382,7 +5269,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         211   call 37 ntypeargs=2                (baml.Map.set)
         212   pop 1                              
 
-  225   213   load_type 5                        
+  300   213   load_type 5                        
         214   load_type 6                        
         215   load_var 10                        (body)
         216   load_const 30                      ("tool_choice")
@@ -4390,10 +5277,10 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         218   call 37 ntypeargs=2                (baml.Map.set)
         219   pop 1                              
 
-  231   220   load_var 3                         (stream)
+  306   220   load_var 3                         (stream)
         221   pop_jump_if_false +8               (to 229)
 
-  232   222   load_type 5                        
+  307   222   load_type 5                        
         223   load_type 6                        
         224   load_var 10                        (body)
         225   load_const 31                      ("stream")
@@ -4401,7 +5288,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         227   call 37 ntypeargs=2                (baml.Map.set)
         228   pop 1                              
 
-  238   229   load_var 1                         (c)
+  313   229   load_var 1                         (c)
         230   load_field 2                       (base_url)
         231   store_var 24                       (_106)
         232   load_var 24                        (_106)
@@ -4413,12 +5300,12 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         238   load_const 33                      ("https://api.anthropic.com")
         239   store_var 23                       (base)
 
-  241   240   load_type 5                        
+  316   240   load_type 5                        
         241   load_var 23                        (base)
         242   call 138 ntypeargs=1               (baml.String.from)
         243   store_var 25                       (_109)
 
-  243   244   load_var 1                         (c)
+  318   244   load_var 1                         (c)
         245   load_field 1                       (api_key)
         246   store_var 27                       (_114)
         247   load_var2 27 27                    
@@ -4428,7 +5315,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         251   load_const 34                      ("ANTHROPIC_API_KEY")
         252   call 211 ntypeargs=0               (baml.env.get_or_panic)
 
-  242   253   load_const 35                      ("2023-06-01")
+  317   253   load_const 35                      ("2023-06-01")
         254   load_const 36                      ("application/json")
         255   load_const 37                      ("x-api-key")
         256   load_const 38                      ("anthropic-version")
@@ -4438,15 +5325,15 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         260   alloc_map 3                        
         261   store_var 26                       (_112)
 
-  247   262   load_type 19                       
+  322   262   load_type 19                       
         263   load_var 10                        (body)
         264   call 331 ntypeargs=1               (baml.json.to_json)
         265   call 328 ntypeargs=0               (baml.json.stringify)
         266   store_var 28                       (_116)
 
-  239   267   load_const 40                      ("POST")
+  314   267   load_const 40                      ("POST")
 
-  241   268   load_var 25                        (_109)
+  316   268   load_var 25                        (_109)
         269   load_const 41                      ("/v1/messages")
         270   bin_op +                           
         271   load_var2 26 28                    
@@ -4455,61 +5342,61 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 }
 
 function anthropic.internal._anthropic_stop_reason(s: string) -> ai.content.StopReason {
-  253   0    load_var 1             (s)
+  328   0    load_var 1             (s)
         1    load_const 0           ("tool_use")
         2    cmp_op ==              
         3    pop_jump_if_false +2   (to 5)
         4    jump +20               (to 24)
 
-  255   5    load_var 1             (s)
+  330   5    load_var 1             (s)
         6    load_const 1           ("max_tokens")
         7    cmp_op ==              
         8    pop_jump_if_false +2   (to 10)
         9    jump +12               (to 21)
 
-  257   10   load_var 1             (s)
+  332   10   load_var 1             (s)
         11   load_const 2           ("refusal")
         12   cmp_op ==              
         13   pop_jump_if_false +2   (to 15)
         14   jump +4                (to 18)
 
-  260   15   load_const 3           (ai.content.StopReason.Complete)
-        16   alloc_variant 436      (ai.content.StopReason)
+  335   15   load_const 3           (ai.content.StopReason.Complete)
+        16   alloc_variant 438      (ai.content.StopReason)
 
-  257   17   jump +9                (to 26)
+  332   17   jump +9                (to 26)
 
-  258   18   load_const 4           (ai.content.StopReason.Refused)
-        19   alloc_variant 436      (ai.content.StopReason)
+  333   18   load_const 4           (ai.content.StopReason.Refused)
+        19   alloc_variant 438      (ai.content.StopReason)
 
-  257   20   jump +6                (to 26)
+  332   20   jump +6                (to 26)
 
-  256   21   load_const 5           (ai.content.StopReason.MaxTokens)
-        22   alloc_variant 436      (ai.content.StopReason)
+  331   21   load_const 5           (ai.content.StopReason.MaxTokens)
+        22   alloc_variant 438      (ai.content.StopReason)
 
-  255   23   jump +3                (to 26)
+  330   23   jump +3                (to 26)
 
-  254   24   load_const 6           (ai.content.StopReason.ToolUse)
-        25   alloc_variant 436      (ai.content.StopReason)
+  329   24   load_const 6           (ai.content.StopReason.ToolUse)
+        25   alloc_variant 438      (ai.content.StopReason)
         26   return                 
 }
 
 function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
-  266   0     load_var2 1 2                      
+  341   0     load_var2 1 2                      
         1     load_const 0                       (false)
-        2     call 846 ntypeargs=0               (anthropic.internal._anthropic_request)
+        2     call 852 ntypeargs=0               (anthropic.internal._anthropic_request)
         3     store_var 3                        (req)
 
-  267   4     load_type 1                        
+  342   4     load_type 1                        
         5     load_var 3                         (req)
         6     load_const 2                       ("anthropic")
         7     call 781 ntypeargs=1               (ai.wire.send_as)
         8     store_var 4                        (resp)
 
-  269   9     load_type 3                        
+  344   9     load_type 3                        
         10    alloc_array 0                      
         11    store_var 5                        (content)
 
-  270   12    load_var 4                         (resp)
+  345   12    load_var 4                         (resp)
         13    load_field 0                       (content)
         14    load_type 4                        
         15    load_const 5                       ("iter")
@@ -4527,26 +5414,26 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         27    load_var 7                         (_10)
         28    store_var_load_var 8               (b)
 
-  271   29    load_field 0                       (type)
+  346   29    load_field 0                       (type)
         30    load_const 9                       ("text")
         31    cmp_op ==                          
         32    pop_jump_if_false +2               (to 34)
         33    jump +69                           (to 102)
 
-  274   34    load_var 8                         (b)
+  349   34    load_var 8                         (b)
         35    load_field 0                       (type)
         36    load_const 10                      ("thinking")
         37    cmp_op ==                          
         38    pop_jump_if_false +2               (to 40)
         39    jump +47                           (to 86)
 
-  277   40    load_var 8                         (b)
+  352   40    load_var 8                         (b)
         41    load_field 0                       (type)
         42    load_const 11                      ("tool_use")
         43    cmp_op ==                          
         44    pop_jump_if_false -26              (to 18)
 
-  281   45    load_var 8                         (b)
+  356   45    load_var 8                         (b)
         46    load_field 3                       (id)
         47    store_var 14                       (_34)
         48    load_var 14                        (_34)
@@ -4558,7 +5445,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         54    load_const 13                      ("")
         55    store_var 13                       (_33)
 
-  282   56    load_var 8                         (b)
+  357   56    load_var 8                         (b)
         57    load_field 4                       (name)
         58    store_var 16                       (_37)
         59    load_var 16                        (_37)
@@ -4570,7 +5457,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         65    load_const 14                      ("")
         66    store_var 15                       (_36)
 
-  283   67    load_var 8                         (b)
+  358   67    load_var 8                         (b)
         68    load_field 5                       (input)
         69    store_var 18                       (_40)
         70    load_var 18                        (_40)
@@ -4580,20 +5467,20 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         74    cmp_op ==                          
         75    pop_jump_if_false +5               (to 80)
 
-  278   76    load_type 15                       
+  353   76    load_type 15                       
         77    load_type 16                       
         78    alloc_map 0                        
         79    store_var 17                       (_39)
 
-  279   80    load_var2 5 13                     
+  354   80    load_var2 5 13                     
 
-  280   81    load_var2 15 17                    
+  355   81    load_var2 15 17                    
         82    init_instance 0                    (ai.content.ToolUse .id, .name, .args)
         83    call 4 ntypeargs=0                 (baml.Array.push)
         84    pop 1                              
         85    jump -67                           (to 18)
 
-  275   86    load_var 8                         (b)
+  350   86    load_var 8                         (b)
         87    load_field 2                       (thinking)
         88    store_var 12                       (_26)
         89    load_var 12                        (_26)
@@ -4610,7 +5497,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         100   pop 1                              
         101   jump -83                           (to 18)
 
-  272   102   load_var 8                         (b)
+  347   102   load_var 8                         (b)
         103   load_field 1                       (text)
         104   store_var 10                       (_19)
         105   load_var 10                        (_19)
@@ -4627,7 +5514,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         116   pop 1                              
         117   jump -99                           (to 18)
 
-  292   118   load_var 4                         (resp)
+  367   118   load_var 4                         (resp)
         119   load_field 1                       (stop_reason)
         120   store_var_load_var 20              (_43)
         121   load_const 12                      (null)
@@ -4635,15 +5522,15 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         123   pop_jump_if_false +2               (to 125)
         124   jump +5                            (to 129)
         125   load_var 20                        (_43)
-        126   call 847 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+        126   call 853 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         127   store_var 19                       (stop)
         128   jump +4                            (to 132)
 
-  293   129   load_const 19                      (ai.content.StopReason.Complete)
-        130   alloc_variant 436                  (ai.content.StopReason)
+  368   129   load_const 19                      (ai.content.StopReason.Complete)
+        130   alloc_variant 438                  (ai.content.StopReason)
         131   store_var 19                       (stop)
 
-  297   132   load_var 4                         (resp)
+  372   132   load_var 4                         (resp)
         133   load_field 2                       (usage)
         134   store_var 22                       (_49)
         135   load_var 22                        (_49)
@@ -4651,39 +5538,39 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         137   pop_jump_if_false +2               (to 139)
         138   jump +4                            (to 142)
 
-  306   139   load_const 12                      (null)
+  381   139   load_const 12                      (null)
         140   store_var 21                       (usage)
 
-  297   141   jump +10                           (to 151)
+  372   141   jump +10                           (to 151)
         142   load_var 22                        (_49)
         143   store_var_load_var 23              (u)
 
-  300   144   load_field 0                       (input_tokens)
+  375   144   load_field 0                       (input_tokens)
 
-  301   145   load_var 23                        (u)
+  376   145   load_var 23                        (u)
         146   load_field 1                       (output_tokens)
         147   load_const 12                      (null)
         148   load_const 12                      (null)
         149   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
         150   store_var 21                       (usage)
 
-  309   151   load_var2 5 19                     
+  384   151   load_var2 5 19                     
         152   load_var 21                        (usage)
         153   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
         154   return                             
 }
 
 function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
-  415   0    load_var2 1 2          
+  490   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 846 ntypeargs=0   (anthropic.internal._anthropic_request)
+        2    call 852 ntypeargs=0   (anthropic.internal._anthropic_request)
 
-  416   3    sys_op 232             (baml.http.fetch_sse)
+  491   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
         5    load_var 3             (e)
         6    throw_if_panic         
 
-  420   7    load_type 1            
+  495   7    load_type 1            
         8    load_var 3             (e)
         9    call 138 ntypeargs=1   (baml.String.from)
         10   store_var 5            (_10)
@@ -4692,17 +5579,17 @@ function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: a
         13   call 138 ntypeargs=1   (baml.String.from)
         14   store_var 4            (_9)
 
-  418   15   load_const 3           ("anthropic")
+  493   15   load_const 3           ("anthropic")
 
-  420   16   load_const 4           ("transport failed before a response arrived: ")
+  495   16   load_const 4           ("transport failed before a response arrived: ")
         17   load_var 4             (_9)
         18   bin_op +               
         19   load_const 5           (null)
         20   init_instance 0        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
         21   throw                  
 
-  425   22   load_const 6           (anthropic.internal._anthropic_decode_batch)
-        23   call 803 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+  500   22   load_const 6           (anthropic.internal._anthropic_decode_batch)
+        23   call 806 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -4883,13 +5770,13 @@ function claude_code.ClaudeCodeClient.ai.Client.id(self: claude_code.ClaudeCodeC
 
 function claude_code.ClaudeCodeClient.ai.Client.invoke(self: claude_code.ClaudeCodeClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   44   0   load_var2 1 2          
-       1   call 879 ntypeargs=0   (claude_code.internal.invoke)
+       1   call 887 ntypeargs=0   (claude_code.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   45   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 814 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
@@ -5105,7 +5992,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         122   load_const 31                      (".thinking")
         123   load_const 32                      ("")
         124   call 340 ntypeargs=1               (baml.json.path_or)
-        125   call 875 ntypeargs=0               (claude_code.internal._preview)
+        125   call 883 ntypeargs=0               (claude_code.internal._preview)
         126   store_var 17                       (_55)
         127   load_type 0                        
         128   load_var 17                        (_55)
@@ -5126,7 +6013,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         140   load_const 34                      (".text")
         141   load_const 35                      ("")
         142   call 340 ntypeargs=1               (baml.json.path_or)
-        143   call 875 ntypeargs=0               (claude_code.internal._preview)
+        143   call 883 ntypeargs=0               (claude_code.internal._preview)
         144   store_var 15                       (_47)
         145   load_type 0                        
         146   load_var 15                        (_47)
@@ -5320,7 +6207,7 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         34   throw                              
 
   136   35   load_var 6                         (raw)
-        36   call 876 ntypeargs=0               (claude_code.internal._log_cc_event)
+        36   call 884 ntypeargs=0               (claude_code.internal._log_cc_event)
         37   pop 1                              
 
   137   38   load_type 8                        
@@ -5382,7 +6269,7 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
         8    load_type 2           
         9    load_var 3            (_3)
 
-  220   10   make_closure 2178 0   
+  220   10   make_closure 2327 0   
         11   call 16 ntypeargs=3   (baml.Array.map)
         12   store_var 2           (_2)
 
@@ -5415,7 +6302,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        16    store_var 5            (call_props)
 
   55   17    load_const 4           ("string")
-       18    call 872 ntypeargs=0   (claude_code.internal._type_schema)
+       18    call 880 ntypeargs=0   (claude_code.internal._type_schema)
        19    store_var 6            (_10)
        20    load_type 1            
        21    load_type 2            
@@ -5426,7 +6313,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        26    pop 1                  
 
   56   27    load_const 6           ("string")
-       28    call 872 ntypeargs=0   (claude_code.internal._type_schema)
+       28    call 880 ntypeargs=0   (claude_code.internal._type_schema)
        29    store_var 7            (_14)
        30    load_type 1            
        31    load_type 2            
@@ -5437,7 +6324,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        36    pop 1                  
 
   57   37    load_const 8           ("object")
-       38    call 872 ntypeargs=0   (claude_code.internal._type_schema)
+       38    call 880 ntypeargs=0   (claude_code.internal._type_schema)
        39    store_var 8            (_18)
        40    load_type 1            
        41    load_type 2            
@@ -5679,7 +6566,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 
   236   18    load_var 2                         (input)
         19    load_field 3                       (output_type)
-        20    call 871 ntypeargs=0               (claude_code.internal.envelope_schema)
+        20    call 879 ntypeargs=0               (claude_code.internal.envelope_schema)
         21    store_var 7                        (_11)
         22    load_type 1                        
         23    load_var 7                         (_11)
@@ -5696,7 +6583,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         32    store_var 14                       (_29)
         33    load_var 2                         (input)
         34    load_field 1                       (journal)
-        35    call 870 ntypeargs=0               (claude_code.internal.transcript_text)
+        35    call 878 ntypeargs=0               (claude_code.internal.transcript_text)
         36    store_var 16                       (_33)
         37    load_type 2                        
         38    load_var 16                        (_33)
@@ -5714,7 +6601,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         48    store_var 9                        (_18)
         49    load_var 2                         (input)
         50    load_field 1                       (journal)
-        51    call 870 ntypeargs=0               (claude_code.internal.transcript_text)
+        51    call 878 ntypeargs=0               (claude_code.internal.transcript_text)
         52    store_var 11                       (_22)
         53    load_type 2                        
         54    load_var 11                        (_22)
@@ -5722,7 +6609,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         56    store_var 10                       (_21)
         57    load_var 2                         (input)
         58    load_field 2                       (toolbox)
-        59    call 873 ntypeargs=0               (claude_code.internal.tool_protocol)
+        59    call 881 ntypeargs=0               (claude_code.internal.tool_protocol)
         60    store_var 13                       (_26)
         61    load_type 2                        
         62    load_var 13                        (_26)
@@ -5844,7 +6731,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         162   pop 1                              
 
   267   163   load_var 1                         (c)
-        164   call 877 ntypeargs=0               (claude_code.internal.mcp_config_json)
+        164   call 885 ntypeargs=0               (claude_code.internal.mcp_config_json)
         165   store_var 24                       (_70)
         166   load_var 24                        (_70)
         167   narrow_bind 21 24                  
@@ -5867,7 +6754,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         181   pop 1                              
 
   271   182   load_var 1                         (c)
-        183   call 878 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
+        183   call 886 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
         184   store_var 27                       (_79)
         185   load_type 2                        
         186   load_var 27                        (_79)
@@ -5941,7 +6828,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         243   throw_if_panic                     
 
   299   244   load_var 29                        (p)
-        245   call 874 ntypeargs=0               (claude_code.internal._read_result)
+        245   call 882 ntypeargs=0               (claude_code.internal._read_result)
         246   store_var 36                       (result)
 
   300   247   load_var 29                        (p)
@@ -6092,7 +6979,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         375   store_var 57                       (content)
 
   349   376   load_const 56                      (ai.content.StopReason.Complete)
-        377   alloc_variant 436                  (ai.content.StopReason)
+        377   alloc_variant 438                  (ai.content.StopReason)
         378   store_var 58                       (stop)
 
   350   379   load_var 5                         (has_tools)
@@ -6229,7 +7116,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
   355   491   jump -70                           (to 421)
 
   373   492   load_const 21                      (ai.content.StopReason.ToolUse)
-        493   alloc_variant 436                  (ai.content.StopReason)
+        493   alloc_variant 438                  (ai.content.StopReason)
         494   store_var 58                       (stop)
 
   380   495   load_var2 57 58                    
@@ -6645,20 +7532,20 @@ function google.GoogleClient.ai.Client.id(self: google.GoogleClient) -> string {
 
 function google.GoogleClient.ai.Client.invoke(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   22   0   load_var2 1 2          
-       1   call 864 ntypeargs=0   (google.internal.invoke)
+       1   call 872 ntypeargs=0   (google.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   23   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 814 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function google.GoogleClient.ai.stream.StreamingClient.invoke_stream(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   30   0   load_var2 1 2          
-       1   call 866 ntypeargs=0   (google.internal.invoke_stream)
+       1   call 874 ntypeargs=0   (google.internal.invoke_stream)
        2   return                 
 }
 
@@ -6718,42 +7605,236 @@ function google.internal._gm_content(role: string, parts: map<string, unknown>[]
 }
 
 function google.internal._gm_function_response(name: string, response: map<string, unknown>) -> map<string, unknown> {
-  62   0    load_type 0           
-       1    load_type 1           
-       2    alloc_map 0           
-       3    store_var 3           (fr)
+  110   0    load_type 0           
+        1    load_type 1           
+        2    alloc_map 0           
+        3    store_var 3           (fr)
 
-  63   4    load_type 0           
-       5    load_type 1           
-       6    load_var 3            (fr)
-       7    load_const 2          ("name")
-       8    load_var 1            (name)
-       9    call 37 ntypeargs=2   (baml.Map.set)
-       10   pop 1                 
+  111   4    load_type 0           
+        5    load_type 1           
+        6    load_var 3            (fr)
+        7    load_const 2          ("name")
+        8    load_var 1            (name)
+        9    call 37 ntypeargs=2   (baml.Map.set)
+        10   pop 1                 
 
-  64   11   load_type 0           
-       12   load_type 1           
-       13   load_var 3            (fr)
-       14   load_const 3          ("response")
-       15   load_var 2            (response)
-       16   call 37 ntypeargs=2   (baml.Map.set)
-       17   pop 1                 
+  112   11   load_type 0           
+        12   load_type 1           
+        13   load_var 3            (fr)
+        14   load_const 3          ("response")
+        15   load_var 2            (response)
+        16   call 37 ntypeargs=2   (baml.Map.set)
+        17   pop 1                 
 
-  65   18   load_type 0           
-       19   load_type 1           
-       20   alloc_map 0           
-       21   store_var 4           (part)
+  113   18   load_type 0           
+        19   load_type 1           
+        20   alloc_map 0           
+        21   store_var 4           (part)
 
-  66   22   load_type 0           
-       23   load_type 1           
-       24   load_var 4            (part)
-       25   load_const 4          ("functionResponse")
-       26   load_var 3            (fr)
-       27   call 37 ntypeargs=2   (baml.Map.set)
-       28   pop 1                 
+  114   22   load_type 0           
+        23   load_type 1           
+        24   load_var 4            (part)
+        25   load_const 4          ("functionResponse")
+        26   load_var 3            (fr)
+        27   call 37 ntypeargs=2   (baml.Map.set)
+        28   pop 1                 
 
-  67   29   load_var 4            (part)
-       30   return                
+  115   29   load_var 4            (part)
+        30   return                
+}
+
+function google.internal._gm_media_part(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf) -> map<string, unknown> {
+  58   0    load_var 1             (media)
+       1    load_const 0           (true)
+       2    call 785 ntypeargs=0   (ai.wire.resolve_media)
+       3    store_var 2            (resolved)
+
+  59   4    load_type 1            
+       5    load_type 2            
+       6    alloc_map 0            
+       7    store_var 3            (media_part)
+
+  60   8    load_var 2             (resolved)
+       9    load_field 0           (url)
+       10   store_var 4            (_5)
+       11   load_var 4             (_5)
+       12   narrow_bind 3 4        
+       13   pop_jump_if_false +2   (to 15)
+       14   jump +39               (to 53)
+
+  67   15   load_type 1            
+       16   load_type 2            
+       17   alloc_map 0            
+       18   store_var 7            (inline_data)
+
+  68   19   load_type 1            
+       20   load_type 2            
+       21   load_var 7             (inline_data)
+       22   load_const 4           ("mimeType")
+       23   load_var 2             (resolved)
+       24   load_field 2           (mime_type)
+       25   call 37 ntypeargs=2    (baml.Map.set)
+       26   pop 1                  
+
+  69   27   load_var 2             (resolved)
+       28   load_field 1           (base64)
+       29   store_var 9            (_27)
+       30   load_var 9             (_27)
+       31   store_var 8            (_26)
+       32   load_var 9             (_27)
+       33   load_const 5           (null)
+       34   cmp_op ==              
+       35   pop_jump_if_false +3   (to 38)
+       36   load_const 6           ("")
+       37   store_var 8            (_26)
+       38   load_type 1            
+       39   load_type 2            
+       40   load_var 7             (inline_data)
+       41   load_const 7           ("data")
+       42   load_var 8             (_26)
+       43   call 37 ntypeargs=2    (baml.Map.set)
+       44   pop 1                  
+
+  70   45   load_type 1            
+       46   load_type 2            
+       47   load_var 3             (media_part)
+       48   load_const 8           ("inlineData")
+       49   load_var 7             (inline_data)
+       50   call 37 ntypeargs=2    (baml.Map.set)
+       51   pop 1                  
+       52   jump +29               (to 81)
+
+  60   53   load_var 4             (_5)
+       54   store_var 5            (url)
+
+  61   55   load_type 1            
+       56   load_type 2            
+       57   alloc_map 0            
+       58   store_var 6            (file_data)
+
+  62   59   load_type 1            
+       60   load_type 2            
+       61   load_var 6             (file_data)
+       62   load_const 9           ("mimeType")
+       63   load_var 2             (resolved)
+       64   load_field 2           (mime_type)
+       65   call 37 ntypeargs=2    (baml.Map.set)
+       66   pop 1                  
+
+  63   67   load_type 1            
+       68   load_type 2            
+       69   load_var 6             (file_data)
+       70   load_const 10          ("fileUri")
+       71   load_var 5             (url)
+       72   call 37 ntypeargs=2    (baml.Map.set)
+       73   pop 1                  
+
+  64   74   load_type 1            
+       75   load_type 2            
+       76   load_var 3             (media_part)
+       77   load_const 11          ("fileData")
+       78   load_var 6             (file_data)
+       79   call 37 ntypeargs=2    (baml.Map.set)
+       80   pop 1                  
+
+  73   81   load_var 3             (media_part)
+       82   return                 
+}
+
+function google.internal._gm_prompt_parts(message: ai.PromptMessage) -> map<string, unknown>[] {
+  77    0    load_type 0                        
+        1    alloc_array 0                      
+        2    store_var 2                        (parts)
+
+  78    3    load_var 1                         (message)
+        4    load_field 2                       (parts)
+        5    load_type 1                        
+        6    load_const 2                       ("iter")
+        7    virtual_call nargs=1 ntypeargs=0   
+        8    store_var 3                        (_4)
+        9    load_var 3                         (_4)
+        10   load_type 3                        
+        11   load_const 4                       ("next")
+        12   virtual_call nargs=1 ntypeargs=0   
+        13   store_var 4                        (_5)
+        14   load_var 4                         (_5)
+        15   is_type 5                          
+        16   pop_jump_if_false +2               (to 18)
+        17   jump +62                           (to 79)
+        18   load_var 4                         (_5)
+        19   store_var 5                        (part)
+
+  79    20   load_var 5                         (part)
+        21   store_var 6                        (_9)
+        22   load_var 6                         (_9)
+        23   narrow_bind 6 6                    
+        24   pop_jump_if_false +2               (to 26)
+        25   jump +47                           (to 72)
+        26   load_var 5                         (part)
+        27   store_var 8                        (_14)
+        28   load_var 8                         (_14)
+        29   narrow_bind 7 8                    
+        30   pop_jump_if_false +2               (to 32)
+        31   jump +34                           (to 65)
+        32   load_var 5                         (part)
+        33   store_var 10                       (_19)
+        34   load_var 10                        (_19)
+        35   narrow_bind 8 10                   
+        36   pop_jump_if_false +2               (to 38)
+        37   jump +21                           (to 58)
+        38   load_var 5                         (part)
+        39   store_var 12                       (_24)
+        40   load_var 12                        (_24)
+        41   narrow_bind 9 12                   
+        42   pop_jump_if_false +2               (to 44)
+        43   jump +8                            (to 51)
+        44   load_var 5                         (part)
+        45   call 863 ntypeargs=0               (google.internal._gm_media_part)
+        46   store_var 14                       (_31)
+
+  97    47   load_var2 2 14                     
+        48   call 4 ntypeargs=0                 (baml.Array.push)
+        49   pop 1                              
+        50   jump -41                           (to 9)
+
+  79    51   load_var 12                        (_24)
+        52   call 863 ntypeargs=0               (google.internal._gm_media_part)
+        53   store_var 13                       (_27)
+
+  93    54   load_var2 2 13                     
+        55   call 4 ntypeargs=0                 (baml.Array.push)
+        56   pop 1                              
+        57   jump -48                           (to 9)
+
+  79    58   load_var 10                        (_19)
+        59   call 863 ntypeargs=0               (google.internal._gm_media_part)
+        60   store_var 11                       (_22)
+
+  89    61   load_var2 2 11                     
+        62   call 4 ntypeargs=0                 (baml.Array.push)
+        63   pop 1                              
+        64   jump -55                           (to 9)
+
+  79    65   load_var 8                         (_14)
+        66   call 863 ntypeargs=0               (google.internal._gm_media_part)
+        67   store_var 9                        (_17)
+
+  85    68   load_var2 2 9                      
+        69   call 4 ntypeargs=0                 (baml.Array.push)
+        70   pop 1                              
+        71   jump -62                           (to 9)
+
+  79    72   load_var 6                         (_9)
+        73   call 862 ntypeargs=0               (google.internal._gm_text_part)
+        74   store_var 7                        (_12)
+
+  81    75   load_var2 2 7                      
+        76   call 4 ntypeargs=0                 (baml.Array.push)
+        77   pop 1                              
+        78   jump -69                           (to 9)
+
+  102   79   load_var 2                         (parts)
+        80   return                             
 }
 
 function google.internal._gm_text_part(text: string) -> map<string, unknown> {
@@ -6775,10 +7856,10 @@ function google.internal._gm_text_part(text: string) -> map<string, unknown> {
 }
 
 function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string {
-  109   0    load_const 0                       ("")
+  159   0    load_const 0                       ("")
         1    store_var 3                        (name)
 
-  110   2    load_var 1                         (j)
+  160   2    load_var 1                         (j)
         3    call 760 ntypeargs=0               (ai.Journal.entries)
         4    load_type 1                        
         5    load_const 2                       ("iter")
@@ -6796,7 +7877,7 @@ function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string 
         17   load_var 5                         (_6)
         18   store_var 6                        (_10)
 
-  111   19   load_var 6                         (_10)
+  161   19   load_var 6                         (_10)
         20   narrow_bind 6 6                    
         21   pop_jump_if_false -13              (to 8)
         22   load_var 6                         (_10)
@@ -6806,7 +7887,7 @@ function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string 
         26   virtual_call nargs=1 ntypeargs=0   
         27   store_var 7                        (_13)
 
-  113   28   load_var 7                         (_13)
+  163   28   load_var 7                         (_13)
         29   load_type 9                        
         30   load_const 10                      ("next")
         31   virtual_call nargs=1 ntypeargs=0   
@@ -6818,34 +7899,34 @@ function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string 
         37   load_var 8                         (_14)
         38   store_var 9                        (_18)
 
-  114   39   load_var 9                         (_18)
+  164   39   load_var 9                         (_18)
         40   narrow_bind 11 9                   
         41   pop_jump_if_false -13              (to 28)
         42   load_var 9                         (_18)
         43   store_var_load_var 10              (u)
 
-  116   44   load_field 0                       (id)
+  166   44   load_field 0                       (id)
         45   load_var 2                         (id)
         46   cmp_op ==                          
         47   pop_jump_if_false -19              (to 28)
 
-  117   48   load_var 10                        (u)
+  167   48   load_var 10                        (u)
         49   load_field 1                       (name)
         50   store_var 3                        (name)
 
-  116   51   jump -23                           (to 28)
+  166   51   jump -23                           (to 28)
 
-  131   52   load_var 3                         (name)
+  181   52   load_var 3                         (name)
         53   return                             
 }
 
 function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone)[] {
-  367   0     load_type 0                        
+  417   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 2                        (out)
 
-  368   3     load_var 1                         (batch)
-        4     call 802 ntypeargs=0               (ai.stream.decode_sse_batch)
+  418   3     load_var 1                         (batch)
+        4     call 805 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -6863,29 +7944,29 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         19    load_field 1                       (data)
         20    store_var 5                        (_10)
 
-  369   21    load_var 5                         (_10)
+  419   21    load_var 5                         (_10)
         22    narrow_bind 6 5                    
         23    pop_jump_if_false -14              (to 9)
 
-  370   24    load_type 7                        
+  420   24    load_type 7                        
 
-  369   25    load_var 5                         (_10)
+  419   25    load_var 5                         (_10)
         26    call 333 ntypeargs=1               (baml.json.from_string)
         27    jump +4                            (to 31)
 
-  370   28    load_var 6                         (e)
+  420   28    load_var 6                         (e)
         29    throw_if_panic                     
 
-  371   30    load_const 8                       (null)
+  421   30    load_const 8                       (null)
 
-  373   31    store_var 7                        (_16)
+  423   31    store_var 7                        (_16)
         32    load_var 7                         (_16)
         33    narrow_bind 9 7                    
         34    pop_jump_if_false -25              (to 9)
         35    load_var 7                         (_16)
         36    store_var_load_var 8               (resp)
 
-  374   37    load_field 0                       (candidates)
+  424   37    load_field 0                       (candidates)
         38    load_const 8                       (null)
         39    cmp_op ==                          
         40    pop_jump_if_false +2               (to 42)
@@ -6900,7 +7981,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         49    load_const 8                       (null)
         50    store_var 9                        (cand)
 
-  375   51    load_var 9                         (cand)
+  425   51    load_var 9                         (cand)
         52    load_const 8                       (null)
         53    cmp_op ==                          
         54    pop_jump_if_false +2               (to 56)
@@ -6933,7 +8014,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         81    alloc_array 0                      
         82    store_var 10                       (parts)
 
-  376   83    load_var 10                        (parts)
+  426   83    load_var 10                        (parts)
         84    load_type 12                       
         85    load_const 13                      ("iter")
         86    virtual_call nargs=1 ntypeargs=0   
@@ -6950,7 +8031,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         97    load_var 13                        (_37)
         98    store_var_load_var 14              (p)
 
-  377   99    load_field 0                       (text)
+  427   99    load_field 0                       (text)
         100   store_var 15                       (_42)
         101   load_var 15                        (_42)
         102   narrow_bind 6 15                   
@@ -6958,7 +8039,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         104   load_var 15                        (_42)
         105   store_var 16                       (t)
 
-  378   106   load_var 14                        (p)
+  428   106   load_var 14                        (p)
         107   load_field 1                       (thought)
         108   store_var 18                       (_45)
         109   load_var 18                        (_45)
@@ -6973,13 +8054,13 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         118   pop_jump_if_false +2               (to 120)
         119   jump -31                           (to 88)
 
-  381   120   load_var2 2 16                     
+  431   120   load_var2 2 16                     
         121   init_instance 0                    (ai.stream.TextDelta .text)
         122   call 4 ntypeargs=0                 (baml.Array.push)
         123   pop 1                              
         124   jump -36                           (to 88)
 
-  388   125   load_var 9                         (cand)
+  438   125   load_var 9                         (cand)
         126   load_const 8                       (null)
         127   cmp_op ==                          
         128   pop_jump_if_false +2               (to 130)
@@ -6999,7 +8080,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         142   load_const 17                      ("")
         143   store_var 19                       (finish)
 
-  389   144   load_var 8                         (resp)
+  439   144   load_var 8                         (resp)
         145   load_field 2                       (promptFeedback)
         146   load_const 8                       (null)
         147   cmp_op ==                          
@@ -7014,73 +8095,73 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         156   call 612 ntypeargs=0               (baml.ops.equals_equals)
         157   store_var 21                       (_61)
 
-  390   158   load_var 19                        (finish)
+  440   158   load_var 19                        (finish)
         159   load_const 18                      ("MAX_TOKENS")
         160   cmp_op ==                          
         161   pop_jump_if_false +2               (to 163)
         162   jump +39                           (to 201)
 
-  389   163   load_var 21                        (_61)
+  439   163   load_var 21                        (_61)
         164   unary_op !                         
         165   jump_if_false +2                   (to 167)
         166   jump +5                            (to 171)
         167   pop 1                              
 
-  394   168   load_var 19                        (finish)
+  444   168   load_var 19                        (finish)
         169   load_const 19                      ("SAFETY")
         170   cmp_op ==                          
 
-  393   171   jump_if_false +2                   (to 173)
+  443   171   jump_if_false +2                   (to 173)
         172   jump +5                            (to 177)
         173   pop 1                              
 
-  395   174   load_var 19                        (finish)
+  445   174   load_var 19                        (finish)
         175   load_const 20                      ("RECITATION")
         176   cmp_op ==                          
 
-  393   177   jump_if_false +2                   (to 179)
+  443   177   jump_if_false +2                   (to 179)
         178   jump +5                            (to 183)
         179   pop 1                              
 
-  396   180   load_var 19                        (finish)
+  446   180   load_var 19                        (finish)
         181   load_const 21                      ("PROHIBITED_CONTENT")
         182   cmp_op ==                          
 
-  392   183   pop_jump_if_false +2               (to 185)
+  442   183   pop_jump_if_false +2               (to 185)
         184   jump +13                           (to 197)
 
-  399   185   load_var 19                        (finish)
+  449   185   load_var 19                        (finish)
         186   load_const 22                      ("")
         187   cmp_op !=                          
         188   pop_jump_if_false +2               (to 190)
         189   jump +4                            (to 193)
 
-  402   190   load_const 8                       (null)
+  452   190   load_const 8                       (null)
         191   store_var 22                       (stop)
 
-  399   192   jump +12                           (to 204)
+  449   192   jump +12                           (to 204)
 
-  400   193   load_const 10                      (ai.content.StopReason.Complete)
-        194   alloc_variant 436                  (ai.content.StopReason)
+  450   193   load_const 10                      (ai.content.StopReason.Complete)
+        194   alloc_variant 438                  (ai.content.StopReason)
         195   store_var 22                       (stop)
 
-  399   196   jump +8                            (to 204)
+  449   196   jump +8                            (to 204)
 
-  398   197   load_const 23                      (ai.content.StopReason.Refused)
-        198   alloc_variant 436                  (ai.content.StopReason)
+  448   197   load_const 23                      (ai.content.StopReason.Refused)
+        198   alloc_variant 438                  (ai.content.StopReason)
         199   store_var 22                       (stop)
 
-  392   200   jump +4                            (to 204)
+  442   200   jump +4                            (to 204)
 
-  391   201   load_const 24                      (ai.content.StopReason.MaxTokens)
-        202   alloc_variant 436                  (ai.content.StopReason)
+  441   201   load_const 24                      (ai.content.StopReason.MaxTokens)
+        202   alloc_variant 438                  (ai.content.StopReason)
         203   store_var 22                       (stop)
 
-  404   204   load_var 8                         (resp)
+  454   204   load_var 8                         (resp)
         205   load_field 1                       (usageMetadata)
         206   store_var 23                       (usage)
 
-  405   207   load_var 22                        (stop)
+  455   207   load_var 22                        (stop)
         208   load_const 8                       (null)
         209   call 612 ntypeargs=0               (baml.ops.equals_equals)
         210   unary_op !                         
@@ -7093,10 +8174,10 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         217   unary_op !                         
         218   pop_jump_if_false -209             (to 9)
 
-  408   219   load_var 22                        (stop)
+  458   219   load_var 22                        (stop)
         220   store_var 24                       (_83)
 
-  409   221   load_var 23                        (usage)
+  459   221   load_var 23                        (usage)
         222   load_const 8                       (null)
         223   cmp_op ==                          
         224   pop_jump_if_false +2               (to 226)
@@ -7108,7 +8189,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         230   load_const 8                       (null)
         231   store_var 25                       (_84)
 
-  410   232   load_var 23                        (usage)
+  460   232   load_var 23                        (usage)
         233   load_const 8                       (null)
         234   cmp_op ==                          
         235   pop_jump_if_false +2               (to 237)
@@ -7120,20 +8201,20 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         241   load_const 8                       (null)
         242   store_var 26                       (_88)
 
-  406   243   load_var2 2 24                     
+  456   243   load_var2 2 24                     
 
-  407   244   load_var2 25 26                    
+  457   244   load_var2 25 26                    
         245   init_instance 1                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
         246   call 4 ntypeargs=0                 (baml.Array.push)
         247   pop 1                              
         248   jump -239                          (to 9)
 
-  426   249   load_var 2                         (out)
+  476   249   load_var 2                         (out)
         250   return                             
 }
 
 function google.internal._google_request(c: google.GoogleClient, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
-  226   0     load_var 2                         (input)
+  276   0     load_var 2                         (input)
         1     load_field 0                       (prompt)
         2     store_var 4                        (_5)
         3     load_var 2                         (input)
@@ -7142,16 +8223,16 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         6     load_var 4                         (_5)
         7     call_indirect                      
 
-  227   8     call 858 ntypeargs=0               (google.internal.google_lower_prompt)
+  277   8     call 866 ntypeargs=0               (google.internal.google_lower_prompt)
         9     store_var 5                        (prompt_parts)
 
-  228   10    load_var 5                         (prompt_parts)
+  278   10    load_var 5                         (prompt_parts)
         11    load_field 1                       (contents)
         12    store_var 6                        (contents)
 
-  229   13    load_var 2                         (input)
+  279   13    load_var 2                         (input)
         14    load_field 1                       (journal)
-        15    call 860 ntypeargs=0               (google.internal.google_lower_journal)
+        15    call 868 ntypeargs=0               (google.internal.google_lower_journal)
         16    load_type 0                        
         17    load_const 1                       ("iter")
         18    virtual_call nargs=1 ntypeargs=0   
@@ -7166,25 +8247,25 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         27    pop_jump_if_false +2               (to 29)
         28    jump +5                            (to 33)
 
-  230   29    load_var2 6 8                      
+  280   29    load_var2 6 8                      
 
-  229   30    call 4 ntypeargs=0                 (baml.Array.push)
+  279   30    call 4 ntypeargs=0                 (baml.Array.push)
         31    pop 1                              
         32    jump -12                           (to 20)
 
-  232   33    load_type 5                        
+  282   33    load_type 5                        
         34    load_type 6                        
         35    alloc_map 0                        
         36    store_var 9                        (body)
 
-  237   37    load_var 5                         (prompt_parts)
+  287   37    load_var 5                         (prompt_parts)
         38    load_field 2                       (first_role)
         39    load_const 7                       ("user")
         40    cmp_op !=                          
         41    jump_if_false +9                   (to 50)
         42    pop 1                              
 
-  238   43    load_var 5                         (prompt_parts)
+  288   43    load_var 5                         (prompt_parts)
         44    load_field 0                       (system_parts)
         45    container_len                      
         46    store_var 10                       (_25)
@@ -7194,7 +8275,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         50    pop_jump_if_false +2               (to 52)
         51    jump +29                           (to 80)
 
-  241   52    load_var 5                         (prompt_parts)
+  291   52    load_var 5                         (prompt_parts)
         53    load_field 0                       (system_parts)
         54    container_len                      
         55    store_var 12                       (_33)
@@ -7203,12 +8284,12 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         58    cmp_int_op >                       
         59    pop_jump_if_false +33              (to 92)
 
-  242   60    load_type 5                        
+  292   60    load_type 5                        
         61    load_type 6                        
         62    alloc_map 0                        
         63    store_var 13                       (system_instruction)
 
-  243   64    load_type 5                        
+  293   64    load_type 5                        
         65    load_type 6                        
         66    load_var 13                        (system_instruction)
         67    load_const 9                       ("parts")
@@ -7217,7 +8298,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         70    call 37 ntypeargs=2                (baml.Map.set)
         71    pop 1                              
 
-  244   72    load_type 5                        
+  294   72    load_type 5                        
         73    load_type 6                        
         74    load_var 9                         (body)
         75    load_const 10                      ("systemInstruction")
@@ -7226,10 +8307,10 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         78    pop 1                              
         79    jump +13                           (to 92)
 
-  239   80    load_const 11                      ("user")
+  289   80    load_const 11                      ("user")
         81    load_var 5                         (prompt_parts)
         82    load_field 0                       (system_parts)
-        83    call 855 ntypeargs=0               (google.internal._gm_content)
+        83    call 861 ntypeargs=0               (google.internal._gm_content)
         84    store_var 11                       (_28)
         85    load_type 12                       
         86    load_var 11                        (_28)
@@ -7239,7 +8320,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         90    call 7 ntypeargs=1                 (baml.Array.concat)
         91    store_var 6                        (contents)
 
-  249   92    load_type 5                        
+  299   92    load_type 5                        
         93    load_type 6                        
         94    load_var 9                         (body)
         95    load_const 13                      ("contents")
@@ -7247,17 +8328,17 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         97    call 37 ntypeargs=2                (baml.Map.set)
         98    pop 1                              
 
-  250   99    load_var 2                         (input)
+  300   99    load_var 2                         (input)
         100   load_field 2                       (toolbox)
         101   call 778 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         102   unary_op !                         
         103   pop_jump_if_false +103             (to 206)
 
-  251   104   load_type 12                       
+  301   104   load_type 12                       
         105   alloc_array 0                      
         106   store_var 14                       (decls)
 
-  252   107   load_var 2                         (input)
+  302   107   load_var 2                         (input)
         108   load_field 2                       (toolbox)
         109   call 776 ntypeargs=0               (ai.tools.Toolbox.list)
         110   load_type 14                       
@@ -7276,12 +8357,12 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         123   load_var 16                        (_55)
         124   store_var 17                       (t)
 
-  253   125   load_type 5                        
+  303   125   load_type 5                        
         126   load_type 6                        
         127   alloc_map 0                        
         128   store_var 18                       (d)
 
-  254   129   load_type 5                        
+  304   129   load_type 5                        
         130   load_type 6                        
         131   load_var 18                        (d)
         132   load_const 18                      ("name")
@@ -7290,7 +8371,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         135   call 37 ntypeargs=2                (baml.Map.set)
         136   pop 1                              
 
-  255   137   load_type 5                        
+  305   137   load_type 5                        
         138   load_type 6                        
         139   load_var 18                        (d)
         140   load_const 19                      ("description")
@@ -7299,7 +8380,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         143   call 37 ntypeargs=2                (baml.Map.set)
         144   pop 1                              
 
-  256   145   load_type 5                        
+  306   145   load_type 5                        
         146   load_type 6                        
         147   load_var 18                        (d)
         148   load_const 20                      ("parametersJsonSchema")
@@ -7308,17 +8389,17 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         151   call 37 ntypeargs=2                (baml.Map.set)
         152   pop 1                              
 
-  257   153   load_var2 14 18                    
+  307   153   load_var2 14 18                    
         154   call 4 ntypeargs=0                 (baml.Array.push)
         155   pop 1                              
         156   jump -42                           (to 114)
 
-  259   157   load_type 5                        
+  309   157   load_type 5                        
         158   load_type 6                        
         159   alloc_map 0                        
         160   store_var 19                       (group)
 
-  260   161   load_type 5                        
+  310   161   load_type 5                        
         162   load_type 6                        
         163   load_var 19                        (group)
         164   load_const 21                      ("functionDeclarations")
@@ -7326,7 +8407,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         166   call 37 ntypeargs=2                (baml.Map.set)
         167   pop 1                              
 
-  261   168   load_type 5                        
+  311   168   load_type 5                        
         169   load_type 6                        
         170   load_var 9                         (body)
         171   load_const 22                      ("tools")
@@ -7336,12 +8417,12 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         175   call 37 ntypeargs=2                (baml.Map.set)
         176   pop 1                              
 
-  262   177   load_type 5                        
+  312   177   load_type 5                        
         178   load_type 6                        
         179   alloc_map 0                        
         180   store_var 20                       (fcc)
 
-  263   181   load_type 5                        
+  313   181   load_type 5                        
         182   load_type 6                        
         183   load_var 20                        (fcc)
         184   load_const 23                      ("mode")
@@ -7349,12 +8430,12 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         186   call 37 ntypeargs=2                (baml.Map.set)
         187   pop 1                              
 
-  264   188   load_type 5                        
+  314   188   load_type 5                        
         189   load_type 6                        
         190   alloc_map 0                        
         191   store_var 21                       (tc)
 
-  265   192   load_type 5                        
+  315   192   load_type 5                        
         193   load_type 6                        
         194   load_var 21                        (tc)
         195   load_const 25                      ("functionCallingConfig")
@@ -7362,7 +8443,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         197   call 37 ntypeargs=2                (baml.Map.set)
         198   pop 1                              
 
-  266   199   load_type 5                        
+  316   199   load_type 5                        
         200   load_type 6                        
         201   load_var 9                         (body)
         202   load_const 26                      ("toolConfig")
@@ -7370,19 +8451,19 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         204   call 37 ntypeargs=2                (baml.Map.set)
         205   pop 1                              
 
-  271   206   load_var 3                         (stream)
+  321   206   load_var 3                         (stream)
         207   pop_jump_if_false +2               (to 209)
         208   jump +4                            (to 212)
 
-  274   209   load_const 27                      (":generateContent")
+  324   209   load_const 27                      (":generateContent")
         210   store_var 22                       (method)
 
-  271   211   jump +3                            (to 214)
+  321   211   jump +3                            (to 214)
 
-  272   212   load_const 28                      (":streamGenerateContent?alt=sse")
+  322   212   load_const 28                      (":streamGenerateContent?alt=sse")
         213   store_var 22                       (method)
 
-  278   214   load_var 1                         (c)
+  328   214   load_var 1                         (c)
         215   load_field 2                       (base_url)
         216   store_var 25                       (_103)
         217   load_var 25                        (_103)
@@ -7407,7 +8488,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         236   call 138 ntypeargs=1               (baml.String.from)
         237   store_var 27                       (_109)
 
-  280   238   load_var 1                         (c)
+  330   238   load_var 1                         (c)
         239   load_field 1                       (api_key)
         240   store_var 29                       (_114)
         241   load_var2 29 29                    
@@ -7417,7 +8498,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         245   load_const 31                      ("GOOGLE_API_KEY")
         246   call 211 ntypeargs=0               (baml.env.get_or_panic)
 
-  279   247   load_const 32                      ("application/json")
+  329   247   load_const 32                      ("application/json")
         248   load_const 33                      ("x-goog-api-key")
         249   load_const 34                      ("content-type")
         250   load_type 5                        
@@ -7425,15 +8506,15 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         252   alloc_map 2                        
         253   store_var 28                       (_112)
 
-  283   254   load_type 12                       
+  333   254   load_type 12                       
         255   load_var 9                         (body)
         256   call 331 ntypeargs=1               (baml.json.to_json)
         257   call 328 ntypeargs=0               (baml.json.stringify)
         258   store_var 30                       (_116)
 
-  276   259   load_const 35                      ("POST")
+  326   259   load_const 35                      ("POST")
 
-  278   260   load_var 23                        (_101)
+  328   260   load_var 23                        (_101)
         261   load_const 36                      ("/models/")
         262   bin_op +                           
         263   load_var 26                        (_106)
@@ -7446,15 +8527,15 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 }
 
 function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unknown>[] {
-  139   0     load_type 0                        
+  189   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 2                        (contents)
 
-  140   3     load_type 0                        
+  190   3     load_type 0                        
         4     alloc_array 0                      
         5     store_var 3                        (pending)
 
-  141   6     load_var 1                         (j)
+  191   6     load_var 1                         (j)
         7     call 760 ntypeargs=0               (ai.Journal.entries)
         8     load_type 1                        
         9     load_const 2                       ("iter")
@@ -7472,7 +8553,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         21    load_var 5                         (_6)
         22    store_var 6                        (e)
 
-  142   23    load_var 6                         (e)
+  192   23    load_var 6                         (e)
         24    store_var 7                        (_10)
         25    load_var 7                         (_10)
         26    narrow_bind 6 7                    
@@ -7498,12 +8579,12 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         46    load_var 33                        (_76)
         47    store_var 34                       (f)
 
-  197   48    load_type 10                       
+  247   48    load_type 10                       
         49    load_type 11                       
         50    alloc_map 0                        
         51    store_var 35                       (response)
 
-  198   52    load_type 10                       
+  248   52    load_type 10                       
         53    load_type 11                       
         54    load_var 35                        (response)
         55    load_const 12                      ("error")
@@ -7512,26 +8593,26 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         58    call 37 ntypeargs=2                (baml.Map.set)
         59    pop 1                              
 
-  199   60    load_var2 1 34                     
+  249   60    load_var2 1 34                     
         61    load_field 0                       (id)
-        62    call 859 ntypeargs=0               (google.internal._gm_tool_name_for)
+        62    call 867 ntypeargs=0               (google.internal._gm_tool_name_for)
         63    load_var 35                        (response)
-        64    call 857 ntypeargs=0               (google.internal._gm_function_response)
+        64    call 865 ntypeargs=0               (google.internal._gm_function_response)
         65    store_var 36                       (_84)
         66    load_var2 3 36                     
         67    call 4 ntypeargs=0                 (baml.Array.push)
         68    pop 1                              
         69    jump -57                           (to 12)
 
-  142   70    load_var 29                        (_64)
+  192   70    load_var 29                        (_64)
         71    store_var 30                       (c)
 
-  191   72    load_type 10                       
+  241   72    load_type 10                       
         73    load_type 11                       
         74    alloc_map 0                        
         75    store_var 31                       (response)
 
-  192   76    load_type 10                       
+  242   76    load_type 10                       
         77    load_type 11                       
         78    load_var 31                        (response)
         79    load_const 13                      ("result")
@@ -7540,21 +8621,21 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         82    call 37 ntypeargs=2                (baml.Map.set)
         83    pop 1                              
 
-  193   84    load_var2 1 30                     
+  243   84    load_var2 1 30                     
         85    load_field 0                       (id)
-        86    call 859 ntypeargs=0               (google.internal._gm_tool_name_for)
+        86    call 867 ntypeargs=0               (google.internal._gm_tool_name_for)
         87    load_var 31                        (response)
-        88    call 857 ntypeargs=0               (google.internal._gm_function_response)
+        88    call 865 ntypeargs=0               (google.internal._gm_function_response)
         89    store_var 32                       (_72)
         90    load_var2 3 32                     
         91    call 4 ntypeargs=0                 (baml.Array.push)
         92    pop 1                              
         93    jump -81                           (to 12)
 
-  142   94    load_var 13                        (_22)
+  192   94    load_var 13                        (_22)
         95    store_var 14                       (a)
 
-  155   96    load_var 3                         (pending)
+  205   96    load_var 3                         (pending)
         97    container_len                      
         98    store_var 15                       (_25)
         99    load_var 15                        (_25)
@@ -7562,23 +8643,23 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         101   cmp_int_op >                       
         102   pop_jump_if_false +11              (to 113)
 
-  156   103   load_const 15                      ("user")
+  206   103   load_const 15                      ("user")
         104   load_var 3                         (pending)
-        105   call 855 ntypeargs=0               (google.internal._gm_content)
+        105   call 861 ntypeargs=0               (google.internal._gm_content)
         106   store_var 16                       (_27)
         107   load_var2 2 16                     
         108   call 4 ntypeargs=0                 (baml.Array.push)
         109   pop 1                              
 
-  157   110   load_type 0                        
+  207   110   load_type 0                        
         111   alloc_array 0                      
         112   store_var 3                        (pending)
 
-  162   113   load_type 0                        
+  212   113   load_type 0                        
         114   alloc_array 0                      
         115   store_var 17                       (parts)
 
-  163   116   load_var 14                        (a)
+  213   116   load_var 14                        (a)
         117   load_field 0                       (content)
         118   load_type 16                       
         119   load_const 17                      ("iter")
@@ -7596,7 +8677,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         131   load_var 19                        (_32)
         132   store_var 20                       (b)
 
-  164   133   load_var 20                        (b)
+  214   133   load_var 20                        (b)
         134   store_var 21                       (_36)
         135   load_var 21                        (_36)
         136   narrow_bind 20 21                  
@@ -7610,12 +8691,12 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         144   load_var 23                        (_41)
         145   store_var 24                       (use)
 
-  170   146   load_type 10                       
+  220   146   load_type 10                       
         147   load_type 11                       
         148   alloc_map 0                        
         149   store_var 25                       (fc)
 
-  171   150   load_type 10                       
+  221   150   load_type 10                       
         151   load_type 11                       
         152   load_var 25                        (fc)
         153   load_const 22                      ("name")
@@ -7624,7 +8705,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         156   call 37 ntypeargs=2                (baml.Map.set)
         157   pop 1                              
 
-  172   158   load_type 10                       
+  222   158   load_type 10                       
         159   load_type 11                       
         160   load_var 25                        (fc)
         161   load_const 23                      ("args")
@@ -7633,12 +8714,12 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         164   call 37 ntypeargs=2                (baml.Map.set)
         165   pop 1                              
 
-  173   166   load_type 10                       
+  223   166   load_type 10                       
         167   load_type 11                       
         168   alloc_map 0                        
         169   store_var 26                       (part)
 
-  174   170   load_type 10                       
+  224   170   load_type 10                       
         171   load_type 11                       
         172   load_var 26                        (part)
         173   load_const 24                      ("functionCall")
@@ -7646,22 +8727,22 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         175   call 37 ntypeargs=2                (baml.Map.set)
         176   pop 1                              
 
-  175   177   load_var2 17 26                    
+  225   177   load_var2 17 26                    
         178   call 4 ntypeargs=0                 (baml.Array.push)
         179   pop 1                              
         180   jump -58                           (to 122)
 
-  164   181   load_var 21                        (_36)
+  214   181   load_var 21                        (_36)
         182   load_field 0                       (text)
-        183   call 856 ntypeargs=0               (google.internal._gm_text_part)
+        183   call 862 ntypeargs=0               (google.internal._gm_text_part)
         184   store_var 22                       (_39)
 
-  166   185   load_var2 17 22                    
+  216   185   load_var2 17 22                    
         186   call 4 ntypeargs=0                 (baml.Array.push)
         187   pop 1                              
         188   jump -66                           (to 122)
 
-  182   189   load_var 17                        (parts)
+  232   189   load_var 17                        (parts)
         190   container_len                      
         191   store_var 27                       (_60)
         192   load_var 27                        (_60)
@@ -7669,19 +8750,19 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         194   cmp_int_op >                       
         195   pop_jump_if_false -183             (to 12)
 
-  183   196   load_const 25                      ("model")
+  233   196   load_const 25                      ("model")
         197   load_var 17                        (parts)
-        198   call 855 ntypeargs=0               (google.internal._gm_content)
+        198   call 861 ntypeargs=0               (google.internal._gm_content)
         199   store_var 28                       (_62)
         200   load_var2 2 28                     
         201   call 4 ntypeargs=0                 (baml.Array.push)
         202   pop 1                              
         203   jump -191                          (to 12)
 
-  142   204   load_var 7                         (_10)
+  192   204   load_var 7                         (_10)
         205   store_var 8                        (u)
 
-  144   206   load_var 3                         (pending)
+  194   206   load_var 3                         (pending)
         207   container_len                      
         208   store_var 9                        (_13)
         209   load_var 9                         (_13)
@@ -7689,34 +8770,34 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         211   cmp_int_op >                       
         212   pop_jump_if_false +11              (to 223)
 
-  145   213   load_const 26                      ("user")
+  195   213   load_const 26                      ("user")
         214   load_var 3                         (pending)
-        215   call 855 ntypeargs=0               (google.internal._gm_content)
+        215   call 861 ntypeargs=0               (google.internal._gm_content)
         216   store_var 10                       (_15)
         217   load_var2 2 10                     
         218   call 4 ntypeargs=0                 (baml.Array.push)
         219   pop 1                              
 
-  146   220   load_type 0                        
+  196   220   load_type 0                        
         221   alloc_array 0                      
         222   store_var 3                        (pending)
 
-  151   223   load_var 8                         (u)
+  201   223   load_var 8                         (u)
         224   load_field 0                       (content)
-        225   call 856 ntypeargs=0               (google.internal._gm_text_part)
+        225   call 862 ntypeargs=0               (google.internal._gm_text_part)
         226   store_var 12                       (_20)
         227   load_const 27                      ("user")
         228   load_var 12                        (_20)
         229   load_type 0                        
         230   alloc_array 1                      
-        231   call 855 ntypeargs=0               (google.internal._gm_content)
+        231   call 861 ntypeargs=0               (google.internal._gm_content)
         232   store_var 11                       (_18)
         233   load_var2 2 11                     
         234   call 4 ntypeargs=0                 (baml.Array.push)
         235   pop 1                              
         236   jump -224                          (to 12)
 
-  205   237   load_var 3                         (pending)
+  255   237   load_var 3                         (pending)
         238   container_len                      
         239   store_var 37                       (_89)
         240   load_var 37                        (_89)
@@ -7724,31 +8805,31 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         242   cmp_int_op >                       
         243   pop_jump_if_false +8               (to 251)
 
-  206   244   load_const 28                      ("user")
+  256   244   load_const 28                      ("user")
         245   load_var 3                         (pending)
-        246   call 855 ntypeargs=0               (google.internal._gm_content)
+        246   call 861 ntypeargs=0               (google.internal._gm_content)
         247   store_var 38                       (_91)
         248   load_var2 2 38                     
         249   call 4 ntypeargs=0                 (baml.Array.push)
         250   pop 1                              
 
-  211   251   load_var 2                         (contents)
+  261   251   load_var 2                         (contents)
         252   return                             
 }
 
 function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.internal.GooglePrompt {
-  79    0    load_type 0                        
+  127   0    load_type 0                        
         1    alloc_array 0                      
         2    store_var 2                        (system_parts)
 
-  80    3    load_type 0                        
+  128   3    load_type 0                        
         4    alloc_array 0                      
         5    store_var 3                        (contents)
 
-  81    6    load_const 1                       ("")
+  129   6    load_const 1                       ("")
         7    store_var 4                        (first_role)
 
-  82    8    load_var 1                         (prompt)
+  130   8    load_var 1                         (prompt)
         9    call 764 ntypeargs=0               (ai.Prompt.messages)
         10   load_type 2                        
         11   load_const 3                       ("iter")
@@ -7762,77 +8843,90 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
         19   load_var 6                         (_7)
         20   is_type 6                          
         21   pop_jump_if_false +2               (to 23)
-        22   jump +42                           (to 64)
+        22   jump +53                           (to 75)
         23   load_var 6                         (_7)
         24   store_var_load_var 7               (message)
 
-  83    25   load_field 1                       (content)
-        26   call 856 ntypeargs=0               (google.internal._gm_text_part)
-        27   store_var 8                        (part)
+  131   25   call 864 ntypeargs=0               (google.internal._gm_prompt_parts)
+        26   store_var 8                        (parts)
 
-  84    28   load_var 7                         (message)
-        29   load_field 0                       (role)
-        30   load_const 7                       ("system")
-        31   cmp_op ==                          
-        32   pop_jump_if_false +2               (to 34)
-        33   jump +27                           (to 60)
+  132   27   load_var 7                         (message)
+        28   load_field 0                       (role)
+        29   load_const 7                       ("system")
+        30   cmp_op ==                          
+        31   pop_jump_if_false +2               (to 33)
+        32   jump +25                           (to 57)
 
-  88    34   load_var 7                         (message)
-        35   load_field 0                       (role)
-        36   load_const 8                       ("assistant")
-        37   cmp_op ==                          
-        38   pop_jump_if_false +2               (to 40)
-        39   jump +4                            (to 43)
+  138   33   load_var 7                         (message)
+        34   load_field 0                       (role)
+        35   load_const 8                       ("assistant")
+        36   cmp_op ==                          
+        37   pop_jump_if_false +2               (to 39)
+        38   jump +4                            (to 42)
 
-  91    40   load_const 9                       ("user")
-        41   store_var 9                        (role)
+  141   39   load_const 9                       ("user")
+        40   store_var 11                       (role)
 
-  88    42   jump +3                            (to 45)
+  138   41   jump +3                            (to 44)
 
-  89    43   load_const 10                      ("model")
-        44   store_var 9                        (role)
+  139   42   load_const 10                      ("model")
+        43   store_var 11                       (role)
 
-  93    45   load_var 4                         (first_role)
-        46   load_const 11                      ("")
-        47   cmp_op ==                          
-        48   pop_jump_if_false +3               (to 51)
+  143   44   load_var 4                         (first_role)
+        45   load_const 11                      ("")
+        46   cmp_op ==                          
+        47   pop_jump_if_false +3               (to 50)
 
-  94    49   load_var 9                         (role)
-        50   store_var 4                        (first_role)
+  144   48   load_var 11                        (role)
+        49   store_var 4                        (first_role)
 
-  99    51   load_var2 9 8                      
-        52   load_type 0                        
-        53   alloc_array 1                      
-        54   call 855 ntypeargs=0               (google.internal._gm_content)
-        55   store_var 10                       (_23)
-        56   load_var2 3 10                     
-        57   call 4 ntypeargs=0                 (baml.Array.push)
-        58   pop 1                              
-        59   jump -45                           (to 14)
+  149   50   load_var2 11 8                     
+        51   call 861 ntypeargs=0               (google.internal._gm_content)
+        52   store_var 12                       (_29)
+        53   load_var2 3 12                     
+        54   call 4 ntypeargs=0                 (baml.Array.push)
+        55   pop 1                              
+        56   jump -42                           (to 14)
 
-  85    60   load_var2 2 8                      
-        61   call 4 ntypeargs=0                 (baml.Array.push)
-        62   pop 1                              
-        63   jump -49                           (to 14)
+  133   57   load_var 8                         (parts)
+        58   load_type 12                       
+        59   load_const 13                      ("iter")
+        60   virtual_call nargs=1 ntypeargs=0   
+        61   store_var 9                        (_16)
+        62   load_var 9                         (_16)
+        63   load_type 14                       
+        64   load_const 15                      ("next")
+        65   virtual_call nargs=1 ntypeargs=0   
+        66   store_var 10                       (_17)
+        67   load_var 10                        (_17)
+        68   is_type 6                          
+        69   pop_jump_if_false +2               (to 71)
+        70   jump -56                           (to 14)
 
-  103   64   load_var2 2 3                      
-        65   load_var 4                         (first_role)
-        66   init_instance 0                    (google.internal.GooglePrompt .system_parts, .contents, .first_role)
-        67   return                             
+  134   71   load_var2 2 10                     
+
+  133   72   call 4 ntypeargs=0                 (baml.Array.push)
+        73   pop 1                              
+        74   jump -12                           (to 62)
+
+  153   75   load_var2 2 3                      
+        76   load_var 4                         (first_role)
+        77   init_instance 0                    (google.internal.GooglePrompt .system_parts, .contents, .first_role)
+        78   return                             
 }
 
 function google.internal.google_parse(resp: google.internal.GmResponse, seq: int) -> ai.ModelTurn {
-  291   0     load_type 0                        
+  341   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 3                        (content)
 
-  292   3     load_const 1                       (false)
+  342   3     load_const 1                       (false)
         4     store_var 4                        (has_call)
 
-  293   5     load_const 2                       (0)
+  343   5     load_const 2                       (0)
         6     store_var 5                        (call_index)
 
-  294   7     load_var 1                         (resp)
+  344   7     load_var 1                         (resp)
         8     load_field 0                       (candidates)
         9     load_const 3                       (null)
         10    cmp_op ==                          
@@ -7848,7 +8942,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         20    load_const 3                       (null)
         21    store_var 6                        (cand)
 
-  295   22    load_var 6                         (cand)
+  345   22    load_var 6                         (cand)
         23    load_const 3                       (null)
         24    cmp_op ==                          
         25    pop_jump_if_false +2               (to 27)
@@ -7868,7 +8962,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         39    load_const 4                       ("")
         40    store_var 7                        (finish)
 
-  296   41    load_var 6                         (cand)
+  346   41    load_var 6                         (cand)
         42    load_const 3                       (null)
         43    cmp_op ==                          
         44    pop_jump_if_false +2               (to 46)
@@ -7901,7 +8995,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         71    alloc_array 0                      
         72    store_var 9                        (parts)
 
-  297   73    load_var 9                         (parts)
+  347   73    load_var 9                         (parts)
         74    load_type 6                        
         75    load_const 7                       ("iter")
         76    virtual_call nargs=1 ntypeargs=0   
@@ -7918,14 +9012,14 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         87    load_var 12                        (_31)
         88    store_var_load_var 13              (p)
 
-  298   89    load_field 2                       (functionCall)
+  348   89    load_field 2                       (functionCall)
         90    store_var 14                       (_36)
         91    load_var 14                        (_36)
         92    narrow_bind 11 14                  
         93    pop_jump_if_false +2               (to 95)
         94    jump +33                           (to 127)
 
-  310   95    load_var 13                        (p)
+  360   95    load_var 13                        (p)
         96    load_field 0                       (text)
         97    store_var 20                       (_55)
         98    load_var 20                        (_55)
@@ -7934,7 +9028,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         101   load_var 20                        (_55)
         102   store_var 21                       (t)
 
-  311   103   load_var 13                        (p)
+  361   103   load_var 13                        (p)
         104   load_field 1                       (thought)
         105   store_var 23                       (_58)
         106   load_var 23                        (_58)
@@ -7949,27 +9043,27 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         115   pop_jump_if_false +2               (to 117)
         116   jump +6                            (to 122)
 
-  315   117   load_var2 3 21                     
+  365   117   load_var2 3 21                     
         118   init_instance 0                    (ai.content.Text .text)
         119   call 4 ntypeargs=0                 (baml.Array.push)
         120   pop 1                              
         121   jump -43                           (to 78)
 
-  312   122   load_var2 3 21                     
+  362   122   load_var2 3 21                     
         123   init_instance 1                    (ai.content.Reasoning .summary)
         124   call 4 ntypeargs=0                 (baml.Array.push)
         125   pop 1                              
         126   jump -48                           (to 78)
 
-  298   127   load_var 14                        (_36)
+  348   127   load_var 14                        (_36)
         128   store_var 15                       (fc)
 
-  299   129   load_type 13                       
+  349   129   load_type 13                       
         130   load_type 14                       
         131   alloc_map 0                        
         132   store_var 16                       (args)
 
-  300   133   load_var 15                        (fc)
+  350   133   load_var 15                        (fc)
         134   load_field 1                       (args)
         135   store_var 17                       (_40)
         136   load_var 17                        (_40)
@@ -7978,7 +9072,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         139   load_var 17                        (_40)
         140   store_var 16                       (args)
 
-  304   141   load_type 16                       
+  354   141   load_type 16                       
         142   load_var 2                         (seq)
         143   call 138 ntypeargs=1               (baml.String.from)
         144   store_var 18                       (_47)
@@ -7987,9 +9081,9 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         147   call 138 ntypeargs=1               (baml.String.from)
         148   store_var 19                       (_49)
 
-  303   149   load_var 3                         (content)
+  353   149   load_var 3                         (content)
 
-  304   150   load_const 17                      ("call_")
+  354   150   load_const 17                      ("call_")
         151   load_var 18                        (_47)
         152   bin_op +                           
         153   load_const 18                      ("_")
@@ -8003,17 +9097,17 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         161   call 4 ntypeargs=0                 (baml.Array.push)
         162   pop 1                              
 
-  306   163   load_var 5                         (call_index)
+  356   163   load_var 5                         (call_index)
         164   load_const 12                      (1)
         165   add_int                            
         166   store_var 5                        (call_index)
 
-  307   167   load_const 19                      (true)
+  357   167   load_const 19                      (true)
         168   store_var 4                        (has_call)
 
-  298   169   jump -91                           (to 78)
+  348   169   jump -91                           (to 78)
 
-  323   170   load_var 1                         (resp)
+  373   170   load_var 1                         (resp)
         171   load_field 2                       (promptFeedback)
         172   load_const 3                       (null)
         173   cmp_op ==                          
@@ -8028,23 +9122,23 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         182   call 612 ntypeargs=0               (baml.ops.equals_equals)
         183   store_var 24                       (_71)
 
-  324   184   load_var 4                         (has_call)
+  374   184   load_var 4                         (has_call)
         185   pop_jump_if_false +2               (to 187)
         186   jump +40                           (to 226)
 
-  326   187   load_var 7                         (finish)
+  376   187   load_var 7                         (finish)
         188   load_const 20                      ("MAX_TOKENS")
         189   cmp_op ==                          
         190   pop_jump_if_false +2               (to 192)
         191   jump +31                           (to 222)
 
-  323   192   load_var 24                        (_71)
+  373   192   load_var 24                        (_71)
         193   unary_op !                         
         194   jump_if_false +2                   (to 196)
         195   jump +5                            (to 200)
         196   pop 1                              
 
-  328   197   load_var 7                         (finish)
+  378   197   load_var 7                         (finish)
         198   load_const 21                      ("SAFETY")
         199   cmp_op ==                          
         200   jump_if_false +2                   (to 202)
@@ -8062,29 +9156,29 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         212   pop_jump_if_false +2               (to 214)
         213   jump +5                            (to 218)
 
-  331   214   load_const 2                       (ai.content.StopReason.Complete)
-        215   alloc_variant 436                  (ai.content.StopReason)
+  381   214   load_const 2                       (ai.content.StopReason.Complete)
+        215   alloc_variant 438                  (ai.content.StopReason)
         216   store_var 25                       (stop)
 
-  328   217   jump +12                           (to 229)
+  378   217   jump +12                           (to 229)
 
-  329   218   load_const 24                      (ai.content.StopReason.Refused)
-        219   alloc_variant 436                  (ai.content.StopReason)
+  379   218   load_const 24                      (ai.content.StopReason.Refused)
+        219   alloc_variant 438                  (ai.content.StopReason)
         220   store_var 25                       (stop)
 
-  328   221   jump +8                            (to 229)
+  378   221   jump +8                            (to 229)
 
-  327   222   load_const 25                      (ai.content.StopReason.MaxTokens)
-        223   alloc_variant 436                  (ai.content.StopReason)
+  377   222   load_const 25                      (ai.content.StopReason.MaxTokens)
+        223   alloc_variant 438                  (ai.content.StopReason)
         224   store_var 25                       (stop)
 
-  326   225   jump +4                            (to 229)
+  376   225   jump +4                            (to 229)
 
-  325   226   load_const 12                      (ai.content.StopReason.ToolUse)
-        227   alloc_variant 436                  (ai.content.StopReason)
+  375   226   load_const 12                      (ai.content.StopReason.ToolUse)
+        227   alloc_variant 438                  (ai.content.StopReason)
         228   store_var 25                       (stop)
 
-  333   229   load_var 1                         (resp)
+  383   229   load_var 1                         (resp)
         230   load_field 1                       (usageMetadata)
         231   store_var 27                       (_85)
         232   load_var 27                        (_85)
@@ -8092,14 +9186,14 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         234   pop_jump_if_false +2               (to 236)
         235   jump +4                            (to 239)
 
-  341   236   load_const 3                       (null)
+  391   236   load_const 3                       (null)
         237   store_var 26                       (usage)
 
-  333   238   jump +30                           (to 268)
+  383   238   jump +30                           (to 268)
         239   load_var 27                        (_85)
         240   store_var 28                       (um)
 
-  335   241   load_var 28                        (um)
+  385   241   load_var 28                        (um)
         242   load_field 0                       (promptTokenCount)
         243   store_var 30                       (_88)
         244   load_var 30                        (_88)
@@ -8111,7 +9205,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         250   load_const 2                       (0)
         251   store_var 29                       (_87)
 
-  336   252   load_var 28                        (um)
+  386   252   load_var 28                        (um)
         253   load_field 1                       (candidatesTokenCount)
         254   store_var 32                       (_91)
         255   load_var 32                        (_91)
@@ -8123,57 +9217,57 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         261   load_const 2                       (0)
         262   store_var 31                       (_90)
 
-  334   263   load_var2 29 31                    
+  384   263   load_var2 29 31                    
         264   load_const 3                       (null)
         265   load_const 3                       (null)
         266   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
         267   store_var 26                       (usage)
 
-  343   268   load_var2 3 25                     
+  393   268   load_var2 3 25                     
         269   load_var 26                        (usage)
         270   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
         271   return                             
 }
 
 function google.internal.google_render(c: google.GoogleClient, input: ai.ModelTurnInput) -> baml.http.Request {
-  216   0   load_var2 1 2          
+  266   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 862 ntypeargs=0   (google.internal._google_request)
+        2   call 870 ntypeargs=0   (google.internal._google_request)
         3   return                 
 }
 
 function google.internal.invoke(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
-  351   0    load_var 2             (input)
+  401   0    load_var 2             (input)
         1    load_field 1           (journal)
         2    call 760 ntypeargs=0   (ai.Journal.entries)
         3    container_len          
         4    store_var 3            (seq)
 
-  352   5    load_var2 1 2          
-        6    call 861 ntypeargs=0   (google.internal.google_render)
+  402   5    load_var2 1 2          
+        6    call 869 ntypeargs=0   (google.internal.google_render)
         7    store_var 4            (req)
 
-  353   8    load_type 0            
+  403   8    load_type 0            
         9    load_var 4             (req)
         10   load_const 1           ("google")
         11   call 781 ntypeargs=1   (ai.wire.send_as)
 
-  354   12   load_var 3             (seq)
-        13   call 863 ntypeargs=0   (google.internal.google_parse)
+  404   12   load_var 3             (seq)
+        13   call 871 ntypeargs=0   (google.internal.google_parse)
         14   return                 
 }
 
 function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
-  432   0    load_var2 1 2          
+  482   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 862 ntypeargs=0   (google.internal._google_request)
+        2    call 870 ntypeargs=0   (google.internal._google_request)
 
-  433   3    sys_op 232             (baml.http.fetch_sse)
+  483   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
         5    load_var 3             (e)
         6    throw_if_panic         
 
-  437   7    load_type 1            
+  487   7    load_type 1            
         8    load_var 3             (e)
         9    call 138 ntypeargs=1   (baml.String.from)
         10   store_var 5            (_10)
@@ -8182,17 +9276,17 @@ function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTu
         13   call 138 ntypeargs=1   (baml.String.from)
         14   store_var 4            (_9)
 
-  435   15   load_const 3           ("google")
+  485   15   load_const 3           ("google")
 
-  437   16   load_const 4           ("transport failed before a response arrived: ")
+  487   16   load_const 4           ("transport failed before a response arrived: ")
         17   load_var 4             (_9)
         18   bin_op +               
         19   load_const 5           (null)
         20   init_instance 0        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
         21   throw                  
 
-  442   22   load_const 6           (google.internal._google_decode_batch)
-        23   call 803 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+  492   22   load_const 6           (google.internal._google_decode_batch)
+        23   call 806 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -8210,20 +9304,20 @@ function openai.OpenAiClient.ai.Client.id(self: openai.OpenAiClient) -> string {
 
 function openai.OpenAiClient.ai.Client.invoke(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   62   0   load_var2 1 2          
-       1   call 834 ntypeargs=0   (openai.internal.invoke)
+       1   call 838 ntypeargs=0   (openai.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   63   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 814 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function openai.OpenAiClient.ai.stream.StreamingClient.invoke_stream(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   70   0   load_var2 1 2          
-       1   call 836 ntypeargs=0   (openai.internal.invoke_stream)
+       1   call 840 ntypeargs=0   (openai.internal.invoke_stream)
        2   return                 
 }
 
@@ -8336,12 +9430,12 @@ function openai.OpenAiClient.resolved_base_url(self: openai.OpenAiClient) -> str
 }
 
 function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone)[] {
-  254   0     load_type 0                        
+  337   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 2                        (out)
 
-  255   3     load_var 1                         (batch)
-        4     call 802 ntypeargs=0               (ai.stream.decode_sse_batch)
+  338   3     load_var 1                         (batch)
+        4     call 805 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -8358,31 +9452,31 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         18    load_var 4                         (_5)
         19    store_var_load_var 5               (raw)
 
-  256   20    load_field 1                       (data)
+  339   20    load_field 1                       (data)
         21    store_var 6                        (_10)
         22    load_var 6                         (_10)
         23    narrow_bind 6 6                    
         24    pop_jump_if_false -15              (to 9)
 
-  257   25    load_type 7                        
+  340   25    load_type 7                        
 
-  256   26    load_var 6                         (_10)
+  339   26    load_var 6                         (_10)
         27    call 333 ntypeargs=1               (baml.json.from_string)
         28    jump +4                            (to 32)
 
-  257   29    load_var 7                         (e)
+  340   29    load_var 7                         (e)
         30    throw_if_panic                     
 
-  258   31    load_const 8                       (null)
+  341   31    load_const 8                       (null)
 
-  260   32    store_var 8                        (_16)
+  343   32    store_var 8                        (_16)
         33    load_var 8                         (_16)
         34    narrow_bind 9 8                    
         35    pop_jump_if_false -26              (to 9)
         36    load_var 8                         (_16)
         37    store_var 9                        (event)
 
-  261   38    load_var 9                         (event)
+  344   38    load_var 9                         (event)
         39    load_field 0                       (type)
         40    store_var 12                       (_20)
         41    load_var 12                        (_20)
@@ -8403,13 +9497,13 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         56    load_const 10                      ("")
         57    store_var 10                       (t)
 
-  262   58    load_var 10                        (t)
+  345   58    load_var 10                        (t)
         59    load_const 11                      ("response.output_text.delta")
         60    cmp_op ==                          
         61    pop_jump_if_false +2               (to 63)
         62    jump +65                           (to 127)
 
-  270   63    load_var 10                        (t)
+  353   63    load_var 10                        (t)
         64    load_const 12                      ("response.completed")
         65    cmp_op ==                          
         66    jump_if_false +2                   (to 68)
@@ -8426,21 +9520,21 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         77    cmp_op ==                          
         78    pop_jump_if_false -69              (to 9)
 
-  271   79    load_var 9                         (event)
+  354   79    load_var 9                         (event)
         80    load_field 2                       (response)
         81    store_var 14                       (_38)
         82    load_var 14                        (_38)
         83    narrow_bind 15 14                  
         84    pop_jump_if_false +38              (to 122)
         85    load_var 14                        (_38)
-        86    call 833 ntypeargs=0               (openai.internal.openai_parse)
+        86    call 837 ntypeargs=0               (openai.internal.openai_parse)
         87    store_var 15                       (turn)
 
-  275   88    load_var 15                        (turn)
+  358   88    load_var 15                        (turn)
         89    load_field 1                       (stop_reason)
         90    store_var 16                       (_44)
 
-  276   91    load_var 15                        (turn)
+  359   91    load_var 15                        (turn)
         92    load_field 2                       (usage)
         93    load_const 8                       (null)
         94    cmp_op ==                          
@@ -8454,7 +9548,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         102   load_const 8                       (null)
         103   store_var 17                       (_45)
 
-  277   104   load_var 15                        (turn)
+  360   104   load_var 15                        (turn)
         105   load_field 2                       (usage)
         106   load_const 8                       (null)
         107   cmp_op ==                          
@@ -8468,39 +9562,468 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         115   load_const 8                       (null)
         116   store_var 18                       (_49)
 
-  273   117   load_var2 2 16                     
+  356   117   load_var2 2 16                     
 
-  274   118   load_var2 17 18                    
+  357   118   load_var2 17 18                    
         119   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
         120   call 4 ntypeargs=0                 (baml.Array.push)
         121   pop 1                              
 
-  284   122   load_var 2                         (out)
-        123   alloc_instance 358 ntypeargs=0     (ai.stream.TurnDone)
+  367   122   load_var 2                         (out)
+        123   alloc_instance 360 ntypeargs=0     (ai.stream.TurnDone)
         124   call 4 ntypeargs=0                 (baml.Array.push)
         125   pop 1                              
         126   jump -117                          (to 9)
 
-  263   127   load_var 9                         (event)
+  346   127   load_var 9                         (event)
         128   load_field 1                       (delta)
         129   store_var 13                       (_26)
         130   load_var 13                        (_26)
         131   narrow_bind 6 13                   
         132   pop_jump_if_false -123             (to 9)
 
-  264   133   load_var2 2 13                     
+  347   133   load_var2 2 13                     
 
-  263   134   init_instance 1                    (ai.stream.TextDelta .text)
+  346   134   init_instance 1                    (ai.stream.TextDelta .text)
         135   call 4 ntypeargs=0                 (baml.Array.push)
         136   pop 1                              
         137   jump -128                          (to 9)
 
-  298   138   load_var 2                         (out)
+  381   138   load_var 2                         (out)
         139   return                             
 }
 
+function openai.internal._openai_prompt_content(message: ai.PromptMessage, role: string) -> map<string, unknown>[] {
+  37    0     load_type 0                        
+        1     alloc_array 0                      
+        2     store_var 3                        (content)
+
+  38    3     load_var 1                         (message)
+        4     load_field 2                       (parts)
+        5     load_type 1                        
+        6     load_const 2                       ("iter")
+        7     virtual_call nargs=1 ntypeargs=0   
+        8     store_var 4                        (_5)
+        9     load_var 4                         (_5)
+        10    load_type 3                        
+        11    load_const 4                       ("next")
+        12    virtual_call nargs=1 ntypeargs=0   
+        13    store_var 5                        (_6)
+        14    load_var 5                         (_6)
+        15    is_type 5                          
+        16    pop_jump_if_false +2               (to 18)
+        17    jump +351                          (to 368)
+        18    load_var 5                         (_6)
+        19    store_var 6                        (part)
+
+  39    20    load_var 6                         (part)
+        21    store_var 7                        (_10)
+        22    load_var 7                         (_10)
+        23    narrow_bind 6 7                    
+        24    pop_jump_if_false +2               (to 26)
+        25    jump +309                          (to 334)
+        26    load_var 6                         (part)
+        27    store_var 11                       (_24)
+        28    load_var 11                        (_24)
+        29    narrow_bind 7 11                   
+        30    pop_jump_if_false +2               (to 32)
+        31    jump +224                          (to 255)
+        32    load_var 6                         (part)
+        33    store_var 22                       (_56)
+        34    load_var 22                        (_56)
+        35    narrow_bind 8 22                   
+        36    pop_jump_if_false +2               (to 38)
+        37    jump +89                           (to 126)
+        38    load_var 6                         (part)
+        39    store_var 30                       (_98)
+        40    load_var 30                        (_98)
+        41    narrow_bind 9 30                   
+        42    pop_jump_if_false +2               (to 44)
+        43    jump +4                            (to 47)
+
+  110   44    load_const 10                      ("OpenAI Responses does not support video prompt input")
+        45    init_instance 0                    (baml.errors.InvalidArgument .message)
+        46    throw                              
+
+  39    47    load_var 30                        (_98)
+        48    store_var 31                       (pdf)
+
+  96    49    load_var 2                         (role)
+        50    load_const 11                      ("user")
+        51    cmp_op !=                          
+        52    pop_jump_if_false +2               (to 54)
+        53    jump +64                           (to 117)
+
+  101   54    load_var 31                        (pdf)
+        55    load_const 12                      (false)
+        56    call 785 ntypeargs=0               (ai.wire.resolve_media)
+        57    store_var 33                       (resolved)
+
+  102   58    load_var 33                        (resolved)
+        59    load_field 0                       (url)
+        60    store_var 35                       (_108)
+        61    load_var 35                        (_108)
+        62    store_var 34                       (file_data)
+        63    load_var 35                        (_108)
+        64    load_const 13                      (null)
+        65    cmp_op ==                          
+        66    pop_jump_if_false +29              (to 95)
+        67    load_type 14                       
+        68    load_var 33                        (resolved)
+        69    load_field 2                       (mime_type)
+        70    call 138 ntypeargs=1               (baml.String.from)
+        71    store_var 36                       (_112)
+        72    load_var 33                        (resolved)
+        73    load_field 1                       (base64)
+        74    store_var 39                       (_117)
+        75    load_var 39                        (_117)
+        76    store_var 38                       (_116)
+        77    load_var 39                        (_117)
+        78    load_const 13                      (null)
+        79    cmp_op ==                          
+        80    pop_jump_if_false +3               (to 83)
+        81    load_const 15                      ("")
+        82    store_var 38                       (_116)
+        83    load_type 14                       
+        84    load_var 38                        (_116)
+        85    call 138 ntypeargs=1               (baml.String.from)
+        86    store_var 37                       (_115)
+        87    load_const 16                      ("data:")
+        88    load_var 36                        (_112)
+        89    bin_op +                           
+        90    load_const 17                      (";base64,")
+        91    bin_op +                           
+        92    load_var 37                        (_115)
+        93    bin_op +                           
+        94    store_var 34                       (file_data)
+
+  103   95    load_type 14                       
+        96    load_type 18                       
+        97    alloc_map 0                        
+        98    store_var 40                       (item)
+
+  104   99    load_type 14                       
+        100   load_type 18                       
+        101   load_var 40                        (item)
+        102   load_const 19                      ("type")
+        103   load_const 20                      ("input_file")
+        104   call 37 ntypeargs=2                (baml.Map.set)
+        105   pop 1                              
+
+  105   106   load_type 14                       
+        107   load_type 18                       
+        108   load_var 40                        (item)
+        109   load_const 21                      ("file_data")
+        110   load_var 34                        (file_data)
+        111   call 37 ntypeargs=2                (baml.Map.set)
+        112   pop 1                              
+
+  106   113   load_var2 3 40                     
+        114   call 4 ntypeargs=0                 (baml.Array.push)
+        115   pop 1                              
+        116   jump -107                          (to 9)
+
+  98    117   load_type 14                       
+        118   load_var 2                         (role)
+        119   call 138 ntypeargs=1               (baml.String.from)
+        120   store_var 32                       (_103)
+        121   load_const 22                      ("OpenAI Responses only supports PDF input in user messages, found ")
+        122   load_var 32                        (_103)
+        123   bin_op +                           
+        124   init_instance 1                    (baml.errors.InvalidArgument .message)
+        125   throw                              
+
+  39    126   load_var 22                        (_56)
+        127   store_var 23                       (audio)
+
+  69    128   load_var 2                         (role)
+        129   load_const 23                      ("user")
+        130   cmp_op !=                          
+        131   pop_jump_if_false +2               (to 133)
+        132   jump +114                          (to 246)
+
+  74    133   load_var 23                        (audio)
+        134   load_const 24                      (true)
+        135   call 785 ntypeargs=0               (ai.wire.resolve_media)
+        136   store_var 25                       (resolved)
+
+  75    137   load_var 25                        (resolved)
+        138   load_field 2                       (mime_type)
+        139   load_const 25                      ("audio/wav")
+        140   cmp_op ==                          
+        141   jump_if_false +2                   (to 143)
+        142   jump +6                            (to 148)
+        143   pop 1                              
+        144   load_var 25                        (resolved)
+        145   load_field 2                       (mime_type)
+        146   load_const 26                      ("audio/x-wav")
+        147   cmp_op ==                          
+        148   pop_jump_if_false +2               (to 150)
+        149   jump +55                           (to 204)
+
+  77    150   load_var 25                        (resolved)
+        151   load_field 2                       (mime_type)
+        152   load_const 27                      ("audio/mpeg")
+        153   cmp_op ==                          
+        154   jump_if_false +2                   (to 156)
+        155   jump +6                            (to 161)
+        156   pop 1                              
+        157   load_var 25                        (resolved)
+        158   load_field 2                       (mime_type)
+        159   load_const 28                      ("audio/mp3")
+        160   cmp_op ==                          
+        161   pop_jump_if_false +2               (to 163)
+        162   jump +39                           (to 201)
+
+  79    163   load_var 25                        (resolved)
+        164   load_field 2                       (mime_type)
+        165   load_const 29                      ("audio/flac")
+        166   cmp_op ==                          
+        167   jump_if_false +2                   (to 169)
+        168   jump +6                            (to 174)
+        169   pop 1                              
+        170   load_var 25                        (resolved)
+        171   load_field 2                       (mime_type)
+        172   load_const 30                      ("audio/x-flac")
+        173   cmp_op ==                          
+        174   pop_jump_if_false +2               (to 176)
+        175   jump +23                           (to 198)
+
+  81    176   load_var 25                        (resolved)
+        177   load_field 2                       (mime_type)
+        178   load_const 31                      ("audio/ogg")
+        179   cmp_op ==                          
+        180   pop_jump_if_false +2               (to 182)
+        181   jump +14                           (to 195)
+
+  83    182   load_var 25                        (resolved)
+        183   load_field 2                       (mime_type)
+        184   load_const 32                      ("audio/webm")
+        185   cmp_op ==                          
+        186   pop_jump_if_false +2               (to 188)
+        187   jump +5                            (to 192)
+
+  86    188   load_var 25                        (resolved)
+        189   load_field 2                       (mime_type)
+        190   store_var 26                       (format)
+
+  83    191   jump +15                           (to 206)
+
+  84    192   load_const 33                      ("webm")
+        193   store_var 26                       (format)
+
+  83    194   jump +12                           (to 206)
+
+  82    195   load_const 34                      ("ogg")
+        196   store_var 26                       (format)
+
+  81    197   jump +9                            (to 206)
+
+  80    198   load_const 35                      ("flac")
+        199   store_var 26                       (format)
+
+  79    200   jump +6                            (to 206)
+
+  78    201   load_const 36                      ("mp3")
+        202   store_var 26                       (format)
+
+  77    203   jump +3                            (to 206)
+
+  76    204   load_const 37                      ("wav")
+        205   store_var 26                       (format)
+
+  88    206   load_type 14                       
+        207   load_type 18                       
+        208   alloc_map 0                        
+        209   store_var 27                       (item)
+
+  89    210   load_type 14                       
+        211   load_type 18                       
+        212   load_var 27                        (item)
+        213   load_const 38                      ("type")
+        214   load_const 39                      ("input_audio")
+        215   call 37 ntypeargs=2                (baml.Map.set)
+        216   pop 1                              
+
+  90    217   load_var 25                        (resolved)
+        218   load_field 1                       (base64)
+        219   store_var 29                       (_88)
+        220   load_var 29                        (_88)
+        221   store_var 28                       (_87)
+        222   load_var 29                        (_88)
+        223   load_const 13                      (null)
+        224   cmp_op ==                          
+        225   pop_jump_if_false +3               (to 228)
+        226   load_const 40                      ("")
+        227   store_var 28                       (_87)
+        228   load_type 14                       
+        229   load_type 18                       
+        230   load_var 27                        (item)
+        231   load_const 41                      ("data")
+        232   load_var 28                        (_87)
+        233   call 37 ntypeargs=2                (baml.Map.set)
+        234   pop 1                              
+
+  91    235   load_type 14                       
+        236   load_type 18                       
+        237   load_var 27                        (item)
+        238   load_const 42                      ("format")
+        239   load_var 26                        (format)
+        240   call 37 ntypeargs=2                (baml.Map.set)
+        241   pop 1                              
+
+  92    242   load_var2 3 27                     
+        243   call 4 ntypeargs=0                 (baml.Array.push)
+        244   pop 1                              
+        245   jump -236                          (to 9)
+
+  71    246   load_type 14                       
+        247   load_var 2                         (role)
+        248   call 138 ntypeargs=1               (baml.String.from)
+        249   store_var 24                       (_61)
+        250   load_const 43                      ("OpenAI Responses only supports audio input in user messages, found ")
+        251   load_var 24                        (_61)
+        252   bin_op +                           
+        253   init_instance 2                    (baml.errors.InvalidArgument .message)
+        254   throw                              
+
+  39    255   load_var 11                        (_24)
+        256   store_var 12                       (image)
+
+  55    257   load_var 2                         (role)
+        258   load_const 44                      ("user")
+        259   cmp_op !=                          
+        260   pop_jump_if_false +2               (to 262)
+        261   jump +64                           (to 325)
+
+  60    262   load_var 12                        (image)
+        263   load_const 12                      (false)
+        264   call 785 ntypeargs=0               (ai.wire.resolve_media)
+        265   store_var 14                       (resolved)
+
+  61    266   load_var 14                        (resolved)
+        267   load_field 0                       (url)
+        268   store_var 16                       (_34)
+        269   load_var 16                        (_34)
+        270   store_var 15                       (image_url)
+        271   load_var 16                        (_34)
+        272   load_const 13                      (null)
+        273   cmp_op ==                          
+        274   pop_jump_if_false +29              (to 303)
+        275   load_type 14                       
+        276   load_var 14                        (resolved)
+        277   load_field 2                       (mime_type)
+        278   call 138 ntypeargs=1               (baml.String.from)
+        279   store_var 17                       (_38)
+        280   load_var 14                        (resolved)
+        281   load_field 1                       (base64)
+        282   store_var 20                       (_43)
+        283   load_var 20                        (_43)
+        284   store_var 19                       (_42)
+        285   load_var 20                        (_43)
+        286   load_const 13                      (null)
+        287   cmp_op ==                          
+        288   pop_jump_if_false +3               (to 291)
+        289   load_const 45                      ("")
+        290   store_var 19                       (_42)
+        291   load_type 14                       
+        292   load_var 19                        (_42)
+        293   call 138 ntypeargs=1               (baml.String.from)
+        294   store_var 18                       (_41)
+        295   load_const 46                      ("data:")
+        296   load_var 17                        (_38)
+        297   bin_op +                           
+        298   load_const 47                      (";base64,")
+        299   bin_op +                           
+        300   load_var 18                        (_41)
+        301   bin_op +                           
+        302   store_var 15                       (image_url)
+
+  62    303   load_type 14                       
+        304   load_type 18                       
+        305   alloc_map 0                        
+        306   store_var 21                       (item)
+
+  63    307   load_type 14                       
+        308   load_type 18                       
+        309   load_var 21                        (item)
+        310   load_const 48                      ("type")
+        311   load_const 49                      ("input_image")
+        312   call 37 ntypeargs=2                (baml.Map.set)
+        313   pop 1                              
+
+  64    314   load_type 14                       
+        315   load_type 18                       
+        316   load_var 21                        (item)
+        317   load_const 50                      ("image_url")
+        318   load_var 15                        (image_url)
+        319   call 37 ntypeargs=2                (baml.Map.set)
+        320   pop 1                              
+
+  65    321   load_var2 3 21                     
+        322   call 4 ntypeargs=0                 (baml.Array.push)
+        323   pop 1                              
+        324   jump -315                          (to 9)
+
+  57    325   load_type 14                       
+        326   load_var 2                         (role)
+        327   call 138 ntypeargs=1               (baml.String.from)
+        328   store_var 13                       (_29)
+        329   load_const 51                      ("OpenAI Responses only supports image input in user messages, found ")
+        330   load_var 13                        (_29)
+        331   bin_op +                           
+        332   init_instance 3                    (baml.errors.InvalidArgument .message)
+        333   throw                              
+
+  39    334   load_var 7                         (_10)
+        335   store_var 8                        (text)
+
+  41    336   load_type 14                       
+        337   load_type 18                       
+        338   alloc_map 0                        
+        339   store_var 9                        (item)
+
+  44    340   load_var 2                         (role)
+        341   load_const 52                      ("assistant")
+        342   cmp_op ==                          
+        343   pop_jump_if_false +2               (to 345)
+        344   jump +4                            (to 348)
+
+  47    345   load_const 53                      ("input_text")
+        346   store_var 10                       (_14)
+
+  44    347   jump +3                            (to 350)
+
+  45    348   load_const 54                      ("output_text")
+        349   store_var 10                       (_14)
+
+  42    350   load_type 14                       
+        351   load_type 18                       
+        352   load_var 9                         (item)
+        353   load_const 55                      ("type")
+        354   load_var 10                        (_14)
+        355   call 37 ntypeargs=2                (baml.Map.set)
+        356   pop 1                              
+
+  50    357   load_type 14                       
+        358   load_type 18                       
+        359   load_var 9                         (item)
+        360   load_const 56                      ("text")
+        361   load_var 8                         (text)
+        362   call 37 ntypeargs=2                (baml.Map.set)
+        363   pop 1                              
+
+  51    364   load_var2 3 9                      
+        365   call 4 ntypeargs=0                 (baml.Array.push)
+        366   pop 1                              
+        367   jump -358                          (to 9)
+
+  116   368   load_var 3                         (content)
+        369   return                             
+}
+
 function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
-  128   0     load_var 2                         (input)
+  211   0     load_var 2                         (input)
         1     load_field 0                       (prompt)
         2     store_var 4                        (_5)
         3     load_var 2                         (input)
@@ -8509,12 +10032,12 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         6     load_var 4                         (_5)
         7     call_indirect                      
 
-  129   8     call 829 ntypeargs=0               (openai.internal.openai_lower_prompt)
+  212   8     call 833 ntypeargs=0               (openai.internal.openai_lower_prompt)
         9     store_var 5                        (items)
 
-  130   10    load_var 2                         (input)
+  213   10    load_var 2                         (input)
         11    load_field 1                       (journal)
-        12    call 830 ntypeargs=0               (openai.internal.openai_lower_journal)
+        12    call 834 ntypeargs=0               (openai.internal.openai_lower_journal)
         13    load_type 0                        
         14    load_const 1                       ("iter")
         15    virtual_call nargs=1 ntypeargs=0   
@@ -8529,18 +10052,18 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         24    pop_jump_if_false +2               (to 26)
         25    jump +5                            (to 30)
 
-  131   26    load_var2 5 7                      
+  214   26    load_var2 5 7                      
 
-  130   27    call 4 ntypeargs=0                 (baml.Array.push)
+  213   27    call 4 ntypeargs=0                 (baml.Array.push)
         28    pop 1                              
         29    jump -12                           (to 17)
 
-  133   30    load_type 5                        
+  216   30    load_type 5                        
         31    load_type 6                        
         32    alloc_map 0                        
         33    store_var 8                        (body)
 
-  134   34    load_type 5                        
+  217   34    load_type 5                        
         35    load_type 6                        
         36    load_var 8                         (body)
         37    load_const 7                       ("model")
@@ -8549,7 +10072,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         40    call 37 ntypeargs=2                (baml.Map.set)
         41    pop 1                              
 
-  135   42    load_type 5                        
+  218   42    load_type 5                        
         43    load_type 6                        
         44    load_var 8                         (body)
         45    load_const 8                       ("store")
@@ -8557,7 +10080,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         47    call 37 ntypeargs=2                (baml.Map.set)
         48    pop 1                              
 
-  136   49    load_type 5                        
+  219   49    load_type 5                        
         50    load_type 6                        
         51    load_var 8                         (body)
         52    load_const 10                      ("input")
@@ -8565,17 +10088,17 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         54    call 37 ntypeargs=2                (baml.Map.set)
         55    pop 1                              
 
-  137   56    load_var 2                         (input)
+  220   56    load_var 2                         (input)
         57    load_field 2                       (toolbox)
         58    call 778 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         59    unary_op !                         
         60    pop_jump_if_false +82              (to 142)
 
-  138   61    load_type 11                       
+  221   61    load_type 11                       
         62    alloc_array 0                      
         63    store_var 9                        (tools)
 
-  139   64    load_var 2                         (input)
+  222   64    load_var 2                         (input)
         65    load_field 2                       (toolbox)
         66    call 776 ntypeargs=0               (ai.tools.Toolbox.list)
         67    load_type 12                       
@@ -8594,12 +10117,12 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         80    load_var 11                        (_38)
         81    store_var 12                       (t)
 
-  140   82    load_type 5                        
+  223   82    load_type 5                        
         83    load_type 6                        
         84    alloc_map 0                        
         85    store_var 13                       (entry)
 
-  141   86    load_type 5                        
+  224   86    load_type 5                        
         87    load_type 6                        
         88    load_var 13                        (entry)
         89    load_const 16                      ("type")
@@ -8607,7 +10130,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         91    call 37 ntypeargs=2                (baml.Map.set)
         92    pop 1                              
 
-  142   93    load_type 5                        
+  225   93    load_type 5                        
         94    load_type 6                        
         95    load_var 13                        (entry)
         96    load_const 18                      ("name")
@@ -8616,7 +10139,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         99    call 37 ntypeargs=2                (baml.Map.set)
         100   pop 1                              
 
-  143   101   load_type 5                        
+  226   101   load_type 5                        
         102   load_type 6                        
         103   load_var 13                        (entry)
         104   load_const 19                      ("description")
@@ -8625,7 +10148,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         107   call 37 ntypeargs=2                (baml.Map.set)
         108   pop 1                              
 
-  144   109   load_type 5                        
+  227   109   load_type 5                        
         110   load_type 6                        
         111   load_var 13                        (entry)
         112   load_const 20                      ("parameters")
@@ -8634,7 +10157,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         115   call 37 ntypeargs=2                (baml.Map.set)
         116   pop 1                              
 
-  145   117   load_type 5                        
+  228   117   load_type 5                        
         118   load_type 6                        
         119   load_var 13                        (entry)
         120   load_const 21                      ("strict")
@@ -8642,12 +10165,12 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         122   call 37 ntypeargs=2                (baml.Map.set)
         123   pop 1                              
 
-  146   124   load_var2 9 13                     
+  229   124   load_var2 9 13                     
         125   call 4 ntypeargs=0                 (baml.Array.push)
         126   pop 1                              
         127   jump -56                           (to 71)
 
-  148   128   load_type 5                        
+  231   128   load_type 5                        
         129   load_type 6                        
         130   load_var 8                         (body)
         131   load_const 22                      ("tools")
@@ -8655,7 +10178,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         133   call 37 ntypeargs=2                (baml.Map.set)
         134   pop 1                              
 
-  149   135   load_type 5                        
+  232   135   load_type 5                        
         136   load_type 6                        
         137   load_var 8                         (body)
         138   load_const 23                      ("tool_choice")
@@ -8663,10 +10186,10 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         140   call 37 ntypeargs=2                (baml.Map.set)
         141   pop 1                              
 
-  154   142   load_var 3                         (stream)
+  237   142   load_var 3                         (stream)
         143   pop_jump_if_false +8               (to 151)
 
-  155   144   load_type 5                        
+  238   144   load_type 5                        
         145   load_type 6                        
         146   load_var 8                         (body)
         147   load_const 25                      ("stream")
@@ -8674,8 +10197,8 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         149   call 37 ntypeargs=2                (baml.Map.set)
         150   pop 1                              
 
-  162   151   load_var 1                         (c)
-        152   call 825 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
+  245   151   load_var 1                         (c)
+        152   call 828 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
         153   store_var 16                       (_76)
         154   load_var 16                        (_76)
         155   store_var 15                       (_75)
@@ -8690,27 +10213,27 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         164   call 138 ntypeargs=1               (baml.String.from)
         165   store_var 14                       (_74)
 
-  163   166   load_var 1                         (c)
-        167   call 824 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
+  246   166   load_var 1                         (c)
+        167   call 827 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
         168   store_var 18                       (_82)
         169   load_type 5                        
         170   load_var 18                        (_82)
         171   call 138 ntypeargs=1               (baml.String.from)
         172   store_var 17                       (_81)
 
-  164   173   load_type 11                       
+  247   173   load_type 11                       
         174   load_var 8                         (body)
         175   call 331 ntypeargs=1               (baml.json.to_json)
         176   call 328 ntypeargs=0               (baml.json.stringify)
         177   store_var 19                       (_84)
 
-  160   178   load_const 29                      ("POST")
+  243   178   load_const 29                      ("POST")
 
-  162   179   load_var 14                        (_74)
+  245   179   load_var 14                        (_74)
         180   load_const 30                      ("/responses")
         181   bin_op +                           
 
-  163   182   load_const 31                      ("Bearer ")
+  246   182   load_const 31                      ("Bearer ")
         183   load_var 17                        (_81)
         184   bin_op +                           
         185   load_const 32                      ("application/json")
@@ -8725,30 +10248,30 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 }
 
 function openai.internal.invoke(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
-  231   0   load_var2 1 2          
-        1   call 831 ntypeargs=0   (openai.internal.openai_render)
+  314   0   load_var2 1 2          
+        1   call 835 ntypeargs=0   (openai.internal.openai_render)
         2   store_var 3            (req)
 
-  232   3   load_type 0            
+  315   3   load_type 0            
         4   load_var 3             (req)
         5   load_const 1           ("openai")
         6   call 781 ntypeargs=1   (ai.wire.send_as)
 
-  233   7   call 833 ntypeargs=0   (openai.internal.openai_parse)
+  316   7   call 837 ntypeargs=0   (openai.internal.openai_parse)
         8   return                 
 }
 
 function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
-  304   0    load_var2 1 2          
+  387   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 832 ntypeargs=0   (openai.internal._openai_request)
+        2    call 836 ntypeargs=0   (openai.internal._openai_request)
 
-  305   3    sys_op 232             (baml.http.fetch_sse)
+  388   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
         5    load_var 3             (e)
         6    throw_if_panic         
 
-  309   7    load_type 1            
+  392   7    load_type 1            
         8    load_var 3             (e)
         9    call 138 ntypeargs=1   (baml.String.from)
         10   store_var 5            (_10)
@@ -8757,26 +10280,26 @@ function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTu
         13   call 138 ntypeargs=1   (baml.String.from)
         14   store_var 4            (_9)
 
-  307   15   load_const 3           ("openai")
+  390   15   load_const 3           ("openai")
 
-  309   16   load_const 4           ("transport failed before a response arrived: ")
+  392   16   load_const 4           ("transport failed before a response arrived: ")
         17   load_var 4             (_9)
         18   bin_op +               
         19   load_const 5           (null)
         20   init_instance 0        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
         21   throw                  
 
-  314   22   load_const 6           (openai.internal._openai_decode_batch)
-        23   call 803 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+  397   22   load_const 6           (openai.internal._openai_decode_batch)
+        23   call 806 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
 function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unknown>[] {
-  57    0     load_type 0                        
+  140   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 2                        (items)
 
-  58    3     load_var 1                         (j)
+  141   3     load_var 1                         (j)
         4     call 760 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
@@ -8794,7 +10317,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         18    load_var 4                         (_5)
         19    store_var 5                        (e)
 
-  59    20    load_var 5                         (e)
+  142   20    load_var 5                         (e)
         21    store_var 6                        (_9)
         22    load_var 6                         (_9)
         23    narrow_bind 6 6                    
@@ -8820,12 +10343,12 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         43    load_var 23                        (_80)
         44    store_var 24                       (f)
 
-  101   45    load_type 10                       
+  184   45    load_type 10                       
         46    load_type 11                       
         47    alloc_map 0                        
         48    store_var 25                       (err)
 
-  102   49    load_type 10                       
+  185   49    load_type 10                       
         50    load_type 11                       
         51    load_var 25                        (err)
         52    load_const 12                      ("error")
@@ -8834,12 +10357,12 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         55    call 37 ntypeargs=2                (baml.Map.set)
         56    pop 1                              
 
-  103   57    load_type 10                       
+  186   57    load_type 10                       
         58    load_type 11                       
         59    alloc_map 0                        
         60    store_var 26                       (m)
 
-  104   61    load_type 10                       
+  187   61    load_type 10                       
         62    load_type 11                       
         63    load_var 26                        (m)
         64    load_const 13                      ("type")
@@ -8847,7 +10370,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         66    call 37 ntypeargs=2                (baml.Map.set)
         67    pop 1                              
 
-  105   68    load_type 10                       
+  188   68    load_type 10                       
         69    load_type 11                       
         70    load_var 26                        (m)
         71    load_const 15                      ("call_id")
@@ -8856,7 +10379,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         74    call 37 ntypeargs=2                (baml.Map.set)
         75    pop 1                              
 
-  106   76    load_type 0                        
+  189   76    load_type 0                        
         77    load_var 25                        (err)
         78    call 331 ntypeargs=1               (baml.json.to_json)
         79    call 328 ntypeargs=0               (baml.json.stringify)
@@ -8869,20 +10392,20 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         86    call 37 ntypeargs=2                (baml.Map.set)
         87    pop 1                              
 
-  107   88    load_var2 2 26                     
+  190   88    load_var2 2 26                     
         89    call 4 ntypeargs=0                 (baml.Array.push)
         90    pop 1                              
         91    jump -82                           (to 9)
 
-  59    92    load_var 20                        (_64)
+  142   92    load_var 20                        (_64)
         93    store_var 21                       (c)
 
-  93    94    load_type 10                       
+  176   94    load_type 10                       
         95    load_type 11                       
         96    alloc_map 0                        
         97    store_var 22                       (m)
 
-  94    98    load_type 10                       
+  177   98    load_type 10                       
         99    load_type 11                       
         100   load_var 22                        (m)
         101   load_const 17                      ("type")
@@ -8890,7 +10413,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         103   call 37 ntypeargs=2                (baml.Map.set)
         104   pop 1                              
 
-  95    105   load_type 10                       
+  178   105   load_type 10                       
         106   load_type 11                       
         107   load_var 22                        (m)
         108   load_const 19                      ("call_id")
@@ -8899,7 +10422,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         111   call 37 ntypeargs=2                (baml.Map.set)
         112   pop 1                              
 
-  96    113   load_type 10                       
+  179   113   load_type 10                       
         114   load_type 11                       
         115   load_var 22                        (m)
         116   load_const 20                      ("output")
@@ -8908,19 +10431,19 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         119   call 37 ntypeargs=2                (baml.Map.set)
         120   pop 1                              
 
-  97    121   load_var2 2 22                     
+  180   121   load_var2 2 22                     
         122   call 4 ntypeargs=0                 (baml.Array.push)
         123   pop 1                              
         124   jump -115                          (to 9)
 
-  59    125   load_var 9                         (_21)
+  142   125   load_var 9                         (_21)
         126   load_field 0                       (content)
         127   load_type 21                       
         128   load_const 22                      ("iter")
         129   virtual_call nargs=1 ntypeargs=0   
         130   store_var 10                       (_24)
 
-  68    131   load_var 10                        (_24)
+  151   131   load_var 10                        (_24)
         132   load_type 23                       
         133   load_const 24                      ("next")
         134   virtual_call nargs=1 ntypeargs=0   
@@ -8932,7 +10455,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         140   load_var 11                        (_25)
         141   store_var 12                       (b)
 
-  69    142   load_var 12                        (b)
+  152   142   load_var 12                        (b)
         143   store_var 13                       (_29)
         144   load_var 13                        (_29)
         145   narrow_bind 25 13                  
@@ -8946,12 +10469,12 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         153   load_var 16                        (_41)
         154   store_var 17                       (use)
 
-  78    155   load_type 10                       
+  161   155   load_type 10                       
         156   load_type 11                       
         157   alloc_map 0                        
         158   store_var 18                       (m)
 
-  79    159   load_type 10                       
+  162   159   load_type 10                       
         160   load_type 11                       
         161   load_var 18                        (m)
         162   load_const 27                      ("type")
@@ -8959,7 +10482,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         164   call 37 ntypeargs=2                (baml.Map.set)
         165   pop 1                              
 
-  80    166   load_type 10                       
+  163   166   load_type 10                       
         167   load_type 11                       
         168   load_var 18                        (m)
         169   load_const 29                      ("call_id")
@@ -8968,7 +10491,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         172   call 37 ntypeargs=2                (baml.Map.set)
         173   pop 1                              
 
-  81    174   load_type 10                       
+  164   174   load_type 10                       
         175   load_type 11                       
         176   load_var 18                        (m)
         177   load_const 30                      ("name")
@@ -8977,7 +10500,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         180   call 37 ntypeargs=2                (baml.Map.set)
         181   pop 1                              
 
-  82    182   load_type 0                        
+  165   182   load_type 0                        
         183   load_var 17                        (use)
         184   load_field 2                       (args)
         185   call 331 ntypeargs=1               (baml.json.to_json)
@@ -8991,20 +10514,20 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         193   call 37 ntypeargs=2                (baml.Map.set)
         194   pop 1                              
 
-  83    195   load_var2 2 18                     
+  166   195   load_var2 2 18                     
         196   call 4 ntypeargs=0                 (baml.Array.push)
         197   pop 1                              
         198   jump -67                           (to 131)
 
-  69    199   load_var 13                        (_29)
+  152   199   load_var 13                        (_29)
         200   store_var 14                       (t)
 
-  71    201   load_type 10                       
+  154   201   load_type 10                       
         202   load_type 11                       
         203   alloc_map 0                        
         204   store_var 15                       (m)
 
-  72    205   load_type 10                       
+  155   205   load_type 10                       
         206   load_type 11                       
         207   load_var 15                        (m)
         208   load_const 32                      ("role")
@@ -9012,7 +10535,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         210   call 37 ntypeargs=2                (baml.Map.set)
         211   pop 1                              
 
-  73    212   load_type 10                       
+  156   212   load_type 10                       
         213   load_type 11                       
         214   load_var 15                        (m)
         215   load_const 34                      ("content")
@@ -9021,20 +10544,20 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         218   call 37 ntypeargs=2                (baml.Map.set)
         219   pop 1                              
 
-  74    220   load_var2 2 15                     
+  157   220   load_var2 2 15                     
         221   call 4 ntypeargs=0                 (baml.Array.push)
         222   pop 1                              
         223   jump -92                           (to 131)
 
-  59    224   load_var 6                         (_9)
+  142   224   load_var 6                         (_9)
         225   store_var 7                        (u)
 
-  61    226   load_type 10                       
+  144   226   load_type 10                       
         227   load_type 11                       
         228   alloc_map 0                        
         229   store_var 8                        (m)
 
-  62    230   load_type 10                       
+  145   230   load_type 10                       
         231   load_type 11                       
         232   load_var 8                         (m)
         233   load_const 35                      ("role")
@@ -9042,7 +10565,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         235   call 37 ntypeargs=2                (baml.Map.set)
         236   pop 1                              
 
-  63    237   load_type 10                       
+  146   237   load_type 10                       
         238   load_type 11                       
         239   load_var 8                         (m)
         240   load_const 37                      ("content")
@@ -9051,105 +10574,107 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         243   call 37 ntypeargs=2                (baml.Map.set)
         244   pop 1                              
 
-  64    245   load_var2 2 8                      
+  147   245   load_var2 2 8                      
         246   call 4 ntypeargs=0                 (baml.Array.push)
         247   pop 1                              
         248   jump -239                          (to 9)
 
-  113   249   load_var 2                         (items)
+  196   249   load_var 2                         (items)
         250   return                             
 }
 
 function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> map<string, unknown>[] {
-  37   0    load_type 0                        
-       1    alloc_array 0                      
-       2    store_var 2                        (items)
+  120   0    load_type 0                        
+        1    alloc_array 0                      
+        2    store_var 2                        (items)
 
-  38   3    load_var 1                         (prompt)
-       4    call 764 ntypeargs=0               (ai.Prompt.messages)
-       5    load_type 1                        
-       6    load_const 2                       ("iter")
-       7    virtual_call nargs=1 ntypeargs=0   
-       8    store_var 3                        (_4)
-       9    load_var 3                         (_4)
-       10   load_type 3                        
-       11   load_const 4                       ("next")
-       12   virtual_call nargs=1 ntypeargs=0   
-       13   store_var 4                        (_5)
-       14   load_var 4                         (_5)
-       15   is_type 5                          
-       16   pop_jump_if_false +2               (to 18)
-       17   jump +46                           (to 63)
-       18   load_var 4                         (_5)
-       19   store_var_load_var 5               (message)
+  121   3    load_var 1                         (prompt)
+        4    call 764 ntypeargs=0               (ai.Prompt.messages)
+        5    load_type 1                        
+        6    load_const 2                       ("iter")
+        7    virtual_call nargs=1 ntypeargs=0   
+        8    store_var 3                        (_4)
+        9    load_var 3                         (_4)
+        10   load_type 3                        
+        11   load_const 4                       ("next")
+        12   virtual_call nargs=1 ntypeargs=0   
+        13   store_var 4                        (_5)
+        14   load_var 4                         (_5)
+        15   is_type 5                          
+        16   pop_jump_if_false +2               (to 18)
+        17   jump +48                           (to 65)
+        18   load_var 4                         (_5)
+        19   store_var_load_var 5               (message)
 
-  39   20   load_field 0                       (role)
-       21   load_const 6                       ("")
-       22   cmp_op ==                          
-       23   pop_jump_if_false +2               (to 25)
-       24   jump +14                           (to 38)
+  122   20   load_field 0                       (role)
+        21   load_const 6                       ("")
+        22   cmp_op ==                          
+        23   pop_jump_if_false +2               (to 25)
+        24   jump +14                           (to 38)
 
-  41   25   load_var 5                         (message)
-       26   load_field 0                       (role)
-       27   load_const 7                       ("tool")
-       28   cmp_op ==                          
-       29   pop_jump_if_false +2               (to 31)
-       30   jump +5                            (to 35)
+  124   25   load_var 5                         (message)
+        26   load_field 0                       (role)
+        27   load_const 7                       ("tool")
+        28   cmp_op ==                          
+        29   pop_jump_if_false +2               (to 31)
+        30   jump +5                            (to 35)
 
-  44   31   load_var 5                         (message)
-       32   load_field 0                       (role)
-       33   store_var 6                        (role)
+  127   31   load_var 5                         (message)
+        32   load_field 0                       (role)
+        33   store_var 6                        (role)
 
-  41   34   jump +6                            (to 40)
+  124   34   jump +6                            (to 40)
 
-  42   35   load_const 8                       ("user")
-       36   store_var 6                        (role)
+  125   35   load_const 8                       ("user")
+        36   store_var 6                        (role)
 
-  41   37   jump +3                            (to 40)
+  124   37   jump +3                            (to 40)
 
-  40   38   load_const 9                       ("user")
-       39   store_var 6                        (role)
+  123   38   load_const 9                       ("user")
+        39   store_var 6                        (role)
 
-  46   40   load_type 10                       
-       41   load_type 11                       
-       42   alloc_map 0                        
-       43   store_var 7                        (item)
+  129   40   load_type 10                       
+        41   load_type 11                       
+        42   alloc_map 0                        
+        43   store_var 7                        (item)
 
-  47   44   load_type 10                       
-       45   load_type 11                       
-       46   load_var 7                         (item)
-       47   load_const 12                      ("role")
-       48   load_var 6                         (role)
-       49   call 37 ntypeargs=2                (baml.Map.set)
-       50   pop 1                              
+  130   44   load_type 10                       
+        45   load_type 11                       
+        46   load_var 7                         (item)
+        47   load_const 12                      ("role")
+        48   load_var 6                         (role)
+        49   call 37 ntypeargs=2                (baml.Map.set)
+        50   pop 1                              
 
-  48   51   load_type 10                       
-       52   load_type 11                       
-       53   load_var 7                         (item)
-       54   load_const 13                      ("content")
-       55   load_var 5                         (message)
-       56   load_field 1                       (content)
-       57   call 37 ntypeargs=2                (baml.Map.set)
-       58   pop 1                              
+  131   51   load_var2 5 6                      
+        52   call 832 ntypeargs=0               (openai.internal._openai_prompt_content)
+        53   store_var 8                        (_20)
+        54   load_type 10                       
+        55   load_type 11                       
+        56   load_var 7                         (item)
+        57   load_const 13                      ("content")
+        58   load_var 8                         (_20)
+        59   call 37 ntypeargs=2                (baml.Map.set)
+        60   pop 1                              
 
-  49   59   load_var2 2 7                      
-       60   call 4 ntypeargs=0                 (baml.Array.push)
-       61   pop 1                              
-       62   jump -53                           (to 9)
+  132   61   load_var2 2 7                      
+        62   call 4 ntypeargs=0                 (baml.Array.push)
+        63   pop 1                              
+        64   jump -55                           (to 9)
 
-  51   63   load_var 2                         (items)
-       64   return                             
+  134   65   load_var 2                         (items)
+        66   return                             
 }
 
 function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.ModelTurn {
-  170   0     load_type 0                        
+  253   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 2                        (content)
 
-  171   3     load_const 1                       (false)
+  254   3     load_const 1                       (false)
         4     store_var 3                        (has_call)
 
-  172   5     load_var 1                         (resp)
+  255   5     load_var 1                         (resp)
         6     load_field 1                       (output)
         7     load_type 2                        
         8     load_const 3                       ("iter")
@@ -9167,26 +10692,26 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         20    load_var 5                         (_6)
         21    store_var_load_var 6               (item)
 
-  173   22    load_field 0                       (type)
+  256   22    load_field 0                       (type)
         23    load_const 7                       ("function_call")
         24    cmp_op ==                          
         25    pop_jump_if_false +2               (to 27)
         26    jump +108                          (to 134)
 
-  183   27    load_var 6                         (item)
+  266   27    load_var 6                         (item)
         28    load_field 0                       (type)
         29    load_const 8                       ("message")
         30    cmp_op ==                          
         31    pop_jump_if_false +2               (to 33)
         32    jump +43                           (to 75)
 
-  194   33    load_var 6                         (item)
+  277   33    load_var 6                         (item)
         34    load_field 0                       (type)
         35    load_const 9                       ("reasoning")
         36    cmp_op ==                          
         37    pop_jump_if_false -26              (to 11)
 
-  195   38    load_var 6                         (item)
+  278   38    load_var 6                         (item)
         39    load_field 5                       (summary)
         40    store_var 23                       (_50)
         41    load_var 23                        (_50)
@@ -9199,7 +10724,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         48    alloc_array 0                      
         49    store_var 22                       (parts)
 
-  196   50    load_var 22                        (parts)
+  279   50    load_var 22                        (parts)
         51    load_type 12                       
         52    load_const 13                      ("iter")
         53    virtual_call nargs=1 ntypeargs=0   
@@ -9217,18 +10742,18 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         65    load_field 1                       (text)
         66    store_var 26                       (_59)
 
-  197   67    load_var 26                        (_59)
+  280   67    load_var 26                        (_59)
         68    narrow_bind 16 26                  
         69    pop_jump_if_false -14              (to 55)
 
-  198   70    load_var2 2 26                     
+  281   70    load_var2 2 26                     
 
-  197   71    init_instance 0                    (ai.content.Reasoning .summary)
+  280   71    init_instance 0                    (ai.content.Reasoning .summary)
         72    call 4 ntypeargs=0                 (baml.Array.push)
         73    pop 1                              
         74    jump -19                           (to 55)
 
-  184   75    load_var 6                         (item)
+  267   75    load_var 6                         (item)
         76    load_field 4                       (content)
         77    store_var 14                       (_30)
         78    load_var 14                        (_30)
@@ -9241,7 +10766,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         85    alloc_array 0                      
         86    store_var 13                       (parts)
 
-  185   87    load_var 13                        (parts)
+  268   87    load_var 13                        (parts)
         88    load_type 12                       
         89    load_const 17                      ("iter")
         90    virtual_call nargs=1 ntypeargs=0   
@@ -9258,7 +10783,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         101   load_var 16                        (_34)
         102   store_var 17                       (part)
 
-  186   103   load_var 17                        (part)
+  269   103   load_var 17                        (part)
         104   load_field 0                       (type)
         105   store_var 19                       (_40)
         106   load_var 19                        (_40)
@@ -9274,7 +10799,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         116   cmp_op ==                          
         117   pop_jump_if_false -25              (to 92)
 
-  187   118   load_var 17                        (part)
+  270   118   load_var 17                        (part)
         119   load_field 1                       (text)
         120   store_var 21                       (_45)
         121   load_var 21                        (_45)
@@ -9291,28 +10816,28 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         132   pop 1                              
         133   jump -41                           (to 92)
 
-  174   134   load_const 22                      (true)
+  257   134   load_const 22                      (true)
         135   store_var 3                        (has_call)
 
-  175   136   load_type 23                       
+  258   136   load_type 23                       
         137   load_type 24                       
         138   alloc_map 0                        
         139   store_var 7                        (args)
 
-  176   140   load_var 6                         (item)
+  259   140   load_var 6                         (item)
         141   load_field 3                       (arguments)
         142   store_var 8                        (_14)
         143   load_var 8                         (_14)
         144   narrow_bind 16 8                   
         145   pop_jump_if_false +5               (to 150)
 
-  177   146   load_type 25                       
+  260   146   load_type 25                       
 
-  176   147   load_var 8                         (_14)
+  259   147   load_var 8                         (_14)
         148   call 333 ntypeargs=1               (baml.json.from_string)
         149   store_var 7                        (args)
 
-  180   150   load_var 6                         (item)
+  263   150   load_var 6                         (item)
         151   load_field 1                       (call_id)
         152   store_var 10                       (_21)
         153   load_var 10                        (_21)
@@ -9335,19 +10860,19 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         170   load_const 27                      ("")
         171   store_var 11                       (_23)
 
-  179   172   load_var2 2 9                      
+  262   172   load_var2 2 9                      
 
-  180   173   load_var2 11 7                     
+  263   173   load_var2 11 7                     
         174   init_instance 2                    (ai.content.ToolUse .id, .name, .args)
         175   call 4 ntypeargs=0                 (baml.Array.push)
         176   pop 1                              
         177   jump -166                          (to 11)
 
-  209   178   load_var 3                         (has_call)
+  292   178   load_var 3                         (has_call)
         179   pop_jump_if_false +2               (to 181)
         180   jump +25                           (to 205)
 
-  211   181   load_var 1                         (resp)
+  294   181   load_var 1                         (resp)
         182   load_field 0                       (status)
         183   store_var 29                       (_68)
         184   load_var 29                        (_68)
@@ -9364,23 +10889,23 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         195   pop_jump_if_false +2               (to 197)
         196   jump +5                            (to 201)
 
-  214   197   load_const 30                      (ai.content.StopReason.Complete)
-        198   alloc_variant 436                  (ai.content.StopReason)
+  297   197   load_const 30                      (ai.content.StopReason.Complete)
+        198   alloc_variant 438                  (ai.content.StopReason)
         199   store_var 27                       (stop)
 
-  211   200   jump +8                            (to 208)
+  294   200   jump +8                            (to 208)
 
-  212   201   load_const 31                      (ai.content.StopReason.MaxTokens)
-        202   alloc_variant 436                  (ai.content.StopReason)
+  295   201   load_const 31                      (ai.content.StopReason.MaxTokens)
+        202   alloc_variant 438                  (ai.content.StopReason)
         203   store_var 27                       (stop)
 
-  211   204   jump +4                            (to 208)
+  294   204   jump +4                            (to 208)
 
-  210   205   load_const 16                      (ai.content.StopReason.ToolUse)
-        206   alloc_variant 436                  (ai.content.StopReason)
+  293   205   load_const 16                      (ai.content.StopReason.ToolUse)
+        206   alloc_variant 438                  (ai.content.StopReason)
         207   store_var 27                       (stop)
 
-  216   208   load_var 1                         (resp)
+  299   208   load_var 1                         (resp)
         209   load_field 2                       (usage)
         210   store_var 31                       (_72)
         211   load_var 31                        (_72)
@@ -9388,32 +10913,32 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         213   pop_jump_if_false +2               (to 215)
         214   jump +4                            (to 218)
 
-  224   215   load_const 10                      (null)
+  307   215   load_const 10                      (null)
         216   store_var 30                       (usage)
 
-  216   217   jump +10                           (to 227)
+  299   217   jump +10                           (to 227)
         218   load_var 31                        (_72)
         219   store_var_load_var 32              (u)
 
-  218   220   load_field 0                       (input_tokens)
+  301   220   load_field 0                       (input_tokens)
 
-  219   221   load_var 32                        (u)
+  302   221   load_var 32                        (u)
         222   load_field 1                       (output_tokens)
         223   load_const 10                      (null)
         224   load_const 10                      (null)
         225   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
         226   store_var 30                       (usage)
 
-  226   227   load_var2 2 27                     
+  309   227   load_var2 2 27                     
         228   load_var 30                        (usage)
         229   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
         230   return                             
 }
 
 function openai.internal.openai_render(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> baml.http.Request {
-  118   0   load_var2 1 2          
+  201   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 832 ntypeargs=0   (openai.internal._openai_request)
+        2   call 836 ntypeargs=0   (openai.internal._openai_request)
         3   return                 
 }
 
@@ -9430,7 +10955,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  104   0   make_closure 1559 0   
+  104   0   make_closure 1561 0   
         1   return                
 }
 
@@ -9455,7 +10980,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   76   16   load_var 1             (threshold)
-       17   make_closure 1554 1    
+       17   make_closure 1556 1    
        18   return                 
 }
 
@@ -9494,7 +11019,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1538 2    
+       29   make_closure 1540 2    
        30   return                 
 }
 
@@ -9513,12 +11038,12 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   42   10   load_var 1             (max_attempts)
-       11   make_closure 1548 1    
+       11   make_closure 1550 1    
        12   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  98   0   make_closure 1557 0   
+  98   0   make_closure 1559 0   
        1   return                
 }
 
@@ -12026,7 +13551,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   486   25   load_var 5                         (child)
-        26   make_closure 1438 1                
+        26   make_closure 1440 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   load_type 7                        
@@ -12119,7 +13644,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   496   3    load_var 1             (body)
-        4    make_closure 1450 1    
+        4    make_closure 1452 1    
         5    store_var 3            (base_run)
 
   527   6    load_var 2             (runner)
@@ -12380,7 +13905,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   364   6    load_var2 1 2         
 
   366   7    load_var 3            (runner)
-        8    make_closure 1415 2   
+        8    make_closure 1417 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   return                
 }
@@ -12397,7 +13922,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   375   8    load_var2 1 2         
-        9    make_closure 1417 2   
+        9    make_closure 1419 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   return                
 }
@@ -12418,7 +13943,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   391   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1419 3   
+        13   make_closure 1421 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   return                
 }
@@ -12578,7 +14103,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 889 ntypeargs=0   (user.score)
+       7    call 897 ntypeargs=0   (user.score)
        8    store_var 3            (base)
 
   11   9    load_var 3             (base)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -37,7 +37,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         29    load_deref 1                               
         30    load_deref 6                               
         31    load_const 2                               (0)
-        32    call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        32    call 803 ntypeargs=1                       (ai.Agent._emit_from)
         33    store_var 7                                (seen)
 
   201   34    load_const 2                               (0)
@@ -73,7 +73,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         59    load_deref 6                               
         60    load_var 9                                 (total)
         61    load_const 5                               (2)
-        62    call 799 ntypeargs=1                       (ai.Agent._attempt_turn)
+        62    call 802 ntypeargs=1                       (ai.Agent._attempt_turn)
         63    store_var 11                               (turn)
 
   213   64    load_var 8                                 (steps)
@@ -85,7 +85,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         69    load_deref 1                               
         70    load_deref 6                               
         71    load_var 7                                 (seen)
-        72    call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        72    call 803 ntypeargs=1                       (ai.Agent._emit_from)
         73    store_var 7                                (seen)
 
   215   74    load_var 11                                (turn)
@@ -163,7 +163,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         136   load_deref 1                               
         137   load_deref 6                               
         138   load_var 7                                 (seen)
-        139   call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        139   call 803 ntypeargs=1                       (ai.Agent._emit_from)
         140   store_var 7                                (seen)
 
   266   141   load_var 36                                (value)
@@ -187,7 +187,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         157   load_type 1                                
         158   load_var2 1 2                              
         159   load_var 6                                 (j)
-        160   make_closure 1675 captures=3 ntypeargs=1   
+        160   make_closure 1739 captures=3 ntypeargs=1   
         161   call 16 ntypeargs=3                        (baml.Array.map)
         162   store_var 15                               (futures)
 
@@ -202,7 +202,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         170   load_deref 1                               
         171   load_deref 6                               
         172   load_var 7                                 (seen)
-        173   call 800 ntypeargs=1                       (ai.Agent._emit_from)
+        173   call 803 ntypeargs=1                       (ai.Agent._emit_from)
         174   store_var 7                                (seen)
 
   227   175   load_deref 6                               
@@ -236,7 +236,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         199   load_var 12                                (calls)
         200   load_type 1                                
         201   load_var 21                                (f)
-        202   make_closure 1676 captures=1 ntypeargs=1   
+        202   make_closure 1740 captures=1 ntypeargs=1   
         203   call 19 ntypeargs=2                        (baml.Array.find)
 
   234   204   store_var 22                               (_58)
@@ -515,7 +515,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
   150   159   load_var 7                         (turn)
         160   load_field 1                       (stop_reason)
         161   load_const 14                      (ai.content.StopReason.MaxTokens)
-        162   alloc_variant 436                  (ai.content.StopReason)
+        162   alloc_variant 438                  (ai.content.StopReason)
         163   call 612 ntypeargs=0               (baml.ops.equals_equals)
 
   149   164   jump_if_false +2                   (to 166)
@@ -525,7 +525,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
   151   167   load_var 7                         (turn)
         168   load_field 1                       (stop_reason)
         169   load_const 15                      (ai.content.StopReason.Refused)
-        170   alloc_variant 436                  (ai.content.StopReason)
+        170   alloc_variant 438                  (ai.content.StopReason)
         171   call 612 ntypeargs=0               (baml.ops.equals_equals)
 
   149   172   jump_if_false +2                   (to 174)
@@ -534,7 +534,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   152   175   load_type 0                        
         176   load_var2 1 29                     
-        177   call 798 ntypeargs=1               (ai.Agent._parses)
+        177   call 801 ntypeargs=1               (ai.Agent._parses)
 
   153   178   pop_jump_if_false +2               (to 180)
         179   jump +33                           (to 212)
@@ -575,7 +575,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         207   load_var2 5 6                      
         208   load_const 16                      (1)
         209   sub_int                            
-        210   call 799 ntypeargs=1               (ai.Agent._attempt_turn)
+        210   call 802 ntypeargs=1               (ai.Agent._attempt_turn)
         211   jump +19                           (to 230)
 
   154   212   load_var2 4 21                     
@@ -786,7 +786,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        61    store_var 11            (_19)
        62    load_var 11             (_19)
        63    load_const 6            (ai.tools.ErrorMode.Raise)
-       64    alloc_variant 437       (ai.tools.ErrorMode)
+       64    alloc_variant 439       (ai.tools.ErrorMode)
        65    call 612 ntypeargs=0    (baml.ops.equals_equals)
        66    pop_jump_if_false +2    (to 68)
        67    jump +4                 (to 71)
@@ -874,7 +874,7 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
        15   pop_jump_if_false +4                       (to 19)
 
   32   16   load_const 3                               (ai.tools.ErrorMode.Report)
-       17   alloc_variant 437                          (ai.tools.ErrorMode)
+       17   alloc_variant 439                          (ai.tools.ErrorMode)
        18   store_var 3                                (tool_errors)
        19   load_var 4                                 (on_event)
        20   load_const 0                               (<omitted>)
@@ -892,7 +892,7 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
        30   pop_jump_if_false +4                       (to 34)
 
   41   31   load_type 4                                
-       32   make_closure 1657 captures=0 ntypeargs=1   
+       32   make_closure 1721 captures=0 ntypeargs=1   
        33   store_var 5                                (_9)
 
   35   34   load_var2 1 2                              
@@ -903,19 +903,19 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
 }
 
 function ai.FunctionSpec.arguments(self: ai.FunctionSpec<#0>) -> map<string, unknown> {
-  73   0   load_var 1     (self)
+  82   0   load_var 1     (self)
        1   load_field 1   (args)
        2   return         
 }
 
 function ai.FunctionSpec.name(self: ai.FunctionSpec<#0>) -> string {
-  69   0   load_var 1     (self)
+  78   0   load_var 1     (self)
        1   load_field 0   (spec_name)
        2   return         
 }
 
 function ai.FunctionSpec.output_type(self: ai.FunctionSpec<#0>) -> type {
-  77   0   load_type 0   
+  86   0   load_type 0   
        1   store_var 2   (_0)
        2   load_var 2    (_0)
        3   return        
@@ -927,17 +927,17 @@ function ai.FunctionSpec.prompt(self: ai.FunctionSpec<#0>, output_format: string
        2   cmp_op ==              
        3   pop_jump_if_false +3   (to 6)
 
-  80   4   load_const 1           ("")
+  89   4   load_const 1           ("")
        5   store_var 2            (output_format)
 
-  81   6   load_var2 2 1          
+  90   6   load_var2 2 1          
        7   load_field 2           (prompt_template)
        8   call_indirect          
        9   return                 
 }
 
 function ai.FunctionSpec.tools(self: ai.FunctionSpec<#0>) -> ai.tools.Toolbox {
-  85   0   load_var 1     (self)
+  94   0   load_var 1     (self)
        1   load_field 3   (toolbox)
        2   return         
 }
@@ -1082,7 +1082,7 @@ function ai.ModelTurn.tool_uses(self: ai.ModelTurn) -> ai.content.ToolUse[] {
 }
 
 function ai.Prompt.baml.ToString.to_string(self: ai.Prompt) -> string {
-  35   0   load_var 1             (self)
+  44   0   load_var 1             (self)
        1   call 763 ntypeargs=0   (ai.Prompt.text)
        2   return                 
 }
@@ -1248,7 +1248,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         48   store_var 11                       (_17)
         49   load_var 11                        (_17)
         50   load_const 6                       (ai.errors.RetrySafety.Safe)
-        51   alloc_variant 438                  (ai.errors.RetrySafety)
+        51   alloc_variant 440                  (ai.errors.RetrySafety)
         52   call 612 ntypeargs=0               (baml.ops.equals_equals)
 
   155   53   pop_jump_if_false +2               (to 55)
@@ -1261,7 +1261,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         58   load_var 3                         (index)
         59   load_const 4                       (1)
         60   add_int                            
-        61   call 793 ntypeargs=0               (ai.clients.Fallback._try)
+        61   call 796 ntypeargs=0               (ai.clients.Fallback._try)
         62   return                             
 }
 
@@ -1296,13 +1296,13 @@ function ai.clients.Fallback.root.Client.id(self: ai.clients.Fallback) -> string
 function ai.clients.Fallback.root.Client.invoke(self: ai.clients.Fallback, input: ai.ModelTurnInput) -> ai.ModelTurn {
   185   0   load_var2 1 2          
         1   load_const 0           (0)
-        2   call 793 ntypeargs=0   (ai.clients.Fallback._try)
+        2   call 796 ntypeargs=0   (ai.clients.Fallback._try)
         3   jump +6                (to 9)
         4   load_var 3             (e)
         5   throw_if_panic         
 
   186   6   load_var 3             (e)
-        7   call 811 ntypeargs=0   (ai.errors.normalize)
+        7   call 814 ntypeargs=0   (ai.errors.normalize)
         8   throw                  
         9   return                 
 }
@@ -1343,7 +1343,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        28   store_var 7                        (_11)
        29   load_var 7                         (_11)
        30   load_const 5                       (ai.errors.RetrySafety.Safe)
-       31   alloc_variant 438                  (ai.errors.RetrySafety)
+       31   alloc_variant 440                  (ai.errors.RetrySafety)
        32   call 612 ntypeargs=0               (baml.ops.equals_equals)
 
   74   33   jump_if_false +5                   (to 38)
@@ -1370,7 +1370,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
   80   49   load_var 1                         (self)
        50   load_field 3                       (backoff)
        51   load_var2 8 6                      
-       52   call 785 ntypeargs=0               (ai.clients.Backoff.delay_ms)
+       52   call 788 ntypeargs=0               (ai.clients.Backoff.delay_ms)
        53   call 502 ntypeargs=0               (baml.time.Duration.from_milliseconds)
 
   79   54   sys_op 255                         (baml.sys.sleep)
@@ -1383,7 +1383,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        60   load_var 3                         (remaining)
        61   load_const 3                       (1)
        62   sub_int                            
-       63   call 787 ntypeargs=0               (ai.clients.Retry._attempt)
+       63   call 790 ntypeargs=0               (ai.clients.Retry._attempt)
        64   return                             
 }
 
@@ -1428,7 +1428,7 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
        32   load_const 0           (<omitted>)
        33   load_const 0           (<omitted>)
        34   load_const 0           (<omitted>)
-       35   call 784 ntypeargs=0   (ai.clients.Backoff.new)
+       35   call 787 ntypeargs=0   (ai.clients.Backoff.new)
        36   store_var 6            (_10)
 
   61   37   load_var2 1 2          
@@ -1452,13 +1452,13 @@ function ai.clients.Retry.root.Client.invoke(self: ai.clients.Retry, input: ai.M
   99    0    load_var2 1 2          
         1    load_var 1             (self)
         2    load_field 1           (max_attempts)
-        3    call 787 ntypeargs=0   (ai.clients.Retry._attempt)
+        3    call 790 ntypeargs=0   (ai.clients.Retry._attempt)
         4    jump +6                (to 10)
         5    load_var 3             (e)
         6    throw_if_panic         
 
   100   7    load_var 3             (e)
-        8    call 811 ntypeargs=0   (ai.errors.normalize)
+        8    call 814 ntypeargs=0   (ai.errors.normalize)
         9    throw                  
         10   return                 
 }
@@ -1560,7 +1560,7 @@ function ai.clients.RoundRobin.root.Client.invoke(self: ai.clients.RoundRobin, i
         37   throw_if_panic                     
 
   141   38   load_var 4                         (e)
-        39   call 811 ntypeargs=0               (ai.errors.normalize)
+        39   call 814 ntypeargs=0               (ai.errors.normalize)
         40   throw                              
         41   load_var 3                         (_0)
         42   return                             
@@ -1604,7 +1604,7 @@ function ai.clients.default_retry_judgment(f: ai.errors.Failure) -> bool {
 
 function ai.errors.InvalidRequest.Failure.retry_safety(self: ai.errors.InvalidRequest) -> ai.errors.RetrySafety {
   54   0   load_const 0        (ai.errors.RetrySafety.Safe)
-       1   alloc_variant 438   (ai.errors.RetrySafety)
+       1   alloc_variant 440   (ai.errors.RetrySafety)
        2   store_var 2         (_0)
        3   load_var 2          (_0)
        4   return              
@@ -1612,7 +1612,7 @@ function ai.errors.InvalidRequest.Failure.retry_safety(self: ai.errors.InvalidRe
 
 function ai.errors.NetworkFailure.Failure.retry_safety(self: ai.errors.NetworkFailure) -> ai.errors.RetrySafety {
   42   0   load_const 0        (ai.errors.RetrySafety.Safe)
-       1   alloc_variant 438   (ai.errors.RetrySafety)
+       1   alloc_variant 440   (ai.errors.RetrySafety)
        2   store_var 2         (_0)
        3   load_var 2          (_0)
        4   return              
@@ -1620,7 +1620,7 @@ function ai.errors.NetworkFailure.Failure.retry_safety(self: ai.errors.NetworkFa
 
 function ai.errors.ParseFailed.Failure.retry_safety(self: ai.errors.ParseFailed) -> ai.errors.RetrySafety {
   75   0   load_const 0        (ai.errors.RetrySafety.Safe)
-       1   alloc_variant 438   (ai.errors.RetrySafety)
+       1   alloc_variant 440   (ai.errors.RetrySafety)
        2   store_var 2         (_0)
        3   load_var 2          (_0)
        4   return              
@@ -1628,7 +1628,7 @@ function ai.errors.ParseFailed.Failure.retry_safety(self: ai.errors.ParseFailed)
 
 function ai.errors.RateLimited.Failure.retry_safety(self: ai.errors.RateLimited) -> ai.errors.RetrySafety {
   31   0   load_const 0        (ai.errors.RetrySafety.Safe)
-       1   alloc_variant 438   (ai.errors.RetrySafety)
+       1   alloc_variant 440   (ai.errors.RetrySafety)
        2   store_var 2         (_0)
        3   load_var 2          (_0)
        4   return              
@@ -1636,7 +1636,7 @@ function ai.errors.RateLimited.Failure.retry_safety(self: ai.errors.RateLimited)
 
 function ai.errors.Refused.Failure.retry_safety(self: ai.errors.Refused) -> ai.errors.RetrySafety {
   65   0   load_const 0        (ai.errors.RetrySafety.Safe)
-       1   alloc_variant 438   (ai.errors.RetrySafety)
+       1   alloc_variant 440   (ai.errors.RetrySafety)
        2   store_var 2         (_0)
        3   load_var 2          (_0)
        4   return              
@@ -1644,7 +1644,7 @@ function ai.errors.Refused.Failure.retry_safety(self: ai.errors.Refused) -> ai.e
 
 function ai.errors.StepBudgetExceeded.Failure.retry_safety(self: ai.errors.StepBudgetExceeded) -> ai.errors.RetrySafety {
   88   0   load_const 0        (ai.errors.RetrySafety.Unsafe)
-       1   alloc_variant 438   (ai.errors.RetrySafety)
+       1   alloc_variant 440   (ai.errors.RetrySafety)
        2   store_var 2         (_0)
        3   load_var 2          (_0)
        4   return              
@@ -1652,7 +1652,7 @@ function ai.errors.StepBudgetExceeded.Failure.retry_safety(self: ai.errors.StepB
 
 function ai.errors.StreamingUnsupported.Failure.retry_safety(self: ai.errors.StreamingUnsupported) -> ai.errors.RetrySafety {
   117   0   load_const 0        (ai.errors.RetrySafety.Safe)
-        1   alloc_variant 438   (ai.errors.RetrySafety)
+        1   alloc_variant 440   (ai.errors.RetrySafety)
         2   store_var 2         (_0)
         3   load_var 2          (_0)
         4   return              
@@ -1660,7 +1660,7 @@ function ai.errors.StreamingUnsupported.Failure.retry_safety(self: ai.errors.Str
 
 function ai.errors.ToolFailedError.Failure.retry_safety(self: ai.errors.ToolFailedError) -> ai.errors.RetrySafety {
   104   0   load_const 0        (ai.errors.RetrySafety.Unsafe)
-        1   alloc_variant 438   (ai.errors.RetrySafety)
+        1   alloc_variant 440   (ai.errors.RetrySafety)
         2   store_var 2         (_0)
         3   load_var 2          (_0)
         4   return              
@@ -1841,10 +1841,10 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
 
   102   9     load_var2 4 2                      
         10    load_var 3                         (params)
-        11    call 881 ntypeargs=0               (ai.mcp.rpc_line)
+        11    call 889 ntypeargs=0               (ai.mcp.rpc_line)
         12    store_var 5                        (_6)
         13    load_var2 1 5                      
-        14    call 883 ntypeargs=0               (ai.mcp.McpConnection._send)
+        14    call 891 ntypeargs=0               (ai.mcp.McpConnection._send)
         15    pop 1                              
 
   103   16    load_const 1                       (true)
@@ -2089,7 +2089,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
   184   7    load_var 1                         (self)
         8    load_const 4                       ("tools/call")
         9    load_var 5                         (params)
-        10   call 884 ntypeargs=0               (ai.mcp.McpConnection._request)
+        10   call 892 ntypeargs=0               (ai.mcp.McpConnection._request)
         11   store_var 6                        (result)
 
   185   12   load_type 2                        
@@ -2261,16 +2261,16 @@ function ai.mcp.McpConnection.connect(name: string, command: string, args: strin
   75   61   load_var 11            (conn)
        62   load_const 19          ("initialize")
        63   load_var 12            (init)
-       64   call 884 ntypeargs=0   (ai.mcp.McpConnection._request)
+       64   call 892 ntypeargs=0   (ai.mcp.McpConnection._request)
        65   pop 1                  
 
   76   66   load_const 2           (null)
        67   load_const 20          ("notifications/initialized")
        68   load_const 2           (null)
-       69   call 881 ntypeargs=0   (ai.mcp.rpc_line)
+       69   call 889 ntypeargs=0   (ai.mcp.rpc_line)
        70   store_var 13           (_26)
        71   load_var2 11 13        
-       72   call 883 ntypeargs=0   (ai.mcp.McpConnection._send)
+       72   call 891 ntypeargs=0   (ai.mcp.McpConnection._send)
        73   pop 1                  
 
   77   74   load_var 11            (conn)
@@ -2285,7 +2285,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         2    load_type 1                        
         3    load_type 2                        
         4    alloc_map 0                        
-        5    call 884 ntypeargs=0               (ai.mcp.McpConnection._request)
+        5    call 892 ntypeargs=0               (ai.mcp.McpConnection._request)
         6    store_var 3                        (result)
 
   157   7    load_type 3                        
@@ -2357,7 +2357,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         65   store_var 15                       (_31)
 
   173   66   load_var2 1 8                      
-        67   call 880 ntypeargs=0               (ai.mcp._proxy)
+        67   call 888 ntypeargs=0               (ai.mcp._proxy)
         68   store_var 16                       (_32)
 
   170   69   load_var2 8 14                     
@@ -2386,7 +2386,7 @@ function ai.mcp._proxy(conn: ai.mcp.McpConnection, name: string) -> (map<string,
        5    store_var 2           
 
   20   6    load_var2 1 2         
-       7    make_closure 2241 2   
+       7    make_closure 2390 2   
        8    store_var 3           (_0)
        9    load_var 3            (_0)
        10   return                
@@ -2446,11 +2446,11 @@ function ai.prompt(body: ((string) -> baml.prompt.Role throws never, baml.prompt
        1   make_cell             
        2   store_var 1           
 
-  49   3   load_var 1            (body)
-       4   make_closure 1591 1   
+  58   3   load_var 1            (body)
+       4   make_closure 1593 1   
        5   store_var 3           (render)
 
-  53   6   load_var 3            (render)
+  62   6   load_var 3            (render)
        7   store_var 2           (_0)
        8   load_var 2            (_0)
        9   return                
@@ -2554,10 +2554,10 @@ function ai.stream.Stream.next(self: ai.stream.Stream<#0, #1>) -> #0 | ai.stream
         43   load_const 0                     (true)
         44   store_field 3                    (_finished)
 
-  259   45   alloc_instance 359 ntypeargs=0   (ai.stream.Done)
+  259   45   alloc_instance 361 ntypeargs=0   (ai.stream.Done)
         46   jump +2                          (to 48)
 
-  254   47   alloc_instance 359 ntypeargs=0   (ai.stream.Done)
+  254   47   alloc_instance 361 ntypeargs=0   (ai.stream.Done)
         48   return                           
 }
 
@@ -2590,7 +2590,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         1    pop_jump_if_false +7   (to 8)
 
   216   2    load_var 1             (self)
-        3    call 806 ntypeargs=0   (ai.stream.TurnStream.next)
+        3    call 809 ntypeargs=0   (ai.stream.TurnStream.next)
         4    store_var 2            (_3)
         5    load_var 2             (_3)
         6    narrow_bind 1 2        
@@ -2657,7 +2657,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         60   cmp_op ==              
         61   pop_jump_if_false +4   (to 65)
         62   load_const 3           (ai.content.StopReason.Complete)
-        63   alloc_variant 436      (ai.content.StopReason)
+        63   alloc_variant 438      (ai.content.StopReason)
         64   store_var 8            (_20)
 
   234   65   load_var 1             (self)
@@ -2759,10 +2759,10 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         38    jump +6                            (to 44)
 
   202   39    load_var 1                         (self)
-        40    call 805 ntypeargs=0               (ai.stream.TurnStream._finish)
+        40    call 808 ntypeargs=0               (ai.stream.TurnStream._finish)
         41    pop 1                              
 
-  203   42    alloc_instance 359 ntypeargs=0     (ai.stream.Done)
+  203   42    alloc_instance 361 ntypeargs=0     (ai.stream.Done)
         43    jump +160                          (to 203)
 
   195   44    load_var 27                        (_58)
@@ -2842,10 +2842,10 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         110   jump -17                           (to 93)
 
   176   111   load_var 1                         (self)
-        112   call 805 ntypeargs=0               (ai.stream.TurnStream._finish)
+        112   call 808 ntypeargs=0               (ai.stream.TurnStream._finish)
         113   pop 1                              
 
-  177   114   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
+  177   114   alloc_instance 361 ntypeargs=0     (ai.stream.Done)
         115   jump +88                           (to 203)
 
   145   116   load_type 12                       
@@ -2882,10 +2882,10 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         145   pop_jump_if_false -145             (to 0)
 
   165   146   load_var 1                         (self)
-        147   call 805 ntypeargs=0               (ai.stream.TurnStream._finish)
+        147   call 808 ntypeargs=0               (ai.stream.TurnStream._finish)
         148   pop 1                              
 
-  166   149   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
+  166   149   alloc_instance 361 ntypeargs=0     (ai.stream.Done)
         150   jump +53                           (to 203)
 
   147   151   load_var 9                         (_19)
@@ -2950,7 +2950,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         200   load_field 0                       (text)
         201   jump +2                            (to 203)
 
-  141   202   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
+  141   202   alloc_instance 361 ntypeargs=0     (ai.stream.Done)
         203   return                             
 }
 
@@ -3067,7 +3067,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
   340   81    load_type 8                                
         82    load_type 2                                
         83    load_var 14                                (turns)
-        84    make_closure 1697 captures=1 ntypeargs=2   
+        84    make_closure 1761 captures=1 ntypeargs=2   
         85    load_var 19                                (_36)
         86    load_const 9                               ("")
         87    load_const 10                              (false)
@@ -3192,7 +3192,7 @@ function ai.tools.Toolbox.get(self: ai.tools.Toolbox, name: string) -> ai.tools.
         5    load_var 1            (self)
         6    load_field 0          (entries)
         7    load_var 2            (name)
-        8    make_closure 1617 1   
+        8    make_closure 1619 1   
         9    call 19 ntypeargs=2   (baml.Array.find)
         10   return                
 }
@@ -3371,7 +3371,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        61   store_var 9            (_17)
 
   58   62   load_var 1             (handler)
-       63   call 821 ntypeargs=0   (ai.internal._schema_for_signature)
+       63   call 824 ntypeargs=0   (ai.internal._schema_for_signature)
        64   store_var 11           (_21)
 
   56   65   load_var2 8 9          
@@ -3386,10 +3386,634 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        73   throw                  
 }
 
+function ai.wire._media_mime_type(explicit: string | null, source_value: string, kind: string) -> string {
+  49   0     load_var 1             (explicit)
+       1     store_var 4            (_4)
+       2     load_var 4             (_4)
+       3     narrow_bind 0 4        
+       4     pop_jump_if_false +2   (to 6)
+       5     jump +145              (to 150)
+
+  52   6     load_var 2             (source_value)
+       7     call 142 ntypeargs=0   (baml.String.to_lower_case)
+       8     store_var 6            (source)
+
+  53   9     load_var 6             (source)
+       10    load_const 1           (".jpg")
+       11    call 147 ntypeargs=0   (baml.String.includes)
+       12    jump_if_false +2       (to 14)
+       13    jump +5                (to 18)
+       14    pop 1                  
+       15    load_var 6             (source)
+       16    load_const 2           (".jpeg")
+       17    call 147 ntypeargs=0   (baml.String.includes)
+       18    pop_jump_if_false +2   (to 20)
+       19    jump +129              (to 148)
+
+  55   20    load_var 6             (source)
+       21    load_const 3           (".png")
+       22    call 147 ntypeargs=0   (baml.String.includes)
+       23    pop_jump_if_false +2   (to 25)
+       24    jump +122              (to 146)
+
+  57   25    load_var 6             (source)
+       26    load_const 4           (".webp")
+       27    call 147 ntypeargs=0   (baml.String.includes)
+       28    pop_jump_if_false +2   (to 30)
+       29    jump +115              (to 144)
+
+  59   30    load_var 6             (source)
+       31    load_const 5           (".gif")
+       32    call 147 ntypeargs=0   (baml.String.includes)
+       33    pop_jump_if_false +2   (to 35)
+       34    jump +108              (to 142)
+
+  61   35    load_var 6             (source)
+       36    load_const 6           (".svg")
+       37    call 147 ntypeargs=0   (baml.String.includes)
+       38    pop_jump_if_false +2   (to 40)
+       39    jump +101              (to 140)
+
+  63   40    load_var 6             (source)
+       41    load_const 7           (".wav")
+       42    call 147 ntypeargs=0   (baml.String.includes)
+       43    pop_jump_if_false +2   (to 45)
+       44    jump +94               (to 138)
+
+  65   45    load_var 6             (source)
+       46    load_const 8           (".mp3")
+       47    call 147 ntypeargs=0   (baml.String.includes)
+       48    pop_jump_if_false +2   (to 50)
+       49    jump +87               (to 136)
+
+  67   50    load_var 6             (source)
+       51    load_const 9           (".flac")
+       52    call 147 ntypeargs=0   (baml.String.includes)
+       53    pop_jump_if_false +2   (to 55)
+       54    jump +80               (to 134)
+
+  69   55    load_var 6             (source)
+       56    load_const 10          (".ogg")
+       57    call 147 ntypeargs=0   (baml.String.includes)
+       58    pop_jump_if_false +2   (to 60)
+       59    jump +73               (to 132)
+
+  71   60    load_var 6             (source)
+       61    load_const 11          (".webm")
+       62    call 147 ntypeargs=0   (baml.String.includes)
+       63    pop_jump_if_false +2   (to 65)
+       64    jump +59               (to 123)
+
+  77   65    load_var 6             (source)
+       66    load_const 12          (".mov")
+       67    call 147 ntypeargs=0   (baml.String.includes)
+       68    pop_jump_if_false +2   (to 70)
+       69    jump +52               (to 121)
+
+  79   70    load_var 6             (source)
+       71    load_const 13          (".mp4")
+       72    call 147 ntypeargs=0   (baml.String.includes)
+       73    pop_jump_if_false +2   (to 75)
+       74    jump +45               (to 119)
+
+  81   75    load_var 6             (source)
+       76    load_const 14          (".avi")
+       77    call 147 ntypeargs=0   (baml.String.includes)
+       78    pop_jump_if_false +2   (to 80)
+       79    jump +38               (to 117)
+
+  83   80    load_var 6             (source)
+       81    load_const 15          (".mkv")
+       82    call 147 ntypeargs=0   (baml.String.includes)
+       83    pop_jump_if_false +2   (to 85)
+       84    jump +31               (to 115)
+
+  85   85    load_var 6             (source)
+       86    load_const 16          (".pdf")
+       87    call 147 ntypeargs=0   (baml.String.includes)
+       88    pop_jump_if_false +2   (to 90)
+       89    jump +24               (to 113)
+
+  87   90    load_var 3             (kind)
+       91    load_const 17          ("audio")
+       92    cmp_op ==              
+       93    pop_jump_if_false +2   (to 95)
+       94    jump +17               (to 111)
+
+  89   95    load_var 3             (kind)
+       96    load_const 18          ("video")
+       97    cmp_op ==              
+       98    pop_jump_if_false +2   (to 100)
+       99    jump +10               (to 109)
+
+  91   100   load_var 3             (kind)
+       101   load_const 19          ("pdf")
+       102   cmp_op ==              
+       103   pop_jump_if_false +2   (to 105)
+       104   jump +3                (to 107)
+
+  94   105   load_const 20          ("image/png")
+
+  91   106   jump +47               (to 153)
+
+  92   107   load_const 21          ("application/pdf")
+
+  91   108   jump +45               (to 153)
+
+  90   109   load_const 22          ("video/mp4")
+
+  89   110   jump +43               (to 153)
+
+  88   111   load_const 23          ("audio/mpeg")
+
+  87   112   jump +41               (to 153)
+
+  86   113   load_const 24          ("application/pdf")
+
+  85   114   jump +39               (to 153)
+
+  84   115   load_const 25          ("video/x-matroska")
+
+  83   116   jump +37               (to 153)
+
+  82   117   load_const 26          ("video/x-msvideo")
+
+  81   118   jump +35               (to 153)
+
+  80   119   load_const 27          ("video/mp4")
+
+  79   120   jump +33               (to 153)
+
+  78   121   load_const 28          ("video/quicktime")
+
+  77   122   jump +31               (to 153)
+
+  72   123   load_var 3             (kind)
+       124   load_const 29          ("audio")
+       125   cmp_op ==              
+       126   pop_jump_if_false +2   (to 128)
+       127   jump +3                (to 130)
+
+  75   128   load_const 30          ("video/webm")
+
+  72   129   jump +24               (to 153)
+
+  73   130   load_const 31          ("audio/webm")
+
+  72   131   jump +22               (to 153)
+
+  70   132   load_const 32          ("audio/ogg")
+
+  69   133   jump +20               (to 153)
+
+  68   134   load_const 33          ("audio/flac")
+
+  67   135   jump +18               (to 153)
+
+  66   136   load_const 34          ("audio/mpeg")
+
+  65   137   jump +16               (to 153)
+
+  64   138   load_const 35          ("audio/wav")
+
+  63   139   jump +14               (to 153)
+
+  62   140   load_const 36          ("image/svg+xml")
+
+  61   141   jump +12               (to 153)
+
+  60   142   load_const 37          ("image/gif")
+
+  59   143   jump +10               (to 153)
+
+  58   144   load_const 38          ("image/webp")
+
+  57   145   jump +8                (to 153)
+
+  56   146   load_const 39          ("image/png")
+
+  55   147   jump +6                (to 153)
+
+  54   148   load_const 40          ("image/jpeg")
+
+  53   149   jump +4                (to 153)
+
+  49   150   load_var 4             (_4)
+       151   store_var 5            (supplied)
+
+  50   152   load_var 5             (supplied)
+       153   return                 
+}
+
+function ai.wire._resolve_media_content(url: string | null, file: string | null, inline: string, mime: string, fetch_url: bool) -> ai.wire.ResolvedMedia {
+  105   0     load_var 2              (file)
+        1     store_var 6             (_6)
+        2     load_var 6              (_6)
+        3     narrow_bind 0 6         
+        4     pop_jump_if_false +2    (to 6)
+        5     jump +138               (to 143)
+
+  111   6     load_var 3              (inline)
+        7     load_const 1            ("")
+        8     cmp_op !=               
+        9     pop_jump_if_false +2    (to 11)
+        10    jump +129               (to 139)
+
+  114   11    load_var 1              (url)
+        12    store_var 10            (_15)
+        13    load_var 10             (_15)
+        14    narrow_bind 0 10        
+        15    pop_jump_if_false +2    (to 17)
+        16    jump +4                 (to 20)
+
+  142   17    load_const 2            ("media has no URL, file, or base64 content")
+        18    init_instance 0         (baml.errors.InvalidArgument .message)
+        19    throw                   
+
+  114   20    load_var 10             (_15)
+        21    store_var 11            (media_url)
+
+  115   22    load_var 11             (media_url)
+        23    load_const 3            ("data:")
+        24    call 148 ntypeargs=0    (baml.String.starts_with)
+        25    pop_jump_if_false +9    (to 34)
+
+  116   26    load_var 11             (media_url)
+        27    load_const 4            (";base64,")
+        28    call 155 ntypeargs=0    (baml.String.index_of)
+        29    store_var 12            (_19)
+        30    load_var 12             (_19)
+        31    narrow_bind 5 12        
+        32    pop_jump_if_false +2    (to 34)
+        33    jump +85                (to 118)
+
+  124   34    load_var 5              (fetch_url)
+        35    unary_op !              
+        36    jump_if_false +2        (to 38)
+        37    jump +5                 (to 42)
+        38    pop 1                   
+        39    load_var 11             (media_url)
+        40    load_const 6            ("gs://")
+        41    call 148 ntypeargs=0    (baml.String.starts_with)
+        42    pop_jump_if_false +2    (to 44)
+        43    jump +70                (to 113)
+
+  127   44    load_var 11             (media_url)
+        45    load_const 7            (<omitted>)
+        46    call 228 ntypeargs=0    (baml.http.fetch)
+        47    store_var 18            (response)
+
+  128   48    load_var 18             (response)
+        49    call 220 ntypeargs=0    (baml.http.Response.ok)
+        50    unary_op !              
+        51    pop_jump_if_false +2    (to 53)
+        52    jump +41                (to 93)
+
+  135   53    load_type 8             
+        54    load_type 8             
+        55    load_var 18             (response)
+        56    load_field 1            (headers)
+        57    load_const 9            ("content-type")
+        58    call 38 ntypeargs=2     (baml.Map.get)
+        59    store_var 22            (_45)
+        60    load_var 22             (_45)
+        61    store_var 21            (response_mime)
+        62    load_var 22             (_45)
+        63    load_const 10           (null)
+        64    cmp_op ==               
+        65    pop_jump_if_false +3    (to 68)
+        66    load_var 4              (mime)
+        67    store_var 21            (response_mime)
+
+  138   68    load_var 18             (response)
+        69    sys_op 219              (baml.http.Response.bytes)
+        70    call 197 ntypeargs=0    (baml.Uint8Array.to_base64)
+        71    store_var 23            (_50)
+
+  139   72    load_var 21             (response_mime)
+        73    load_const 11           (";")
+        74    call 150 ntypeargs=0    (baml.String.split)
+        75    store_var 26            (_54)
+        76    load_type 8             
+        77    load_var 26             (_54)
+        78    load_const 5            (0)
+        79    call 3 ntypeargs=1      (baml.Array.at)
+        80    store_var 25            (_53)
+        81    load_var 25             (_53)
+        82    store_var 24            (_52)
+        83    load_var 25             (_53)
+        84    load_const 10           (null)
+        85    cmp_op ==               
+        86    pop_jump_if_false +3    (to 89)
+        87    load_var 4              (mime)
+        88    store_var 24            (_52)
+
+  136   89    load_const 10           (null)
+        90    load_var2 23 24         
+        91    init_instance 1         (ai.wire.ResolvedMedia .url, .base64, .mime_type)
+        92    jump +66                (to 158)
+
+  131   93    load_type 8             
+        94    load_var 11             (media_url)
+        95    call 138 ntypeargs=1    (baml.String.from)
+        96    store_var 19            (_38)
+        97    load_type 12            
+        98    load_var 18             (response)
+        99    load_field 0            (status_code)
+        100   call 138 ntypeargs=1    (baml.String.from)
+        101   store_var 20            (_41)
+
+  129   102   load_const 13           ("media")
+
+  131   103   load_const 14           ("media URL ")
+        104   load_var 19             (_38)
+        105   bin_op +                
+        106   load_const 15           (" returned HTTP ")
+        107   bin_op +                
+        108   load_var 20             (_41)
+        109   bin_op +                
+        110   load_const 10           (null)
+        111   init_instance 2         (ai.errors.NetworkFailure .provider, .detail, .raw_body)
+        112   throw                   
+
+  125   113   load_var 11             (media_url)
+        114   load_const 10           (null)
+        115   load_var 4              (mime)
+        116   init_instance 3         (ai.wire.ResolvedMedia .url, .base64, .mime_type)
+        117   jump +41                (to 158)
+
+  116   118   load_var 12             (_19)
+        119   store_var_load_var 13   (separator)
+
+  119   120   load_const 16           (8)
+        121   add_int                 
+        122   store_var 15            (_22)
+        123   load_var 11             (media_url)
+        124   call 139 ntypeargs=0    (baml.String.length)
+        125   store_var 16            (_24)
+        126   load_var2 11 15         
+        127   load_var 16             (_24)
+        128   call 153 ntypeargs=0    (baml.String.substring)
+        129   store_var 14            (_21)
+
+  120   130   load_var 11             (media_url)
+        131   load_const 17           (5)
+        132   load_var 13             (separator)
+        133   call 153 ntypeargs=0    (baml.String.substring)
+        134   store_var 17            (_25)
+
+  117   135   load_const 10           (null)
+        136   load_var2 14 17         
+        137   init_instance 4         (ai.wire.ResolvedMedia .url, .base64, .mime_type)
+        138   jump +20                (to 158)
+
+  112   139   load_const 10           (null)
+        140   load_var2 3 4           
+        141   init_instance 5         (ai.wire.ResolvedMedia .url, .base64, .mime_type)
+        142   jump +16                (to 158)
+
+  105   143   load_var 6              (_6)
+        144   store_var_load_var 7    (path)
+
+  106   145   load_const 18           ("r")
+        146   sys_op 268              (baml.fs.open)
+        147   store_var 8             (handle)
+
+  107   148   load_var 8              (handle)
+        149   sys_op 261              (baml.fs.File.bytes)
+        150   call 197 ntypeargs=0    (baml.Uint8Array.to_base64)
+        151   store_var 9             (data)
+
+  108   152   load_var 8              (handle)
+        153   sys_op 264              (baml.fs.File.close)
+        154   pop 1                   
+
+  109   155   load_const 10           (null)
+        156   load_var2 9 4           
+        157   init_instance 6         (ai.wire.ResolvedMedia .url, .base64, .mime_type)
+        158   return                  
+}
+
 function ai.wire.render_output_format(t: type) -> string {
   37   0   load_var 1   (t)
        1   sys_op 418   (baml.prompt.render_output_format)
        2   return       
+}
+
+function ai.wire.resolve_media(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf, fetch_url: bool) -> ai.wire.ResolvedMedia {
+  149   0     load_var 1             (media)
+        1     store_var 3            (_3)
+        2     load_var 3             (_3)
+        3     narrow_bind 0 3        
+        4     pop_jump_if_false +2   (to 6)
+        5     jump +139              (to 144)
+        6     load_var 1             (media)
+        7     store_var 12           (_16)
+        8     load_var 12            (_16)
+        9     narrow_bind 1 12       
+        10    pop_jump_if_false +2   (to 12)
+        11    jump +91               (to 102)
+        12    load_var 1             (media)
+        13    store_var 21           (_29)
+        14    load_var 21            (_29)
+        15    narrow_bind 2 21       
+        16    pop_jump_if_false +2   (to 18)
+        17    jump +43               (to 60)
+        18    load_var 1             (media)
+        19    store_var 30           (pdf)
+
+  181   20    load_var 30            (pdf)
+        21    call 300 ntypeargs=0   (baml.media.Pdf.file)
+        22    store_var 33           (_45)
+        23    load_var 33            (_45)
+        24    store_var 32           (_44)
+        25    load_var 33            (_45)
+        26    load_const 3           (null)
+        27    cmp_op ==              
+        28    pop_jump_if_false +4   (to 32)
+        29    load_var 30            (pdf)
+        30    call 299 ntypeargs=0   (baml.media.Pdf.url)
+        31    store_var 32           (_44)
+        32    load_var 32            (_44)
+        33    store_var 31           (source)
+        34    load_var 32            (_44)
+        35    load_const 3           (null)
+        36    cmp_op ==              
+        37    pop_jump_if_false +3   (to 40)
+        38    load_const 4           ("")
+        39    store_var 31           (source)
+
+  183   40    load_var 30            (pdf)
+        41    call 299 ntypeargs=0   (baml.media.Pdf.url)
+        42    store_var 34           (_48)
+
+  184   43    load_var 30            (pdf)
+        44    call 300 ntypeargs=0   (baml.media.Pdf.file)
+        45    store_var 35           (_49)
+
+  185   46    load_var 30            (pdf)
+        47    call 301 ntypeargs=0   (baml.media.Pdf.base64)
+        48    store_var 36           (_50)
+
+  186   49    load_var 30            (pdf)
+        50    call 302 ntypeargs=0   (baml.media.Pdf.mime_type)
+        51    load_var 31            (source)
+        52    load_const 5           ("pdf")
+        53    call 783 ntypeargs=0   (ai.wire._media_mime_type)
+        54    store_var 37           (_51)
+
+  182   55    load_var2 34 35        
+        56    load_var2 36 37        
+        57    load_var 2             (fetch_url)
+        58    call 784 ntypeargs=0   (ai.wire._resolve_media_content)
+        59    jump +126              (to 185)
+
+  149   60    load_var 21            (_29)
+        61    store_var 22           (video)
+
+  171   62    load_var 22            (video)
+        63    call 314 ntypeargs=0   (baml.media.Video.file)
+        64    store_var 25           (_33)
+        65    load_var 25            (_33)
+        66    store_var 24           (_32)
+        67    load_var 25            (_33)
+        68    load_const 3           (null)
+        69    cmp_op ==              
+        70    pop_jump_if_false +4   (to 74)
+        71    load_var 22            (video)
+        72    call 313 ntypeargs=0   (baml.media.Video.url)
+        73    store_var 24           (_32)
+        74    load_var 24            (_32)
+        75    store_var 23           (source)
+        76    load_var 24            (_32)
+        77    load_const 3           (null)
+        78    cmp_op ==              
+        79    pop_jump_if_false +3   (to 82)
+        80    load_const 6           ("")
+        81    store_var 23           (source)
+
+  173   82    load_var 22            (video)
+        83    call 313 ntypeargs=0   (baml.media.Video.url)
+        84    store_var 26           (_36)
+
+  174   85    load_var 22            (video)
+        86    call 314 ntypeargs=0   (baml.media.Video.file)
+        87    store_var 27           (_37)
+
+  175   88    load_var 22            (video)
+        89    call 315 ntypeargs=0   (baml.media.Video.base64)
+        90    store_var 28           (_38)
+
+  176   91    load_var 22            (video)
+        92    call 316 ntypeargs=0   (baml.media.Video.mime_type)
+        93    load_var 23            (source)
+        94    load_const 7           ("video")
+        95    call 783 ntypeargs=0   (ai.wire._media_mime_type)
+        96    store_var 29           (_39)
+
+  172   97    load_var2 26 27        
+        98    load_var2 28 29        
+        99    load_var 2             (fetch_url)
+        100   call 784 ntypeargs=0   (ai.wire._resolve_media_content)
+        101   jump +84               (to 185)
+
+  149   102   load_var 12            (_16)
+        103   store_var 13           (audio)
+
+  161   104   load_var 13            (audio)
+        105   call 307 ntypeargs=0   (baml.media.Audio.file)
+        106   store_var 16           (_20)
+        107   load_var 16            (_20)
+        108   store_var 15           (_19)
+        109   load_var 16            (_20)
+        110   load_const 3           (null)
+        111   cmp_op ==              
+        112   pop_jump_if_false +4   (to 116)
+        113   load_var 13            (audio)
+        114   call 306 ntypeargs=0   (baml.media.Audio.url)
+        115   store_var 15           (_19)
+        116   load_var 15            (_19)
+        117   store_var 14           (source)
+        118   load_var 15            (_19)
+        119   load_const 3           (null)
+        120   cmp_op ==              
+        121   pop_jump_if_false +3   (to 124)
+        122   load_const 8           ("")
+        123   store_var 14           (source)
+
+  163   124   load_var 13            (audio)
+        125   call 306 ntypeargs=0   (baml.media.Audio.url)
+        126   store_var 17           (_23)
+
+  164   127   load_var 13            (audio)
+        128   call 307 ntypeargs=0   (baml.media.Audio.file)
+        129   store_var 18           (_24)
+
+  165   130   load_var 13            (audio)
+        131   call 308 ntypeargs=0   (baml.media.Audio.base64)
+        132   store_var 19           (_25)
+
+  166   133   load_var 13            (audio)
+        134   call 309 ntypeargs=0   (baml.media.Audio.mime_type)
+        135   load_var 14            (source)
+        136   load_const 9           ("audio")
+        137   call 783 ntypeargs=0   (ai.wire._media_mime_type)
+        138   store_var 20           (_26)
+
+  162   139   load_var2 17 18        
+        140   load_var2 19 20        
+        141   load_var 2             (fetch_url)
+        142   call 784 ntypeargs=0   (ai.wire._resolve_media_content)
+        143   jump +42               (to 185)
+
+  149   144   load_var 3             (_3)
+        145   store_var 4            (image)
+
+  151   146   load_var 4             (image)
+        147   call 321 ntypeargs=0   (baml.media.Image.file)
+        148   store_var 7            (_7)
+        149   load_var 7             (_7)
+        150   store_var 6            (_6)
+        151   load_var 7             (_7)
+        152   load_const 3           (null)
+        153   cmp_op ==              
+        154   pop_jump_if_false +4   (to 158)
+        155   load_var 4             (image)
+        156   call 320 ntypeargs=0   (baml.media.Image.url)
+        157   store_var 6            (_6)
+        158   load_var 6             (_6)
+        159   store_var 5            (source)
+        160   load_var 6             (_6)
+        161   load_const 3           (null)
+        162   cmp_op ==              
+        163   pop_jump_if_false +3   (to 166)
+        164   load_const 10          ("")
+        165   store_var 5            (source)
+
+  153   166   load_var 4             (image)
+        167   call 320 ntypeargs=0   (baml.media.Image.url)
+        168   store_var 8            (_10)
+
+  154   169   load_var 4             (image)
+        170   call 321 ntypeargs=0   (baml.media.Image.file)
+        171   store_var 9            (_11)
+
+  155   172   load_var 4             (image)
+        173   call 322 ntypeargs=0   (baml.media.Image.base64)
+        174   store_var 10           (_12)
+
+  156   175   load_var 4             (image)
+        176   call 323 ntypeargs=0   (baml.media.Image.mime_type)
+        177   load_var 5             (source)
+        178   load_const 11          ("image")
+        179   call 783 ntypeargs=0   (ai.wire._media_mime_type)
+        180   store_var 11           (_13)
+
+  152   181   load_var2 8 9          
+        182   load_var2 10 11        
+        183   load_var 2             (fetch_url)
+        184   call 784 ntypeargs=0   (ai.wire._resolve_media_content)
+        185   return                 
 }
 
 function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
@@ -3453,7 +4077,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
   27   48   load_var2 2 3          
        49   load_field 0           (status_code)
        50   load_var 7             (text)
-       51   call 820 ntypeargs=0   (ai.errors.classify_http)
+       51   call 823 ntypeargs=0   (ai.errors.classify_http)
        52   throw                  
 }
 
@@ -3473,20 +4097,20 @@ function anthropic.AnthropicClient.ai.Client.id(self: anthropic.AnthropicClient)
 
 function anthropic.AnthropicClient.ai.Client.invoke(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   32   0   load_var2 1 2          
-       1   call 848 ntypeargs=0   (anthropic.internal.invoke)
+       1   call 854 ntypeargs=0   (anthropic.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   33   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 814 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function anthropic.AnthropicClient.ai.stream.StreamingClient.invoke_stream(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   40   0   load_var2 1 2          
-       1   call 850 ntypeargs=0   (anthropic.internal.invoke_stream)
+       1   call 856 ntypeargs=0   (anthropic.internal.invoke_stream)
        2   return                 
 }
 
@@ -3527,130 +4151,130 @@ function anthropic.AnthropicClient.new(model: string, api_key: string | null, ba
 }
 
 function anthropic.internal._anthropic_assistant_blocks(content: (ai.content.Text | ai.content.Reasoning | ai.content.ToolUse)[]) -> map<string, unknown>[] {
-  74   0     load_type 0                        
-       1     alloc_array 0                      
-       2     store_var 3                        (out)
-
-  75   3     load_var 1                         (content)
-       4     load_type 1                        
-       5     load_const 2                       ("iter")
-       6     virtual_call nargs=1 ntypeargs=0   
-       7     store_var 4                        (_3)
-       8     load_var 4                         (_3)
-       9     load_type 3                        
-       10    load_const 4                       ("next")
-       11    virtual_call nargs=1 ntypeargs=0   
-       12    store_var 5                        (_4)
-       13    load_var 5                         (_4)
-       14    is_type 5                          
-       15    pop_jump_if_false +2               (to 17)
-       16    jump +81                           (to 97)
-       17    load_var 5                         (_4)
-       18    store_var 6                        (b)
-
-  76   19    load_var 6                         (b)
-       20    store_var 7                        (_8)
-       21    load_var 7                         (_8)
-       22    narrow_bind 6 7                    
-       23    pop_jump_if_false +2               (to 25)
-       24    jump +48                           (to 72)
-       25    load_var 6                         (b)
-       26    store_var 10                       (_20)
-       27    load_var 10                        (_20)
-       28    narrow_bind 7 10                   
-       29    pop_jump_if_false +2               (to 31)
-       30    jump -22                           (to 8)
-       31    load_var 6                         (b)
-       32    store_var 11                       (u)
-
-  88   33    load_type 8                        
-       34    load_type 9                        
-       35    alloc_map 0                        
-       36    store_var 12                       (bb)
-
-  89   37    load_type 8                        
-       38    load_type 9                        
-       39    load_var 12                        (bb)
-       40    load_const 10                      ("type")
-       41    load_const 11                      ("tool_use")
-       42    call 37 ntypeargs=2                (baml.Map.set)
-       43    pop 1                              
-
-  90   44    load_type 8                        
-       45    load_type 9                        
-       46    load_var 12                        (bb)
-       47    load_const 12                      ("id")
-       48    load_var 11                        (u)
-       49    load_field 0                       (id)
-       50    call 37 ntypeargs=2                (baml.Map.set)
-       51    pop 1                              
-
-  91   52    load_type 8                        
-       53    load_type 9                        
-       54    load_var 12                        (bb)
-       55    load_const 13                      ("name")
-       56    load_var 11                        (u)
-       57    load_field 1                       (name)
-       58    call 37 ntypeargs=2                (baml.Map.set)
-       59    pop 1                              
-
-  92   60    load_type 8                        
-       61    load_type 9                        
-       62    load_var 12                        (bb)
-       63    load_const 14                      ("input")
-       64    load_var 11                        (u)
-       65    load_field 2                       (args)
-       66    call 37 ntypeargs=2                (baml.Map.set)
-       67    pop 1                              
-
-  93   68    load_var2 3 12                     
-       69    call 4 ntypeargs=0                 (baml.Array.push)
-       70    pop 1                              
-       71    jump -63                           (to 8)
-
-  76   72    load_var 7                         (_8)
-       73    store_var 8                        (t)
-
-  78   74    load_type 8                        
-       75    load_type 9                        
-       76    alloc_map 0                        
-       77    store_var 9                        (bb)
-
-  79   78    load_type 8                        
-       79    load_type 9                        
-       80    load_var 9                         (bb)
-       81    load_const 15                      ("type")
-       82    load_const 16                      ("text")
-       83    call 37 ntypeargs=2                (baml.Map.set)
-       84    pop 1                              
-
-  80   85    load_type 8                        
-       86    load_type 9                        
-       87    load_var 9                         (bb)
-       88    load_const 17                      ("text")
-       89    load_var 8                         (t)
-       90    load_field 0                       (text)
-       91    call 37 ntypeargs=2                (baml.Map.set)
-       92    pop 1                              
-
-  81   93    load_var2 3 9                      
-       94    call 4 ntypeargs=0                 (baml.Array.push)
-       95    pop 1                              
-       96    jump -88                           (to 8)
-
-  98   97    load_var 3                         (out)
-       98    store_var 2                        (_0)
-       99    load_var 2                         (_0)
-       100   return                             
-}
-
-function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone)[] {
-  348   0     load_type 0                        
+  149   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 3                        (out)
 
-  349   3     load_var 1                         (batch)
-        4     call 802 ntypeargs=0               (ai.stream.decode_sse_batch)
+  150   3     load_var 1                         (content)
+        4     load_type 1                        
+        5     load_const 2                       ("iter")
+        6     virtual_call nargs=1 ntypeargs=0   
+        7     store_var 4                        (_3)
+        8     load_var 4                         (_3)
+        9     load_type 3                        
+        10    load_const 4                       ("next")
+        11    virtual_call nargs=1 ntypeargs=0   
+        12    store_var 5                        (_4)
+        13    load_var 5                         (_4)
+        14    is_type 5                          
+        15    pop_jump_if_false +2               (to 17)
+        16    jump +81                           (to 97)
+        17    load_var 5                         (_4)
+        18    store_var 6                        (b)
+
+  151   19    load_var 6                         (b)
+        20    store_var 7                        (_8)
+        21    load_var 7                         (_8)
+        22    narrow_bind 6 7                    
+        23    pop_jump_if_false +2               (to 25)
+        24    jump +48                           (to 72)
+        25    load_var 6                         (b)
+        26    store_var 10                       (_20)
+        27    load_var 10                        (_20)
+        28    narrow_bind 7 10                   
+        29    pop_jump_if_false +2               (to 31)
+        30    jump -22                           (to 8)
+        31    load_var 6                         (b)
+        32    store_var 11                       (u)
+
+  163   33    load_type 8                        
+        34    load_type 9                        
+        35    alloc_map 0                        
+        36    store_var 12                       (bb)
+
+  164   37    load_type 8                        
+        38    load_type 9                        
+        39    load_var 12                        (bb)
+        40    load_const 10                      ("type")
+        41    load_const 11                      ("tool_use")
+        42    call 37 ntypeargs=2                (baml.Map.set)
+        43    pop 1                              
+
+  165   44    load_type 8                        
+        45    load_type 9                        
+        46    load_var 12                        (bb)
+        47    load_const 12                      ("id")
+        48    load_var 11                        (u)
+        49    load_field 0                       (id)
+        50    call 37 ntypeargs=2                (baml.Map.set)
+        51    pop 1                              
+
+  166   52    load_type 8                        
+        53    load_type 9                        
+        54    load_var 12                        (bb)
+        55    load_const 13                      ("name")
+        56    load_var 11                        (u)
+        57    load_field 1                       (name)
+        58    call 37 ntypeargs=2                (baml.Map.set)
+        59    pop 1                              
+
+  167   60    load_type 8                        
+        61    load_type 9                        
+        62    load_var 12                        (bb)
+        63    load_const 14                      ("input")
+        64    load_var 11                        (u)
+        65    load_field 2                       (args)
+        66    call 37 ntypeargs=2                (baml.Map.set)
+        67    pop 1                              
+
+  168   68    load_var2 3 12                     
+        69    call 4 ntypeargs=0                 (baml.Array.push)
+        70    pop 1                              
+        71    jump -63                           (to 8)
+
+  151   72    load_var 7                         (_8)
+        73    store_var 8                        (t)
+
+  153   74    load_type 8                        
+        75    load_type 9                        
+        76    alloc_map 0                        
+        77    store_var 9                        (bb)
+
+  154   78    load_type 8                        
+        79    load_type 9                        
+        80    load_var 9                         (bb)
+        81    load_const 15                      ("type")
+        82    load_const 16                      ("text")
+        83    call 37 ntypeargs=2                (baml.Map.set)
+        84    pop 1                              
+
+  155   85    load_type 8                        
+        86    load_type 9                        
+        87    load_var 9                         (bb)
+        88    load_const 17                      ("text")
+        89    load_var 8                         (t)
+        90    load_field 0                       (text)
+        91    call 37 ntypeargs=2                (baml.Map.set)
+        92    pop 1                              
+
+  156   93    load_var2 3 9                      
+        94    call 4 ntypeargs=0                 (baml.Array.push)
+        95    pop 1                              
+        96    jump -88                           (to 8)
+
+  173   97    load_var 3                         (out)
+        98    store_var 2                        (_0)
+        99    load_var 2                         (_0)
+        100   return                             
+}
+
+function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone)[] {
+  423   0     load_type 0                        
+        1     alloc_array 0                      
+        2     store_var 3                        (out)
+
+  424   3     load_var 1                         (batch)
+        4     call 805 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -3667,7 +4291,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         18    load_var 5                         (_5)
         19    store_var_load_var 6               (raw)
 
-  350   20    load_field 1                       (data)
+  425   20    load_field 1                       (data)
         21    store_var 7                        (_10)
         22    load_var 7                         (_10)
         23    narrow_bind 6 7                    
@@ -3675,23 +4299,23 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         25    load_var 7                         (_10)
         26    store_var 8                        (data)
 
-  351   27    load_type 7                        
+  426   27    load_type 7                        
         28    load_var 8                         (data)
         29    call 333 ntypeargs=1               (baml.json.from_string)
         30    jump +4                            (to 34)
         31    load_var 9                         (e)
         32    throw_if_panic                     
 
-  352   33    load_const 8                       (null)
+  427   33    load_const 8                       (null)
 
-  354   34    store_var 10                       (_16)
+  429   34    store_var 10                       (_16)
         35    load_var 10                        (_16)
         36    narrow_bind 9 10                   
         37    pop_jump_if_false -28              (to 9)
         38    load_var 10                        (_16)
         39    store_var 11                       (event)
 
-  355   40    load_var 11                        (event)
+  430   40    load_var 11                        (event)
         41    load_field 0                       (type)
         42    store_var 14                       (_20)
         43    load_var 14                        (_20)
@@ -3712,36 +4336,36 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         58    load_const 10                      ("")
         59    store_var 12                       (t)
 
-  356   60    load_var 12                        (t)
+  431   60    load_var 12                        (t)
         61    load_const 11                      ("content_block_delta")
         62    cmp_op ==                          
         63    pop_jump_if_false +2               (to 65)
         64    jump +140                          (to 204)
 
-  372   65    load_var 12                        (t)
+  447   65    load_var 12                        (t)
         66    load_const 12                      ("message_start")
         67    cmp_op ==                          
         68    pop_jump_if_false +2               (to 70)
         69    jump +74                           (to 143)
 
-  381   70    load_var 12                        (t)
+  456   70    load_var 12                        (t)
         71    load_const 13                      ("message_delta")
         72    cmp_op ==                          
         73    pop_jump_if_false +2               (to 75)
         74    jump +10                           (to 84)
 
-  394   75    load_var 12                        (t)
+  469   75    load_var 12                        (t)
         76    load_const 14                      ("message_stop")
         77    cmp_op ==                          
         78    pop_jump_if_false -69              (to 9)
 
-  395   79    load_var 3                         (out)
-        80    alloc_instance 358 ntypeargs=0     (ai.stream.TurnDone)
+  470   79    load_var 3                         (out)
+        80    alloc_instance 360 ntypeargs=0     (ai.stream.TurnDone)
         81    call 4 ntypeargs=0                 (baml.Array.push)
         82    pop 1                              
         83    jump -74                           (to 9)
 
-  382   84    load_var 11                        (event)
+  457   84    load_var 11                        (event)
         85    load_field 1                       (delta)
         86    load_const 8                       (null)
         87    cmp_op ==                          
@@ -3762,17 +4386,17 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         102   load_var 24                        (_65)
         103   store_var_load_var 25              (s)
 
-  384   104   call 847 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+  459   104   call 853 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         105   store_var 23                       (stop)
         106   jump +3                            (to 109)
 
-  383   107   load_const 8                       (null)
+  458   107   load_const 8                       (null)
         108   store_var 23                       (stop)
 
-  388   109   load_var 23                        (stop)
+  463   109   load_var 23                        (stop)
         110   store_var 26                       (_74)
 
-  389   111   load_var 11                        (event)
+  464   111   load_var 11                        (event)
         112   load_field 3                       (usage)
         113   load_const 8                       (null)
         114   cmp_op ==                          
@@ -3786,7 +4410,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         122   load_const 8                       (null)
         123   store_var 27                       (_75)
 
-  390   124   load_var 11                        (event)
+  465   124   load_var 11                        (event)
         125   load_field 3                       (usage)
         126   load_const 8                       (null)
         127   cmp_op ==                          
@@ -3800,15 +4424,15 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         135   load_const 8                       (null)
         136   store_var 28                       (_79)
 
-  386   137   load_var2 3 26                     
+  461   137   load_var2 3 26                     
 
-  387   138   load_var2 27 28                    
+  462   138   load_var2 27 28                    
         139   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
         140   call 4 ntypeargs=0                 (baml.Array.push)
         141   pop 1                              
         142   jump -133                          (to 9)
 
-  376   143   load_var 11                        (event)
+  451   143   load_var 11                        (event)
         144   load_field 2                       (message)
         145   load_const 8                       (null)
         146   cmp_op ==                          
@@ -3836,7 +4460,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         168   load_const 8                       (null)
         169   store_var 21                       (_42)
 
-  377   170   load_var 11                        (event)
+  452   170   load_var 11                        (event)
         171   load_field 2                       (message)
         172   load_const 8                       (null)
         173   cmp_op ==                          
@@ -3864,16 +4488,16 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         195   load_const 8                       (null)
         196   store_var 22                       (_52)
 
-  373   197   load_var 3                         (out)
+  448   197   load_var 3                         (out)
 
-  374   198   load_const 8                       (null)
+  449   198   load_const 8                       (null)
         199   load_var2 21 22                    
         200   init_instance 1                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
         201   call 4 ntypeargs=0                 (baml.Array.push)
         202   pop 1                              
         203   jump -194                          (to 9)
 
-  357   204   load_var 11                        (event)
+  432   204   load_var 11                        (event)
         205   load_field 1                       (delta)
         206   store_var 15                       (_26)
         207   load_var 15                        (_26)
@@ -3882,7 +4506,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         210   load_var 15                        (_26)
         211   store_var 16                       (d)
 
-  358   212   load_var 16                        (d)
+  433   212   load_var 16                        (d)
         213   load_field 0                       (type)
         214   store_var 18                       (_30)
         215   load_var 18                        (_30)
@@ -3898,7 +4522,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         225   cmp_op ==                          
         226   pop_jump_if_false -217             (to 9)
 
-  359   227   load_var 16                        (d)
+  434   227   load_var 16                        (d)
         228   load_field 1                       (text)
         229   store_var 19                       (_33)
         230   load_var 19                        (_33)
@@ -3907,24 +4531,24 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         233   load_var 19                        (_33)
         234   store_var 20                       (text)
 
-  360   235   load_var2 3 20                     
+  435   235   load_var2 3 20                     
         236   init_instance 2                    (ai.stream.TextDelta .text)
         237   call 4 ntypeargs=0                 (baml.Array.push)
         238   pop 1                              
         239   jump -230                          (to 9)
 
-  409   240   load_var 3                         (out)
+  484   240   load_var 3                         (out)
         241   store_var 2                        (_0)
         242   load_var 2                         (_0)
         243   return                             
 }
 
 function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic.internal.AnthropicMessage[] {
-  131   0     load_type 0                        
+  206   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 3                        (msgs)
 
-  132   3     load_var 1                         (j)
+  207   3     load_var 1                         (j)
         4     call 760 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
@@ -3942,7 +4566,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         18    load_var 5                         (_5)
         19    store_var 6                        (e)
 
-  133   20    load_var 6                         (e)
+  208   20    load_var 6                         (e)
         21    store_var 7                        (_10)
         22    load_var 7                         (_10)
         23    narrow_bind 6 7                    
@@ -3968,37 +4592,37 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         43    load_var 15                        (_35)
         44    store_var 16                       (f)
 
-  154   45    load_var2 3 16                     
+  229   45    load_var2 3 16                     
         46    load_field 0                       (id)
         47    load_var 16                        (f)
         48    load_field 1                       (message)
         49    load_const 10                      (true)
-        50    call 843 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        50    call 849 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         51    pop 1                              
         52    jump -43                           (to 9)
 
-  133   53    load_var 13                        (_30)
+  208   53    load_var 13                        (_30)
         54    store_var 14                       (c)
 
-  152   55    load_var2 3 14                     
+  227   55    load_var2 3 14                     
         56    load_field 0                       (id)
         57    load_var 14                        (c)
         58    load_field 1                       (output)
         59    load_const 11                      (false)
-        60    call 843 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        60    call 849 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         61    pop 1                              
         62    jump -53                           (to 9)
 
-  133   63    load_var 10                        (_24)
+  208   63    load_var 10                        (_24)
         64    store_var_load_var 11              (m)
 
-  146   65    load_field 0                       (content)
-        66    call 842 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
+  221   65    load_field 0                       (content)
+        66    call 848 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
         67    store_var 12                       (_28)
 
-  142   68    load_var 3                         (msgs)
+  217   68    load_var 3                         (msgs)
 
-  143   69    load_const 12                      ("assistant")
+  218   69    load_const 12                      ("assistant")
         70    load_const 11                      (false)
         71    load_var 12                        (_28)
         72    init_instance 0                    (anthropic.internal.AnthropicMessage .role, .tool_results, .blocks)
@@ -4006,15 +4630,15 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         74    pop 1                              
         75    jump -66                           (to 9)
 
-  133   76    load_var 7                         (_10)
+  208   76    load_var 7                         (_10)
         77    store_var 8                        (m)
 
-  135   78    load_type 13                       
+  210   78    load_type 13                       
         79    load_type 14                       
         80    alloc_map 0                        
         81    store_var 9                        (block)
 
-  136   82    load_type 13                       
+  211   82    load_type 13                       
         83    load_type 14                       
         84    load_var 9                         (block)
         85    load_const 15                      ("type")
@@ -4022,7 +4646,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         87    call 37 ntypeargs=2                (baml.Map.set)
         88    pop 1                              
 
-  137   89    load_type 13                       
+  212   89    load_type 13                       
         90    load_type 14                       
         91    load_var 9                         (block)
         92    load_const 17                      ("text")
@@ -4031,7 +4655,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         95    call 37 ntypeargs=2                (baml.Map.set)
         96    pop 1                              
 
-  138   97    load_var 3                         (msgs)
+  213   97    load_var 3                         (msgs)
         98    load_const 18                      ("user")
         99    load_const 11                      (false)
         100   load_var 9                         (block)
@@ -4042,112 +4666,387 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         105   pop 1                              
         106   jump -97                           (to 9)
 
-  158   107   load_var 3                         (msgs)
+  233   107   load_var 3                         (msgs)
         108   store_var 2                        (_0)
         109   load_var 2                         (_0)
         110   return                             
 }
 
 function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthropic.internal.AnthropicPrompt {
-  51   0    load_type 0                        
-       1    alloc_array 0                      
-       2    store_var 3                        (system)
+  121   0    load_type 0                        
+        1    alloc_array 0                      
+        2    store_var 3                        (system)
 
-  52   3    load_type 1                        
-       4    alloc_array 0                      
-       5    store_var 4                        (messages)
+  122   3    load_type 1                        
+        4    alloc_array 0                      
+        5    store_var 4                        (messages)
 
-  53   6    load_var 1                         (prompt)
-       7    call 764 ntypeargs=0               (ai.Prompt.messages)
-       8    load_type 2                        
-       9    load_const 3                       ("iter")
-       10   virtual_call nargs=1 ntypeargs=0   
-       11   store_var 5                        (_5)
-       12   load_var 5                         (_5)
-       13   load_type 4                        
-       14   load_const 5                       ("next")
-       15   virtual_call nargs=1 ntypeargs=0   
-       16   store_var 6                        (_6)
-       17   load_var 6                         (_6)
-       18   is_type 6                          
-       19   pop_jump_if_false +2               (to 21)
-       20   jump +52                           (to 72)
-       21   load_var 6                         (_6)
-       22   store_var 7                        (message)
+  123   6    load_var 1                         (prompt)
+        7    call 764 ntypeargs=0               (ai.Prompt.messages)
+        8    load_type 2                        
+        9    load_const 3                       ("iter")
+        10   virtual_call nargs=1 ntypeargs=0   
+        11   store_var 5                        (_5)
+        12   load_var 5                         (_5)
+        13   load_type 4                        
+        14   load_const 5                       ("next")
+        15   virtual_call nargs=1 ntypeargs=0   
+        16   store_var 6                        (_6)
+        17   load_var 6                         (_6)
+        18   is_type 6                          
+        19   pop_jump_if_false +2               (to 21)
+        20   jump +53                           (to 73)
+        21   load_var 6                         (_6)
+        22   store_var_load_var 7               (message)
 
-  54   23   load_type 7                        
-       24   load_type 8                        
-       25   alloc_map 0                        
-       26   store_var 8                        (block)
+  124   23   load_field 0                       (role)
+        24   load_const 7                       ("system")
+        25   cmp_op ==                          
+        26   pop_jump_if_false +2               (to 28)
+        27   jump +24                           (to 51)
 
-  55   27   load_type 7                        
-       28   load_type 8                        
-       29   load_var 8                         (block)
-       30   load_const 9                       ("type")
-       31   load_const 10                      ("text")
-       32   call 37 ntypeargs=2                (baml.Map.set)
-       33   pop 1                              
+  130   28   load_var 7                         (message)
+        29   load_field 0                       (role)
+        30   load_const 8                       ("assistant")
+        31   cmp_op ==                          
+        32   pop_jump_if_false +2               (to 34)
+        33   jump +4                            (to 37)
 
-  56   34   load_type 7                        
-       35   load_type 8                        
-       36   load_var 8                         (block)
-       37   load_const 11                      ("text")
-       38   load_var 7                         (message)
-       39   load_field 1                       (content)
-       40   call 37 ntypeargs=2                (baml.Map.set)
-       41   pop 1                              
+  133   34   load_const 9                       ("user")
+        35   store_var 11                       (role)
 
-  57   42   load_var 7                         (message)
-       43   load_field 0                       (role)
-       44   load_const 12                      ("system")
-       45   cmp_op ==                          
-       46   pop_jump_if_false +2               (to 48)
-       47   jump +21                           (to 68)
+  130   36   jump +3                            (to 39)
 
-  61   48   load_var 7                         (message)
-       49   load_field 0                       (role)
-       50   load_const 13                      ("assistant")
-       51   cmp_op ==                          
-       52   pop_jump_if_false +2               (to 54)
-       53   jump +4                            (to 57)
+  131   37   load_const 10                      ("assistant")
+        38   store_var 11                       (role)
 
-  64   54   load_const 14                      ("user")
-       55   store_var 9                        (role)
+  137   39   load_var 11                        (role)
+        40   store_var 12                       (_26)
 
-  61   56   jump +3                            (to 59)
+  139   41   load_var2 7 11                     
+        42   call 846 ntypeargs=0               (anthropic.internal._anthropic_prompt_blocks)
+        43   store_var 13                       (_27)
 
-  62   57   load_const 15                      ("assistant")
-       58   store_var 9                        (role)
+  135   44   load_var2 4 12                     
 
-  66   59   load_var2 4 9                      
-       60   load_const 16                      (false)
-       61   load_var 8                         (block)
-       62   load_type 0                        
-       63   alloc_array 1                      
-       64   init_instance 0                    (anthropic.internal.AnthropicMessage .role, .tool_results, .blocks)
-       65   call 4 ntypeargs=0                 (baml.Array.push)
-       66   pop 1                              
-       67   jump -55                           (to 12)
+  136   45   load_const 11                      (false)
+        46   load_var 13                        (_27)
+        47   init_instance 0                    (anthropic.internal.AnthropicMessage .role, .tool_results, .blocks)
+        48   call 4 ntypeargs=0                 (baml.Array.push)
+        49   pop 1                              
+        50   jump -38                           (to 12)
 
-  58   68   load_var2 3 8                      
-       69   call 4 ntypeargs=0                 (baml.Array.push)
-       70   pop 1                              
-       71   jump -59                           (to 12)
+  125   51   load_var 7                         (message)
+        52   load_const 12                      ("system")
+        53   call 846 ntypeargs=0               (anthropic.internal._anthropic_prompt_blocks)
+        54   load_type 13                       
+        55   load_const 14                      ("iter")
+        56   virtual_call nargs=1 ntypeargs=0   
+        57   store_var 8                        (_14)
+        58   load_var 8                         (_14)
+        59   load_type 15                       
+        60   load_const 16                      ("next")
+        61   virtual_call nargs=1 ntypeargs=0   
+        62   store_var 9                        (_15)
+        63   load_var 9                         (_15)
+        64   is_type 6                          
+        65   pop_jump_if_false +2               (to 67)
+        66   jump -54                           (to 12)
+        67   load_var 9                         (_15)
+        68   store_var 10                       (block)
 
-  70   72   load_var2 3 4                      
-       73   init_instance 1                    (anthropic.internal.AnthropicPrompt .system, .messages)
-       74   store_var 2                        (_0)
-       75   load_var 2                         (_0)
-       76   return                             
+  126   69   load_var2 3 10                     
+        70   call 4 ntypeargs=0                 (baml.Array.push)
+        71   pop 1                              
+        72   jump -14                           (to 58)
+
+  145   73   load_var2 3 4                      
+        74   init_instance 1                    (anthropic.internal.AnthropicPrompt .system, .messages)
+        75   store_var 2                        (_0)
+        76   load_var 2                         (_0)
+        77   return                             
+}
+
+function anthropic.internal._anthropic_media_block(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf, block_type: string) -> map<string, unknown> {
+  51   0    load_var 1             (media)
+       1    load_const 0           (false)
+       2    call 785 ntypeargs=0   (ai.wire.resolve_media)
+       3    store_var 4            (resolved)
+
+  52   4    load_type 1            
+       5    load_type 2            
+       6    alloc_map 0            
+       7    store_var 5            (source)
+
+  53   8    load_var 4             (resolved)
+       9    load_field 0           (url)
+       10   store_var 6            (_6)
+       11   load_var 6             (_6)
+       12   narrow_bind 3 6        
+       13   pop_jump_if_false +2   (to 15)
+       14   jump +35               (to 49)
+
+  58   15   load_type 1            
+       16   load_type 2            
+       17   load_var 5             (source)
+       18   load_const 4           ("type")
+       19   load_const 5           ("base64")
+       20   call 37 ntypeargs=2    (baml.Map.set)
+       21   pop 1                  
+
+  59   22   load_type 1            
+       23   load_type 2            
+       24   load_var 5             (source)
+       25   load_const 6           ("media_type")
+       26   load_var 4             (resolved)
+       27   load_field 2           (mime_type)
+       28   call 37 ntypeargs=2    (baml.Map.set)
+       29   pop 1                  
+
+  60   30   load_var 4             (resolved)
+       31   load_field 1           (base64)
+       32   store_var 9            (_24)
+       33   load_var 9             (_24)
+       34   store_var 8            (_23)
+       35   load_var 9             (_24)
+       36   load_const 7           (null)
+       37   cmp_op ==              
+       38   pop_jump_if_false +3   (to 41)
+       39   load_const 8           ("")
+       40   store_var 8            (_23)
+       41   load_type 1            
+       42   load_type 2            
+       43   load_var 5             (source)
+       44   load_const 9           ("data")
+       45   load_var 8             (_23)
+       46   call 37 ntypeargs=2    (baml.Map.set)
+       47   pop 1                  
+       48   jump +17               (to 65)
+
+  53   49   load_var 6             (_6)
+       50   store_var 7            (url)
+
+  54   51   load_type 1            
+       52   load_type 2            
+       53   load_var 5             (source)
+       54   load_const 10          ("type")
+       55   load_const 11          ("url")
+       56   call 37 ntypeargs=2    (baml.Map.set)
+       57   pop 1                  
+
+  55   58   load_type 1            
+       59   load_type 2            
+       60   load_var 5             (source)
+       61   load_const 12          ("url")
+       62   load_var 7             (url)
+       63   call 37 ntypeargs=2    (baml.Map.set)
+       64   pop 1                  
+
+  63   65   load_type 1            
+       66   load_type 2            
+       67   alloc_map 0            
+       68   store_var 10           (block)
+
+  64   69   load_type 1            
+       70   load_type 2            
+       71   load_var 10            (block)
+       72   load_const 13          ("type")
+       73   load_var 2             (block_type)
+       74   call 37 ntypeargs=2    (baml.Map.set)
+       75   pop 1                  
+
+  65   76   load_type 1            
+       77   load_type 2            
+       78   load_var 10            (block)
+       79   load_const 14          ("source")
+       80   load_var 5             (source)
+       81   call 37 ntypeargs=2    (baml.Map.set)
+       82   pop 1                  
+
+  66   83   load_var 10            (block)
+       84   store_var 3            (_0)
+       85   load_var 3             (_0)
+       86   return                 
+}
+
+function anthropic.internal._anthropic_prompt_blocks(message: ai.PromptMessage, role: string) -> map<string, unknown>[] {
+  73    0     load_type 0                        
+        1     alloc_array 0                      
+        2     store_var 4                        (blocks)
+
+  74    3     load_var 1                         (message)
+        4     load_field 2                       (parts)
+        5     load_type 1                        
+        6     load_const 2                       ("iter")
+        7     virtual_call nargs=1 ntypeargs=0   
+        8     store_var 5                        (_5)
+        9     load_var 5                         (_5)
+        10    load_type 3                        
+        11    load_const 4                       ("next")
+        12    virtual_call nargs=1 ntypeargs=0   
+        13    store_var 6                        (_6)
+        14    load_var 6                         (_6)
+        15    is_type 5                          
+        16    pop_jump_if_false +2               (to 18)
+        17    jump +126                          (to 143)
+        18    load_var 6                         (_6)
+        19    store_var 7                        (part)
+
+  75    20    load_var 7                         (part)
+        21    store_var 8                        (_10)
+        22    load_var 8                         (_10)
+        23    narrow_bind 6 8                    
+        24    pop_jump_if_false +2               (to 26)
+        25    jump +94                           (to 119)
+        26    load_var 7                         (part)
+        27    store_var 11                       (_22)
+        28    load_var 11                        (_22)
+        29    narrow_bind 7 11                   
+        30    pop_jump_if_false +2               (to 32)
+        31    jump +64                           (to 95)
+        32    load_var 7                         (part)
+        33    store_var 15                       (_32)
+        34    load_var 15                        (_32)
+        35    narrow_bind 8 15                   
+        36    pop_jump_if_false +2               (to 38)
+        37    jump +34                           (to 71)
+        38    load_var 7                         (part)
+        39    store_var 19                       (_42)
+        40    load_var 19                        (_42)
+        41    narrow_bind 9 19                   
+        42    pop_jump_if_false +2               (to 44)
+        43    jump +4                            (to 47)
+
+  111   44    load_const 10                      ("Anthropic does not support video prompt input")
+        45    init_instance 0                    (baml.errors.InvalidArgument .message)
+        46    throw                              
+
+  75    47    load_var 19                        (_42)
+        48    store_var 20                       (pdf)
+
+  102   49    load_var 2                         (role)
+        50    load_const 11                      ("user")
+        51    cmp_op !=                          
+        52    pop_jump_if_false +2               (to 54)
+        53    jump +9                            (to 62)
+
+  107   54    load_var 20                        (pdf)
+        55    load_const 12                      ("document")
+        56    call 845 ntypeargs=0               (anthropic.internal._anthropic_media_block)
+        57    store_var 22                       (_50)
+        58    load_var2 4 22                     
+        59    call 4 ntypeargs=0                 (baml.Array.push)
+        60    pop 1                              
+        61    jump -52                           (to 9)
+
+  104   62    load_type 13                       
+        63    load_var 2                         (role)
+        64    call 138 ntypeargs=1               (baml.String.from)
+        65    store_var 21                       (_47)
+        66    load_const 14                      ("Anthropic only supports PDF input in user messages, found ")
+        67    load_var 21                        (_47)
+        68    bin_op +                           
+        69    init_instance 1                    (baml.errors.InvalidArgument .message)
+        70    throw                              
+
+  75    71    load_var 15                        (_32)
+        72    store_var 16                       (audio)
+
+  93    73    load_var 2                         (role)
+        74    load_const 15                      ("user")
+        75    cmp_op !=                          
+        76    pop_jump_if_false +2               (to 78)
+        77    jump +9                            (to 86)
+
+  98    78    load_var 16                        (audio)
+        79    load_const 16                      ("input_audio")
+        80    call 845 ntypeargs=0               (anthropic.internal._anthropic_media_block)
+        81    store_var 18                       (_40)
+        82    load_var2 4 18                     
+        83    call 4 ntypeargs=0                 (baml.Array.push)
+        84    pop 1                              
+        85    jump -76                           (to 9)
+
+  95    86    load_type 13                       
+        87    load_var 2                         (role)
+        88    call 138 ntypeargs=1               (baml.String.from)
+        89    store_var 17                       (_37)
+        90    load_const 17                      ("Anthropic only supports audio input in user messages, found ")
+        91    load_var 17                        (_37)
+        92    bin_op +                           
+        93    init_instance 2                    (baml.errors.InvalidArgument .message)
+        94    throw                              
+
+  75    95    load_var 11                        (_22)
+        96    store_var 12                       (image)
+
+  84    97    load_var 2                         (role)
+        98    load_const 18                      ("user")
+        99    cmp_op !=                          
+        100   pop_jump_if_false +2               (to 102)
+        101   jump +9                            (to 110)
+
+  89    102   load_var 12                        (image)
+        103   load_const 19                      ("image")
+        104   call 845 ntypeargs=0               (anthropic.internal._anthropic_media_block)
+        105   store_var 14                       (_30)
+        106   load_var2 4 14                     
+        107   call 4 ntypeargs=0                 (baml.Array.push)
+        108   pop 1                              
+        109   jump -100                          (to 9)
+
+  86    110   load_type 13                       
+        111   load_var 2                         (role)
+        112   call 138 ntypeargs=1               (baml.String.from)
+        113   store_var 13                       (_27)
+        114   load_const 20                      ("Anthropic only supports image input in user messages, found ")
+        115   load_var 13                        (_27)
+        116   bin_op +                           
+        117   init_instance 3                    (baml.errors.InvalidArgument .message)
+        118   throw                              
+
+  75    119   load_var 8                         (_10)
+        120   store_var 9                        (text)
+
+  77    121   load_type 13                       
+        122   load_type 21                       
+        123   alloc_map 0                        
+        124   store_var 10                       (block)
+
+  78    125   load_type 13                       
+        126   load_type 21                       
+        127   load_var 10                        (block)
+        128   load_const 22                      ("type")
+        129   load_const 23                      ("text")
+        130   call 37 ntypeargs=2                (baml.Map.set)
+        131   pop 1                              
+
+  79    132   load_type 13                       
+        133   load_type 21                       
+        134   load_var 10                        (block)
+        135   load_const 24                      ("text")
+        136   load_var 9                         (text)
+        137   call 37 ntypeargs=2                (baml.Map.set)
+        138   pop 1                              
+
+  80    139   load_var2 4 10                     
+        140   call 4 ntypeargs=0                 (baml.Array.push)
+        141   pop 1                              
+        142   jump -133                          (to 9)
+
+  117   143   load_var 4                         (blocks)
+        144   store_var 3                        (_0)
+        145   load_var 3                         (_0)
+        146   return                             
 }
 
 function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal.AnthropicMessage[], id: string, content: string, is_error: bool) -> null {
-  108   0    load_type 0            
+  183   0    load_type 0            
         1    load_type 1            
         2    alloc_map 0            
         3    store_var 5            (block)
 
-  109   4    load_type 0            
+  184   4    load_type 0            
         5    load_type 1            
         6    load_var 5             (block)
         7    load_const 2           ("type")
@@ -4155,7 +5054,7 @@ function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal
         9    call 37 ntypeargs=2    (baml.Map.set)
         10   pop 1                  
 
-  110   11   load_type 0            
+  185   11   load_type 0            
         12   load_type 1            
         13   load_var 5             (block)
         14   load_const 4           ("tool_use_id")
@@ -4163,7 +5062,7 @@ function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal
         16   call 37 ntypeargs=2    (baml.Map.set)
         17   pop 1                  
 
-  111   18   load_type 0            
+  186   18   load_type 0            
         19   load_type 1            
         20   load_var 5             (block)
         21   load_const 5           ("content")
@@ -4171,7 +5070,7 @@ function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal
         23   call 37 ntypeargs=2    (baml.Map.set)
         24   pop 1                  
 
-  112   25   load_type 0            
+  187   25   load_type 0            
         26   load_type 1            
         27   load_var 5             (block)
         28   load_const 6           ("is_error")
@@ -4179,7 +5078,7 @@ function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal
         30   call 37 ntypeargs=2    (baml.Map.set)
         31   pop 1                  
 
-  114   32   load_var 1             (msgs)
+  189   32   load_var 1             (msgs)
         33   container_len          
         34   store_var 6            (_20)
         35   load_type 7            
@@ -4193,7 +5092,7 @@ function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal
         43   pop_jump_if_false +2   (to 45)
         44   jump +12               (to 56)
 
-  123   45   load_var 1             (msgs)
+  198   45   load_var 1             (msgs)
         46   load_const 10          ("user")
         47   load_const 11          (true)
         48   load_var 5             (block)
@@ -4203,17 +5102,17 @@ function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal
         52   call 4 ntypeargs=0     (baml.Array.push)
         53   pop 1                  
 
-  124   54   load_const 13          (null)
+  199   54   load_const 13          (null)
 
-  114   55   jump +24               (to 79)
+  189   55   jump +24               (to 79)
         56   load_var 7             (_22)
         57   store_var_load_var 8   (m)
 
-  115   58   load_field 1           (tool_results)
+  190   58   load_field 1           (tool_results)
         59   pop_jump_if_false +2   (to 61)
         60   jump +12               (to 72)
 
-  119   61   load_var 1             (msgs)
+  194   61   load_var 1             (msgs)
         62   load_const 14          ("user")
         63   load_const 11          (true)
         64   load_var 5             (block)
@@ -4223,27 +5122,27 @@ function anthropic.internal._anthropic_push_tool_result(msgs: anthropic.internal
         68   call 4 ntypeargs=0     (baml.Array.push)
         69   pop 1                  
 
-  120   70   load_const 13          (null)
+  195   70   load_const 13          (null)
 
-  115   71   jump +8                (to 79)
+  190   71   jump +8                (to 79)
 
-  116   72   load_type 12           
+  191   72   load_type 12           
         73   load_var 8             (m)
         74   load_field 2           (blocks)
         75   load_var 5             (block)
         76   call 4 ntypeargs=1     (baml.Array.push)
         77   pop 1                  
 
-  117   78   load_const 13          (null)
+  192   78   load_const 13          (null)
         79   return                 
 }
 
 function anthropic.internal._anthropic_render_messages(msgs: anthropic.internal.AnthropicMessage[]) -> map<string, unknown>[] {
-  162   0    load_type 0                        
+  237   0    load_type 0                        
         1    alloc_array 0                      
         2    store_var 3                        (out)
 
-  163   3    load_var 1                         (msgs)
+  238   3    load_var 1                         (msgs)
         4    load_type 1                        
         5    load_const 2                       ("iter")
         6    virtual_call nargs=1 ntypeargs=0   
@@ -4260,12 +5159,12 @@ function anthropic.internal._anthropic_render_messages(msgs: anthropic.internal.
         17   load_var 5                         (_4)
         18   store_var 6                        (m)
 
-  164   19   load_type 6                        
+  239   19   load_type 6                        
         20   load_type 7                        
         21   alloc_map 0                        
         22   store_var 7                        (mm)
 
-  165   23   load_type 6                        
+  240   23   load_type 6                        
         24   load_type 7                        
         25   load_var 7                         (mm)
         26   load_const 8                       ("role")
@@ -4274,7 +5173,7 @@ function anthropic.internal._anthropic_render_messages(msgs: anthropic.internal.
         29   call 37 ntypeargs=2                (baml.Map.set)
         30   pop 1                              
 
-  166   31   load_type 6                        
+  241   31   load_type 6                        
         32   load_type 7                        
         33   load_var 7                         (mm)
         34   load_const 9                       ("content")
@@ -4283,19 +5182,19 @@ function anthropic.internal._anthropic_render_messages(msgs: anthropic.internal.
         37   call 37 ntypeargs=2                (baml.Map.set)
         38   pop 1                              
 
-  167   39   load_var2 3 7                      
+  242   39   load_var2 3 7                      
         40   call 4 ntypeargs=0                 (baml.Array.push)
         41   pop 1                              
         42   jump -34                           (to 8)
 
-  169   43   load_var 3                         (out)
+  244   43   load_var 3                         (out)
         44   store_var 2                        (_0)
         45   load_var 2                         (_0)
         46   return                             
 }
 
 function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
-  182   0     load_var 2                         (input)
+  257   0     load_var 2                         (input)
         1     load_field 0                       (prompt)
         2     store_var 5                        (_5)
         3     load_var 2                         (input)
@@ -4304,20 +5203,20 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         6     load_var 5                         (_5)
         7     call_indirect                      
 
-  183   8     call 841 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
+  258   8     call 847 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
         9     store_var 6                        (prompt_parts)
 
-  184   10    load_var 6                         (prompt_parts)
+  259   10    load_var 6                         (prompt_parts)
         11    load_field 0                       (system)
         12    store_var 7                        (system)
 
-  185   13    load_var 6                         (prompt_parts)
+  260   13    load_var 6                         (prompt_parts)
         14    load_field 1                       (messages)
         15    store_var 8                        (lowered)
 
-  186   16    load_var 2                         (input)
+  261   16    load_var 2                         (input)
         17    load_field 1                       (journal)
-        18    call 844 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
+        18    call 850 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
         19    load_type 0                        
         20    load_const 1                       ("iter")
         21    virtual_call nargs=1 ntypeargs=0   
@@ -4334,17 +5233,17 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         32    load_var 10                        (_15)
         33    store_var 11                       (message)
 
-  187   34    load_var2 8 11                     
+  262   34    load_var2 8 11                     
         35    call 4 ntypeargs=0                 (baml.Array.push)
         36    pop 1                              
         37    jump -14                           (to 23)
 
-  190   38    load_type 5                        
+  265   38    load_type 5                        
         39    load_type 6                        
         40    alloc_map 0                        
         41    store_var 12                       (body)
 
-  191   42    load_type 5                        
+  266   42    load_type 5                        
         43    load_type 6                        
         44    load_var 12                        (body)
         45    load_const 7                       ("model")
@@ -4353,7 +5252,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         48    call 37 ntypeargs=2                (baml.Map.set)
         49    pop 1                              
 
-  192   50    load_type 5                        
+  267   50    load_type 5                        
         51    load_type 6                        
         52    load_var 12                        (body)
         53    load_const 8                       ("max_tokens")
@@ -4362,7 +5261,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         56    call 37 ntypeargs=2                (baml.Map.set)
         57    pop 1                              
 
-  198   58    load_type 9                        
+  273   58    load_type 9                        
         59    load_var 8                         (lowered)
         60    load_const 10                      (0)
         61    call 3 ntypeargs=1                 (baml.Array.at)
@@ -4388,7 +5287,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         81    load_const 12                      ("")
         82    store_var 13                       (first_role)
 
-  199   83    load_var 13                        (first_role)
+  274   83    load_var 13                        (first_role)
         84    load_const 13                      ("user")
         85    cmp_op !=                          
         86    jump_if_false +8                   (to 94)
@@ -4402,7 +5301,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         94    pop_jump_if_false +2               (to 96)
         95    jump +26                           (to 121)
 
-  204   96    load_var 7                         (system)
+  279   96    load_var 7                         (system)
         97    container_len                      
         98    store_var 18                       (_54)
         99    load_var 18                        (_54)
@@ -4410,7 +5309,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         101   cmp_int_op >                       
         102   pop_jump_if_false +8               (to 110)
 
-  205   103   load_type 5                        
+  280   103   load_type 5                        
         104   load_type 6                        
         105   load_var 12                        (body)
         106   load_const 14                      ("system")
@@ -4418,8 +5317,8 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         108   call 37 ntypeargs=2                (baml.Map.set)
         109   pop 1                              
 
-  210   110   load_var 8                         (lowered)
-        111   call 845 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+  285   110   load_var 8                         (lowered)
+        111   call 851 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         112   store_var 19                       (_60)
         113   load_type 5                        
         114   load_type 6                        
@@ -4430,19 +5329,19 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         119   pop 1                              
         120   jump +21                           (to 141)
 
-  200   121   load_const 16                      ("user")
+  275   121   load_const 16                      ("user")
         122   load_const 17                      (false)
         123   load_var 7                         (system)
         124   init_instance 0                    (anthropic.internal.AnthropicMessage .role, .tool_results, .blocks)
         125   store_var 16                       (first)
 
-  201   126   load_type 9                        
+  276   126   load_type 9                        
         127   load_var 16                        (first)
         128   load_type 9                        
         129   alloc_array 1                      
         130   load_var 8                         (lowered)
         131   call 7 ntypeargs=1                 (baml.Array.concat)
-        132   call 845 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        132   call 851 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         133   store_var 17                       (_45)
         134   load_type 5                        
         135   load_type 6                        
@@ -4452,17 +5351,17 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         139   call 37 ntypeargs=2                (baml.Map.set)
         140   pop 1                              
 
-  213   141   load_var 2                         (input)
+  288   141   load_var 2                         (input)
         142   load_field 2                       (toolbox)
         143   call 778 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         144   unary_op !                         
         145   pop_jump_if_false +79              (to 224)
 
-  214   146   load_type 19                       
+  289   146   load_type 19                       
         147   alloc_array 0                      
         148   store_var 20                       (tools)
 
-  215   149   load_var 2                         (input)
+  290   149   load_var 2                         (input)
         150   load_field 2                       (toolbox)
         151   call 776 ntypeargs=0               (ai.tools.Toolbox.list)
         152   load_type 20                       
@@ -4481,12 +5380,12 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         165   load_var 22                        (_71)
         166   store_var 23                       (t)
 
-  216   167   load_type 5                        
+  291   167   load_type 5                        
         168   load_type 6                        
         169   alloc_map 0                        
         170   store_var 24                       (tw)
 
-  217   171   load_type 5                        
+  292   171   load_type 5                        
         172   load_type 6                        
         173   load_var 24                        (tw)
         174   load_const 24                      ("name")
@@ -4495,7 +5394,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         177   call 37 ntypeargs=2                (baml.Map.set)
         178   pop 1                              
 
-  218   179   load_type 5                        
+  293   179   load_type 5                        
         180   load_type 6                        
         181   load_var 24                        (tw)
         182   load_const 25                      ("description")
@@ -4504,7 +5403,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         185   call 37 ntypeargs=2                (baml.Map.set)
         186   pop 1                              
 
-  219   187   load_type 5                        
+  294   187   load_type 5                        
         188   load_type 6                        
         189   load_var 24                        (tw)
         190   load_const 26                      ("input_schema")
@@ -4513,17 +5412,17 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         193   call 37 ntypeargs=2                (baml.Map.set)
         194   pop 1                              
 
-  220   195   load_var2 20 24                    
+  295   195   load_var2 20 24                    
         196   call 4 ntypeargs=0                 (baml.Array.push)
         197   pop 1                              
         198   jump -42                           (to 156)
 
-  222   199   load_type 5                        
+  297   199   load_type 5                        
         200   load_type 6                        
         201   alloc_map 0                        
         202   store_var 25                       (tc)
 
-  223   203   load_type 5                        
+  298   203   load_type 5                        
         204   load_type 6                        
         205   load_var 25                        (tc)
         206   load_const 27                      ("type")
@@ -4531,7 +5430,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         208   call 37 ntypeargs=2                (baml.Map.set)
         209   pop 1                              
 
-  224   210   load_type 5                        
+  299   210   load_type 5                        
         211   load_type 6                        
         212   load_var 12                        (body)
         213   load_const 29                      ("tools")
@@ -4539,7 +5438,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         215   call 37 ntypeargs=2                (baml.Map.set)
         216   pop 1                              
 
-  225   217   load_type 5                        
+  300   217   load_type 5                        
         218   load_type 6                        
         219   load_var 12                        (body)
         220   load_const 30                      ("tool_choice")
@@ -4547,10 +5446,10 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         222   call 37 ntypeargs=2                (baml.Map.set)
         223   pop 1                              
 
-  231   224   load_var 3                         (stream)
+  306   224   load_var 3                         (stream)
         225   pop_jump_if_false +8               (to 233)
 
-  232   226   load_type 5                        
+  307   226   load_type 5                        
         227   load_type 6                        
         228   load_var 12                        (body)
         229   load_const 31                      ("stream")
@@ -4558,7 +5457,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         231   call 37 ntypeargs=2                (baml.Map.set)
         232   pop 1                              
 
-  238   233   load_var 1                         (c)
+  313   233   load_var 1                         (c)
         234   load_field 2                       (base_url)
         235   store_var 27                       (_106)
         236   load_var 27                        (_106)
@@ -4570,12 +5469,12 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         242   load_const 33                      ("https://api.anthropic.com")
         243   store_var 26                       (base)
 
-  241   244   load_type 5                        
+  316   244   load_type 5                        
         245   load_var 26                        (base)
         246   call 138 ntypeargs=1               (baml.String.from)
         247   store_var 28                       (_109)
 
-  243   248   load_var 1                         (c)
+  318   248   load_var 1                         (c)
         249   load_field 1                       (api_key)
         250   store_var 30                       (_114)
         251   load_var2 30 30                    
@@ -4585,7 +5484,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         255   load_const 34                      ("ANTHROPIC_API_KEY")
         256   call 211 ntypeargs=0               (baml.env.get_or_panic)
 
-  242   257   load_const 35                      ("2023-06-01")
+  317   257   load_const 35                      ("2023-06-01")
         258   load_const 36                      ("application/json")
         259   load_const 37                      ("x-api-key")
         260   load_const 38                      ("anthropic-version")
@@ -4595,15 +5494,15 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         264   alloc_map 3                        
         265   store_var 29                       (_112)
 
-  247   266   load_type 19                       
+  322   266   load_type 19                       
         267   load_var 12                        (body)
         268   call 331 ntypeargs=1               (baml.json.to_json)
         269   call 328 ntypeargs=0               (baml.json.stringify)
         270   store_var 31                       (_116)
 
-  239   271   load_const 40                      ("POST")
+  314   271   load_const 40                      ("POST")
 
-  241   272   load_var 28                        (_109)
+  316   272   load_var 28                        (_109)
         273   load_const 41                      ("/v1/messages")
         274   bin_op +                           
         275   load_var2 29 31                    
@@ -4614,61 +5513,61 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 }
 
 function anthropic.internal._anthropic_stop_reason(s: string) -> ai.content.StopReason {
-  253   0    load_var 1             (s)
+  328   0    load_var 1             (s)
         1    load_const 0           ("tool_use")
         2    cmp_op ==              
         3    pop_jump_if_false +2   (to 5)
         4    jump +20               (to 24)
 
-  255   5    load_var 1             (s)
+  330   5    load_var 1             (s)
         6    load_const 1           ("max_tokens")
         7    cmp_op ==              
         8    pop_jump_if_false +2   (to 10)
         9    jump +12               (to 21)
 
-  257   10   load_var 1             (s)
+  332   10   load_var 1             (s)
         11   load_const 2           ("refusal")
         12   cmp_op ==              
         13   pop_jump_if_false +2   (to 15)
         14   jump +4                (to 18)
 
-  260   15   load_const 3           (ai.content.StopReason.Complete)
-        16   alloc_variant 436      (ai.content.StopReason)
+  335   15   load_const 3           (ai.content.StopReason.Complete)
+        16   alloc_variant 438      (ai.content.StopReason)
 
-  257   17   jump +9                (to 26)
+  332   17   jump +9                (to 26)
 
-  258   18   load_const 4           (ai.content.StopReason.Refused)
-        19   alloc_variant 436      (ai.content.StopReason)
+  333   18   load_const 4           (ai.content.StopReason.Refused)
+        19   alloc_variant 438      (ai.content.StopReason)
 
-  257   20   jump +6                (to 26)
+  332   20   jump +6                (to 26)
 
-  256   21   load_const 5           (ai.content.StopReason.MaxTokens)
-        22   alloc_variant 436      (ai.content.StopReason)
+  331   21   load_const 5           (ai.content.StopReason.MaxTokens)
+        22   alloc_variant 438      (ai.content.StopReason)
 
-  255   23   jump +3                (to 26)
+  330   23   jump +3                (to 26)
 
-  254   24   load_const 6           (ai.content.StopReason.ToolUse)
-        25   alloc_variant 436      (ai.content.StopReason)
+  329   24   load_const 6           (ai.content.StopReason.ToolUse)
+        25   alloc_variant 438      (ai.content.StopReason)
         26   return                 
 }
 
 function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
-  266   0     load_var2 1 2                      
+  341   0     load_var2 1 2                      
         1     load_const 0                       (false)
-        2     call 846 ntypeargs=0               (anthropic.internal._anthropic_request)
+        2     call 852 ntypeargs=0               (anthropic.internal._anthropic_request)
         3     store_var 3                        (req)
 
-  267   4     load_type 1                        
+  342   4     load_type 1                        
         5     load_var 3                         (req)
         6     load_const 2                       ("anthropic")
         7     call 781 ntypeargs=1               (ai.wire.send_as)
         8     store_var 4                        (resp)
 
-  269   9     load_type 3                        
+  344   9     load_type 3                        
         10    alloc_array 0                      
         11    store_var 5                        (content)
 
-  270   12    load_var 4                         (resp)
+  345   12    load_var 4                         (resp)
         13    load_field 0                       (content)
         14    load_type 4                        
         15    load_const 5                       ("iter")
@@ -4686,31 +5585,31 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         27    load_var 7                         (_10)
         28    store_var_load_var 8               (b)
 
-  271   29    load_field 0                       (type)
+  346   29    load_field 0                       (type)
         30    load_const 9                       ("text")
         31    cmp_op ==                          
         32    pop_jump_if_false +2               (to 34)
         33    jump +71                           (to 104)
 
-  274   34    load_var 8                         (b)
+  349   34    load_var 8                         (b)
         35    load_field 0                       (type)
         36    load_const 10                      ("thinking")
         37    cmp_op ==                          
         38    pop_jump_if_false +2               (to 40)
         39    jump +49                           (to 88)
 
-  277   40    load_var 8                         (b)
+  352   40    load_var 8                         (b)
         41    load_field 0                       (type)
         42    load_const 11                      ("tool_use")
         43    cmp_op ==                          
         44    pop_jump_if_false -26              (to 18)
 
-  278   45    load_type 12                       
+  353   45    load_type 12                       
         46    load_type 13                       
         47    alloc_map 0                        
         48    store_var 13                       (empty_args)
 
-  281   49    load_var 8                         (b)
+  356   49    load_var 8                         (b)
         50    load_field 3                       (id)
         51    store_var 15                       (_34)
         52    load_var 15                        (_34)
@@ -4722,7 +5621,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         58    load_const 15                      ("")
         59    store_var 14                       (_33)
 
-  282   60    load_var 8                         (b)
+  357   60    load_var 8                         (b)
         61    load_field 4                       (name)
         62    store_var 17                       (_37)
         63    load_var 17                        (_37)
@@ -4734,7 +5633,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         69    load_const 16                      ("")
         70    store_var 16                       (_36)
 
-  283   71    load_var 8                         (b)
+  358   71    load_var 8                         (b)
         72    load_field 5                       (input)
         73    store_var 19                       (_40)
         74    load_var 19                        (_40)
@@ -4746,15 +5645,15 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         80    load_var 13                        (empty_args)
         81    store_var 18                       (_39)
 
-  279   82    load_var2 5 14                     
+  354   82    load_var2 5 14                     
 
-  280   83    load_var2 16 18                    
+  355   83    load_var2 16 18                    
         84    init_instance 0                    (ai.content.ToolUse .id, .name, .args)
         85    call 4 ntypeargs=0                 (baml.Array.push)
         86    pop 1                              
         87    jump -69                           (to 18)
 
-  275   88    load_var 8                         (b)
+  350   88    load_var 8                         (b)
         89    load_field 2                       (thinking)
         90    store_var 12                       (_26)
         91    load_var 12                        (_26)
@@ -4771,7 +5670,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         102   pop 1                              
         103   jump -85                           (to 18)
 
-  272   104   load_var 8                         (b)
+  347   104   load_var 8                         (b)
         105   load_field 1                       (text)
         106   store_var 10                       (_19)
         107   load_var 10                        (_19)
@@ -4788,7 +5687,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         118   pop 1                              
         119   jump -101                          (to 18)
 
-  292   120   load_var 4                         (resp)
+  367   120   load_var 4                         (resp)
         121   load_field 1                       (stop_reason)
         122   store_var_load_var 21              (_43)
         123   load_const 14                      (null)
@@ -4798,15 +5697,15 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         127   load_var 21                        (_43)
         128   store_var_load_var 22              (s)
 
-  294   129   call 847 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+  369   129   call 853 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         130   store_var 20                       (stop)
         131   jump +4                            (to 135)
 
-  293   132   load_const 19                      (ai.content.StopReason.Complete)
-        133   alloc_variant 436                  (ai.content.StopReason)
+  368   132   load_const 19                      (ai.content.StopReason.Complete)
+        133   alloc_variant 438                  (ai.content.StopReason)
         134   store_var 20                       (stop)
 
-  297   135   load_var 4                         (resp)
+  372   135   load_var 4                         (resp)
         136   load_field 2                       (usage)
         137   store_var 24                       (_49)
         138   load_var 24                        (_49)
@@ -4814,39 +5713,39 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         140   pop_jump_if_false +2               (to 142)
         141   jump +4                            (to 145)
 
-  306   142   load_const 14                      (null)
+  381   142   load_const 14                      (null)
         143   store_var 23                       (usage)
 
-  297   144   jump +10                           (to 154)
+  372   144   jump +10                           (to 154)
         145   load_var 24                        (_49)
         146   store_var_load_var 25              (u)
 
-  300   147   load_field 0                       (input_tokens)
+  375   147   load_field 0                       (input_tokens)
 
-  301   148   load_var 25                        (u)
+  376   148   load_var 25                        (u)
         149   load_field 1                       (output_tokens)
         150   load_const 14                      (null)
         151   load_const 14                      (null)
         152   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
         153   store_var 23                       (usage)
 
-  309   154   load_var2 5 20                     
+  384   154   load_var2 5 20                     
         155   load_var 23                        (usage)
         156   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
         157   return                             
 }
 
 function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
-  415   0    load_var2 1 2          
+  490   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 846 ntypeargs=0   (anthropic.internal._anthropic_request)
+        2    call 852 ntypeargs=0   (anthropic.internal._anthropic_request)
 
-  416   3    sys_op 232             (baml.http.fetch_sse)
+  491   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
         5    load_var 3             (e)
         6    throw_if_panic         
 
-  420   7    load_type 1            
+  495   7    load_type 1            
         8    load_var 3             (e)
         9    call 138 ntypeargs=1   (baml.String.from)
         10   store_var 5            (_10)
@@ -4855,17 +5754,17 @@ function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: a
         13   call 138 ntypeargs=1   (baml.String.from)
         14   store_var 4            (_9)
 
-  418   15   load_const 3           ("anthropic")
+  493   15   load_const 3           ("anthropic")
 
-  420   16   load_const 4           ("transport failed before a response arrived: ")
+  495   16   load_const 4           ("transport failed before a response arrived: ")
         17   load_var 4             (_9)
         18   bin_op +               
         19   load_const 5           (null)
         20   init_instance 0        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
         21   throw                  
 
-  425   22   load_const 6           (anthropic.internal._anthropic_decode_batch)
-        23   call 803 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+  500   22   load_const 6           (anthropic.internal._anthropic_decode_batch)
+        23   call 806 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -5048,13 +5947,13 @@ function claude_code.ClaudeCodeClient.ai.Client.id(self: claude_code.ClaudeCodeC
 
 function claude_code.ClaudeCodeClient.ai.Client.invoke(self: claude_code.ClaudeCodeClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   44   0   load_var2 1 2          
-       1   call 879 ntypeargs=0   (claude_code.internal.invoke)
+       1   call 887 ntypeargs=0   (claude_code.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   45   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 814 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
@@ -5272,7 +6171,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         122   load_const 31                      (".thinking")
         123   load_const 32                      ("")
         124   call 340 ntypeargs=1               (baml.json.path_or)
-        125   call 875 ntypeargs=0               (claude_code.internal._preview)
+        125   call 883 ntypeargs=0               (claude_code.internal._preview)
         126   store_var 18                       (_55)
         127   load_type 0                        
         128   load_var 18                        (_55)
@@ -5293,7 +6192,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         140   load_const 34                      (".text")
         141   load_const 35                      ("")
         142   call 340 ntypeargs=1               (baml.json.path_or)
-        143   call 875 ntypeargs=0               (claude_code.internal._preview)
+        143   call 883 ntypeargs=0               (claude_code.internal._preview)
         144   store_var 16                       (_47)
         145   load_type 0                        
         146   load_var 16                        (_47)
@@ -5492,7 +6391,7 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         36   throw                              
 
   136   37   load_var 7                         (raw)
-        38   call 876 ntypeargs=0               (claude_code.internal._log_cc_event)
+        38   call 884 ntypeargs=0               (claude_code.internal._log_cc_event)
         39   pop 1                              
 
   137   40   load_type 8                        
@@ -5556,7 +6455,7 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
         8    load_type 2           
         9    load_var 3            (_3)
 
-  220   10   make_closure 2177 0   
+  220   10   make_closure 2326 0   
         11   call 16 ntypeargs=3   (baml.Array.map)
         12   store_var 2           (_2)
 
@@ -5589,7 +6488,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        16    store_var 6            (call_props)
 
   55   17    load_const 4           ("string")
-       18    call 872 ntypeargs=0   (claude_code.internal._type_schema)
+       18    call 880 ntypeargs=0   (claude_code.internal._type_schema)
        19    store_var 7            (_10)
        20    load_type 1            
        21    load_type 2            
@@ -5600,7 +6499,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        26    pop 1                  
 
   56   27    load_const 6           ("string")
-       28    call 872 ntypeargs=0   (claude_code.internal._type_schema)
+       28    call 880 ntypeargs=0   (claude_code.internal._type_schema)
        29    store_var 8            (_14)
        30    load_type 1            
        31    load_type 2            
@@ -5611,7 +6510,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        36    pop 1                  
 
   57   37    load_const 8           ("object")
-       38    call 872 ntypeargs=0   (claude_code.internal._type_schema)
+       38    call 880 ntypeargs=0   (claude_code.internal._type_schema)
        39    store_var 9            (_18)
        40    load_type 1            
        41    load_type 2            
@@ -5855,7 +6754,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 
   236   18    load_var 2                         (input)
         19    load_field 3                       (output_type)
-        20    call 871 ntypeargs=0               (claude_code.internal.envelope_schema)
+        20    call 879 ntypeargs=0               (claude_code.internal.envelope_schema)
         21    store_var 7                        (_11)
         22    load_type 1                        
         23    load_var 7                         (_11)
@@ -5872,7 +6771,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         32    store_var 14                       (_29)
         33    load_var 2                         (input)
         34    load_field 1                       (journal)
-        35    call 870 ntypeargs=0               (claude_code.internal.transcript_text)
+        35    call 878 ntypeargs=0               (claude_code.internal.transcript_text)
         36    store_var 16                       (_33)
         37    load_type 2                        
         38    load_var 16                        (_33)
@@ -5890,7 +6789,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         48    store_var 9                        (_18)
         49    load_var 2                         (input)
         50    load_field 1                       (journal)
-        51    call 870 ntypeargs=0               (claude_code.internal.transcript_text)
+        51    call 878 ntypeargs=0               (claude_code.internal.transcript_text)
         52    store_var 11                       (_22)
         53    load_type 2                        
         54    load_var 11                        (_22)
@@ -5898,7 +6797,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         56    store_var 10                       (_21)
         57    load_var 2                         (input)
         58    load_field 2                       (toolbox)
-        59    call 873 ntypeargs=0               (claude_code.internal.tool_protocol)
+        59    call 881 ntypeargs=0               (claude_code.internal.tool_protocol)
         60    store_var 13                       (_26)
         61    load_type 2                        
         62    load_var 13                        (_26)
@@ -6020,7 +6919,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         162   pop 1                              
 
   267   163   load_var 1                         (c)
-        164   call 877 ntypeargs=0               (claude_code.internal.mcp_config_json)
+        164   call 885 ntypeargs=0               (claude_code.internal.mcp_config_json)
         165   store_var 24                       (_70)
         166   load_var 24                        (_70)
         167   narrow_bind 21 24                  
@@ -6043,7 +6942,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         181   pop 1                              
 
   271   182   load_var 1                         (c)
-        183   call 878 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
+        183   call 886 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
         184   store_var 27                       (_79)
         185   load_type 2                        
         186   load_var 27                        (_79)
@@ -6117,7 +7016,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         243   throw_if_panic                     
 
   299   244   load_var 29                        (p)
-        245   call 874 ntypeargs=0               (claude_code.internal._read_result)
+        245   call 882 ntypeargs=0               (claude_code.internal._read_result)
         246   store_var 36                       (result)
 
   300   247   load_var 29                        (p)
@@ -6274,7 +7173,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         380   store_var 58                       (content)
 
   349   381   load_const 56                      (ai.content.StopReason.Complete)
-        382   alloc_variant 436                  (ai.content.StopReason)
+        382   alloc_variant 438                  (ai.content.StopReason)
         383   store_var 59                       (stop)
 
   350   384   load_var 5                         (has_tools)
@@ -6416,7 +7315,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
   355   500   jump -72                           (to 428)
 
   373   501   load_const 21                      (ai.content.StopReason.ToolUse)
-        502   alloc_variant 436                  (ai.content.StopReason)
+        502   alloc_variant 438                  (ai.content.StopReason)
         503   store_var 59                       (stop)
 
   380   504   load_var2 58 59                    
@@ -6835,20 +7734,20 @@ function google.GoogleClient.ai.Client.id(self: google.GoogleClient) -> string {
 
 function google.GoogleClient.ai.Client.invoke(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   22   0   load_var2 1 2          
-       1   call 864 ntypeargs=0   (google.internal.invoke)
+       1   call 872 ntypeargs=0   (google.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   23   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 814 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function google.GoogleClient.ai.stream.StreamingClient.invoke_stream(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   30   0   load_var2 1 2          
-       1   call 866 ntypeargs=0   (google.internal.invoke_stream)
+       1   call 874 ntypeargs=0   (google.internal.invoke_stream)
        2   return                 
 }
 
@@ -6910,44 +7809,247 @@ function google.internal._gm_content(role: string, parts: map<string, unknown>[]
 }
 
 function google.internal._gm_function_response(name: string, response: map<string, unknown>) -> map<string, unknown> {
-  62   0    load_type 0           
-       1    load_type 1           
-       2    alloc_map 0           
-       3    store_var 4           (fr)
+  110   0    load_type 0           
+        1    load_type 1           
+        2    alloc_map 0           
+        3    store_var 4           (fr)
 
-  63   4    load_type 0           
-       5    load_type 1           
-       6    load_var 4            (fr)
-       7    load_const 2          ("name")
-       8    load_var 1            (name)
-       9    call 37 ntypeargs=2   (baml.Map.set)
-       10   pop 1                 
+  111   4    load_type 0           
+        5    load_type 1           
+        6    load_var 4            (fr)
+        7    load_const 2          ("name")
+        8    load_var 1            (name)
+        9    call 37 ntypeargs=2   (baml.Map.set)
+        10   pop 1                 
 
-  64   11   load_type 0           
-       12   load_type 1           
-       13   load_var 4            (fr)
-       14   load_const 3          ("response")
-       15   load_var 2            (response)
-       16   call 37 ntypeargs=2   (baml.Map.set)
-       17   pop 1                 
+  112   11   load_type 0           
+        12   load_type 1           
+        13   load_var 4            (fr)
+        14   load_const 3          ("response")
+        15   load_var 2            (response)
+        16   call 37 ntypeargs=2   (baml.Map.set)
+        17   pop 1                 
 
-  65   18   load_type 0           
-       19   load_type 1           
-       20   alloc_map 0           
-       21   store_var 5           (part)
+  113   18   load_type 0           
+        19   load_type 1           
+        20   alloc_map 0           
+        21   store_var 5           (part)
 
-  66   22   load_type 0           
-       23   load_type 1           
-       24   load_var 5            (part)
-       25   load_const 4          ("functionResponse")
-       26   load_var 4            (fr)
-       27   call 37 ntypeargs=2   (baml.Map.set)
-       28   pop 1                 
+  114   22   load_type 0           
+        23   load_type 1           
+        24   load_var 5            (part)
+        25   load_const 4          ("functionResponse")
+        26   load_var 4            (fr)
+        27   call 37 ntypeargs=2   (baml.Map.set)
+        28   pop 1                 
 
-  67   29   load_var 5            (part)
-       30   store_var 3           (_0)
-       31   load_var 3            (_0)
-       32   return                
+  115   29   load_var 5            (part)
+        30   store_var 3           (_0)
+        31   load_var 3            (_0)
+        32   return                
+}
+
+function google.internal._gm_media_part(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf) -> map<string, unknown> {
+  58   0    load_var 1             (media)
+       1    load_const 0           (true)
+       2    call 785 ntypeargs=0   (ai.wire.resolve_media)
+       3    store_var 3            (resolved)
+
+  59   4    load_type 1            
+       5    load_type 2            
+       6    alloc_map 0            
+       7    store_var 4            (media_part)
+
+  60   8    load_var 3             (resolved)
+       9    load_field 0           (url)
+       10   store_var 5            (_5)
+       11   load_var 5             (_5)
+       12   narrow_bind 3 5        
+       13   pop_jump_if_false +2   (to 15)
+       14   jump +39               (to 53)
+
+  67   15   load_type 1            
+       16   load_type 2            
+       17   alloc_map 0            
+       18   store_var 8            (inline_data)
+
+  68   19   load_type 1            
+       20   load_type 2            
+       21   load_var 8             (inline_data)
+       22   load_const 4           ("mimeType")
+       23   load_var 3             (resolved)
+       24   load_field 2           (mime_type)
+       25   call 37 ntypeargs=2    (baml.Map.set)
+       26   pop 1                  
+
+  69   27   load_var 3             (resolved)
+       28   load_field 1           (base64)
+       29   store_var 10           (_27)
+       30   load_var 10            (_27)
+       31   store_var 9            (_26)
+       32   load_var 10            (_27)
+       33   load_const 5           (null)
+       34   cmp_op ==              
+       35   pop_jump_if_false +3   (to 38)
+       36   load_const 6           ("")
+       37   store_var 9            (_26)
+       38   load_type 1            
+       39   load_type 2            
+       40   load_var 8             (inline_data)
+       41   load_const 7           ("data")
+       42   load_var 9             (_26)
+       43   call 37 ntypeargs=2    (baml.Map.set)
+       44   pop 1                  
+
+  70   45   load_type 1            
+       46   load_type 2            
+       47   load_var 4             (media_part)
+       48   load_const 8           ("inlineData")
+       49   load_var 8             (inline_data)
+       50   call 37 ntypeargs=2    (baml.Map.set)
+       51   pop 1                  
+       52   jump +29               (to 81)
+
+  60   53   load_var 5             (_5)
+       54   store_var 6            (url)
+
+  61   55   load_type 1            
+       56   load_type 2            
+       57   alloc_map 0            
+       58   store_var 7            (file_data)
+
+  62   59   load_type 1            
+       60   load_type 2            
+       61   load_var 7             (file_data)
+       62   load_const 9           ("mimeType")
+       63   load_var 3             (resolved)
+       64   load_field 2           (mime_type)
+       65   call 37 ntypeargs=2    (baml.Map.set)
+       66   pop 1                  
+
+  63   67   load_type 1            
+       68   load_type 2            
+       69   load_var 7             (file_data)
+       70   load_const 10          ("fileUri")
+       71   load_var 6             (url)
+       72   call 37 ntypeargs=2    (baml.Map.set)
+       73   pop 1                  
+
+  64   74   load_type 1            
+       75   load_type 2            
+       76   load_var 4             (media_part)
+       77   load_const 11          ("fileData")
+       78   load_var 7             (file_data)
+       79   call 37 ntypeargs=2    (baml.Map.set)
+       80   pop 1                  
+
+  73   81   load_var 4             (media_part)
+       82   store_var 2            (_0)
+       83   load_var 2             (_0)
+       84   return                 
+}
+
+function google.internal._gm_prompt_parts(message: ai.PromptMessage) -> map<string, unknown>[] {
+  77    0    load_type 0                        
+        1    alloc_array 0                      
+        2    store_var 3                        (parts)
+
+  78    3    load_var 1                         (message)
+        4    load_field 2                       (parts)
+        5    load_type 1                        
+        6    load_const 2                       ("iter")
+        7    virtual_call nargs=1 ntypeargs=0   
+        8    store_var 4                        (_4)
+        9    load_var 4                         (_4)
+        10   load_type 3                        
+        11   load_const 4                       ("next")
+        12   virtual_call nargs=1 ntypeargs=0   
+        13   store_var 5                        (_5)
+        14   load_var 5                         (_5)
+        15   is_type 5                          
+        16   pop_jump_if_false +2               (to 18)
+        17   jump +67                           (to 84)
+        18   load_var 5                         (_5)
+        19   store_var 6                        (part)
+
+  79    20   load_var 6                         (part)
+        21   store_var 7                        (_9)
+        22   load_var 7                         (_9)
+        23   narrow_bind 6 7                    
+        24   pop_jump_if_false +2               (to 26)
+        25   jump +51                           (to 76)
+        26   load_var 6                         (part)
+        27   store_var 10                       (_14)
+        28   load_var 10                        (_14)
+        29   narrow_bind 7 10                   
+        30   pop_jump_if_false +2               (to 32)
+        31   jump +37                           (to 68)
+        32   load_var 6                         (part)
+        33   store_var 13                       (_19)
+        34   load_var 13                        (_19)
+        35   narrow_bind 8 13                   
+        36   pop_jump_if_false +2               (to 38)
+        37   jump +23                           (to 60)
+        38   load_var 6                         (part)
+        39   store_var 16                       (_24)
+        40   load_var 16                        (_24)
+        41   narrow_bind 9 16                   
+        42   pop_jump_if_false +2               (to 44)
+        43   jump +9                            (to 52)
+        44   load_var 6                         (part)
+        45   store_var_load_var 19              (pdf)
+
+  97    46   call 863 ntypeargs=0               (google.internal._gm_media_part)
+        47   store_var 20                       (_31)
+        48   load_var2 3 20                     
+        49   call 4 ntypeargs=0                 (baml.Array.push)
+        50   pop 1                              
+        51   jump -42                           (to 9)
+
+  79    52   load_var 16                        (_24)
+        53   store_var_load_var 17              (video)
+
+  93    54   call 863 ntypeargs=0               (google.internal._gm_media_part)
+        55   store_var 18                       (_27)
+        56   load_var2 3 18                     
+        57   call 4 ntypeargs=0                 (baml.Array.push)
+        58   pop 1                              
+        59   jump -50                           (to 9)
+
+  79    60   load_var 13                        (_19)
+        61   store_var_load_var 14              (audio)
+
+  89    62   call 863 ntypeargs=0               (google.internal._gm_media_part)
+        63   store_var 15                       (_22)
+        64   load_var2 3 15                     
+        65   call 4 ntypeargs=0                 (baml.Array.push)
+        66   pop 1                              
+        67   jump -58                           (to 9)
+
+  79    68   load_var 10                        (_14)
+        69   store_var_load_var 11              (image)
+
+  85    70   call 863 ntypeargs=0               (google.internal._gm_media_part)
+        71   store_var 12                       (_17)
+        72   load_var2 3 12                     
+        73   call 4 ntypeargs=0                 (baml.Array.push)
+        74   pop 1                              
+        75   jump -66                           (to 9)
+
+  79    76   load_var 7                         (_9)
+        77   store_var_load_var 8               (text)
+
+  81    78   call 862 ntypeargs=0               (google.internal._gm_text_part)
+        79   store_var 9                        (_12)
+        80   load_var2 3 9                      
+        81   call 4 ntypeargs=0                 (baml.Array.push)
+        82   pop 1                              
+        83   jump -74                           (to 9)
+
+  102   84   load_var 3                         (parts)
+        85   store_var 2                        (_0)
+        86   load_var 2                         (_0)
+        87   return                             
 }
 
 function google.internal._gm_text_part(text: string) -> map<string, unknown> {
@@ -6971,10 +8073,10 @@ function google.internal._gm_text_part(text: string) -> map<string, unknown> {
 }
 
 function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string {
-  109   0    load_const 0                       ("")
+  159   0    load_const 0                       ("")
         1    store_var 3                        (name)
 
-  110   2    load_var 1                         (j)
+  160   2    load_var 1                         (j)
         3    call 760 ntypeargs=0               (ai.Journal.entries)
         4    load_type 1                        
         5    load_const 2                       ("iter")
@@ -6992,7 +8094,7 @@ function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string 
         17   load_var 5                         (_6)
         18   store_var 6                        (e)
 
-  111   19   load_var 6                         (e)
+  161   19   load_var 6                         (e)
         20   store_var 7                        (_10)
         21   load_var 7                         (_10)
         22   narrow_bind 6 7                    
@@ -7000,7 +8102,7 @@ function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string 
         24   load_var 7                         (_10)
         25   store_var_load_var 8               (a)
 
-  113   26   load_field 0                       (content)
+  163   26   load_field 0                       (content)
         27   load_type 7                        
         28   load_const 8                       ("iter")
         29   virtual_call nargs=1 ntypeargs=0   
@@ -7017,7 +8119,7 @@ function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string 
         40   load_var 10                        (_14)
         41   store_var 11                       (b)
 
-  114   42   load_var 11                        (b)
+  164   42   load_var 11                        (b)
         43   store_var 12                       (_18)
         44   load_var 12                        (_18)
         45   narrow_bind 11 12                  
@@ -7025,28 +8127,28 @@ function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string 
         47   load_var 12                        (_18)
         48   store_var_load_var 13              (u)
 
-  116   49   load_field 0                       (id)
+  166   49   load_field 0                       (id)
         50   load_var 2                         (id)
         51   cmp_op ==                          
         52   pop_jump_if_false -21              (to 31)
 
-  117   53   load_var 13                        (u)
+  167   53   load_var 13                        (u)
         54   load_field 1                       (name)
         55   store_var 3                        (name)
 
-  116   56   jump -25                           (to 31)
+  166   56   jump -25                           (to 31)
 
-  131   57   load_var 3                         (name)
+  181   57   load_var 3                         (name)
         58   return                             
 }
 
 function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone)[] {
-  367   0     load_type 0                        
+  417   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 3                        (out)
 
-  368   3     load_var 1                         (batch)
-        4     call 802 ntypeargs=0               (ai.stream.decode_sse_batch)
+  418   3     load_var 1                         (batch)
+        4     call 805 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -7063,7 +8165,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         18    load_var 5                         (_5)
         19    store_var_load_var 6               (raw)
 
-  369   20    load_field 1                       (data)
+  419   20    load_field 1                       (data)
         21    store_var 7                        (_10)
         22    load_var 7                         (_10)
         23    narrow_bind 6 7                    
@@ -7071,23 +8173,23 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         25    load_var 7                         (_10)
         26    store_var 8                        (data)
 
-  370   27    load_type 7                        
+  420   27    load_type 7                        
         28    load_var 8                         (data)
         29    call 333 ntypeargs=1               (baml.json.from_string)
         30    jump +4                            (to 34)
         31    load_var 9                         (e)
         32    throw_if_panic                     
 
-  371   33    load_const 8                       (null)
+  421   33    load_const 8                       (null)
 
-  373   34    store_var 10                       (_16)
+  423   34    store_var 10                       (_16)
         35    load_var 10                        (_16)
         36    narrow_bind 9 10                   
         37    pop_jump_if_false -28              (to 9)
         38    load_var 10                        (_16)
         39    store_var_load_var 11              (resp)
 
-  374   40    load_field 0                       (candidates)
+  424   40    load_field 0                       (candidates)
         41    load_const 8                       (null)
         42    cmp_op ==                          
         43    pop_jump_if_false +2               (to 45)
@@ -7102,7 +8204,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         52    load_const 8                       (null)
         53    store_var 12                       (cand)
 
-  375   54    load_var 12                        (cand)
+  425   54    load_var 12                        (cand)
         55    load_const 8                       (null)
         56    cmp_op ==                          
         57    pop_jump_if_false +2               (to 59)
@@ -7135,7 +8237,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         84    alloc_array 0                      
         85    store_var 13                       (parts)
 
-  376   86    load_var 13                        (parts)
+  426   86    load_var 13                        (parts)
         87    load_type 12                       
         88    load_const 13                      ("iter")
         89    virtual_call nargs=1 ntypeargs=0   
@@ -7152,7 +8254,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         100   load_var 16                        (_37)
         101   store_var_load_var 17              (p)
 
-  377   102   load_field 0                       (text)
+  427   102   load_field 0                       (text)
         103   store_var 18                       (_42)
         104   load_var 18                        (_42)
         105   narrow_bind 6 18                   
@@ -7160,7 +8262,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         107   load_var 18                        (_42)
         108   store_var 19                       (t)
 
-  378   109   load_var 17                        (p)
+  428   109   load_var 17                        (p)
         110   load_field 1                       (thought)
         111   store_var 21                       (_45)
         112   load_var 21                        (_45)
@@ -7175,13 +8277,13 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         121   pop_jump_if_false +2               (to 123)
         122   jump -31                           (to 91)
 
-  381   123   load_var2 3 19                     
+  431   123   load_var2 3 19                     
         124   init_instance 0                    (ai.stream.TextDelta .text)
         125   call 4 ntypeargs=0                 (baml.Array.push)
         126   pop 1                              
         127   jump -36                           (to 91)
 
-  388   128   load_var 12                        (cand)
+  438   128   load_var 12                        (cand)
         129   load_const 8                       (null)
         130   cmp_op ==                          
         131   pop_jump_if_false +2               (to 133)
@@ -7201,7 +8303,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         145   load_const 17                      ("")
         146   store_var 22                       (finish)
 
-  389   147   load_var 11                        (resp)
+  439   147   load_var 11                        (resp)
         148   load_field 2                       (promptFeedback)
         149   load_const 8                       (null)
         150   cmp_op ==                          
@@ -7217,72 +8319,72 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         160   unary_op !                         
         161   store_var 24                       (blocked)
 
-  390   162   load_var 22                        (finish)
+  440   162   load_var 22                        (finish)
         163   load_const 18                      ("MAX_TOKENS")
         164   cmp_op ==                          
         165   pop_jump_if_false +2               (to 167)
         166   jump +38                           (to 204)
 
-  393   167   load_var 24                        (blocked)
+  443   167   load_var 24                        (blocked)
         168   jump_if_false +2                   (to 170)
         169   jump +5                            (to 174)
         170   pop 1                              
 
-  394   171   load_var 22                        (finish)
+  444   171   load_var 22                        (finish)
         172   load_const 19                      ("SAFETY")
         173   cmp_op ==                          
 
-  393   174   jump_if_false +2                   (to 176)
+  443   174   jump_if_false +2                   (to 176)
         175   jump +5                            (to 180)
         176   pop 1                              
 
-  395   177   load_var 22                        (finish)
+  445   177   load_var 22                        (finish)
         178   load_const 20                      ("RECITATION")
         179   cmp_op ==                          
 
-  393   180   jump_if_false +2                   (to 182)
+  443   180   jump_if_false +2                   (to 182)
         181   jump +5                            (to 186)
         182   pop 1                              
 
-  396   183   load_var 22                        (finish)
+  446   183   load_var 22                        (finish)
         184   load_const 21                      ("PROHIBITED_CONTENT")
         185   cmp_op ==                          
 
-  392   186   pop_jump_if_false +2               (to 188)
+  442   186   pop_jump_if_false +2               (to 188)
         187   jump +13                           (to 200)
 
-  399   188   load_var 22                        (finish)
+  449   188   load_var 22                        (finish)
         189   load_const 22                      ("")
         190   cmp_op !=                          
         191   pop_jump_if_false +2               (to 193)
         192   jump +4                            (to 196)
 
-  402   193   load_const 8                       (null)
+  452   193   load_const 8                       (null)
         194   store_var 25                       (stop)
 
-  399   195   jump +12                           (to 207)
+  449   195   jump +12                           (to 207)
 
-  400   196   load_const 10                      (ai.content.StopReason.Complete)
-        197   alloc_variant 436                  (ai.content.StopReason)
+  450   196   load_const 10                      (ai.content.StopReason.Complete)
+        197   alloc_variant 438                  (ai.content.StopReason)
         198   store_var 25                       (stop)
 
-  399   199   jump +8                            (to 207)
+  449   199   jump +8                            (to 207)
 
-  398   200   load_const 23                      (ai.content.StopReason.Refused)
-        201   alloc_variant 436                  (ai.content.StopReason)
+  448   200   load_const 23                      (ai.content.StopReason.Refused)
+        201   alloc_variant 438                  (ai.content.StopReason)
         202   store_var 25                       (stop)
 
-  392   203   jump +4                            (to 207)
+  442   203   jump +4                            (to 207)
 
-  391   204   load_const 24                      (ai.content.StopReason.MaxTokens)
-        205   alloc_variant 436                  (ai.content.StopReason)
+  441   204   load_const 24                      (ai.content.StopReason.MaxTokens)
+        205   alloc_variant 438                  (ai.content.StopReason)
         206   store_var 25                       (stop)
 
-  404   207   load_var 11                        (resp)
+  454   207   load_var 11                        (resp)
         208   load_field 1                       (usageMetadata)
         209   store_var 26                       (usage)
 
-  405   210   load_var 25                        (stop)
+  455   210   load_var 25                        (stop)
         211   load_const 8                       (null)
         212   call 612 ntypeargs=0               (baml.ops.equals_equals)
         213   unary_op !                         
@@ -7295,10 +8397,10 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         220   unary_op !                         
         221   pop_jump_if_false -212             (to 9)
 
-  408   222   load_var 25                        (stop)
+  458   222   load_var 25                        (stop)
         223   store_var 27                       (_83)
 
-  409   224   load_var 26                        (usage)
+  459   224   load_var 26                        (usage)
         225   load_const 8                       (null)
         226   cmp_op ==                          
         227   pop_jump_if_false +2               (to 229)
@@ -7310,7 +8412,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         233   load_const 8                       (null)
         234   store_var 28                       (_84)
 
-  410   235   load_var 26                        (usage)
+  460   235   load_var 26                        (usage)
         236   load_const 8                       (null)
         237   cmp_op ==                          
         238   pop_jump_if_false +2               (to 240)
@@ -7322,22 +8424,22 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         244   load_const 8                       (null)
         245   store_var 29                       (_88)
 
-  406   246   load_var2 3 27                     
+  456   246   load_var2 3 27                     
 
-  407   247   load_var2 28 29                    
+  457   247   load_var2 28 29                    
         248   init_instance 1                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
         249   call 4 ntypeargs=0                 (baml.Array.push)
         250   pop 1                              
         251   jump -242                          (to 9)
 
-  426   252   load_var 3                         (out)
+  476   252   load_var 3                         (out)
         253   store_var 2                        (_0)
         254   load_var 2                         (_0)
         255   return                             
 }
 
 function google.internal._google_request(c: google.GoogleClient, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
-  226   0     load_var 2                         (input)
+  276   0     load_var 2                         (input)
         1     load_field 0                       (prompt)
         2     store_var 5                        (_5)
         3     load_var 2                         (input)
@@ -7346,16 +8448,16 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         6     load_var 5                         (_5)
         7     call_indirect                      
 
-  227   8     call 858 ntypeargs=0               (google.internal.google_lower_prompt)
+  277   8     call 866 ntypeargs=0               (google.internal.google_lower_prompt)
         9     store_var 6                        (prompt_parts)
 
-  228   10    load_var 6                         (prompt_parts)
+  278   10    load_var 6                         (prompt_parts)
         11    load_field 1                       (contents)
         12    store_var 7                        (contents)
 
-  229   13    load_var 2                         (input)
+  279   13    load_var 2                         (input)
         14    load_field 1                       (journal)
-        15    call 860 ntypeargs=0               (google.internal.google_lower_journal)
+        15    call 868 ntypeargs=0               (google.internal.google_lower_journal)
         16    load_type 0                        
         17    load_const 1                       ("iter")
         18    virtual_call nargs=1 ntypeargs=0   
@@ -7372,21 +8474,21 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         29    load_var 9                         (_14)
         30    store_var 10                       (item)
 
-  230   31    load_var2 7 10                     
+  280   31    load_var2 7 10                     
         32    call 4 ntypeargs=0                 (baml.Array.push)
         33    pop 1                              
         34    jump -14                           (to 20)
 
-  232   35    load_type 5                        
+  282   35    load_type 5                        
         36    load_type 6                        
         37    alloc_map 0                        
         38    store_var 11                       (body)
 
-  237   39    load_var 6                         (prompt_parts)
+  287   39    load_var 6                         (prompt_parts)
         40    load_field 2                       (first_role)
         41    store_var_load_var 12              (first_role)
 
-  238   42    load_const 7                       ("user")
+  288   42    load_const 7                       ("user")
         43    cmp_op !=                          
         44    jump_if_false +9                   (to 53)
         45    pop 1                              
@@ -7400,7 +8502,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         53    pop_jump_if_false +2               (to 55)
         54    jump +29                           (to 83)
 
-  241   55    load_var 6                         (prompt_parts)
+  291   55    load_var 6                         (prompt_parts)
         56    load_field 0                       (system_parts)
         57    container_len                      
         58    store_var 15                       (_33)
@@ -7409,12 +8511,12 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         61    cmp_int_op >                       
         62    pop_jump_if_false +33              (to 95)
 
-  242   63    load_type 5                        
+  292   63    load_type 5                        
         64    load_type 6                        
         65    alloc_map 0                        
         66    store_var 16                       (system_instruction)
 
-  243   67    load_type 5                        
+  293   67    load_type 5                        
         68    load_type 6                        
         69    load_var 16                        (system_instruction)
         70    load_const 9                       ("parts")
@@ -7423,7 +8525,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         73    call 37 ntypeargs=2                (baml.Map.set)
         74    pop 1                              
 
-  244   75    load_type 5                        
+  294   75    load_type 5                        
         76    load_type 6                        
         77    load_var 11                        (body)
         78    load_const 10                      ("systemInstruction")
@@ -7432,10 +8534,10 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         81    pop 1                              
         82    jump +13                           (to 95)
 
-  239   83    load_const 11                      ("user")
+  289   83    load_const 11                      ("user")
         84    load_var 6                         (prompt_parts)
         85    load_field 0                       (system_parts)
-        86    call 855 ntypeargs=0               (google.internal._gm_content)
+        86    call 861 ntypeargs=0               (google.internal._gm_content)
         87    store_var 14                       (_28)
         88    load_type 12                       
         89    load_var 14                        (_28)
@@ -7445,7 +8547,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         93    call 7 ntypeargs=1                 (baml.Array.concat)
         94    store_var 7                        (contents)
 
-  249   95    load_type 5                        
+  299   95    load_type 5                        
         96    load_type 6                        
         97    load_var 11                        (body)
         98    load_const 13                      ("contents")
@@ -7453,17 +8555,17 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         100   call 37 ntypeargs=2                (baml.Map.set)
         101   pop 1                              
 
-  250   102   load_var 2                         (input)
+  300   102   load_var 2                         (input)
         103   load_field 2                       (toolbox)
         104   call 778 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         105   unary_op !                         
         106   pop_jump_if_false +103             (to 209)
 
-  251   107   load_type 12                       
+  301   107   load_type 12                       
         108   alloc_array 0                      
         109   store_var 17                       (decls)
 
-  252   110   load_var 2                         (input)
+  302   110   load_var 2                         (input)
         111   load_field 2                       (toolbox)
         112   call 776 ntypeargs=0               (ai.tools.Toolbox.list)
         113   load_type 14                       
@@ -7482,12 +8584,12 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         126   load_var 19                        (_55)
         127   store_var 20                       (t)
 
-  253   128   load_type 5                        
+  303   128   load_type 5                        
         129   load_type 6                        
         130   alloc_map 0                        
         131   store_var 21                       (d)
 
-  254   132   load_type 5                        
+  304   132   load_type 5                        
         133   load_type 6                        
         134   load_var 21                        (d)
         135   load_const 18                      ("name")
@@ -7496,7 +8598,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         138   call 37 ntypeargs=2                (baml.Map.set)
         139   pop 1                              
 
-  255   140   load_type 5                        
+  305   140   load_type 5                        
         141   load_type 6                        
         142   load_var 21                        (d)
         143   load_const 19                      ("description")
@@ -7505,7 +8607,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         146   call 37 ntypeargs=2                (baml.Map.set)
         147   pop 1                              
 
-  256   148   load_type 5                        
+  306   148   load_type 5                        
         149   load_type 6                        
         150   load_var 21                        (d)
         151   load_const 20                      ("parametersJsonSchema")
@@ -7514,17 +8616,17 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         154   call 37 ntypeargs=2                (baml.Map.set)
         155   pop 1                              
 
-  257   156   load_var2 17 21                    
+  307   156   load_var2 17 21                    
         157   call 4 ntypeargs=0                 (baml.Array.push)
         158   pop 1                              
         159   jump -42                           (to 117)
 
-  259   160   load_type 5                        
+  309   160   load_type 5                        
         161   load_type 6                        
         162   alloc_map 0                        
         163   store_var 22                       (group)
 
-  260   164   load_type 5                        
+  310   164   load_type 5                        
         165   load_type 6                        
         166   load_var 22                        (group)
         167   load_const 21                      ("functionDeclarations")
@@ -7532,7 +8634,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         169   call 37 ntypeargs=2                (baml.Map.set)
         170   pop 1                              
 
-  261   171   load_type 5                        
+  311   171   load_type 5                        
         172   load_type 6                        
         173   load_var 11                        (body)
         174   load_const 22                      ("tools")
@@ -7542,12 +8644,12 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         178   call 37 ntypeargs=2                (baml.Map.set)
         179   pop 1                              
 
-  262   180   load_type 5                        
+  312   180   load_type 5                        
         181   load_type 6                        
         182   alloc_map 0                        
         183   store_var 23                       (fcc)
 
-  263   184   load_type 5                        
+  313   184   load_type 5                        
         185   load_type 6                        
         186   load_var 23                        (fcc)
         187   load_const 23                      ("mode")
@@ -7555,12 +8657,12 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         189   call 37 ntypeargs=2                (baml.Map.set)
         190   pop 1                              
 
-  264   191   load_type 5                        
+  314   191   load_type 5                        
         192   load_type 6                        
         193   alloc_map 0                        
         194   store_var 24                       (tc)
 
-  265   195   load_type 5                        
+  315   195   load_type 5                        
         196   load_type 6                        
         197   load_var 24                        (tc)
         198   load_const 25                      ("functionCallingConfig")
@@ -7568,7 +8670,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         200   call 37 ntypeargs=2                (baml.Map.set)
         201   pop 1                              
 
-  266   202   load_type 5                        
+  316   202   load_type 5                        
         203   load_type 6                        
         204   load_var 11                        (body)
         205   load_const 26                      ("toolConfig")
@@ -7576,19 +8678,19 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         207   call 37 ntypeargs=2                (baml.Map.set)
         208   pop 1                              
 
-  271   209   load_var 3                         (stream)
+  321   209   load_var 3                         (stream)
         210   pop_jump_if_false +2               (to 212)
         211   jump +4                            (to 215)
 
-  274   212   load_const 27                      (":generateContent")
+  324   212   load_const 27                      (":generateContent")
         213   store_var 25                       (method)
 
-  271   214   jump +3                            (to 217)
+  321   214   jump +3                            (to 217)
 
-  272   215   load_const 28                      (":streamGenerateContent?alt=sse")
+  322   215   load_const 28                      (":streamGenerateContent?alt=sse")
         216   store_var 25                       (method)
 
-  278   217   load_var 1                         (c)
+  328   217   load_var 1                         (c)
         218   load_field 2                       (base_url)
         219   store_var 28                       (_103)
         220   load_var 28                        (_103)
@@ -7613,7 +8715,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         239   call 138 ntypeargs=1               (baml.String.from)
         240   store_var 30                       (_109)
 
-  280   241   load_var 1                         (c)
+  330   241   load_var 1                         (c)
         242   load_field 1                       (api_key)
         243   store_var 32                       (_114)
         244   load_var2 32 32                    
@@ -7623,7 +8725,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         248   load_const 31                      ("GOOGLE_API_KEY")
         249   call 211 ntypeargs=0               (baml.env.get_or_panic)
 
-  279   250   load_const 32                      ("application/json")
+  329   250   load_const 32                      ("application/json")
         251   load_const 33                      ("x-goog-api-key")
         252   load_const 34                      ("content-type")
         253   load_type 5                        
@@ -7631,15 +8733,15 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         255   alloc_map 2                        
         256   store_var 31                       (_112)
 
-  283   257   load_type 12                       
+  333   257   load_type 12                       
         258   load_var 11                        (body)
         259   call 331 ntypeargs=1               (baml.json.to_json)
         260   call 328 ntypeargs=0               (baml.json.stringify)
         261   store_var 33                       (_116)
 
-  276   262   load_const 35                      ("POST")
+  326   262   load_const 35                      ("POST")
 
-  278   263   load_var 26                        (_101)
+  328   263   load_var 26                        (_101)
         264   load_const 36                      ("/models/")
         265   bin_op +                           
         266   load_var 29                        (_106)
@@ -7654,15 +8756,15 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 }
 
 function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unknown>[] {
-  139   0     load_type 0                        
+  189   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 3                        (contents)
 
-  140   3     load_type 0                        
+  190   3     load_type 0                        
         4     alloc_array 0                      
         5     store_var 4                        (pending)
 
-  141   6     load_var 1                         (j)
+  191   6     load_var 1                         (j)
         7     call 760 ntypeargs=0               (ai.Journal.entries)
         8     load_type 1                        
         9     load_const 2                       ("iter")
@@ -7680,7 +8782,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         21    load_var 6                         (_6)
         22    store_var 7                        (e)
 
-  142   23    load_var 7                         (e)
+  192   23    load_var 7                         (e)
         24    store_var 8                        (_10)
         25    load_var 8                         (_10)
         26    narrow_bind 6 8                    
@@ -7706,12 +8808,12 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         46    load_var 35                        (_76)
         47    store_var 36                       (f)
 
-  197   48    load_type 10                       
+  247   48    load_type 10                       
         49    load_type 11                       
         50    alloc_map 0                        
         51    store_var 37                       (response)
 
-  198   52    load_type 10                       
+  248   52    load_type 10                       
         53    load_type 11                       
         54    load_var 37                        (response)
         55    load_const 12                      ("error")
@@ -7720,26 +8822,26 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         58    call 37 ntypeargs=2                (baml.Map.set)
         59    pop 1                              
 
-  199   60    load_var2 1 36                     
+  249   60    load_var2 1 36                     
         61    load_field 0                       (id)
-        62    call 859 ntypeargs=0               (google.internal._gm_tool_name_for)
+        62    call 867 ntypeargs=0               (google.internal._gm_tool_name_for)
         63    load_var 37                        (response)
-        64    call 857 ntypeargs=0               (google.internal._gm_function_response)
+        64    call 865 ntypeargs=0               (google.internal._gm_function_response)
         65    store_var 38                       (_84)
         66    load_var2 4 38                     
         67    call 4 ntypeargs=0                 (baml.Array.push)
         68    pop 1                              
         69    jump -57                           (to 12)
 
-  142   70    load_var 31                        (_64)
+  192   70    load_var 31                        (_64)
         71    store_var 32                       (c)
 
-  191   72    load_type 10                       
+  241   72    load_type 10                       
         73    load_type 11                       
         74    alloc_map 0                        
         75    store_var 33                       (response)
 
-  192   76    load_type 10                       
+  242   76    load_type 10                       
         77    load_type 11                       
         78    load_var 33                        (response)
         79    load_const 13                      ("result")
@@ -7748,21 +8850,21 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         82    call 37 ntypeargs=2                (baml.Map.set)
         83    pop 1                              
 
-  193   84    load_var2 1 32                     
+  243   84    load_var2 1 32                     
         85    load_field 0                       (id)
-        86    call 859 ntypeargs=0               (google.internal._gm_tool_name_for)
+        86    call 867 ntypeargs=0               (google.internal._gm_tool_name_for)
         87    load_var 33                        (response)
-        88    call 857 ntypeargs=0               (google.internal._gm_function_response)
+        88    call 865 ntypeargs=0               (google.internal._gm_function_response)
         89    store_var 34                       (_72)
         90    load_var2 4 34                     
         91    call 4 ntypeargs=0                 (baml.Array.push)
         92    pop 1                              
         93    jump -81                           (to 12)
 
-  142   94    load_var 14                        (_22)
+  192   94    load_var 14                        (_22)
         95    store_var 15                       (a)
 
-  155   96    load_var 4                         (pending)
+  205   96    load_var 4                         (pending)
         97    container_len                      
         98    store_var 16                       (_25)
         99    load_var 16                        (_25)
@@ -7770,23 +8872,23 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         101   cmp_int_op >                       
         102   pop_jump_if_false +11              (to 113)
 
-  156   103   load_const 15                      ("user")
+  206   103   load_const 15                      ("user")
         104   load_var 4                         (pending)
-        105   call 855 ntypeargs=0               (google.internal._gm_content)
+        105   call 861 ntypeargs=0               (google.internal._gm_content)
         106   store_var 17                       (_27)
         107   load_var2 3 17                     
         108   call 4 ntypeargs=0                 (baml.Array.push)
         109   pop 1                              
 
-  157   110   load_type 0                        
+  207   110   load_type 0                        
         111   alloc_array 0                      
         112   store_var 4                        (pending)
 
-  162   113   load_type 0                        
+  212   113   load_type 0                        
         114   alloc_array 0                      
         115   store_var 18                       (parts)
 
-  163   116   load_var 15                        (a)
+  213   116   load_var 15                        (a)
         117   load_field 0                       (content)
         118   load_type 16                       
         119   load_const 17                      ("iter")
@@ -7804,7 +8906,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         131   load_var 20                        (_32)
         132   store_var 21                       (b)
 
-  164   133   load_var 21                        (b)
+  214   133   load_var 21                        (b)
         134   store_var 22                       (_36)
         135   load_var 22                        (_36)
         136   narrow_bind 20 22                  
@@ -7818,12 +8920,12 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         144   load_var 25                        (_41)
         145   store_var 26                       (use)
 
-  170   146   load_type 10                       
+  220   146   load_type 10                       
         147   load_type 11                       
         148   alloc_map 0                        
         149   store_var 27                       (fc)
 
-  171   150   load_type 10                       
+  221   150   load_type 10                       
         151   load_type 11                       
         152   load_var 27                        (fc)
         153   load_const 22                      ("name")
@@ -7832,7 +8934,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         156   call 37 ntypeargs=2                (baml.Map.set)
         157   pop 1                              
 
-  172   158   load_type 10                       
+  222   158   load_type 10                       
         159   load_type 11                       
         160   load_var 27                        (fc)
         161   load_const 23                      ("args")
@@ -7841,12 +8943,12 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         164   call 37 ntypeargs=2                (baml.Map.set)
         165   pop 1                              
 
-  173   166   load_type 10                       
+  223   166   load_type 10                       
         167   load_type 11                       
         168   alloc_map 0                        
         169   store_var 28                       (part)
 
-  174   170   load_type 10                       
+  224   170   load_type 10                       
         171   load_type 11                       
         172   load_var 28                        (part)
         173   load_const 24                      ("functionCall")
@@ -7854,23 +8956,23 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         175   call 37 ntypeargs=2                (baml.Map.set)
         176   pop 1                              
 
-  175   177   load_var2 18 28                    
+  225   177   load_var2 18 28                    
         178   call 4 ntypeargs=0                 (baml.Array.push)
         179   pop 1                              
         180   jump -58                           (to 122)
 
-  164   181   load_var 22                        (_36)
+  214   181   load_var 22                        (_36)
         182   store_var_load_var 23              (t)
 
-  166   183   load_field 0                       (text)
-        184   call 856 ntypeargs=0               (google.internal._gm_text_part)
+  216   183   load_field 0                       (text)
+        184   call 862 ntypeargs=0               (google.internal._gm_text_part)
         185   store_var 24                       (_39)
         186   load_var2 18 24                    
         187   call 4 ntypeargs=0                 (baml.Array.push)
         188   pop 1                              
         189   jump -67                           (to 122)
 
-  182   190   load_var 18                        (parts)
+  232   190   load_var 18                        (parts)
         191   container_len                      
         192   store_var 29                       (_60)
         193   load_var 29                        (_60)
@@ -7878,19 +8980,19 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         195   cmp_int_op >                       
         196   pop_jump_if_false -184             (to 12)
 
-  183   197   load_const 25                      ("model")
+  233   197   load_const 25                      ("model")
         198   load_var 18                        (parts)
-        199   call 855 ntypeargs=0               (google.internal._gm_content)
+        199   call 861 ntypeargs=0               (google.internal._gm_content)
         200   store_var 30                       (_62)
         201   load_var2 3 30                     
         202   call 4 ntypeargs=0                 (baml.Array.push)
         203   pop 1                              
         204   jump -192                          (to 12)
 
-  142   205   load_var 8                         (_10)
+  192   205   load_var 8                         (_10)
         206   store_var 9                        (u)
 
-  144   207   load_var 4                         (pending)
+  194   207   load_var 4                         (pending)
         208   container_len                      
         209   store_var 10                       (_13)
         210   load_var 10                        (_13)
@@ -7898,34 +9000,34 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         212   cmp_int_op >                       
         213   pop_jump_if_false +11              (to 224)
 
-  145   214   load_const 26                      ("user")
+  195   214   load_const 26                      ("user")
         215   load_var 4                         (pending)
-        216   call 855 ntypeargs=0               (google.internal._gm_content)
+        216   call 861 ntypeargs=0               (google.internal._gm_content)
         217   store_var 11                       (_15)
         218   load_var2 3 11                     
         219   call 4 ntypeargs=0                 (baml.Array.push)
         220   pop 1                              
 
-  146   221   load_type 0                        
+  196   221   load_type 0                        
         222   alloc_array 0                      
         223   store_var 4                        (pending)
 
-  151   224   load_var 9                         (u)
+  201   224   load_var 9                         (u)
         225   load_field 0                       (content)
-        226   call 856 ntypeargs=0               (google.internal._gm_text_part)
+        226   call 862 ntypeargs=0               (google.internal._gm_text_part)
         227   store_var 13                       (_20)
         228   load_const 27                      ("user")
         229   load_var 13                        (_20)
         230   load_type 0                        
         231   alloc_array 1                      
-        232   call 855 ntypeargs=0               (google.internal._gm_content)
+        232   call 861 ntypeargs=0               (google.internal._gm_content)
         233   store_var 12                       (_18)
         234   load_var2 3 12                     
         235   call 4 ntypeargs=0                 (baml.Array.push)
         236   pop 1                              
         237   jump -225                          (to 12)
 
-  205   238   load_var 4                         (pending)
+  255   238   load_var 4                         (pending)
         239   container_len                      
         240   store_var 39                       (_89)
         241   load_var 39                        (_89)
@@ -7933,33 +9035,33 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         243   cmp_int_op >                       
         244   pop_jump_if_false +8               (to 252)
 
-  206   245   load_const 28                      ("user")
+  256   245   load_const 28                      ("user")
         246   load_var 4                         (pending)
-        247   call 855 ntypeargs=0               (google.internal._gm_content)
+        247   call 861 ntypeargs=0               (google.internal._gm_content)
         248   store_var 40                       (_91)
         249   load_var2 3 40                     
         250   call 4 ntypeargs=0                 (baml.Array.push)
         251   pop 1                              
 
-  211   252   load_var 3                         (contents)
+  261   252   load_var 3                         (contents)
         253   store_var 2                        (_0)
         254   load_var 2                         (_0)
         255   return                             
 }
 
 function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.internal.GooglePrompt {
-  79    0    load_type 0                        
+  127   0    load_type 0                        
         1    alloc_array 0                      
         2    store_var 2                        (system_parts)
 
-  80    3    load_type 0                        
+  128   3    load_type 0                        
         4    alloc_array 0                      
         5    store_var 3                        (contents)
 
-  81    6    load_const 1                       ("")
+  129   6    load_const 1                       ("")
         7    store_var 4                        (first_role)
 
-  82    8    load_var 1                         (prompt)
+  130   8    load_var 1                         (prompt)
         9    call 764 ntypeargs=0               (ai.Prompt.messages)
         10   load_type 2                        
         11   load_const 3                       ("iter")
@@ -7973,77 +9075,91 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
         19   load_var 6                         (_7)
         20   is_type 6                          
         21   pop_jump_if_false +2               (to 23)
-        22   jump +42                           (to 64)
+        22   jump +55                           (to 77)
         23   load_var 6                         (_7)
         24   store_var_load_var 7               (message)
 
-  83    25   load_field 1                       (content)
-        26   call 856 ntypeargs=0               (google.internal._gm_text_part)
-        27   store_var 8                        (part)
+  131   25   call 864 ntypeargs=0               (google.internal._gm_prompt_parts)
+        26   store_var 8                        (parts)
 
-  84    28   load_var 7                         (message)
-        29   load_field 0                       (role)
-        30   load_const 7                       ("system")
-        31   cmp_op ==                          
-        32   pop_jump_if_false +2               (to 34)
-        33   jump +27                           (to 60)
+  132   27   load_var 7                         (message)
+        28   load_field 0                       (role)
+        29   load_const 7                       ("system")
+        30   cmp_op ==                          
+        31   pop_jump_if_false +2               (to 33)
+        32   jump +25                           (to 57)
 
-  88    34   load_var 7                         (message)
-        35   load_field 0                       (role)
-        36   load_const 8                       ("assistant")
-        37   cmp_op ==                          
-        38   pop_jump_if_false +2               (to 40)
-        39   jump +4                            (to 43)
+  138   33   load_var 7                         (message)
+        34   load_field 0                       (role)
+        35   load_const 8                       ("assistant")
+        36   cmp_op ==                          
+        37   pop_jump_if_false +2               (to 39)
+        38   jump +4                            (to 42)
 
-  91    40   load_const 9                       ("user")
-        41   store_var 9                        (role)
+  141   39   load_const 9                       ("user")
+        40   store_var 12                       (role)
 
-  88    42   jump +3                            (to 45)
+  138   41   jump +3                            (to 44)
 
-  89    43   load_const 10                      ("model")
-        44   store_var 9                        (role)
+  139   42   load_const 10                      ("model")
+        43   store_var 12                       (role)
 
-  93    45   load_var 4                         (first_role)
-        46   load_const 11                      ("")
-        47   cmp_op ==                          
-        48   pop_jump_if_false +3               (to 51)
+  143   44   load_var 4                         (first_role)
+        45   load_const 11                      ("")
+        46   cmp_op ==                          
+        47   pop_jump_if_false +3               (to 50)
 
-  94    49   load_var 9                         (role)
-        50   store_var 4                        (first_role)
+  144   48   load_var 12                        (role)
+        49   store_var 4                        (first_role)
 
-  99    51   load_var2 9 8                      
-        52   load_type 0                        
-        53   alloc_array 1                      
-        54   call 855 ntypeargs=0               (google.internal._gm_content)
-        55   store_var 10                       (_23)
-        56   load_var2 3 10                     
-        57   call 4 ntypeargs=0                 (baml.Array.push)
-        58   pop 1                              
-        59   jump -45                           (to 14)
+  149   50   load_var2 12 8                     
+        51   call 861 ntypeargs=0               (google.internal._gm_content)
+        52   store_var 13                       (_29)
+        53   load_var2 3 13                     
+        54   call 4 ntypeargs=0                 (baml.Array.push)
+        55   pop 1                              
+        56   jump -42                           (to 14)
 
-  85    60   load_var2 2 8                      
-        61   call 4 ntypeargs=0                 (baml.Array.push)
-        62   pop 1                              
-        63   jump -49                           (to 14)
+  133   57   load_var 8                         (parts)
+        58   load_type 12                       
+        59   load_const 13                      ("iter")
+        60   virtual_call nargs=1 ntypeargs=0   
+        61   store_var 9                        (_16)
+        62   load_var 9                         (_16)
+        63   load_type 14                       
+        64   load_const 15                      ("next")
+        65   virtual_call nargs=1 ntypeargs=0   
+        66   store_var 10                       (_17)
+        67   load_var 10                        (_17)
+        68   is_type 6                          
+        69   pop_jump_if_false +2               (to 71)
+        70   jump -56                           (to 14)
+        71   load_var 10                        (_17)
+        72   store_var 11                       (part)
 
-  103   64   load_var2 2 3                      
-        65   load_var 4                         (first_role)
-        66   init_instance 0                    (google.internal.GooglePrompt .system_parts, .contents, .first_role)
-        67   return                             
+  134   73   load_var2 2 11                     
+        74   call 4 ntypeargs=0                 (baml.Array.push)
+        75   pop 1                              
+        76   jump -14                           (to 62)
+
+  153   77   load_var2 2 3                      
+        78   load_var 4                         (first_role)
+        79   init_instance 0                    (google.internal.GooglePrompt .system_parts, .contents, .first_role)
+        80   return                             
 }
 
 function google.internal.google_parse(resp: google.internal.GmResponse, seq: int) -> ai.ModelTurn {
-  291   0     load_type 0                        
+  341   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 3                        (content)
 
-  292   3     load_const 1                       (false)
+  342   3     load_const 1                       (false)
         4     store_var 4                        (has_call)
 
-  293   5     load_const 2                       (0)
+  343   5     load_const 2                       (0)
         6     store_var 5                        (call_index)
 
-  294   7     load_var 1                         (resp)
+  344   7     load_var 1                         (resp)
         8     load_field 0                       (candidates)
         9     load_const 3                       (null)
         10    cmp_op ==                          
@@ -8059,7 +9175,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         20    load_const 3                       (null)
         21    store_var 6                        (cand)
 
-  295   22    load_var 6                         (cand)
+  345   22    load_var 6                         (cand)
         23    load_const 3                       (null)
         24    cmp_op ==                          
         25    pop_jump_if_false +2               (to 27)
@@ -8079,7 +9195,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         39    load_const 4                       ("")
         40    store_var 7                        (finish)
 
-  296   41    load_var 6                         (cand)
+  346   41    load_var 6                         (cand)
         42    load_const 3                       (null)
         43    cmp_op ==                          
         44    pop_jump_if_false +2               (to 46)
@@ -8112,7 +9228,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         71    alloc_array 0                      
         72    store_var 9                        (parts)
 
-  297   73    load_var 9                         (parts)
+  347   73    load_var 9                         (parts)
         74    load_type 6                        
         75    load_const 7                       ("iter")
         76    virtual_call nargs=1 ntypeargs=0   
@@ -8129,14 +9245,14 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         87    load_var 12                        (_31)
         88    store_var_load_var 13              (p)
 
-  298   89    load_field 2                       (functionCall)
+  348   89    load_field 2                       (functionCall)
         90    store_var 14                       (_36)
         91    load_var 14                        (_36)
         92    narrow_bind 11 14                  
         93    pop_jump_if_false +2               (to 95)
         94    jump +33                           (to 127)
 
-  310   95    load_var 13                        (p)
+  360   95    load_var 13                        (p)
         96    load_field 0                       (text)
         97    store_var 21                       (_55)
         98    load_var 21                        (_55)
@@ -8145,7 +9261,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         101   load_var 21                        (_55)
         102   store_var 22                       (t)
 
-  311   103   load_var 13                        (p)
+  361   103   load_var 13                        (p)
         104   load_field 1                       (thought)
         105   store_var 24                       (_58)
         106   load_var 24                        (_58)
@@ -8160,27 +9276,27 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         115   pop_jump_if_false +2               (to 117)
         116   jump +6                            (to 122)
 
-  315   117   load_var2 3 22                     
+  365   117   load_var2 3 22                     
         118   init_instance 0                    (ai.content.Text .text)
         119   call 4 ntypeargs=0                 (baml.Array.push)
         120   pop 1                              
         121   jump -43                           (to 78)
 
-  312   122   load_var2 3 22                     
+  362   122   load_var2 3 22                     
         123   init_instance 1                    (ai.content.Reasoning .summary)
         124   call 4 ntypeargs=0                 (baml.Array.push)
         125   pop 1                              
         126   jump -48                           (to 78)
 
-  298   127   load_var 14                        (_36)
+  348   127   load_var 14                        (_36)
         128   store_var 15                       (fc)
 
-  299   129   load_type 13                       
+  349   129   load_type 13                       
         130   load_type 14                       
         131   alloc_map 0                        
         132   store_var 16                       (args)
 
-  300   133   load_var 15                        (fc)
+  350   133   load_var 15                        (fc)
         134   load_field 1                       (args)
         135   store_var 17                       (_40)
         136   load_var 17                        (_40)
@@ -8189,10 +9305,10 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         139   load_var 17                        (_40)
         140   store_var 18                       (a)
 
-  301   141   load_var 18                        (a)
+  351   141   load_var 18                        (a)
         142   store_var 16                       (args)
 
-  304   143   load_type 16                       
+  354   143   load_type 16                       
         144   load_var 2                         (seq)
         145   call 138 ntypeargs=1               (baml.String.from)
         146   store_var 19                       (_47)
@@ -8201,9 +9317,9 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         149   call 138 ntypeargs=1               (baml.String.from)
         150   store_var 20                       (_49)
 
-  303   151   load_var 3                         (content)
+  353   151   load_var 3                         (content)
 
-  304   152   load_const 17                      ("call_")
+  354   152   load_const 17                      ("call_")
         153   load_var 19                        (_47)
         154   bin_op +                           
         155   load_const 18                      ("_")
@@ -8217,17 +9333,17 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         163   call 4 ntypeargs=0                 (baml.Array.push)
         164   pop 1                              
 
-  306   165   load_var 5                         (call_index)
+  356   165   load_var 5                         (call_index)
         166   load_const 12                      (1)
         167   add_int                            
         168   store_var 5                        (call_index)
 
-  307   169   load_const 19                      (true)
+  357   169   load_const 19                      (true)
         170   store_var 4                        (has_call)
 
-  298   171   jump -93                           (to 78)
+  348   171   jump -93                           (to 78)
 
-  323   172   load_var 1                         (resp)
+  373   172   load_var 1                         (resp)
         173   load_field 2                       (promptFeedback)
         174   load_const 3                       (null)
         175   cmp_op ==                          
@@ -8243,17 +9359,17 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         185   unary_op !                         
         186   store_var 25                       (blocked)
 
-  324   187   load_var 4                         (has_call)
+  374   187   load_var 4                         (has_call)
         188   pop_jump_if_false +2               (to 190)
         189   jump +39                           (to 228)
 
-  326   190   load_var 7                         (finish)
+  376   190   load_var 7                         (finish)
         191   load_const 20                      ("MAX_TOKENS")
         192   cmp_op ==                          
         193   pop_jump_if_false +2               (to 195)
         194   jump +30                           (to 224)
 
-  328   195   load_var 25                        (blocked)
+  378   195   load_var 25                        (blocked)
         196   jump_if_false +2                   (to 198)
         197   jump +5                            (to 202)
         198   pop 1                              
@@ -8275,29 +9391,29 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         214   pop_jump_if_false +2               (to 216)
         215   jump +5                            (to 220)
 
-  331   216   load_const 2                       (ai.content.StopReason.Complete)
-        217   alloc_variant 436                  (ai.content.StopReason)
+  381   216   load_const 2                       (ai.content.StopReason.Complete)
+        217   alloc_variant 438                  (ai.content.StopReason)
         218   store_var 26                       (stop)
 
-  328   219   jump +12                           (to 231)
+  378   219   jump +12                           (to 231)
 
-  329   220   load_const 24                      (ai.content.StopReason.Refused)
-        221   alloc_variant 436                  (ai.content.StopReason)
+  379   220   load_const 24                      (ai.content.StopReason.Refused)
+        221   alloc_variant 438                  (ai.content.StopReason)
         222   store_var 26                       (stop)
 
-  328   223   jump +8                            (to 231)
+  378   223   jump +8                            (to 231)
 
-  327   224   load_const 25                      (ai.content.StopReason.MaxTokens)
-        225   alloc_variant 436                  (ai.content.StopReason)
+  377   224   load_const 25                      (ai.content.StopReason.MaxTokens)
+        225   alloc_variant 438                  (ai.content.StopReason)
         226   store_var 26                       (stop)
 
-  326   227   jump +4                            (to 231)
+  376   227   jump +4                            (to 231)
 
-  325   228   load_const 12                      (ai.content.StopReason.ToolUse)
-        229   alloc_variant 436                  (ai.content.StopReason)
+  375   228   load_const 12                      (ai.content.StopReason.ToolUse)
+        229   alloc_variant 438                  (ai.content.StopReason)
         230   store_var 26                       (stop)
 
-  333   231   load_var 1                         (resp)
+  383   231   load_var 1                         (resp)
         232   load_field 1                       (usageMetadata)
         233   store_var 28                       (_85)
         234   load_var 28                        (_85)
@@ -8305,14 +9421,14 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         236   pop_jump_if_false +2               (to 238)
         237   jump +4                            (to 241)
 
-  341   238   load_const 3                       (null)
+  391   238   load_const 3                       (null)
         239   store_var 27                       (usage)
 
-  333   240   jump +30                           (to 270)
+  383   240   jump +30                           (to 270)
         241   load_var 28                        (_85)
         242   store_var 29                       (um)
 
-  335   243   load_var 29                        (um)
+  385   243   load_var 29                        (um)
         244   load_field 0                       (promptTokenCount)
         245   store_var 31                       (_88)
         246   load_var 31                        (_88)
@@ -8324,7 +9440,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         252   load_const 2                       (0)
         253   store_var 30                       (_87)
 
-  336   254   load_var 29                        (um)
+  386   254   load_var 29                        (um)
         255   load_field 1                       (candidatesTokenCount)
         256   store_var 33                       (_91)
         257   load_var 33                        (_91)
@@ -8336,57 +9452,57 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         263   load_const 2                       (0)
         264   store_var 32                       (_90)
 
-  334   265   load_var2 30 32                    
+  384   265   load_var2 30 32                    
         266   load_const 3                       (null)
         267   load_const 3                       (null)
         268   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
         269   store_var 27                       (usage)
 
-  343   270   load_var2 3 26                     
+  393   270   load_var2 3 26                     
         271   load_var 27                        (usage)
         272   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
         273   return                             
 }
 
 function google.internal.google_render(c: google.GoogleClient, input: ai.ModelTurnInput) -> baml.http.Request {
-  216   0   load_var2 1 2          
+  266   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 862 ntypeargs=0   (google.internal._google_request)
+        2   call 870 ntypeargs=0   (google.internal._google_request)
         3   return                 
 }
 
 function google.internal.invoke(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
-  351   0    load_var 2             (input)
+  401   0    load_var 2             (input)
         1    load_field 1           (journal)
         2    call 760 ntypeargs=0   (ai.Journal.entries)
         3    container_len          
         4    store_var 3            (seq)
 
-  352   5    load_var2 1 2          
-        6    call 861 ntypeargs=0   (google.internal.google_render)
+  402   5    load_var2 1 2          
+        6    call 869 ntypeargs=0   (google.internal.google_render)
         7    store_var 4            (req)
 
-  353   8    load_type 0            
+  403   8    load_type 0            
         9    load_var 4             (req)
         10   load_const 1           ("google")
         11   call 781 ntypeargs=1   (ai.wire.send_as)
 
-  354   12   load_var 3             (seq)
-        13   call 863 ntypeargs=0   (google.internal.google_parse)
+  404   12   load_var 3             (seq)
+        13   call 871 ntypeargs=0   (google.internal.google_parse)
         14   return                 
 }
 
 function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
-  432   0    load_var2 1 2          
+  482   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 862 ntypeargs=0   (google.internal._google_request)
+        2    call 870 ntypeargs=0   (google.internal._google_request)
 
-  433   3    sys_op 232             (baml.http.fetch_sse)
+  483   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
         5    load_var 3             (e)
         6    throw_if_panic         
 
-  437   7    load_type 1            
+  487   7    load_type 1            
         8    load_var 3             (e)
         9    call 138 ntypeargs=1   (baml.String.from)
         10   store_var 5            (_10)
@@ -8395,17 +9511,17 @@ function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTu
         13   call 138 ntypeargs=1   (baml.String.from)
         14   store_var 4            (_9)
 
-  435   15   load_const 3           ("google")
+  485   15   load_const 3           ("google")
 
-  437   16   load_const 4           ("transport failed before a response arrived: ")
+  487   16   load_const 4           ("transport failed before a response arrived: ")
         17   load_var 4             (_9)
         18   bin_op +               
         19   load_const 5           (null)
         20   init_instance 0        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
         21   throw                  
 
-  442   22   load_const 6           (google.internal._google_decode_batch)
-        23   call 803 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+  492   22   load_const 6           (google.internal._google_decode_batch)
+        23   call 806 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -8425,20 +9541,20 @@ function openai.OpenAiClient.ai.Client.id(self: openai.OpenAiClient) -> string {
 
 function openai.OpenAiClient.ai.Client.invoke(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   62   0   load_var2 1 2          
-       1   call 834 ntypeargs=0   (openai.internal.invoke)
+       1   call 838 ntypeargs=0   (openai.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   63   5   load_var 3             (e)
-       6   call 811 ntypeargs=0   (ai.errors.normalize)
+       6   call 814 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function openai.OpenAiClient.ai.stream.StreamingClient.invoke_stream(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   70   0   load_var2 1 2          
-       1   call 836 ntypeargs=0   (openai.internal.invoke_stream)
+       1   call 840 ntypeargs=0   (openai.internal.invoke_stream)
        2   return                 
 }
 
@@ -8562,12 +9678,12 @@ function openai.OpenAiClient.resolved_base_url(self: openai.OpenAiClient) -> str
 }
 
 function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone)[] {
-  254   0     load_type 0                        
+  337   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 3                        (out)
 
-  255   3     load_var 1                         (batch)
-        4     call 802 ntypeargs=0               (ai.stream.decode_sse_batch)
+  338   3     load_var 1                         (batch)
+        4     call 805 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -8584,7 +9700,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         18    load_var 5                         (_5)
         19    store_var_load_var 6               (raw)
 
-  256   20    load_field 1                       (data)
+  339   20    load_field 1                       (data)
         21    store_var 7                        (_10)
         22    load_var 7                         (_10)
         23    narrow_bind 6 7                    
@@ -8592,23 +9708,23 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         25    load_var 7                         (_10)
         26    store_var 8                        (data)
 
-  257   27    load_type 7                        
+  340   27    load_type 7                        
         28    load_var 8                         (data)
         29    call 333 ntypeargs=1               (baml.json.from_string)
         30    jump +4                            (to 34)
         31    load_var 9                         (e)
         32    throw_if_panic                     
 
-  258   33    load_const 8                       (null)
+  341   33    load_const 8                       (null)
 
-  260   34    store_var 10                       (_16)
+  343   34    store_var 10                       (_16)
         35    load_var 10                        (_16)
         36    narrow_bind 9 10                   
         37    pop_jump_if_false -28              (to 9)
         38    load_var 10                        (_16)
         39    store_var 11                       (event)
 
-  261   40    load_var 11                        (event)
+  344   40    load_var 11                        (event)
         41    load_field 0                       (type)
         42    store_var 14                       (_20)
         43    load_var 14                        (_20)
@@ -8629,13 +9745,13 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         58    load_const 10                      ("")
         59    store_var 12                       (t)
 
-  262   60    load_var 12                        (t)
+  345   60    load_var 12                        (t)
         61    load_const 11                      ("response.output_text.delta")
         62    cmp_op ==                          
         63    pop_jump_if_false +2               (to 65)
         64    jump +66                           (to 130)
 
-  270   65    load_var 12                        (t)
+  353   65    load_var 12                        (t)
         66    load_const 12                      ("response.completed")
         67    cmp_op ==                          
         68    jump_if_false +2                   (to 70)
@@ -8652,7 +9768,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         79    cmp_op ==                          
         80    pop_jump_if_false -71              (to 9)
 
-  271   81    load_var 11                        (event)
+  354   81    load_var 11                        (event)
         82    load_field 2                       (response)
         83    store_var 17                       (_38)
         84    load_var 17                        (_38)
@@ -8661,14 +9777,14 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         87    load_var 17                        (_38)
         88    store_var_load_var 18              (r)
 
-  272   89    call 833 ntypeargs=0               (openai.internal.openai_parse)
+  355   89    call 837 ntypeargs=0               (openai.internal.openai_parse)
         90    store_var 19                       (turn)
 
-  275   91    load_var 19                        (turn)
+  358   91    load_var 19                        (turn)
         92    load_field 1                       (stop_reason)
         93    store_var 20                       (_44)
 
-  276   94    load_var 19                        (turn)
+  359   94    load_var 19                        (turn)
         95    load_field 2                       (usage)
         96    load_const 8                       (null)
         97    cmp_op ==                          
@@ -8682,7 +9798,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         105   load_const 8                       (null)
         106   store_var 21                       (_45)
 
-  277   107   load_var 19                        (turn)
+  360   107   load_var 19                        (turn)
         108   load_field 2                       (usage)
         109   load_const 8                       (null)
         110   cmp_op ==                          
@@ -8696,20 +9812,20 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         118   load_const 8                       (null)
         119   store_var 22                       (_49)
 
-  273   120   load_var2 3 20                     
+  356   120   load_var2 3 20                     
 
-  274   121   load_var2 21 22                    
+  357   121   load_var2 21 22                    
         122   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
         123   call 4 ntypeargs=0                 (baml.Array.push)
         124   pop 1                              
 
-  284   125   load_var 3                         (out)
-        126   alloc_instance 358 ntypeargs=0     (ai.stream.TurnDone)
+  367   125   load_var 3                         (out)
+        126   alloc_instance 360 ntypeargs=0     (ai.stream.TurnDone)
         127   call 4 ntypeargs=0                 (baml.Array.push)
         128   pop 1                              
         129   jump -120                          (to 9)
 
-  263   130   load_var 11                        (event)
+  346   130   load_var 11                        (event)
         131   load_field 1                       (delta)
         132   store_var 15                       (_26)
         133   load_var 15                        (_26)
@@ -8718,20 +9834,451 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         136   load_var 15                        (_26)
         137   store_var 16                       (d)
 
-  264   138   load_var2 3 16                     
+  347   138   load_var2 3 16                     
         139   init_instance 1                    (ai.stream.TextDelta .text)
         140   call 4 ntypeargs=0                 (baml.Array.push)
         141   pop 1                              
         142   jump -133                          (to 9)
 
-  298   143   load_var 3                         (out)
+  381   143   load_var 3                         (out)
         144   store_var 2                        (_0)
         145   load_var 2                         (_0)
         146   return                             
 }
 
+function openai.internal._openai_prompt_content(message: ai.PromptMessage, role: string) -> map<string, unknown>[] {
+  37    0     load_type 0                        
+        1     alloc_array 0                      
+        2     store_var 4                        (content)
+
+  38    3     load_var 1                         (message)
+        4     load_field 2                       (parts)
+        5     load_type 1                        
+        6     load_const 2                       ("iter")
+        7     virtual_call nargs=1 ntypeargs=0   
+        8     store_var 5                        (_5)
+        9     load_var 5                         (_5)
+        10    load_type 3                        
+        11    load_const 4                       ("next")
+        12    virtual_call nargs=1 ntypeargs=0   
+        13    store_var 6                        (_6)
+        14    load_var 6                         (_6)
+        15    is_type 5                          
+        16    pop_jump_if_false +2               (to 18)
+        17    jump +351                          (to 368)
+        18    load_var 6                         (_6)
+        19    store_var 7                        (part)
+
+  39    20    load_var 7                         (part)
+        21    store_var 8                        (_10)
+        22    load_var 8                         (_10)
+        23    narrow_bind 6 8                    
+        24    pop_jump_if_false +2               (to 26)
+        25    jump +309                          (to 334)
+        26    load_var 7                         (part)
+        27    store_var 12                       (_24)
+        28    load_var 12                        (_24)
+        29    narrow_bind 7 12                   
+        30    pop_jump_if_false +2               (to 32)
+        31    jump +224                          (to 255)
+        32    load_var 7                         (part)
+        33    store_var 23                       (_56)
+        34    load_var 23                        (_56)
+        35    narrow_bind 8 23                   
+        36    pop_jump_if_false +2               (to 38)
+        37    jump +89                           (to 126)
+        38    load_var 7                         (part)
+        39    store_var 31                       (_98)
+        40    load_var 31                        (_98)
+        41    narrow_bind 9 31                   
+        42    pop_jump_if_false +2               (to 44)
+        43    jump +4                            (to 47)
+
+  110   44    load_const 10                      ("OpenAI Responses does not support video prompt input")
+        45    init_instance 0                    (baml.errors.InvalidArgument .message)
+        46    throw                              
+
+  39    47    load_var 31                        (_98)
+        48    store_var 32                       (pdf)
+
+  96    49    load_var 2                         (role)
+        50    load_const 11                      ("user")
+        51    cmp_op !=                          
+        52    pop_jump_if_false +2               (to 54)
+        53    jump +64                           (to 117)
+
+  101   54    load_var 32                        (pdf)
+        55    load_const 12                      (false)
+        56    call 785 ntypeargs=0               (ai.wire.resolve_media)
+        57    store_var 34                       (resolved)
+
+  102   58    load_var 34                        (resolved)
+        59    load_field 0                       (url)
+        60    store_var 36                       (_108)
+        61    load_var 36                        (_108)
+        62    store_var 35                       (file_data)
+        63    load_var 36                        (_108)
+        64    load_const 13                      (null)
+        65    cmp_op ==                          
+        66    pop_jump_if_false +29              (to 95)
+        67    load_type 14                       
+        68    load_var 34                        (resolved)
+        69    load_field 2                       (mime_type)
+        70    call 138 ntypeargs=1               (baml.String.from)
+        71    store_var 37                       (_112)
+        72    load_var 34                        (resolved)
+        73    load_field 1                       (base64)
+        74    store_var 40                       (_117)
+        75    load_var 40                        (_117)
+        76    store_var 39                       (_116)
+        77    load_var 40                        (_117)
+        78    load_const 13                      (null)
+        79    cmp_op ==                          
+        80    pop_jump_if_false +3               (to 83)
+        81    load_const 15                      ("")
+        82    store_var 39                       (_116)
+        83    load_type 14                       
+        84    load_var 39                        (_116)
+        85    call 138 ntypeargs=1               (baml.String.from)
+        86    store_var 38                       (_115)
+        87    load_const 16                      ("data:")
+        88    load_var 37                        (_112)
+        89    bin_op +                           
+        90    load_const 17                      (";base64,")
+        91    bin_op +                           
+        92    load_var 38                        (_115)
+        93    bin_op +                           
+        94    store_var 35                       (file_data)
+
+  103   95    load_type 14                       
+        96    load_type 18                       
+        97    alloc_map 0                        
+        98    store_var 41                       (item)
+
+  104   99    load_type 14                       
+        100   load_type 18                       
+        101   load_var 41                        (item)
+        102   load_const 19                      ("type")
+        103   load_const 20                      ("input_file")
+        104   call 37 ntypeargs=2                (baml.Map.set)
+        105   pop 1                              
+
+  105   106   load_type 14                       
+        107   load_type 18                       
+        108   load_var 41                        (item)
+        109   load_const 21                      ("file_data")
+        110   load_var 35                        (file_data)
+        111   call 37 ntypeargs=2                (baml.Map.set)
+        112   pop 1                              
+
+  106   113   load_var2 4 41                     
+        114   call 4 ntypeargs=0                 (baml.Array.push)
+        115   pop 1                              
+        116   jump -107                          (to 9)
+
+  98    117   load_type 14                       
+        118   load_var 2                         (role)
+        119   call 138 ntypeargs=1               (baml.String.from)
+        120   store_var 33                       (_103)
+        121   load_const 22                      ("OpenAI Responses only supports PDF input in user messages, found ")
+        122   load_var 33                        (_103)
+        123   bin_op +                           
+        124   init_instance 1                    (baml.errors.InvalidArgument .message)
+        125   throw                              
+
+  39    126   load_var 23                        (_56)
+        127   store_var 24                       (audio)
+
+  69    128   load_var 2                         (role)
+        129   load_const 23                      ("user")
+        130   cmp_op !=                          
+        131   pop_jump_if_false +2               (to 133)
+        132   jump +114                          (to 246)
+
+  74    133   load_var 24                        (audio)
+        134   load_const 24                      (true)
+        135   call 785 ntypeargs=0               (ai.wire.resolve_media)
+        136   store_var 26                       (resolved)
+
+  75    137   load_var 26                        (resolved)
+        138   load_field 2                       (mime_type)
+        139   load_const 25                      ("audio/wav")
+        140   cmp_op ==                          
+        141   jump_if_false +2                   (to 143)
+        142   jump +6                            (to 148)
+        143   pop 1                              
+        144   load_var 26                        (resolved)
+        145   load_field 2                       (mime_type)
+        146   load_const 26                      ("audio/x-wav")
+        147   cmp_op ==                          
+        148   pop_jump_if_false +2               (to 150)
+        149   jump +55                           (to 204)
+
+  77    150   load_var 26                        (resolved)
+        151   load_field 2                       (mime_type)
+        152   load_const 27                      ("audio/mpeg")
+        153   cmp_op ==                          
+        154   jump_if_false +2                   (to 156)
+        155   jump +6                            (to 161)
+        156   pop 1                              
+        157   load_var 26                        (resolved)
+        158   load_field 2                       (mime_type)
+        159   load_const 28                      ("audio/mp3")
+        160   cmp_op ==                          
+        161   pop_jump_if_false +2               (to 163)
+        162   jump +39                           (to 201)
+
+  79    163   load_var 26                        (resolved)
+        164   load_field 2                       (mime_type)
+        165   load_const 29                      ("audio/flac")
+        166   cmp_op ==                          
+        167   jump_if_false +2                   (to 169)
+        168   jump +6                            (to 174)
+        169   pop 1                              
+        170   load_var 26                        (resolved)
+        171   load_field 2                       (mime_type)
+        172   load_const 30                      ("audio/x-flac")
+        173   cmp_op ==                          
+        174   pop_jump_if_false +2               (to 176)
+        175   jump +23                           (to 198)
+
+  81    176   load_var 26                        (resolved)
+        177   load_field 2                       (mime_type)
+        178   load_const 31                      ("audio/ogg")
+        179   cmp_op ==                          
+        180   pop_jump_if_false +2               (to 182)
+        181   jump +14                           (to 195)
+
+  83    182   load_var 26                        (resolved)
+        183   load_field 2                       (mime_type)
+        184   load_const 32                      ("audio/webm")
+        185   cmp_op ==                          
+        186   pop_jump_if_false +2               (to 188)
+        187   jump +5                            (to 192)
+
+  86    188   load_var 26                        (resolved)
+        189   load_field 2                       (mime_type)
+        190   store_var 27                       (format)
+
+  83    191   jump +15                           (to 206)
+
+  84    192   load_const 33                      ("webm")
+        193   store_var 27                       (format)
+
+  83    194   jump +12                           (to 206)
+
+  82    195   load_const 34                      ("ogg")
+        196   store_var 27                       (format)
+
+  81    197   jump +9                            (to 206)
+
+  80    198   load_const 35                      ("flac")
+        199   store_var 27                       (format)
+
+  79    200   jump +6                            (to 206)
+
+  78    201   load_const 36                      ("mp3")
+        202   store_var 27                       (format)
+
+  77    203   jump +3                            (to 206)
+
+  76    204   load_const 37                      ("wav")
+        205   store_var 27                       (format)
+
+  88    206   load_type 14                       
+        207   load_type 18                       
+        208   alloc_map 0                        
+        209   store_var 28                       (item)
+
+  89    210   load_type 14                       
+        211   load_type 18                       
+        212   load_var 28                        (item)
+        213   load_const 38                      ("type")
+        214   load_const 39                      ("input_audio")
+        215   call 37 ntypeargs=2                (baml.Map.set)
+        216   pop 1                              
+
+  90    217   load_var 26                        (resolved)
+        218   load_field 1                       (base64)
+        219   store_var 30                       (_88)
+        220   load_var 30                        (_88)
+        221   store_var 29                       (_87)
+        222   load_var 30                        (_88)
+        223   load_const 13                      (null)
+        224   cmp_op ==                          
+        225   pop_jump_if_false +3               (to 228)
+        226   load_const 40                      ("")
+        227   store_var 29                       (_87)
+        228   load_type 14                       
+        229   load_type 18                       
+        230   load_var 28                        (item)
+        231   load_const 41                      ("data")
+        232   load_var 29                        (_87)
+        233   call 37 ntypeargs=2                (baml.Map.set)
+        234   pop 1                              
+
+  91    235   load_type 14                       
+        236   load_type 18                       
+        237   load_var 28                        (item)
+        238   load_const 42                      ("format")
+        239   load_var 27                        (format)
+        240   call 37 ntypeargs=2                (baml.Map.set)
+        241   pop 1                              
+
+  92    242   load_var2 4 28                     
+        243   call 4 ntypeargs=0                 (baml.Array.push)
+        244   pop 1                              
+        245   jump -236                          (to 9)
+
+  71    246   load_type 14                       
+        247   load_var 2                         (role)
+        248   call 138 ntypeargs=1               (baml.String.from)
+        249   store_var 25                       (_61)
+        250   load_const 43                      ("OpenAI Responses only supports audio input in user messages, found ")
+        251   load_var 25                        (_61)
+        252   bin_op +                           
+        253   init_instance 2                    (baml.errors.InvalidArgument .message)
+        254   throw                              
+
+  39    255   load_var 12                        (_24)
+        256   store_var 13                       (image)
+
+  55    257   load_var 2                         (role)
+        258   load_const 44                      ("user")
+        259   cmp_op !=                          
+        260   pop_jump_if_false +2               (to 262)
+        261   jump +64                           (to 325)
+
+  60    262   load_var 13                        (image)
+        263   load_const 12                      (false)
+        264   call 785 ntypeargs=0               (ai.wire.resolve_media)
+        265   store_var 15                       (resolved)
+
+  61    266   load_var 15                        (resolved)
+        267   load_field 0                       (url)
+        268   store_var 17                       (_34)
+        269   load_var 17                        (_34)
+        270   store_var 16                       (image_url)
+        271   load_var 17                        (_34)
+        272   load_const 13                      (null)
+        273   cmp_op ==                          
+        274   pop_jump_if_false +29              (to 303)
+        275   load_type 14                       
+        276   load_var 15                        (resolved)
+        277   load_field 2                       (mime_type)
+        278   call 138 ntypeargs=1               (baml.String.from)
+        279   store_var 18                       (_38)
+        280   load_var 15                        (resolved)
+        281   load_field 1                       (base64)
+        282   store_var 21                       (_43)
+        283   load_var 21                        (_43)
+        284   store_var 20                       (_42)
+        285   load_var 21                        (_43)
+        286   load_const 13                      (null)
+        287   cmp_op ==                          
+        288   pop_jump_if_false +3               (to 291)
+        289   load_const 45                      ("")
+        290   store_var 20                       (_42)
+        291   load_type 14                       
+        292   load_var 20                        (_42)
+        293   call 138 ntypeargs=1               (baml.String.from)
+        294   store_var 19                       (_41)
+        295   load_const 46                      ("data:")
+        296   load_var 18                        (_38)
+        297   bin_op +                           
+        298   load_const 47                      (";base64,")
+        299   bin_op +                           
+        300   load_var 19                        (_41)
+        301   bin_op +                           
+        302   store_var 16                       (image_url)
+
+  62    303   load_type 14                       
+        304   load_type 18                       
+        305   alloc_map 0                        
+        306   store_var 22                       (item)
+
+  63    307   load_type 14                       
+        308   load_type 18                       
+        309   load_var 22                        (item)
+        310   load_const 48                      ("type")
+        311   load_const 49                      ("input_image")
+        312   call 37 ntypeargs=2                (baml.Map.set)
+        313   pop 1                              
+
+  64    314   load_type 14                       
+        315   load_type 18                       
+        316   load_var 22                        (item)
+        317   load_const 50                      ("image_url")
+        318   load_var 16                        (image_url)
+        319   call 37 ntypeargs=2                (baml.Map.set)
+        320   pop 1                              
+
+  65    321   load_var2 4 22                     
+        322   call 4 ntypeargs=0                 (baml.Array.push)
+        323   pop 1                              
+        324   jump -315                          (to 9)
+
+  57    325   load_type 14                       
+        326   load_var 2                         (role)
+        327   call 138 ntypeargs=1               (baml.String.from)
+        328   store_var 14                       (_29)
+        329   load_const 51                      ("OpenAI Responses only supports image input in user messages, found ")
+        330   load_var 14                        (_29)
+        331   bin_op +                           
+        332   init_instance 3                    (baml.errors.InvalidArgument .message)
+        333   throw                              
+
+  39    334   load_var 8                         (_10)
+        335   store_var 9                        (text)
+
+  41    336   load_type 14                       
+        337   load_type 18                       
+        338   alloc_map 0                        
+        339   store_var 10                       (item)
+
+  44    340   load_var 2                         (role)
+        341   load_const 52                      ("assistant")
+        342   cmp_op ==                          
+        343   pop_jump_if_false +2               (to 345)
+        344   jump +4                            (to 348)
+
+  47    345   load_const 53                      ("input_text")
+        346   store_var 11                       (_14)
+
+  44    347   jump +3                            (to 350)
+
+  45    348   load_const 54                      ("output_text")
+        349   store_var 11                       (_14)
+
+  42    350   load_type 14                       
+        351   load_type 18                       
+        352   load_var 10                        (item)
+        353   load_const 55                      ("type")
+        354   load_var 11                        (_14)
+        355   call 37 ntypeargs=2                (baml.Map.set)
+        356   pop 1                              
+
+  50    357   load_type 14                       
+        358   load_type 18                       
+        359   load_var 10                        (item)
+        360   load_const 56                      ("text")
+        361   load_var 9                         (text)
+        362   call 37 ntypeargs=2                (baml.Map.set)
+        363   pop 1                              
+
+  51    364   load_var2 4 10                     
+        365   call 4 ntypeargs=0                 (baml.Array.push)
+        366   pop 1                              
+        367   jump -358                          (to 9)
+
+  116   368   load_var 4                         (content)
+        369   store_var 3                        (_0)
+        370   load_var 3                         (_0)
+        371   return                             
+}
+
 function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
-  128   0     load_var 2                         (input)
+  211   0     load_var 2                         (input)
         1     load_field 0                       (prompt)
         2     store_var 5                        (_5)
         3     load_var 2                         (input)
@@ -8740,12 +10287,12 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         6     load_var 5                         (_5)
         7     call_indirect                      
 
-  129   8     call 829 ntypeargs=0               (openai.internal.openai_lower_prompt)
+  212   8     call 833 ntypeargs=0               (openai.internal.openai_lower_prompt)
         9     store_var 6                        (items)
 
-  130   10    load_var 2                         (input)
+  213   10    load_var 2                         (input)
         11    load_field 1                       (journal)
-        12    call 830 ntypeargs=0               (openai.internal.openai_lower_journal)
+        12    call 834 ntypeargs=0               (openai.internal.openai_lower_journal)
         13    load_type 0                        
         14    load_const 1                       ("iter")
         15    virtual_call nargs=1 ntypeargs=0   
@@ -8762,17 +10309,17 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         26    load_var 8                         (_13)
         27    store_var 9                        (item)
 
-  131   28    load_var2 6 9                      
+  214   28    load_var2 6 9                      
         29    call 4 ntypeargs=0                 (baml.Array.push)
         30    pop 1                              
         31    jump -14                           (to 17)
 
-  133   32    load_type 5                        
+  216   32    load_type 5                        
         33    load_type 6                        
         34    alloc_map 0                        
         35    store_var 10                       (body)
 
-  134   36    load_type 5                        
+  217   36    load_type 5                        
         37    load_type 6                        
         38    load_var 10                        (body)
         39    load_const 7                       ("model")
@@ -8781,7 +10328,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         42    call 37 ntypeargs=2                (baml.Map.set)
         43    pop 1                              
 
-  135   44    load_type 5                        
+  218   44    load_type 5                        
         45    load_type 6                        
         46    load_var 10                        (body)
         47    load_const 8                       ("store")
@@ -8789,7 +10336,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         49    call 37 ntypeargs=2                (baml.Map.set)
         50    pop 1                              
 
-  136   51    load_type 5                        
+  219   51    load_type 5                        
         52    load_type 6                        
         53    load_var 10                        (body)
         54    load_const 10                      ("input")
@@ -8797,17 +10344,17 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         56    call 37 ntypeargs=2                (baml.Map.set)
         57    pop 1                              
 
-  137   58    load_var 2                         (input)
+  220   58    load_var 2                         (input)
         59    load_field 2                       (toolbox)
         60    call 778 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         61    unary_op !                         
         62    pop_jump_if_false +82              (to 144)
 
-  138   63    load_type 11                       
+  221   63    load_type 11                       
         64    alloc_array 0                      
         65    store_var 11                       (tools)
 
-  139   66    load_var 2                         (input)
+  222   66    load_var 2                         (input)
         67    load_field 2                       (toolbox)
         68    call 776 ntypeargs=0               (ai.tools.Toolbox.list)
         69    load_type 12                       
@@ -8826,12 +10373,12 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         82    load_var 13                        (_38)
         83    store_var 14                       (t)
 
-  140   84    load_type 5                        
+  223   84    load_type 5                        
         85    load_type 6                        
         86    alloc_map 0                        
         87    store_var 15                       (entry)
 
-  141   88    load_type 5                        
+  224   88    load_type 5                        
         89    load_type 6                        
         90    load_var 15                        (entry)
         91    load_const 16                      ("type")
@@ -8839,7 +10386,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         93    call 37 ntypeargs=2                (baml.Map.set)
         94    pop 1                              
 
-  142   95    load_type 5                        
+  225   95    load_type 5                        
         96    load_type 6                        
         97    load_var 15                        (entry)
         98    load_const 18                      ("name")
@@ -8848,7 +10395,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         101   call 37 ntypeargs=2                (baml.Map.set)
         102   pop 1                              
 
-  143   103   load_type 5                        
+  226   103   load_type 5                        
         104   load_type 6                        
         105   load_var 15                        (entry)
         106   load_const 19                      ("description")
@@ -8857,7 +10404,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         109   call 37 ntypeargs=2                (baml.Map.set)
         110   pop 1                              
 
-  144   111   load_type 5                        
+  227   111   load_type 5                        
         112   load_type 6                        
         113   load_var 15                        (entry)
         114   load_const 20                      ("parameters")
@@ -8866,7 +10413,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         117   call 37 ntypeargs=2                (baml.Map.set)
         118   pop 1                              
 
-  145   119   load_type 5                        
+  228   119   load_type 5                        
         120   load_type 6                        
         121   load_var 15                        (entry)
         122   load_const 21                      ("strict")
@@ -8874,12 +10421,12 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         124   call 37 ntypeargs=2                (baml.Map.set)
         125   pop 1                              
 
-  146   126   load_var2 11 15                    
+  229   126   load_var2 11 15                    
         127   call 4 ntypeargs=0                 (baml.Array.push)
         128   pop 1                              
         129   jump -56                           (to 73)
 
-  148   130   load_type 5                        
+  231   130   load_type 5                        
         131   load_type 6                        
         132   load_var 10                        (body)
         133   load_const 22                      ("tools")
@@ -8887,7 +10434,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         135   call 37 ntypeargs=2                (baml.Map.set)
         136   pop 1                              
 
-  149   137   load_type 5                        
+  232   137   load_type 5                        
         138   load_type 6                        
         139   load_var 10                        (body)
         140   load_const 23                      ("tool_choice")
@@ -8895,10 +10442,10 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         142   call 37 ntypeargs=2                (baml.Map.set)
         143   pop 1                              
 
-  154   144   load_var 3                         (stream)
+  237   144   load_var 3                         (stream)
         145   pop_jump_if_false +8               (to 153)
 
-  155   146   load_type 5                        
+  238   146   load_type 5                        
         147   load_type 6                        
         148   load_var 10                        (body)
         149   load_const 25                      ("stream")
@@ -8906,8 +10453,8 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         151   call 37 ntypeargs=2                (baml.Map.set)
         152   pop 1                              
 
-  162   153   load_var 1                         (c)
-        154   call 825 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
+  245   153   load_var 1                         (c)
+        154   call 828 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
         155   store_var 18                       (_76)
         156   load_var 18                        (_76)
         157   store_var 17                       (_75)
@@ -8922,27 +10469,27 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         166   call 138 ntypeargs=1               (baml.String.from)
         167   store_var 16                       (_74)
 
-  163   168   load_var 1                         (c)
-        169   call 824 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
+  246   168   load_var 1                         (c)
+        169   call 827 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
         170   store_var 20                       (_82)
         171   load_type 5                        
         172   load_var 20                        (_82)
         173   call 138 ntypeargs=1               (baml.String.from)
         174   store_var 19                       (_81)
 
-  164   175   load_type 11                       
+  247   175   load_type 11                       
         176   load_var 10                        (body)
         177   call 331 ntypeargs=1               (baml.json.to_json)
         178   call 328 ntypeargs=0               (baml.json.stringify)
         179   store_var 21                       (_84)
 
-  160   180   load_const 29                      ("POST")
+  243   180   load_const 29                      ("POST")
 
-  162   181   load_var 16                        (_74)
+  245   181   load_var 16                        (_74)
         182   load_const 30                      ("/responses")
         183   bin_op +                           
 
-  163   184   load_const 31                      ("Bearer ")
+  246   184   load_const 31                      ("Bearer ")
         185   load_var 19                        (_81)
         186   bin_op +                           
         187   load_const 32                      ("application/json")
@@ -8959,30 +10506,30 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 }
 
 function openai.internal.invoke(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
-  231   0   load_var2 1 2          
-        1   call 831 ntypeargs=0   (openai.internal.openai_render)
+  314   0   load_var2 1 2          
+        1   call 835 ntypeargs=0   (openai.internal.openai_render)
         2   store_var 3            (req)
 
-  232   3   load_type 0            
+  315   3   load_type 0            
         4   load_var 3             (req)
         5   load_const 1           ("openai")
         6   call 781 ntypeargs=1   (ai.wire.send_as)
 
-  233   7   call 833 ntypeargs=0   (openai.internal.openai_parse)
+  316   7   call 837 ntypeargs=0   (openai.internal.openai_parse)
         8   return                 
 }
 
 function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
-  304   0    load_var2 1 2          
+  387   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 832 ntypeargs=0   (openai.internal._openai_request)
+        2    call 836 ntypeargs=0   (openai.internal._openai_request)
 
-  305   3    sys_op 232             (baml.http.fetch_sse)
+  388   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
         5    load_var 3             (e)
         6    throw_if_panic         
 
-  309   7    load_type 1            
+  392   7    load_type 1            
         8    load_var 3             (e)
         9    call 138 ntypeargs=1   (baml.String.from)
         10   store_var 5            (_10)
@@ -8991,26 +10538,26 @@ function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTu
         13   call 138 ntypeargs=1   (baml.String.from)
         14   store_var 4            (_9)
 
-  307   15   load_const 3           ("openai")
+  390   15   load_const 3           ("openai")
 
-  309   16   load_const 4           ("transport failed before a response arrived: ")
+  392   16   load_const 4           ("transport failed before a response arrived: ")
         17   load_var 4             (_9)
         18   bin_op +               
         19   load_const 5           (null)
         20   init_instance 0        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
         21   throw                  
 
-  314   22   load_const 6           (openai.internal._openai_decode_batch)
-        23   call 803 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+  397   22   load_const 6           (openai.internal._openai_decode_batch)
+        23   call 806 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
 function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unknown>[] {
-  57    0     load_type 0                        
+  140   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 3                        (items)
 
-  58    3     load_var 1                         (j)
+  141   3     load_var 1                         (j)
         4     call 760 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
@@ -9028,7 +10575,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         18    load_var 5                         (_5)
         19    store_var 6                        (e)
 
-  59    20    load_var 6                         (e)
+  142   20    load_var 6                         (e)
         21    store_var 7                        (_9)
         22    load_var 7                         (_9)
         23    narrow_bind 6 7                    
@@ -9054,12 +10601,12 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         43    load_var 25                        (_80)
         44    store_var 26                       (f)
 
-  101   45    load_type 10                       
+  184   45    load_type 10                       
         46    load_type 11                       
         47    alloc_map 0                        
         48    store_var 27                       (err)
 
-  102   49    load_type 10                       
+  185   49    load_type 10                       
         50    load_type 11                       
         51    load_var 27                        (err)
         52    load_const 12                      ("error")
@@ -9068,12 +10615,12 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         55    call 37 ntypeargs=2                (baml.Map.set)
         56    pop 1                              
 
-  103   57    load_type 10                       
+  186   57    load_type 10                       
         58    load_type 11                       
         59    alloc_map 0                        
         60    store_var 28                       (m)
 
-  104   61    load_type 10                       
+  187   61    load_type 10                       
         62    load_type 11                       
         63    load_var 28                        (m)
         64    load_const 13                      ("type")
@@ -9081,7 +10628,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         66    call 37 ntypeargs=2                (baml.Map.set)
         67    pop 1                              
 
-  105   68    load_type 10                       
+  188   68    load_type 10                       
         69    load_type 11                       
         70    load_var 28                        (m)
         71    load_const 15                      ("call_id")
@@ -9090,7 +10637,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         74    call 37 ntypeargs=2                (baml.Map.set)
         75    pop 1                              
 
-  106   76    load_type 0                        
+  189   76    load_type 0                        
         77    load_var 27                        (err)
         78    call 331 ntypeargs=1               (baml.json.to_json)
         79    call 328 ntypeargs=0               (baml.json.stringify)
@@ -9103,20 +10650,20 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         86    call 37 ntypeargs=2                (baml.Map.set)
         87    pop 1                              
 
-  107   88    load_var2 3 28                     
+  190   88    load_var2 3 28                     
         89    call 4 ntypeargs=0                 (baml.Array.push)
         90    pop 1                              
         91    jump -82                           (to 9)
 
-  59    92    load_var 22                        (_64)
+  142   92    load_var 22                        (_64)
         93    store_var 23                       (c)
 
-  93    94    load_type 10                       
+  176   94    load_type 10                       
         95    load_type 11                       
         96    alloc_map 0                        
         97    store_var 24                       (m)
 
-  94    98    load_type 10                       
+  177   98    load_type 10                       
         99    load_type 11                       
         100   load_var 24                        (m)
         101   load_const 17                      ("type")
@@ -9124,7 +10671,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         103   call 37 ntypeargs=2                (baml.Map.set)
         104   pop 1                              
 
-  95    105   load_type 10                       
+  178   105   load_type 10                       
         106   load_type 11                       
         107   load_var 24                        (m)
         108   load_const 19                      ("call_id")
@@ -9133,7 +10680,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         111   call 37 ntypeargs=2                (baml.Map.set)
         112   pop 1                              
 
-  96    113   load_type 10                       
+  179   113   load_type 10                       
         114   load_type 11                       
         115   load_var 24                        (m)
         116   load_const 20                      ("output")
@@ -9142,15 +10689,15 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         119   call 37 ntypeargs=2                (baml.Map.set)
         120   pop 1                              
 
-  97    121   load_var2 3 24                     
+  180   121   load_var2 3 24                     
         122   call 4 ntypeargs=0                 (baml.Array.push)
         123   pop 1                              
         124   jump -115                          (to 9)
 
-  59    125   load_var 10                        (_21)
+  142   125   load_var 10                        (_21)
         126   store_var_load_var 11              (a)
 
-  68    127   load_field 0                       (content)
+  151   127   load_field 0                       (content)
         128   load_type 21                       
         129   load_const 22                      ("iter")
         130   virtual_call nargs=1 ntypeargs=0   
@@ -9167,7 +10714,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         141   load_var 13                        (_25)
         142   store_var 14                       (b)
 
-  69    143   load_var 14                        (b)
+  152   143   load_var 14                        (b)
         144   store_var 15                       (_29)
         145   load_var 15                        (_29)
         146   narrow_bind 25 15                  
@@ -9181,12 +10728,12 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         154   load_var 18                        (_41)
         155   store_var 19                       (use)
 
-  78    156   load_type 10                       
+  161   156   load_type 10                       
         157   load_type 11                       
         158   alloc_map 0                        
         159   store_var 20                       (m)
 
-  79    160   load_type 10                       
+  162   160   load_type 10                       
         161   load_type 11                       
         162   load_var 20                        (m)
         163   load_const 27                      ("type")
@@ -9194,7 +10741,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         165   call 37 ntypeargs=2                (baml.Map.set)
         166   pop 1                              
 
-  80    167   load_type 10                       
+  163   167   load_type 10                       
         168   load_type 11                       
         169   load_var 20                        (m)
         170   load_const 29                      ("call_id")
@@ -9203,7 +10750,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         173   call 37 ntypeargs=2                (baml.Map.set)
         174   pop 1                              
 
-  81    175   load_type 10                       
+  164   175   load_type 10                       
         176   load_type 11                       
         177   load_var 20                        (m)
         178   load_const 30                      ("name")
@@ -9212,7 +10759,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         181   call 37 ntypeargs=2                (baml.Map.set)
         182   pop 1                              
 
-  82    183   load_type 0                        
+  165   183   load_type 0                        
         184   load_var 19                        (use)
         185   load_field 2                       (args)
         186   call 331 ntypeargs=1               (baml.json.to_json)
@@ -9226,20 +10773,20 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         194   call 37 ntypeargs=2                (baml.Map.set)
         195   pop 1                              
 
-  83    196   load_var2 3 20                     
+  166   196   load_var2 3 20                     
         197   call 4 ntypeargs=0                 (baml.Array.push)
         198   pop 1                              
         199   jump -67                           (to 132)
 
-  69    200   load_var 15                        (_29)
+  152   200   load_var 15                        (_29)
         201   store_var 16                       (t)
 
-  71    202   load_type 10                       
+  154   202   load_type 10                       
         203   load_type 11                       
         204   alloc_map 0                        
         205   store_var 17                       (m)
 
-  72    206   load_type 10                       
+  155   206   load_type 10                       
         207   load_type 11                       
         208   load_var 17                        (m)
         209   load_const 32                      ("role")
@@ -9247,7 +10794,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         211   call 37 ntypeargs=2                (baml.Map.set)
         212   pop 1                              
 
-  73    213   load_type 10                       
+  156   213   load_type 10                       
         214   load_type 11                       
         215   load_var 17                        (m)
         216   load_const 34                      ("content")
@@ -9256,20 +10803,20 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         219   call 37 ntypeargs=2                (baml.Map.set)
         220   pop 1                              
 
-  74    221   load_var2 3 17                     
+  157   221   load_var2 3 17                     
         222   call 4 ntypeargs=0                 (baml.Array.push)
         223   pop 1                              
         224   jump -92                           (to 132)
 
-  59    225   load_var 7                         (_9)
+  142   225   load_var 7                         (_9)
         226   store_var 8                        (u)
 
-  61    227   load_type 10                       
+  144   227   load_type 10                       
         228   load_type 11                       
         229   alloc_map 0                        
         230   store_var 9                        (m)
 
-  62    231   load_type 10                       
+  145   231   load_type 10                       
         232   load_type 11                       
         233   load_var 9                         (m)
         234   load_const 35                      ("role")
@@ -9277,7 +10824,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         236   call 37 ntypeargs=2                (baml.Map.set)
         237   pop 1                              
 
-  63    238   load_type 10                       
+  146   238   load_type 10                       
         239   load_type 11                       
         240   load_var 9                         (m)
         241   load_const 37                      ("content")
@@ -9286,109 +10833,111 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         244   call 37 ntypeargs=2                (baml.Map.set)
         245   pop 1                              
 
-  64    246   load_var2 3 9                      
+  147   246   load_var2 3 9                      
         247   call 4 ntypeargs=0                 (baml.Array.push)
         248   pop 1                              
         249   jump -240                          (to 9)
 
-  113   250   load_var 3                         (items)
+  196   250   load_var 3                         (items)
         251   store_var 2                        (_0)
         252   load_var 2                         (_0)
         253   return                             
 }
 
 function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> map<string, unknown>[] {
-  37   0    load_type 0                        
-       1    alloc_array 0                      
-       2    store_var 3                        (items)
+  120   0    load_type 0                        
+        1    alloc_array 0                      
+        2    store_var 3                        (items)
 
-  38   3    load_var 1                         (prompt)
-       4    call 764 ntypeargs=0               (ai.Prompt.messages)
-       5    load_type 1                        
-       6    load_const 2                       ("iter")
-       7    virtual_call nargs=1 ntypeargs=0   
-       8    store_var 4                        (_4)
-       9    load_var 4                         (_4)
-       10   load_type 3                        
-       11   load_const 4                       ("next")
-       12   virtual_call nargs=1 ntypeargs=0   
-       13   store_var 5                        (_5)
-       14   load_var 5                         (_5)
-       15   is_type 5                          
-       16   pop_jump_if_false +2               (to 18)
-       17   jump +46                           (to 63)
-       18   load_var 5                         (_5)
-       19   store_var_load_var 6               (message)
+  121   3    load_var 1                         (prompt)
+        4    call 764 ntypeargs=0               (ai.Prompt.messages)
+        5    load_type 1                        
+        6    load_const 2                       ("iter")
+        7    virtual_call nargs=1 ntypeargs=0   
+        8    store_var 4                        (_4)
+        9    load_var 4                         (_4)
+        10   load_type 3                        
+        11   load_const 4                       ("next")
+        12   virtual_call nargs=1 ntypeargs=0   
+        13   store_var 5                        (_5)
+        14   load_var 5                         (_5)
+        15   is_type 5                          
+        16   pop_jump_if_false +2               (to 18)
+        17   jump +48                           (to 65)
+        18   load_var 5                         (_5)
+        19   store_var_load_var 6               (message)
 
-  39   20   load_field 0                       (role)
-       21   load_const 6                       ("")
-       22   cmp_op ==                          
-       23   pop_jump_if_false +2               (to 25)
-       24   jump +14                           (to 38)
+  122   20   load_field 0                       (role)
+        21   load_const 6                       ("")
+        22   cmp_op ==                          
+        23   pop_jump_if_false +2               (to 25)
+        24   jump +14                           (to 38)
 
-  41   25   load_var 6                         (message)
-       26   load_field 0                       (role)
-       27   load_const 7                       ("tool")
-       28   cmp_op ==                          
-       29   pop_jump_if_false +2               (to 31)
-       30   jump +5                            (to 35)
+  124   25   load_var 6                         (message)
+        26   load_field 0                       (role)
+        27   load_const 7                       ("tool")
+        28   cmp_op ==                          
+        29   pop_jump_if_false +2               (to 31)
+        30   jump +5                            (to 35)
 
-  44   31   load_var 6                         (message)
-       32   load_field 0                       (role)
-       33   store_var 7                        (role)
+  127   31   load_var 6                         (message)
+        32   load_field 0                       (role)
+        33   store_var 7                        (role)
 
-  41   34   jump +6                            (to 40)
+  124   34   jump +6                            (to 40)
 
-  42   35   load_const 8                       ("user")
-       36   store_var 7                        (role)
+  125   35   load_const 8                       ("user")
+        36   store_var 7                        (role)
 
-  41   37   jump +3                            (to 40)
+  124   37   jump +3                            (to 40)
 
-  40   38   load_const 9                       ("user")
-       39   store_var 7                        (role)
+  123   38   load_const 9                       ("user")
+        39   store_var 7                        (role)
 
-  46   40   load_type 10                       
-       41   load_type 11                       
-       42   alloc_map 0                        
-       43   store_var 8                        (item)
+  129   40   load_type 10                       
+        41   load_type 11                       
+        42   alloc_map 0                        
+        43   store_var 8                        (item)
 
-  47   44   load_type 10                       
-       45   load_type 11                       
-       46   load_var 8                         (item)
-       47   load_const 12                      ("role")
-       48   load_var 7                         (role)
-       49   call 37 ntypeargs=2                (baml.Map.set)
-       50   pop 1                              
+  130   44   load_type 10                       
+        45   load_type 11                       
+        46   load_var 8                         (item)
+        47   load_const 12                      ("role")
+        48   load_var 7                         (role)
+        49   call 37 ntypeargs=2                (baml.Map.set)
+        50   pop 1                              
 
-  48   51   load_type 10                       
-       52   load_type 11                       
-       53   load_var 8                         (item)
-       54   load_const 13                      ("content")
-       55   load_var 6                         (message)
-       56   load_field 1                       (content)
-       57   call 37 ntypeargs=2                (baml.Map.set)
-       58   pop 1                              
+  131   51   load_var2 6 7                      
+        52   call 832 ntypeargs=0               (openai.internal._openai_prompt_content)
+        53   store_var 9                        (_20)
+        54   load_type 10                       
+        55   load_type 11                       
+        56   load_var 8                         (item)
+        57   load_const 13                      ("content")
+        58   load_var 9                         (_20)
+        59   call 37 ntypeargs=2                (baml.Map.set)
+        60   pop 1                              
 
-  49   59   load_var2 3 8                      
-       60   call 4 ntypeargs=0                 (baml.Array.push)
-       61   pop 1                              
-       62   jump -53                           (to 9)
+  132   61   load_var2 3 8                      
+        62   call 4 ntypeargs=0                 (baml.Array.push)
+        63   pop 1                              
+        64   jump -55                           (to 9)
 
-  51   63   load_var 3                         (items)
-       64   store_var 2                        (_0)
-       65   load_var 2                         (_0)
-       66   return                             
+  134   65   load_var 3                         (items)
+        66   store_var 2                        (_0)
+        67   load_var 2                         (_0)
+        68   return                             
 }
 
 function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.ModelTurn {
-  170   0     load_type 0                        
+  253   0     load_type 0                        
         1     alloc_array 0                      
         2     store_var 2                        (content)
 
-  171   3     load_const 1                       (false)
+  254   3     load_const 1                       (false)
         4     store_var 3                        (has_call)
 
-  172   5     load_var 1                         (resp)
+  255   5     load_var 1                         (resp)
         6     load_field 1                       (output)
         7     load_type 2                        
         8     load_const 3                       ("iter")
@@ -9406,26 +10955,26 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         20    load_var 5                         (_6)
         21    store_var_load_var 6               (item)
 
-  173   22    load_field 0                       (type)
+  256   22    load_field 0                       (type)
         23    load_const 7                       ("function_call")
         24    cmp_op ==                          
         25    pop_jump_if_false +2               (to 27)
         26    jump +111                          (to 137)
 
-  183   27    load_var 6                         (item)
+  266   27    load_var 6                         (item)
         28    load_field 0                       (type)
         29    load_const 8                       ("message")
         30    cmp_op ==                          
         31    pop_jump_if_false +2               (to 33)
         32    jump +46                           (to 78)
 
-  194   33    load_var 6                         (item)
+  277   33    load_var 6                         (item)
         34    load_field 0                       (type)
         35    load_const 9                       ("reasoning")
         36    cmp_op ==                          
         37    pop_jump_if_false -26              (to 11)
 
-  195   38    load_var 6                         (item)
+  278   38    load_var 6                         (item)
         39    load_field 5                       (summary)
         40    store_var 24                       (_50)
         41    load_var 24                        (_50)
@@ -9438,7 +10987,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         48    alloc_array 0                      
         49    store_var 23                       (parts)
 
-  196   50    load_var 23                        (parts)
+  279   50    load_var 23                        (parts)
         51    load_type 12                       
         52    load_const 13                      ("iter")
         53    virtual_call nargs=1 ntypeargs=0   
@@ -9455,7 +11004,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         64    load_var 26                        (_54)
         65    store_var_load_var 27              (part)
 
-  197   66    load_field 1                       (text)
+  280   66    load_field 1                       (text)
         67    store_var 28                       (_59)
         68    load_var 28                        (_59)
         69    narrow_bind 16 28                  
@@ -9463,13 +11012,13 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         71    load_var 28                        (_59)
         72    store_var 29                       (txt)
 
-  198   73    load_var2 2 29                     
+  281   73    load_var2 2 29                     
         74    init_instance 0                    (ai.content.Reasoning .summary)
         75    call 4 ntypeargs=0                 (baml.Array.push)
         76    pop 1                              
         77    jump -22                           (to 55)
 
-  184   78    load_var 6                         (item)
+  267   78    load_var 6                         (item)
         79    load_field 4                       (content)
         80    store_var 15                       (_30)
         81    load_var 15                        (_30)
@@ -9482,7 +11031,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         88    alloc_array 0                      
         89    store_var 14                       (parts)
 
-  185   90    load_var 14                        (parts)
+  268   90    load_var 14                        (parts)
         91    load_type 12                       
         92    load_const 17                      ("iter")
         93    virtual_call nargs=1 ntypeargs=0   
@@ -9499,7 +11048,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         104   load_var 17                        (_34)
         105   store_var 18                       (part)
 
-  186   106   load_var 18                        (part)
+  269   106   load_var 18                        (part)
         107   load_field 0                       (type)
         108   store_var 20                       (_40)
         109   load_var 20                        (_40)
@@ -9515,7 +11064,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         119   cmp_op ==                          
         120   pop_jump_if_false -25              (to 95)
 
-  187   121   load_var 18                        (part)
+  270   121   load_var 18                        (part)
         122   load_field 1                       (text)
         123   store_var 22                       (_45)
         124   load_var 22                        (_45)
@@ -9532,15 +11081,15 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         135   pop 1                              
         136   jump -41                           (to 95)
 
-  174   137   load_const 22                      (true)
+  257   137   load_const 22                      (true)
         138   store_var 3                        (has_call)
 
-  175   139   load_type 23                       
+  258   139   load_type 23                       
         140   load_type 24                       
         141   alloc_map 0                        
         142   store_var 7                        (args)
 
-  176   143   load_var 6                         (item)
+  259   143   load_var 6                         (item)
         144   load_field 3                       (arguments)
         145   store_var 8                        (_14)
         146   load_var 8                         (_14)
@@ -9549,12 +11098,12 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         149   load_var 8                         (_14)
         150   store_var 9                        (s)
 
-  177   151   load_type 25                       
+  260   151   load_type 25                       
         152   load_var 9                         (s)
         153   call 333 ntypeargs=1               (baml.json.from_string)
         154   store_var 7                        (args)
 
-  180   155   load_var 6                         (item)
+  263   155   load_var 6                         (item)
         156   load_field 1                       (call_id)
         157   store_var 11                       (_21)
         158   load_var 11                        (_21)
@@ -9577,19 +11126,19 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         175   load_const 27                      ("")
         176   store_var 12                       (_23)
 
-  179   177   load_var2 2 10                     
+  262   177   load_var2 2 10                     
 
-  180   178   load_var2 12 7                     
+  263   178   load_var2 12 7                     
         179   init_instance 2                    (ai.content.ToolUse .id, .name, .args)
         180   call 4 ntypeargs=0                 (baml.Array.push)
         181   pop 1                              
         182   jump -171                          (to 11)
 
-  209   183   load_var 3                         (has_call)
+  292   183   load_var 3                         (has_call)
         184   pop_jump_if_false +2               (to 186)
         185   jump +25                           (to 210)
 
-  211   186   load_var 1                         (resp)
+  294   186   load_var 1                         (resp)
         187   load_field 0                       (status)
         188   store_var 32                       (_68)
         189   load_var 32                        (_68)
@@ -9606,23 +11155,23 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         200   pop_jump_if_false +2               (to 202)
         201   jump +5                            (to 206)
 
-  214   202   load_const 30                      (ai.content.StopReason.Complete)
-        203   alloc_variant 436                  (ai.content.StopReason)
+  297   202   load_const 30                      (ai.content.StopReason.Complete)
+        203   alloc_variant 438                  (ai.content.StopReason)
         204   store_var 30                       (stop)
 
-  211   205   jump +8                            (to 213)
+  294   205   jump +8                            (to 213)
 
-  212   206   load_const 31                      (ai.content.StopReason.MaxTokens)
-        207   alloc_variant 436                  (ai.content.StopReason)
+  295   206   load_const 31                      (ai.content.StopReason.MaxTokens)
+        207   alloc_variant 438                  (ai.content.StopReason)
         208   store_var 30                       (stop)
 
-  211   209   jump +4                            (to 213)
+  294   209   jump +4                            (to 213)
 
-  210   210   load_const 16                      (ai.content.StopReason.ToolUse)
-        211   alloc_variant 436                  (ai.content.StopReason)
+  293   210   load_const 16                      (ai.content.StopReason.ToolUse)
+        211   alloc_variant 438                  (ai.content.StopReason)
         212   store_var 30                       (stop)
 
-  216   213   load_var 1                         (resp)
+  299   213   load_var 1                         (resp)
         214   load_field 2                       (usage)
         215   store_var 34                       (_72)
         216   load_var 34                        (_72)
@@ -9630,32 +11179,32 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         218   pop_jump_if_false +2               (to 220)
         219   jump +4                            (to 223)
 
-  224   220   load_const 10                      (null)
+  307   220   load_const 10                      (null)
         221   store_var 33                       (usage)
 
-  216   222   jump +10                           (to 232)
+  299   222   jump +10                           (to 232)
         223   load_var 34                        (_72)
         224   store_var_load_var 35              (u)
 
-  218   225   load_field 0                       (input_tokens)
+  301   225   load_field 0                       (input_tokens)
 
-  219   226   load_var 35                        (u)
+  302   226   load_var 35                        (u)
         227   load_field 1                       (output_tokens)
         228   load_const 10                      (null)
         229   load_const 10                      (null)
         230   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
         231   store_var 33                       (usage)
 
-  226   232   load_var2 2 30                     
+  309   232   load_var2 2 30                     
         233   load_var 33                        (usage)
         234   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
         235   return                             
 }
 
 function openai.internal.openai_render(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> baml.http.Request {
-  118   0   load_var2 1 2          
+  201   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 832 ntypeargs=0   (openai.internal._openai_request)
+        2   call 836 ntypeargs=0   (openai.internal._openai_request)
         3   return                 
 }
 
@@ -9672,7 +11221,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  104   0   make_closure 1558 0   
+  104   0   make_closure 1560 0   
         1   store_var 1           (_0)
         2   load_var 1            (_0)
         3   return                
@@ -9699,7 +11248,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   76   16   load_var 1             (threshold)
-       17   make_closure 1553 1    
+       17   make_closure 1555 1    
        18   store_var 2            (_0)
        19   load_var 2             (_0)
        20   return                 
@@ -9740,7 +11289,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1537 2    
+       29   make_closure 1539 2    
        30   store_var 3            (_0)
        31   load_var 3             (_0)
        32   return                 
@@ -9761,14 +11310,14 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   42   10   load_var 1             (max_attempts)
-       11   make_closure 1547 1    
+       11   make_closure 1549 1    
        12   store_var 2            (_0)
        13   load_var 2             (_0)
        14   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  98   0   make_closure 1556 0   
+  98   0   make_closure 1558 0   
        1   store_var 1           (_0)
        2   load_var 1            (_0)
        3   return                
@@ -12350,7 +13899,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   486   25   load_var 5                         (child)
-        26   make_closure 1438 1                
+        26   make_closure 1440 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   load_type 7                        
@@ -12450,7 +13999,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   496   3    load_var 1             (body)
-        4    make_closure 1450 1    
+        4    make_closure 1452 1    
         5    store_var 3            (base_run)
 
   527   6    load_var 2             (runner)
@@ -12720,7 +14269,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   364   6    load_var2 1 2         
 
   366   7    load_var 3            (runner)
-        8    make_closure 1415 2   
+        8    make_closure 1417 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   store_var 4           (_0)
         11   load_var 4            (_0)
@@ -12739,7 +14288,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   375   8    load_var2 1 2         
-        9    make_closure 1417 2   
+        9    make_closure 1419 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   store_var 3           (_0)
         12   load_var 3            (_0)
@@ -12762,7 +14311,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   391   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1419 3   
+        13   make_closure 1421 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   store_var 4           (_0)
         16   load_var 4            (_0)
@@ -12928,7 +14477,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 889 ntypeargs=0   (user.score)
+       7    call 897 ntypeargs=0   (user.score)
        8    store_var 4            (base)
 
   11   9    load_var 4             (base)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -3326,9 +3326,662 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
     throw
 }
 
+function ai.wire._media_mime_type(explicit: string | null, source_value: string, kind: string) -> string {
+    load_var explicit
+    store_var _4
+    load_var _4
+    narrow_bind string, slot=4
+    pop_jump_if_false L0
+    jump L41
+
+  L0:
+    load_var source_value
+    call baml.String.to_lower_case
+    store_var source
+    load_var source
+    load_const ".jpg"
+    call baml.String.includes
+    jump_if_false L1
+    jump L2
+
+  L1:
+    pop 1
+    load_var source
+    load_const ".jpeg"
+    call baml.String.includes
+
+  L2:
+    pop_jump_if_false L3
+    jump L40
+
+  L3:
+    load_var source
+    load_const ".png"
+    call baml.String.includes
+    pop_jump_if_false L4
+    jump L39
+
+  L4:
+    load_var source
+    load_const ".webp"
+    call baml.String.includes
+    pop_jump_if_false L5
+    jump L38
+
+  L5:
+    load_var source
+    load_const ".gif"
+    call baml.String.includes
+    pop_jump_if_false L6
+    jump L37
+
+  L6:
+    load_var source
+    load_const ".svg"
+    call baml.String.includes
+    pop_jump_if_false L7
+    jump L36
+
+  L7:
+    load_var source
+    load_const ".wav"
+    call baml.String.includes
+    pop_jump_if_false L8
+    jump L35
+
+  L8:
+    load_var source
+    load_const ".mp3"
+    call baml.String.includes
+    pop_jump_if_false L9
+    jump L34
+
+  L9:
+    load_var source
+    load_const ".flac"
+    call baml.String.includes
+    pop_jump_if_false L10
+    jump L33
+
+  L10:
+    load_var source
+    load_const ".ogg"
+    call baml.String.includes
+    pop_jump_if_false L11
+    jump L32
+
+  L11:
+    load_var source
+    load_const ".webm"
+    call baml.String.includes
+    pop_jump_if_false L12
+    jump L29
+
+  L12:
+    load_var source
+    load_const ".mov"
+    call baml.String.includes
+    pop_jump_if_false L13
+    jump L28
+
+  L13:
+    load_var source
+    load_const ".mp4"
+    call baml.String.includes
+    pop_jump_if_false L14
+    jump L27
+
+  L14:
+    load_var source
+    load_const ".avi"
+    call baml.String.includes
+    pop_jump_if_false L15
+    jump L26
+
+  L15:
+    load_var source
+    load_const ".mkv"
+    call baml.String.includes
+    pop_jump_if_false L16
+    jump L25
+
+  L16:
+    load_var source
+    load_const ".pdf"
+    call baml.String.includes
+    pop_jump_if_false L17
+    jump L24
+
+  L17:
+    load_var kind
+    load_const "audio"
+    cmp_op ==
+    pop_jump_if_false L18
+    jump L23
+
+  L18:
+    load_var kind
+    load_const "video"
+    cmp_op ==
+    pop_jump_if_false L19
+    jump L22
+
+  L19:
+    load_var kind
+    load_const "pdf"
+    cmp_op ==
+    pop_jump_if_false L20
+    jump L21
+
+  L20:
+    load_const "image/png"
+    jump L42
+
+  L21:
+    load_const "application/pdf"
+    jump L42
+
+  L22:
+    load_const "video/mp4"
+    jump L42
+
+  L23:
+    load_const "audio/mpeg"
+    jump L42
+
+  L24:
+    load_const "application/pdf"
+    jump L42
+
+  L25:
+    load_const "video/x-matroska"
+    jump L42
+
+  L26:
+    load_const "video/x-msvideo"
+    jump L42
+
+  L27:
+    load_const "video/mp4"
+    jump L42
+
+  L28:
+    load_const "video/quicktime"
+    jump L42
+
+  L29:
+    load_var kind
+    load_const "audio"
+    cmp_op ==
+    pop_jump_if_false L30
+    jump L31
+
+  L30:
+    load_const "video/webm"
+    jump L42
+
+  L31:
+    load_const "audio/webm"
+    jump L42
+
+  L32:
+    load_const "audio/ogg"
+    jump L42
+
+  L33:
+    load_const "audio/flac"
+    jump L42
+
+  L34:
+    load_const "audio/mpeg"
+    jump L42
+
+  L35:
+    load_const "audio/wav"
+    jump L42
+
+  L36:
+    load_const "image/svg+xml"
+    jump L42
+
+  L37:
+    load_const "image/gif"
+    jump L42
+
+  L38:
+    load_const "image/webp"
+    jump L42
+
+  L39:
+    load_const "image/png"
+    jump L42
+
+  L40:
+    load_const "image/jpeg"
+    jump L42
+
+  L41:
+    load_var _4
+
+  L42:
+    return
+}
+
+function ai.wire._resolve_media_content(url: string | null, file: string | null, inline: string, mime: string, fetch_url: bool) -> ai.wire.ResolvedMedia {
+    load_var file
+    store_var _6
+    load_var _6
+    narrow_bind string, slot=6
+    pop_jump_if_false L0
+    jump L15
+
+  L0:
+    load_var inline
+    load_const ""
+    cmp_op !=
+    pop_jump_if_false L1
+    jump L14
+
+  L1:
+    load_var url
+    store_var _15
+    load_var _15
+    narrow_bind string, slot=9
+    pop_jump_if_false L2
+    jump L3
+
+  L2:
+    load_const "media has no URL, file, or base64 content"
+    init_instance baml.errors.InvalidArgument .message
+    throw
+
+  L3:
+    load_var _15
+    store_var media_url
+    load_var media_url
+    load_const "data:"
+    call baml.String.starts_with
+    pop_jump_if_false L4
+    load_var media_url
+    load_const ";base64,"
+    call baml.String.index_of
+    store_var _19
+    load_var _19
+    narrow_bind int, slot=11
+    pop_jump_if_false L4
+    jump L13
+
+  L4:
+    load_var fetch_url
+    unary_op !
+    jump_if_false L5
+    jump L6
+
+  L5:
+    pop 1
+    load_var media_url
+    load_const "gs://"
+    call baml.String.starts_with
+
+  L6:
+    pop_jump_if_false L7
+    jump L12
+
+  L7:
+    load_var media_url
+    load_const <omitted>
+    call baml.http.fetch
+    store_var response
+    load_var response
+    call baml.http.Response.ok
+    unary_op !
+    pop_jump_if_false L8
+    jump L11
+
+  L8:
+    load_type string
+    load_type string
+    load_var response
+    load_field .headers
+    load_const "content-type"
+    call baml.Map.get
+    store_var _45
+    load_var _45
+    store_var response_mime
+    load_var _45
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L9
+    load_var mime
+    store_var response_mime
+
+  L9:
+    load_var response
+    sys_op baml.http.Response.bytes
+    call baml.Uint8Array.to_base64
+    store_var _50
+    load_var response_mime
+    load_const ";"
+    call baml.String.split
+    store_var _54
+    load_type string
+    load_var _54
+    load_const 0
+    call baml.Array.at
+    store_var _53
+    load_var _53
+    store_var _52
+    load_var _53
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L10
+    load_var mime
+    store_var _52
+
+  L10:
+    load_const null
+    load_var2 22 23
+    init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
+    jump L16
+
+  L11:
+    load_type string
+    load_var media_url
+    call baml.String.from
+    store_var _38
+    load_type int
+    load_var response
+    load_field .status_code
+    call baml.String.from
+    store_var _41
+    load_const "media"
+    load_const "media URL "
+    load_var _38
+    bin_op +
+    load_const " returned HTTP "
+    bin_op +
+    load_var _41
+    bin_op +
+    load_const null
+    init_instance ai.errors.NetworkFailure .provider, .detail, .raw_body
+    throw
+
+  L12:
+    load_var media_url
+    load_const null
+    load_var mime
+    init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
+    jump L16
+
+  L13:
+    load_var _19
+    store_var_load_var separator
+    load_const 8
+    add_int
+    store_var _22
+    load_var media_url
+    call baml.String.length
+    store_var _24
+    load_var2 10 14
+    load_var _24
+    call baml.String.substring
+    store_var _21
+    load_var media_url
+    load_const 5
+    load_var separator
+    call baml.String.substring
+    store_var _25
+    load_const null
+    load_var2 13 16
+    init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
+    jump L16
+
+  L14:
+    load_const null
+    load_var2 3 4
+    init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
+    jump L16
+
+  L15:
+    load_var _6
+    load_const "r"
+    sys_op baml.fs.open
+    store_var handle
+    load_var handle
+    sys_op baml.fs.File.bytes
+    call baml.Uint8Array.to_base64
+    store_var data
+    load_var handle
+    sys_op baml.fs.File.close
+    pop 1
+    load_const null
+    load_var2 8 4
+    init_instance ai.wire.ResolvedMedia .url, .base64, .mime_type
+
+  L16:
+    return
+}
+
 function ai.wire.render_output_format(t: type) -> string {
     load_var t
     sys_op baml.prompt.render_output_format
+    return
+}
+
+function ai.wire.resolve_media(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf, fetch_url: bool) -> ai.wire.ResolvedMedia {
+    load_var media
+    store_var _3
+    load_var _3
+    narrow_bind baml.media.Image, slot=3
+    pop_jump_if_false L0
+    jump L11
+
+  L0:
+    load_var media
+    store_var _16
+    load_var _16
+    narrow_bind baml.media.Audio, slot=12
+    pop_jump_if_false L1
+    jump L8
+
+  L1:
+    load_var media
+    store_var _29
+    load_var _29
+    narrow_bind baml.media.Video, slot=21
+    pop_jump_if_false L2
+    jump L5
+
+  L2:
+    load_var media
+    call baml.media.Pdf.file
+    store_var _45
+    load_var _45
+    store_var _44
+    load_var _45
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L3
+    load_var media
+    call baml.media.Pdf.url
+    store_var _44
+
+  L3:
+    load_var _44
+    store_var source
+    load_var _44
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L4
+    load_const ""
+    store_var source
+
+  L4:
+    load_var media
+    call baml.media.Pdf.url
+    store_var _48
+    load_var media
+    call baml.media.Pdf.file
+    store_var _49
+    load_var media
+    call baml.media.Pdf.base64
+    store_var _50
+    load_var media
+    call baml.media.Pdf.mime_type
+    load_var source
+    load_const "pdf"
+    call ai.wire._media_mime_type
+    store_var _51
+    load_var2 33 34
+    load_var2 35 36
+    load_var fetch_url
+    call ai.wire._resolve_media_content
+    jump L14
+
+  L5:
+    load_var _29
+    store_var video
+    load_var video
+    call baml.media.Video.file
+    store_var _33
+    load_var _33
+    store_var _32
+    load_var _33
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L6
+    load_var video
+    call baml.media.Video.url
+    store_var _32
+
+  L6:
+    load_var _32
+    store_var source
+    load_var _32
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L7
+    load_const ""
+    store_var source
+
+  L7:
+    load_var video
+    call baml.media.Video.url
+    store_var _36
+    load_var video
+    call baml.media.Video.file
+    store_var _37
+    load_var video
+    call baml.media.Video.base64
+    store_var _38
+    load_var video
+    call baml.media.Video.mime_type
+    load_var source
+    load_const "video"
+    call ai.wire._media_mime_type
+    store_var _39
+    load_var2 26 27
+    load_var2 28 29
+    load_var fetch_url
+    call ai.wire._resolve_media_content
+    jump L14
+
+  L8:
+    load_var _16
+    store_var audio
+    load_var audio
+    call baml.media.Audio.file
+    store_var _20
+    load_var _20
+    store_var _19
+    load_var _20
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L9
+    load_var audio
+    call baml.media.Audio.url
+    store_var _19
+
+  L9:
+    load_var _19
+    store_var source
+    load_var _19
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L10
+    load_const ""
+    store_var source
+
+  L10:
+    load_var audio
+    call baml.media.Audio.url
+    store_var _23
+    load_var audio
+    call baml.media.Audio.file
+    store_var _24
+    load_var audio
+    call baml.media.Audio.base64
+    store_var _25
+    load_var audio
+    call baml.media.Audio.mime_type
+    load_var source
+    load_const "audio"
+    call ai.wire._media_mime_type
+    store_var _26
+    load_var2 17 18
+    load_var2 19 20
+    load_var fetch_url
+    call ai.wire._resolve_media_content
+    jump L14
+
+  L11:
+    load_var _3
+    store_var image
+    load_var image
+    call baml.media.Image.file
+    store_var _7
+    load_var _7
+    store_var _6
+    load_var _7
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L12
+    load_var image
+    call baml.media.Image.url
+    store_var _6
+
+  L12:
+    load_var _6
+    store_var source
+    load_var _6
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L13
+    load_const ""
+    store_var source
+
+  L13:
+    load_var image
+    call baml.media.Image.url
+    store_var _10
+    load_var image
+    call baml.media.Image.file
+    store_var _11
+    load_var image
+    call baml.media.Image.base64
+    store_var _12
+    load_var image
+    call baml.media.Image.mime_type
+    load_var source
+    load_const "image"
+    call ai.wire._media_mime_type
+    store_var _13
+    load_var2 8 9
+    load_var2 10 11
+    load_var fetch_url
+    call ai.wire._resolve_media_content
+
+  L14:
     return
 }
 
@@ -4045,31 +4698,11 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
     load_var _6
     is_type baml.iter.Done
     pop_jump_if_false L1
-    jump L7
+    jump L9
 
   L1:
     load_var _6
-    store_var message
-    load_type string
-    load_type unknown
-    alloc_map 0
-    store_var block
-    load_type string
-    load_type unknown
-    load_var block
-    load_const "type"
-    load_const "text"
-    call baml.Map.set
-    pop 1
-    load_type string
-    load_type unknown
-    load_var block
-    load_const "text"
-    load_var message
-    load_field .content
-    call baml.Map.set
-    pop 1
-    load_var message
+    store_var_load_var message
     load_field .role
     load_const "system"
     cmp_op ==
@@ -4094,25 +4727,326 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
     store_var role
 
   L5:
-    load_var2 3 8
+    load_var role
+    store_var _26
+    load_var2 6 9
+    call anthropic.internal._anthropic_prompt_blocks
+    store_var _27
+    load_var2 3 10
     load_const false
-    load_var block
-    load_type map<string, unknown>
-    alloc_array 1
+    load_var _27
     init_instance anthropic.internal.AnthropicMessage .role, .tool_results, .blocks
     call baml.Array.push
     pop 1
     jump L0
 
   L6:
-    load_var2 2 7
+    load_var message
+    load_const "system"
+    call anthropic.internal._anthropic_prompt_blocks
+    load_type baml.iter.Iterable<Error = never, Item = map<string, unknown>>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _14
+
+  L7:
+    load_var _14
+    load_type baml.iter.Iterator<Error = never, Item = map<string, unknown>>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _15
+    load_var _15
+    is_type baml.iter.Done
+    pop_jump_if_false L8
+    jump L0
+
+  L8:
+    load_var2 2 8
+    call baml.Array.push
+    pop 1
+    jump L7
+
+  L9:
+    load_var2 2 3
+    init_instance anthropic.internal.AnthropicPrompt .system, .messages
+    return
+}
+
+function anthropic.internal._anthropic_media_block(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf, block_type: string) -> map<string, unknown> {
+    load_var media
+    load_const false
+    call ai.wire.resolve_media
+    store_var resolved
+    load_type string
+    load_type unknown
+    alloc_map 0
+    store_var source
+    load_var resolved
+    load_field .url
+    store_var _6
+    load_var _6
+    narrow_bind string, slot=5
+    pop_jump_if_false L0
+    jump L2
+
+  L0:
+    load_type string
+    load_type unknown
+    load_var source
+    load_const "type"
+    load_const "base64"
+    call baml.Map.set
+    pop 1
+    load_type string
+    load_type unknown
+    load_var source
+    load_const "media_type"
+    load_var resolved
+    load_field .mime_type
+    call baml.Map.set
+    pop 1
+    load_var resolved
+    load_field .base64
+    store_var _24
+    load_var _24
+    store_var _23
+    load_var _24
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L1
+    load_const ""
+    store_var _23
+
+  L1:
+    load_type string
+    load_type unknown
+    load_var source
+    load_const "data"
+    load_var _23
+    call baml.Map.set
+    pop 1
+    jump L3
+
+  L2:
+    load_var _6
+    store_var url
+    load_type string
+    load_type unknown
+    load_var source
+    load_const "type"
+    load_const "url"
+    call baml.Map.set
+    pop 1
+    load_type string
+    load_type unknown
+    load_var source
+    load_const "url"
+    load_var url
+    call baml.Map.set
+    pop 1
+
+  L3:
+    load_type string
+    load_type unknown
+    alloc_map 0
+    store_var block
+    load_type string
+    load_type unknown
+    load_var block
+    load_const "type"
+    load_var block_type
+    call baml.Map.set
+    pop 1
+    load_type string
+    load_type unknown
+    load_var block
+    load_const "source"
+    load_var source
+    call baml.Map.set
+    pop 1
+    load_var block
+    return
+}
+
+function anthropic.internal._anthropic_prompt_blocks(message: ai.PromptMessage, role: string) -> map<string, unknown>[] {
+    load_type map<string, unknown>
+    alloc_array 0
+    store_var blocks
+    load_var message
+    load_field .parts
+    load_type baml.iter.Iterable<Error = never, Item = string | baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _5
+
+  L0:
+    load_var _5
+    load_type baml.iter.Iterator<Error = never, Item = string | baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _6
+    load_var _6
+    is_type baml.iter.Done
+    pop_jump_if_false L1
+    jump L16
+
+  L1:
+    load_var _6
+    store_var part
+    load_var part
+    store_var _10
+    load_var _10
+    narrow_bind string, slot=7
+    pop_jump_if_false L2
+    jump L15
+
+  L2:
+    load_var part
+    store_var _22
+    load_var _22
+    narrow_bind baml.media.Image, slot=10
+    pop_jump_if_false L3
+    jump L12
+
+  L3:
+    load_var part
+    store_var _32
+    load_var _32
+    narrow_bind baml.media.Audio, slot=14
+    pop_jump_if_false L4
+    jump L9
+
+  L4:
+    load_var part
+    store_var _42
+    load_var _42
+    narrow_bind baml.media.Pdf, slot=18
+    pop_jump_if_false L5
+    jump L6
+
+  L5:
+    load_const "Anthropic does not support video prompt input"
+    init_instance baml.errors.InvalidArgument .message
+    throw
+
+  L6:
+    load_var _42
+    store_var pdf
+    load_var role
+    load_const "user"
+    cmp_op !=
+    pop_jump_if_false L7
+    jump L8
+
+  L7:
+    load_var pdf
+    load_const "document"
+    call anthropic.internal._anthropic_media_block
+    store_var _50
+    load_var2 3 21
     call baml.Array.push
     pop 1
     jump L0
 
-  L7:
-    load_var2 2 3
-    init_instance anthropic.internal.AnthropicPrompt .system, .messages
+  L8:
+    load_type string
+    load_var role
+    call baml.String.from
+    store_var _47
+    load_const "Anthropic only supports PDF input in user messages, found "
+    load_var _47
+    bin_op +
+    init_instance baml.errors.InvalidArgument .message
+    throw
+
+  L9:
+    load_var _32
+    store_var audio
+    load_var role
+    load_const "user"
+    cmp_op !=
+    pop_jump_if_false L10
+    jump L11
+
+  L10:
+    load_var audio
+    load_const "input_audio"
+    call anthropic.internal._anthropic_media_block
+    store_var _40
+    load_var2 3 17
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L11:
+    load_type string
+    load_var role
+    call baml.String.from
+    store_var _37
+    load_const "Anthropic only supports audio input in user messages, found "
+    load_var _37
+    bin_op +
+    init_instance baml.errors.InvalidArgument .message
+    throw
+
+  L12:
+    load_var _22
+    store_var image
+    load_var role
+    load_const "user"
+    cmp_op !=
+    pop_jump_if_false L13
+    jump L14
+
+  L13:
+    load_var image
+    load_const "image"
+    call anthropic.internal._anthropic_media_block
+    store_var _30
+    load_var2 3 13
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L14:
+    load_type string
+    load_var role
+    call baml.String.from
+    store_var _27
+    load_const "Anthropic only supports image input in user messages, found "
+    load_var _27
+    bin_op +
+    init_instance baml.errors.InvalidArgument .message
+    throw
+
+  L15:
+    load_var _10
+    store_var text
+    load_type string
+    load_type unknown
+    alloc_map 0
+    store_var block
+    load_type string
+    load_type unknown
+    load_var block
+    load_const "type"
+    load_const "text"
+    call baml.Map.set
+    pop 1
+    load_type string
+    load_type unknown
+    load_var block
+    load_const "text"
+    load_var text
+    call baml.Map.set
+    pop 1
+    load_var2 3 9
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L16:
+    load_var blocks
     return
 }
 
@@ -6871,6 +7805,206 @@ function google.internal._gm_function_response(name: string, response: map<strin
     return
 }
 
+function google.internal._gm_media_part(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf) -> map<string, unknown> {
+    load_var media
+    load_const true
+    call ai.wire.resolve_media
+    store_var resolved
+    load_type string
+    load_type unknown
+    alloc_map 0
+    store_var media_part
+    load_var resolved
+    load_field .url
+    store_var _5
+    load_var _5
+    narrow_bind string, slot=4
+    pop_jump_if_false L0
+    jump L2
+
+  L0:
+    load_type string
+    load_type unknown
+    alloc_map 0
+    store_var inline_data
+    load_type string
+    load_type unknown
+    load_var inline_data
+    load_const "mimeType"
+    load_var resolved
+    load_field .mime_type
+    call baml.Map.set
+    pop 1
+    load_var resolved
+    load_field .base64
+    store_var _27
+    load_var _27
+    store_var _26
+    load_var _27
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L1
+    load_const ""
+    store_var _26
+
+  L1:
+    load_type string
+    load_type unknown
+    load_var inline_data
+    load_const "data"
+    load_var _26
+    call baml.Map.set
+    pop 1
+    load_type string
+    load_type unknown
+    load_var media_part
+    load_const "inlineData"
+    load_var inline_data
+    call baml.Map.set
+    pop 1
+    jump L3
+
+  L2:
+    load_var _5
+    store_var url
+    load_type string
+    load_type unknown
+    alloc_map 0
+    store_var file_data
+    load_type string
+    load_type unknown
+    load_var file_data
+    load_const "mimeType"
+    load_var resolved
+    load_field .mime_type
+    call baml.Map.set
+    pop 1
+    load_type string
+    load_type unknown
+    load_var file_data
+    load_const "fileUri"
+    load_var url
+    call baml.Map.set
+    pop 1
+    load_type string
+    load_type unknown
+    load_var media_part
+    load_const "fileData"
+    load_var file_data
+    call baml.Map.set
+    pop 1
+
+  L3:
+    load_var media_part
+    return
+}
+
+function google.internal._gm_prompt_parts(message: ai.PromptMessage) -> map<string, unknown>[] {
+    load_type map<string, unknown>
+    alloc_array 0
+    store_var parts
+    load_var message
+    load_field .parts
+    load_type baml.iter.Iterable<Error = never, Item = string | baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _4
+
+  L0:
+    load_var _4
+    load_type baml.iter.Iterator<Error = never, Item = string | baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _5
+    load_var _5
+    is_type baml.iter.Done
+    pop_jump_if_false L1
+    jump L10
+
+  L1:
+    load_var _5
+    store_var part
+    load_var part
+    store_var _9
+    load_var _9
+    narrow_bind string, slot=6
+    pop_jump_if_false L2
+    jump L9
+
+  L2:
+    load_var part
+    store_var _14
+    load_var _14
+    narrow_bind baml.media.Image, slot=8
+    pop_jump_if_false L3
+    jump L8
+
+  L3:
+    load_var part
+    store_var _19
+    load_var _19
+    narrow_bind baml.media.Audio, slot=10
+    pop_jump_if_false L4
+    jump L7
+
+  L4:
+    load_var part
+    store_var _24
+    load_var _24
+    narrow_bind baml.media.Video, slot=12
+    pop_jump_if_false L5
+    jump L6
+
+  L5:
+    load_var part
+    call google.internal._gm_media_part
+    store_var _31
+    load_var2 2 14
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L6:
+    load_var _24
+    call google.internal._gm_media_part
+    store_var _27
+    load_var2 2 13
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L7:
+    load_var _19
+    call google.internal._gm_media_part
+    store_var _22
+    load_var2 2 11
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L8:
+    load_var _14
+    call google.internal._gm_media_part
+    store_var _17
+    load_var2 2 9
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L9:
+    load_var _9
+    call google.internal._gm_text_part
+    store_var _12
+    load_var2 2 7
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L10:
+    load_var parts
+    return
+}
+
 function google.internal._gm_text_part(text: string) -> map<string, unknown> {
     load_type string
     load_type unknown
@@ -7920,14 +9054,13 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
     load_var _7
     is_type baml.iter.Done
     pop_jump_if_false L1
-    jump L8
+    jump L10
 
   L1:
     load_var _7
     store_var_load_var message
-    load_field .content
-    call google.internal._gm_text_part
-    store_var part
+    call google.internal._gm_prompt_parts
+    store_var parts
     load_var message
     load_field .role
     load_const "system"
@@ -7961,23 +9094,39 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
     store_var first_role
 
   L6:
-    load_var2 9 8
-    load_type map<string, unknown>
-    alloc_array 1
+    load_var2 11 8
     call google.internal._gm_content
-    store_var _23
-    load_var2 3 10
+    store_var _29
+    load_var2 3 12
     call baml.Array.push
     pop 1
     jump L0
 
   L7:
-    load_var2 2 8
-    call baml.Array.push
-    pop 1
-    jump L0
+    load_var parts
+    load_type baml.iter.Iterable<Error = never, Item = map<string, unknown>>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _16
 
   L8:
+    load_var _16
+    load_type baml.iter.Iterator<Error = never, Item = map<string, unknown>>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _17
+    load_var _17
+    is_type baml.iter.Done
+    pop_jump_if_false L9
+    jump L0
+
+  L9:
+    load_var2 2 10
+    call baml.Array.push
+    pop 1
+    jump L8
+
+  L10:
     load_var2 2 3
     load_var first_role
     init_instance google.internal.GooglePrompt .system_parts, .contents, .first_role
@@ -8735,6 +9884,463 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
     return
 }
 
+function openai.internal._openai_prompt_content(message: ai.PromptMessage, role: string) -> map<string, unknown>[] {
+    load_type map<string, unknown>
+    alloc_array 0
+    store_var content
+    load_var message
+    load_field .parts
+    load_type baml.iter.Iterable<Error = never, Item = string | baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _5
+
+  L0:
+    load_var _5
+    load_type baml.iter.Iterator<Error = never, Item = string | baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _6
+    load_var _6
+    is_type baml.iter.Done
+    pop_jump_if_false L1
+    jump L41
+
+  L1:
+    load_var _6
+    store_var part
+    load_var part
+    store_var _10
+    load_var _10
+    narrow_bind string, slot=7
+    pop_jump_if_false L2
+    jump L37
+
+  L2:
+    load_var part
+    store_var _24
+    load_var _24
+    narrow_bind baml.media.Image, slot=11
+    pop_jump_if_false L3
+    jump L32
+
+  L3:
+    load_var part
+    store_var _56
+    load_var _56
+    narrow_bind baml.media.Audio, slot=22
+    pop_jump_if_false L4
+    jump L11
+
+  L4:
+    load_var part
+    store_var _98
+    load_var _98
+    narrow_bind baml.media.Pdf, slot=30
+    pop_jump_if_false L5
+    jump L6
+
+  L5:
+    load_const "OpenAI Responses does not support video prompt input"
+    init_instance baml.errors.InvalidArgument .message
+    throw
+
+  L6:
+    load_var _98
+    store_var pdf
+    load_var role
+    load_const "user"
+    cmp_op !=
+    pop_jump_if_false L7
+    jump L10
+
+  L7:
+    load_var pdf
+    load_const false
+    call ai.wire.resolve_media
+    store_var resolved
+    load_var resolved
+    load_field .url
+    store_var _108
+    load_var _108
+    store_var file_data
+    load_var _108
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L9
+    load_type string
+    load_var resolved
+    load_field .mime_type
+    call baml.String.from
+    store_var _112
+    load_var resolved
+    load_field .base64
+    store_var _117
+    load_var _117
+    store_var _116
+    load_var _117
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L8
+    load_const ""
+    store_var _116
+
+  L8:
+    load_type string
+    load_var _116
+    call baml.String.from
+    store_var _115
+    load_const "data:"
+    load_var _112
+    bin_op +
+    load_const ";base64,"
+    bin_op +
+    load_var _115
+    bin_op +
+    store_var file_data
+
+  L9:
+    load_type string
+    load_type unknown
+    alloc_map 0
+    store_var item
+    load_type string
+    load_type unknown
+    load_var item
+    load_const "type"
+    load_const "input_file"
+    call baml.Map.set
+    pop 1
+    load_type string
+    load_type unknown
+    load_var item
+    load_const "file_data"
+    load_var file_data
+    call baml.Map.set
+    pop 1
+    load_var2 3 40
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L10:
+    load_type string
+    load_var role
+    call baml.String.from
+    store_var _103
+    load_const "OpenAI Responses only supports PDF input in user messages, found "
+    load_var _103
+    bin_op +
+    init_instance baml.errors.InvalidArgument .message
+    throw
+
+  L11:
+    load_var _56
+    store_var audio
+    load_var role
+    load_const "user"
+    cmp_op !=
+    pop_jump_if_false L12
+    jump L31
+
+  L12:
+    load_var audio
+    load_const true
+    call ai.wire.resolve_media
+    store_var resolved
+    load_var resolved
+    load_field .mime_type
+    load_const "audio/wav"
+    cmp_op ==
+    jump_if_false L13
+    jump L14
+
+  L13:
+    pop 1
+    load_var resolved
+    load_field .mime_type
+    load_const "audio/x-wav"
+    cmp_op ==
+
+  L14:
+    pop_jump_if_false L15
+    jump L28
+
+  L15:
+    load_var resolved
+    load_field .mime_type
+    load_const "audio/mpeg"
+    cmp_op ==
+    jump_if_false L16
+    jump L17
+
+  L16:
+    pop 1
+    load_var resolved
+    load_field .mime_type
+    load_const "audio/mp3"
+    cmp_op ==
+
+  L17:
+    pop_jump_if_false L18
+    jump L27
+
+  L18:
+    load_var resolved
+    load_field .mime_type
+    load_const "audio/flac"
+    cmp_op ==
+    jump_if_false L19
+    jump L20
+
+  L19:
+    pop 1
+    load_var resolved
+    load_field .mime_type
+    load_const "audio/x-flac"
+    cmp_op ==
+
+  L20:
+    pop_jump_if_false L21
+    jump L26
+
+  L21:
+    load_var resolved
+    load_field .mime_type
+    load_const "audio/ogg"
+    cmp_op ==
+    pop_jump_if_false L22
+    jump L25
+
+  L22:
+    load_var resolved
+    load_field .mime_type
+    load_const "audio/webm"
+    cmp_op ==
+    pop_jump_if_false L23
+    jump L24
+
+  L23:
+    load_var resolved
+    load_field .mime_type
+    store_var format
+    jump L29
+
+  L24:
+    load_const "webm"
+    store_var format
+    jump L29
+
+  L25:
+    load_const "ogg"
+    store_var format
+    jump L29
+
+  L26:
+    load_const "flac"
+    store_var format
+    jump L29
+
+  L27:
+    load_const "mp3"
+    store_var format
+    jump L29
+
+  L28:
+    load_const "wav"
+    store_var format
+
+  L29:
+    load_type string
+    load_type unknown
+    alloc_map 0
+    store_var item
+    load_type string
+    load_type unknown
+    load_var item
+    load_const "type"
+    load_const "input_audio"
+    call baml.Map.set
+    pop 1
+    load_var resolved
+    load_field .base64
+    store_var _88
+    load_var _88
+    store_var _87
+    load_var _88
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L30
+    load_const ""
+    store_var _87
+
+  L30:
+    load_type string
+    load_type unknown
+    load_var item
+    load_const "data"
+    load_var _87
+    call baml.Map.set
+    pop 1
+    load_type string
+    load_type unknown
+    load_var item
+    load_const "format"
+    load_var format
+    call baml.Map.set
+    pop 1
+    load_var2 3 27
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L31:
+    load_type string
+    load_var role
+    call baml.String.from
+    store_var _61
+    load_const "OpenAI Responses only supports audio input in user messages, found "
+    load_var _61
+    bin_op +
+    init_instance baml.errors.InvalidArgument .message
+    throw
+
+  L32:
+    load_var _24
+    store_var image
+    load_var role
+    load_const "user"
+    cmp_op !=
+    pop_jump_if_false L33
+    jump L36
+
+  L33:
+    load_var image
+    load_const false
+    call ai.wire.resolve_media
+    store_var resolved
+    load_var resolved
+    load_field .url
+    store_var _34
+    load_var _34
+    store_var image_url
+    load_var _34
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L35
+    load_type string
+    load_var resolved
+    load_field .mime_type
+    call baml.String.from
+    store_var _38
+    load_var resolved
+    load_field .base64
+    store_var _43
+    load_var _43
+    store_var _42
+    load_var _43
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L34
+    load_const ""
+    store_var _42
+
+  L34:
+    load_type string
+    load_var _42
+    call baml.String.from
+    store_var _41
+    load_const "data:"
+    load_var _38
+    bin_op +
+    load_const ";base64,"
+    bin_op +
+    load_var _41
+    bin_op +
+    store_var image_url
+
+  L35:
+    load_type string
+    load_type unknown
+    alloc_map 0
+    store_var item
+    load_type string
+    load_type unknown
+    load_var item
+    load_const "type"
+    load_const "input_image"
+    call baml.Map.set
+    pop 1
+    load_type string
+    load_type unknown
+    load_var item
+    load_const "image_url"
+    load_var image_url
+    call baml.Map.set
+    pop 1
+    load_var2 3 21
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L36:
+    load_type string
+    load_var role
+    call baml.String.from
+    store_var _29
+    load_const "OpenAI Responses only supports image input in user messages, found "
+    load_var _29
+    bin_op +
+    init_instance baml.errors.InvalidArgument .message
+    throw
+
+  L37:
+    load_var _10
+    store_var text
+    load_type string
+    load_type unknown
+    alloc_map 0
+    store_var item
+    load_var role
+    load_const "assistant"
+    cmp_op ==
+    pop_jump_if_false L38
+    jump L39
+
+  L38:
+    load_const "input_text"
+    store_var _14
+    jump L40
+
+  L39:
+    load_const "output_text"
+    store_var _14
+
+  L40:
+    load_type string
+    load_type unknown
+    load_var item
+    load_const "type"
+    load_var _14
+    call baml.Map.set
+    pop 1
+    load_type string
+    load_type unknown
+    load_var item
+    load_const "text"
+    load_var text
+    call baml.Map.set
+    pop 1
+    load_var2 3 9
+    call baml.Array.push
+    pop 1
+    jump L0
+
+  L41:
+    load_var content
+    return
+}
+
 function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
     load_var input
     load_field .prompt
@@ -9338,12 +10944,14 @@ function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> map<string, u
     load_var role
     call baml.Map.set
     pop 1
+    load_var2 5 6
+    call openai.internal._openai_prompt_content
+    store_var _20
     load_type string
     load_type unknown
     load_var item
     load_const "content"
-    load_var message
-    load_field .content
+    load_var _20
     call baml.Map.set
     pop 1
     load_var2 2 7

--- a/baml_language/crates/baml_tests/tests/promptast_accessors.rs
+++ b/baml_language/crates/baml_tests/tests/promptast_accessors.rs
@@ -101,3 +101,36 @@ function main() -> ai.PromptMessage[] {
         other => panic!("expected a PromptMessage array, got {other:?}"),
     }
 }
+
+#[tokio::test]
+async fn message_parts_preserve_all_media_structurally() {
+    let output = run_string(
+        r#"
+function main() -> string {
+  let cc = baml.prompt.ContextClient { name: "c", provider: "openai", default_role: "user", allowed_roles: ["user"] }
+  let ctx = baml.prompt.Context { client: cc, tags: {} }
+  let img = image.from_url("https://example.com/photo.png", "image/png")
+  let sound = audio.from_url("https://example.com/sound.mp3", "audio/mpeg")
+  let movie = video.from_url("https://example.com/movie.mp4", "video/mp4")
+  let document = pdf.from_url("https://example.com/document.pdf", "application/pdf")
+  let render = prompt`before:${img}:${sound}:${movie}:${document}:after`
+  let kinds: string[] = []
+  for (let part in render(ctx).messages()[0].parts) {
+    match (part) {
+      let text: string => kinds.push(`text=${text}`),
+      let image: baml.media.Image => kinds.push(`image=${image.url() ?? ""}`),
+      let audio: baml.media.Audio => kinds.push(`audio=${audio.url() ?? ""}`),
+      let video: baml.media.Video => kinds.push(`video=${video.url() ?? ""}`),
+      let pdf: baml.media.Pdf => kinds.push(`pdf=${pdf.url() ?? ""}`),
+    };
+  }
+  kinds.join("|")
+}
+"#,
+    )
+    .await;
+    assert_eq!(
+        output,
+        "text=before:|image=https://example.com/photo.png|text=:|audio=https://example.com/sound.mp3|text=:|video=https://example.com/movie.mp4|text=:|pdf=https://example.com/document.pdf|text=:after"
+    );
+}

--- a/baml_language/crates/baml_tests/tests/structured_prompt_requests.rs
+++ b/baml_language/crates/baml_tests/tests/structured_prompt_requests.rs
@@ -32,6 +32,47 @@ function main() -> string {{
     serde_json::from_str(&body).expect("provider request body should be valid JSON")
 }
 
+async fn media_request_body(expr: &str, include_video: bool) -> serde_json::Value {
+    let video_parameter = if include_video { ", movie: video" } else { "" };
+    let video_prompt = if include_video { "${movie}" } else { "" };
+    let video_argument = if include_video {
+        r#", video.from_base64("video-data", "video/mp4")"#
+    } else {
+        ""
+    };
+    let source = format!(
+        r#"
+function MediaShape(photo: image, sound: audio, document: pdf{video_parameter}) -> string {{
+  client "google/gemini-2.5-flash"
+  tools []
+  prompt `${{role("user")}}Inspect:${{photo}}:${{sound}}:${{document}}:{video_prompt}`
+}}
+
+function main() -> string {{
+  let spec = MediaShape$spec(
+    image.from_base64("image-data", "image/png"),
+    audio.from_base64("audio-data", "audio/mpeg"),
+    pdf.from_base64("pdf-data", "application/pdf")
+    {video_argument}
+  )
+  let input = ai.ModelTurnInput {{
+    prompt: spec.prompt_template,
+    journal: ai.Journal {{ log: [] }},
+    toolbox: ai.tools.Toolbox.new([]),
+    output_type: reflect.type_of<string>(),
+  }}
+  {expr}.body
+}}
+"#
+    );
+    let output = baml_test!(&source);
+    let body = match output.result {
+        Ok(BexExternalValue::String(body)) => body.to_string(),
+        other => panic!("expected a media request body string, got {other:?}"),
+    };
+    serde_json::from_str(&body).expect("provider media request body should be valid JSON")
+}
+
 #[tokio::test]
 async fn openai_preserves_prompt_message_roles() {
     let body = request_body(
@@ -44,10 +85,11 @@ async fn openai_preserves_prompt_message_roles() {
     let input = body["input"].as_array().expect("OpenAI input array");
     assert_eq!(input.len(), 2);
     assert_eq!(input[0]["role"], "system");
-    assert_eq!(input[0]["content"], "Follow the rules.");
+    assert_eq!(input[0]["content"][0]["type"], "input_text");
+    assert_eq!(input[0]["content"][0]["text"], "Follow the rules.");
     assert_eq!(input[1]["role"], "user");
     assert!(
-        input[1]["content"]
+        input[1]["content"][0]["text"]
             .as_str()
             .expect("user prompt text")
             .starts_with("Answer this.")
@@ -96,4 +138,89 @@ async fn google_splits_system_and_maps_user_prompt() {
             .expect("Gemini user text")
             .starts_with("Answer this.")
     );
+}
+
+#[tokio::test]
+async fn openai_lowers_image_audio_and_pdf_parts() {
+    let body = media_request_body(
+        r#"openai.internal.openai_render(
+    openai.OpenAiClient.new(model = "gpt-test", api_key = "test-key"),
+    input,
+  )"#,
+        false,
+    )
+    .await;
+    let parts = body["input"][0]["content"]
+        .as_array()
+        .expect("OpenAI content parts");
+    let by_type = |kind: &str| {
+        parts
+            .iter()
+            .find(|part| part["type"] == kind)
+            .unwrap_or_else(|| panic!("missing OpenAI {kind} part: {parts:?}"))
+    };
+    assert_eq!(
+        by_type("input_image")["image_url"],
+        "data:image/png;base64,image-data"
+    );
+    assert_eq!(by_type("input_audio")["data"], "audio-data");
+    assert_eq!(by_type("input_audio")["format"], "mp3");
+    assert_eq!(
+        by_type("input_file")["file_data"],
+        "data:application/pdf;base64,pdf-data"
+    );
+}
+
+#[tokio::test]
+async fn anthropic_lowers_image_audio_and_pdf_parts() {
+    let body = media_request_body(
+        r#"anthropic.internal._anthropic_request(
+    anthropic.AnthropicClient.new(model = "claude-test", api_key = "test-key"),
+    input,
+    false,
+  )"#,
+        false,
+    )
+    .await;
+    let parts = body["messages"][0]["content"]
+        .as_array()
+        .expect("Anthropic content parts");
+    let by_type = |kind: &str| {
+        parts
+            .iter()
+            .find(|part| part["type"] == kind)
+            .unwrap_or_else(|| panic!("missing Anthropic {kind} part: {parts:?}"))
+    };
+    assert_eq!(by_type("image")["source"]["type"], "base64");
+    assert_eq!(by_type("image")["source"]["data"], "image-data");
+    assert_eq!(by_type("input_audio")["source"]["data"], "audio-data");
+    assert_eq!(by_type("document")["source"]["data"], "pdf-data");
+}
+
+#[tokio::test]
+async fn google_lowers_every_supported_media_part() {
+    let body = media_request_body(
+        r#"google.internal.google_render(
+    google.GoogleClient.new(model = "gemini-test", api_key = "test-key"),
+    input,
+  )"#,
+        true,
+    )
+    .await;
+    let parts = body["contents"][0]["parts"]
+        .as_array()
+        .expect("Gemini content parts");
+    let inline_parts: Vec<_> = parts
+        .iter()
+        .filter_map(|part| part.get("inlineData"))
+        .collect();
+    assert_eq!(inline_parts.len(), 4, "Gemini media parts: {parts:?}");
+    assert_eq!(inline_parts[0]["mimeType"], "image/png");
+    assert_eq!(inline_parts[0]["data"], "image-data");
+    assert_eq!(inline_parts[1]["mimeType"], "audio/mpeg");
+    assert_eq!(inline_parts[1]["data"], "audio-data");
+    assert_eq!(inline_parts[2]["mimeType"], "application/pdf");
+    assert_eq!(inline_parts[2]["data"], "pdf-data");
+    assert_eq!(inline_parts[3]["mimeType"], "video/mp4");
+    assert_eq!(inline_parts[3]["data"], "video-data");
 }

--- a/baml_language/crates/bex_vm/src/package_baml/prompt.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/prompt.rs
@@ -222,17 +222,43 @@ impl BamlClassPrompt for PackageAiImpl {
             let data = instance.load_field(0);
             vm.as_rust_data::<PromptAst>(&data)
                 .expect("ai.Prompt._data must contain baml_builtins2::PromptAst")
-                .to_messages()
+                .to_structured_messages()
         };
         let message_class = vm.resolve_class("ai.PromptMessage");
         messages
             .into_iter()
             .map(|(role, content)| {
                 let role = Value::object(vm.alloc_string(role));
-                let content = Value::object(vm.alloc_string(content));
-                Value::object(vm.alloc_instance(message_class, vec![role, content]))
+                let readable = Value::object(vm.alloc_string(content.to_text()));
+                let parts = prompt_content_values(vm, content.as_ref());
+                let parts = Value::object(vm.alloc_array(baml_type::RealizedTy::unknown(), parts));
+                Value::object(vm.alloc_instance(message_class, vec![role, readable, parts]))
             })
             .collect()
+    }
+}
+
+fn prompt_content_values(vm: &mut BexVm, content: &PromptAstSimple) -> Vec<Value> {
+    match content {
+        PromptAstSimple::String(text) => vec![Value::object(vm.alloc_string(text.clone()))],
+        PromptAstSimple::Media(media) => {
+            let class_name = match media.kind {
+                baml_type::MediaKind::Image => "baml.media.Image",
+                baml_type::MediaKind::Audio => "baml.media.Audio",
+                baml_type::MediaKind::Video => "baml.media.Video",
+                baml_type::MediaKind::Pdf => "baml.media.Pdf",
+                baml_type::MediaKind::Generic => {
+                    panic!("generic media cannot inhabit a concrete prompt part")
+                }
+            };
+            let class = vm.resolve_class(class_name);
+            let data = Value::object(vm.alloc_rust_data(media.clone()));
+            vec![Value::object(vm.alloc_instance(class, vec![data]))]
+        }
+        PromptAstSimple::Multiple(parts) => parts
+            .iter()
+            .flat_map(|part| prompt_content_values(vm, part.as_ref()))
+            .collect(),
     }
 }
 


### PR DESCRIPTION
## What changed

- Preserve structured prompt parts through `ai.Prompt.messages()` instead of flattening media into readable placeholders.
- Resolve local files, base64/data URLs, HTTP URLs, MIME types, and Google Cloud URLs before provider lowering.
- Lower image, audio, PDF, and video inputs into the native OpenAI Responses, Anthropic Messages, and Gemini request shapes.
- Match `sys_llm` provider capabilities: Gemini supports all four media kinds; OpenAI and Anthropic support image/audio/PDF and return an explicit error for video.
- Add structural prompt and provider request-body regression coverage, including Gemini video.

## Why

The new stdlib clients consumed the readable `PromptMessage.content` projection. That converted BAML media values into placeholder text before provider request construction, so LLM functions with `image`, `audio`, `video`, or `pdf` inputs could not send the media to the model. The clients now consume ordered structural prompt parts and lower each media value at the provider boundary.

## Impact

BAML LLM functions using media input types now work through the new stdlib provider clients. Existing readable prompt inspection remains unchanged through `PromptMessage.content` and `Prompt.text()`.

## Validation

- `cargo fmt --all -- --check`
- `cargo nextest run -p baml_tests -E 'test(~__ai_std__)'`
- `cargo nextest run -p baml_tests --test promptast_accessors --test structured_prompt_requests`
- `cargo nextest run -p baml_builtins2 -p bex_vm`
- Live local-image test with Infisical through OpenAI, then Gemini

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes provider request construction and media resolution (file I/O and HTTP fetches) across OpenAI, Anthropic, and Gemini clients. Readable prompt inspection is unchanged, but incorrect lowering could send malformed multimodal payloads.
> 
> **Overview**
> **Media inputs now reach the model** through stdlib LLM clients instead of being flattened into readable placeholders before request construction.
> 
> `PromptMessage` gains a structural `parts` field (`string | MediaPart`). Rust `PromptAst` exposes `to_structured_messages()` so media survives `messages()`, while `content` / `text()` stay as the readable projection.
> 
> Adds shared `ai.wire.resolve_media` to resolve local files, base64/data URLs, HTTP(S) fetches, MIME types, and `gs://` URLs before provider lowering.
> 
> OpenAI Responses, Anthropic Messages, and Gemini now lower those parts into native request shapes. Gemini accepts all four media kinds; OpenAI and Anthropic accept image/audio/PDF and reject video.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf12bcd4bed607836e25c008953ca09b8a434881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->