### PR TITLE
fix(cli): guide baml update to toolchain update

### DIFF
--- a/baml_language/crates/baml/src/main.rs
+++ b/baml_language/crates/baml/src/main.rs
@@ -155,6 +155,10 @@ language toolchain. Package-manager-managed wrappers refuse self-update and
 print the package-manager upgrade command instead.
 "#;
 
+const UPDATE_GUIDANCE: &str = "`baml update` is ambiguous.\n\
+To use the latest version of BAML, run `baml toolchain update`.\n\
+To update the BAML wrapper itself, run `baml self-update`.";
+
 fn main() {
     let exit = match run() {
         Ok(code) => code,
@@ -176,6 +180,9 @@ fn run() -> Result<i32> {
     if matches!(args.first().map(String::as_str), Some("--version" | "-V")) {
         print_version();
         return Ok(0);
+    }
+    if args.first().map(String::as_str) == Some("update") {
+        return Err(anyhow!(UPDATE_GUIDANCE));
     }
     if args.first().map(String::as_str) == Some("toolchain") {
         args.remove(0);

--- a/baml_language/crates/baml/tests/update_e2e.rs
+++ b/baml_language/crates/baml/tests/update_e2e.rs
@@ -1,0 +1,19 @@
+use std::process::Command;
+
+#[test]
+fn update_suggests_the_toolchain_command_before_resolving_a_toolchain() {
+    let output = Command::new(env!("CARGO_BIN_EXE_baml"))
+        .arg("update")
+        .env("BAML_VERSION", "missing-test-toolchain")
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "`baml update` is ambiguous.\n\
+To use the latest version of BAML, run `baml toolchain update`.\n\
+To update the BAML wrapper itself, run `baml self-update`.\n"
+    );
+}

--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -126,7 +126,7 @@ pub fn run_cli(argv: Vec<String>) -> Result<ExitCode> {
         return Err(anyhow!(
             "`baml update` is ambiguous.\n\
              To use the latest version of BAML, run `baml toolchain update`.\n\
-             To use the latest BAML toolchain selector, run `baml self-update`."
+             To update the BAML wrapper itself, run `baml self-update`."
         ));
     }
     let cli = commands::RuntimeCli::parse_from_smart(argv);

--- a/baml_language/crates/baml_cli/tests/update_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/update_e2e.rs
@@ -19,7 +19,7 @@ fn update_suggests_the_toolchain_and_wrapper_commands() {
         "{stderr}"
     );
     assert!(
-        stderr.contains("To use the latest BAML toolchain selector, run `baml self-update`."),
+        stderr.contains("To update the BAML wrapper itself, run `baml self-update`."),
         "{stderr}"
     );
 }


### PR DESCRIPTION
## Summary

- intercept `baml update` in the wrapper before resolving or launching a selected toolchain
- recommend `baml toolchain update` as the primary command and describe `baml self-update` separately as a wrapper update
- cover both wrapper and direct `baml-cli` behavior with end-to-end tests

## Root cause

The compatibility guidance existed only in `baml-cli`. The `baml` wrapper delegated unknown commands to the selected toolchain, so users with an older toolchain still received Clap's generic `unrecognized subcommand 'update'` response.

## Impact

`baml update` now consistently returns actionable guidance, even when the selected toolchain is missing or predates the CLI-side compatibility handling.

Fixes B-995.

## Validation

- `cargo fmt --package baml --package baml_cli -- --check`
- `cargo test -p baml`
- `cargo test -p baml --no-default-features --features no-self-update`
- `cargo test -p baml_cli --test update_e2e`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified that the ambiguous `baml update` command is no longer accepted.
  * Added guidance to use `baml toolchain update` for the latest toolchain or `baml self-update` to update the BAML wrapper.
  * The command now exits without producing standard output and displays the appropriate instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->