### PR TITLE
fix(jetbrains): use supported TextMate handoff

### DIFF
--- a/jetbrains/src/main/kotlin/com/boundaryml/jetbrains_ext/BamlFileType.kt
+++ b/jetbrains/src/main/kotlin/com/boundaryml/jetbrains_ext/BamlFileType.kt
@@ -1,6 +1,7 @@
 package com.boundaryml.jetbrains_ext
 
 import com.intellij.openapi.fileTypes.LanguageFileType
+import org.jetbrains.plugins.textmate.TextMateBackedFileType
 import javax.swing.Icon
 
 /**
@@ -8,7 +9,7 @@ import javax.swing.Icon
  *
  * @see [Language and File Type](https://plugins.jetbrains.com/docs/intellij/language-and-filetype.html)
  */
-class BamlFileType private constructor() : LanguageFileType(BamlLanguage) {
+class BamlFileType private constructor() : LanguageFileType(BamlLanguage), TextMateBackedFileType {
 
     companion object {
         val INSTANCE: BamlFileType = BamlFileType()

--- a/jetbrains/src/main/resources/META-INF/plugin.xml
+++ b/jetbrains/src/main/resources/META-INF/plugin.xml
@@ -46,16 +46,9 @@
 
         <textmate.bundleProvider implementation="com.boundaryml.jetbrains_ext.BamlTextMateBundleProvider" />
         <!--
-          We have to explicitly register textmate as the highlight provider because of a bug in how jetbrains textmate
-          works (and it's incredibly poorly documented). See jetbrains-plugin-fss for prior art
-          https://github.com/qligier/jetbrains-plugin-fss/blob/905622be4058fda8014f874af4acae46f24cc556/src/main/resources/META-INF/plugin.xml#L51-L53
+          BamlFileType implements TextMateBackedFileType, allowing TextMate's file type detector to select its own
+          highlighter for files recognized by the bundle without referencing TextMate implementation classes here.
         -->
-        <editorHighlighterProvider
-                filetype="BAML"
-                implementationClass="org.jetbrains.plugins.textmate.language.syntax.highlighting.TextMateEditorHighlighterProvider"/>
-        <lang.syntaxHighlighterFactory
-                language="baml"
-                implementationClass="org.jetbrains.plugins.textmate.language.syntax.highlighting.TextMateSyntaxHighlighterFactory"/>
 
     </extensions>
 

--- a/jetbrains/src/test/kotlin/com/boundaryml/jetbrains_ext/BamlPluginTest.kt
+++ b/jetbrains/src/test/kotlin/com/boundaryml/jetbrains_ext/BamlPluginTest.kt
@@ -6,6 +6,10 @@ import com.intellij.psi.xml.XmlFile
 import com.intellij.testFramework.TestDataPath
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.PsiErrorElementUtil
+import org.jetbrains.plugins.textmate.TextMateBackedFileType
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.xpath.XPathConstants
+import javax.xml.xpath.XPathFactory
 
 @TestDataPath("\$CONTENT_ROOT/src/test/testData")
 class BamlPluginTest : BasePlatformTestCase() {
@@ -32,6 +36,30 @@ class BamlPluginTest : BasePlatformTestCase() {
 //        val projectService = project.service<BamlProjectService>()
 //
 //        assertNotSame(projectService.getRandomNumber(), projectService.getRandomNumber())
+    }
+
+    fun testTextMateDescriptorUsesSupportedHandoff() {
+        assertInstanceOf(BamlFileType.INSTANCE, TextMateBackedFileType::class.java)
+
+        val pluginDescriptor = requireNotNull(javaClass.classLoader.getResourceAsStream("META-INF/plugin.xml"))
+            .use { DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(it) }
+        val xpath = XPathFactory.newInstance().newXPath()
+
+        // This element is added by patchPluginXml, proving this test inspects Gradle's packaged descriptor rather than
+        // the source XML.
+        assertEquals("242", xpath.evaluate("string(/idea-plugin/idea-version/@since-build)", pluginDescriptor))
+        assertEquals(
+            BamlTextMateBundleProvider::class.java.name,
+            xpath.evaluate("string(/idea-plugin/extensions/textmate.bundleProvider/@implementation)", pluginDescriptor),
+        )
+        assertEquals(
+            0.0,
+            xpath.evaluate(
+                "count(/idea-plugin/extensions/*[starts-with(@implementation, 'org.jetbrains.plugins.textmate.') or starts-with(@implementationClass, 'org.jetbrains.plugins.textmate.')])",
+                pluginDescriptor,
+                XPathConstants.NUMBER,
+            ),
+        )
     }
 
     override fun getTestDataPath() = "src/test/testData/rename"


### PR DESCRIPTION
## What changed

- mark `BamlFileType` with IntelliJ's public `TextMateBackedFileType` contract
- retain the public BAML `textmate.bundleProvider` registration and packaged grammar
- remove direct descriptor registrations of two `org.jetbrains.plugins.textmate.*` implementation classes
- add descriptor-level regression coverage against Gradle's patched plugin descriptor

## Why

JetBrains Marketplace rejected 0.225.0 for using an internal API even though the release workflow uploaded successfully. Standalone Plugin Verifier does not report an internal API usage because it analyzes bytecode and does not treat implementation class names in plugin XML as API calls. The direct foreign implementation-class registrations are therefore the likely Marketplace rejection path, but that remains an inference because the Marketplace review detail is not accessible.

`TextMateBackedFileType` is IntelliJ's supported handoff for a plugin-owned file type backed by a TextMate bundle. At the plugin's declared minimum and current release target, IC 2024.2.5 (`IC-242.24807.4`), it is a public interface with no internal or experimental annotation. The plugin has no `until-build`, so this claim is intentionally limited to the declared minimum/exact release target rather than every future IDE build.

## Validation

- focused descriptor regression test passes
- changed plugin ZIP builds successfully
- packaged descriptor retains `textmate.bundleProvider`, contains `since-build=242`, and has no foreign TextMate implementation registrations
- Plugin Verifier 1.409 against IC-242.24807.4: changed 0.225.0 is compatible, 0 internal API usages, 6 experimental LSP4IJ usages
- identical verifier/IDE comparison against approved 0.219.0: compatible with the exact same 6 experimental LSP4IJ usages

Linear: B-1518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved BAML syntax highlighting integration with IntelliJ’s supported TextMate-based highlighting.

* **Bug Fixes**
  * Updated plugin configuration to use the supported TextMate handoff, improving compatibility with newer IntelliJ versions.

* **Tests**
  * Added validation to ensure the packaged plugin uses the correct TextMate configuration and compatibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->