### PR TITLE
test(python): cover bridge version mismatch diagnostic

### DIFF
--- a/baml_language/sdks/python/tests/test_engine.py
+++ b/baml_language/sdks/python/tests/test_engine.py
@@ -21,6 +21,8 @@ from baml_bridge import (
     BamlRuntime,
     FunctionResult,
     HostSpanManager,
+    get_bridge_runtime_version,
+    get_toolchain_version,
     get_version,
     call_function,
     call_function_sync,
@@ -167,6 +169,36 @@ class TestBasics:
             ".", {"empty.baml": ""}
         )
         assert rt is not None
+
+    def test_generated_bytecode_version_skew_fails_before_deserialization(self):
+        """Generated SDK imports report bridge skew instead of a bytecode panic."""
+        generated_toolchain = "999.0.0"
+        embedded_baml_toml = f"""\
+[package]
+name = "version-skew-test"
+
+[__baml_codegen]
+metadata_version = 1
+
+[__baml_codegen.toolchain]
+version = "{generated_toolchain}"
+"""
+
+        with pytest.raises(RuntimeError) as exc_info:
+            BamlRuntime.initialize_runtime_from_bytecode(
+                b"\x00", embedded_baml_toml
+            )
+
+        message = str(exc_info.value)
+        assert message.startswith("BAML startup failed: version skew error.")
+        assert f"generated using BAML toolchain {generated_toolchain}" in message
+        assert f"baml-bridge is installed at {get_bridge_runtime_version()}" in message
+        assert (
+            "expects baml_sdk to be generated using BAML toolchain "
+            f"{get_toolchain_version()}" in message
+        )
+        assert "Re-run `baml generate`" in message
+        assert "Failed to deserialize BAML bytecode" not in message
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- add Python integration coverage for generated-bytecode toolchain mismatches
- verify the complete bridge identity diagnostic survives the PyO3 boundary
- verify compatibility validation runs before bytecode deserialization

## Root cause and relation to #4315

The B-1473 report used generator `0.15.1-nightly.20260731.a` with `baml_bridge==0.15.0`. That generator predates #4315 and emitted only raw bytecode, so the bridge had no independently readable generator identity and surfaced `Unexpected variant tag: 7`.

#4315 already fixed the supported regenerated-SDK path by embedding generation metadata and validating it before deserialization. Current coverage tests metadata emission and core `bridge_cffi` diagnostics separately; this PR closes the remaining Python host-boundary gap.

Legacy SDKs generated before #4315 must be regenerated to gain the compatibility preflight because their raw-bytecode-only payload has no toolchain identity to inspect.

## Controlled reproduction

| State | Generator | Installed Python bridge | Result |
| --- | --- | --- | --- |
| Before #4315 | `0.15.1-nightly.20260731.a` | `0.15.0` | Reproduces `BamlPanic: Failed to deserialize BAML bytecode: Unexpected variant tag: 7` |
| With #4315 | `0.16.0` | `0.15.1.dev2026080700` | Raises an actionable version-skew `RuntimeError` before deserialization with generated, installed, and required versions plus repair guidance |

## Validation

- `uv run pytest -n 0 tests/test_engine.py::TestBasics -q` — 4 passed, 1 expected xfail
- `cargo test -p bridge_cffi generated_metadata_tests` — 5 passed
- `uv run ruff check tests/test_engine.py`
- `git diff --check`

Linear: B-1473

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime handling of bytecode generated with an incompatible toolchain.
  * Displays a clear version-mismatch error with installed and expected versions instead of an initialization failure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->