### PR TITLE
test(cli): preserve slashes in test names

### DIFF
--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -649,6 +649,61 @@ test "passes" {
     common::assert_no_compile_file_status(&String::from_utf8_lossy(&output.stderr));
 }
 
+/// A slash inside a user-provided test name is data, not a hierarchy separator.
+/// Regression for B-360.
+#[test]
+fn test_slash_in_name_is_rendered_verbatim() {
+    let built = &common::baml_cli();
+    let tmp = tempfile::tempdir().unwrap();
+
+    create_project(
+        tmp.path(),
+        r#"
+function f() -> int { 1 }
+
+test "alpha/beta gamma" {
+  assert.equal(f(), 1)
+}
+"#,
+    );
+
+    let listed = run_baml_cli(built, tmp.path(), &["test", "--from", ".", "--list"]);
+    assert!(
+        listed.status.success(),
+        "Expected list to succeed, got: {:?}\nstdout: {}\nstderr: {}",
+        listed.status.code(),
+        String::from_utf8_lossy(&listed.stdout),
+        String::from_utf8_lossy(&listed.stderr),
+    );
+    let listed_stdout = String::from_utf8_lossy(&listed.stdout);
+    assert!(
+        listed_stdout.contains("root::alpha/beta gamma"),
+        "Expected the slash to be preserved in list output, got:\n{listed_stdout}",
+    );
+    assert!(
+        !listed_stdout.contains("root::alpha::beta gamma"),
+        "The slash was rendered as a hierarchy separator:\n{listed_stdout}",
+    );
+
+    let executed = run_baml_cli(built, tmp.path(), &["test", "--from", "."]);
+    assert!(
+        executed.status.success(),
+        "Expected test to pass, got: {:?}\nstdout: {}\nstderr: {}",
+        executed.status.code(),
+        String::from_utf8_lossy(&executed.stdout),
+        String::from_utf8_lossy(&executed.stderr),
+    );
+    let executed_stdout = String::from_utf8_lossy(&executed.stdout);
+    assert!(
+        executed_stdout.contains("PASS root::alpha/beta gamma"),
+        "Expected the slash to be preserved in test output, got:\n{executed_stdout}",
+    );
+    assert!(
+        !executed_stdout.contains("PASS root::alpha::beta gamma"),
+        "The slash was rendered as a hierarchy separator:\n{executed_stdout}",
+    );
+}
+
 /// BAML log events stay silent by default and become stdout lines only when
 /// the caller opts into a level threshold with `--logs`.
 #[test]


### PR DESCRIPTION
## Summary

- add an end-to-end regression for B-360 using the reported `alpha/beta gamma` test name
- verify `baml test --list` preserves the literal slash in the canonical ID
- verify executed `PASS` output preserves the literal slash and never renders it as `::`

## Context

The historical renderer split test paths on `/`, which made a user-provided slash look like the `::` hierarchy separator. The canonical-ID path on `canary` now carries the complete test ID through rendering without splitting on `/`; this test locks that behavior at the CLI boundary.

## Validation

- `cargo test -p baml_cli --test exit_code_e2e test_slash_in_name_is_rendered_verbatim -- --nocapture`
- `cargo test -p baml_cli --test test_profiles_e2e failed_expansion_is_not_cached_and_literal_slash_selector_is_legal -- --nocapture`
- `cargo fmt --check --package baml_cli`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage ensuring test names containing `/` appear verbatim when listing tests and in execution results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->