### PR TITLE
feat: log when shutdown waits for active futures

### DIFF
--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -41,6 +41,7 @@ pub(crate) mod project_load;
 pub(crate) mod project_session;
 pub mod reporter;
 pub(crate) mod run_command;
+pub(crate) mod shutdown;
 pub(crate) mod skill_check;
 pub(crate) mod telemetry;
 pub(crate) mod telemetry_command;

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -640,7 +640,7 @@ impl RunArgs {
             json_args,
             output_format,
         ));
-        rt.block_on(engine.shutdown());
+        crate::shutdown::shutdown_engine(&rt, &engine, reporter);
         let unhandled_spawn_failed = report_unhandled_spawn_errors(&engine, reporter);
 
         self.vlog(format_args!("Completed in {:.2?}", start.elapsed()));
@@ -962,7 +962,7 @@ impl RunArgs {
             }
             Ok(())
         });
-        rt.block_on(engine.shutdown());
+        crate::shutdown::shutdown_engine(&rt, &engine, reporter);
         let unhandled_spawn_failed = report_unhandled_spawn_errors(&engine, reporter);
 
         match result {

--- a/baml_language/crates/baml_cli/src/shutdown.rs
+++ b/baml_language/crates/baml_cli/src/shutdown.rs
@@ -1,0 +1,37 @@
+use std::sync::Arc;
+
+use bex_engine::BexEngine;
+
+use crate::reporter::Reporter;
+
+pub(crate) fn shutdown_engine(
+    rt: &tokio::runtime::Runtime,
+    engine: &Arc<BexEngine>,
+    reporter: &Reporter,
+) {
+    rt.block_on(engine.shutdown_with_progress(|count| {
+        reporter.status("Waiting", wait_message(count));
+    }));
+}
+
+fn wait_message(count: usize) -> String {
+    let threads = if count == 1 { "thread" } else { "threads" };
+    format!("for {count} remaining BAML {threads} to finish; press Ctrl+C to cancel")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wait_message_pluralizes_thread_count() {
+        assert_eq!(
+            wait_message(1),
+            "for 1 remaining BAML thread to finish; press Ctrl+C to cancel"
+        );
+        assert_eq!(
+            wait_message(2),
+            "for 2 remaining BAML threads to finish; press Ctrl+C to cancel"
+        );
+    }
+}

--- a/baml_language/crates/baml_cli/src/shutdown.rs
+++ b/baml_language/crates/baml_cli/src/shutdown.rs
@@ -15,8 +15,8 @@ pub(crate) fn shutdown_engine(
 }
 
 fn wait_message(count: usize) -> String {
-    let threads = if count == 1 { "thread" } else { "threads" };
-    format!("for {count} remaining BAML {threads} to finish; press Ctrl+C to cancel")
+    let futures = if count == 1 { "future" } else { "futures" };
+    format!("for {count} remaining BAML {futures} to finish (press Ctrl+C to cancel now)")
 }
 
 #[cfg(test)]
@@ -24,14 +24,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn wait_message_pluralizes_thread_count() {
+    fn wait_message_pluralizes_future_count() {
         assert_eq!(
             wait_message(1),
-            "for 1 remaining BAML thread to finish; press Ctrl+C to cancel"
+            "for 1 remaining BAML future to finish (press Ctrl+C to cancel now)"
         );
         assert_eq!(
             wait_message(2),
-            "for 2 remaining BAML threads to finish; press Ctrl+C to cancel"
+            "for 2 remaining BAML futures to finish (press Ctrl+C to cancel now)"
         );
     }
 }

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -404,8 +404,8 @@ impl RunCtx<'_> {
     }
 }
 
