### PR TITLE
fix(cli): require manifest directory for implicit projects

### DIFF
--- a/baml_language/crates/baml_cli/src/project_load.rs
+++ b/baml_language/crates/baml_cli/src/project_load.rs
@@ -183,15 +183,17 @@ pub(crate) fn projectless_search_dir(from: Option<&Path>) -> Result<PathBuf> {
 ///    while a disjoint explicit source tree is loaded directly. Manifest
 ///    validation is intentionally skipped: introspection doesn't need a valid
 ///    `[package].name`, and a malformed manifest shouldn't block it.
-/// 2. With no explicit `from`, walk ancestors for `baml.toml` or `baml_src/`.
-///    If no marker exists, return a **default state** holding only the BAML
-///    stdlib (`baml.*`) and zero user files. This makes `baml describe
-///    baml.String` work in any directory without recursively loading it.
+/// 2. With no explicit `from`, use a `baml.toml` in the current directory or
+///    walk ancestors for a manifest-less `baml_src/` marker. An ancestor
+///    `baml.toml` is rejected with guidance to run from its directory. If no
+///    marker exists, return a **default state** holding only the BAML stdlib
+///    (`baml.*`) and zero user files. This makes `baml describe baml.String`
+///    work in any directory without recursively loading it.
 ///
 /// Note the two branches differ in what they load:
 /// - The **default-state** branch (2) loads zero user files, so omitted
 ///   `--from` can never trigger the workspace-slurp hang.
-/// - The **walk-up** branch (1) loads the ancestor project exactly as
+/// - The **explicit walk-up** branch (1) loads the ancestor project exactly as
 ///   [`load_project_from`] would — including the "no `baml_src/` → walk the
 ///   whole root" path. So if an ancestor
 ///   `baml.toml` sits at a workspace root with hundreds of loose `.baml`
@@ -261,6 +263,11 @@ pub(crate) fn resolve_project_layout(from: Option<&Path>) -> Result<Option<Proje
 
     match find_baml_project_root(&canonical) {
         Some(discovered_root) => {
+            require_manifest_directory_for_implicit_discovery(
+                from,
+                &explicit_root,
+                &discovered_root,
+            )?;
             let discovered_source_root = project_source_root(&discovered_root);
             if from.is_none() || paths_overlap(&explicit_root, &discovered_source_root) {
                 return Ok(Some(ProjectLayout {
@@ -288,6 +295,26 @@ pub(crate) fn resolve_project_layout(from: Option<&Path>) -> Result<Option<Proje
         })),
         None => Ok(None),
     }
+}
+
+/// Keep implicit project resolution independent of the caller's depth within a
+/// repository. A manifest owns relative paths, so commands that rely on it must
+/// start in its directory unless the caller explicitly selects a project root.
+fn require_manifest_directory_for_implicit_discovery(
+    from: Option<&Path>,
+    search_dir: &Path,
+    discovered_root: &Path,
+) -> Result<()> {
+    if from.is_some() || search_dir == discovered_root || !discovered_root.join(BAML_TOML).is_file()
+    {
+        return Ok(());
+    }
+
+    anyhow::bail!(
+        "`baml.toml` was found at `{}`, but BAML commands without `--project` or `--from` must be run from the directory containing it.\nChange to `{}` and try again.",
+        discovered_root.join(BAML_TOML).display(),
+        discovered_root.display(),
+    );
 }
 
 pub(crate) fn find_project_root_from(from: Option<&Path>) -> Result<Option<PathBuf>> {

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -166,10 +166,28 @@ fn check_from_below_manifest_requires_explicit_project() {
         String::from_utf8_lossy(&implicit.stderr),
     );
     let stderr = String::from_utf8_lossy(&implicit.stderr);
-    assert!(stderr.contains("baml.toml"), "got stderr:\n{stderr}");
-    assert!(
-        stderr.contains("Change to `"),
-        "expected change-directory guidance in stderr:\n{stderr}",
+    let path_after = |marker: &str| {
+        let remainder = stderr
+            .split_once(marker)
+            .unwrap_or_else(|| panic!("expected {marker:?} in stderr:\n{stderr}"))
+            .1;
+        let path = remainder
+            .split_once('`')
+            .unwrap_or_else(|| panic!("expected a quoted path after {marker:?}:\n{stderr}"))
+            .0;
+        std::path::PathBuf::from(path)
+    };
+    let reported_manifest = path_after("`baml.toml` was found at `");
+    let reported_directory = path_after("Change to `");
+    assert_eq!(
+        reported_manifest.canonicalize().unwrap(),
+        tmp.path().join("baml.toml").canonicalize().unwrap(),
+        "expected the discovered manifest path in stderr:\n{stderr}",
+    );
+    assert_eq!(
+        reported_directory.canonicalize().unwrap(),
+        tmp.path().canonicalize().unwrap(),
+        "expected the required working directory in stderr:\n{stderr}",
     );
     assert!(
         stderr.contains("must be run from the directory containing it"),

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -141,6 +141,56 @@ fn check_defaults_from_to_current_directory() {
     );
 }
 
+/// Implicit project discovery must not make relative paths depend on how deep
+/// the command is run within a project. The manifest directory is required
+/// unless the project is selected explicitly.
+#[test]
+fn check_from_below_manifest_requires_explicit_project() {
+    let built = &common::baml_cli();
+    let tmp = tempfile::tempdir().unwrap();
+
+    create_project(
+        tmp.path(),
+        "function greet(name: string) -> string {\n  \"Hello, \" + name\n}\n",
+    );
+    let nested = tmp.path().join("baml_src/nested");
+    std::fs::create_dir_all(&nested).unwrap();
+
+    let implicit = run_baml_cli(built, &nested, &["check"]);
+    assert_eq!(
+        implicit.status.code(),
+        Some(4),
+        "Expected exit 4 below the manifest directory, got: {:?}\nstdout: {}\nstderr: {}",
+        implicit.status.code(),
+        String::from_utf8_lossy(&implicit.stdout),
+        String::from_utf8_lossy(&implicit.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&implicit.stderr);
+    let project_root = tmp.path().canonicalize().unwrap();
+    assert!(stderr.contains("baml.toml"), "got stderr:\n{stderr}");
+    assert!(
+        stderr.contains(&project_root.display().to_string()),
+        "expected project directory in stderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("must be run from the directory containing it"),
+        "got stderr:\n{stderr}",
+    );
+
+    let explicit = run_baml_cli(
+        built,
+        &nested,
+        &["check", "--from", tmp.path().to_str().unwrap()],
+    );
+    assert!(
+        explicit.status.success(),
+        "Expected explicit --from to work below the manifest directory, got: {:?}\nstdout: {}\nstderr: {}",
+        explicit.status.code(),
+        String::from_utf8_lossy(&explicit.stdout),
+        String::from_utf8_lossy(&explicit.stderr),
+    );
+}
+
 /// Compilation errors must result in a non-zero exit code for `baml check`.
 #[test]
 fn check_compilation_error_returns_nonzero_exit_code() {
@@ -1329,10 +1379,10 @@ fn describe_stdlib_without_baml_toml_succeeds() {
     );
 }
 
-/// `baml describe` walks up to an ancestor `baml.toml`, so introspection
-/// from a project subdirectory resolves a user-defined symbol.
+/// `baml describe` follows the same manifest-directory rule as build-shaped
+/// commands; an explicit project still enables introspection from a subdir.
 #[test]
-fn describe_walks_up_to_ancestor_project() {
+fn describe_from_below_manifest_requires_explicit_project() {
     let built = &common::baml_cli();
     let tmp = tempfile::tempdir().unwrap();
     create_project(
@@ -1342,8 +1392,22 @@ fn describe_walks_up_to_ancestor_project() {
     let nested = tmp.path().join("baml_src").join("nested");
     std::fs::create_dir_all(&nested).unwrap();
 
-    // Invoke from the nested subdir (default --from is ".").
-    let output = run_baml_cli(built, &nested, &["describe", "greet"]);
+    let implicit = run_baml_cli(built, &nested, &["describe", "greet"]);
+
+    assert_eq!(
+        implicit.status.code(),
+        Some(4),
+        "Expected exit 4 resolving implicitly from a subdir, got: {:?}\nstdout: {}\nstderr: {}",
+        implicit.status.code(),
+        String::from_utf8_lossy(&implicit.stdout),
+        String::from_utf8_lossy(&implicit.stderr),
+    );
+
+    let output = run_baml_cli(
+        built,
+        &nested,
+        &["describe", "greet", "--from", tmp.path().to_str().unwrap()],
+    );
 
     assert!(
         output.status.success(),
@@ -1376,11 +1440,10 @@ fn fmt_without_from_or_project_is_noop_success() {
     );
 }
 
-/// `baml describe` walks up to an ancestor with a **malformed** `baml.toml`
-/// (no `[package].name`) and still succeeds — introspection tolerates a bad
-/// manifest, unlike the strict build/execute path.
+/// With an explicit project, `baml describe` tolerates a **malformed**
+/// `baml.toml` (no `[package].name`), unlike the strict build/execute path.
 #[test]
-fn describe_walks_up_to_ancestor_with_invalid_manifest() {
+fn describe_tolerates_explicit_invalid_manifest() {
     let built = &common::baml_cli();
     let tmp = tempfile::tempdir().unwrap();
     // Malformed manifest: no [package] table.
@@ -1388,7 +1451,16 @@ fn describe_walks_up_to_ancestor_with_invalid_manifest() {
     let nested = tmp.path().join("sub");
     std::fs::create_dir_all(&nested).unwrap();
 
-    let output = run_baml_cli(built, &nested, &["describe", "baml.String"]);
+    let output = run_baml_cli(
+        built,
+        &nested,
+        &[
+            "describe",
+            "baml.String",
+            "--from",
+            tmp.path().to_str().unwrap(),
+        ],
+    );
 
     assert!(
         output.status.success(),

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -166,11 +166,10 @@ fn check_from_below_manifest_requires_explicit_project() {
         String::from_utf8_lossy(&implicit.stderr),
     );
     let stderr = String::from_utf8_lossy(&implicit.stderr);
-    let project_root = tmp.path().canonicalize().unwrap();
     assert!(stderr.contains("baml.toml"), "got stderr:\n{stderr}");
     assert!(
-        stderr.contains(&project_root.display().to_string()),
-        "expected project directory in stderr:\n{stderr}",
+        stderr.contains("Change to `"),
+        "expected change-directory guidance in stderr:\n{stderr}",
     );
     assert!(
         stderr.contains("must be run from the directory containing it"),


### PR DESCRIPTION
## Summary

- reject implicit BAML project discovery when `baml.toml` is only found in an ancestor directory
- report the manifest path and the directory the user should enter
- keep explicit `--project` / `--from` selection and manifest-less `baml_src/` projects working
- apply the same behavior to strict and lenient project-loading commands

## Root cause

The shared CLI resolver always walked up from the current directory, so relative paths could silently resolve against a project root chosen from the caller's directory depth. This made command behavior stateful and difficult for SDK callers to predict.

## User impact

Commands that implicitly find an ancestor `baml.toml` now exit with a focused error telling the user to run from the manifest directory. Users who intentionally run elsewhere can select the project explicitly.

## Validation

- `cargo fmt --manifest-path baml_language/Cargo.toml --package baml_cli -- --check`
- `cargo test --manifest-path baml_language/Cargo.toml -p baml_cli project_load::tests` (21 passed)
- `cargo test --manifest-path baml_language/Cargo.toml -p baml_cli --test exit_code_e2e` (48 passed)
- `git diff --check`

Linear: B-527

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved project discovery when commands are run from a subdirectory.
  * Added a clear error message directing you to run commands from the directory containing `baml.toml` or provide `--from`.
  * Preserved support for explicitly selected projects and manifest-less `baml_src/` discovery.
  * Improved project inspection behavior when an explicitly selected manifest is malformed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->