### PR TITLE
test: fix flaky pack tests with nextest setup

### DIFF
--- a/baml_language/.config/nextest.toml
+++ b/baml_language/.config/nextest.toml
@@ -114,6 +114,27 @@ filter = 'package(=baml_bridge)'
 platform = { host = 'cfg(windows)' }
 setup = 'rust_bridge_engine_win'
 
+# `pack_e2e` needs the `baml-pack-host` executable from another Cargo package.
+# Build it once before nextest fans the individual cases out into separate
+# processes. The setup scripts mark matching tests through NEXTEST_ENV, so the
+# test helper validates the prebuilt sibling instead of recursively invoking
+# Cargo once per case. Plain `cargo test` retains its one-process fallback.
+[scripts.setup.baml_pack_host_unix]
+command = './crates/baml_cli/tests/build-pack-host.sh'
+
+[scripts.setup.baml_pack_host_win]
+command = ['powershell', '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', './crates/baml_cli/tests/build-pack-host.ps1']
+
+[[profile.default.scripts]]
+filter = 'binary(=pack_e2e)'
+platform = { host = 'cfg(unix)' }
+setup = 'baml_pack_host_unix'
+
+[[profile.default.scripts]]
+filter = 'binary(=pack_e2e)'
+platform = { host = 'cfg(windows)' }
+setup = 'baml_pack_host_win'
+
 # java tests need the shared Gradle home staged (and, once the Java
 # bridge lands, the native bridge library built + per-fixture Gradle
 # dependency resolution warmed). fire only when a java sdk-test is

--- a/baml_language/crates/baml_cli/tests/build-pack-host.ps1
+++ b/baml_language/crates/baml_cli/tests/build-pack-host.ps1
@@ -1,0 +1,45 @@
+# Build the native pack host once before nextest runs the pack_e2e cases in
+# separate processes. Cargo has already built baml-cli by setup time, so its
+# profile directory tells us which host artifact the tests need as a sibling.
+
+$ErrorActionPreference = "Stop"
+
+$workspaceRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..\..")).Path
+Set-Location $workspaceRoot
+
+if ($env:CARGO_TARGET_DIR) {
+    if ([System.IO.Path]::IsPathRooted($env:CARGO_TARGET_DIR)) {
+        $targetDir = $env:CARGO_TARGET_DIR
+    } else {
+        $targetDir = Join-Path $workspaceRoot $env:CARGO_TARGET_DIR
+    }
+} else {
+    $targetDir = Join-Path $workspaceRoot "target"
+}
+
+$built = $false
+if (Test-Path (Join-Path $targetDir "debug\baml-cli.exe")) {
+    Write-Host "==> cargo build -p baml_pack_host (nextest pack_e2e setup)"
+    cargo build -p baml_pack_host
+    if ($LASTEXITCODE -ne 0) {
+        throw "cargo build -p baml_pack_host failed with exit code $LASTEXITCODE"
+    }
+    $built = $true
+}
+if (Test-Path (Join-Path $targetDir "release\baml-cli.exe")) {
+    Write-Host "==> cargo build -p baml_pack_host --release (nextest pack_e2e setup)"
+    cargo build -p baml_pack_host --release
+    if ($LASTEXITCODE -ne 0) {
+        throw "cargo build -p baml_pack_host --release failed with exit code $LASTEXITCODE"
+    }
+    $built = $true
+}
+
+if (-not $built) {
+    throw "baml-cli.exe was not found under $targetDir\debug or $targetDir\release"
+}
+if (-not $env:NEXTEST_ENV) {
+    throw "nextest did not provide NEXTEST_ENV"
+}
+
+Add-Content -LiteralPath $env:NEXTEST_ENV -Value "BAML_PACK_HOST_PREBUILT=1"

