### PR TITLE
fix(jetbrains): avoid unsupported IntelliJ 2026.2

### DIFF
--- a/.github/workflows/build-jetbrains-release.reusable.yaml
+++ b/.github/workflows/build-jetbrains-release.reusable.yaml
@@ -13,15 +13,6 @@
 name: BAML Release - Build JetBrains
 on:
   workflow_call: {}
-  pull_request:
-    paths:
-      - .github/actions/setup-java/**
-      - .github/workflows/build-jetbrains-release.reusable.yaml
-      - jetbrains/**
-      - README.v0.md
-      - typescript/apps/vscode-ext/language-configuration.json
-      - typescript/apps/vscode-ext/package.json
-      - typescript/apps/vscode-ext/syntaxes/**
   push:
     branches:
       - sam/jetbrains

--- a/.github/workflows/build-jetbrains-release.reusable.yaml
+++ b/.github/workflows/build-jetbrains-release.reusable.yaml
@@ -18,6 +18,10 @@ on:
       - .github/actions/setup-java/**
       - .github/workflows/build-jetbrains-release.reusable.yaml
       - jetbrains/**
+      - README.v0.md
+      - typescript/apps/vscode-ext/language-configuration.json
+      - typescript/apps/vscode-ext/package.json
+      - typescript/apps/vscode-ext/syntaxes/**
   push:
     branches:
       - sam/jetbrains

--- a/.github/workflows/build-jetbrains-release.reusable.yaml
+++ b/.github/workflows/build-jetbrains-release.reusable.yaml
@@ -13,6 +13,11 @@
 name: BAML Release - Build JetBrains
 on:
   workflow_call: {}
+  pull_request:
+    paths:
+      - .github/actions/setup-java/**
+      - .github/workflows/build-jetbrains-release.reusable.yaml
+      - jetbrains/**
   push:
     branches:
       - sam/jetbrains
@@ -63,7 +68,7 @@ jobs:
           CHANGELOG="$(./gradlew getChangelog --unreleased --no-header --console=plain -q)"
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "pluginVerifierHomeDir=~/.pluginVerifier" >> $GITHUB_OUTPUT
+          echo "pluginVerifierHomeDir=${HOME}/.pluginVerifier" >> $GITHUB_OUTPUT
 
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
@@ -147,40 +152,39 @@ jobs:
   #       with:
   #         cache-default-branch-only: true
 
-  # # Run plugin structure verification along with IntelliJ Plugin Verifier
-  # verify:
-  #   name: Verify plugin
-  #   needs: [ build ]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v6
+  # Verify the release artifact at the newest supported IntelliJ boundary. This resolves mandatory Marketplace plugin
+  # dependencies, so it catches both missing/incompatible LSP4IJ releases and internal IntelliJ API usage before upload.
+  verify:
+    name: Verify Marketplace compatibility
+    needs: [ build ]
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
 
-  #     # Set up Java environment for the next steps
-  #     - name: Setup Java
-  #       uses: actions/setup-java@v4
-  #       with:
-  #         distribution: temurin
-  #         java-version: 23
+      - name: Setup Java
+        uses: ./.github/actions/setup-java
 
-  #     # Setup Gradle
-  #     - name: Setup Gradle
-  #       uses: gradle/actions/setup-gradle@v4
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
 
-  #     # Cache Plugin Verifier IDEs
-  #     - name: Setup Plugin Verifier IDEs Cache
-  #       uses: actions/cache@v5
-  #       with:
-  #         path: ${{ needs.build.outputs.pluginVerifierHomeDir }}/ides
-  #         key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
+      - name: Cache Plugin Verifier IDEs
+        uses: actions/cache@v5
+        with:
+          path: ${{ needs.build.outputs.pluginVerifierHomeDir }}/ides
+          key: jetbrains-plugin-verifier-${{ runner.os }}-${{ hashFiles('jetbrains/gradle.properties') }}
 
-  #     # Run Verify Plugin task and IntelliJ Plugin Verifier tool
-  #     - name: Run Plugin Verification tasks
-  #       run: ./gradlew verifyPlugin -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
+      - name: Run packaged descriptor regression test
+        run: ./gradlew --no-daemon --stacktrace test --tests 'com.boundaryml.jetbrains_ext.BamlPluginTest.testTextMateDescriptorUsesSupportedHandoff'
 
-  #     # Collect Plugin Verifier Result
-  #     - name: Collect Plugin Verifier Result
-  #       if: ${{ always() }}
-  #       uses: actions/upload-artifact@v7
-  #       with:
-  #         name: pluginVerifier-result
-  #         path: ./build/reports/pluginVerifier
+      - name: Run Marketplace boundary verification
+        run: ./gradlew --no-daemon --stacktrace verifyPlugin -PverifyMarketplaceBoundary=true -Dplugin.verifier.home.dir=${{ needs.build.outputs.pluginVerifierHomeDir }}
+
+      - name: Collect Plugin Verifier result
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: pluginVerifier-result
+          path: ./jetbrains/build/reports/pluginVerifier
+          if-no-files-found: warn
+          retention-days: 14

--- a/jetbrains/build.gradle.kts
+++ b/jetbrains/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.jetbrains.changelog.Changelog
 import org.jetbrains.changelog.markdownToHTML
+import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
@@ -83,7 +84,7 @@ intellijPlatform {
 
         ideaVersion {
             sinceBuild = providers.gradleProperty("pluginSinceBuild")
-            // untilBuild = providers.gradleProperty("pluginUntilBuild")
+            untilBuild = providers.gradleProperty("pluginUntilBuild")
         }
     }
 
@@ -105,6 +106,9 @@ intellijPlatform {
         ides {
             if (providers.gradleProperty("verifyDeclaredPlatformOnly").map(String::toBoolean).getOrElse(false)) {
                 ide(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
+            } else if (providers.gradleProperty("verifyMarketplaceBoundary").map(String::toBoolean).getOrElse(false)) {
+                ide(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"))
+                ide(IntelliJPlatformType.IntellijIdeaUltimate, providers.gradleProperty("marketplaceVerificationVersion").get())
             } else {
                 recommended()
             }

--- a/jetbrains/gradle.properties
+++ b/jetbrains/gradle.properties
@@ -14,9 +14,12 @@ pluginVersion = 0.225.0
 # - https://plugins.jetbrains.com/docs/intellij/api-notable-list-2024.html#20243
 # - https://plugins.jetbrains.com/docs/intellij/api-notable-list-2025.html
 pluginSinceBuild = 242
-# Leaving this unset to make it installable on any future version
-# If Jetbrains makes a breaking change that messes up our plugin, we'll update our testing strategy then
-# pluginUntilBuild =
+# LSP4IJ 0.20.1 is binary incompatible with IntelliJ 2026.2 (build 262), so BAML cannot support 262 until a
+# compatible LSP4IJ release is available. Keep this boundary in sync with marketplaceVerificationVersion.
+pluginUntilBuild = 261.*
+
+# Highest supported IntelliJ release verified with Marketplace dependency resolution.
+marketplaceVerificationVersion = 2026.1.5
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC

--- a/jetbrains/gradle.properties
+++ b/jetbrains/gradle.properties
@@ -14,8 +14,9 @@ pluginVersion = 0.225.0
 # - https://plugins.jetbrains.com/docs/intellij/api-notable-list-2024.html#20243
 # - https://plugins.jetbrains.com/docs/intellij/api-notable-list-2025.html
 pluginSinceBuild = 242
-# LSP4IJ 0.20.1 is binary incompatible with IntelliJ 2026.2 (build 262), so BAML cannot support 262 until a
-# compatible LSP4IJ release is available. Keep this boundary in sync with marketplaceVerificationVersion.
+# BAML compiles against LSP4IJ 0.14.0, while Marketplace currently resolves the mandatory dependency to 0.20.1.
+# The latest Marketplace release is binary incompatible with IntelliJ 2026.2 (build 262), so BAML cannot support 262
+# until a compatible LSP4IJ release is available. Keep this boundary in sync with marketplaceVerificationVersion.
 pluginUntilBuild = 261.*
 
 # Highest supported IntelliJ release verified with Marketplace dependency resolution.

--- a/jetbrains/src/main/kotlin/com/boundaryml/jetbrains_ext/BamlLanguageServerService.kt
+++ b/jetbrains/src/main/kotlin/com/boundaryml/jetbrains_ext/BamlLanguageServerService.kt
@@ -1,6 +1,6 @@
 package com.boundaryml.jetbrains_ext
 
-import com.intellij.ide.plugins.PluginManagerCore
+import com.intellij.ide.plugins.PluginManager
 import com.intellij.openapi.application.Application
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.ComponentManager
@@ -10,7 +10,6 @@ import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.event.CaretEvent
 import com.intellij.openapi.editor.event.CaretListener
-import com.intellij.openapi.extensions.PluginId
 import com.intellij.openapi.fileEditor.FileDocumentManager
 import com.intellij.openapi.project.Project
 import com.intellij.util.messages.Topic
@@ -29,8 +28,7 @@ class BamlLanguageServerService() {
 
         // Cache the plugin version to avoid repeated lookups
         private val BUNDLED_VERSION: String by lazy {
-            val pluginId = PluginId.getId("com.boundaryml.jetbrains_ext")
-            val plugin = PluginManagerCore.getPlugin(pluginId)
+            val plugin = PluginManager.getPluginByClass(BamlLanguageServerService::class.java)
             thisLogger().info("Resolved bundled plugin: $plugin")
             plugin?.version ?: "0.207.0"
         }

--- a/jetbrains/src/test/kotlin/com/boundaryml/jetbrains_ext/BamlPluginTest.kt
+++ b/jetbrains/src/test/kotlin/com/boundaryml/jetbrains_ext/BamlPluginTest.kt
@@ -48,6 +48,7 @@ class BamlPluginTest : BasePlatformTestCase() {
         // This element is added by patchPluginXml, proving this test inspects Gradle's packaged descriptor rather than
         // the source XML.
         assertEquals("242", xpath.evaluate("string(/idea-plugin/idea-version/@since-build)", pluginDescriptor))
+        assertEquals("261.*", xpath.evaluate("string(/idea-plugin/idea-version/@until-build)", pluginDescriptor))
         assertEquals(
             BamlTextMateBundleProvider::class.java.name,
             xpath.evaluate("string(/idea-plugin/extensions/textmate.bundleProvider/@implementation)", pluginDescriptor),


### PR DESCRIPTION
## Summary

- cap the JetBrains plugin at IntelliJ build `261.*` while its mandatory LSP4IJ dependency is incompatible with build 262
- replace `PluginManagerCore.getPlugin` with the supported class-based `PluginManager.getPluginByClass` API
- run Plugin Verifier against both the declared minimum and newest supported IntelliJ release in PR/release CI, with Marketplace dependency resolution

## Root cause

JetBrains Marketplace verifier 1.408 could not resolve mandatory `com.redhat.devtools.lsp4ij` for IU-262.9437.185. Running the same verifier directly against LSP4IJ 0.20.1 reproduced two upstream compatibility failures involving removed `PsiTreeElementBase` and `StructureViewWrapperImpl` classes. LSP4IJ remains compatible with IU-261.27258.48, so this PR advertises the range BAML can actually install and run on. The only existing upstream 2026.2 issue is [redhat-developer/lsp4ij#1503](https://github.com/redhat-developer/lsp4ij/issues/1503), which addressed a separate inlay-hints failure; current LSP4IJ main still references these structure-view classes.

## Validation

- `actionlint .github/workflows/build-jetbrains-release.reusable.yaml .github/workflows/publish-jetbrains-0.225.1.yml`
- targeted packaged-descriptor test plus `verifyPluginProjectConfiguration` and `verifyPluginStructure`
- Plugin Verifier 1.409: compatible on IC-242.24807.4 and IU-261.27258.48, with zero internal API usages
- Marketplace Plugin Verifier 1.408: fixed artifact compatible on IU-261.27258.48 with its mandatory dependencies resolved

Linear: B-1518


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility checks for supported IntelliJ Platform versions.
  * Updated plugin discovery to improve runtime compatibility.
  * Set the supported upper build limit to prevent installation on incompatible future releases.

* **Tests**
  * Added automated marketplace-boundary and packaged descriptor verification.
  * Expanded compatibility checks to include IntelliJ IDEA Ultimate.
  * Verification reports are retained as build artifacts for troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->