### PR TITLE
fix: allow 'baml run -e' to work when project doesn't compile

### DIFF
--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -889,7 +889,10 @@ impl RunArgs {
     /// Evaluate a BAML expression.
     ///
     /// Wraps the expression in a synthetic `function $expr_main() { <body> }`
-    /// and compiles/runs it. If inside a project, project context is available.
+    /// and compiles/runs it. Expressions are first compiled with only the
+    /// standard library in scope, so unrelated project errors cannot block an
+    /// independent probe. If that fails and a project is available, retry with
+    /// project context so expressions can still reference project declarations.
     ///
     /// `expr_body` is the resolved expression text — already de-referenced
     /// from inline / `@file` / stdin by the caller. We avoid re-reading
@@ -903,32 +906,58 @@ impl RunArgs {
         // `-> unknown` lets any return type through.
         let synthetic = format!("function baml_run_expr_main__() -> unknown {{\n{expr_body}\n}}");
 
-        let (mut db, project_root) = if find_project_root_from(self.from.as_deref())?.is_some() {
-            let (db_with_project, root, baml_files) =
+        let discovered_root = find_project_root_from(self.from.as_deref())?;
+        let isolated_root = discovered_root
+            .clone()
+            .unwrap_or_else(|| std::env::temp_dir().join("baml_expr"));
+        if discovered_root.is_none() {
+            std::fs::create_dir_all(&isolated_root).ok();
+        }
+
+        // Fast and resilient path: most `-e` probes only need the standard
+        // library. Compiling them in an isolated database means neither loading
+        // nor diagnosing every project file, and therefore unrelated project
+        // errors cannot prevent evaluation.
+        let mut isolated_db = ProjectDatabase::new();
+        isolated_db.set_project_root(&isolated_root);
+        isolated_db.add_or_update_file(&isolated_root.join("__expr__.baml"), &synthetic);
+        let isolated_diagnostics = baml_project::collect_diagnostics(&isolated_db);
+        let isolated_has_errors = isolated_diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.severity == Severity::Error);
+
+        let db = if isolated_has_errors {
+            if discovered_root.is_none() {
+                self.render_and_bail_on_errors(
+                    &isolated_diagnostics,
+                    &isolated_db,
+                    "cannot evaluate expression: compilation errors",
+                    reporter,
+                )?;
+                unreachable!("isolated expression diagnostics contain an error");
+            }
+
+            // The expression may refer to project declarations. Preserve that
+            // existing behavior by retrying with the surrounding project only
+            // when the isolated compile proves it is necessary.
+            let (mut project_db, project_root, baml_files) =
                 load_project_or_default(self.from.as_deref())?;
             self.vlog(format_args!(
-                "Project context: loaded {} file(s)",
+                "Expression requires project context: loaded {} file(s)",
                 baml_files.len()
             ));
-            (db_with_project, root)
+            project_db.add_or_update_file(&project_root.join("__expr__.baml"), &synthetic);
+            self.check_project_diagnostics(
+                &project_db,
+                "cannot evaluate expression: compilation errors",
+                reporter,
+            )?;
+            project_db
         } else {
-            let tmp = std::env::temp_dir().join("baml_expr");
-            std::fs::create_dir_all(&tmp).ok();
-            let mut db = ProjectDatabase::new();
-            db.set_project_root(&tmp);
-            self.vlog(format_args!(
-                "Project context: none (standalone expression)"
-            ));
-            (db, tmp)
+            self.vlog(format_args!("Expression compiled without project context"));
+            isolated_db
         };
 
-        db.add_or_update_file(&project_root.join("__expr__.baml"), &synthetic);
-
-        self.check_project_diagnostics(
-            &db,
-            "cannot evaluate expression: compilation errors",
-            reporter,
-        )?;
         // BEP-027 §"`baml.argv`": `argv[1]` for `-e` is "the expression
         // source" — the loaded body text, not the `@path` reference. This
         // matches the inline case: `-e '2 + 2'` and `-e @file` (with

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -1796,6 +1796,39 @@ fn run_expr_without_baml_toml_picks_up_baml_src_context() {
     );
 }
 
+/// B-359: an expression that only needs the standard library must not compile
+/// or diagnose the surrounding project. Unrelated project errors should not
+/// block `-e` from being used as an interactive probe.
+#[test]
+fn run_expr_ignores_unrelated_project_compile_errors() {
+    let built = &common::baml_cli();
+    let tmp = tempfile::tempdir().unwrap();
+    create_project(
+        tmp.path(),
+        "function broken() -> int {\n  Int.parse(\"1\")\n}\n",
+    );
+
+    let output = run_baml_cli(
+        built,
+        tmp.path(),
+        &["run", "-e", "int.parse(\"42\")", "--from", "."],
+    );
+
+    assert!(
+        output.status.success(),
+        "Expected an independent expression to ignore unrelated project errors, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "42");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("unresolved name: Int"),
+        "Unrelated project diagnostic leaked into expression evaluation:\n{stderr}"
+    );
+}
+
 /// `baml test` reaches test discovery on a manifest-less `baml_src/`
 /// project — a project with no test blocks returns the `NoTestsRun` code (5),
 /// proving the loader accepted it rather than bailing on the missing manifest.


### PR DESCRIPTION
## Summary

- compile `baml run -e` probes against the standard library before loading project sources
- fall back to the surrounding project when the expression needs project declarations
- add end-to-end coverage for unrelated project compile errors and retain project-context coverage

## Root cause

Expression mode always loaded, diagnosed, and emitted bytecode for every project source before evaluating its synthetic function. Any unrelated project diagnostic therefore blocked an otherwise independent probe.

## User impact

Independent expressions such as `baml run -e 'int.parse("42")'` now run even when another project file does not compile. Expressions that reference project functions or types retain their existing behavior through the project-context fallback.

## Validation

- `cargo fmt -p baml_cli`
- `cargo check -p baml_cli`
- `cargo test -p baml_cli --test exit_code_e2e run_expr_ -- --nocapture` (2 passed)
- `cargo test -p baml_cli --lib run_command::tests -- --nocapture` (39 passed)
- `git diff --check`

Linear: [B-359](https://linear.app/boundaryml2/issue/B-359/baml-run-e-recompiles-entire-project-blocked-by-unrelated-compile)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standard-library expressions can now be evaluated successfully even when unrelated project errors exist.
  - Expression evaluation provides clearer diagnostics when compilation fails outside a project context.
  - Existing project-aware evaluation and execution behavior remains unchanged.

- **Tests**
  - Added coverage confirming independent expressions return the expected result without displaying unrelated project errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->