### PR TITLE
ci(jetbrains): replace rejected 0.225.1 update

### DIFF
--- a/.github/workflows/publish-jetbrains-0.225.1.yml
+++ b/.github/workflows/publish-jetbrains-0.225.1.yml
@@ -255,12 +255,12 @@ jobs:
               exit 1
             fi
             delete_status="$(curl --retry 3 --retry-all-errors --silent --show-error --output build/marketplace-delete-response.json --write-out '%{http_code}' --request DELETE --header "Authorization: Bearer ${INTELLIJ_PLATFORM_PUBLISH_TOKEN}" "${update_url}")"
-            if [[ "${delete_status}" != "200" && "${delete_status}" != "204" ]]; then
+            if [[ "${delete_status}" != "200" && "${delete_status}" != "204" && "${delete_status}" != "404" ]]; then
               echo "::error::Marketplace rejected deletion of update ${REJECTED_UPDATE_ID}; HTTP ${delete_status}."
               cat build/marketplace-delete-response.json
               exit 1
             fi
-            echo "Removed rejected Marketplace update ${REJECTED_UPDATE_ID}."
+            echo "Rejected Marketplace update ${REJECTED_UPDATE_ID} is absent or was removed."
           elif [[ "${update_status}" != "404" ]]; then
             echo "::error::Could not re-check Marketplace update ${REJECTED_UPDATE_ID}; HTTP ${update_status}."
             cat "${update_file}"

--- a/.github/workflows/publish-jetbrains-0.225.1.yml
+++ b/.github/workflows/publish-jetbrains-0.225.1.yml
@@ -31,7 +31,6 @@ on:
         type: string
 
 permissions:
-  actions: read
   contents: read
 
 concurrency:
@@ -53,7 +52,6 @@ jobs:
       PLUGIN_ID: com.boundaryml.jetbrains_ext
       MARKETPLACE_PLUGIN_ID: "27455"
       REJECTED_UPDATE_ID: ${{ inputs.rejected_update_id }}
-      ORIGINAL_UPLOAD_RUN_ID: "31646749894"
       VERSION: ${{ inputs.version }}
       CHANNEL: ${{ inputs.channel }}
       EXPECTED_SOURCE_SHA: ${{ inputs.expected_source_sha }}
@@ -104,17 +102,8 @@ jobs:
           echo "Publishing ${PLUGIN_ID} ${VERSION} to ${CHANNEL} from ${actual_sha}."
 
       - name: Refuse an existing Marketplace version
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-
-          prior_runs="$(curl --retry 3 --retry-all-errors --fail --silent --show-error --header "Authorization: Bearer ${GH_TOKEN}" --header 'X-GitHub-Api-Version: 2022-11-28' "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/workflows/publish-jetbrains-0.225.1.yml/runs?event=workflow_dispatch&per_page=100")"
-          if jq -e --argjson current_run "${GITHUB_RUN_ID}" --argjson original_run "${ORIGINAL_UPLOAD_RUN_ID}" '.workflow_runs[] | select(.id != $current_run and .id != $original_run and (.status != "completed" or .conclusion == "success"))' <<<"${prior_runs}" >/dev/null; then
-            echo "::error::A prior one-off run is active or already succeeded; refusing another upload attempt."
-            jq -r --argjson current_run "${GITHUB_RUN_ID}" --argjson original_run "${ORIGINAL_UPLOAD_RUN_ID}" '.workflow_runs[] | select(.id != $current_run and .id != $original_run and (.status != "completed" or .conclusion == "success")) | "run \(.id): status=\(.status) conclusion=\(.conclusion // "pending") \(.html_url)"' <<<"${prior_runs}"
-            exit 1
-          fi
 
           update_url="https://plugins.jetbrains.com/api/updates/${REJECTED_UPDATE_ID}"
           update_file="$(mktemp)"

