### PR TITLE
chore: fix oncall fill-schedule authentication

### DIFF
--- a/.github/workflows/oncall.yml
+++ b/.github/workflows/oncall.yml
@@ -88,10 +88,12 @@ jobs:
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           fi
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@v8
         if: steps.check_changes.outputs.has_changes == 'true'
         with:
+          # Use a PAT so the generated pull_request event triggers CI.
           token: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE }}
+          base: canary
           branch: oncall/fill-schedule
           title: "oncall: fill schedule horizon"
           commit-message: "fill schedule to 4mo horizon"


### PR DESCRIPTION
## Summary

- upgrade `peter-evans/create-pull-request` from v6 to v8, which includes native compatibility with checkout v6 credential files
- explicitly target `canary` while retaining the PAT that allows the generated pull request to trigger CI

## Root cause

In the [failed scheduled run](https://github.com/BoundaryML/baml/actions/runs/31823593113/job/94842394211), `actions/checkout@v6` persisted `GITHUB_TOKEN` in a credential file included from local Git config. `create-pull-request@v6` only checked the direct local `http.https://github.com/.extraheader`, did not see checkout's included Authorization header, and added the PAT as another Authorization header. Git sent both during `git remote prune origin`, and GitHub returned HTTP 400 with `Duplicate header: "Authorization"`.

Upstream fixed this checkout v6 incompatibility in [create-pull-request#4230](https://github.com/peter-evans/create-pull-request/pull/4230), released in v7.0.9; v8 includes that fix and uses the supported Node 24 runtime.

## Validation

- `actionlint .github/workflows/oncall.yml`
- `./tools/bctl oncall check`
- isolated `./tools/bctl oncall fill-schedule` in a temporary archive: appended 14 weeks, changed only `schedule.oncall`, and the resulting schedule passed `oncall check`
- safe test strategy: do not dispatch the production `fill-schedule` path from this feature branch because it can mutate the shared `oncall/fill-schedule` branch and create/update a real PR with a production PAT; exercise the real path after merge via the normal scheduled/manual run
