### PR TITLE
chore: rename BexMulitProject to BexMultiProject

### DIFF
--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/mod.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/mod.rs
@@ -233,7 +233,7 @@ type SemanticTokensCache = std::sync::Arc<
 >;
 
 #[derive(Clone)]
-struct BexMulitProject {
+struct BexMultiProject {
     projects:
         std::sync::Arc<std::sync::Mutex<HashMap<crate::fs::FsPath, std::sync::Arc<LiveProject>>>>,
     sys_op_factory: SysOpFactory,
@@ -349,7 +349,7 @@ enum ProjectRefreshMode {
     ClosedDocuments(Vec<vfs::VfsPath>),
 }
 
-impl BexMulitProject {
+impl BexMultiProject {
     fn new(
         sys_op_factory: SysOpFactory,
         sender: std::sync::Arc<dyn LspClientSenderTrait + Send + Sync>,
@@ -1826,7 +1826,7 @@ fn ensure_source_belongs_to_project(
         }
         expected_root = project_root.as_str().to_string();
     } else {
-        let source_root = BexMulitProject::project_source_root(project_root)?;
+        let source_root = BexMultiProject::project_source_root(project_root)?;
         expected_root = source_root.as_str().to_string();
         let root = source_root.as_str().trim_end_matches('/');
         let source = source_path.as_str();
@@ -1846,7 +1846,7 @@ fn ensure_source_belongs_to_project(
 }
 
 #[async_trait::async_trait]
-impl super::BexLsp for BexMulitProject {
+impl super::BexLsp for BexMultiProject {
     fn new_lsp_session(
         &self,
         sender: Arc<dyn LspClientSenderTrait + Send + Sync>,
@@ -2199,7 +2199,7 @@ pub fn new_lsp(
     fs: crate::fs::BamlVFS,
     spawner: BackgroundSpawner,
 ) -> impl crate::bex_lsp::BexLsp {
-    BexMulitProject::new(sys_op_factory, sender, playground_sender, fs, spawner)
+    BexMultiProject::new(sys_op_factory, sender, playground_sender, fs, spawner)
 }
 
 #[cfg(test)]
@@ -2258,10 +2258,10 @@ mod tests {
         ws.file("baml_language/case.baml", "// standalone");
         let file = ws.vfs_path("baml_language/case.baml");
 
-        let lenient = BexMulitProject::get_baml_project_root(&file).unwrap();
+        let lenient = BexMultiProject::get_baml_project_root(&file).unwrap();
         assert_eq!(lenient.as_str(), file.as_str());
 
-        let strict = BexMulitProject::get_marked_baml_project_root(&file);
+        let strict = BexMultiProject::get_marked_baml_project_root(&file);
         assert!(matches!(strict, Err(LspError::ProjectRootNotFound(..))));
     }
 
@@ -2271,7 +2271,7 @@ mod tests {
         ws.file("proj/baml_src/main.baml", "// main");
         let file = ws.vfs_path("proj/baml_src/main.baml");
 
-        let root = BexMulitProject::get_marked_baml_project_root(&file).unwrap();
+        let root = BexMultiProject::get_marked_baml_project_root(&file).unwrap();
         assert_eq!(root.as_str(), ws.vfs_path("proj").as_str());
     }
 
@@ -2283,7 +2283,7 @@ mod tests {
         ws.dir("node_modules/pkg/baml_src");
         ws.dir(".hidden/baml_src");
 
-        let found = BexMulitProject::scan_marked_project_roots_native(&ws.root);
+        let found = BexMultiProject::scan_marked_project_roots_native(&ws.root);
         assert_eq!(
             found,
             vec![ws.root.join("proj")],
@@ -2300,7 +2300,7 @@ mod tests {
         ws.dir("generated/baml_src");
         ws.file("app/baml_src/main.baml", "// main");
 
-        let found = BexMulitProject::scan_marked_project_roots_native(&ws.root);
+        let found = BexMultiProject::scan_marked_project_roots_native(&ws.root);
         assert_eq!(
             found,
             vec![ws.root.join("app")],
@@ -2488,7 +2488,7 @@ mod tests {
 
         let (publication_tx, publication_rx) = std::sync::mpsc::sync_channel(1);
         let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
-        let lsp = std::sync::Arc::new(BexMulitProject::new(
+        let lsp = std::sync::Arc::new(BexMultiProject::new(
             std::sync::Arc::new(|_: &vfs::VfsPath| {
                 std::sync::Arc::new(sys_ops::SysOpsBuilder::new().build())
             }),
@@ -2585,7 +2585,7 @@ mod tests {
             .unwrap();
 
         let mut found = Vec::new();
-        BexMulitProject::collect_marked_project_roots_vfs(&root, &mut found);
+        BexMultiProject::collect_marked_project_roots_vfs(&root, &mut found);
         let mut names: Vec<_> = found.iter().map(vfs::VfsPath::as_str).collect();
         names.sort_unstable();
         assert_eq!(names, vec!["/manifest_proj", "/proj"]);
@@ -2646,7 +2646,7 @@ mod tests {
         let sender = Arc::new(RecordingSender {
             notifications: std::sync::Mutex::new(Vec::new()),
         });
-        let root = BexMulitProject::new(
+        let root = BexMultiProject::new(
             Arc::new(|_: &vfs::VfsPath| Arc::new(sys_ops::SysOpsBuilder::new().build())),
             sender.clone(),
             Arc::new(NoopPlaygroundSender),

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/notification.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/notification.rs
@@ -6,10 +6,10 @@
 //! authoritative over disk; `didClose` re-applies disk content and drops the
 //! version in the same batch.
 
-use super::{BexMulitProject, LspError, OverlayDocument, ProjectRefreshMode};
+use super::{BexMultiProject, LspError, OverlayDocument, ProjectRefreshMode};
 use crate::bex_lsp::notification::BexLspNotification;
 
-impl BexLspNotification for BexMulitProject {
+impl BexLspNotification for BexMultiProject {
     fn notification_sender(
         &self,
     ) -> Box<dyn Fn(lsp_server::Notification) -> Result<(), LspError> + '_> {

--- a/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
+++ b/baml_language/crates/bex_project/src/bex_lsp/multi_project/request.rs
@@ -18,7 +18,7 @@ use lsp_types::{
     WorkspaceServerCapabilities,
 };
 
-use super::{BexMulitProject, LspError, commands, read_for_request, wasm_helpers};
+use super::{BexMultiProject, LspError, commands, read_for_request, wasm_helpers};
 use crate::bex_lsp::{
     multi_project::commands::BexLspCommand,
     position_codec::{PositionCodec, PositionEncoding},
@@ -123,7 +123,7 @@ fn initialize_result(encoding: PositionEncoding) -> lsp_types::InitializeResult 
     }
 }
 
-impl BexLspRequest for BexMulitProject {
+impl BexLspRequest for BexMultiProject {
     fn request_sender(
         &self,
     ) -> Box<
@@ -1123,7 +1123,7 @@ fn definition_kind_to_lsp_symbol_kind(
     }
 }
 
-impl BexMulitProject {
+impl BexMultiProject {
     /// Store `tokens` as the latest semantic tokens for `path` under a fresh
     /// `result_id`, returning that id so the next `full/delta` can diff against it.
     ///


### PR DESCRIPTION
## Summary

Rename the misspelled `BexMulitProject` type to `BexMultiProject` throughout the multi-project LSP implementation and its tests.

## Why

The type name transposed the letters in “Multi.” Correcting the declaration and every reference removes the typo without changing behavior.

## Impact

This is an internal identifier-only rename. No runtime behavior, public API, generated output, or fixtures change.

## Validation

- `cargo fmt --package bex_project -- --check`
- `cargo check --package bex_project --all-targets`
- `cargo test --package bex_project` (60 passed, 1 ignored benchmark)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Corrected internal naming inconsistencies for multi-project language server components.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->