### PR TITLE
fix(mise): build cargo-shear with a 1.95+ toolchain

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -28,7 +28,8 @@ ninja = "1.13.2"
 "cargo:prek" = "0.3.13"
 "cargo:cargo-nextest" = "latest"
 "cargo:cargo-insta" = "latest"
-"cargo:cargo-shear" = "latest"
+# cargo-shear >=1.13.3 needs rustc 1.95; the repo is pinned to 1.93.0, so build it with a newer toolchain.
+"cargo:cargo-shear" = { version = "latest", install_env = { RUSTUP_TOOLCHAIN = "1.97.1" } }
 "cargo:https://github.com/astral-sh/hawk" = { version = "rev:42b09e72b2bf79f75aa8ce5f4563576f2dedf4c1", crate = "cargo-hawk", locked = true, install_env = { RUSTC_BOOTSTRAP = "1", RUSTUP_TOOLCHAIN = "1.97.1" } }
 
 # Go tools


### PR DESCRIPTION
## Problem

`cargo-shear` 1.13.3+ requires rustc 1.95, but the repo pins 1.93.0 via `rust-toolchain.toml`. mise builds `cargo:` tools from source under the active toolchain, so the install fails:

```
error: cannot install package `cargo-shear 1.13.4`, it requires rustc 1.95 or newer,
while the currently active rustc version is 1.93.0
```

Because mise auto-installs missing tools before running a task, this made `mise run fmt` and `mise run clippy` abort before doing any work — so the `cargo fmt` and `cargo clippy` pre-commit hooks silently stopped running locally.

## Fix

Pin the install to 1.97.1 via `install_env`, matching the pattern the `cargo-hawk` entry directly below it already uses. This affects only the build of that one tool; the repo's 1.93.0 pin is unchanged and everything else still compiles against it.

## Verification

- `mise install cargo:cargo-shear` → cargo-shear v1.13.4 installed, `--version` runs
- `mise run fmt` → clean, no file changes
- `mise run clippy` → finished in 5m34s, no clippy warnings

## Caveat

`1.97.1` is hardcoded, so this needs that exact toolchain installed — the same tradeoff the existing `cargo-hawk` entry makes. `stable` would float instead, at the cost of reproducibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DT8o9rzu9TLRjFZFzWL3WF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Cargo Shear installation to use Rust toolchain version 1.97.1.
  * Added documentation noting the required compiler version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->