### PR TITLE
Set up the toolchain before IDE install

### DIFF
--- a/baml_language/crates/baml/src/main.rs
+++ b/baml_language/crates/baml/src/main.rs
@@ -487,7 +487,11 @@ fn ensure_toolchain_for_ide_install(selector: &ResolvedSelector, args: &[String]
         return Ok(());
     }
 
-    let resolved_version = concrete_version_for_selector(selector).ok();
+    let resolved_version = match concrete_version_for_selector(selector) {
+        Ok(version) => Some(version),
+        Err(_) if channel_needs_initial_setup(&selector.selector, &read_state()) => None,
+        Err(error) => return Err(error),
+    };
     let toolchain_is_installed = resolved_version.as_deref().is_some_and(toolchain_is_usable);
     if toolchain_is_installed {
         return Ok(());
@@ -500,6 +504,10 @@ fn ensure_toolchain_for_ide_install(selector: &ResolvedSelector, args: &[String]
         false,
     )
     .context("failed to set up the BAML toolchain required by `baml ide install`")
+}
+
+fn channel_needs_initial_setup(selector: &str, state: &State) -> bool {
+    is_channel(selector) && !state.channels.contains_key(selector)
 }
 
 fn is_ide_install(args: &[String]) -> bool {
@@ -1803,6 +1811,24 @@ mod tests {
             let args = args.iter().map(ToString::to_string).collect::<Vec<_>>();
             assert!(!is_ide_install(&args), "{args:?}");
         }
+    }
+
+    #[test]
+    fn only_channels_without_active_state_need_initial_setup() {
+        let mut state = State::default();
+        assert!(channel_needs_initial_setup("canary", &state));
+        assert!(!channel_needs_initial_setup("0.16.0", &state));
+
+        state.channels.insert(
+            "canary".to_string(),
+            ChannelState {
+                active_version: "0.16.0".to_string(),
+                resolved_at: "x".to_string(),
+                manifest_path: "y".to_string(),
+                manifest_base_url: Some("https://old.example.test".to_string()),
+            },
+        );
+        assert!(!channel_needs_initial_setup("canary", &state));
     }
 
     fn resolved(selector: &str, source: SelectorSource) -> ResolvedSelector {

--- a/baml_language/crates/baml/src/main.rs
+++ b/baml_language/crates/baml/src/main.rs
@@ -571,7 +571,11 @@ fn next_cli_command(args: &[String]) -> Option<(&str, &[String])> {
 
 fn toolchain_is_usable(version: &str) -> bool {
     let root = toolchains_dir().join(version);
-    toolchain_cli_path(version).is_file()
+    installed_toolchain_is_usable(&root, version)
+}
+
+fn installed_toolchain_is_usable(root: &Path, version: &str) -> bool {
+    verify_path_toolchain(&root.join("bin").join(cli_exe_name()), "").is_ok()
         && fs::read_to_string(root.join("VERSION"))
             .is_ok_and(|installed| installed.trim() == version)
 }
@@ -1829,6 +1833,26 @@ mod tests {
             },
         );
         assert!(!channel_needs_initial_setup("canary", &state));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn managed_toolchain_without_executable_permission_is_unusable() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().join("0.16.0");
+        let bin = root.join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        fs::write(root.join("VERSION"), "0.16.0\n").unwrap();
+        let cli = bin.join(cli_exe_name());
+        fs::write(&cli, "#!/bin/sh\n").unwrap();
+        fs::set_permissions(&cli, fs::Permissions::from_mode(0o644)).unwrap();
+
+        assert!(!installed_toolchain_is_usable(&root, "0.16.0"));
+
+        fs::set_permissions(&cli, fs::Permissions::from_mode(0o755)).unwrap();
+        assert!(installed_toolchain_is_usable(&root, "0.16.0"));
     }
 
     fn resolved(selector: &str, source: SelectorSource) -> ResolvedSelector {

--- a/baml_language/crates/baml/src/main.rs
+++ b/baml_language/crates/baml/src/main.rs
@@ -424,6 +424,7 @@ fn pass_through(args: Vec<String>) -> Result<i32> {
     if let Some(cli) = path_selector(&selector.selector) {
         return exec_path_toolchain(cli, &selector, args);
     }
+    ensure_toolchain_for_ide_install(&selector, &args)?;
     let version = concrete_version_for_selector(&selector)?;
     let cli = toolchain_cli_path(&version);
     if !cli.exists() {
@@ -470,6 +471,101 @@ fn pass_through(args: Vec<String>) -> Result<i32> {
         warn_if_channel_outdated(&selector, &version);
     }
     Ok(status.code().unwrap_or(1))
+}
+
+/// `baml ide install` needs a released toolchain because the matching VSIX is
+/// shipped inside the toolchain archive. Make that command usable on a fresh
+/// wrapper install by preparing its selected managed toolchain before passing
+/// control to `baml-cli`.
+///
+/// Local path selectors are deliberately left alone: replacing an explicit
+/// local override with a managed release would violate the user's selection,
+/// and the toolchain binary already explains that released IDE assets require
+/// a managed toolchain.
+fn ensure_toolchain_for_ide_install(selector: &ResolvedSelector, args: &[String]) -> Result<()> {
+    if !is_ide_install(args) || is_path_selector(&selector.selector) {
+        return Ok(());
+    }
+
+    let resolved_version = concrete_version_for_selector(selector).ok();
+    let toolchain_is_installed = resolved_version.as_deref().is_some_and(toolchain_is_usable);
+    if toolchain_is_installed {
+        return Ok(());
+    }
+
+    install_toolchain(
+        &selector.selector,
+        is_channel(&selector.selector),
+        None,
+        false,
+    )
+    .context("failed to set up the BAML toolchain required by `baml ide install`")
+}
+
+fn is_ide_install(args: &[String]) -> bool {
+    if args
+        .iter()
+        .any(|arg| matches!(arg.as_str(), "--help" | "-h"))
+    {
+        return false;
+    }
+
+    let Some((command, rest)) = next_cli_command(args) else {
+        return false;
+    };
+    if command != "ide" {
+        return false;
+    }
+    next_cli_command(rest).is_some_and(|(subcommand, _)| subcommand == "install")
+}
+
+/// Skip the toolchain CLI's global options and return its next positional
+/// command. Keeping this small parser here avoids downloading a toolchain for
+/// an unrelated invocation whose arguments happen to contain `ide install`.
+fn next_cli_command(args: &[String]) -> Option<(&str, &[String])> {
+    let mut index = 0;
+    while let Some(arg) = args.get(index).map(String::as_str) {
+        if matches!(
+            arg,
+            "--directory"
+                | "--project"
+                | "--output-preset"
+                | "--color"
+                | "--hyperlinks"
+                | "--diagnostic-format"
+        ) {
+            index += 2;
+            continue;
+        }
+        if arg.starts_with("--directory=")
+            || arg.starts_with("--project=")
+            || arg.starts_with("--output-preset=")
+            || arg.starts_with("--color=")
+            || arg.starts_with("--hyperlinks=")
+            || arg.starts_with("--diagnostic-format=")
+            || arg == "--quiet"
+            || arg == "--verbose"
+            || arg == "--no-progress"
+            || (arg.starts_with('-')
+                && arg.len() > 1
+                && arg[1..].chars().all(|flag| matches!(flag, 'q' | 'v')))
+        {
+            index += 1;
+            continue;
+        }
+        if arg.starts_with('-') {
+            return None;
+        }
+        return Some((arg, &args[index + 1..]));
+    }
+    None
+}
+
+fn toolchain_is_usable(version: &str) -> bool {
+    let root = toolchains_dir().join(version);
+    toolchain_cli_path(version).is_file()
+        && fs::read_to_string(root.join("VERSION"))
+            .is_ok_and(|installed| installed.trim() == version)
 }
 
 /// Run a path toolchain. None of the version bookkeeping applies to a binary
@@ -1681,6 +1777,32 @@ mod tests {
             missing,
             FetchPolicy::CacheAllowed
         ));
+    }
+
+    #[test]
+    fn ide_install_is_detected_with_editor_and_global_options() {
+        for args in [
+            &["ide", "install", "--code"][..],
+            &["ide", "install", "--cursor"][..],
+            &["--quiet", "ide", "install", "--output-dir", "out"][..],
+            &["ide", "install", "--output-dir", "help"][..],
+        ] {
+            let args = args.iter().map(ToString::to_string).collect::<Vec<_>>();
+            assert!(is_ide_install(&args), "{args:?}");
+        }
+    }
+
+    #[test]
+    fn ide_install_help_and_other_commands_do_not_trigger_setup() {
+        for args in [
+            &["ide", "install", "--help"][..],
+            &["help", "ide", "install"][..],
+            &["ide", "status"][..],
+            &["run", "ide", "install"][..],
+        ] {
+            let args = args.iter().map(ToString::to_string).collect::<Vec<_>>();
+            assert!(!is_ide_install(&args), "{args:?}");
+        }
     }
 
     fn resolved(selector: &str, source: SelectorSource) -> ResolvedSelector {

--- a/baml_language/crates/baml/tests/ide_install_e2e.rs
+++ b/baml_language/crates/baml/tests/ide_install_e2e.rs
@@ -1,0 +1,33 @@
+//! End-to-end coverage for the wrapper's first-run IDE installation path.
+
+use std::process::Command;
+
+#[test]
+fn ide_install_attempts_toolchain_setup_on_a_fresh_install() {
+    let home = tempfile::tempdir().unwrap();
+    let manifest_base_url = "http://127.0.0.1:1/manifest";
+    let output = Command::new(env!("CARGO_BIN_EXE_baml"))
+        .args(["ide", "install", "--code"])
+        .current_dir(home.path())
+        .env("BAML_HOME", home.path())
+        .env("HOME", home.path())
+        .env("BAML_MANIFEST_BASE_URL", manifest_base_url)
+        .env_remove("BAML_VERSION")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("failed to set up the BAML toolchain required by `baml ide install`"),
+        "{stderr}"
+    );
+    assert!(
+        stderr.contains(&format!("failed to fetch {manifest_base_url}/canary.json")),
+        "{stderr}"
+    );
+    assert!(
+        !stderr.contains("no BAML toolchain is installed"),
+        "{stderr}"
+    );
+}


### PR DESCRIPTION
## Summary

- Set up the selected managed BAML toolchain automatically before `baml ide install`.
- Preserve explicit local toolchain behavior and avoid side effects for help or unrelated commands.
- Add first-run end-to-end regression coverage plus command-detection unit tests.

## Root cause

The wrapper resolved and required an installed toolchain before delegating `ide install` to `baml-cli`, so a fresh wrapper installation exited with manual toolchain setup instructions before reaching the IDE installer.

## Validation

- `cargo test -p baml`
- `cargo clippy -p baml --all-targets -- -D warnings`
- `cargo fmt --check --package baml`
- `git diff --check`
- Isolated live smoke test installed toolchain `0.16.0` and extracted `baml-vscode.vsix`

Linear: [B-1113](https://linear.app/boundaryml2/issue/B-1113/set-up-the-toolchain-before-baml-ide-install-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `baml ide install` to automatically prepare required managed toolchains before installation.
  * Added clearer error messages when toolchain setup cannot complete.
  * Preserved support for path-based toolchain selections and global command options.
  * Improved validation for unavailable or unusable toolchains.

* **Tests**
  * Added coverage for command detection, help handling, channel setup, and fresh-install scenarios.
  * Verified that unreachable toolchain sources report the expected fetch error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->