### PR TITLE
test(fmt): cover baml.spawn paths in type positions

### DIFF
--- a/baml_language/crates/baml_fmt/src/ast/tokens.rs
+++ b/baml_language/crates/baml_fmt/src/ast/tokens.rs
@@ -597,11 +597,11 @@ impl Word {
 /// True for token kinds the parser accepts as identifiers in name positions.
 ///
 /// The lexer emits dedicated keyword kinds for these words, but the parser
-/// keeps them valid as field, parameter, method, and member-access names
-/// (e.g. a class field or parameter named `client`, or `x.implements(y)` on
-/// the reflection `type` value). The CST therefore contains the keyword kind
-/// where the strong AST expects a name, and [`Word::from_cst`] must accept it.
-/// Mirrors `at_member_name` and `parse_parameter` in `baml_compiler_parser`.
+/// keeps them valid as field, parameter, method, and member-access names, as
+/// well as path segments in expressions and types (e.g.
+/// `baml.spawn.CancelToken`). The CST therefore contains the keyword kind where
+/// the strong AST expects a name, and [`Word::from_cst`] must accept it. Mirrors
+/// the contextual identifier checks in `baml_compiler_parser`.
 #[must_use]
 pub fn is_word_like(kind: SyntaxKind) -> bool {
     matches!(

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -780,6 +780,34 @@ mod linear_formatter_regression_tests {
         let second = format(&formatted, &options).expect("formatter should be idempotent");
         assert_eq!(formatted, second, "formatter should be idempotent");
     }
+
+    /// B-1509: `spawn` lexes as `KW_SPAWN`, including when it is the middle
+    /// segment of a type path. Every type position accepted by the parser must
+    /// also be accepted by the formatter's strong AST.
+    #[test]
+    fn spawn_namespace_formats_in_type_positions() {
+        let cases = [
+            "function f(tok:baml.spawn.CancelToken)->bool { true }\n",
+            "function f()->baml.spawn.CancelToken { baml.spawn.CancelToken.new() }\n",
+            "class Holder { tok:baml.spawn.CancelToken }\n",
+            "type Tokens=map<string,baml.spawn.CancelToken>\n",
+        ];
+
+        for source in cases {
+            let formatted = format(source, &FormatOptions::default())
+                .unwrap_or_else(|error| panic!("failed to format `{source}`: {error}"));
+            assert!(
+                formatted.contains("baml.spawn.CancelToken"),
+                "type path was not preserved: {formatted}"
+            );
+            assert_eq!(
+                formatted,
+                format(&formatted, &FormatOptions::default())
+                    .expect("formatted type path should remain valid"),
+                "formatter should be idempotent for `{source}`"
+            );
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- add B-1509 regression coverage for `baml.spawn.CancelToken` in parameter, return, class-field, and generic-argument type positions
- document that formatter contextual identifiers cover both expression and type path segments
- keep the existing B-258 expression-position behavior covered alongside the new cases

## Root cause

`spawn` is lexed as `KW_SPAWN` even when it appears as a namespace segment. The formatter previously expected a plain `WORD` in type paths. The shared contextual-keyword handling now accepts this valid parser output, but type-position coverage was missing.

## Impact

Files with signatures such as `tok: baml.spawn.CancelToken` remain formatable and formatter behavior stays aligned with the parser across all reported type positions.

## Validation

- `cargo test -p baml_fmt --lib` (125 passed)
- `cargo fmt --all -- --check`
- `git diff --check`

Linear: B-1509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting support for qualified type paths containing keyword-like segments, such as `baml.spawn.CancelToken`.
  * Ensured these paths remain intact across parameters, return types, class fields, and generic types.

* **Tests**
  * Added regression coverage verifying formatting succeeds and produces consistent, repeatable output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->