### PR TITLE
fix(website): drop atb trophies:list limit below Convex's byte ceiling

### DIFF
--- a/typescript2/app-website/app/api/atb/feed/route.ts
+++ b/typescript2/app-website/app/api/atb/feed/route.ts
@@ -1,7 +1,13 @@
 import { NextResponse } from 'next/server';
 import type { Feed, FeedItem } from '@/app/atb/_lib/feed';
 import { feedStatus } from '@/app/atb/_lib/feed';
-import type { Build, Issue, Task, Trophy } from '@/app/atb/_lib/types';
+import {
+  ATB_TROPHIES_QUERY_LIMIT,
+  type Build,
+  type Issue,
+  type Task,
+  type Trophy,
+} from '@/app/atb/_lib/types';
 
 // Builds the front-page feed: every whatWentWell observation from run
 // self-reports becomes a win card, every tracked issue becomes a bug card
@@ -45,9 +51,7 @@ const trunc = (s: string | undefined | null, n: number) =>
 
 async function buildFeed(): Promise<Feed> {
   const [trophies, tasks, issues, builds] = await Promise.all([
-    // see app/api/atb/state/route.ts: trophies embed turnLog/filesCreated
-    // inline, so a limit of 500 exceeds Convex's per-query byte ceiling.
-    convexQuery<Trophy[]>('trophies:list', { limit: 100 }),
+    convexQuery<Trophy[]>('trophies:list', { limit: ATB_TROPHIES_QUERY_LIMIT }),
     convexQuery<Task[]>('tasks:list', { limit: 500 }),
     convexQuery<Issue[]>('issues:list', { limit: 500 }),
     convexQuery<Build[]>('bamlBuilds:list', { limit: 50 }),

--- a/typescript2/app-website/app/api/atb/feed/route.ts
+++ b/typescript2/app-website/app/api/atb/feed/route.ts
@@ -45,7 +45,9 @@ const trunc = (s: string | undefined | null, n: number) =>
 
 async function buildFeed(): Promise<Feed> {
   const [trophies, tasks, issues, builds] = await Promise.all([
-    convexQuery<Trophy[]>("trophies:list", { limit: 500 }),
+    // see app/api/atb/state/route.ts: trophies embed turnLog/filesCreated
+    // inline, so a limit of 500 exceeds Convex's per-query byte ceiling.
+    convexQuery<Trophy[]>("trophies:list", { limit: 100 }),
     convexQuery<Task[]>("tasks:list", { limit: 500 }),
     convexQuery<Issue[]>("issues:list", { limit: 500 }),
     convexQuery<Build[]>("bamlBuilds:list", { limit: 50 }),

--- a/typescript2/app-website/app/api/atb/feed/route.ts
+++ b/typescript2/app-website/app/api/atb/feed/route.ts
@@ -1,7 +1,7 @@
-import { NextResponse } from "next/server";
-import type { Feed, FeedItem } from "@/app/atb/_lib/feed";
-import { feedStatus } from "@/app/atb/_lib/feed";
-import type { Build, Issue, Task, Trophy } from "@/app/atb/_lib/types";
+import { NextResponse } from 'next/server';
+import type { Feed, FeedItem } from '@/app/atb/_lib/feed';
+import { feedStatus } from '@/app/atb/_lib/feed';
+import type { Build, Issue, Task, Trophy } from '@/app/atb/_lib/types';
 
 // Builds the front-page feed: every whatWentWell observation from run
 // self-reports becomes a win card, every tracked issue becomes a bug card
@@ -12,31 +12,31 @@ const CONVEX_URL = process.env.NEXT_PUBLIC_ATB_CONVEX_URL;
 
 async function convexQuery<T>(path: string, args: object): Promise<T> {
   const res = await fetch(`${CONVEX_URL}/api/query`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ path, args, format: "json" }),
-    cache: "no-store",
+    body: JSON.stringify({ args, format: 'json', path }),
+    cache: 'no-store',
+    headers: { 'Content-Type': 'application/json' },
+    method: 'POST',
   });
   if (!res.ok) throw new Error(`convex ${path}: ${res.status}`);
   const body = (await res.json()) as { status: string; value: T };
-  if (body.status !== "success") throw new Error(`convex ${path} failed`);
+  if (body.status !== 'success') throw new Error(`convex ${path} failed`);
   return body.value;
 }
 
 const refLabel = (ref?: string | null) =>
-  ref ? ref.replace(/^baml-language-/, "") : null;
+  ref ? ref.replace(/^baml-language-/, '') : null;
 
 /** First readable sentence-ish chunk of an issue's markdown description. */
 function snippet(md: string, max = 220): string {
   const text = md
-    .replace(/^#+\s.*$/gm, "") // headings
-    .replace(/```[\s\S]*?```/g, "") // code fences
-    .replace(/`([^`]+)`/g, "$1")
-    .replace(/\n{2,}/g, "\n")
+    .replace(/^#+\s.*$/gm, '') // headings
+    .replace(/```[\s\S]*?```/g, '') // code fences
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\n{2,}/g, '\n')
     .trim()
-    .split("\n")[0]
+    .split('\n')[0]
     ?.trim();
-  if (!text) return "";
+  if (!text) return '';
   return text.length > max ? `${text.slice(0, max).trimEnd()}…` : text;
 }
 
@@ -47,18 +47,18 @@ async function buildFeed(): Promise<Feed> {
   const [trophies, tasks, issues, builds] = await Promise.all([
     // see app/api/atb/state/route.ts: trophies embed turnLog/filesCreated
     // inline, so a limit of 500 exceeds Convex's per-query byte ceiling.
-    convexQuery<Trophy[]>("trophies:list", { limit: 100 }),
-    convexQuery<Task[]>("tasks:list", { limit: 500 }),
-    convexQuery<Issue[]>("issues:list", { limit: 500 }),
-    convexQuery<Build[]>("bamlBuilds:list", { limit: 50 }),
+    convexQuery<Trophy[]>('trophies:list', { limit: 100 }),
+    convexQuery<Task[]>('tasks:list', { limit: 500 }),
+    convexQuery<Issue[]>('issues:list', { limit: 500 }),
+    convexQuery<Build[]>('bamlBuilds:list', { limit: 50 }),
   ]);
 
   const taskById = new Map(tasks.map((t) => [t._id, t]));
   const trophyById = new Map(trophies.map((t) => [t._id, t]));
   const labelBySha = new Map(builds.map((b) => [b.sha, refLabel(b.ref)]));
   const versionLabel = (sha?: string | null) =>
-    sha === "coldstart"
-      ? "cold start"
+    sha === 'coldstart'
+      ? 'cold start'
       : (sha && (labelBySha.get(sha) ?? sha.slice(0, 8))) || null;
 
   const items: FeedItem[] = [];
@@ -72,15 +72,15 @@ async function buildFeed(): Promise<Feed> {
     well.forEach((text, i) => {
       wins++;
       items.push({
-        id: `${tr._id}-w${i}`,
-        kind: "win",
-        text,
         at: tr.createdAt - i, // keep a stable order within one run
+        bamlVersion: versionLabel(tr.bamlVersion),
+        id: `${tr._id}-w${i}`,
+        kind: 'win',
+        runId: tr._id,
         skillRef: task?.skillRef ?? null,
         source: task?.source ?? null,
         taskPrompt: trunc(task?.prompt, 120),
-        bamlVersion: versionLabel(tr.bamlVersion),
-        runId: tr._id,
+        text,
       });
     });
   }
@@ -92,43 +92,43 @@ async function buildFeed(): Promise<Feed> {
     const status = feedStatus(issue);
     if (!status) continue;
     bugs++;
-    if (status === "fixed") fixed++;
+    if (status === 'fixed') fixed++;
     // the run that first hit it tells us which version it broke in
     const firstEvidence = (issue.evidence ?? []).find((e) => e.trophyId);
-    const evidenceTrophy = firstEvidence
-      ? trophyById.get(firstEvidence.trophyId!)
+    const evidenceTrophy = firstEvidence?.trophyId
+      ? trophyById.get(firstEvidence.trophyId)
       : undefined;
     const extra = issue as Issue & {
       brokeIn?: string | null;
       fixedIn?: string | null;
     };
     items.push({
-      id: issue._id,
-      kind: "bug",
-      text: issue.title,
-      detail: snippet(issue.description),
       at: issue.lastSeenAt,
       bamlVersion: versionLabel(evidenceTrophy?.bamlVersion),
-      issueId: issue._id,
-      status,
-      issueKind: issue.kind,
-      category: issue.category ?? null,
-      evidenceCount: (issue.evidence ?? []).length,
       brokeIn: extra.brokeIn ?? versionLabel(evidenceTrophy?.bamlVersion),
+      category: issue.category ?? null,
+      detail: snippet(issue.description),
+      evidenceCount: (issue.evidence ?? []).length,
       fixedIn: extra.fixedIn ?? null,
+      id: issue._id,
+      issueId: issue._id,
+      issueKind: issue.kind,
+      kind: 'bug',
+      status,
+      text: issue.title,
     });
   }
 
   items.sort((a, b) => b.at - a.at);
 
   return {
-    generatedAt: Date.now(),
     counts: {
-      wins,
       bugs,
       fixed,
       runs: trophies.filter((t) => !t.isCohortReport).length,
+      wins,
     },
+    generatedAt: Date.now(),
     items: items.slice(0, 600),
   };
 }
@@ -153,7 +153,7 @@ function refresh(): Promise<Feed> {
 
 export async function GET() {
   if (!CONVEX_URL) {
-    return new NextResponse("atb data source not configured", { status: 503 });
+    return new NextResponse('atb data source not configured', { status: 503 });
   }
   let feed: Feed;
   if (cache && Date.now() - cache.at < TTL_MS) {
@@ -166,7 +166,7 @@ export async function GET() {
   }
   return NextResponse.json(feed, {
     headers: {
-      "Cache-Control": "public, s-maxage=30, stale-while-revalidate=300",
+      'Cache-Control': 'public, s-maxage=30, stale-while-revalidate=300',
     },
   });
 }

--- a/typescript2/app-website/app/api/atb/state/route.ts
+++ b/typescript2/app-website/app/api/atb/state/route.ts
@@ -1,15 +1,16 @@
 import { NextResponse } from 'next/server';
-import type {
-  AtbState,
-  Build,
-  Cohort,
-  Issue,
-  SlimIssue,
-  SlimTask,
-  SlimTrophy,
-  Task,
-  Trophy,
-  Worker,
+import {
+  ATB_TROPHIES_QUERY_LIMIT,
+  type AtbState,
+  type Build,
+  type Cohort,
+  type Issue,
+  type SlimIssue,
+  type SlimTask,
+  type SlimTrophy,
+  type Task,
+  type Trophy,
+  type Worker,
 } from '@/app/atb/_lib/types';
 
 // The Convex deployment's generic list queries return full documents. A
@@ -103,10 +104,9 @@ async function buildState(): Promise<AtbState> {
   const [tasks, trophies, issues, cohorts, builds, workers] = await Promise.all(
     [
       convexQuery<Task[]>('tasks:list', { limit: 500 }),
-      // trophies embed heavy fields inline (turnLog, filesCreated) unlike the
-      // other queue tables, so a limit of 500 blows Convex's per-query byte
-      // ceiling once recent runs get long enough. Keep this well under that.
-      convexQuery<Trophy[]>('trophies:list', { limit: 100 }),
+      convexQuery<Trophy[]>('trophies:list', {
+        limit: ATB_TROPHIES_QUERY_LIMIT,
+      }),
       convexQuery<Issue[]>('issues:list', { limit: 500 }),
       convexQuery<Cohort[]>('cohorts:list', { limit: 100 }),
       convexQuery<Build[]>('bamlBuilds:list', { limit: 50 }),

--- a/typescript2/app-website/app/api/atb/state/route.ts
+++ b/typescript2/app-website/app/api/atb/state/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextResponse } from 'next/server';
 import type {
   AtbState,
   Build,
@@ -10,7 +10,7 @@ import type {
   Task,
   Trophy,
   Worker,
-} from "@/app/atb/_lib/types";
+} from '@/app/atb/_lib/types';
 
 // The Convex deployment's generic list queries return full documents. A
 // full trophies:list is ~5 MB (turn logs, file contents, reports), which
@@ -23,14 +23,14 @@ const CONVEX_URL = process.env.NEXT_PUBLIC_ATB_CONVEX_URL;
 
 async function convexQuery<T>(path: string, args: object): Promise<T> {
   const res = await fetch(`${CONVEX_URL}/api/query`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ path, args, format: "json" }),
-    cache: "no-store",
+    body: JSON.stringify({ args, format: 'json', path }),
+    cache: 'no-store',
+    headers: { 'Content-Type': 'application/json' },
+    method: 'POST',
   });
   if (!res.ok) throw new Error(`convex ${path}: ${res.status}`);
   const body = (await res.json()) as { status: string; value: T };
-  if (body.status !== "success") throw new Error(`convex ${path} failed`);
+  if (body.status !== 'success') throw new Error(`convex ${path} failed`);
   return body.value;
 }
 
@@ -40,87 +40,90 @@ const trunc = (s: string | undefined | null, n: number) =>
 function slimTask(t: Task): SlimTask {
   return {
     _id: t._id,
-    source: t.source,
-    prompt: trunc(t.prompt, 280) ?? "",
-    status: t.status,
-    createdAt: t.createdAt,
-    updatedAt: t.updatedAt,
-    claimedBy: t.claimedBy ?? null,
+    bamlVersion: t.bamlVersion ?? null,
     claimedAt: t.claimedAt ?? null,
+    claimedBy: t.claimedBy ?? null,
     cohortId: t.cohortId ?? null,
+    createdAt: t.createdAt,
+    prompt: trunc(t.prompt, 280) ?? '',
     skillRef: t.skillRef ?? null,
     skillStorageId: t.skillStorageId ?? null,
-    bamlVersion: t.bamlVersion ?? null,
+    source: t.source,
+    status: t.status,
+    updatedAt: t.updatedAt,
   };
 }
 
 function slimTrophy(t: Trophy): SlimTrophy {
   return {
     _id: t._id,
-    taskId: t.taskId,
+    bamlVersion: t.bamlVersion ?? null,
+    claimedAt: t.claimedAt ?? null,
+    claimedBy: t.claimedBy ?? null,
+    cohortId: t.cohortId ?? null,
+    createdAt: t.createdAt,
+    findingsCount: t.findings?.length ?? 0,
+    isCohortReport: t.isCohortReport ?? false,
+    metrics: t.metrics,
     outcome: t.outcome,
     status: t.status,
-    metrics: t.metrics,
-    findingsCount: t.findings?.length ?? 0,
-    createdAt: t.createdAt,
+    taskId: t.taskId,
     updatedAt: t.updatedAt,
-    claimedBy: t.claimedBy ?? null,
-    claimedAt: t.claimedAt ?? null,
-    cohortId: t.cohortId ?? null,
-    isCohortReport: t.isCohortReport ?? false,
-    bamlVersion: t.bamlVersion ?? null,
   };
 }
 
 function slimIssue(i: Issue): SlimIssue {
   return {
     _id: i._id,
-    kind: i.kind,
-    category: i.category ?? null,
-    title: i.title,
-    status: i.status,
-    fixSlackTs: i.fixSlackTs ?? null,
-    notionSyncStatus: i.notionSyncStatus,
-    linearSyncStatus: i.linearSyncStatus,
-    evidenceCount: i.evidence?.length ?? 0,
-    evidence: (i.evidence ?? []).map((e) => ({
-      trophyId: e.trophyId,
-      call_index: e.call_index ?? null,
-    })),
     bamlVersion: i.bamlVersion ?? null,
+    brokeIn: i.brokeIn ?? null,
+    category: i.category ?? null,
+    createdAt: i.createdAt,
+    evidence: (i.evidence ?? []).map((e) => ({
+      call_index: e.call_index ?? null,
+      trophyId: e.trophyId,
+    })),
+    evidenceCount: i.evidence?.length ?? 0,
+    firstSeenAt: i.firstSeenAt,
+    fixedIn: i.fixedIn ?? null,
+    fixSlackTs: i.fixSlackTs ?? null,
+    kind: i.kind,
+    lastSeenAt: i.lastSeenAt,
+    linearSyncStatus: i.linearSyncStatus,
+    notionSyncStatus: i.notionSyncStatus,
     skillUsed: i.skillUsed ?? null,
     skillVersion: i.skillVersion ?? null,
-    brokeIn: i.brokeIn ?? null,
-    fixedIn: i.fixedIn ?? null,
+    status: i.status,
+    title: i.title,
     verifiedAt: i.verifiedAt ?? null,
-    firstSeenAt: i.firstSeenAt,
-    lastSeenAt: i.lastSeenAt,
-    createdAt: i.createdAt,
   };
 }
 
 async function buildState(): Promise<AtbState> {
-  const [tasks, trophies, issues, cohorts, builds, workers] =
-    await Promise.all([
-      convexQuery<Task[]>("tasks:list", { limit: 500 }),
+  const [tasks, trophies, issues, cohorts, builds, workers] = await Promise.all(
+    [
+      convexQuery<Task[]>('tasks:list', { limit: 500 }),
       // trophies embed heavy fields inline (turnLog, filesCreated) unlike the
       // other queue tables, so a limit of 500 blows Convex's per-query byte
       // ceiling once recent runs get long enough. Keep this well under that.
-      convexQuery<Trophy[]>("trophies:list", { limit: 100 }),
-      convexQuery<Issue[]>("issues:list", { limit: 500 }),
-      convexQuery<Cohort[]>("cohorts:list", { limit: 100 }),
-      convexQuery<Build[]>("bamlBuilds:list", { limit: 50 }),
-      convexQuery<Worker[]>("workers:list", { limit: 100 }),
-    ]);
+      convexQuery<Trophy[]>('trophies:list', { limit: 100 }),
+      convexQuery<Issue[]>('issues:list', { limit: 500 }),
+      convexQuery<Cohort[]>('cohorts:list', { limit: 100 }),
+      convexQuery<Build[]>('bamlBuilds:list', { limit: 50 }),
+      convexQuery<Worker[]>('workers:list', { limit: 100 }),
+    ],
+  );
   const newestFirst = <T extends { createdAt: number }>(rows: T[]) =>
     [...rows].sort((a, b) => b.createdAt - a.createdAt);
   return {
+    builds: newestFirst(
+      builds.map(({ buildLogTail: _drop, ...b }) => b as Build),
+    ),
+    cohorts: newestFirst(cohorts),
     generatedAt: Date.now(),
+    issues: newestFirst(issues.map(slimIssue)),
     tasks: newestFirst(tasks.map(slimTask)),
     trophies: newestFirst(trophies.map(slimTrophy)),
-    issues: newestFirst(issues.map(slimIssue)),
-    cohorts: newestFirst(cohorts),
-    builds: newestFirst(builds.map(({ buildLogTail: _drop, ...b }) => b as Build)),
     workers,
   };
 }
@@ -145,7 +148,7 @@ function refresh(): Promise<AtbState> {
       })
       .catch((e) => {
         // Surface the failure so a frozen dashboard is visible in logs.
-        console.error("atb state refresh failed", e);
+        console.error('atb state refresh failed', e);
         throw e;
       })
       .finally(() => {
@@ -157,11 +160,11 @@ function refresh(): Promise<AtbState> {
 
 export async function GET() {
   if (!CONVEX_URL) {
-    return new NextResponse("atb data source not configured", { status: 503 });
+    return new NextResponse('atb data source not configured', { status: 503 });
   }
-  const age = cache ? Date.now() - cache.at : Infinity;
+  const age = cache ? Date.now() - cache.at : Number.POSITIVE_INFINITY;
   const fresh = {
-    "Cache-Control": "public, s-maxage=10, stale-while-revalidate=120",
+    'Cache-Control': 'public, s-maxage=10, stale-while-revalidate=120',
   };
   if (cache && age < TTL_MS) {
     return NextResponse.json(cache.state, { headers: fresh });
@@ -177,9 +180,11 @@ export async function GET() {
   } catch {
     if (cache) {
       return NextResponse.json(cache.state, {
-        headers: { "Cache-Control": "no-store", "X-Atb-Stale": "true" },
+        headers: { 'Cache-Control': 'no-store', 'X-Atb-Stale': 'true' },
       });
     }
-    return new NextResponse("atb data temporarily unavailable", { status: 503 });
+    return new NextResponse('atb data temporarily unavailable', {
+      status: 503,
+    });
   }
 }

--- a/typescript2/app-website/app/api/atb/state/route.ts
+++ b/typescript2/app-website/app/api/atb/state/route.ts
@@ -103,7 +103,10 @@ async function buildState(): Promise<AtbState> {
   const [tasks, trophies, issues, cohorts, builds, workers] =
     await Promise.all([
       convexQuery<Task[]>("tasks:list", { limit: 500 }),
-      convexQuery<Trophy[]>("trophies:list", { limit: 500 }),
+      // trophies embed heavy fields inline (turnLog, filesCreated) unlike the
+      // other queue tables, so a limit of 500 blows Convex's per-query byte
+      // ceiling once recent runs get long enough. Keep this well under that.
+      convexQuery<Trophy[]>("trophies:list", { limit: 100 }),
       convexQuery<Issue[]>("issues:list", { limit: 500 }),
       convexQuery<Cohort[]>("cohorts:list", { limit: 100 }),
       convexQuery<Build[]>("bamlBuilds:list", { limit: 50 }),

--- a/typescript2/app-website/app/atb/_lib/types.ts
+++ b/typescript2/app-website/app/atb/_lib/types.ts
@@ -1,6 +1,16 @@
 // Row types mirroring the agent-tries-baml Convex deployment
 // (see tools/agent-tries-baml/docs/data-model.md in the baml monorepo).
 
+// trophies embed turnLog/filesCreated inline (unlike the other queue tables,
+// which only carry blob pointers), so a trophies:list limit of 500 exceeds
+// Convex's per-query bytes-read ceiling once recent runs get long enough.
+// Capped here as a stopgap; the real fix is externalizing those fields to
+// blob storage like transcriptStorageId already does. Trade-off: an issue
+// whose only evidence trophy has aged out of this window loses its
+// bamlVersion/brokeIn enrichment in the feed (falls back to null, not a
+// crash) rather than the whole endpoint erroring out.
+export const ATB_TROPHIES_QUERY_LIMIT = 100;
+
 export type QueueFields = {
   _id: string;
   _creationTime: number;
@@ -63,7 +73,7 @@ export type Metrics = {
 };
 
 export type Finding = {
-  kind: "skill" | "language";
+  kind: 'skill' | 'language';
   title: string;
   description: string;
   anchor?: { call_index?: number | null; turn_index?: number | null };
@@ -98,7 +108,7 @@ export type Trophy = QueueFields & {
 };
 
 export type Issue = QueueFields & {
-  kind: "skill" | "language";
+  kind: 'skill' | 'language';
   category?: string | null; // bug | suggestion
   title: string;
   description: string;
@@ -202,7 +212,7 @@ export type SlimTrophy = {
 
 export type SlimIssue = {
   _id: string;
-  kind: "skill" | "language";
+  kind: 'skill' | 'language';
   category?: string | null;
   title: string;
   status: string;


### PR DESCRIPTION
## Summary
- `trophies` documents embed `turnLog`/`filesCreated` inline (unlike the other queue tables, which only carry blob pointers), so fetching 500 of them in one Convex query now exceeds the per-query bytes-read ceiling and the query errors outright.
- Both `/api/atb/state` and `/api/atb/feed` independently call `trophies:list` with `limit: 500` — dropped both to `100`.

This surfaced as the `/atb` dashboard returning "atb data temporarily unavailable" and the feed 500ing. Verified locally against prod Convex (`charming-terrier-498`): both routes return `200` with real data at `limit: 100`, both 500 at `limit: 500`.

Not the permanent fix — that's externalizing `turnLog`/`filesCreated` to blob storage the way `transcriptStorageId` already works, tracked separately. This just keeps the dashboard alive in the meantime.

## Test plan
- [x] `curl localhost:3000/api/atb/state` → 200, against prod Convex
- [x] `curl localhost:3000/api/atb/feed` → 200, against prod Convex
- [x] `curl localhost:3000/atb` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNqoYK7w1xtTPrMntBL1JK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when loading feeds and state data by limiting trophy queries.
  * Improved handling of feed entries without associated trophy information.
  * Reduced the risk of oversized trophy responses affecting loading performance.

* **Refactor**
  * Standardized internal formatting while preserving existing response and caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->