### PR TITLE
ci: temporarily disable flaky macOS cargo test (B-1545)

### DIFF
--- a/.github/workflows/canary-cache-refresh.yml
+++ b/.github/workflows/canary-cache-refresh.yml
@@ -33,7 +33,8 @@ jobs:
           # actual keys look like `v0-rust-linux-cargo-<toolchain>-<hash>`.
           # Without the `v0-rust-` lead, the prefix match never hits and
           # the loop silently deletes nothing.
-          for sk in linux-cargo linux-wasm linux-msrv macos-cargo windows-cargo; do
+          # TODO(B-1545): Resume purging macos-cargo when cargo-test-macos is re-enabled as its cache writer.
+          for sk in linux-cargo linux-wasm linux-msrv windows-cargo; do
             gh cache list -R "$REPO" --ref refs/heads/canary --key "v0-rust-$sk" \
               --limit 200 --json id --jq '.[].id' | while read -r id; do
               [ -n "$id" ] || continue

--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -269,90 +269,91 @@ jobs:
           path: baml_language/target/cargo-timings/cargo-timing-test-linux-musl.html
           if-no-files-found: ignore
 
-  cargo-test-macos:
-    name: "cargo test (aarch64-apple-darwin)"
-    # Skip in the merge queue: macos already ran on the PR. The merge_group
-    # event is inherited from ci.yaml through the workflow_call boundary.
-    if: ${{ github.event_name != 'merge_group' }}
-    runs-on: blacksmith-6vcpu-macos-latest
-    timeout-minutes: 35
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
+  # TODO(B-1545): Temporarily disabled due to flakiness; re-enable via https://linear.app/boundaryml2/issue/B-1545/investigate-flakiness-in-cargo-test-aarch64-apple-darwin-ci-job
+  # cargo-test-macos:
+  #   name: "cargo test (aarch64-apple-darwin)"
+  #   # Skip in the merge queue: macos already ran on the PR. The merge_group
+  #   # event is inherited from ci.yaml through the workflow_call boundary.
+  #   if: ${{ github.event_name != 'merge_group' }}
+  #   runs-on: blacksmith-6vcpu-macos-latest
+  #   timeout-minutes: 35
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #       with:
+  #         persist-credentials: false
 
-      - name: "Install Rust toolchain"
-        run: rustup show
-        working-directory: baml_language
+  #     - name: "Install Rust toolchain"
+  #       run: rustup show
+  #       working-directory: baml_language
 
-      - name: "Install tools (mise)"
-        uses: ./.github/actions/setup-mise
-        with:
-          install_args: "sccache direnv cargo:cargo-nextest"
+  #     - name: "Install tools (mise)"
+  #       uses: ./.github/actions/setup-mise
+  #       with:
+  #         install_args: "sccache direnv cargo:cargo-nextest"
 
-      - name: "Verify sccache"
-        run: sccache --version
+  #     - name: "Verify sccache"
+  #       run: sccache --version
 
-      - uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: "baml_language -> target"
-          cache-all-crates: true
-          cache-targets: false
-          save-if: ${{ github.ref == 'refs/heads/canary' }}
-          shared-key: "macos-cargo"
+  #     - uses: Swatinem/rust-cache@v2
+  #       with:
+  #         workspaces: "baml_language -> target"
+  #         cache-all-crates: true
+  #         cache-targets: false
+  #         save-if: ${{ github.ref == 'refs/heads/canary' }}
+  #         shared-key: "macos-cargo"
 
-      - name: "Load .envrc with direnv"
-        run: |
-          set -euo pipefail
+  #     - name: "Load .envrc with direnv"
+  #       run: |
+  #         set -euo pipefail
 
-          direnv allow .envrc
-          direnv export gha >> "$GITHUB_ENV"
+  #         direnv allow .envrc
+  #         direnv export gha >> "$GITHUB_ENV"
 
-      # Separate step so if fetch is slow, build is fast.
-      - name: "Fetch cargo dependencies"
-        run: cargo fetch
-        working-directory: baml_language
+  #     # Separate step so if fetch is slow, build is fast.
+  #     - name: "Fetch cargo dependencies"
+  #       run: cargo fetch
+  #       working-directory: baml_language
 
-      # Snapshot tests live in `baml_tests` and are exercised end-to-end by
-      # the dedicated `snapshot-tests` job. The `sdk_test_*` crates need uv
-      # and run in the dedicated `sdk-tests` matrix below. Skip both here —
-      # at the cargo level (`--exclude`), not a nextest `-E` filter, so their
-      # test binaries (the heaviest links in the workspace) aren't built.
-      - name: "Build tests with --timings"
-        run: cargo test --no-run --all-features --timings --workspace --exclude baml_tests --exclude "sdk_test_*" --exclude baml_bridge
-        working-directory: baml_language
+  #     # Snapshot tests live in `baml_tests` and are exercised end-to-end by
+  #     # the dedicated `snapshot-tests` job. The `sdk_test_*` crates need uv
+  #     # and run in the dedicated `sdk-tests` matrix below. Skip both here —
+  #     # at the cargo level (`--exclude`), not a nextest `-E` filter, so their
+  #     # test binaries (the heaviest links in the workspace) aren't built.
+  #     - name: "Build tests with --timings"
+  #       run: cargo test --no-run --all-features --timings --workspace --exclude baml_tests --exclude "sdk_test_*" --exclude baml_bridge
+  #       working-directory: baml_language
 
