### PR TITLE
Improve Prompt Fiddle deployed playground

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -83,6 +83,7 @@ jobs:
         run: |
           if git diff --quiet "${MERGE_BASE}...HEAD" -- \
             ':baml_language/**' \
+            ':typescript2/app-promptfiddle/src/playground/default.baml' \
             ':scripts/baml-language-version' \
             ':scripts/baml-wrapper-version' \
             ':scripts/baml-release-manifests' \

--- a/baml_language/crates/baml_tests/tests/baml_src.rs
+++ b/baml_language/crates/baml_tests/tests/baml_src.rs
@@ -67,6 +67,15 @@ fn compile_baml_src() -> Program {
     baml_project::testing::compile_multi_file(&refs)
 }
 
+#[test]
+fn promptfiddle_demo_compiles() {
+    // This cross-workspace include is intentionally cursed: Prompt Fiddle owns
+    // the demo, while this existing test binary checks it without a second compiler build.
+    let source =
+        include_str!("../../../../typescript2/app-promptfiddle/src/playground/default.baml");
+    baml_project::testing::compile_multi_file(&[("baml_src/main.baml", source)]);
+}
+
 /// Strip the `ns_` prefix from a directory segment if it names a valid namespace
 /// (BAML identifier: starts with a letter or `_`, rest alphanumeric or `_`),
 /// matching the compiler's `file_package` rule. Returns `None` otherwise.

--- a/baml_language/crates/bridge_wasm/build.rs
+++ b/baml_language/crates/bridge_wasm/build.rs
@@ -1,4 +1,26 @@
-use std::time::UNIX_EPOCH;
+use std::{path::PathBuf, process::Command, time::UNIX_EPOCH};
+
+fn git_output(args: &[&str]) -> Option<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_owned())
+}
+
+fn track_git_path(path: &str) {
+    let path = PathBuf::from(path);
+    let path = if path.is_absolute() {
+        path
+    } else {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(path)
+    };
+    println!("cargo:rerun-if-changed={}", path.display());
+}
 
 fn main() {
     if std::env::var("BRIDGE_WASM_FORCE_RERUN").is_ok() {
@@ -14,4 +36,18 @@ fn main() {
         .unwrap()
         .as_secs();
     println!("cargo:rustc-env=BRIDGE_WASM_BUILD_TS={ts}");
+
+    if let Some(path) = git_output(&["rev-parse", "--git-path", "HEAD"]) {
+        track_git_path(&path);
+    }
+    if let Some(head_ref) = git_output(&["symbolic-ref", "-q", "HEAD"])
+        && let Some(path) = git_output(&["rev-parse", "--git-path", &head_ref])
+    {
+        track_git_path(&path);
+    }
+
+    let git_sha = git_output(&["rev-parse", "--short=7", "HEAD"])
+        .filter(|sha| sha.len() == 7 && sha.bytes().all(|byte| byte.is_ascii_hexdigit()))
+        .unwrap_or_default();
+    println!("cargo:rustc-env=BRIDGE_WASM_GIT_SHA={git_sha}");
 }

--- a/baml_language/crates/bridge_wasm/src/lib.rs
+++ b/baml_language/crates/bridge_wasm/src/lib.rs
@@ -547,6 +547,12 @@ pub fn version() -> String {
     baml_version::CANONICAL_VERSION.to_string()
 }
 
+/// Get the Git commit used to build the `bridge_wasm` crate.
+#[wasm_bindgen(js_name = commitHash)]
+pub fn commit_hash() -> String {
+    env!("BRIDGE_WASM_GIT_SHA").to_string()
+}
+
 /// Returns the build timestamp (unix seconds) for hot-reload / build-identity checks.
 #[wasm_bindgen(js_name = getBuildTime)]
 pub fn get_build_time() -> String {

--- a/typescript2/app-promptfiddle/next.config.js
+++ b/typescript2/app-promptfiddle/next.config.js
@@ -1,6 +1,6 @@
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createRequire } from 'node:module';
 import { PHASE_DEVELOPMENT_SERVER } from 'next/constants.js';
 
 const projectDir = path.dirname(fileURLToPath(import.meta.url));
@@ -17,7 +17,12 @@ try {
   );
   const { TerserPlugin } = require(terserPath);
   const origOptimize = TerserPlugin.prototype.optimize;
-  TerserPlugin.prototype.optimize = async function (compiler, compilation, assets, ...rest) {
+  TerserPlugin.prototype.optimize = async function (
+    compiler,
+    compilation,
+    assets,
+    ...rest
+  ) {
     for (const [name, info] of compilation.assetsInfo) {
       if (/worker/i.test(name) && /\.js$/i.test(name)) {
         compilation.assetsInfo.set(name, { ...info, minimized: true });
@@ -35,10 +40,10 @@ export default function nextConfig(phase) {
     // Keep dev and production builds isolated so a running dev server
     // can't corrupt the manifests that `next build` needs to finalize.
     distDir: phase === PHASE_DEVELOPMENT_SERVER ? '.next-dev' : '.next-build',
-    reactStrictMode: true,
     experimental: {
-      typedRoutes: true
+      typedRoutes: true,
     },
+    reactStrictMode: true,
     transpilePackages: ['pkg-editor', 'pkg-playground', 'pkg-proto'],
     webpack: (config, { webpack }) => {
       config.resolve = config.resolve || {};
@@ -46,7 +51,7 @@ export default function nextConfig(phase) {
         ...config.resolve.alias,
         'pkg-editor': path.resolve(projectDir, '../pkg-editor/src'),
         'pkg-playground': path.resolve(projectDir, '../pkg-playground/src'),
-        'pkg-proto': path.resolve(projectDir, '../pkg-proto/src')
+        'pkg-proto': path.resolve(projectDir, '../pkg-proto/src'),
       };
 
       // Enable WASM support for bridge_wasm
@@ -54,6 +59,11 @@ export default function nextConfig(phase) {
         ...config.experiments,
         asyncWebAssembly: true,
       };
+
+      config.module.rules.push({
+        test: /\.baml$/,
+        type: 'asset/source',
+      });
 
       // just-bash/browser bundle still references a few Node.js built-ins
       // (gzip/gunzip commands — dead code in browser). Webpack 5 treats
@@ -63,7 +73,7 @@ export default function nextConfig(phase) {
       config.plugins.push(
         new webpack.NormalModuleReplacementPlugin(/^node:/, (resource) => {
           resource.request = resource.request.replace(/^node:/, '');
-        })
+        }),
       );
       config.resolve.fallback = {
         ...config.resolve.fallback,
@@ -71,6 +81,6 @@ export default function nextConfig(phase) {
       };
 
       return config;
-    }
+    },
   };
 }

--- a/typescript2/app-promptfiddle/src/app/globals.css
+++ b/typescript2/app-promptfiddle/src/app/globals.css
@@ -9,15 +9,10 @@
 /* ── Scan promptfiddle's own local components ──────────────────────── */
 @source "../playground/**/*.tsx";
 
-/* ── App chrome tokens (promptfiddle page shell only) ──────────────── */
+/* Page-load fallbacks before the VS Code theme initializes */
 @theme inline {
-  --color-app-bg: #0d1117;
-  --color-app-surface: #161b22;
-  --color-app-border: #30363d;
-  --color-app-text: #c9d1d9;
-  --color-app-text-bright: #e6edf3;
-  --color-app-text-muted: #8b949e;
-  --color-app-accent: #58a6ff;
+  --color-app-bg: #171f2b;
+  --color-app-text: #d9dfe7;
 }
 
 /* ── Page-level base styles ────────────────────────────────────────── */
@@ -27,22 +22,14 @@
   box-sizing: border-box;
 }
 
-html, body {
+html,
+body {
   height: 100%;
-  margin: 0;
   padding: 0;
+  margin: 0;
   overflow: hidden;
+  font-family: var(--font-vsc);
+  color: var(--color-app-text);
   color-scheme: dark;
   background: var(--color-app-bg);
-  color: var(--color-app-text);
-  font-family: var(--font-vsc);
 }
-
-a { color: var(--color-app-accent); text-decoration: none; }
-a:hover { text-decoration: underline; }
-
-/* ── Scrollbar ────────────────────────────────────────────────────── */
-::-webkit-scrollbar { width: 8px; height: 8px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb { background: var(--color-app-border); border-radius: 4px; }
-::-webkit-scrollbar-thumb:hover { background: #484f58; }

--- a/typescript2/app-promptfiddle/src/playground/PlaygroundProvider.tsx
+++ b/typescript2/app-promptfiddle/src/playground/PlaygroundProvider.tsx
@@ -1,7 +1,9 @@
+// biome-ignore-all lint/style/useFilenamingConvention: Keep the existing public module path.
 'use client';
 
-import { useCallback, useMemo } from 'react';
 import { atom, useAtom } from 'jotai';
+import { useCallback, useMemo } from 'react';
+import defaultBaml from './default.baml';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -28,58 +30,8 @@ const STORAGE_KEY = 'baml-playground-files';
 const MEDIA_STORAGE_KEY = 'baml-playground-media';
 const OLD_STORAGE_KEY = 'baml-playground-code'; // migration from single-file
 
-const DEFAULT_BAML_CODE = `// Configure the LLM client
-client<llm> Gpt5 {
-  provider openai
-  options {
-    model "gpt-5.4-mini"
-    api_key env.OPENAI_API_KEY
-  }
-}
-
-
-client<llm> Sonnet {
-  provider anthropic
-  options {
-    model "claude-sonnet-4-6"
-    api_key env.ANTHROPIC_API_KEY
-  }
-}
-
-// Define a structured output type
-class Sentiment {
-  feeling string @description("The detected sentiment: positive, negative, or neutral")
-  confidence float @description("Confidence score between 0 and 1")
-  reasoning string @description("Brief explanation of why this sentiment was detected")
-}
-
-// Define a function that calls the LLM
-function ClassifySentiment(text: string) -> Sentiment {
-  client Gpt5
-  prompt #"
-    Classify the sentiment of the following text.
-
-    {{ ctx.output_format }}
-
-    Text:
-    ---
-    {{ text }}
-    ---
-  "#
-}
-
-// Add a test case
-test HappySentiment {
-  functions [ClassifySentiment]
-  args {
-    text "I absolutely love this new feature! It makes everything so much easier."
-  }
-}
-
-`;
-
 const DEFAULT_FILES: Record<string, string> = {
-  'baml_src/main.baml': DEFAULT_BAML_CODE,
+  'baml_src/main.baml': defaultBaml,
 };
 
 // ---------------------------------------------------------------------------
@@ -108,7 +60,9 @@ function loadPersistedFiles(): Record<string, string> {
         localStorage.removeItem(OLD_STORAGE_KEY);
       }
     }
-  } catch { /* localStorage unavailable */ }
+  } catch {
+    /* localStorage unavailable */
+  }
 
   // Merge in any separately-persisted media files (migration from old split storage)
   try {
@@ -120,7 +74,7 @@ function loadPersistedFiles(): Record<string, string> {
       }
       localStorage.removeItem(MEDIA_STORAGE_KEY);
     }
-  } catch { }
+  } catch {}
 
   if (Object.keys(result).length === 0) {
     return { ...DEFAULT_FILES };
@@ -148,12 +102,17 @@ export const blobUrlsAtom = atom<Record<string, string>>({});
 export const usePlayground = (): PlaygroundState => {
   const [files, setFilesRaw] = useAtom(filesAtom);
 
-  const setFiles = useCallback((value: Record<string, string>) => {
-    setFilesRaw(value);
-    try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
-    } catch { /* localStorage full or unavailable */ }
-  }, [setFilesRaw]);
+  const setFiles = useCallback(
+    (value: Record<string, string>) => {
+      setFilesRaw(value);
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(value));
+      } catch {
+        /* localStorage full or unavailable */
+      }
+    },
+    [setFilesRaw],
+  );
 
   const resetFiles = useCallback(() => {
     const defaults = { ...DEFAULT_FILES };
@@ -162,11 +121,13 @@ export const usePlayground = (): PlaygroundState => {
       localStorage.removeItem(STORAGE_KEY);
       localStorage.removeItem(MEDIA_STORAGE_KEY);
       localStorage.removeItem(OLD_STORAGE_KEY);
-    } catch { /* localStorage unavailable */ }
+    } catch {
+      /* localStorage unavailable */
+    }
   }, [setFilesRaw]);
 
   return useMemo<PlaygroundState>(
-    () => ({ files, setFiles, resetFiles }),
+    () => ({ files, resetFiles, setFiles }),
     [files, setFiles, resetFiles],
   );
 };

--- a/typescript2/app-promptfiddle/src/playground/SplitPreview.tsx
+++ b/typescript2/app-promptfiddle/src/playground/SplitPreview.tsx
@@ -1,3 +1,4 @@
+// biome-ignore-all lint/style/useFilenamingConvention: Keep the existing public module path.
 /**
  * SplitPreview — composition shell for the promptfiddle editor + execution panel.
  *
@@ -9,12 +10,12 @@
  * and opens the execution panel pane via ExecutionPanelPane.ts.
  */
 
-import type { FC } from 'react';
-import { useState, useRef, useEffect, useMemo } from 'react';
-import { useSetAtom } from 'jotai';
 import { MonacoEditor } from '@b/pkg-editor';
 import { configureProxyEnvVar, initPlaygroundEnv } from '@b/pkg-playground';
