### PR TITLE
Fix toolchain install project pin resolution

### DIFF
--- a/baml_language/crates/baml/src/main.rs
+++ b/baml_language/crates/baml/src/main.rs
@@ -120,7 +120,7 @@ Usage:
 Commands:
   use <canary|nightly|version|path>  Install if needed and select as default
   pin <canary|nightly|version|path>  Select in the nearest baml.toml
-  install <canary|nightly|version>   Download without selecting
+  install [canary|nightly|version]   Download without selecting
   update                             Advance the active channel
   status                             Check latest remote version without installing
   list                               Show installed toolchains, local only
@@ -143,6 +143,18 @@ Network behavior:
 
 Wrapper updates:
   baml self-update                   Update curl-installed wrapper only
+"#;
+
+const TOOLCHAIN_INSTALL_HELP: &str = r#"Install a BAML toolchain without selecting it as the global default
+
+Usage:
+  baml toolchain install [canary|nightly|version] [--force]
+
+When the selector is omitted, install uses the toolchain pin from the nearest
+baml.toml.
+
+Options:
+  --force  Reinstall the toolchain if it is already installed
 "#;
 
 const SELF_UPDATE_HELP: &str = r#"BAML wrapper self-update
@@ -353,13 +365,7 @@ fn toolchain(args: Vec<String>) -> Result<()> {
             print!("{TOOLCHAIN_HELP}");
             Ok(())
         }
-        Some("install") => {
-            let selector = args
-                .get(1)
-                .ok_or_else(|| anyhow!("usage: baml toolchain install <canary|nightly|version>"))?;
-            let force = args.iter().any(|arg| arg == "--force");
-            install_toolchain(selector, false, manifest_base_url.as_deref(), force)
-        }
+        Some("install") => install_toolchain_command(&args[1..], manifest_base_url.as_deref()),
         Some("use") => {
             let selector = args.get(1).ok_or_else(|| {
                 anyhow!("usage: baml toolchain use <canary|nightly|version|path>")
@@ -394,6 +400,41 @@ fn toolchain(args: Vec<String>) -> Result<()> {
             "unknown toolchain command {other:?}\n\n{TOOLCHAIN_HELP}"
         )),
     }
+}
+
+fn install_toolchain_command(args: &[String], manifest_base_url: Option<&str>) -> Result<()> {
+    if args.iter().any(|arg| is_help_arg(arg)) {
+        print!("{TOOLCHAIN_INSTALL_HELP}");
+        return Ok(());
+    }
+
+    let mut selector = None;
+    let mut force = false;
+    for arg in args {
+        if arg == "--force" {
+            force = true;
+        } else if arg.starts_with('-') {
+            return Err(anyhow!(
+                "unknown option {arg:?}\n\n{TOOLCHAIN_INSTALL_HELP}"
+            ));
+        } else if selector.replace(arg.as_str()).is_some() {
+            return Err(anyhow!(
+                "unexpected argument {arg:?}\n\n{TOOLCHAIN_INSTALL_HELP}"
+            ));
+        }
+    }
+
+    let selector = match selector {
+        Some(selector) => selector.to_string(),
+        None => project_toolchain_selector()?
+            .map(|(_, selector)| selector)
+            .ok_or_else(|| {
+                anyhow!(
+                    "no BAML toolchain is pinned in baml.toml\nRun: baml toolchain install <canary|nightly|version>"
+                )
+            })?,
+    };
+    install_toolchain(&selector, false, manifest_base_url, force)
 }
 
 fn is_help_arg(arg: &str) -> bool {

--- a/baml_language/crates/baml/src/main.rs
+++ b/baml_language/crates/baml/src/main.rs
@@ -424,17 +424,18 @@ fn install_toolchain_command(args: &[String], manifest_base_url: Option<&str>) -
         }
     }
 
-    let selector = match selector {
-        Some(selector) => selector.to_string(),
+    let (selector, activate_channel) = match selector {
+        Some(selector) => (selector.to_string(), false),
         None => project_toolchain_selector()?
             .map(|(_, selector)| selector)
             .ok_or_else(|| {
                 anyhow!(
                     "no BAML toolchain is pinned in baml.toml\nRun: baml toolchain install <canary|nightly|version>"
                 )
-            })?,
+            })
+            .map(|selector| (selector, true))?,
     };