-      - name: "Run tests with nextest"
-        run: cargo nextest run --all-features --workspace --exclude baml_tests --exclude "sdk_test_*" --exclude baml_bridge
-        working-directory: baml_language
+  #     - name: "Run tests with nextest"
+  #       run: cargo nextest run --all-features --workspace --exclude baml_tests --exclude "sdk_test_*" --exclude baml_bridge
+  #       working-directory: baml_language
 
-      - name: "Show sccache stats"
-        if: always()
-        run: sccache --show-stats
+  #     - name: "Show sccache stats"
+  #       if: always()
+  #       run: sccache --show-stats
 
-      - name: "Dump sccache stats (json)"
-        if: always()
-        run: sccache --show-stats --stats-format json > sccache-stats-test-macos.json
+  #     - name: "Dump sccache stats (json)"
+  #       if: always()
+  #       run: sccache --show-stats --stats-format json > sccache-stats-test-macos.json
 
-      - name: "Upload sccache stats"
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: sccache-stats-test-macos
-          path: sccache-stats-test-macos.json
-          if-no-files-found: ignore
+  #     - name: "Upload sccache stats"
+  #       if: always()
+  #       uses: actions/upload-artifact@v7
+  #       with:
+  #         name: sccache-stats-test-macos
+  #         path: sccache-stats-test-macos.json
+  #         if-no-files-found: ignore
 
-      - name: "Rename cargo timings"
-        if: always()
-        run: mv target/cargo-timings/cargo-timing.html target/cargo-timings/cargo-timing-test-macos.html
-        working-directory: baml_language
-      - name: "Upload cargo timings"
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: cargo-timings-test-macos
-          path: baml_language/target/cargo-timings/cargo-timing-test-macos.html
-          if-no-files-found: ignore
+  #     - name: "Rename cargo timings"
+  #       if: always()
+  #       run: mv target/cargo-timings/cargo-timing.html target/cargo-timings/cargo-timing-test-macos.html
+  #       working-directory: baml_language
+  #     - name: "Upload cargo timings"
+  #       if: always()
+  #       uses: actions/upload-artifact@v7
+  #       with:
+  #         name: cargo-timings-test-macos
+  #         path: baml_language/target/cargo-timings/cargo-timing-test-macos.html
+  #         if-no-files-found: ignore
 
   cargo-test-windows:
     name: "cargo test (x86_64-pc-windows-msvc)"
@@ -845,7 +846,7 @@ jobs:
       fail-fast: false
       # In the merge queue (`merge_group`) only the linux leg runs — the
       # macos/windows legs already ran on the PR. Keep these entries in sync
-      # with the standalone cargo-test-macos/windows jobs above.
+      # with the standalone platform cargo-test jobs above.
       matrix:
         include: ${{ fromJSON(needs.sdk-test-matrix.outputs.matrix) }}
     runs-on: ${{ matrix.runs-on }}
@@ -1426,7 +1427,6 @@ jobs:
     needs:
       - cargo-test-linux
       - cargo-test-linux-musl
-      - cargo-test-macos
       - cargo-test-windows
       - sdk-tests
       - cargo-test-wasm
@@ -1446,7 +1446,6 @@ jobs:
     needs:
       - cargo-test-linux
       - cargo-test-linux-musl
-      - cargo-test-macos
       - cargo-test-windows
       - sdk-tests
       - cargo-test-wasm


### PR DESCRIPTION
## B-1545 removal path

This temporary suppression is tracked by [B-1545](https://linear.app/boundaryml2/issue/B-1545/investigate-flakiness-in-cargo-test-aarch64-apple-darwin-ci-job). Re-enable `cargo-test-macos` and resume purging its cache key when that investigation is complete.

## What changed

- Commented out the complete `cargo-test-macos` job so it remains easy to restore.
- Removed the disabled job from the cargo timings and sccache aggregation dependencies.
- Temporarily stopped the scheduled refresh from purging `macos-cargo`, because the disabled job is its only writer.
- Left every other Apple target, release build, and CI job enabled.

## Why

The `cargo test (aarch64-apple-darwin)` job is flaky. This PR only suppresses that job temporarily and preserves the cache used by remaining macOS consumers; B-1545 owns root-cause investigation and re-enablement.

## Validation

- `mise exec -- prek run check-yaml --files .github/workflows/cargo-tests.reusable.yaml .github/workflows/canary-cache-refresh.yml`
- `mise exec -- actionlint .github/workflows/cargo-tests.reusable.yaml .github/workflows/canary-cache-refresh.yml`
- Ruby/Psych YAML parse for both workflow files
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the flaky macOS cargo test workflow.
  * Updated build and test job dependencies to continue running without the macOS test job.
  * Clarified comments describing platform-specific cargo test jobs.
  * Stopped purging macOS build caches until the macOS test workflow is re-enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->