-import { usePlayground, blobUrlsAtom } from './PlaygroundProvider';
+import { useSetAtom } from 'jotai';
+import type { FC } from 'react';
+import { useEffect, useMemo } from 'react';
+import { blobUrlsAtom, usePlayground } from './PlaygroundProvider';
 import { createWorkerBackend } from './worker-backend';
 
 /**
@@ -28,80 +29,36 @@ const BOUNDARY_PROXY_URL = 'https://proxy.promptfiddle.com';
 // promptfiddle surfaces a Boundary-gateway on/off toggle in the env-vars dialog
 // (the VS Code extension and CLI playground hide it). Configure at import,
 // before the ExecutionPanel pane mounts.
-configureProxyEnvVar({ visible: true, url: BOUNDARY_PROXY_URL });
-
-const ResetIcon: FC<{ size?: number }> = ({ size = 14 }) => (
-  <svg
-    aria-hidden="true"
-    fill="none"
-    height={size}
-    stroke="currentColor"
-    strokeLinecap="round"
-    strokeLinejoin="round"
-    strokeWidth="2"
-    viewBox="0 0 24 24"
-    width={size}
-  >
-    <path d="M3 2v6h6" />
-    <path d="M3 8a9 9 0 1 0 2.6-4.9L3 6" />
-  </svg>
-);
+configureProxyEnvVar({ url: BOUNDARY_PROXY_URL, visible: true });
 
 export const SplitPreview: FC = () => {
   const { files, setFiles, resetFiles } = usePlayground();
   const setBlobUrls = useSetAtom(blobUrlsAtom);
-  const backend = useMemo(() => createWorkerBackend(), []);
-  const [showConfirm, setShowConfirm] = useState(false);
-  const confirmTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const backend = useMemo(
+    () =>
+      createWorkerBackend({
+        onReset: () => {
+          resetFiles();
+          window.location.reload();
+        },
+      }),
+    [resetFiles],
+  );
 
   // Seed playground env defaults once: placeholder provider keys + gateway on.
   useEffect(() => {
     initPlaygroundEnv();
   }, []);
 
-  useEffect(() => {
-    return () => {
-      if (confirmTimeoutRef.current) {
-        clearTimeout(confirmTimeoutRef.current);
-      }
-    };
-  }, []);
-
-  const handleReset = () => {
-    if (showConfirm) {
-      if (confirmTimeoutRef.current) {
-        clearTimeout(confirmTimeoutRef.current);
-        confirmTimeoutRef.current = null;
-      }
-      resetFiles();
-      setShowConfirm(false);
-      window.location.reload();
-    } else {
-      if (confirmTimeoutRef.current) {
-        clearTimeout(confirmTimeoutRef.current);
-      }
-      setShowConfirm(true);
-      confirmTimeoutRef.current = setTimeout(() => setShowConfirm(false), 3000);
-    }
-  };
-
   return (
-    <div className="font-vsc text-vsc-text relative h-full w-full">
+    <div className="font-vsc text-vsc-text h-full w-full">
       <MonacoEditor
-        files={files}
-        onFilesChange={setFiles}
         backend={backend}
-        onBlobUrlsChange={setBlobUrls}
+        files={files}
         height="100%"
+        onBlobUrlsChange={setBlobUrls}
+        onFilesChange={setFiles}
       />
-      <button
-        onClick={handleReset}
-        className="absolute bottom-4 left-4 z-50 flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded bg-vsc-bg-secondary hover:bg-vsc-bg-tertiary border border-vsc-border text-vsc-text-muted hover:text-vsc-text transition-colors"
-        title="Reset to default code"
-      >
-        <ResetIcon size={14} />
-        {showConfirm ? 'Click again to confirm' : 'Reset'}
-      </button>
     </div>
   );
 };

--- a/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
+++ b/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
@@ -40,6 +40,8 @@ onWasmPanic((message) => {
 
 import initWasm, {
   BamlWasmRuntime,
+  version as bamlVersion,
+  commitHash,
   getBuildTime,
   type LspNotification,
   type LspRequest,
@@ -214,7 +216,7 @@ async function executeExec(
   // Build the command line: program + args joined. just-bash executes this
   // as a shell script so we must quote args to prevent shell splitting.
   const quotedArgs = (args ?? [])
-    .map((a) => "'" + a.replace(/'/g, "'\\''") + "'")
+    .map((a) => `'${a.replace(/'/g, "'\\''")}'`)
     .join(' ');
   const commandLine = quotedArgs ? `${program} ${quotedArgs}` : program;
 
@@ -724,7 +726,7 @@ self.onmessage = async (event: MessageEvent) => {
     connection.listen();
 
     // 7. Notify main thread and push initial state
-    postOut({ type: 'ready' });
+    postOut({ commit: commitHash(), type: 'ready', version: bamlVersion() });
     postOut({ type: 'buildTime', value: getBuildTime() });
     // notifySourceChanged();
 

--- a/typescript2/app-promptfiddle/src/playground/default.baml
+++ b/typescript2/app-promptfiddle/src/playground/default.baml
@@ -1,0 +1,137 @@
+// Review an invoice with plain BAML logic or extract one from text with an LLM.
+
+//# review the invoice
+function ReviewInvoice(invoice: Invoice) -> Report {
+  let issues: ValidationIssue[] = [];
+
+  //# check the math
+  let line_total = LineTotal(invoice.line_items);
+  let difference = line_total - invoice.total;
+  if (difference < 0.0) {
+    difference = -difference;
+  };
+
+  if (difference > 0.02) {
+    //## flag a mismatch
+    issues.push(ValidationIssue {
+      path: "total",
+      severity: "error",
+      message: "line item sum does not match total",
+    });
+  };
+
+  //# check the due date
+  if (invoice.due_date == null) {
+    //## flag a missing due date
+    issues.push(ValidationIssue {
+      path: "due_date",
+      severity: "warning",
+      message: "invoice has no due date",
+    });
+  };
+
+  //# score the risk
+  let risk: RiskTier = RiskTier.Low;
+  if (invoice.total > 25000.0) {
+    //## block large invoices
+    risk = RiskTier.Block;
+  } else if (invoice.due_date == null) {
+    //## review incomplete invoices
+    risk = RiskTier.Review;
+  };
+
+  Report {
+    risk,
+    issues,
+    total: invoice.total,
+  }
+}
+
+//# add up the line items
+function LineTotal(items: LineItem[]) -> float {
+  let total = 0.0;
+  for (let item in items) {
+    total += item.quantity * item.price;
+  }
+  total
+}
+
+// This path calls an LLM. The other functions and tests run locally.
+function ReviewFromText(text: string) -> Report {
+  ReviewInvoice(ExtractInvoice(text))
+}
+
+function ExtractInvoice(text: string) -> Invoice {
+  client: "openai/gpt-5.4-mini"
+  prompt: `
+    Extract a structured invoice from the text below.
+
+    ${ctx.output_format}
+
+    ${role("user")}
+    ${text}
+  `
+}
+
+class LineItem {
+  name: string,
+  quantity: int,
+  price: float,
+}
+
+class Invoice {
+  vendor: string,
+  total: float,
+  due_date: string?,
+  line_items: LineItem[],
+}
+
+class ValidationIssue {
+  path: string,
+  severity: string,
+  message: string,
+}
+
+enum RiskTier {
+  Low,
+  Review,
+  Block,
+}
+
+class Report {
+  risk: RiskTier,
+  issues: ValidationIssue[],
+  total: float,
+}
+
+testset "invoice review" {
+  test "line totals multiply and sum" {
+    let items = [
+      LineItem { name: "Widget", quantity: 3, price: 10.0 },
+      LineItem { name: "Gizmo", quantity: 2, price: 49.5 },
+    ];
+    assert.equal(LineTotal(items), 129.0);
+  }
+
+  test "mismatched totals are flagged" {
+    let report = ReviewInvoice(Invoice {
+      vendor: "Acme",
+      total: 1247.5,
+      due_date: "2026-09-01",
+      line_items: [
+        LineItem { name: "Widget", quantity: 3, price: 10.0 },
+      ],
+    });
+    assert.equal(report.issues[0].path, "total");
+  }
+
+  test "large invoices are blocked" {
+    let report = ReviewInvoice(Invoice {
+      vendor: "BigCo",
+      total: 50000.0,
+      due_date: "2026-09-01",
+      line_items: [],
+    });
+    assert.equal(report.risk, RiskTier.Block);
+  }
+}

--- a/typescript2/app-promptfiddle/src/playground/worker-backend.ts
+++ b/typescript2/app-promptfiddle/src/playground/worker-backend.ts
@@ -11,8 +11,12 @@
  * `@b/pkg-editor` stays free of WASM and can also run against a remote server.
  */
 