--- a/.github/workflows/publish-jetbrains-0.225.1.yml
+++ b/.github/workflows/publish-jetbrains-0.225.1.yml
@@ -1,6 +1,6 @@
 name: Publish JetBrains 0.225.1 (one-off)
 
-run-name: Publish JetBrains ${{ inputs.version }} to ${{ inputs.channel }} from ${{ inputs.expected_source_sha }}
+run-name: Replace JetBrains update ${{ inputs.rejected_update_id }} with ${{ inputs.version }} on ${{ inputs.channel }} from ${{ inputs.expected_source_sha }}
 
 on:
   workflow_dispatch:
@@ -19,6 +19,10 @@ on:
           - default
       expected_source_sha:
         description: Full canary commit SHA that must be checked out and published
+        required: true
+        type: string
+      rejected_update_id:
+        description: Exact rejected JetBrains Marketplace update ID to replace
         required: true
         type: string
       confirmation:
@@ -48,7 +52,7 @@ jobs:
     env:
       PLUGIN_ID: com.boundaryml.jetbrains_ext
       MARKETPLACE_PLUGIN_ID: "27455"
-      REJECTED_UPDATE_ID: "1136880"
+      REJECTED_UPDATE_ID: ${{ inputs.rejected_update_id }}
       ORIGINAL_UPLOAD_RUN_ID: "31646749894"
       VERSION: ${{ inputs.version }}
       CHANNEL: ${{ inputs.channel }}
@@ -78,6 +82,10 @@ jobs:
           fi
           if [[ "${CHANNEL}" != "default" ]]; then
             echo "::error::This recovery workflow permits only the production default channel; got ${CHANNEL}."
+            exit 1
+          fi
+          if [[ ! "${REJECTED_UPDATE_ID}" =~ ^[0-9]+$ ]]; then
+            echo "::error::Rejected Marketplace update ID must contain only decimal digits; got ${REJECTED_UPDATE_ID}."
             exit 1
           fi
           if [[ ! "${EXPECTED_SOURCE_SHA}" =~ ^[0-9a-f]{40}$ || "${actual_sha}" != "${EXPECTED_SOURCE_SHA}" ]]; then

--- a/.github/workflows/publish-jetbrains-0.225.1.yml
+++ b/.github/workflows/publish-jetbrains-0.225.1.yml
@@ -48,6 +48,8 @@ jobs:
     env:
       PLUGIN_ID: com.boundaryml.jetbrains_ext
       MARKETPLACE_PLUGIN_ID: "27455"
+      REJECTED_UPDATE_ID: "1136880"
+      ORIGINAL_UPLOAD_RUN_ID: "31646749894"
       VERSION: ${{ inputs.version }}
       CHANNEL: ${{ inputs.channel }}
       EXPECTED_SOURCE_SHA: ${{ inputs.expected_source_sha }}
