### PR TITLE
test: cover uncaught JSON parse diagnostics

### DIFF
--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -859,30 +859,23 @@ test "assert-equal-failure" {
     );
 }
 
-/// Non-assertion errors should retain their type, fields, and BAML stack
-/// context instead of producing a bare `FAIL` line.
+/// B-356: declared errors thrown by builtins should retain their type, message,
+/// and BAML stack context instead of producing a bare `FAIL` line.
 #[test]
-fn test_thrown_error_prints_rendered_error_context() {
+fn test_json_parse_error_prints_rendered_error_context() {
     let built = &common::baml_cli();
     let tmp = tempfile::tempdir().unwrap();
 
     create_project(
         tmp.path(),
         r#"
-class ProviderFailure {
-  message string
-  status int
+class Foo {
+  x int
 }
 
-function fail_request() -> void {
-  throw ProviderFailure {
-    message: "provider rejected request",
-    status: 429,
-  }
-}
-
-test "provider-failure" {
-  fail_request()
+test "throws-during-parse" {
+  let value = baml.json.from_string<Foo>("045");
+  assert.is_true(true)
 }
 "#,
     );
@@ -899,19 +892,15 @@ test "provider-failure" {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("user.ProviderFailure"),
+        stderr.contains("baml.json.JsonParseError"),
         "Expected the thrown error type in stderr, got: {stderr}",
     );
     assert!(
-        stderr.contains(r#"message: "provider rejected request""#),
+        stderr.contains(r#"message: "invalid number at line 1 column 2""#),
         "Expected the thrown error message in stderr, got: {stderr}",
     );
     assert!(
-        stderr.contains("status: 429"),
-        "Expected the thrown error fields in stderr, got: {stderr}",
-    );
-    assert!(
-        stderr.contains("main.baml"),
+        stderr.contains("baml_src/main.baml"),
         "Expected BAML source context in stderr, got: {stderr}",
     );
     assert!(

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -899,8 +899,9 @@ test "throws-during-parse" {
         stderr.contains(r#"message: "invalid number at line 1 column 2""#),
         "Expected the thrown error message in stderr, got: {stderr}",
     );
+    let source_path = Path::new("baml_src").join("main.baml");
     assert!(
-        stderr.contains("baml_src/main.baml"),
+        stderr.contains(&source_path.display().to_string()),
         "Expected BAML source context in stderr, got: {stderr}",
     );
     assert!(


### PR DESCRIPTION
## Summary

Updates the CLI end-to-end regression test for B-356 to use the issue's exact failure mode: an uncaught `baml.json.JsonParseError` from parsing invalid JSON.

The production path already captures `ErrorContext` for uncaught throws. This test now verifies that `baml test` renders the thrown class, exact message, and BAML source stack instead of printing only a bare failure line, while continuing to reject leaked internal Rust span details.

## Validation

- `cargo test -p baml_cli --test exit_code_e2e test_json_parse_error_prints_rendered_error_context -- --exact --nocapture`
- `cargo test -p baml_cli --lib test_command::tests`
- `cargo fmt --all -- --check`
- `git diff --check`

Linear: B-356

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for invalid numeric values in BAML JSON parsing.
  * Errors now include the appropriate parse error type, clear validation details, and relevant source context.
  * Removed internal debugging details from displayed error messages.
  * Parsing failures now return the expected exit code.
  * Malformed numeric input now produces a clear, actionable parsing error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->