-    install_toolchain(&selector, false, manifest_base_url, force)
+    install_toolchain(&selector, activate_channel, manifest_base_url, force)
 }
 
 fn is_help_arg(arg: &str) -> bool {

--- a/baml_language/crates/baml/src/main.rs
+++ b/baml_language/crates/baml/src/main.rs
@@ -151,7 +151,7 @@ Usage:
   baml toolchain install [canary|nightly|version] [--force]
 
 When the selector is omitted, install uses the toolchain pin from the nearest
-baml.toml.
+baml.toml, or canary if the project does not specify one.
 
 Options:
   --force  Reinstall the toolchain if it is already installed
@@ -426,14 +426,12 @@ fn install_toolchain_command(args: &[String], manifest_base_url: Option<&str>) -
 
     let (selector, activate_channel) = match selector {
         Some(selector) => (selector.to_string(), false),
-        None => project_toolchain_selector()?
-            .map(|(_, selector)| selector)
-            .ok_or_else(|| {
-                anyhow!(
-                    "no BAML toolchain is pinned in baml.toml\nRun: baml toolchain install <canary|nightly|version>"
-                )
-            })
-            .map(|selector| (selector, true))?,
+        None => (
+            project_toolchain_selector()?
+                .map(|(_, selector)| selector)
+                .unwrap_or_else(|| "canary".to_string()),
+            true,
+        ),
     };
     install_toolchain(&selector, activate_channel, manifest_base_url, force)
 }