-import type { EditorBackend, EditorConnection, WorkbenchHandle } from '@b/pkg-editor';
-import { isMediaPath, fromDataUrl } from '@b/pkg-editor';
+import type {
+  EditorBackend,
+  EditorConnection,
+  WorkbenchHandle,
+} from '@b/pkg-editor';
+import { fromDataUrl, isMediaPath } from '@b/pkg-editor';
 import type { DecorationOptions, TextEditor } from 'vscode';
 
 interface LogDecoration {
@@ -22,36 +26,94 @@ interface LogDecoration {
   count: number;
 }
 
-export function createWorkerBackend(): EditorBackend {
+interface WorkerBackendOptions {
+  onReset?: () => void;
+}
+
+const RESET_COMMAND = 'baml.promptfiddle.reset';
+
+export function createWorkerBackend(
+  options: WorkerBackendOptions = {},
+): EditorBackend {
   return {
-    windowLabel: 'BAML Playground — Edit, compile, and run BAML in the browser',
-    supportsReload: true,
     async connect(handle: WorkbenchHandle): Promise<EditorConnection> {
-      const { BrowserMessageReader, BrowserMessageWriter } = await import('vscode-languageclient/browser');
+      const { BrowserMessageReader, BrowserMessageWriter } = await import(
+        'vscode-languageclient/browser'
+      );
       const { WorkerRuntimePort } = await import('@b/pkg-playground');
 
       const vscode = handle.vscode;
       const disposers: Array<() => void> = [];
+
+      const resetStatus = vscode.window.createStatusBarItem(
+        vscode.StatusBarAlignment.Left,
+        100,
+      );
+      resetStatus.command = RESET_COMMAND;
+      resetStatus.text = '$(discard) Reset';
+      resetStatus.tooltip = 'Reset Prompt Fiddle to its default files';
+      resetStatus.show();
+
+      let resetConfirmationTimeout: ReturnType<typeof setTimeout> | undefined;
+      const clearResetConfirmation = () => {
+        if (resetConfirmationTimeout !== undefined) {
+          clearTimeout(resetConfirmationTimeout);
+          resetConfirmationTimeout = undefined;
+        }
+        resetStatus.text = '$(discard) Reset';
+      };
+      const resetCommand = vscode.commands.registerCommand(
+        RESET_COMMAND,
+        () => {
+          if (resetConfirmationTimeout !== undefined) {
+            clearResetConfirmation();
+            options.onReset?.();
+            return;
+          }
+
+          resetStatus.text = '$(warning) Click again to reset';
+          resetConfirmationTimeout = setTimeout(clearResetConfirmation, 3000);
+        },
+      );
+
+      const versionStatus = vscode.window.createStatusBarItem(
+        vscode.StatusBarAlignment.Left,
+        99,
+      );
+      versionStatus.tooltip = 'Deployed BAML runtime version';
+
+      disposers.push(
+        () => clearResetConfirmation(),
+        () => resetCommand.dispose(),
+        () => resetStatus.dispose(),
+        () => versionStatus.dispose(),
+      );
 
       // Spawn worker — WASM loads inside the worker, doesn't block main thread.
       // The `new URL(..., import.meta.url)` must live in app source so the
       // bundler emits the worker as an asset.
       const worker = new Worker(
         new URL('./baml-lsp-worker.ts', import.meta.url),
-        { type: 'module', name: 'BAML Worker' },
+        { name: 'BAML Worker', type: 'module' },
       );
 
-      // Listen for the 'ready' message IMMEDIATELY — before any awaits — so we
-      // don't miss it if WASM loads fast (e.g. from cache).
-      const workerReadyPromise = new Promise<void>((resolve) => {
-        const onMsg = (event: MessageEvent) => {
-          if (event.data?.type === 'ready') {
-            worker.removeEventListener('message', onMsg);
-            resolve();
-          }
-        };
-        worker.addEventListener('message', onMsg);
-      });
+      const onWorkerReady = (event: MessageEvent) => {
+        if (event.data?.type !== 'ready') return;
+        worker.removeEventListener('message', onWorkerReady);
+        if (typeof event.data.version === 'string') {
+          const commit =
+            typeof event.data.commit === 'string' &&
+            event.data.commit.length > 0
+              ? ` (${event.data.commit})`
+              : '';
+          versionStatus.text = `BAML ${event.data.version}${commit}`;
+          versionStatus.show();
+        }
+      };
+      worker.addEventListener('message', onWorkerReady);
+      disposers.push(() =>
+        worker.removeEventListener('message', onWorkerReady),
+      );
 
       // ── VFS mutations from the WASM runtime (worker → main) ────────────
       let vfsQueue: Promise<void> = Promise.resolve();
@@ -65,21 +127,32 @@ export function createWorkerBackend(): EditorBackend {
         if (handle.isDisposed()) return;
         const data = event.data;
         if (data?.type === 'vfsFileChanged') {
-          const { path: relPath, content } = data as { path: string; content: string };
+          const { path: relPath, content } = data as {
+            path: string;
+            content: string;
+          };
           handle.liveFiles[relPath] = content;
           const absPath = `/workspace/${relPath}`;
           const isMedia = isMediaPath(relPath);
-          const bytes = isMedia ? fromDataUrl(content) : handle.encoder.encode(content);
+          const bytes = isMedia
+            ? fromDataUrl(content)
+            : handle.encoder.encode(content);
           enqueueVfs(async () => {
             const parts = absPath.split('/');
             for (let i = 2; i < parts.length; i++) {
               const parentPath = parts.slice(0, i).join('/');
-              try { await handle.fileSystemProvider.mkdir(vscode.Uri.file(parentPath)); } catch { /* exists */ }
+              try {
+                await handle.fileSystemProvider.mkdir(
+                  vscode.Uri.file(parentPath),
+                );
+              } catch {
+                /* exists */
+              }
             }
             await handle.fileSystemProvider.writeFile(
               vscode.Uri.file(absPath),
               bytes,
-              { create: true, overwrite: true, unlock: false, atomic: false },
+              { atomic: false, create: true, overwrite: true, unlock: false },
             );
             if (isMedia) handle.updateBlobUrl(relPath, bytes);
             handle.notifyFilesChanged();
@@ -90,7 +163,11 @@ export function createWorkerBackend(): EditorBackend {
           const absPath = `/workspace/${relPath}`;
           enqueueVfs(async () => {
             await Promise.resolve(
-              handle.fileSystemProvider.delete(vscode.Uri.file(absPath), { recursive: false, useTrash: false, atomic: false }),
+              handle.fileSystemProvider.delete(vscode.Uri.file(absPath), {
+                atomic: false,
+                recursive: false,
+                useTrash: false,
+              }),
             ).catch(() => {});
             if (isMediaPath(relPath)) handle.removeBlobUrl(relPath);
             handle.notifyFilesChanged();
@@ -104,8 +181,8 @@ export function createWorkerBackend(): EditorBackend {
       const channel = new MessageChannel();
       worker.postMessage(
         {
-          port: channel.port2,
           initialFiles: { ...handle.liveFiles },
+          port: channel.port2,
           rootPath: '/workspace',
         },
         [channel.port2],
@@ -120,10 +197,22 @@ export function createWorkerBackend(): EditorBackend {
       // ── Log decorations (inline display like ErrorLens) ───────────────
       let lastDecoratedEditor: TextEditor | undefined;
       const logDecorationTypes = {
-        debug: vscode.window.createTextEditorDecorationType({ after: { color: '#888888', margin: '0 0 0 1em' }, isWholeLine: true }),
-        info: vscode.window.createTextEditorDecorationType({ after: { color: '#3794ff', margin: '0 0 0 1em' }, isWholeLine: true }),
-        warn: vscode.window.createTextEditorDecorationType({ after: { color: '#cca700', margin: '0 0 0 1em' }, isWholeLine: true }),
-        error: vscode.window.createTextEditorDecorationType({ after: { color: '#f14c4c', margin: '0 0 0 1em' }, isWholeLine: true }),
+        debug: vscode.window.createTextEditorDecorationType({
+          after: { color: '#888888', margin: '0 0 0 1em' },
+          isWholeLine: true,
+        }),
+        error: vscode.window.createTextEditorDecorationType({
+          after: { color: '#f14c4c', margin: '0 0 0 1em' },
+          isWholeLine: true,
+        }),
+        info: vscode.window.createTextEditorDecorationType({
+          after: { color: '#3794ff', margin: '0 0 0 1em' },
+          isWholeLine: true,
+        }),
+        warn: vscode.window.createTextEditorDecorationType({
+          after: { color: '#cca700', margin: '0 0 0 1em' },
+          isWholeLine: true,
+        }),
       };
       disposers.push(
         () => logDecorationTypes.debug.dispose(),
@@ -136,12 +225,19 @@ export function createWorkerBackend(): EditorBackend {
         try {
           let editor = vscode.window.activeTextEditor;
           if (!editor) {
-            editor = vscode.window.visibleTextEditors.find((e) => e.document.uri.path.endsWith('.baml'));
+            editor = vscode.window.visibleTextEditors.find((e) =>
+              e.document.uri.path.endsWith('.baml'),
+            );
           }
           if (!editor) return;
           lastDecoratedEditor = editor;
 
-          const byLevel: Record<string, DecorationOptions[]> = { debug: [], info: [], warn: [], error: [] };
+          const byLevel: Record<string, DecorationOptions[]> = {
+            debug: [],
+            error: [],
+            info: [],
+            warn: [],
+          };
           for (const dec of decorations) {
             const level = dec.level as keyof typeof byLevel;
             if (!(level in byLevel)) continue;
@@ -182,28 +278,43 @@ export function createWorkerBackend(): EditorBackend {
         }
       };
       worker.addEventListener('message', onLogDecorations);
-      disposers.push(() => worker.removeEventListener('message', onLogDecorations));
+      disposers.push(() =>
+        worker.removeEventListener('message', onLogDecorations),
+      );
 
       return {
-        lcConnection: {
-          options: { $type: 'WorkerDirect', worker, messagePort: channel.port1 },
-          messageTransports: { reader, writer },
-        },
-        runtimePort,
-        onFilesChanged(files) {
-          worker.postMessage({ type: 'filesChanged', files });
-        },
-        onCursorMoved(file, line, column) {
-          worker.postMessage({ type: 'cursorPosition', file, line, column });
-        },
         dispose() {
           for (const d of disposers) {
-            try { d(); } catch { /* no-op */ }
+            try {
+              d();
+            } catch {
+              /* no-op */
+            }
           }
-          try { worker.postMessage({ type: 'dispose' }); } catch { /* already gone */ }
+          try {
+            worker.postMessage({ type: 'dispose' });
+          } catch {
+            /* already gone */
+          }
           worker.terminate();
         },
+        lcConnection: {
+          messageTransports: { reader, writer },
+          options: {
+            $type: 'WorkerDirect',
+            messagePort: channel.port1,
+            worker,
+          },
+        },
+        onCursorMoved(file, line, column) {
+          worker.postMessage({ column, file, line, type: 'cursorPosition' });
+        },
+        onFilesChanged(files) {
+          worker.postMessage({ files, type: 'filesChanged' });
+        },
+        runtimePort,
       };
     },
+    supportsReload: true,
   };
 }

--- a/typescript2/app-promptfiddle/src/types/baml.d.ts
+++ b/typescript2/app-promptfiddle/src/types/baml.d.ts
@@ -1,0 +1,4 @@
+declare module '*.baml' {
+  const source: string;
+  export default source;
+}

--- a/typescript2/biome.json
+++ b/typescript2/biome.json
@@ -25,6 +25,7 @@
       "!app-beps/**",
       "!**/.turbo/**",
       "!**/*.min.*",
+      "!pkg-editor/src/themes/**",
       "!bun.lock",
       "!**/.vscode-test/**",
       "!**/build/**",

--- a/typescript2/pkg-editor/package.json
+++ b/typescript2/pkg-editor/package.json
@@ -1,30 +1,9 @@
 {
-  "name": "@b/pkg-editor",
-  "version": "0.1.0",
-  "type": "module",
-  "main": "src/index.ts",
-  "types": "src/index.ts",
-  "exports": {
-    ".": {
-      "types": "./src/index.ts",
-      "default": "./src/index.ts"
-    },
-    "./remote": {
-      "types": "./src/remote-backend.ts",
-      "default": "./src/remote-backend.ts"
-    },
-    "./views-workbench.css": "./src/views-workbench.css"
-  },
-  "files": [
-    "src"
-  ],
-  "scripts": {
-    "typecheck": "tsc --noEmit"
-  },
   "dependencies": {
     "@b/pkg-grammar": "workspace:*",
     "@b/pkg-playground": "workspace:*",
     "@codingame/monaco-vscode-api": "^25.1.2",
+    "@codingame/monaco-vscode-editor-api": "^25.1.2",
     "@codingame/monaco-vscode-environment-service-override": "^25.1.2",
     "@codingame/monaco-vscode-explorer-service-override": "^25.1.2",
     "@codingame/monaco-vscode-files-service-override": "^25.1.2",
@@ -36,6 +15,7 @@
     "@codingame/monaco-vscode-search-service-override": "^25.1.2",
     "@codingame/monaco-vscode-secret-storage-service-override": "^25.1.2",
     "@codingame/monaco-vscode-storage-service-override": "^25.1.2",
+    "@codingame/monaco-vscode-textmate-service-override": "^25.1.2",
     "@codingame/monaco-vscode-view-banner-service-override": "^25.1.2",
     "@codingame/monaco-vscode-view-status-bar-service-override": "^25.1.2",
     "@codingame/monaco-vscode-view-title-bar-service-override": "^25.1.2",
@@ -45,15 +25,37 @@
     "vscode": "npm:@codingame/monaco-vscode-extension-api@^25.1.2",
     "vscode-languageclient": "^9.0.1"
   },
-  "peerDependencies": {
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1"
-  },
   "devDependencies": {
     "@types/react": "^18.3.26",
     "@types/react-dom": "^18.3.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "typescript": "^5.9.3"
-  }
+  },
+  "exports": {
+    ".": {
+      "default": "./src/index.ts",
+      "types": "./src/index.ts"
+    },
+    "./remote": {
+      "default": "./src/remote-backend.ts",
+      "types": "./src/remote-backend.ts"
+    },
+    "./views-workbench.css": "./src/views-workbench.css"
+  },
+  "files": [
+    "src"
+  ],
+  "main": "src/index.ts",
+  "name": "@b/pkg-editor",
+  "peerDependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "type": "module",
+  "types": "src/index.ts",
+  "version": "0.1.0"
 }

--- a/typescript2/pkg-editor/src/ExecutionPanelPane.ts
+++ b/typescript2/pkg-editor/src/ExecutionPanelPane.ts
@@ -223,7 +223,11 @@ export function setRuntimePort(
     const shouldOpen = !singletonInput || singletonInput.isDisposed?.();
     portResolve(port);
     portResolve = null;
-    if (shouldOpen) openPlaygroundTab();
+    if (shouldOpen) {
+      void openPlaygroundTab().catch((error: unknown) => {
+        console.error('[ExecutionPanelPane] failed to open Playground:', error);
+      });
+    }
   } else {
     portChangeListeners.forEach((cb) => cb(port));
   }

--- a/typescript2/pkg-editor/src/ExecutionPanelPane.ts
+++ b/typescript2/pkg-editor/src/ExecutionPanelPane.ts
@@ -1,3 +1,5 @@
+// biome-ignore-all lint/style/useFilenamingConvention: Keep the existing public module path.
+// biome-ignore-all lint/suspicious/noExplicitAny: Monaco's dynamic editor registration APIs are not publicly typed.
 /**
  * ExecutionPanelPane — registers a custom Monaco EditorPane that hosts
  * the ExecutionPanel React component inside the VS Code workbench.
@@ -10,25 +12,23 @@
  *   3. The command "baml.openPlayground" or setRuntimePort both open the tab
  */
 
-import { createRoot, type Root } from 'react-dom/client';
-import { createElement } from 'react';
 import type { RuntimePort, SourceNavigationTarget } from '@b/pkg-playground';
 import type { Dimension } from '@codingame/monaco-vscode-api/vscode/vs/base/browser/dom';
+import { createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
 
 // ---------------------------------------------------------------------------
 // Module-level state — bridges imperative EditorPane with React component
 // ---------------------------------------------------------------------------
 
 let portResolve: ((port: RuntimePort) => void) | null = null;
-let portPromise = new Promise<RuntimePort>((resolve) => {
+const portPromise = new Promise<RuntimePort>((resolve) => {
   portResolve = resolve;
 });
 /** Latest port (updated on every setRuntimePort); used when reconnecting after restart. */
 let currentPort: RuntimePort | null = null;
 /** Connection version passed from MonacoEditor (survives HMR); used as React key to force remount. */
 let currentConnectionVersion = 0;
-/** Incremented when port changes on restart so ExecutionPanel remounts and requests state. */
-let portKey = 0;
 const portChangeListeners = new Set<(port: RuntimePort) => void>();
 /** Callback to reload the backend connection (set by MonacoEditor). */
 let reloadCallback: (() => void) | null = null;
@@ -59,7 +59,11 @@ async function openPlaygroundTab(): Promise<void> {
 
   const editorService = StandaloneServices.get(IEditorService);
   const SIDE_GROUP = -2;
-  await editorService.openEditor(singletonInput, { revealIfOpened: true }, SIDE_GROUP);
+  await editorService.openEditor(
+    singletonInput,
+    { revealIfOpened: true },
+    SIDE_GROUP,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -73,7 +77,12 @@ export async function registerExecutionPanelPane(): Promise<void> {
   registered = true;
 
   const [
-    { SimpleEditorPane, SimpleEditorInput, registerEditorPane, EditorInputCapabilities },
+    {
+      SimpleEditorPane,
+      SimpleEditorInput,
+      registerEditorPane,
+      EditorInputCapabilities,
+    },
     vscode,
   ] = await Promise.all([
     import('@codingame/monaco-vscode-api/service-override/tools/views'),
@@ -107,8 +116,11 @@ export async function registerExecutionPanelPane(): Promise<void> {
   class PlaygroundEditorPane extends SimpleEditorPane {
     private reactRoot: Root | null = null;
     private _el: HTMLElement | null = null;
+    private _portChangeCleanup: (() => void) | undefined;
 
-    async renderInput() { return { dispose() {} }; }
+    async renderInput() {
+      return { dispose() {} };
+    }
 
     initialize(): HTMLElement {
       const el = document.createElement('div');
@@ -122,20 +134,24 @@ export async function registerExecutionPanelPane(): Promise<void> {
 
       // Show loading state, then swap to ExecutionPanel when port is ready
       this.reactRoot.render(
-        createElement('div', {
-          style: { padding: 20, color: '#888', fontSize: 12 },
-        }, 'Loading playground…'),
+        createElement(
+          'div',
+          {
+            style: { color: '#888', fontSize: 12, padding: 20 },
+          },
+          'Loading playground...',
+        ),
       );
 
       const renderWithPort = (port: RuntimePort) => {
         import('@b/pkg-playground').then(({ ExecutionPanel }) => {
           this.reactRoot?.render(
             createElement(ExecutionPanel, {
-              port,
-              key: `playground-${currentConnectionVersion}`,
               connectionVersion: currentConnectionVersion,
-              onReload: reloadCallback ?? undefined,
+              key: `playground-${currentConnectionVersion}`,
               onNavigateToSource: navigateToSource ?? undefined,
+              onReload: reloadCallback ?? undefined,
+              port,
             }),
           );
         });
@@ -148,7 +164,7 @@ export async function registerExecutionPanelPane(): Promise<void> {
       };
       portChangeListeners.add(onPortChange);
       const removeListener = () => portChangeListeners.delete(onPortChange);
-      (this as any)._portChangeCleanup = removeListener;
+      this._portChangeCleanup = removeListener;
 
       return el;
     }
@@ -164,8 +180,8 @@ export async function registerExecutionPanelPane(): Promise<void> {
     }
 
     dispose(): void {
-      const cleanup = (this as any)._portChangeCleanup as (() => void) | undefined;
-      if (typeof cleanup === 'function') cleanup();
+      this._portChangeCleanup?.();
+      this._portChangeCleanup = undefined;
       this.reactRoot?.unmount();
       this.reactRoot = null;
       this._el = null;
@@ -173,16 +189,13 @@ export async function registerExecutionPanelPane(): Promise<void> {
     }
   }
 
-  registerEditorPane(
-    PANE_TYPE_ID,
-    'Playground',
-    PlaygroundEditorPane as any,
-    [PlaygroundInput],
-  );
+  registerEditorPane(PANE_TYPE_ID, 'Playground', PlaygroundEditorPane as any, [
+    PlaygroundInput,
+  ]);
 
-  vscode.commands.registerCommand('baml.openPlayground', () => {
-    openPlaygroundTab();
-  });
+  vscode.commands.registerCommand('baml.openPlayground', () =>
+    openPlaygroundTab(),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -199,15 +212,19 @@ export interface SetRuntimePortOptions {
  * On first call: resolves the port promise and opens the tab.
  * On restart: updates the existing pane with the new port (no new tab).
  */
-export function setRuntimePort(port: RuntimePort, options?: SetRuntimePortOptions): void {
+export function setRuntimePort(
+  port: RuntimePort,
+  options?: SetRuntimePortOptions,
+): void {
   currentPort = port;
-  currentConnectionVersion = options?.connectionVersion ?? currentConnectionVersion;
+  currentConnectionVersion =
+    options?.connectionVersion ?? currentConnectionVersion;
   if (portResolve) {
+    const shouldOpen = !singletonInput || singletonInput.isDisposed?.();
     portResolve(port);
     portResolve = null;
-    openPlaygroundTab();
+    if (shouldOpen) openPlaygroundTab();
   } else {
-    portKey += 1;
     portChangeListeners.forEach((cb) => cb(port));
   }
 }
@@ -224,7 +241,9 @@ export function setReloadCallback(cb: () => void): void {
  * Set the callback to navigate to a source location.
  * Called from MonacoEditor after workbench setup.
  */
-export function setNavigateToSource(cb: (source: SourceNavigationTarget) => void): void {
+export function setNavigateToSource(
+  cb: (source: SourceNavigationTarget) => void,
+): void {
   navigateToSource = cb;
 }
 

--- a/typescript2/pkg-editor/src/MonacoEditor.tsx
+++ b/typescript2/pkg-editor/src/MonacoEditor.tsx
@@ -1,3 +1,5 @@
+// biome-ignore-all lint/style/useFilenamingConvention: Keep the existing public module path.
+// biome-ignore-all lint/suspicious/noExplicitAny: Monaco's dynamic editor and filesystem internals are not publicly typed.
 /**
  * MonacoEditor — BAML editor with file tree (explorer) and LSP.
  *
@@ -17,12 +19,17 @@
  *     WebSocket to a real server). See `@b/pkg-editor/remote`.
  */
 
-import { useEffect, useRef, useState, type FC } from 'react';
+import { type FC, useEffect, useRef, useState } from 'react';
 import './views-workbench.css';
-import { type IFileWriteOptions } from '@codingame/monaco-vscode-files-service-override';
 import type { Dimension } from '@codingame/monaco-vscode-api/vscode/vs/base/browser/dom';
-import { isMediaPath, mimeFromPath, toDataUrl, fromDataUrl } from './media';
-import type { EditorBackend, EditorConnection, WorkbenchHandle } from './backend';
+import type { IFileWriteOptions } from '@codingame/monaco-vscode-files-service-override';
+import type {
+  EditorBackend,
+  EditorConnection,
+  WorkbenchHandle,
+} from './backend';
+import { fromDataUrl, isMediaPath, mimeFromPath, toDataUrl } from './media';
+import monospaceDarkTheme from './themes/monospace/monospace-dark.json';
 
 declare const __DEV__: boolean | undefined;
 declare const process: { env: { NODE_ENV?: string } } | undefined;
@@ -31,7 +38,9 @@ function isDevelopmentBuild(): boolean {
   if (typeof __DEV__ !== 'undefined') {
     return __DEV__;
   }
-  return typeof process !== 'undefined' && process.env.NODE_ENV === 'development';
+  return (
+    typeof process !== 'undefined' && process.env.NODE_ENV === 'development'
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -85,65 +94,188 @@ function createWorkspaceContent(workspacePath: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Loading skeleton — matches "Default Dark Modern" so the transition is smooth.
+// Loading skeleton matches Monospace Dark so the transition is smooth.
 // Token colors are inline because they're hardcoded to the pre-workbench theme;
-// structural layout uses Tailwind.
+// structural layout is package-owned CSS.
 // ---------------------------------------------------------------------------
 
 const sk = {
-  bg: '#1f1f1f', sidebar: '#181818', sidebarBorder: '#2b2b2b',
-  lineNum: '#6e7681', text: '#9da5b4', keyword: '#569cd6',
-  string: '#ce9178', comment: '#6a9955',
+  accent: '#a87ffb',
+  activityInactive: '#738295',
+  bg: '#171f2b',
+  border: '#333e4f',
+  comment: '#7f8d9f',
+  keyword: '#fd8da3',
+  lineNum: '#475365',
+  sidebar: '#10151d',
+  status: '#1f2939',
+  statusForeground: '#a4afbd',
+  string: '#77d5a3',
+  text: '#d9dfe7',
 } as const;
 
-const SkeletonLine: FC<{ indent?: number; tokens: Array<{ w: number; color: string }> }> = ({ indent = 0, tokens }) => (
-  <div className="flex items-center h-[21px]" style={{ paddingLeft: indent * 16 }}>
+const SkeletonLine: FC<{
+  indent?: number;
+  tokens: Array<{ w: number; color: string }>;
+}> = ({ indent = 0, tokens }) => (
+  <div
+    className="baml-editor-skeleton-line"
+    style={{ paddingLeft: indent * 16 }}
+  >
     {tokens.map((t, i) => (
-      <div key={i} className="h-2.5 rounded-sm opacity-35 mr-2" style={{ width: t.w, background: t.color }} />
+      <div
+        className="baml-editor-skeleton-token"
+        // biome-ignore lint/suspicious/noArrayIndexKey: Skeleton tokens are a static ordered list.
+        key={i}
+        style={{ background: t.color, width: t.w }}
+      />
     ))}
   </div>
 );
 
 const EditorSkeleton: FC<{ height: string }> = ({ height }) => (
-  <div className="w-full flex font-mono overflow-hidden bg-[#1f1f1f]" style={{ height }}>
-    {/* Sidebar skeleton */}
-    <div className="w-[200px] shrink-0 py-2.5 bg-[#181818] border-r border-[#2b2b2b]">
-      <div className="px-3 mb-2.5">
-        <div className="w-20 h-[9px] rounded-sm opacity-20 bg-[#9da5b4]" />
-      </div>
-      {[90, 70, 110, 60].map((w, i) => (
-        <div key={i} className="py-0.5 px-3 pl-5">
-          <div className="h-[9px] rounded-sm opacity-15 bg-[#9da5b4]" style={{ width: w }} />
-        </div>
-      ))}
+  <div
+    aria-hidden="true"
+    className="baml-editor-skeleton"
+    style={{ background: sk.bg, height }}
+  >
+    <div
+      className="baml-editor-skeleton-titlebar"
+      style={{ background: sk.bg, borderColor: sk.border }}
+    >
+      <div
+        className="baml-editor-skeleton-window-title"
+        style={{ background: sk.text }}
+      />
     </div>
 
-    {/* Editor skeleton */}
-    <div className="flex-1 flex min-w-0">
-      {/* Gutter */}
-      <div className="w-12 shrink-0 pt-3 bg-[#1f1f1f]">
-        {Array.from({ length: 12 }, (_, i) => (
-          <div key={i} className="h-[21px] flex items-center justify-end pr-3">
-            <div className="w-2.5 h-2 rounded-sm opacity-25 bg-[#6e7681]" />
+    <div className="baml-editor-skeleton-main">
+      <div
+        className="baml-editor-skeleton-activitybar"
+        style={{ background: sk.bg, borderColor: sk.border }}
+      >
+        {[0, 1, 2, 3].map((item) => (
+          <div className="baml-editor-skeleton-activity-item" key={item}>
+            {item === 0 && (
+              <div
+                className="baml-editor-skeleton-activity-indicator"
+                style={{ background: sk.accent }}
+              />
+            )}
+            <div
+              className="baml-editor-skeleton-activity-icon"
+              style={{ background: item === 0 ? sk.text : sk.activityInactive }}
+            />
           </div>
         ))}
       </div>
 
-      {/* Code area */}
-      <div className="flex-1 pt-3 pl-2">
-        <SkeletonLine tokens={[{ w: 48, color: sk.comment }]} />
-        <SkeletonLine tokens={[{ w: 55, color: sk.keyword }, { w: 80, color: sk.text }]} />
-        <SkeletonLine indent={1} tokens={[{ w: 45, color: sk.keyword }, { w: 60, color: sk.text }]} />
-        <SkeletonLine indent={1} tokens={[{ w: 50, color: sk.keyword }, { w: 90, color: sk.string }]} />
-        <SkeletonLine tokens={[{ w: 10, color: sk.text }]} />
-        <SkeletonLine tokens={[]} />
-        <SkeletonLine tokens={[{ w: 42, color: sk.keyword }, { w: 70, color: sk.text }]} />
-        <SkeletonLine indent={1} tokens={[{ w: 60, color: sk.keyword }, { w: 50, color: sk.text }]} />
-        <SkeletonLine indent={1} tokens={[{ w: 55, color: sk.string }, { w: 80, color: sk.string }]} />
-        <SkeletonLine indent={1} tokens={[{ w: 40, color: sk.keyword }, { w: 100, color: sk.string }]} />
-        <SkeletonLine tokens={[{ w: 10, color: sk.text }]} />
-        <SkeletonLine tokens={[]} />
+      <div
+        className="baml-editor-skeleton-sidebar"
+        style={{ background: sk.sidebar, borderColor: sk.border }}
+      >
+        <div className="baml-editor-skeleton-sidebar-title-row">
+          <div
+            className="baml-editor-skeleton-sidebar-title"
+            style={{ background: sk.text }}
+          />
+        </div>
+        {[90, 70, 110, 60].map((w, i) => (
+          // biome-ignore lint/suspicious/noArrayIndexKey: Skeleton rows are a static ordered list.
+          <div className="baml-editor-skeleton-sidebar-row" key={i}>
+            <div
+              className="baml-editor-skeleton-sidebar-file"
+              style={{ background: sk.text, width: w }}
+            />
+          </div>
+        ))}
       </div>
+
+      <div className="baml-editor-skeleton-editor">
+        <div
+          className="baml-editor-skeleton-gutter"
+          style={{ background: sk.bg }}
+        >
+          {Array.from({ length: 12 }, (_, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: Skeleton lines are a static ordered list.
+            <div className="baml-editor-skeleton-gutter-line" key={i}>
+              <div
+                className="baml-editor-skeleton-line-number"
+                style={{ background: sk.lineNum }}
+              />
+            </div>
+          ))}
+        </div>
+
+        <div className="baml-editor-skeleton-code">
+          <SkeletonLine tokens={[{ color: sk.comment, w: 48 }]} />
+          <SkeletonLine
+            tokens={[
+              { color: sk.keyword, w: 55 },
+              { color: sk.text, w: 80 },
+            ]}
+          />
+          <SkeletonLine
+            indent={1}
+            tokens={[
+              { color: sk.keyword, w: 45 },
+              { color: sk.text, w: 60 },
+            ]}
+          />
+          <SkeletonLine
+            indent={1}
+            tokens={[
+              { color: sk.keyword, w: 50 },
+              { color: sk.string, w: 90 },
+            ]}
+          />
+          <SkeletonLine tokens={[{ color: sk.text, w: 10 }]} />
+          <SkeletonLine tokens={[]} />
+          <SkeletonLine
+            tokens={[
+              { color: sk.keyword, w: 42 },
+              { color: sk.text, w: 70 },
+            ]}
+          />
+          <SkeletonLine
+            indent={1}
+            tokens={[
+              { color: sk.keyword, w: 60 },
+              { color: sk.text, w: 50 },
+            ]}
+          />
+          <SkeletonLine
+            indent={1}
+            tokens={[
+              { color: sk.string, w: 55 },
+              { color: sk.string, w: 80 },
+            ]}
+          />
+          <SkeletonLine
+            indent={1}
+            tokens={[
+              { color: sk.keyword, w: 40 },
+              { color: sk.string, w: 100 },
+            ]}
+          />
+          <SkeletonLine tokens={[{ color: sk.text, w: 10 }]} />
+          <SkeletonLine tokens={[]} />
+        </div>
+      </div>
+    </div>
+
+    <div
+      className="baml-editor-skeleton-statusbar"
+      style={{ background: sk.status, borderColor: sk.border }}
+    >
+      <div
+        className="baml-editor-skeleton-status-item"
+        style={{ background: sk.statusForeground, width: 44 }}
+      />
+      <div
+        className="baml-editor-skeleton-status-item"
+        style={{ background: sk.statusForeground, width: 92 }}
+      />
     </div>
   </div>
 );
@@ -152,7 +284,17 @@ const EditorSkeleton: FC<{ height: string }> = ({ height }) => (
 // Component
 // ---------------------------------------------------------------------------
 
-export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, backend, workspaceRoot = '/workspace', height = '100%', onBlobUrlsChange, autoSaveDelayMs, showSaveHint, onUnsavedChange }) => {
+export const MonacoEditor: FC<MonacoEditorProps> = ({
+  files,
+  onFilesChange,
+  backend,
+  workspaceRoot = '/workspace',
+  height = '100%',
+  onBlobUrlsChange,
+  autoSaveDelayMs,
+  showSaveHint,
+  onUnsavedChange,
+}) => {
   /** Marks a file (by uri string) as saved/clean — set by the save-hint setup so
    *  the disk-change handler can clear externally-applied edits from the hint. */
   const markFileSavedRef = useRef<(uriString: string) => void>(() => {});
@@ -172,7 +314,9 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
   /** Active backend connection (LSP transport + runtime). */
   const currentConnRef = useRef<EditorConnection | null>(null);
   /** Disposables tied to the current connection (language client + connection). */
-  const connDisposablesRef = useRef<Array<{ dispose: () => void | Promise<void> }>>([]);
+  const connDisposablesRef = useRef<
+    Array<{ dispose: () => void | Promise<void> }>
+  >([]);
   /** Increments each time we connect; used as React key to force ExecutionPanel remount. */
   const connectionVersionRef = useRef(0);
   /** Callback to restart the connection; set once `connect` is defined. */
@@ -187,6 +331,7 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
   backendRef.current = backend;
   filesRef.current = files;
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: The workbench lifecycle is intentionally mount-only.
   useEffect(() => {
     if (!containerRef.current) return;
 
@@ -200,9 +345,13 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
 
       // Parallel-import: VS Code API shim + service overrides together
       const [
-        { MonacoVscodeApiWrapper, defaultHtmlAugmentationInstructions, defaultViewsInit },
+        {
+          MonacoVscodeApiWrapper,
+          defaultHtmlAugmentationInstructions,
+          defaultViewsInit,
+        },
         { createDefaultLocaleConfiguration },
-        { useWorkerFactory, Worker: WorkerRef },
+        { useWorkerFactory: configureWorkerFactory, Worker: WorkerRef },
         keybindingsOverride,
         lifecycleOverride,
         localizationOverride,
@@ -212,7 +361,6 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
         statusBarOverride,
         titleBarOverride,
         environmentOverride,
-        remoteAgentOverride,
         searchOverride,
         outlineOverride,
         secretStorageOverride,
@@ -232,7 +380,6 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
         import('@codingame/monaco-vscode-view-status-bar-service-override'),
         import('@codingame/monaco-vscode-view-title-bar-service-override'),
         import('@codingame/monaco-vscode-environment-service-override'),
-        import('@codingame/monaco-vscode-remote-agent-service-override'),
         import('@codingame/monaco-vscode-search-service-override'),
         import('@codingame/monaco-vscode-outline-service-override'),
         import('@codingame/monaco-vscode-secret-storage-service-override'),
@@ -244,19 +391,27 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
       if (disposed || !containerRef.current) return;
 
       // Workspace root (absolute path the in-memory FS is rooted at).
-      const root = (workspaceRoot.replace(/\/+$/, '') || '') || '/workspace';
+      const root = workspaceRoot.replace(/\/+$/, '') || '' || '/workspace';
       const rootPrefix = `${root}/`;
       const workspaceConfigPath = `${root}.code-workspace`;
 
       // Set up in-memory filesystem
-      const workspaceFolderUri = vscode.Uri.file(root);
       const workspaceFileUri = vscode.Uri.file(workspaceConfigPath);
 
-      const { InMemoryFileSystemProvider, registerFileSystemOverlay, FileChangeType } = filesOverride;
+      const {
+        InMemoryFileSystemProvider,
+        registerFileSystemOverlay,
+        FileChangeType,
+      } = filesOverride;
       const rawFs = new InMemoryFileSystemProvider();
       const encoder = new TextEncoder();
       const decoder = new TextDecoder();
-      const writeOpts: IFileWriteOptions = { atomic: false, unlock: false, create: true, overwrite: true };
+      const writeOpts: IFileWriteOptions = {
+        atomic: false,
+        create: true,
+        overwrite: true,
+        unlock: false,
+      };
 
       // Sandbox: only allow operations inside the workspace root (plus its config file).
       const WORKSPACE_ROOT = root;
@@ -265,20 +420,28 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
       /** Returns true if the path is inside /workspace or is the workspace config file. */
       const isAllowedPath = (uri: { path: string }): boolean => {
         const p = uri.path;
-        return p === WORKSPACE_ROOT || p.startsWith(WORKSPACE_ROOT + '/') || p === WORKSPACE_CONFIG;
+        return (
+          p === WORKSPACE_ROOT ||
+          p.startsWith(`${WORKSPACE_ROOT}/`) ||
+          p === WORKSPACE_CONFIG
+        );
       };
 
       /** Throws if the path is outside the sandbox. */
       const assertAllowed = (uri: { path: string }, op: string): void => {
         if (!isAllowedPath(uri)) {
-          throw new Error(`Sandbox violation: ${op} not allowed outside ${WORKSPACE_ROOT} (got ${uri.path})`);
+          throw new Error(
+            `Sandbox violation: ${op} not allowed outside ${WORKSPACE_ROOT} (got ${uri.path})`,
+          );
         }
       };
 
       /** Throws if trying to delete/rename the workspace root itself. */
       const assertNotRoot = (uri: { path: string }, op: string): void => {
         if (uri.path === WORKSPACE_ROOT) {
-          throw new Error(`Sandbox violation: cannot ${op} the workspace root directory`);
+          throw new Error(
+            `Sandbox violation: cannot ${op} the workspace root directory`,
+          );
         }
       };
 
@@ -289,25 +452,29 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
           if (typeof val !== 'function') return val;
 
           switch (prop) {
-            case 'writeFile': return (uri: any, content: any, opts: any) => {
-              assertAllowed(uri, 'writeFile');
-              return target.writeFile(uri, content, opts);
-            };
-            case 'mkdir': return (uri: any) => {
-              assertAllowed(uri, 'mkdir');
-              return target.mkdir(uri);
-            };
-            case 'delete': return (uri: any, opts: any) => {
-              assertAllowed(uri, 'delete');
-              assertNotRoot(uri, 'delete');
-              return target.delete(uri, opts);
-            };
-            case 'rename': return (from: any, to: any, opts: any) => {
-              assertAllowed(from, 'rename (source)');
-              assertNotRoot(from, 'rename');
-              assertAllowed(to, 'rename (target)');
-              return target.rename(from, to, opts);
-            };
+            case 'writeFile':
+              return (uri: any, content: any, opts: any) => {
+                assertAllowed(uri, 'writeFile');
+                return target.writeFile(uri, content, opts);
+              };
+            case 'mkdir':
+              return (uri: any) => {
+                assertAllowed(uri, 'mkdir');
+                return target.mkdir(uri);
+              };
+            case 'delete':
+              return (uri: any, opts: any) => {
+                assertAllowed(uri, 'delete');
+                assertNotRoot(uri, 'delete');
+                return target.delete(uri, opts);
+              };
+            case 'rename':
+              return (from: any, to: any, opts: any) => {
+                assertAllowed(from, 'rename (source)');
+                assertNotRoot(from, 'rename');
+                assertAllowed(to, 'rename (target)');
+                return target.rename(from, to, opts);
+              };
             default:
               return val.bind(target);
           }
@@ -324,7 +491,11 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
         for (let i = 2; i <= rootParts.length; i++) {
           const dir = rootParts.slice(0, i).join('/');
           if (!dir) continue;
-          try { await rawFs.mkdir(vscode.Uri.file(dir)); } catch { /* already exists */ }
+          try {
+            await rawFs.mkdir(vscode.Uri.file(dir));
+          } catch {
+            /* already exists */
+          }
         }
       }
 
@@ -335,22 +506,36 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
       blobUrlsRef.current = blobUrlMap;
 
       for (const [filename, content] of Object.entries(allFiles)) {
-        const absPath = filename.startsWith(rootPrefix) ? filename : `${rootPrefix}${filename}`;
+        const absPath = filename.startsWith(rootPrefix)
+          ? filename
+          : `${rootPrefix}${filename}`;
         const parts = absPath.split('/');
         for (let i = 2; i < parts.length; i++) {
           const parentPath = parts.slice(0, i).join('/');
           try {
             await fileSystemProvider.mkdir(vscode.Uri.file(parentPath));
-          } catch { /* already exists */ }
+          } catch {
+            /* already exists */
+          }
         }
 
         if (isMediaPath(filename)) {
           const bytes = fromDataUrl(content);
-          await fileSystemProvider.writeFile(vscode.Uri.file(absPath), bytes, writeOpts);
+          await fileSystemProvider.writeFile(
+            vscode.Uri.file(absPath),
+            bytes,
+            writeOpts,
+          );
           const mime = mimeFromPath(filename);
-          blobUrlMap[filename] = URL.createObjectURL(new Blob([new Uint8Array(bytes)], { type: mime }));
+          blobUrlMap[filename] = URL.createObjectURL(
+            new Blob([new Uint8Array(bytes)], { type: mime }),
+          );
         } else {
-          await fileSystemProvider.writeFile(vscode.Uri.file(absPath), encoder.encode(content), writeOpts);
+          await fileSystemProvider.writeFile(
+            vscode.Uri.file(absPath),
+            encoder.encode(content),
+            writeOpts,
+          );
         }
       }
       onBlobUrlsChangeRef.current?.({ ...blobUrlMap });
@@ -363,32 +548,116 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
       );
       registerFileSystemOverlay(1, fileSystemProvider);
 
-      const windowLabel = backendRef.current.windowLabel ?? 'BAML Playground';
+      const windowLabel = backendRef.current.windowLabel;
 
       // Init VS Code API wrapper and start the workbench
       const apiWrapper = new MonacoVscodeApiWrapper({
         $type: 'extended',
-        viewsConfig: {
-          $type: 'ViewsService',
-          htmlContainer: containerRef.current,
-          htmlAugmentationInstructions: defaultHtmlAugmentationInstructions,
-          viewsInitFunc: defaultViewsInit,
-        },
-        workspaceConfig: {
-          enableWorkspaceTrust: true,
-          windowIndicator: { label: windowLabel, tooltip: '', command: '' },
-          workspaceProvider: {
-            trusted: true,
-            async open() { return true; },
-            workspace: { workspaceUri: workspaceFileUri },
+        extensions: [
+          {
+            config: {
+              contributes: {
+                commands: [
+                  {
+                    command: 'baml.openPlayground',
+                    title: 'BAML: Open Playground',
+                  },
+                  {
+                    command: 'baml.previewImage',
+                    title: 'BAML: Preview Image',
+                  },
+                ],
+                grammars: [
+                  {
+                    language: 'baml',
+                    path: './baml.tmLanguage.json',
+                    scopeName: 'source.baml',
+                  },
+                ],
+                languages: [
+                  {
+                    aliases: ['BAML', 'baml'],
+                    configuration: './language-configuration.json',
+                    extensions: ['.baml'],
+                    id: 'baml',
+                  },
+                ],
+                themes: [
+                  {
+                    id: 'monospace-dark',
+                    label: 'Monospace Dark',
+                    path: './monospace-dark.json',
+                    uiTheme: 'vs-dark',
+                  },
+                ],
+              },
+              engines: { vscode: '*' },
+              name: 'baml-playground',
+              publisher: 'boundaryml',
+              version: '1.0.0',
+            },
+            filesOrContents: new Map<string, string | URL>([
+              ['./baml.tmLanguage.json', JSON.stringify(bamlTmLanguageGrammar)],
+              ['./monospace-dark.json', JSON.stringify(monospaceDarkTheme)],
+              [
+                './language-configuration.json',
+                JSON.stringify({
+                  autoClosingPairs: [
+                    ['{', '}'],
+                    ['[', ']'],
+                    ['(', ')'],
+                    { close: '"', open: '"' },
+                    ['#"', '"#'],
+                    ["'", "'"],
+                    ['{#', '}'],
+                    ['{//', '//}'],
+                  ],
+                  brackets: [
+                    ['{', '}'],
+                    ['[', ']'],
+                    ['(', ')'],
+                  ],
+                  comments: {
+                    blockComment: ['{//', '//}'],
+                    lineComment: '//',
+                  },
+                  surroundingPairs: [
+                    ['{', '}'],
+                    ['[', ']'],
+                    ['(', ')'],
+                    ['"', '"'],
+                    ["'", "'"],
+                  ],
+                }),
+              ],
+            ]),
           },
-          configurationDefaults: {
-            'window.title': 'BAML Playground${separator}${dirty}${activeEditorShort}',
-          },
-          productConfiguration: {
-            nameShort: 'BAML Playground',
-            nameLong: 'BAML Playground',
-          },
+        ],
+        monacoWorkerFactory: () => {
+          // Custom worker factory: the `new URL(..., import.meta.url)` patterns
+          // must be in OUR source code (the consuming app transpiles pkg-editor)
+          // so the bundler can resolve them at build time into proper asset URLs.
+          // eslint-disable-next-line react-hooks/rules-of-hooks -- not a React hook
+          configureWorkerFactory({
+            workerLoaders: {
+              editorWorkerService: () =>
+                new WorkerRef(
+                  new URL(
+                    '@codingame/monaco-vscode-editor-api/esm/vs/editor/editor.worker.js',
+                    import.meta.url,
+                  ),
+                  { type: 'module' },
+                ),
+              TextMateWorker: () =>
+                new WorkerRef(
+                  new URL(
+                    '@codingame/monaco-vscode-textmate-service-override/worker',
+                    import.meta.url,
+                  ),
+                  { type: 'module' },
+                ),
+            },
+          });
         },
         serviceOverrides: {
           ...keybindingsOverride.default(),
@@ -398,107 +667,75 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
           ...statusBarOverride.default(),
           ...titleBarOverride.default(),
           ...explorerOverride.default(),
-          ...remoteAgentOverride.default(),
           ...environmentOverride.default(),
           ...secretStorageOverride.default(),
           ...storageOverride.default(),
           ...searchOverride.default(),
           ...outlineOverride.default(),
         },
-        monacoWorkerFactory: () => {
-          // Custom worker factory — the `new URL(..., import.meta.url)` patterns
-          // must be in OUR source code (the consuming app transpiles pkg-editor)
-          // so the bundler can resolve them at build time into proper asset URLs.
-          // eslint-disable-next-line react-hooks/rules-of-hooks -- not a React hook
-          useWorkerFactory({
-            workerLoaders: {
-              editorWorkerService: () => new WorkerRef(
-                new URL('@codingame/monaco-vscode-editor-api/esm/vs/editor/editor.worker.js', import.meta.url),
-                { type: 'module' },
-              ),
-              TextMateWorker: () => new WorkerRef(
-                new URL('@codingame/monaco-vscode-textmate-service-override/worker', import.meta.url),
-                { type: 'module' },
-              ),
-            },
-          });
-        },
         userConfiguration: {
           json: JSON.stringify({
-            'workbench.colorTheme': 'Default Dark Modern',
-            'window.commandCenter': false,
-            'workbench.layoutControl.enabled': false,
+            'editor.fontSize': 13,
+            'editor.formatOnSave': true,
+            'editor.lineHeight': 1.6,
+            'editor.minimap.enabled': false,
+            'editor.padding.top': 12,
+            'editor.renderLineHighlight': 'line',
+            'editor.scrollBeyondLastLine': false,
             'editor.semanticHighlighting.enabled': true,
             'editor.semanticTokenColorCustomizations': {
               rules: {
                 'namespace:baml': '#808080CC',
               },
             },
-            'editor.wordBasedSuggestions': 'off',
-            'editor.minimap.enabled': false,
-            'editor.scrollBeyondLastLine': false,
-            'editor.fontSize': 13,
-            'editor.lineHeight': 1.6,
             'editor.tabSize': 2,
-            'editor.renderLineHighlight': 'line',
-            'editor.padding.top': 12,
+            'editor.wordBasedSuggestions': 'off',
+            'window.commandCenter': false,
+            'window.titleSeparator': ' - ',
+            'workbench.colorTheme': 'monospace-dark',
+            'workbench.layoutControl.enabled': false,
             ...(autoSaveDelayMs != null
-              ? { 'files.autoSave': 'afterDelay', 'files.autoSaveDelay': autoSaveDelayMs }
+              ? {
+                  'files.autoSave': 'afterDelay',
+                  'files.autoSaveDelay': autoSaveDelayMs,
+                }
               : {}),
           }),
         },
-        extensions: [{
-          config: {
-            name: 'baml-playground',
-            publisher: 'boundaryml',
-            version: '1.0.0',
-            engines: { vscode: '*' },
-            contributes: {
-              commands: [
-                { command: 'baml.openPlayground', title: 'BAML: Open Playground' },
-                { command: 'baml.previewImage', title: 'BAML: Preview Image' },
-              ],
-              languages: [{
-                id: 'baml',
-                extensions: ['.baml'],
-                aliases: ['BAML', 'baml'],
-                configuration: './language-configuration.json',
-              }],
-              grammars: [{
-                language: 'baml',
-                scopeName: 'source.baml',
-                path: './baml.tmLanguage.json',
-              }],
-            },
+        viewsConfig: {
+          $type: 'ViewsService',
+          htmlAugmentationInstructions: defaultHtmlAugmentationInstructions,
+          htmlContainer: containerRef.current,
+          viewsInitFunc: defaultViewsInit,
+        },
+        workspaceConfig: {
+          enableWorkspaceTrust: true,
+          ...(windowLabel
+            ? {
+                windowIndicator: {
+                  command: '',
+                  label: windowLabel,
+                  tooltip: '',
+                },
+              }
+            : {}),
+          configurationDefaults: {
+            'window.title':
+              // biome-ignore lint/suspicious/noTemplateCurlyInString: VS Code expands these placeholders.
+              'BAML Playground${separator}${dirty}${activeEditorShort}',
           },
-          filesOrContents: new Map<string, string | URL>([
-            ['./baml.tmLanguage.json', JSON.stringify(bamlTmLanguageGrammar)],
-            ['./language-configuration.json', JSON.stringify({
-              comments: {
-                lineComment: '//',
-                blockComment: ['{//', '//}'],
-              },
-              brackets: [['{', '}'], ['[', ']'], ['(', ')']],
-              autoClosingPairs: [
-                ['{', '}'],
-                ['[', ']'],
-                ['(', ')'],
-                { open: '"', close: '"' },
-                ['#"', '"#'],
-                ["'", "'"],
-                ['{#', '}'],
-                ['{//', '//}'],
-              ],
-              surroundingPairs: [
-                ['{', '}'],
-                ['[', ']'],
-                ['(', ')'],
-                ['"', '"'],
-                ["'", "'"],
-              ],
-            })],
-          ]),
-        }],
+          productConfiguration: {
+            nameLong: 'BAML Playground',
+            nameShort: 'BAML Playground',
+          },
+          workspaceProvider: {
+            async open() {
+              return true;
+            },
+            trusted: true,
+            workspace: { workspaceUri: workspaceFileUri },
+          },
+        },
       });
 
       await apiWrapper.start();
@@ -506,7 +743,9 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
 
       // Register the ExecutionPanel as a custom editor pane in the workbench.
       // This must happen after start() so the workbench services are available.
-      const { registerExecutionPanelPane } = await import('./ExecutionPanelPane');
+      const { registerExecutionPanelPane } = await import(
+        './ExecutionPanelPane'
+      );
       await registerExecutionPanelPane();
 
       // ── Image preview pane ─────────────────────────────────────────
@@ -518,27 +757,51 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
       // every time a new image is opened and loads content from liveFiles
       // (media files are stored as data URLs) or falls back to rawFs.
       {
-        const { SimpleEditorPane, SimpleEditorInput, registerEditorPane, EditorInputCapabilities } =
-          await import('@codingame/monaco-vscode-api/service-override/tools/views');
-        const { StandaloneServices: SS } = await import('@codingame/monaco-vscode-api');
+        const {
+          SimpleEditorPane,
+          SimpleEditorInput,
+          registerEditorPane,
+          EditorInputCapabilities,
+        } = await import(
+          '@codingame/monaco-vscode-api/service-override/tools/views'
+        );
+        const { StandaloneServices: SS } = await import(
+          '@codingame/monaco-vscode-api'
+        );
         const { IEditorService } = await import(
           '@codingame/monaco-vscode-api/vscode/vs/workbench/services/editor/common/editorService.service'
         );
 
         const IMAGE_PANE_ID = 'baml.imagePreview';
-        const IMAGE_EXTS = new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico']);
+        const IMAGE_EXTS = new Set([
+          'png',
+          'jpg',
+          'jpeg',
+          'gif',
+          'webp',
+          'svg',
+          'bmp',
+          'ico',
+        ]);
         const WORKSPACE_PREFIX = rootPrefix;
 
         class ImagePreviewInput extends SimpleEditorInput {
           constructor(uri: any) {
             super(uri);
-            const name = String(uri.path ?? '').split('/').pop() ?? 'Image';
+            const name =
+              String(uri.path ?? '')
+                .split('/')
+                .pop() ?? 'Image';
             this.setName(name);
             this.setTitle(name);
             this.addCapability(EditorInputCapabilities.Readonly);
           }
-          get typeId() { return IMAGE_PANE_ID; }
-          get editorId() { return IMAGE_PANE_ID; }
+          get typeId() {
+            return IMAGE_PANE_ID;
+          }
+          get editorId() {
+            return IMAGE_PANE_ID;
+          }
         }
 
         class ImagePreviewPane extends SimpleEditorPane {
@@ -580,7 +843,9 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
 
             if (!dataUrl) {
               try {
-                const bytes: Uint8Array = await Promise.resolve(rawFs.readFile(uri));
+                const bytes: Uint8Array = await Promise.resolve(
+                  rawFs.readFile(uri),
+                );
                 dataUrl = toDataUrl(bytes, mimeFromPath(String(uri.path)));
               } catch (err) {
                 console.error('[ImagePreview] readFile failed:', err);
@@ -600,7 +865,11 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
             el.appendChild(img);
             this._img = img;
 
-            return { dispose() { img.remove(); } };
+            return {
+              dispose() {
+                img.remove();
+              },
+            };
           }
 
           layout(dimension: Dimension) {
@@ -624,25 +893,38 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
           }
         }
 
-        registerEditorPane(IMAGE_PANE_ID, 'Image Preview', ImagePreviewPane as any, [ImagePreviewInput]);
+        registerEditorPane(
+          IMAGE_PANE_ID,
+          'Image Preview',
+          ImagePreviewPane as any,
+          [ImagePreviewInput],
+        );
 
         const editorService = SS.get(IEditorService);
         const origOpen = editorService.openEditor.bind(editorService);
 
         // @ts-expect-error override openEditor is expliclity desisred due to override
-        editorService.openEditor = function (input: any, optionsOrGroup?: any, group?: any) {
+        editorService.openEditor = (
+          input: any,
+          optionsOrGroup?: any,
+          group?: any,
+        ) => {
           const resource = input?.resource ?? input?.original?.resource;
           const ext = resource?.path?.split('.')?.pop()?.toLowerCase() ?? '';
           if (resource && IMAGE_EXTS.has(ext)) {
-            return origOpen(new ImagePreviewInput(resource), optionsOrGroup, group);
+            return origOpen(
+              new ImagePreviewInput(resource),
+              optionsOrGroup,
+              group,
+            );
           }
           return origOpen(input, optionsOrGroup, group);
         };
 
         vscode.commands.registerCommand('baml.previewImage', (uri?: any) => {
-          if (!uri) uri = vscode.window.activeTextEditor?.document.uri;
-          if (!uri) return;
-          editorService.openEditor(new ImagePreviewInput(uri));
+          const imageUri = uri ?? vscode.window.activeTextEditor?.document.uri;
+          if (!imageUri) return;
+          editorService.openEditor(new ImagePreviewInput(imageUri));
         });
       }
 
@@ -650,7 +932,9 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
       // Without this, MarkdownRendererService._defaultCodeBlockRenderer is undefined
       // and all code fences in hover widgets render as empty <span> elements.
       {
-        const { StandaloneServices } = await import('@codingame/monaco-vscode-api');
+        const { StandaloneServices } = await import(
+          '@codingame/monaco-vscode-api'
+        );
         const { IMarkdownRendererService } = await import(
           '@codingame/monaco-vscode-api/vscode/vs/platform/markdown/browser/markdownRenderer.service'
         );
@@ -664,7 +948,9 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
           '@codingame/monaco-vscode-api/vscode/vs/editor/common/languages/language.service'
         );
 
-        const markdownService = StandaloneServices.get(IMarkdownRendererService);
+        const markdownService = StandaloneServices.get(
+          IMarkdownRendererService,
+        );
         const codeBlockRenderer = new EditorMarkdownCodeBlockRenderer(
           StandaloneServices.get(IConfigurationService),
           StandaloneServices.get(ILanguageService),
@@ -677,14 +963,17 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
       await new Promise((r) => setTimeout(r, 150));
       if (disposed) return;
 
-      // Close any stale editors restored from a previous session so we start clean.
-      await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+      // Close stale editors and collapse restored groups so the initial split is deterministic.
+      await vscode.commands.executeCommand('workbench.action.closeAllGroups');
       if (disposed) return;
 
       // Determine which file to show — prefer main.baml, fall back to first text file
-      const fileNames = Object.keys(allFiles).filter(f => !isMediaPath(f));
-      const firstFileIndex = fileNames.findIndex(path => path.endsWith('main.baml'));
-      const firstFile = firstFileIndex !== -1 ? fileNames[firstFileIndex] : fileNames[0];
+      const fileNames = Object.keys(allFiles).filter((f) => !isMediaPath(f));
+      const firstFileIndex = fileNames.findIndex((path) =>
+        path.endsWith('main.baml'),
+      );
+      const firstFile =
+        firstFileIndex !== -1 ? fileNames[firstFileIndex] : fileNames[0];
       const firstFileUri = vscode.Uri.file(`${rootPrefix}${firstFile}`);
 
       // Open the document and show it in the editor
@@ -693,8 +982,14 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
       await vscode.window.showTextDocument(firstFileUri);
       if (disposed) return;
 
+      await vscode.commands.executeCommand('baml.openPlayground');
+      if (disposed) return;
+
       // Focus Explorer so file tree shows
-      vscode.commands.executeCommand('workbench.view.explorer').then(() => {}, () => {});
+      vscode.commands.executeCommand('workbench.view.explorer').then(
+        () => {},
+        () => {},
+      );
 
       // Workbench ready — editor is visible, hide skeleton
       setReady(true);
@@ -706,7 +1001,8 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
       // layout (no visible status bar). Externally-applied edits (pushed from
       // disk) are cleared via markFileSavedRef so they don't read as "unsaved".
       if (showSaveHint) {
-        const refresh = () => onUnsavedChangeRef.current?.(unsavedFilesRef.current.size > 0);
+        const refresh = () =>
+          onUnsavedChangeRef.current?.(unsavedFilesRef.current.size > 0);
         const onChange = vscode.workspace.onDidChangeTextDocument((e) => {
           if (e.document.uri.path.endsWith('.baml')) {
             unsavedFilesRef.current.add(e.document.uri.toString());
@@ -755,7 +1051,9 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
           URL.revokeObjectURL(blobUrlMap[filename]);
         }
         const mime = mimeFromPath(filename);
-        blobUrlMap[filename] = URL.createObjectURL(new Blob([new Uint8Array(bytes)], { type: mime }));
+        blobUrlMap[filename] = URL.createObjectURL(
+          new Blob([new Uint8Array(bytes)], { type: mime }),
+        );
         onBlobUrlsChangeRef.current?.({ ...blobUrlMap });
       };
 
@@ -769,30 +1067,43 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
       };
 
       // Listen for text changes from the editor (any .baml file)
-      const changeSubscription = vscode.workspace.onDidChangeTextDocument((e) => {
-        const filename = uriToFilename(e.document.uri);
-        if (filename && filename.endsWith('.baml')) {
-          liveFiles[filename] = e.document.getText();
-          pushUpdate();
-        }
-      });
+      const changeSubscription = vscode.workspace.onDidChangeTextDocument(
+        (e) => {
+          const filename = uriToFilename(e.document.uri);
+          if (filename?.endsWith('.baml')) {
+            liveFiles[filename] = e.document.getText();
+            pushUpdate();
+          }
+        },
+      );
       disposables.push({ dispose: () => changeSubscription.dispose() });
 
       // Cursor position tracking for playground navigation
       let cursorDebounceTimer: ReturnType<typeof setTimeout> | undefined;
-      const cursorSubscription = vscode.window.onDidChangeTextEditorSelection((e: import('vscode').TextEditorSelectionChangeEvent) => {
-        const filename = uriToFilename(e.textEditor.document.uri);
-        if (!filename || !filename.endsWith('.baml')) return;
+      const cursorSubscription = vscode.window.onDidChangeTextEditorSelection(
+        (e: import('vscode').TextEditorSelectionChangeEvent) => {
+          const filename = uriToFilename(e.textEditor.document.uri);
+          if (!filename || !filename.endsWith('.baml')) return;
 
-        clearTimeout(cursorDebounceTimer);
-        cursorDebounceTimer = setTimeout(() => {
-          const pos = e.selections[0]?.active;
-          if (!pos) return;
-          // VS Code API positions are 0-indexed, matching lsp_types::Position.
-          currentConnRef.current?.onCursorMoved?.(filename, pos.line, pos.character);
-        }, 50);
+          clearTimeout(cursorDebounceTimer);
+          cursorDebounceTimer = setTimeout(() => {
+            const pos = e.selections[0]?.active;
+            if (!pos) return;
+            // VS Code API positions are 0-indexed, matching lsp_types::Position.
+            currentConnRef.current?.onCursorMoved?.(
+              filename,
+              pos.line,
+              pos.character,
+            );
+          }, 50);
+        },
+      );
+      disposables.push({
+        dispose: () => {
+          clearTimeout(cursorDebounceTimer);
+          cursorSubscription.dispose();
+        },
       });
-      disposables.push({ dispose: () => { clearTimeout(cursorDebounceTimer); cursorSubscription.dispose(); } });
 
       // Listen for file creation/deletion at the FS level
       const fsWatcher = fileSystemProvider.onDidChangeFile((events) => {
@@ -809,18 +1120,29 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
             delete liveFiles[filename];
             if (isMedia) removeBlobUrl(filename);
             pushUpdate();
-          } else if (event.type === FileChangeType.UPDATED || event.type === FileChangeType.ADDED) {
+          } else if (
+            event.type === FileChangeType.UPDATED ||
+            event.type === FileChangeType.ADDED
+          ) {
             const fileUri = vscode.Uri.file(`${rootPrefix}${filename}`);
-            fileSystemProvider.readFile(fileUri).then((bytes: Uint8Array) => {
-              if (disposed) return;
-              if (isMedia) {
-                liveFiles[filename] = toDataUrl(bytes, mimeFromPath(filename));
-                updateBlobUrl(filename, bytes);
-              } else {
-                liveFiles[filename] = decoder.decode(bytes);
-              }
-              pushUpdate();
-            }).catch(() => { /* file may not be readable yet */ });
+            fileSystemProvider
+              .readFile(fileUri)
+              .then((bytes: Uint8Array) => {
+                if (disposed) return;
+                if (isMedia) {
+                  liveFiles[filename] = toDataUrl(
+                    bytes,
+                    mimeFromPath(filename),
+                  );
+                  updateBlobUrl(filename, bytes);
+                } else {
+                  liveFiles[filename] = decoder.decode(bytes);
+                }
+                pushUpdate();
+              })
+              .catch(() => {
+                /* file may not be readable yet */
+              });
           }
         }
       });
@@ -834,15 +1156,16 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
       // Handle given to backends so they can reflect server/worker-side
       // changes back into the editor without re-running workbench setup.
       const handle: WorkbenchHandle = {
-        vscode,
-        liveFiles,
-        fileSystemProvider,
-        encoder,
         decoder,
-        updateBlobUrl,
-        removeBlobUrl,
-        notifyFilesChanged: (files) => onFilesChangeRef.current(files ?? { ...liveFiles }),
+        encoder,
+        fileSystemProvider,
         isDisposed: () => disposed,
+        liveFiles,
+        notifyFilesChanged: (files) =>
+          onFilesChangeRef.current(files ?? { ...liveFiles }),
+        removeBlobUrl,
+        updateBlobUrl,
+        vscode,
       };
 
       // ════════════════════════════════════════════════════════════════
@@ -852,23 +1175,32 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
       const connect = async () => {
         if (disposed) return;
 
-        const { LanguageClientWrapper } = await import('monaco-languageclient/lcwrapper');
+        const { LanguageClientWrapper } = await import(
+          'monaco-languageclient/lcwrapper'
+        );
         if (disposed) return;
 
         const conn = await backendRef.current.connect(handle);
-        if (disposed) { await conn.dispose(); return; }
+        if (disposed) {
+          await conn.dispose();
+          return;
+        }
         currentConnRef.current = conn;
 
         const lcWrapper = new LanguageClientWrapper({
-          languageId: 'baml',
           clientOptions: {
             documentSelector: ['baml'],
           },
           connection: conn.lcConnection,
+          languageId: 'baml',
         });
 
         await lcWrapper.start();
-        if (disposed) { await lcWrapper.dispose(); await conn.dispose(); return; }
+        if (disposed) {
+          await lcWrapper.dispose();
+          await conn.dispose();
+          return;
+        }
 
         connDisposablesRef.current.push(
           { dispose: () => lcWrapper.dispose() },
@@ -909,23 +1241,36 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
                   await fileSystemProvider.writeFile(
                     fileUri,
                     encoder.encode(params.text),
-                    { create: true, overwrite: true, unlock: false, atomic: false },
+                    {
+                      atomic: false,
+                      create: true,
+                      overwrite: true,
+                      unlock: false,
+                    },
                   );
                 }
                 // The applyEdit above counts as a text change; clear it from the
                 // unsaved indicator since this content came FROM disk.
                 markFileSavedRef.current(target);
               } catch (err) {
-                console.error('[MonacoEditor] applying external file change failed:', err);
+                console.error(
+                  '[MonacoEditor] applying external file change failed:',
+                  err,
+                );
               }
             },
           );
-          connDisposablesRef.current.push({ dispose: () => diskChangeSub.dispose() });
+          connDisposablesRef.current.push({
+            dispose: () => diskChangeSub.dispose(),
+          });
         }
 
-        const { setRuntimePort, setReloadCallback, setNavigateToSource } = await import('./ExecutionPanelPane');
+        const { setRuntimePort, setReloadCallback, setNavigateToSource } =
+          await import('./ExecutionPanelPane');
 
-        setRuntimePort(conn.runtimePort, { connectionVersion: connectionVersionRef.current });
+        setRuntimePort(conn.runtimePort, {
+          connectionVersion: connectionVersionRef.current,
+        });
         setReloadCallback(() => restartRef.current?.());
         setNavigateToSource(async (source) => {
           if (!source.filePath) {
@@ -952,9 +1297,9 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
             visibleEditor?.document ??
             (await vscode.workspace.openTextDocument(targetUri));
           const editor = await vscode.window.showTextDocument(document, {
-            viewColumn: sourceViewColumn,
             preserveFocus: false,
             preview: false,
+            viewColumn: sourceViewColumn,
           });
 
           // The language server also sends line/column/endLine/endColumn unchanged in
@@ -993,7 +1338,10 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
           for (const d of toDispose) {
             try {
               const r = d.dispose();
-              if (r != null && typeof (r as { then?: unknown }).then === 'function') {
+              if (
+                r != null &&
+                typeof (r as { then?: unknown }).then === 'function'
+              ) {
                 await (r as Promise<unknown>);
               }
             } catch {
@@ -1027,13 +1375,21 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
       const toDispose = connDisposablesRef.current;
       connDisposablesRef.current = [];
       for (const d of toDispose) {
-        try { void d.dispose(); } catch { /* no-op */ }
+        try {
+          void d.dispose();
+        } catch {
+          /* no-op */
+        }
       }
       for (const d of disposables) {
-        try { d.dispose(); } catch { /* no-op */ }
+        try {
+          d.dispose();
+        } catch {
+          /* no-op */
+        }
       }
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const isDev = isDevelopmentBuild();
@@ -1047,17 +1403,22 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({ files, onFilesChange, back
         </div>
       )}
       {/* Actual workbench mounts here */}
-      <div ref={containerRef} className="nokey w-full h-full relative overflow-hidden" />
+      <div
+        className="nokey w-full h-full relative overflow-hidden"
+        ref={containerRef}
+      />
       {/* Dev-only: reload button (client-only to avoid hydration mismatch) */}
       {mounted && isDev && backend.supportsReload && (
         <button
-          type="button"
-          onClick={() => restartRef.current?.()}
           className="absolute bottom-2 right-2 z-10 flex items-center gap-2 rounded px-2 py-1 font-mono text-xs text-neutral-400 bg-black/50 border border-neutral-700 text-left cursor-pointer hover:bg-black/70 hover:border-neutral-600 transition-colors"
+          onClick={() => restartRef.current?.()}
           title="Click to reconnect the BAML backend (loads fresh WASM)."
+          type="button"
         >
           <span>Reconnect</span>
-          <span className="text-sky-400/80" title="Connection count">#{connectionCount}</span>
+          <span className="text-sky-400/80" title="Connection count">
+            #{connectionCount}
+          </span>
         </button>
       )}
     </div>

--- a/typescript2/pkg-editor/src/MonacoEditor.tsx
+++ b/typescript2/pkg-editor/src/MonacoEditor.tsx
@@ -134,150 +134,157 @@ const SkeletonLine: FC<{
 );
 
 const EditorSkeleton: FC<{ height: string }> = ({ height }) => (
-  <div
-    aria-hidden="true"
-    className="baml-editor-skeleton"
-    style={{ background: sk.bg, height }}
-  >
+  <>
+    <output className="baml-editor-loading-status">
+      Loading the BAML editor.
+    </output>
     <div
-      className="baml-editor-skeleton-titlebar"
-      style={{ background: sk.bg, borderColor: sk.border }}
+      aria-hidden="true"
+      className="baml-editor-skeleton"
+      style={{ background: sk.bg, height }}
     >
       <div
-        className="baml-editor-skeleton-window-title"
-        style={{ background: sk.text }}
-      />
-    </div>
-
-    <div className="baml-editor-skeleton-main">
-      <div
-        className="baml-editor-skeleton-activitybar"
+        className="baml-editor-skeleton-titlebar"
         style={{ background: sk.bg, borderColor: sk.border }}
       >
-        {[0, 1, 2, 3].map((item) => (
-          <div className="baml-editor-skeleton-activity-item" key={item}>
-            {item === 0 && (
-              <div
-                className="baml-editor-skeleton-activity-indicator"
-                style={{ background: sk.accent }}
-              />
-            )}
-            <div
-              className="baml-editor-skeleton-activity-icon"
-              style={{ background: item === 0 ? sk.text : sk.activityInactive }}
-            />
-          </div>
-        ))}
-      </div>
-
-      <div
-        className="baml-editor-skeleton-sidebar"
-        style={{ background: sk.sidebar, borderColor: sk.border }}
-      >
-        <div className="baml-editor-skeleton-sidebar-title-row">
-          <div
-            className="baml-editor-skeleton-sidebar-title"
-            style={{ background: sk.text }}
-          />
-        </div>
-        {[90, 70, 110, 60].map((w, i) => (
-          // biome-ignore lint/suspicious/noArrayIndexKey: Skeleton rows are a static ordered list.
-          <div className="baml-editor-skeleton-sidebar-row" key={i}>
-            <div
-              className="baml-editor-skeleton-sidebar-file"
-              style={{ background: sk.text, width: w }}
-            />
-          </div>
-        ))}
-      </div>
-
-      <div className="baml-editor-skeleton-editor">
         <div
-          className="baml-editor-skeleton-gutter"
-          style={{ background: sk.bg }}
+          className="baml-editor-skeleton-window-title"
+          style={{ background: sk.text }}
+        />
+      </div>
+
+      <div className="baml-editor-skeleton-main">
+        <div
+          className="baml-editor-skeleton-activitybar"
+          style={{ background: sk.bg, borderColor: sk.border }}
         >
-          {Array.from({ length: 12 }, (_, i) => (
-            // biome-ignore lint/suspicious/noArrayIndexKey: Skeleton lines are a static ordered list.
-            <div className="baml-editor-skeleton-gutter-line" key={i}>
+          {[0, 1, 2, 3].map((item) => (
+            <div className="baml-editor-skeleton-activity-item" key={item}>
+              {item === 0 && (
+                <div
+                  className="baml-editor-skeleton-activity-indicator"
+                  style={{ background: sk.accent }}
+                />
+              )}
               <div
-                className="baml-editor-skeleton-line-number"
-                style={{ background: sk.lineNum }}
+                className="baml-editor-skeleton-activity-icon"
+                style={{
+                  background: item === 0 ? sk.text : sk.activityInactive,
+                }}
               />
             </div>
           ))}
         </div>
 
-        <div className="baml-editor-skeleton-code">
-          <SkeletonLine tokens={[{ color: sk.comment, w: 48 }]} />
-          <SkeletonLine
-            tokens={[
-              { color: sk.keyword, w: 55 },
-              { color: sk.text, w: 80 },
-            ]}
-          />
-          <SkeletonLine
-            indent={1}
-            tokens={[
-              { color: sk.keyword, w: 45 },
-              { color: sk.text, w: 60 },
-            ]}
-          />
-          <SkeletonLine
-            indent={1}
-            tokens={[
-              { color: sk.keyword, w: 50 },
-              { color: sk.string, w: 90 },
-            ]}
-          />
-          <SkeletonLine tokens={[{ color: sk.text, w: 10 }]} />
-          <SkeletonLine tokens={[]} />
-          <SkeletonLine
-            tokens={[
-              { color: sk.keyword, w: 42 },
-              { color: sk.text, w: 70 },
-            ]}
-          />
-          <SkeletonLine
-            indent={1}
-            tokens={[
-              { color: sk.keyword, w: 60 },
-              { color: sk.text, w: 50 },
-            ]}
-          />
-          <SkeletonLine
-            indent={1}
-            tokens={[
-              { color: sk.string, w: 55 },
-              { color: sk.string, w: 80 },
-            ]}
-          />
-          <SkeletonLine
-            indent={1}
-            tokens={[
-              { color: sk.keyword, w: 40 },
-              { color: sk.string, w: 100 },
-            ]}
-          />
-          <SkeletonLine tokens={[{ color: sk.text, w: 10 }]} />
-          <SkeletonLine tokens={[]} />
+        <div
+          className="baml-editor-skeleton-sidebar"
+          style={{ background: sk.sidebar, borderColor: sk.border }}
+        >
+          <div className="baml-editor-skeleton-sidebar-title-row">
+            <div
+              className="baml-editor-skeleton-sidebar-title"
+              style={{ background: sk.text }}
+            />
+          </div>
+          {[90, 70, 110, 60].map((w, i) => (
+            // biome-ignore lint/suspicious/noArrayIndexKey: Skeleton rows are a static ordered list.
+            <div className="baml-editor-skeleton-sidebar-row" key={i}>
+              <div
+                className="baml-editor-skeleton-sidebar-file"
+                style={{ background: sk.text, width: w }}
+              />
+            </div>
+          ))}
+        </div>
+
+        <div className="baml-editor-skeleton-editor">
+          <div
+            className="baml-editor-skeleton-gutter"
+            style={{ background: sk.bg }}
+          >
+            {Array.from({ length: 12 }, (_, i) => (
+              // biome-ignore lint/suspicious/noArrayIndexKey: Skeleton lines are a static ordered list.
+              <div className="baml-editor-skeleton-gutter-line" key={i}>
+                <div
+                  className="baml-editor-skeleton-line-number"
+                  style={{ background: sk.lineNum }}
+                />
+              </div>
+            ))}
+          </div>
+
+          <div className="baml-editor-skeleton-code">
+            <SkeletonLine tokens={[{ color: sk.comment, w: 48 }]} />
+            <SkeletonLine
+              tokens={[
+                { color: sk.keyword, w: 55 },
+                { color: sk.text, w: 80 },
+              ]}
+            />
+            <SkeletonLine
+              indent={1}
+              tokens={[
+                { color: sk.keyword, w: 45 },
+                { color: sk.text, w: 60 },
+              ]}
+            />
+            <SkeletonLine
+              indent={1}
+              tokens={[
+                { color: sk.keyword, w: 50 },
+                { color: sk.string, w: 90 },
+              ]}
+            />
+            <SkeletonLine tokens={[{ color: sk.text, w: 10 }]} />
+            <SkeletonLine tokens={[]} />
+            <SkeletonLine
+              tokens={[
+                { color: sk.keyword, w: 42 },
+                { color: sk.text, w: 70 },
+              ]}
+            />
+            <SkeletonLine
+              indent={1}
+              tokens={[
+                { color: sk.keyword, w: 60 },
+                { color: sk.text, w: 50 },
+              ]}
+            />
+            <SkeletonLine
+              indent={1}
+              tokens={[
+                { color: sk.string, w: 55 },
+                { color: sk.string, w: 80 },
+              ]}
+            />
+            <SkeletonLine
+              indent={1}
+              tokens={[
+                { color: sk.keyword, w: 40 },
+                { color: sk.string, w: 100 },
+              ]}
+            />
+            <SkeletonLine tokens={[{ color: sk.text, w: 10 }]} />
+            <SkeletonLine tokens={[]} />
+          </div>
         </div>
       </div>
-    </div>
 
-    <div
-      className="baml-editor-skeleton-statusbar"
-      style={{ background: sk.status, borderColor: sk.border }}
-    >
       <div
-        className="baml-editor-skeleton-status-item"
-        style={{ background: sk.statusForeground, width: 44 }}
-      />
-      <div
-        className="baml-editor-skeleton-status-item"
-        style={{ background: sk.statusForeground, width: 92 }}
-      />
+        className="baml-editor-skeleton-statusbar"
+        style={{ background: sk.status, borderColor: sk.border }}
+      >
+        <div
+          className="baml-editor-skeleton-status-item"
+          style={{ background: sk.statusForeground, width: 44 }}
+        />
+        <div
+          className="baml-editor-skeleton-status-item"
+          style={{ background: sk.statusForeground, width: 92 }}
+        />
+      </div>
     </div>
-  </div>
+  </>
 );
 
 // ---------------------------------------------------------------------------
@@ -609,7 +616,7 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({
                     { close: '"', open: '"' },
                     ['#"', '"#'],
                     ["'", "'"],
-                    ['{#', '}'],
+                    ['{#', '#}'],
                     ['{//', '//}'],
                   ],
                   brackets: [
@@ -969,18 +976,16 @@ export const MonacoEditor: FC<MonacoEditorProps> = ({
 
       // Determine which file to show — prefer main.baml, fall back to first text file
       const fileNames = Object.keys(allFiles).filter((f) => !isMediaPath(f));
-      const firstFileIndex = fileNames.findIndex((path) =>
-        path.endsWith('main.baml'),
-      );
       const firstFile =
-        firstFileIndex !== -1 ? fileNames[firstFileIndex] : fileNames[0];
-      const firstFileUri = vscode.Uri.file(`${rootPrefix}${firstFile}`);
+        fileNames.find((path) => path.endsWith('main.baml')) ?? fileNames[0];
 
-      // Open the document and show it in the editor
-      await vscode.workspace.openTextDocument(firstFileUri);
-      if (disposed) return;
-      await vscode.window.showTextDocument(firstFileUri);
-      if (disposed) return;
+      if (firstFile) {
+        const firstFileUri = vscode.Uri.file(`${rootPrefix}${firstFile}`);
+        await vscode.workspace.openTextDocument(firstFileUri);
+        if (disposed) return;
+        await vscode.window.showTextDocument(firstFileUri);
+        if (disposed) return;
+      }
 
       await vscode.commands.executeCommand('baml.openPlayground');
       if (disposed) return;

--- a/typescript2/pkg-editor/src/themes/monospace/LICENSE
+++ b/typescript2/pkg-editor/src/themes/monospace/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Keksi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/typescript2/pkg-editor/src/themes/monospace/README.md
+++ b/typescript2/pkg-editor/src/themes/monospace/README.md
@@ -1,0 +1,8 @@
+# Monospace Dark theme
+
+Vendored from https://github.com/keksiqc/monospace-theme at commit
+`50761831abba262d3c259925fbddb1f6492ef891`.
+
+The theme JSON is copied unchanged from `themes/monospace-dark.json`. Update it
+by replacing the JSON from the pinned upstream revision and updating the commit
+above. The upstream MIT license is included in `LICENSE`.

--- a/typescript2/pkg-editor/src/themes/monospace/monospace-dark.json
+++ b/typescript2/pkg-editor/src/themes/monospace/monospace-dark.json
@@ -1,0 +1,626 @@
+{
+  "name": "Monospace Dark",
+  "colors": {
+    "focusBorder": "#8964e8ff",
+    "foreground": "#d9dfe7ff",
+    "icon.foreground": "#d9dfe7ff",
+    "widget.shadow": "#080a0e4d",
+    "descriptionForeground": "#8b98a9ff",
+    "errorForeground": "#f76769ff",
+    "textLink.foreground": "#b895fdff",
+    "textLink.activeForeground": "#c8aaffff",
+    "textBlockQuote.background": "#1f2939ff",
+    "textBlockQuote.border": "#475365ff",
+    "textCodeBlock.background": "#333e4fff",
+    "textPreformat.foreground": "#a4afbdff",
+    "textSeparator.foreground": "#5d6a7dff",
+    "list.warningForeground": "#ffb256ff",
+    "list.errorForeground": "#fa7b7cff",
+    "button.background": "#a87ffbff",
+    "button.hoverBackground": "#b895fdff",
+    "button.foreground": "#000000ff",
+    "button.secondaryBackground": "#475365ff",
+    "button.secondaryForeground": "#ffffffff",
+    "button.secondaryHoverBackground": "#5d6a7dff",
+    "checkbox.background": "#1f2939ff",
+    "checkbox.foreground": "#d9dfe7ff",
+    "checkbox.border": "#3d495aff",
+    "dropdown.background": "#1f2939ff",
+    "dropdown.border": "#3d495aff",
+    "dropdown.foreground": "#d9dfe7ff",
+    "dropdown.listBackground": "#10151dff",
+    "input.background": "#1f2939ff",
+    "input.border": "#3d495aff",
+    "input.foreground": "#d9dfe7ff",
+    "input.placeholderForeground": "#8b98a9ff",
+    "inputValidation.errorBorder": "#f76769ff",
+    "inputOption.activeBorder": "#8964e8ff",
+    "badge.foreground": "#e0ccffff",
+    "badge.background": "#603bceff",
+    "progressBar.background": "#8964e8ff",
+    "titleBar.activeForeground": "#d9dfe7ff",
+    "titleBar.activeBackground": "#171f2bff",
+    "titleBar.inactiveForeground": "#738295ff",
+    "titleBar.inactiveBackground": "#10151dff",
+    "titleBar.border": "#333e4fff",
+    "commandCenter.background": "#171f2bff",
+    "commandCenter.foreground": "#8b98a9ff",
+    "commandCenter.border": "#333e4fff",
+    "commandCenter.activeBackground": "#1f2939ff",
+    "commandCenter.activeForeground": "#d9dfe7ff",
+    "commandCenter.activeBorder": "#3d495aff",
+    "commandCenter.inactiveForeground": "#738295ff",
+    "commandCenter.inactiveBorder": "#333e4fff",
+    "activityBar.foreground": "#d9dfe7ff",
+    "activityBar.inactiveForeground": "#738295ff",
+    "activityBar.background": "#171f2bff",
+    "activityBarBadge.foreground": "#000000ff",
+    "activityBarBadge.background": "#a87ffbff",
+    "activityBar.activeBorder": "#a87ffbff",
+    "activityBar.border": "#333e4fff",
+    "sideBar.foreground": "#d9dfe7ff",
+    "sideBar.background": "#10151dff",
+    "sideBar.border": "#333e4fff",
+    "sideBarTitle.foreground": "#d9dfe7ff",
+    "sideBarSectionHeader.foreground": "#d9dfe7ff",
+    "sideBarSectionHeader.background": "#10151dff",
+    "sideBarSectionHeader.border": "#333e4fff",
+    "list.hoverForeground": "#d9dfe7ff",
+    "list.inactiveSelectionForeground": "#d9dfe7ff",
+    "list.activeSelectionForeground": "#d9dfe7ff",
+    "list.hoverBackground": "#141b25ff",
+    "list.inactiveSelectionBackground": "#1f2939ff",
+    "list.activeSelectionBackground": "#1f2939ff",
+    "list.inactiveFocusBackground": "#34009999",
+    "list.focusBackground": "#340099ff",
+    "tree.indentGuidesStroke": "#333e4fff",
+    "notificationCenterHeader.foreground": "#738295ff",
+    "notificationCenterHeader.background": "#1f2939ff",
+    "notifications.foreground": "#d9dfe7ff",
+    "notifications.background": "#242e3fff",
+    "notifications.border": "#333e4fff",
+    "notificationsErrorIcon.foreground": "#f76769ff",
+    "notificationsWarningIcon.foreground": "#ffa23eff",
+    "notificationsInfoIcon.foreground": "#8b98a9ff",
+    "pickerGroup.border": "#475365ff",
+    "pickerGroup.foreground": "#d9dfe7ff",
+    "quickInput.background": "#10151dff",
+    "quickInput.foreground": "#d9dfe7ff",
+    "quickInputTitle.background": "#10151dff",
+    "keybindingLabel.background": "#171f2bff",
+    "keybindingLabel.foreground": "#d9dfe7ff",
+    "keybindingLabel.border": "#333e4fff",
+    "keybindingLabel.bottomBorder": "#333e4fff",
+    "statusBar.foreground": "#a4afbdff",
+    "statusBar.background": "#1f2939ff",
+    "statusBar.border": "#333e4fff",
+    "statusBar.noFolderBackground": "#1f2939ff",
+    "statusBar.debuggingBackground": "#891524ff",
+    "statusBar.debuggingForeground": "#ffffffff",
+    "statusBarItem.prominentBackground": "#282e34",
+    "editorGroupHeader.tabsBackground": "#10151dff",
+    "editorGroupHeader.tabsBorder": "#333e4fff",
+    "editorGroup.border": "#333e4fff",
+    "tab.activeForeground": "#d9dfe7ff",
+    "tab.inactiveForeground": "#a4afbdff",
+    "tab.inactiveBackground": "#10151dff",
+    "tab.activeBackground": "#171f2bff",
+    "tab.activeBorder": "#171f2bff",
+    "tab.activeBorderTop": "#a87ffbff",
+    "tab.border": "#333e4fff",
+    "tab.hoverBackground": "#171f2bff",
+    "tab.unfocusedActiveForeground": "#738295ff",
+    "tab.unfocusedInactiveForeground": "#738295ff",
+    "tab.unfocusedHoverForeground": "#a4afbdff",
+    "tab.unfocusedHoverBackground": "#1f2939ff",
+    "tab.unfocusedActiveBorderTop": "#333e4fff",
+    "tab.unfocusedActiveBorder": "#171f2bff",
+    "breadcrumb.foreground": "#8b98a9ff",
+    "breadcrumb.focusForeground": "#d9dfe7ff",
+    "breadcrumb.activeSelectionForeground": "#a4afbdff",
+    "breadcrumbPicker.background": "#171f2bff",
+    "editor.foreground": "#d9dfe7ff",
+    "editor.background": "#171f2bff",
+    "editorLink.activeForeground": "#a87ffbff",
+    "editorCodeLens.foreground": "#8b98a9ff",
+    "editorWidget.background": "#10151dff",
+    "editorWidget.border": "#5d6a7dff",
+    "editor.foldBackground": "#1c2533ff",
+    "editor.lineHighlightBackground": "#1f2939ff",
+    "editorLineNumber.foreground": "#475365ff",
+    "editorLineNumber.activeForeground": "#d9dfe7ff",
+    "editorIndentGuide.background": "#333e4fff",
+    "editorIndentGuide.activeBackground": "#475365ff",
+    "editorWhitespace.foreground": "#475365ff",
+    "editorCursor.foreground": "#e0ccffff",
+    "editorError.foreground": "#fc8f8eff",
+    "editorWarning.foreground": "#ffc26eff",
+    "editorInfo.foreground": "#a2b6ffff",
+    "editorHint.foreground": "#66ce98ff",
+    "editorLightBulb.foreground": "#ffc26eff",
+    "problemsErrorIcon.foreground": "#f76769ff",
+    "problemsWarningIcon.foreground": "#ffa23eff",
+    "problemsInfoIcon.foreground": "#8b98a9ff",
+    "sash.hoverBorder": "#a87ffbff",
+    "editor.findMatchBackground": "#83431466",
+    "editor.findMatchBorder": "#ffa23eff",
+    "editor.findMatchHighlightBackground": "#83431499",
+    "editor.findMatchHighlightBorder": "#834314ff",
+    "peekView.border": "#a87ffbff",
+    "peekViewEditor.matchHighlightBackground": "#83431466",
+    "peekViewEditor.matchHighlightBorder": "#ffa23e4d",
+    "peekViewResult.matchHighlightBackground": "#83431466",
+    "peekViewEditor.background": "#10151dff",
+    "peekViewResult.background": "#080a0eff",
+    "peekViewResult.selectionBackground": "#333e4fff",
+    "editor.linkedEditingBackground": "#4d21bb99",
+    "editor.inactiveSelectionBackground": "#264dcb4d",
+    "editor.selectionBackground": "#264dcb80",
+    "editor.selectionHighlightBackground": "#333e4f99",
+    "editor.selectionHighlightBorder": "#333e4fff",
+    "editor.wordHighlightBackground": "#882d0066",
+    "editor.wordHighlightStrongBackground": "#882d0099",
+    "editor.wordHighlightBorder": "#882d00ff",
+    "editor.wordHighlightStrongBorder": "#882d00ff",
+    "editorBracketMatch.background": "#004b5e99",
+    "editorBracketMatch.border": "#004b5eff",
+    "editorGutter.modifiedBackground": "#3c60ddff",
+    "editorGutter.addedBackground": "#17975f80",
+    "editorGutter.deletedBackground": "#df4047ff",
+    "editorGutter.foldingControlForeground": "#8b98a9ff",
+    "diffEditor.insertedTextBackground": "#17975f40",
+    "diffEditor.removedTextBackground": "#df404740",
+    "scrollbar.shadow": "#0008",
+    "scrollbarSlider.background": "#6a737d33",
+    "scrollbarSlider.hoverBackground": "#6a737d44",
+    "scrollbarSlider.activeBackground": "#6a737d88",
+    "editorOverviewRuler.border": "#000000ff",
+    "panel.background": "#10151dff",
+    "panel.border": "#333e4fff",
+    "panelTitle.activeBorder": "#a87ffbff",
+    "panelTitle.activeForeground": "#d9dfe7ff",
+    "panelTitle.inactiveForeground": "#a4afbdff",
+    "panelInput.border": "#333e4fff",
+    "panelSectionHeader.background": "#0000",
+    "panelSectionHeader.foreground": "#d9dfe7ff",
+    "panelSection.border": "#333e4fff",
+    "menu.foreground": "#d9dfe7ff",
+    "menu.background": "#10151dff",
+    "menu.border": "#3d495aff",
+    "menu.selectionForeground": "#d9dfe7ff",
+    "menu.selectionBackground": "#1f2939ff",
+    "menu.separatorBackground": "#333e4fff",
+    "terminal.foreground": "#a4afbdff",
+    "terminal.tab.activeBorder": "#a87ffbff",
+    "terminalCursor.background": "#5d6a7dff",
+    "terminalCursor.foreground": "#c8aaffff",
+    "terminal.ansiBrightWhite": "#fafbfeff",
+    "terminal.ansiWhite": "#a4afbdff",
+    "terminal.ansiBrightBlack": "#8b98a9ff",
+    "terminal.ansiBlack": "#738295ff",
+    "terminal.ansiBlue": "#708fffff",
+    "terminal.ansiBrightBlue": "#a2b6ffff",
+    "terminal.ansiGreen": "#17b877ff",
+    "terminal.ansiBrightGreen": "#66ce98ff",
+    "terminal.ansiCyan": "#25a6e9ff",
+    "terminal.ansiBrightCyan": "#71c2eeff",
+    "terminal.ansiRed": "#f76769ff",
+    "terminal.ansiBrightRed": "#fc8f8eff",
+    "terminal.ansiMagenta": "#a87ffbff",
+    "terminal.ansiBrightMagenta": "#c8aaffff",
+    "terminal.ansiYellow": "#ffa23eff",
+    "terminal.ansiBrightYellow": "#ffc26eff",
+    "gitDecoration.addedResourceForeground": "#17b877ff",
+    "gitDecoration.untrackedResourceForeground": "#17b877ff",
+    "gitDecoration.modifiedResourceForeground": "#708fffff",
+    "gitDecoration.deletedResourceForeground": "#f76769ff",
+    "gitDecoration.conflictingResourceForeground": "#ffc26eff",
+    "gitDecoration.ignoredResourceForeground": "#738295ff",
+    "gitDecoration.submoduleResourceForeground": "#738295ff",
+    "debugToolBar.background": "#1f2939ff",
+    "editor.stackFrameHighlightBackground": "#C6902625",
+    "editor.focusedStackFrameHighlightBackground": "#2b6a3033",
+    "settings.headerForeground": "#d9dfe7ff",
+    "settings.modifiedItemIndicator": "#5173f1ff",
+    "welcomePage.buttonBackground": "#333e4fff",
+    "welcomePage.buttonHoverBackground": "#475365ff",
+    "editorBracketHighlight.foreground1": "#85cdf1ff",
+    "editorBracketHighlight.foreground2": "#ffd395ff",
+    "editorBracketHighlight.foreground3": "#bd9cfeff",
+    "editorBracketHighlight.foreground4": "#85cdf1ff",
+    "editorBracketHighlight.foreground5": "#ffd395ff",
+    "editorBracketHighlight.foreground6": "#bd9cfeff",
+    "editorGhostText.foreground": "#5d6a7dff",
+    "editorInlayHint.foreground": "#8b98a9ff",
+    "editorInlayHint.background": "#73829533",
+    "editorInlayHint.typeForeground": "#8b98a9ff",
+    "editorInlayHint.typeBackground": "#73829533"
+  },
+  "semanticHighlighting": true,
+  "semanticTokenColors": {
+    "property.annotation": "#85cdf1ff",
+    "annotation": "#85cdf1ff",
+    "class": "#92a9ffff"
+  },
+  "tokenColors": [
+    {
+      "scope": ["comment", "punctuation.definition.comment", "string.comment"],
+      "settings": {
+        "foreground": "#7f8d9fff"
+      }
+    },
+    {
+      "scope": [
+        "constant",
+        "entity.name.constant",
+        "variable.other.constant",
+        "variable.language"
+      ],
+      "settings": {
+        "foreground": "#92a9ffff"
+      }
+    },
+    {
+      "scope": ["entity", "entity.name"],
+      "settings": {
+        "foreground": "#bd9cfeff"
+      }
+    },
+    {
+      "scope": "variable.parameter.function",
+      "settings": {
+        "foreground": "#d9dfe7ff"
+      }
+    },
+    {
+      "scope": "entity.name.tag",
+      "settings": {
+        "foreground": "#77d5a3ff"
+      }
+    },
+    {
+      "scope": "keyword",
+      "settings": {
+        "foreground": "#fd8da3ff"
+      }
+    },
+    {
+      "scope": ["storage", "storage.type"],
+      "settings": {
+        "foreground": "#fd8da3ff"
+      }
+    },
+    {
+      "scope": ["annotation"],
+      "settings": {
+        "foreground": "#fd8da3ff"
+      }
+    },
+    {
+      "scope": [
+        "storage.modifier.package",
+        "storage.modifier.import",
+        "storage.type.java"
+      ],
+      "settings": {
+        "foreground": "#d9dfe7ff"
+      }
+    },
+    {
+      "scope": [
+        "string",
+        "punctuation.definition.string",
+        "string punctuation.section.embedded source"
+      ],
+      "settings": {
+        "foreground": "#77d5a3ff"
+      }
+    },
+    {
+      "scope": [
+        "string.quoted.double.html",
+        "string.quoted.single.html",
+        "string.unquoted.html",
+        "punctuation.definition.string.begin.html",
+        "punctuation.definition.string.end.html",
+        "string.quoted.double.xml",
+        "string.quoted.single.xml",
+        "string.unquoted.xml",
+        "punctuation.definition.string.begin.xml",
+        "punctuation.definition.string.end.xml",
+        "string punctuation.section.embedded source"
+      ],
+      "settings": {
+        "foreground": "#85cdf1ff"
+      }
+    },
+    {
+      "scope": "support",
+      "settings": {
+        "foreground": "#92a9ffff"
+      }
+    },
+    {
+      "scope": "support.type.property-name",
+      "settings": {
+        "foreground": "#85cdf1ff"
+      }
+    },
+    {
+      "scope": "meta.property-name",
+      "settings": {
+        "foreground": "#92a9ffff"
+      }
+    },
+    {
+      "scope": "variable",
+      "settings": {
+        "foreground": "#ffd395ff"
+      }
+    },
+    {
+      "scope": "variable.other",
+      "settings": {
+        "foreground": "#d9dfe7ff"
+      }
+    },
+    {
+      "scope": "invalid.broken",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#ffc6d0ff"
+      }
+    },
+    {
+      "scope": "invalid.deprecated",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#ffc6d0ff"
+      }
+    },
+    {
+      "scope": "invalid.illegal",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#ffc6d0ff"
+      }
+    },
+    {
+      "scope": "invalid.unimplemented",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#ffc6d0ff"
+      }
+    },
+    {
+      "scope": "carriage-return",
+      "settings": {
+        "fontStyle": "italic underline",
+        "background": "#fd8da3ff",
+        "foreground": "#1f2939ff",
+        "content": "^M"
+      }
+    },
+    {
+      "scope": "message.error",
+      "settings": {
+        "foreground": "#ffc6d0ff"
+      }
+    },
+    {
+      "scope": "string source",
+      "settings": {
+        "foreground": "#d9dfe7ff"
+      }
+    },
+    {
+      "scope": "string variable",
+      "settings": {
+        "foreground": "#92a9ffff"
+      }
+    },
+    {
+      "scope": ["source.regexp", "string.regexp"],
+      "settings": {
+        "foreground": "#77d5a3ff"
+      }
+    },
+    {
+      "scope": [
+        "string.regexp.character-class",
+        "string.regexp constant.character.escape",
+        "string.regexp source.ruby.embedded",
+        "string.regexp string.regexp.arbitrary-repitition"
+      ],
+      "settings": {
+        "foreground": "#77d5a3ff"
+      }
+    },
+    {
+      "scope": "string.regexp constant.character.escape",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#77d5a3ff"
+      }
+    },
+    {
+      "scope": "support.constant",
+      "settings": {
+        "foreground": "#92a9ffff"
+      }
+    },
+    {
+      "scope": "support.variable",
+      "settings": {
+        "foreground": "#92a9ffff"
+      }
+    },
+    {
+      "scope": "meta.module-reference",
+      "settings": {
+        "foreground": "#92a9ffff"
+      }
+    },
+    {
+      "scope": "punctuation.definition.list.begin.markdown",
+      "settings": {
+        "foreground": "#ffd395ff"
+      }
+    },
+    {
+      "scope": ["markup.heading", "markup.heading entity.name"],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#92a9ffff"
+      }
+    },
+    {
+      "scope": "markup.quote",
+      "settings": {
+        "foreground": "#77d5a3ff"
+      }
+    },
+    {
+      "scope": "markup.italic",
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#d9dfe7ff"
+      }
+    },
+    {
+      "scope": "markup.bold",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#d9dfe7ff"
+      }
+    },
+    {
+      "scope": "markup.raw",
+      "settings": {
+        "foreground": "#92a9ffff"
+      }
+    },
+    {
+      "scope": [
+        "markup.deleted",
+        "meta.diff.header.from-file",
+        "punctuation.definition.deleted"
+      ],
+      "settings": {
+        "background": "#670023ff",
+        "foreground": "#ffc6d0ff"
+      }
+    },
+    {
+      "scope": [
+        "markup.inserted",
+        "meta.diff.header.to-file",
+        "punctuation.definition.inserted"
+      ],
+      "settings": {
+        "background": "#00391fff",
+        "foreground": "#77d5a3ff"
+      }
+    },
+    {
+      "scope": ["markup.changed", "punctuation.definition.changed"],
+      "settings": {
+        "background": "#834314ff",
+        "foreground": "#ffd395ff"
+      }
+    },
+    {
+      "scope": ["markup.ignored", "markup.untracked"],
+      "settings": {
+        "foreground": "#333e4fff",
+        "background": "#92a9ffff"
+      }
+    },
+    {
+      "scope": "meta.diff.range",
+      "settings": {
+        "foreground": "#bd9cfeff",
+        "fontStyle": "bold"
+      }
+    },
+    {
+      "scope": "meta.diff.header",
+      "settings": {
+        "foreground": "#92a9ffff"
+      }
+    },
+    {
+      "scope": "meta.separator",
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#92a9ffff"
+      }
+    },
+    {
+      "scope": "meta.output",
+      "settings": {
+        "foreground": "#92a9ffff"
+      }
+    },
+    {
+      "scope": [
+        "brackethighlighter.tag",
+        "brackethighlighter.curly",
+        "brackethighlighter.round",
+        "brackethighlighter.square",
+        "brackethighlighter.angle",
+        "brackethighlighter.quote"
+      ],
+      "settings": {
+        "foreground": "#9ca7b6ff"
+      }
+    },
+    {
+      "scope": "brackethighlighter.unmatched",
+      "settings": {
+        "foreground": "#ffc6d0ff"
+      }
+    },
+    {
+      "scope": ["constant.other.reference.link", "string.other.link"],
+      "settings": {
+        "foreground": "#77d5a3ff",
+        "fontStyle": "underline"
+      }
+    },
+    {},
+    {
+      "scope": "fenced_code.block.language",
+      "settings": {
+        "foreground": "#92a9ffff"
+      }
+    },
+    {
+      "scope": "markup.inline.raw.string.markdown",
+      "settings": {
+        "foreground": "#77d5a3ff"
+      }
+    },
+    {
+      "scope": ["markup.bold", "punctuation.definition.bold"],
+      "settings": {
+        "fontStyle": "bold",
+        "foreground": "#ffd395ff"
+      }
+    },
+    {
+      "scope": ["markup.italic", "punctuation.definition.italic"],
+      "settings": {
+        "fontStyle": "italic",
+        "foreground": "#85cdf1ff"
+      }
+    },
+    {
+      "scope": ["markup.strikethrough", "punctuation.definition.strikethrough"],
+      "settings": {
+        "fontStyle": "strikethrough",
+        "foreground": "#ffc6d0ff"
+      }
+    }
+  ]
+}

--- a/typescript2/pkg-editor/src/views-workbench.css
+++ b/typescript2/pkg-editor/src/views-workbench.css
@@ -37,7 +37,6 @@ div[is="app"] {
   height: 1px;
   overflow: hidden;
   white-space: nowrap;
-  clip: rect(0 0 0 0);
   clip-path: inset(50%);
 }
 

--- a/typescript2/pkg-editor/src/views-workbench.css
+++ b/typescript2/pkg-editor/src/views-workbench.css
@@ -15,6 +15,171 @@ div[is="app"] {
   overflow: hidden;
 }
 
+:root {
+  --baml-workbench-titlebar-height: 35px;
+  --baml-workbench-activitybar-width: 48px;
+  --baml-workbench-sidebar-width: 200px;
+  --baml-workbench-editor-gutter-width: 48px;
+  --baml-workbench-statusbar-height: 22px;
+}
+
+.baml-editor-skeleton {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  overflow: hidden;
+  font-family: var(--vscode-editor-font-family, monospace);
+}
+
+.baml-editor-skeleton-titlebar {
+  box-sizing: border-box;
+  display: flex;
+  flex: 0 0 var(--baml-workbench-titlebar-height);
+  align-items: center;
+  justify-content: center;
+  border-bottom: 1px solid;
+}
+
+.baml-editor-skeleton-window-title {
+  width: 132px;
+  height: 9px;
+  border-radius: 2px;
+  opacity: 0.2;
+}
+
+.baml-editor-skeleton-main {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+.baml-editor-skeleton-activitybar {
+  box-sizing: border-box;
+  display: flex;
+  flex: 0 0 var(--baml-workbench-activitybar-width);
+  flex-direction: column;
+  width: var(--baml-workbench-activitybar-width);
+  border-right: 1px solid;
+}
+
+.baml-editor-skeleton-activity-item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--baml-workbench-activitybar-width);
+  height: 48px;
+}
+
+.baml-editor-skeleton-activity-indicator {
+  position: absolute;
+  top: 9px;
+  bottom: 9px;
+  left: 0;
+  width: 2px;
+}
+
+.baml-editor-skeleton-activity-icon {
+  width: 20px;
+  height: 20px;
+  border-radius: 3px;
+  opacity: 0.45;
+}
+
+.baml-editor-skeleton-sidebar {
+  box-sizing: border-box;
+  flex: 0 0 var(--baml-workbench-sidebar-width);
+  width: var(--baml-workbench-sidebar-width);
+  padding: 10px 0;
+  border-right: 1px solid;
+}
+
+.baml-editor-skeleton-sidebar-title-row {
+  padding: 0 12px;
+  margin-bottom: 10px;
+}
+
+.baml-editor-skeleton-sidebar-title,
+.baml-editor-skeleton-sidebar-file {
+  height: 9px;
+  border-radius: 2px;
+}
+
+.baml-editor-skeleton-sidebar-title {
+  width: 80px;
+  opacity: 0.2;
+}
+
+.baml-editor-skeleton-sidebar-row {
+  padding: 2px 12px 2px 20px;
+}
+
+.baml-editor-skeleton-sidebar-file {
+  opacity: 0.15;
+}
+
+.baml-editor-skeleton-editor {
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.baml-editor-skeleton-gutter {
+  flex: 0 0 var(--baml-workbench-editor-gutter-width);
+  width: var(--baml-workbench-editor-gutter-width);
+  padding-top: 12px;
+}
+
+.baml-editor-skeleton-gutter-line {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  height: 21px;
+  padding-right: 12px;
+}
+
+.baml-editor-skeleton-line-number {
+  width: 10px;
+  height: 8px;
+  border-radius: 2px;
+  opacity: 0.25;
+}
+
+.baml-editor-skeleton-code {
+  flex: 1 1 auto;
+  padding: 12px 0 0 8px;
+}
+
+.baml-editor-skeleton-line {
+  display: flex;
+  align-items: center;
+  height: 21px;
+}
+
+.baml-editor-skeleton-token {
+  height: 10px;
+  margin-right: 8px;
+  border-radius: 2px;
+  opacity: 0.35;
+}
+
+.baml-editor-skeleton-statusbar {
+  box-sizing: border-box;
+  display: flex;
+  flex: 0 0 var(--baml-workbench-statusbar-height);
+  gap: 14px;
+  align-items: center;
+  padding: 0 8px;
+  border-top: 1px solid;
+}
+
+.baml-editor-skeleton-status-item {
+  height: 7px;
+  border-radius: 2px;
+  opacity: 0.35;
+}
+
 #sidebarDiv,
 #sidebarRightDiv {
   display: flex;
@@ -22,7 +187,7 @@ div[is="app"] {
 }
 
 #sidebar {
-  width: 200px;
+  width: var(--baml-workbench-sidebar-width);
 }
 
 #editorsDiv {
@@ -60,7 +225,18 @@ div[is="app"] {
 }
 
 #statusBar {
-  display: none;
+  flex: none;
+}
+
+.monaco-workbench
+  .activitybar
+  .action-item.checked
+  .active-item-indicator::before,
+.monaco-workbench
+  .activitybar
+  .action-item:focus
+  .active-item-indicator::before {
+  border-left-color: var(--vscode-activityBar-activeBorder) !important;
 }
 
 #workbench-container {

--- a/typescript2/pkg-editor/src/views-workbench.css
+++ b/typescript2/pkg-editor/src/views-workbench.css
@@ -31,6 +31,16 @@ div[is="app"] {
   font-family: var(--vscode-editor-font-family, monospace);
 }
 
+.baml-editor-loading-status {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+}
+
 .baml-editor-skeleton-titlebar {
   box-sizing: border-box;
   display: flex;

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -808,7 +808,7 @@ export type WebSocketInMessage =
 // ---------------------------------------------------------------------------
 
 export type WorkerOutMessage =
-  | { type: 'ready' }
+  | { type: 'ready'; version?: string; commit?: string }
   | { type: 'playgroundNotification'; notification: PlaygroundNotification }
   | ProfileArtifactChunkMessage
   | { type: 'diagnostics'; entries: DiagnosticEntry[] }

--- a/typescript2/pnpm-lock.yaml
+++ b/typescript2/pnpm-lock.yaml
@@ -1001,6 +1001,9 @@ importers:
       '@codingame/monaco-vscode-api':
         specifier: ^25.1.2
         version: 25.1.2
+      '@codingame/monaco-vscode-editor-api':
+        specifier: ^25.1.2
+        version: 25.1.2
       '@codingame/monaco-vscode-environment-service-override':
         specifier: ^25.1.2
         version: 25.1.2
@@ -1032,6 +1035,9 @@ importers:
         specifier: ^25.1.2
         version: 25.1.2
       '@codingame/monaco-vscode-storage-service-override':
+        specifier: ^25.1.2
+        version: 25.1.2
+      '@codingame/monaco-vscode-textmate-service-override':
         specifier: ^25.1.2
         version: 25.1.2
       '@codingame/monaco-vscode-view-banner-service-override':


### PR DESCRIPTION
## Summary
- make Prompt Fiddle use the vendored Monospace theme throughout the VS Code workbench
- move reset and deployed BAML commit/version metadata into the status bar
- stabilize the editor/playground loading sequence and replace the default demo
- compile-check the Prompt Fiddle demo in the existing Rust CI test binary

## Testing
- cargo test --manifest-path baml_language/Cargo.toml -p baml_tests --test baml_src promptfiddle_demo_compiles
- cargo fmt --manifest-path baml_language/Cargo.toml --all --check
- Biome changed-file CI check
- Prompt Fiddle TypeScript check
- Prompt Fiddle production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an invoice-review playground with extraction, validation, risk assessment, and built-in examples.
  * Added BAML file support, syntax highlighting, and a Monospace Dark editor theme.
  * Added runtime version and build information to the playground status display.
* **Improvements**
  * Updated the editor layout with a loading skeleton, status bar, sidebar, and activity indicators.
  * Simplified playground reset behavior with immediate reload support.
* **Bug Fixes**
  * Improved playground compilation checks and editor initialization reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->