### PR TITLE
chore: add CodeRabbit CLI tooling

### DIFF
--- a/README-DEV.md
+++ b/README-DEV.md
@@ -61,33 +61,6 @@ mise upgrade
 mise trust
 ```
 
-## Local Code Reviews with CodeRabbit
-
-The repository's GitHub integration uses CodeRabbit's repository-level UI configuration with the `chill` review profile. CodeRabbit's CLI does not expose a review-profile flag, and CLI reviews intentionally differ from PR reviews, so the local setup leaves the GitHub configuration in place and uses the same repository and default base branch without adding a `.coderabbit.yaml` override.
-
-Install the pinned CLI with the rest of the development tools, then authenticate using CodeRabbit's browser flow. Authentication is stored in CodeRabbit's user-level local storage and must not be added to the repository:
-
-```bash
-mise install http:coderabbit
-coderabbit auth login
-coderabbit auth status
-```
-
-Review all local changes against `canary` with either the repository helper or the equivalent direct command:
-
-```bash
-mise run coderabbit-review
-coderabbit review --base canary
-```
-
-To review only staged changes and edits to tracked files, use:
-
-```bash
-mise run coderabbit-review -- --uncommitted
-```
-
-Untracked files are excluded unless you add them to Git or pass `--include-untracked`. Run `coderabbit doctor` if installation, authentication, repository detection, or service connectivity fails.
-
 ## Manual Setup (Not Recommended)
 
 If you prefer to install tools manually or need to understand what the setup script does:

--- a/README-DEV.md
+++ b/README-DEV.md
@@ -61,6 +61,33 @@ mise upgrade
 mise trust
 ```
 
+## Local Code Reviews with CodeRabbit
+
+The repository's GitHub integration uses CodeRabbit's repository-level UI configuration with the `chill` review profile. CodeRabbit's CLI does not expose a review-profile flag, and CLI reviews intentionally differ from PR reviews, so the local setup leaves the GitHub configuration in place and uses the same repository and default base branch without adding a `.coderabbit.yaml` override.
+
+Install the pinned CLI with the rest of the development tools, then authenticate using CodeRabbit's browser flow. Authentication is stored in CodeRabbit's user-level local storage and must not be added to the repository:
+
+```bash
+mise install http:coderabbit
+coderabbit auth login
+coderabbit auth status
+```
+
+Review all local changes against `canary` with either the repository helper or the equivalent direct command:
+
+```bash
+mise run coderabbit-review
+coderabbit review --base canary
+```
+
+To review only staged changes and edits to tracked files, use:
+
+```bash
+mise run coderabbit-review -- --uncommitted
+```
+
+Untracked files are excluded unless you add them to Git or pass `--include-untracked`. Run `coderabbit doctor` if installation, authentication, repository detection, or service connectivity fails.
+
 ## Manual Setup (Not Recommended)
 
 If you prefer to install tools manually or need to understand what the setup script does:

--- a/mise.toml
+++ b/mise.toml
@@ -53,14 +53,17 @@ actionlint = "latest"
 ast-grep = "0.44.1"
 
 # Code review tools
-[tools."http:coderabbit"]
+[tools.coderabbit]
 version = "0.7.2"
 
-[tools."http:coderabbit".platforms]
+[tools.coderabbit.platforms]
 macos-x64 = { url = "https://cli.coderabbit.ai/releases/0.7.2/coderabbit-darwin-x64.zip", checksum = "sha256:1f54ea386e9f6ef5277101d54fa6f071af65f88a800a786c6f83976396aeb727" }
 macos-arm64 = { url = "https://cli.coderabbit.ai/releases/0.7.2/coderabbit-darwin-arm64.zip", checksum = "sha256:29944665428720e55aa26a452e8f637858607a76f4722cabb88296f6976ee5b7" }
 linux-x64 = { url = "https://cli.coderabbit.ai/releases/0.7.2/coderabbit-linux-x64.zip", checksum = "sha256:32dd3a5a1238fa68eb7cfa95cc19cf6ad4980882589c616c0e300b920f1bb865" }
 linux-arm64 = { url = "https://cli.coderabbit.ai/releases/0.7.2/coderabbit-linux-arm64.zip", checksum = "sha256:cb2aa4a598fab167cdc6467f0a44be504857cc9866057bd94ea7018481937c5d" }
+
+[tool_alias]
+coderabbit = "http:coderabbit"
 
 [tasks.coderabbit-review]
 run = "coderabbit review --base canary"

--- a/mise.toml
+++ b/mise.toml
@@ -52,6 +52,20 @@ protoc = "27.1"
 actionlint = "latest"
 ast-grep = "0.44.1"
 
+# Code review tools
+[tools."http:coderabbit"]
+version = "0.7.2"
+
+[tools."http:coderabbit".platforms]
+macos-x64 = { url = "https://cli.coderabbit.ai/releases/0.7.2/coderabbit-darwin-x64.zip", checksum = "sha256:1f54ea386e9f6ef5277101d54fa6f071af65f88a800a786c6f83976396aeb727" }
+macos-arm64 = { url = "https://cli.coderabbit.ai/releases/0.7.2/coderabbit-darwin-arm64.zip", checksum = "sha256:29944665428720e55aa26a452e8f637858607a76f4722cabb88296f6976ee5b7" }
+linux-x64 = { url = "https://cli.coderabbit.ai/releases/0.7.2/coderabbit-linux-x64.zip", checksum = "sha256:32dd3a5a1238fa68eb7cfa95cc19cf6ad4980882589c616c0e300b920f1bb865" }
+linux-arm64 = { url = "https://cli.coderabbit.ai/releases/0.7.2/coderabbit-linux-arm64.zip", checksum = "sha256:cb2aa4a598fab167cdc6467f0a44be504857cc9866057bd94ea7018481937c5d" }
+
+[tasks.coderabbit-review]
+run = "coderabbit review --base canary"
+description = "Review local changes with CodeRabbit against the canary branch"
+
 [tasks.pr-unresolved]
 run = "./scripts/pr-unresolved"
 description = "Show unresolved PR review threads for the current branch PR"


### PR DESCRIPTION
## Summary

- pin CodeRabbit CLI 0.7.2 in `mise.toml` for macOS and Linux on x64 and arm64, including SHA-256 checksums
- map the `coderabbit` tool name to mise's HTTP backend so contributors can run `mise install coderabbit`
- add a `coderabbit-review` mise task that compares local changes against `canary`

## Why

Contributors should be able to run CodeRabbit reviews against local changes before pushing a branch or opening a PR. The repository currently uses CodeRabbit's Repository UI configuration with the `chill` profile, so this change preserves that setup instead of adding a `.coderabbit.yaml` file that would take precedence over the existing UI settings. The CLI does not expose a review-profile flag, and local CLI reviews intentionally differ from PR reviews.

## Usage

```bash
mise install coderabbit
coderabbit auth login
mise run coderabbit-review
```

Authentication is per-user and no credentials are stored in the repository.

## Verification

- `mise install coderabbit`
- `mise exec -- coderabbit --version` → `0.7.2`
- `mise run coderabbit-review -- --help`
- `mise config --json`
- `coderabbit doctor` → 8 checks passed, authentication warning only
- `git diff --check`

A live review was not started because this environment is not signed in to CodeRabbit.