--- a/baml_language/crates/baml/tests/toolchain_install_e2e.rs
+++ b/baml_language/crates/baml/tests/toolchain_install_e2e.rs
@@ -1,0 +1,72 @@
+use std::{fs, process::Command};
+
+fn baml_command(project: &tempfile::TempDir) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_baml"));
+    command
+        .arg("toolchain")
+        .arg("install")
+        .current_dir(project.path())
+        .env("BAML_HOME", project.path().join(".baml-home"))
+        .env("HOME", project.path())
+        .env_remove("BAML_VERSION");
+    command
+}
+
+#[test]
+fn bare_install_uses_project_toolchain_pin() {
+    let project = tempfile::tempdir().unwrap();
+    fs::write(
+        project.path().join("baml.toml"),
+        "[package]\nname = \"demo\"\n\n[toolchain]\nversion = \"0.15.0\"\n",
+    )
+    .unwrap();
+
+    let output = baml_command(&project)
+        .args(["--manifest-base-url", "http://127.0.0.1:1/manifest"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("http://127.0.0.1:1/manifest/version/0.15.0.json"),
+        "{stderr}"
+    );
+    assert!(!stderr.contains("usage:"), "{stderr}");
+}
+
+#[test]
+fn install_help_is_not_parsed_as_a_version() {
+    let project = tempfile::tempdir().unwrap();
+    let output = baml_command(&project)
+        .args([
+            "--help",
+            "--manifest-base-url",
+            "http://127.0.0.1:1/manifest",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output.status.success());
+    assert!(output.stderr.is_empty());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("baml toolchain install [canary|nightly|version] [--force]"),
+        "{stdout}"
+    );
+    assert!(!stdout.contains("127.0.0.1"), "{stdout}");
+}
+
+#[test]
+fn bare_install_without_a_project_pin_is_actionable() {
+    let project = tempfile::tempdir().unwrap();
+    let output = baml_command(&project).output().unwrap();
+
+    assert!(!output.status.success());
+    assert!(output.stdout.is_empty());
+    assert_eq!(
+        String::from_utf8_lossy(&output.stderr),
+        "no BAML toolchain is pinned in baml.toml\nRun: baml toolchain install <canary|nightly|version>\n"
+    );
+}

--- a/baml_language/crates/baml/tests/toolchain_install_e2e.rs
+++ b/baml_language/crates/baml/tests/toolchain_install_e2e.rs
@@ -1,4 +1,10 @@
-use std::{fs, process::Command};
+use std::{
+    fs,
+    io::{Read, Write},
+    net::TcpListener,
+    process::Command,
+    thread,
+};
 
 fn baml_command(project: &tempfile::TempDir) -> Command {
     let mut command = Command::new(env!("CARGO_BIN_EXE_baml"));
@@ -10,6 +16,38 @@ fn baml_command(project: &tempfile::TempDir) -> Command {
         .env("HOME", project.path())
         .env_remove("BAML_VERSION");
     command
+}
+
+fn serve_manifest(version: &str, channel: &str) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let address = listener.local_addr().unwrap();
+    let artifacts = baml_release::SUPPORTED_RELEASE_TARGETS
+        .iter()
+        .map(|target| {
+            format!(
+                r#""{target}":{{"url":"https://example.com/{target}.tar.gz","sha256":"{}"}}"#,
+                "a".repeat(64)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    let body = format!(
+        r#"{{"schema":1,"version":"{version}","channel":"{channel}","released_at":"2026-08-13T00:00:00Z","artifacts":{{{artifacts}}}}}"#
+    );
+    let server = thread::spawn(move || {
+        let (mut stream, _) = listener.accept().unwrap();
+        let mut request = [0; 1024];
+        let bytes_read = stream.read(&mut request).unwrap();
+        assert!(bytes_read > 0);
+        write!(
+            stream,
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .unwrap();
+    });
+    (format!("http://{address}/manifest"), server)
 }
 
 #[test]
@@ -34,6 +72,36 @@ fn bare_install_uses_project_toolchain_pin() {
         "{stderr}"
     );
     assert!(!stderr.contains("usage:"), "{stderr}");
+}
+
+#[test]
+fn bare_install_records_project_channel_resolution() {
+    let project = tempfile::tempdir().unwrap();
+    let baml_home = project.path().join(".baml-home");
+    fs::write(
+        project.path().join("baml.toml"),
+        "[package]\nname = \"demo\"\n\n[toolchain]\nchannel = \"canary\"\n",
+    )
+    .unwrap();
+    let installed = baml_home.join("toolchains/0.15.0");
+    fs::create_dir_all(&installed).unwrap();
+    fs::write(installed.join("VERSION"), "0.15.0\n").unwrap();
+    let (manifest_base_url, server) = serve_manifest("0.15.0", "canary");
+
+    let output = baml_command(&project)
+        .args(["--manifest-base-url", &manifest_base_url])
+        .output()
+        .unwrap();
+    server.join().unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let state = fs::read_to_string(baml_home.join("state.toml")).unwrap();
+    assert!(state.contains("[channels.canary]"), "{state}");
+    assert!(state.contains("active_version = \"0.15.0\""), "{state}");
 }
 
 #[test]

--- a/baml_language/crates/baml/tests/toolchain_install_e2e.rs
+++ b/baml_language/crates/baml/tests/toolchain_install_e2e.rs
@@ -97,13 +97,13 @@ fn bare_install_records_project_channel_resolution() {
     let baml_home = project.path().join(".baml-home");
     fs::write(
         project.path().join("baml.toml"),
-        "[package]\nname = \"demo\"\n\n[toolchain]\nchannel = \"canary\"\n",
+        "[package]\nname = \"demo\"\n\n[toolchain]\nchannel = \"nightly\"\n",
     )
     .unwrap();
     let installed = baml_home.join("toolchains/0.15.0");
     fs::create_dir_all(&installed).unwrap();
     fs::write(installed.join("VERSION"), "0.15.0\n").unwrap();
-    let (manifest_base_url, server) = serve_manifest("0.15.0", "canary");
+    let (manifest_base_url, server) = serve_manifest("0.15.0", "nightly");
 
     let output = baml_command(&project)
         .args(["--manifest-base-url", &manifest_base_url])
@@ -117,30 +117,32 @@ fn bare_install_records_project_channel_resolution() {
         String::from_utf8_lossy(&output.stderr)
     );
     let state = fs::read_to_string(baml_home.join("state.toml")).unwrap();
-    assert!(state.contains("[channels.canary]"), "{state}");
+    assert!(state.contains("[channels.nightly]"), "{state}");
     assert!(state.contains("active_version = \"0.15.0\""), "{state}");
 }
 
 #[test]
 fn install_help_is_not_parsed_as_a_version() {
-    let project = tempfile::tempdir().unwrap();
-    let output = baml_command(&project)
-        .args([
-            "--help",
-            "--manifest-base-url",
-            "http://127.0.0.1:1/manifest",
-        ])
-        .output()
-        .unwrap();
+    for help_arg in ["--help", "-h", "help"] {
+        let project = tempfile::tempdir().unwrap();
+        let output = baml_command(&project)
+            .args([
+                help_arg,
+                "--manifest-base-url",
+                "http://127.0.0.1:1/manifest",
+            ])
+            .output()
+            .unwrap();
 
-    assert!(output.status.success());
-    assert!(output.stderr.is_empty());
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(
-        stdout.contains("baml toolchain install [canary|nightly|version] [--force]"),
-        "{stdout}"
-    );
-    assert!(!stdout.contains("127.0.0.1"), "{stdout}");
+        assert!(output.status.success(), "{help_arg}");
+        assert!(output.stderr.is_empty(), "{help_arg}");
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert!(
+            stdout.contains("baml toolchain install [canary|nightly|version] [--force]"),
+            "{help_arg}: {stdout}"
+        );
+        assert!(!stdout.contains("127.0.0.1"), "{help_arg}: {stdout}");
+    }
 }
 
 #[test]

--- a/baml_language/crates/baml/tests/toolchain_install_e2e.rs
+++ b/baml_language/crates/baml/tests/toolchain_install_e2e.rs
@@ -144,14 +144,26 @@ fn install_help_is_not_parsed_as_a_version() {
 }
 
 #[test]
-fn bare_install_without_a_project_pin_is_actionable() {
+fn bare_install_without_a_project_pin_falls_back_to_canary() {
     let project = tempfile::tempdir().unwrap();
-    let output = baml_command(&project).output().unwrap();
+    let baml_home = project.path().join(".baml-home");
+    let installed = baml_home.join("toolchains/0.15.0");
+    fs::create_dir_all(&installed).unwrap();
+    fs::write(installed.join("VERSION"), "0.15.0\n").unwrap();
+    let (manifest_base_url, server) = serve_manifest("0.15.0", "canary");
 
-    assert!(!output.status.success());
-    assert!(output.stdout.is_empty());
-    assert_eq!(
-        String::from_utf8_lossy(&output.stderr),
-        "no BAML toolchain is pinned in baml.toml\nRun: baml toolchain install <canary|nightly|version>\n"
+    let output = baml_command(&project)
+        .args(["--manifest-base-url", &manifest_base_url])
+        .output()
+        .unwrap();
+    server.join().unwrap();
+
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
     );
+    let state = fs::read_to_string(baml_home.join("state.toml")).unwrap();
+    assert!(state.contains("[channels.canary]"), "{state}");
+    assert!(state.contains("active_version = \"0.15.0\""), "{state}");
 }

--- a/baml_language/crates/baml/tests/toolchain_install_e2e.rs
+++ b/baml_language/crates/baml/tests/toolchain_install_e2e.rs
@@ -4,6 +4,7 @@ use std::{
     net::TcpListener,
     process::Command,
     thread,
+    time::{Duration, Instant},
 };
 
 fn baml_command(project: &tempfile::TempDir) -> Command {
@@ -20,6 +21,7 @@ fn baml_command(project: &tempfile::TempDir) -> Command {
 
 fn serve_manifest(version: &str, channel: &str) -> (String, thread::JoinHandle<()>) {
     let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
     let address = listener.local_addr().unwrap();
     let artifacts = baml_release::SUPPORTED_RELEASE_TARGETS
         .iter()
@@ -35,7 +37,22 @@ fn serve_manifest(version: &str, channel: &str) -> (String, thread::JoinHandle<(
         r#"{{"schema":1,"version":"{version}","channel":"{channel}","released_at":"2026-08-13T00:00:00Z","artifacts":{{{artifacts}}}}}"#
     );
     let server = thread::spawn(move || {
-        let (mut stream, _) = listener.accept().unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let (mut stream, _) = loop {
+            match listener.accept() {
+                Ok(connection) => break connection,
+                Err(error)
+                    if error.kind() == std::io::ErrorKind::WouldBlock
+                        && Instant::now() < deadline =>
+                {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                    panic!("manifest request was not received within five seconds");
+                }
+                Err(error) => panic!("manifest listener failed: {error}"),
+            }
+        };
         let mut request = [0; 1024];
         let bytes_read = stream.read(&mut request).unwrap();
         assert!(bytes_read > 0);


### PR DESCRIPTION
## Summary

- make bare `baml toolchain install` install the selector pinned by the nearest `baml.toml`
- fall back to the `canary` channel when the project has no toolchain pin
- handle `--help`, `-h`, and `help` before interpreting install arguments as version selectors
- validate install options and add CLI regression coverage for pinned versions, pinned channels, help, and the canary fallback

## Root cause

The `install` command required `args[1]` as an explicit selector and passed it directly to manifest resolution. As a result, it never called the existing project toolchain selector logic, and `--help` was treated as an exact version whose manifest should be fetched.

## Impact

CI and local setup can now run `baml toolchain install` without duplicating the version already declared in `baml.toml`. Projects without a pin install and activate the `canary` channel, matching the wrapper's default selector. Help also remains local and exits successfully instead of requesting a `/version/--help.json` manifest.

## Validation

- `cargo test -p baml`
- `cargo clippy -p baml --all-targets -- -D warnings`
- `cargo fmt --package baml`
- `git diff --check`

Fixes B-1510.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `toolchain install` now accepts an optional selector.
  * Without a selector, it uses the nearest project pin or defaults to the canary channel.
  * Added dedicated installation help and `--force` support.
  * Project-derived channel installations activate the selected channel; explicit installations remain unchanged.

* **Bug Fixes**
  * Improved validation for unknown and duplicate options.

* **Tests**
  * Added coverage for project pins, channel activation, canary fallback, help output, and isolated installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->