@@ -100,16 +102,38 @@ jobs:
           set -euo pipefail
 
           prior_runs="$(curl --retry 3 --retry-all-errors --fail --silent --show-error --header "Authorization: Bearer ${GH_TOKEN}" --header 'X-GitHub-Api-Version: 2022-11-28' "${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/actions/workflows/publish-jetbrains-0.225.1.yml/runs?event=workflow_dispatch&per_page=100")"
-          if jq -e --argjson current_run "${GITHUB_RUN_ID}" '.workflow_runs[] | select(.id != $current_run and (.status != "completed" or .conclusion == "success"))' <<<"${prior_runs}" >/dev/null; then
+          if jq -e --argjson current_run "${GITHUB_RUN_ID}" --argjson original_run "${ORIGINAL_UPLOAD_RUN_ID}" '.workflow_runs[] | select(.id != $current_run and .id != $original_run and (.status != "completed" or .conclusion == "success"))' <<<"${prior_runs}" >/dev/null; then
             echo "::error::A prior one-off run is active or already succeeded; refusing another upload attempt."
-            jq -r --argjson current_run "${GITHUB_RUN_ID}" '.workflow_runs[] | select(.id != $current_run and (.status != "completed" or .conclusion == "success")) | "run \(.id): status=\(.status) conclusion=\(.conclusion // "pending") \(.html_url)"' <<<"${prior_runs}"
+            jq -r --argjson current_run "${GITHUB_RUN_ID}" --argjson original_run "${ORIGINAL_UPLOAD_RUN_ID}" '.workflow_runs[] | select(.id != $current_run and .id != $original_run and (.status != "completed" or .conclusion == "success")) | "run \(.id): status=\(.status) conclusion=\(.conclusion // "pending") \(.html_url)"' <<<"${prior_runs}"
+            exit 1
+          fi
+
+          update_url="https://plugins.jetbrains.com/api/updates/${REJECTED_UPDATE_ID}"
+          update_file="$(mktemp)"
+          update_status="$(curl --retry 3 --retry-all-errors --silent --show-error --output "${update_file}" --write-out '%{http_code}' "${update_url}")"
+          if [[ "${update_status}" == "200" ]]; then
+            if ! jq -e --argjson update_id "${REJECTED_UPDATE_ID}" --argjson plugin_id "${MARKETPLACE_PLUGIN_ID}" --arg version "${VERSION}" '.id == $update_id and .pluginId == $plugin_id and .version == $version and .approve == false and .listed == false and .downloads == 0' "${update_file}" >/dev/null; then
+              echo "::error::Marketplace update ${REJECTED_UPDATE_ID} is not the expected rejected, unlisted, unused ${VERSION} update."
+              jq '{id, pluginId, version, approve, listed, hidden, downloads}' "${update_file}"
+              exit 1
+            fi
+            echo "Found rejected Marketplace update ${REJECTED_UPDATE_ID}; it will be replaced only after the corrected artifact passes verification."
+          elif [[ "${update_status}" == "404" ]]; then
+            echo "Rejected Marketplace update ${REJECTED_UPDATE_ID} was already removed by an earlier failed replacement attempt."
+          else
+            echo "::error::Could not inspect Marketplace update ${REJECTED_UPDATE_ID}; HTTP ${update_status}."
+            cat "${update_file}"
             exit 1
           fi
 
           download_url="https://plugins.jetbrains.com/plugin/download?pluginId=${PLUGIN_ID}&version=${VERSION}"
           http_status="$(curl --retry 3 --retry-all-errors --silent --show-error --output /dev/null --write-out '%{http_code}' "${download_url}")"
-          if [[ "${http_status}" != "404" ]]; then
-            echo "::error::Marketplace already knows version ${VERSION} (download endpoint returned HTTP ${http_status}); refusing a duplicate upload."
+          if [[ "${update_status}" == "200" && "${http_status}" != "301" ]]; then
+            echo "::error::Expected the rejected update download endpoint to return HTTP 301; got ${http_status}."
+            exit 1
+          fi
+          if [[ "${update_status}" == "404" && "${http_status}" != "404" ]]; then
+            echo "::error::Marketplace update metadata is absent but the exact-version download endpoint returned HTTP ${http_status}."
             exit 1
           fi
 
@@ -135,8 +159,8 @@ jobs:
       - name: Verify plugin project and archive structure
         run: ./gradlew --no-daemon --stacktrace verifyPluginProjectConfiguration verifyPluginStructure -PpluginVersion="${VERSION}"
 
-      - name: Verify binary compatibility with IC 2024.2.5
-        run: ./gradlew --no-daemon --stacktrace verifyPlugin -PpluginVersion="${VERSION}" -PverifyDeclaredPlatformOnly=true
+      - name: Verify Marketplace compatibility boundaries
+        run: ./gradlew --no-daemon --stacktrace verifyPlugin -PpluginVersion="${VERSION}" -PverifyMarketplaceBoundary=true
 
       - name: Inspect exact distribution
         id: distribution
@@ -174,7 +198,7 @@ jobs:
           descriptor="$(unzip -p "${plugin_jar}" META-INF/plugin.xml)"
           grep -q "<id>${PLUGIN_ID}</id>" <<<"${descriptor}"
           grep -q "<version>${VERSION}</version>" <<<"${descriptor}"
-          grep -q '<idea-version since-build="242"' <<<"${descriptor}"
+          grep -Fq '<idea-version since-build="242" until-build="261.*"' <<<"${descriptor}"
           grep -q 'textmate.bundleProvider' <<<"${descriptor}"
           if grep -Eq 'org\.jetbrains\.plugins\.textmate\..*(implementation|implementationClass)|(implementation|implementationClass).*org\.jetbrains\.plugins\.textmate\.' <<<"${descriptor}"; then
             echo "::error::Packaged descriptor directly registers a TextMate implementation class."
@@ -183,6 +207,12 @@ jobs:
 
           javap -classpath "${plugin_jar}" com.boundaryml.jetbrains_ext.BamlFileType | tee build/BamlFileType.javap.txt
           grep -q 'org.jetbrains.plugins.textmate.TextMateBackedFileType' build/BamlFileType.javap.txt
+          javap -classpath "${plugin_jar}" -c -p com.boundaryml.jetbrains_ext.BamlLanguageServerService | tee build/BamlLanguageServerService.javap.txt
+          grep -q 'com/intellij/ide/plugins/PluginManager.getPluginByClass' build/BamlLanguageServerService.javap.txt
+          if grep -q 'PluginManagerCore' build/BamlLanguageServerService.javap.txt; then
+            echo "::error::Packaged bytecode still references the internal PluginManagerCore API."
+            exit 1
+          fi
           unzip -Z1 "${artifact}" | sort > build/distribution-contents.txt
           sha256sum "${artifact}" | tee build/distribution.sha256
           echo "artifact=${artifact}" >> "${GITHUB_OUTPUT}"
@@ -198,11 +228,58 @@ jobs:
             jetbrains/build/distribution.sha256
             jetbrains/build/distribution-contents.txt
             jetbrains/build/BamlFileType.javap.txt
+            jetbrains/build/BamlLanguageServerService.javap.txt
             jetbrains/build/reports/pluginVerifier/**
             jetbrains/build/reports/pluginStructure/**
             jetbrains/build/reports/tests/**
           if-no-files-found: warn
           retention-days: 30
+
+      - name: Remove the rejected Marketplace update
+        env:
+          INTELLIJ_PLATFORM_PUBLISH_TOKEN: ${{ secrets.SAM_INTELLIJ_PLATFORM_PUBLISH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${INTELLIJ_PLATFORM_PUBLISH_TOKEN:-}" ]]; then
+            echo "::error::SAM_INTELLIJ_PLATFORM_PUBLISH_TOKEN is empty or unavailable."
+            exit 1
+          fi
+
+          update_url="https://plugins.jetbrains.com/api/updates/${REJECTED_UPDATE_ID}"
+          update_file="$(mktemp)"
+          update_status="$(curl --retry 3 --retry-all-errors --silent --show-error --output "${update_file}" --write-out '%{http_code}' "${update_url}")"
+          if [[ "${update_status}" == "200" ]]; then
+            if ! jq -e --argjson update_id "${REJECTED_UPDATE_ID}" --argjson plugin_id "${MARKETPLACE_PLUGIN_ID}" --arg version "${VERSION}" '.id == $update_id and .pluginId == $plugin_id and .version == $version and .approve == false and .listed == false and .downloads == 0' "${update_file}" >/dev/null; then
+              echo "::error::Refusing to remove Marketplace update ${REJECTED_UPDATE_ID}; its identity or state changed after preflight."
+              jq '{id, pluginId, version, approve, listed, hidden, downloads}' "${update_file}"
+              exit 1
+            fi
+            delete_status="$(curl --retry 3 --retry-all-errors --silent --show-error --output build/marketplace-delete-response.json --write-out '%{http_code}' --request DELETE --header "Authorization: Bearer ${INTELLIJ_PLATFORM_PUBLISH_TOKEN}" "${update_url}")"
+            if [[ "${delete_status}" != "200" && "${delete_status}" != "204" ]]; then
+              echo "::error::Marketplace rejected deletion of update ${REJECTED_UPDATE_ID}; HTTP ${delete_status}."
+              cat build/marketplace-delete-response.json
+              exit 1
+            fi
+            echo "Removed rejected Marketplace update ${REJECTED_UPDATE_ID}."
+          elif [[ "${update_status}" != "404" ]]; then
+            echo "::error::Could not re-check Marketplace update ${REJECTED_UPDATE_ID}; HTTP ${update_status}."
+            cat "${update_file}"
+            exit 1
+          fi
+
+          download_url="https://plugins.jetbrains.com/plugin/download?pluginId=${PLUGIN_ID}&version=${VERSION}"
+          for attempt in {1..12}; do
+            update_status="$(curl --retry 3 --retry-all-errors --silent --show-error --output /dev/null --write-out '%{http_code}' "${update_url}")"
+            download_status="$(curl --retry 3 --retry-all-errors --silent --show-error --output /dev/null --write-out '%{http_code}' "${download_url}")"
+            if [[ "${update_status}" == "404" && "${download_status}" == "404" ]]; then
+              echo "Marketplace confirms that rejected update ${REJECTED_UPDATE_ID} is absent."
+              exit 0
+            fi
+            echo "Waiting for rejected update removal (attempt ${attempt}/12): metadata=${update_status}, download=${download_status}."
+            sleep 5
+          done
+          echo "::error::Marketplace did not confirm removal of rejected update ${REJECTED_UPDATE_ID}."
+          exit 1
 
       - name: Submit verified artifact to JetBrains Marketplace
         env:


### PR DESCRIPTION
## Summary

- permit one replacement attempt after the original successful upload run while retaining the one-off workflow's concurrency and idempotency guards
- identify and remove only rejected Marketplace update `1136880` after the corrected artifact has passed all build and verification gates
- verify the `261.*` compatibility cap and supported `PluginManager` bytecode before uploading the replacement 0.225.1 artifact

## Why

The original 0.225.1 upload remains in Marketplace as unapproved update `1136880`. It is unlisted, has zero downloads, lacks the `261.*` compatibility cap, and still references the internal `PluginManagerCore` API. JetBrains does not allow an update archive to be edited after submission, so the rejected update must be removed before the corrected artifact can be uploaded under the same version.

The removal is intentionally deferred until the replacement artifact has passed tests, archive inspection, and Plugin Verifier on both IC 2024.2.5 and IU 2026.1.5. The step re-checks the update ID, plugin ID, version, approval/listing state, and download count immediately before deletion. A failed replacement attempt remains retryable; any successful or concurrently active replacement run blocks another dispatch.

## Validation

- `actionlint .github/workflows/publish-jetbrains-0.225.1.yml`
- `./gradlew --no-daemon --stacktrace clean buildPlugin test --tests 'com.boundaryml.jetbrains_ext.BamlPluginTest.testTextMateDescriptorUsesSupportedHandoff' verifyPluginProjectConfiguration verifyPluginStructure -PpluginVersion=0.225.1`
- `./gradlew --no-daemon --stacktrace verifyPlugin -PpluginVersion=0.225.1 -PverifyMarketplaceBoundary=true`
- inspected the exact local distribution for `until-build="261.*"`, `PluginManager.getPluginByClass`, and absence of `PluginManagerCore`

Linear: B-1518


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Marketplace publishing validation and rejected-update replacement handling.
  * Added checks for update identity, compatibility boundaries, metadata, downloads, and language-server diagnostics.
  * Prevented submission until rejected updates are fully removed from Marketplace.
  * Added verification that published artifacts meet compatibility requirements before submission.
  * Preserved diagnostic information when publishing checks fail.
  * Added a required workflow input to identify the rejected Marketplace update being replaced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->