--- a/baml_language/crates/baml_cli/tests/build-pack-host.sh
+++ b/baml_language/crates/baml_cli/tests/build-pack-host.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Build the native pack host once before nextest runs the pack_e2e cases in
+# separate processes. Cargo has already built baml-cli by setup time, so its
+# profile directory tells us which host artifact the tests need as a sibling.
+
+set -euo pipefail
+
+workspace_root="$(cd "$(dirname "$0")/../../.." && pwd -P)"
+cd "$workspace_root"
+
+if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+  if [[ "$CARGO_TARGET_DIR" = /* ]]; then
+    target_dir="$CARGO_TARGET_DIR"
+  else
+    target_dir="$workspace_root/$CARGO_TARGET_DIR"
+  fi
+else
+  target_dir="$workspace_root/target"
+fi
+
+built=0
+if [[ -x "$target_dir/debug/baml-cli" ]]; then
+  echo "==> cargo build -p baml_pack_host (nextest pack_e2e setup)"
+  cargo build -p baml_pack_host
+  built=1
+fi
+if [[ -x "$target_dir/release/baml-cli" ]]; then
+  echo "==> cargo build -p baml_pack_host --release (nextest pack_e2e setup)"
+  cargo build -p baml_pack_host --release
+  built=1
+fi
+
+if [[ "$built" -eq 0 ]]; then
+  echo "baml-cli was not found in $target_dir/debug or $target_dir/release" >&2
+  exit 1
+fi
+
+: "${NEXTEST_ENV:?nextest did not provide NEXTEST_ENV}"
+printf 'BAML_PACK_HOST_PREBUILT=1\n' >> "$NEXTEST_ENV"

--- a/baml_language/crates/baml_cli/tests/common/mod.rs
+++ b/baml_language/crates/baml_cli/tests/common/mod.rs
@@ -23,15 +23,16 @@
 // path for free. The *right* fix is cargo's artifact dependencies (RFC 3028):
 //
 //     [dev-dependencies]
-//     baml_pack_host = { workspace = true, artifact = "bin" }
+//     baml_pack_host = { workspace = true, artifact = "bin:baml-pack-host" }
 //
-// With that, `env!("CARGO_BIN_FILE_baml_pack_host_baml-pack-host")` would give
-// us the binary path, cargo would handle rebuilds, and we'd delete the runtime
-// build below. But `artifact = "bin"` requires `-Z bindeps` and is nightly-only
-// as of Rust 1.93 (2026-01). The workspace is pinned to stable, so until that
-// stabilizes we shell out to `cargo build -p baml_pack_host` from inside the
-// test (real cargo freshness tracking, no new dev-deps). `baml pack` locates
-// the host as a sibling of the running `baml-cli`, so we build it into the same
+// With that, `env!("CARGO_BIN_FILE_BAML_PACK_HOST_baml-pack-host")` would give
+// us the binary path, cargo would handle rebuilds, and we'd delete the setup
+// below. But `artifact = "bin"` requires `-Z bindeps` and is nightly-only as of
+// Rust 1.93 (2026-01). The workspace is pinned to stable, so nextest runs one
+// filtered setup script that builds the host before it launches any test case.
+// Plain `cargo test` has no setup-script facility; its single test process uses
+// the fallback build in [`ensure_built`]. `baml pack` locates the host as a
+// sibling of the running `baml-cli`, so both paths build it into the same
 // `target/<profile>` directory `env!` points at.
 
 #![allow(dead_code)] // Shared helpers; individual tests use a subset.
@@ -39,8 +40,9 @@
 
 use std::{path::PathBuf, process::Command, sync::OnceLock};
 
-/// Memoized build: `cargo build -p baml_pack_host` runs at most once per test
-/// binary regardless of how many tests call in.
+/// Memoized host discovery for this test process. Nextest's filtered setup
+/// script prebuilds the host once for the whole run; plain `cargo test` falls
+/// back to one build shared by every case in its single process.
 static BUILT: OnceLock<BuiltPaths> = OnceLock::new();
 
 #[derive(Clone, Debug)]
@@ -90,23 +92,24 @@ pub fn ensure_built() -> &'static BuiltPaths {
             .expect("CARGO_BIN_EXE_baml-cli should have a parent directory")
             .to_path_buf();
 
-        // Build `baml-pack-host` for the same profile the test binary uses —
-        // otherwise `cargo test --release` would build into `target/debug` while
-        // `env!` resolves `baml-cli` from `target/release`, and the two would not
-        // be siblings.
-        let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
-        let mut build = Command::new(&cargo);
-        build.args(["build", "-p", "baml_pack_host"]);
-        if profile() == "release" {
-            build.arg("--release");
-        }
-        let status = build.status().expect("spawn cargo build");
-        assert!(
-            status.success(),
-            "cargo build for baml_pack_host failed — see output above",
-        );
-
         let baml_pack_host = bin_dir.join(bin_name("baml-pack-host"));
+        let setup_prebuilt = std::env::var("BAML_PACK_HOST_PREBUILT").is_ok_and(|v| v == "1");
+        if !setup_prebuilt {
+            // Plain `cargo test` does not run nextest setup scripts. Build the
+            // host for the same profile as the test binary once per process.
+            let cargo = std::env::var("CARGO").unwrap_or_else(|_| "cargo".to_string());
+            let mut build = Command::new(&cargo);
+            build.args(["build", "-p", "baml_pack_host"]);
+            if profile() == "release" {
+                build.arg("--release");
+            }
+            let status = build.status().expect("spawn cargo build");
+            assert!(
+                status.success(),
+                "cargo build for baml_pack_host failed — see output above",
+            );
+        }
+
         assert!(
             baml_cli.exists(),
             "baml-cli not found at {} (CARGO_BIN_EXE_baml-cli)",
@@ -114,7 +117,7 @@ pub fn ensure_built() -> &'static BuiltPaths {
         );
         assert!(
             baml_pack_host.exists(),
-            "baml-pack-host not found at {} after build",
+            "baml-pack-host not found at {}; nextest setup or the plain cargo-test fallback should have built it",
             baml_pack_host.display()
         );
         BuiltPaths {


### PR DESCRIPTION
## Summary

Fix flaky `pack_e2e` tests by building `baml-pack-host` once in a filtered nextest setup step before the test cases fan out.

The setup scripts place the host beside `baml-cli` and export `BAML_PACK_HOST_PREBUILT=1` through `NEXTEST_ENV`. Each nextest process then validates and uses that prepared binary instead of launching Cargo recursively. Plain `cargo test` retains a one-process fallback.

## Problem

Each pack test needs the `baml-pack-host` executable from another workspace package. The test helper previously ran `cargo build -p baml_pack_host` behind a process-local `OnceLock`.

That works under plain `cargo test`, where all cases share one integration-test process. Nextest launches each case in a separate process, so every case received its own `OnceLock` and recursively launched Cargo. Those Cargo processes contended on workspace and target locks before fanning out into concurrent pack work, making the suite flaky.

This signature appeared in [the debug-output case](https://github.com/BoundaryML/baml/actions/runs/31633454299/job/94238256447) and [the JSON-output case](https://github.com/BoundaryML/baml/actions/runs/31635586472/job/94250485066). Both local host builds completed successfully, so these failures were separate from the contemporaneous GitHub Releases download outages.

## Fix

- Add Unix and Windows setup scripts that build `baml-pack-host` once for the same debug or release profile as `baml-cli`.
- Attach those scripts to `binary(=pack_e2e)` through nextest’s filtered setup configuration.
- Propagate a setup marker through `NEXTEST_ENV`, preventing recursive Cargo calls from individual nextest processes.
- Preserve the process-local build fallback for plain `cargo test`.
- Keep pack cases parallel after the prerequisite build completes.

## Validation

- [Full Language CI](https://github.com/BoundaryML/baml/actions/runs/31650105851) passed without reruns.
- [Linux snapshot tests](https://github.com/BoundaryML/baml/actions/runs/31650105851/job/94292451412) ran exactly one `baml_pack_host_unix` setup, then passed all eight `pack_e2e` cases in parallel.
- [Windows Cargo tests](https://github.com/BoundaryML/baml/actions/runs/31650105851/job/94292451305) passed all eight pack cases through the plain-Cargo fallback.
- [Musl Cargo tests](https://github.com/BoundaryML/baml/actions/runs/31650105851/job/94292451385) passed the plain-Cargo pack coverage.
- Local nextest coverage passed 8/8 with one setup invocation.
- `cargo fmt --check -p baml_cli`, shell syntax validation, and `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test setup by prebuilding the required pack host before tests run.
  * Added support for both Unix and Windows environments.
  * Preserved a fallback build path for standard `cargo test` runs.
  * Enhanced error messages when the required test executable cannot be built or found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->