### PR TITLE
chore(ci): upgrade create-pull-request actions to v8

### DIFF
--- a/.github/workflows/size-gate-baseline-refresh.yml
+++ b/.github/workflows/size-gate-baseline-refresh.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: "Open/update baseline-refresh PR"
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           # PAT (not GITHUB_TOKEN) so the PR triggers its own CI, including
           # the size-gate check that confirms the new baseline is green.


### PR DESCRIPTION
## Summary

- upgrade the remaining `peter-evans/create-pull-request` workflow reference from v6 to v8
- leave every repository reference on v8, including the oncall workflow updated by #4423
- retain the existing PAT, explicit `canary` base, and path restrictions for the size-gate baseline refresh PR

## Why

create-pull-request v8 supports checkout v6's credential-file behavior and uses the supported Node 24 runtime. Keeping all uses on the same current major avoids the duplicate Authorization header incompatibility fixed in v7.0.9 and removes the Node 20 deprecation from these jobs.

## Validation

- `actionlint .github/workflows/oncall.yml .github/workflows/size-gate-baseline-refresh.yml`
- repository-wide hidden-file search confirms exactly two create-pull-request references and both use v8
- repository-wide guard confirms no create-pull-request v0-v7, `main`, or `master` references remain
- full `actionlint` was also run and reports pre-existing errors in unrelated workflows; neither affected workflow has an error


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated baseline-refresh process to use a newer pull request action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->