-fn finish_engine(ctx: &RunCtx<'_>) -> usize {
-    ctx.rt.block_on(ctx.engine.shutdown());
+fn finish_engine(ctx: &RunCtx<'_>, reporter: &Reporter) -> usize {
+    crate::shutdown::shutdown_engine(ctx.rt, ctx.engine, reporter);
     ctx.unhandled_spawn_failures.load(Ordering::SeqCst)
 }
 
@@ -597,7 +597,7 @@ impl TestArgs {
                     // continue as if there were no testset tests.
                     reporter.abandon();
                     crate::reporter::print_error(format_args!("testset discovery failed: {e}"));
-                    return Ok(if finish_engine(&run_ctx) != 0 {
+                    return Ok(if finish_engine(&run_ctx, &reporter) != 0 {
                         crate::ExitCode::TestFailure
                     } else {
                         crate::ExitCode::Other
@@ -619,7 +619,7 @@ impl TestArgs {
                     Err(e) => {
                         reporter.abandon();
                         crate::reporter::print_error(format_args!("failed to list tests: {e}"));
-                        return Ok(if finish_engine(&run_ctx) != 0 {
+                        return Ok(if finish_engine(&run_ctx, &reporter) != 0 {
                             crate::ExitCode::TestFailure
                         } else {
                             crate::ExitCode::Other
@@ -629,7 +629,7 @@ impl TestArgs {
                 None => Vec::new(),
             };
 
-            if finish_engine(&run_ctx) != 0 {
+            if finish_engine(&run_ctx, &reporter) != 0 {
                 return Ok(crate::ExitCode::TestFailure);
             }
 
@@ -717,7 +717,7 @@ impl TestArgs {
             }
         }
 
-        let unhandled_spawn_failure_count = finish_engine(&run_ctx);
+        let unhandled_spawn_failure_count = finish_engine(&run_ctx, &reporter);
         if unhandled_spawn_failure_count != 0 {
             failed += unhandled_spawn_failure_count;
             total += unhandled_spawn_failure_count;

--- a/baml_language/crates/bex_engine/Cargo.toml
+++ b/baml_language/crates/bex_engine/Cargo.toml
@@ -48,7 +48,7 @@ indexmap = { workspace = true }
 prost = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
-tokio = { workspace = true, features = [ "rt-multi-thread", "macros" ] }
+tokio = { workspace = true, features = [ "rt-multi-thread", "macros", "test-util" ] }
 wiremock = { workspace = true }
 
 [lints]

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -2207,13 +2207,13 @@ impl BexEngine {
         self.shutdown_with_progress(|count| {
             tracing::warn!(
                 count,
-                "BAML is still waiting for active threads to finish; press Ctrl+C to cancel"
+                "BAML is still waiting for active futures to finish (press Ctrl+C to cancel now)"
             );
         })
         .await;
     }
 
-    /// Shut down the engine, reporting the number of active BAML threads every
+    /// Shut down the engine, reporting the number of active BAML futures every
     /// five seconds while shutdown is blocked.
     pub async fn shutdown_with_progress<F>(self: &Arc<Self>, on_wait: F)
     where

--- a/baml_language/crates/bex_engine/src/lib.rs
+++ b/baml_language/crates/bex_engine/src/lib.rs
@@ -2173,6 +2173,16 @@ impl BexEngine {
         }
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
+    fn active_call_count(&self) -> usize {
+        self.active_calls
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .values()
+            .filter(|call| !call.pending)
+            .count()
+    }
+
     async fn wait_for_active_calls(&self) {
         loop {
             let notified = self.lifecycle_changed.notified();
@@ -2194,11 +2204,45 @@ impl BexEngine {
     /// Wait for spawned work to settle, then run the final GC sweep that
     /// surfaces unreachable unobserved errors.
     pub async fn shutdown(self: &Arc<Self>) {
-        const WAIT_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(20);
+        self.shutdown_with_progress(|count| {
+            tracing::warn!(
+                count,
+                "BAML is still waiting for active threads to finish; press Ctrl+C to cancel"
+            );
+        })
+        .await;
+    }
+
+    /// Shut down the engine, reporting the number of active BAML threads every
+    /// five seconds while shutdown is blocked.
+    pub async fn shutdown_with_progress<F>(self: &Arc<Self>, on_wait: F)
+    where
+        F: FnMut(usize) + Send,
+    {
+        #[cfg(not(target_arch = "wasm32"))]
+        const WAIT_LOG_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+        #[cfg(not(target_arch = "wasm32"))]
+        let mut on_wait = on_wait;
+        #[cfg(target_arch = "wasm32")]
+        let _ = on_wait;
 
         let Some(shutdown) = self.begin_shutdown().await else {
             return;
         };
+        #[cfg(not(target_arch = "wasm32"))]
+        loop {
+            if tokio::time::timeout(WAIT_LOG_INTERVAL, self.wait_for_active_calls())
+                .await
+                .is_ok()
+            {
+                break;
+            }
+            let count = self.active_call_count();
+            if count != 0 {
+                on_wait(count);
+            }
+        }
+        #[cfg(target_arch = "wasm32")]
         self.wait_for_active_calls().await;
 
         loop {
@@ -2209,8 +2253,6 @@ impl BexEngine {
             if handles.is_empty() {
                 break;
             }
-            #[cfg(not(target_arch = "wasm32"))]
-            let count = handles.len();
             let wait = async move {
                 for handle in handles {
                     let _ = handle.wait().await;
@@ -2219,12 +2261,14 @@ impl BexEngine {
             #[cfg(not(target_arch = "wasm32"))]
             {
                 if tokio::time::timeout(WAIT_LOG_INTERVAL, wait).await.is_err() {
-                    tracing::warn!(count, "waiting for pending futures during engine shutdown");
+                    let count = self.active_future_count().await;
+                    if count != 0 {
+                        on_wait(count);
+                    }
                 }
             }
             #[cfg(target_arch = "wasm32")]
             {
-                let _ = WAIT_LOG_INTERVAL;
                 wait.await;
             }
         }

--- a/baml_language/crates/bex_engine/tests/fire_and_forget.rs
+++ b/baml_language/crates/bex_engine/tests/fire_and_forget.rs
@@ -512,7 +512,7 @@ async fn call_completion_does_not_join_but_shutdown_does() {
 }
 
 #[tokio::test(start_paused = true)]
-async fn shutdown_periodically_reports_pending_threads() {
+async fn shutdown_periodically_reports_pending_futures() {
     let source = r#"
         function main() -> int {
             spawn {

--- a/baml_language/crates/bex_engine/tests/fire_and_forget.rs
+++ b/baml_language/crates/bex_engine/tests/fire_and_forget.rs
@@ -511,6 +511,31 @@ async fn call_completion_does_not_join_but_shutdown_does() {
     assert_eq!(errors[0].value, BexExternalValue::String("boom".into()));
 }
 
+#[tokio::test(start_paused = true)]
+async fn shutdown_periodically_reports_pending_threads() {
+    let source = r#"
+        function main() -> int {
+            spawn {
+                baml.sys.sleep(baml.time.Duration.from_seconds(12n));
+                42
+            };
+            1
+        }
+    "#;
+    let engine = make_engine(source);
+    assert_eq!(
+        call_main(&engine, true).await.unwrap(),
+        BexExternalValue::Int(1)
+    );
+
+    let mut reported = Vec::new();
+    engine
+        .shutdown_with_progress(|count| reported.push(count))
+        .await;
+
+    assert_eq!(reported, vec![1, 1]);
+}
+
 /// B-405: awaiting an unrelated future must not surface an error from a
 /// reachable future that this task observes later.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]


### PR DESCRIPTION
## Summary

- report shutdown progress every five seconds while active BAML calls or spawned threads remain
- route CLI shutdown progress through the terminal reporter so the message is visible without a tracing subscriber
- include the remaining thread count and explain that Ctrl+C cancels the wait

## Root cause

The engine emitted a tracing warning only after 20 seconds, but the CLI does not install a tracing subscriber, so users could see completed test output while the process appeared to hang indefinitely with no explanation.

## Validation

- `cargo test -p bex_engine --test fire_and_forget shutdown_periodically_reports_pending_threads -- --exact`
- `cargo test -p baml_cli shutdown::tests::wait_message_pluralizes_thread_count -- --exact`
- `cargo clippy -p bex_engine -p baml_cli --all-targets -- -D warnings`
- `RUSTFLAGS='-A unused -D warnings' cargo check -p bex_engine --target wasm32-unknown-unknown --no-default-features`
- `cargo fmt --all -- --check`
- `git diff --check`

Linear: B-805

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved shutdown handling across command execution paths.
  - Added progress reporting while active operations and background tasks finish.
  - Shutdown status now displays clearer singular and plural thread counts.
  - Active operations are checked more frequently for timely updates.
  - Standard shutdown behavior continues to provide warnings when work remains in progress.

- **Tests**
  - Added coverage verifying progress updates during pending background work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->