### PR TITLE
`pid`, `chmod`, and `symlink`

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_fs/fs.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_fs/fs.baml
@@ -148,3 +148,46 @@ function remove_dir(path: string) -> null throws root.errors.Io {
 function remove_dir_all(path: string) -> null throws root.errors.Io {
     $rust_io_function
 }
+
+/// Changes the permissions of the file at `path` to `mode`.
+///
+/// `mode` is the POSIX (unix) mode octal permissions value:
+/// a numeric bitmask typically using three octal digits `0oUGO` (permissions for user/group/other)
+/// Where each octal digit represents bit flags:
+/// - `0o4` = read
+/// - `0o2` = write
+/// - `0o1` = execute
+///
+/// An optional fourth leading digit carries the setuid (`0o4000`), setgid
+/// (`0o2000`), and sticky (`0o1000`) bits on platforms where these are supported.
+/// `mode` must therefore be in `0 ..= 0o7777`; anything outside that range throws
+/// `InvalidArgument` rather than being silently masked down to it.
+///
+/// On Windows there is no mode as a file is either writable or read-only.
+/// Only the owner-write bit (`0o200`) has any effect: setting it clears the
+/// read-only attribute and clearing it sets it. Every other bit, including the
+/// group and other digits, is accepted and ignored. `path` must exist on
+/// Windows even when the resulting attribute is unchanged.
+function chmod(
+    path: string,
+    mode: int,
+) -> void throws root.errors.Io | root.errors.InvalidArgument {
+    $rust_io_function
+}
+
+/// Creates a symbolic link at `path` that points to `target`.
+///
+/// `target` is stored verbatim and need not exist: a dangling link is created
+/// if it does not. A relative `target` is resolved by the operating system
+/// against the directory containing `path`, not against the working directory.
+///
+/// Throws `Io` if `path` already exists.
+///
+/// On Windows the link is created as a directory link when `target` resolves to
+/// an existing directory and as a file link otherwise (a dangling link is
+/// always a file link), and creating one requires Developer Mode or
+/// `SeCreateSymbolicLinkPrivilege`; without it the OS refuses and this throws
+/// `Io`.
+function symlink(target: string, path: string) -> void throws root.errors.Io {
+    $rust_io_function
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/sys.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/sys.baml
@@ -174,3 +174,12 @@ function exit(code: int) -> never throws never {
 function argv() -> string[] throws never {
     $rust_function
 }
+
+/// Returns the process ID of the current process.
+///
+/// ## Panics
+/// If the environment does not support process IDs (e.g. in a browser), with
+/// `baml.panics.HostUnavailable`.
+function pid() -> int throws never {
+    $rust_io_function
+}

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_cli/src/describe_command_tests.rs
-assertion_line: 417
 expression: output
 ---
 class            baml.Bigint                      <builtin>/baml/bigint.baml:30
@@ -116,7 +115,7 @@ function         baml.fs.mkdir                    <builtin>/baml/ns_fs/fs.baml:1
 function         baml.fs.remove_dir               <builtin>/baml/ns_fs/fs.baml:139
 function         baml.fs.remove_dir_all           <builtin>/baml/ns_fs/fs.baml:148
 function         baml.fs.chmod                    <builtin>/baml/ns_fs/fs.baml:171
-function         baml.fs.symlink                  <builtin>/baml/ns_fs/fs.baml:192
+function         baml.fs.symlink                  <builtin>/baml/ns_fs/fs.baml:191
 enum             baml.future.FutureState          <builtin>/baml/ns_future/future.baml:21
 class            baml.future.Future               <builtin>/baml/ns_future/future.baml:28
 function         baml.future.all_complete         <builtin>/baml/ns_future/future.baml:80

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -274,6 +274,7 @@ function         baml.sys.collect_garbage         <builtin>/baml/ns_sys/sys.baml
 function         baml.sys.panic                   <builtin>/baml/ns_sys/sys.baml:162
 function         baml.sys.exit                    <builtin>/baml/ns_sys/sys.baml:168
 function         baml.sys.argv                    <builtin>/baml/ns_sys/sys.baml:174
+function         baml.sys.pid                     <builtin>/baml/ns_sys/sys.baml:183
 class            baml.time.Duration               <builtin>/baml/ns_time/duration.baml:4
 class            baml.time.Instant                <builtin>/baml/ns_time/instant.baml:2
 class            baml.time.PlainDate              <builtin>/baml/ns_time/plaindate.baml:5

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -115,6 +115,8 @@ function         baml.fs.read_dir                 <builtin>/baml/ns_fs/fs.baml:1
 function         baml.fs.mkdir                    <builtin>/baml/ns_fs/fs.baml:133
 function         baml.fs.remove_dir               <builtin>/baml/ns_fs/fs.baml:139
 function         baml.fs.remove_dir_all           <builtin>/baml/ns_fs/fs.baml:148
+function         baml.fs.chmod                    <builtin>/baml/ns_fs/fs.baml:171
+function         baml.fs.symlink                  <builtin>/baml/ns_fs/fs.baml:192
 enum             baml.future.FutureState          <builtin>/baml/ns_future/future.baml:21
 class            baml.future.Future               <builtin>/baml/ns_future/future.baml:28
 function         baml.future.all_complete         <builtin>/baml/ns_future/future.baml:80

--- a/baml_language/crates/baml_tests/baml_src/ns_fs/fs.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_fs/fs.baml
@@ -714,15 +714,23 @@ test "fs_chmod_on_existing_file" {
 
 // A mode outside `0..=0o7777` is a caller mistake, rejected before the syscall
 // the kernel would have silently masked it in.
-function fs_chmod_rejects_high_mode_fn() -> bool {
-    let path = fs_tmp("chmod_high_mode.txt");
-    baml.fs.write(path, "content");
-    let threw = {
-        baml.fs.chmod(path, 0o10000);
+//
+// Each `catch` is the tail expression of its own helper so its result is
+// returned rather than bound to a local — the caller keeps the setup and
+// cleanup around the call.
+function fs_chmod_rejects_mode(path: string, mode: int) -> bool {
+    {
+        baml.fs.chmod(path, mode);
         false
     } catch (e) {
         baml.errors.InvalidArgument => true
-    };
+    }
+}
+
+function fs_chmod_rejects_high_mode_fn() -> bool {
+    let path = fs_tmp("chmod_high_mode.txt");
+    baml.fs.write(path, "content");
+    let threw = fs_chmod_rejects_mode(path, 0o10000);
     baml.fs.remove(path);
     threw
 }
@@ -734,12 +742,7 @@ test "fs_chmod_rejects_high_mode" {
 function fs_chmod_rejects_negative_mode_fn() -> bool {
     let path = fs_tmp("chmod_negative_mode.txt");
     baml.fs.write(path, "content");
-    let threw = {
-        baml.fs.chmod(path, 0 - 1);
-        false
-    } catch (e) {
-        baml.errors.InvalidArgument => true
-    };
+    let threw = fs_chmod_rejects_mode(path, 0 - 1);
     baml.fs.remove(path);
     threw
 }
@@ -773,15 +776,19 @@ test "fs_chmod_missing_path_errors" {
 // asserted here holds even where symlink creation is refused outright: the call
 // fails with `Io` and leaves the occupied path alone.
 
-function fs_symlink_onto_existing_path_errors_fn() -> bool {
-    let path = fs_tmp("symlink_taken.txt");
-    baml.fs.write(path, "keep me");
-    let threw = {
+function fs_symlink_is_refused_at(path: string) -> bool {
+    {
         baml.fs.symlink(path, path);
         false
     } catch (e) {
         baml.errors.Io => true
-    };
+    }
+}
+
+function fs_symlink_onto_existing_path_errors_fn() -> bool {
+    let path = fs_tmp("symlink_taken.txt");
+    baml.fs.write(path, "keep me");
+    let threw = fs_symlink_is_refused_at(path);
     let intact = baml.fs.read(path) == "keep me";
     baml.fs.remove(path);
     threw && intact

--- a/baml_language/crates/baml_tests/baml_src/ns_fs/fs.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_fs/fs.baml
@@ -34,9 +34,10 @@
 //                                   in the mode union); the Rust test uses
 //                                   #[should_panic] to catch a compile-time panic.
 //                                   No BAML equivalent.
-//     fs_read_dir_reports_symlink_flag — creates a Unix symlink via
-//                                   std::os::unix::fs::symlink; baml.fs has no
-//                                   symlink primitive.
+//     fs_read_dir_reports_symlink_flag — `baml.fs.symlink` could create the
+//                                   link now, but creating one on Windows needs
+//                                   privileges CI does not grant, so the test
+//                                   stays Unix-only in Rust.
 
 // ============================================================================
 // open + read (text)
@@ -687,4 +688,105 @@ function fs_remove_dir_all_idempotent_fn() -> bool {
 
 test "fs_remove_dir_all_idempotent" {
     assert.is_true(fs_remove_dir_all_idempotent_fn())
+}
+
+// ============================================================================
+// chmod
+// ============================================================================
+//
+// Only the platform-independent behavior lives here. What `mode` does to a file
+// is meaningful on unix and reduces to one read-only bit on Windows, and BAML
+// has no way to read a mode back, so the effect is asserted from Rust
+// (tests/fs.rs::fs_chmod_sets_the_exact_mode).
+
+function fs_chmod_on_existing_file_fn() -> bool {
+    let path = fs_tmp("chmod_ok.txt");
+    baml.fs.write(path, "content");
+    baml.fs.chmod(path, 0o644);
+    let existed = baml.fs.exists(path);
+    baml.fs.remove(path);
+    existed
+}
+
+test "fs_chmod_on_existing_file" {
+    assert.is_true(fs_chmod_on_existing_file_fn())
+}
+
+// A mode outside `0..=0o7777` is a caller mistake, rejected before the syscall
+// the kernel would have silently masked it in.
+function fs_chmod_rejects_high_mode_fn() -> bool {
+    let path = fs_tmp("chmod_high_mode.txt");
+    baml.fs.write(path, "content");
+    let threw = {
+        baml.fs.chmod(path, 0o10000);
+        false
+    } catch (e) {
+        baml.errors.InvalidArgument => true
+    };
+    baml.fs.remove(path);
+    threw
+}
+
+test "fs_chmod_rejects_high_mode" {
+    assert.is_true(fs_chmod_rejects_high_mode_fn())
+}
+
+function fs_chmod_rejects_negative_mode_fn() -> bool {
+    let path = fs_tmp("chmod_negative_mode.txt");
+    baml.fs.write(path, "content");
+    let threw = {
+        baml.fs.chmod(path, 0 - 1);
+        false
+    } catch (e) {
+        baml.errors.InvalidArgument => true
+    };
+    baml.fs.remove(path);
+    threw
+}
+
+test "fs_chmod_rejects_negative_mode" {
+    assert.is_true(fs_chmod_rejects_negative_mode_fn())
+}
+
+// A missing path is an I/O failure on every platform — including Windows, where
+// the current attributes are read before they are rewritten.
+function fs_chmod_missing_path_errors_fn() -> bool {
+    let path = fs_tmp("chmod_missing.txt");
+    {
+        baml.fs.chmod(path, 0o644);
+        false
+    } catch (e) {
+        baml.errors.Io => true
+    }
+}
+
+test "fs_chmod_missing_path_errors" {
+    assert.is_true(fs_chmod_missing_path_errors_fn())
+}
+
+// ============================================================================
+// symlink
+// ============================================================================
+//
+// Creating a link needs privileges Windows CI does not grant, so the success
+// path is Unix-only and lives in Rust (tests/fs.rs::fs_symlink_*). What is
+// asserted here holds even where symlink creation is refused outright: the call
+// fails with `Io` and leaves the occupied path alone.
+
+function fs_symlink_onto_existing_path_errors_fn() -> bool {
+    let path = fs_tmp("symlink_taken.txt");
+    baml.fs.write(path, "keep me");
+    let threw = {
+        baml.fs.symlink(path, path);
+        false
+    } catch (e) {
+        baml.errors.Io => true
+    };
+    let intact = baml.fs.read(path) == "keep me";
+    baml.fs.remove(path);
+    threw && intact
+}
+
+test "fs_symlink_onto_existing_path_errors" {
+    assert.is_true(fs_symlink_onto_existing_path_errors_fn())
 }

--- a/baml_language/crates/baml_tests/baml_src/ns_fs/fs_from_rust.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_fs/fs_from_rust.baml
@@ -16,9 +16,12 @@
 //   fs_file_invalid_mode              — mode "x" is not in the string-literal
 //                                       union (compile-time type error);
 //                                       requires #[should_panic].
-//   fs_remove_on_symlink_to_dir_removes_link — needs host-created symlink;
-//                                       baml.fs has no symlink primitive.
-//   fs_read_dir_reports_symlink_flag  — same: needs a host-created symlink.
+//   fs_remove_on_symlink_to_dir_removes_link — `baml.fs.symlink` can create the
+//                                       link, but the assertion needs
+//                                       symlink_metadata (BAML resolves through
+//                                       links), and Windows CI cannot create
+//                                       one; stays Unix-only in Rust.
+//   fs_read_dir_reports_symlink_flag  — same.
 
 // ============================================================================
 // open: nonexistent path errors

--- a/baml_language/crates/baml_tests/baml_src/ns_shell/shell.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_shell/shell.baml
@@ -176,3 +176,19 @@ function exec_echo_fn() -> bool {
 test "exec_echo" {
     assert.is_true(exec_echo_fn())
 }
+
+// ============================================================================
+// pid() tests
+// ============================================================================
+
+// A live process always has a positive ID, on every platform. The exact value
+// is asserted from Rust (`tests/shell.rs::pid_is_the_host_process`), where the
+// host PID is knowable.
+test "pid_is_positive" {
+    assert.is_true(baml.sys.pid() > 0);
+}
+
+// The PID identifies the running process, so it never changes between calls.
+test "pid_is_stable" {
+    assert.equal(baml.sys.pid(), baml.sys.pid());
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/fs.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/fs.snap
@@ -254,6 +254,41 @@ function fs.$init_test_ns_fs_fs(registry: testing.TestCollector) -> null {
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
+    load_var registry
+    load_const "root.fs"
+    load_const "fs_chmod_on_existing_file"
+    make_closure .<lambda($init_test_ns_fs_fs, 36)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.fs"
+    load_const "fs_chmod_rejects_high_mode"
+    make_closure .<lambda($init_test_ns_fs_fs, 37)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.fs"
+    load_const "fs_chmod_rejects_negative_mode"
+    make_closure .<lambda($init_test_ns_fs_fs, 38)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.fs"
+    load_const "fs_chmod_missing_path_errors"
+    make_closure .<lambda($init_test_ns_fs_fs, 39)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.fs"
+    load_const "fs_symlink_onto_existing_path_errors"
+    make_closure .<lambda($init_test_ns_fs_fs, 40)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
     load_const null
     return
 }
@@ -386,6 +421,135 @@ function fs.$init_test_ns_fs_fs_from_rust(registry: testing.TestCollector) -> nu
     call testing.TestCollector.register_test_at
     pop 1
     load_const null
+    return
+}
+
+function fs.fs_chmod_missing_path_errors_fn() -> bool {
+    load_const "chmod_missing.txt"
+    call user.fs.fs_tmp
+    load_const 420
+    sys_op baml.fs.chmod
+    pop 1
+    jump L2
+    load_var e
+    is_type baml.errors.Io
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var e
+    rethrow
+
+  L1:
+    load_const true
+    jump L3
+
+  L2:
+    load_const false
+
+  L3:
+    return
+}
+
+function fs.fs_chmod_on_existing_file_fn() -> bool {
+    load_const "chmod_ok.txt"
+    call user.fs.fs_tmp
+    store_var path
+    load_var path
+    load_const "content"
+    sys_op baml.fs.write
+    pop 1
+    load_var path
+    load_const 420
+    sys_op baml.fs.chmod
+    pop 1
+    load_var path
+    sys_op baml.fs.exists
+    store_var existed
+    load_var path
+    sys_op baml.fs.remove
+    pop 1
+    load_var existed
+    return
+}
+
+function fs.fs_chmod_rejects_high_mode_fn() -> bool {
+    load_const "chmod_high_mode.txt"
+    call user.fs.fs_tmp
+    store_var path
+    load_var path
+    load_const "content"
+    sys_op baml.fs.write
+    pop 1
+    load_var path
+    load_const 4096
+    sys_op baml.fs.chmod
+    pop 1
+    jump L2
+    load_var e
+    is_type baml.errors.InvalidArgument
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var e
+    rethrow
+
+  L1:
+    load_const true
+    store_var threw
+    jump L3
+
+  L2:
+    load_const false
+    store_var threw
+
+  L3:
+    load_var path
+    sys_op baml.fs.remove
+    pop 1
+    load_var threw
+    return
+}
+
+function fs.fs_chmod_rejects_negative_mode_fn() -> bool {
+    load_const "chmod_negative_mode.txt"
+    call user.fs.fs_tmp
+    store_var path
+    load_var path
+    load_const "content"
+    sys_op baml.fs.write
+    pop 1
+    load_var path
+    load_const 0
+    load_const 1
+    sub_int
+    sys_op baml.fs.chmod
+    pop 1
+    jump L2
+    load_var e
+    is_type baml.errors.InvalidArgument
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var e
+    rethrow
+
+  L1:
+    load_const true
+    store_var threw
+    jump L3
+
+  L2:
+    load_const false
+    store_var threw
+
+  L3:
+    load_var path
+    sys_op baml.fs.remove
+    pop 1
+    load_var threw
     return
 }
 
@@ -1911,6 +2075,54 @@ function fs.fs_size_returns_length_fn() -> int {
     sys_op baml.fs.remove
     pop 1
     load_var n
+    return
+}
+
+function fs.fs_symlink_onto_existing_path_errors_fn() -> bool {
+    load_const "symlink_taken.txt"
+    call user.fs.fs_tmp
+    store_var path
+    load_var path
+    load_const "keep me"
+    sys_op baml.fs.write
+    pop 1
+    load_var2 1 1
+    sys_op baml.fs.symlink
+    pop 1
+    jump L2
+    load_var e
+    is_type baml.errors.Io
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var e
+    rethrow
+
+  L1:
+    load_const true
+    store_var threw
+    jump L3
+
+  L2:
+    load_const false
+    store_var threw
+
+  L3:
+    load_var path
+    sys_op baml.fs.read
+    store_var _11
+    load_var path
+    sys_op baml.fs.remove
+    pop 1
+    load_var threw
+    jump_if_false L4
+    pop 1
+    load_var _11
+    load_const "keep me"
+    cmp_op ==
+
+  L4:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/fs.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/fs.snap
@@ -483,6 +483,17 @@ function fs.fs_chmod_rejects_high_mode_fn() -> bool {
     pop 1
     load_var path
     load_const 4096
+    call user.fs.fs_chmod_rejects_mode
+    store_var threw
+    load_var path
+    sys_op baml.fs.remove
+    pop 1
+    load_var threw
+    return
+}
+
+function fs.fs_chmod_rejects_mode(path: string, mode: int) -> bool {
+    load_var2 1 2
     sys_op baml.fs.chmod
     pop 1
     jump L2
@@ -497,18 +508,12 @@ function fs.fs_chmod_rejects_high_mode_fn() -> bool {
 
   L1:
     load_const true
-    store_var threw
     jump L3
 
   L2:
     load_const false
-    store_var threw
 
   L3:
-    load_var path
-    sys_op baml.fs.remove
-    pop 1
-    load_var threw
     return
 }
 
@@ -524,28 +529,8 @@ function fs.fs_chmod_rejects_negative_mode_fn() -> bool {
     load_const 0
     load_const 1
     sub_int
-    sys_op baml.fs.chmod
-    pop 1
-    jump L2
-    load_var e
-    is_type baml.errors.InvalidArgument
-    pop_jump_if_false L0
-    jump L1
-
-  L0:
-    load_var e
-    rethrow
-
-  L1:
-    load_const true
+    call user.fs.fs_chmod_rejects_mode
     store_var threw
-    jump L3
-
-  L2:
-    load_const false
-    store_var threw
-
-  L3:
     load_var path
     sys_op baml.fs.remove
     pop 1
@@ -2078,14 +2063,7 @@ function fs.fs_size_returns_length_fn() -> int {
     return
 }
 
-function fs.fs_symlink_onto_existing_path_errors_fn() -> bool {
-    load_const "symlink_taken.txt"
-    call user.fs.fs_tmp
-    store_var path
-    load_var path
-    load_const "keep me"
-    sys_op baml.fs.write
-    pop 1
+function fs.fs_symlink_is_refused_at(path: string) -> bool {
     load_var2 1 1
     sys_op baml.fs.symlink
     pop 1
@@ -2101,28 +2079,40 @@ function fs.fs_symlink_onto_existing_path_errors_fn() -> bool {
 
   L1:
     load_const true
-    store_var threw
     jump L3
 
   L2:
     load_const false
-    store_var threw
 
   L3:
+    return
+}
+
+function fs.fs_symlink_onto_existing_path_errors_fn() -> bool {
+    load_const "symlink_taken.txt"
+    call user.fs.fs_tmp
+    store_var path
+    load_var path
+    load_const "keep me"
+    sys_op baml.fs.write
+    pop 1
+    load_var path
+    call user.fs.fs_symlink_is_refused_at
+    store_var threw
     load_var path
     sys_op baml.fs.read
-    store_var _11
+    store_var _7
     load_var path
     sys_op baml.fs.remove
     pop 1
     load_var threw
-    jump_if_false L4
+    jump_if_false L0
     pop 1
-    load_var _11
+    load_var _7
     load_const "keep me"
     cmp_op ==
 
-  L4:
+  L0:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/shell.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/shell.snap
@@ -86,6 +86,20 @@ function shell.$init_test_ns_shell_shell(registry: testing.TestCollector) -> nul
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
+    load_var registry
+    load_const "root.shell"
+    load_const "pid_is_positive"
+    make_closure .<lambda($init_test_ns_shell_shell, 12)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.shell"
+    load_const "pid_is_stable"
+    make_closure .<lambda($init_test_ns_shell_shell, 13)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
     load_const null
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
@@ -2141,7 +2141,7 @@ class baml.time.PlainTime$stream {
 function baml.time._from_components(hour: int, minute: int, second: int, millisecond: int, microsecond: int, nanosecond: int) -> baml.time.PlainTime  [builtin]
 function baml.time._to_string_impl(self: ?) -> string  [builtin]
 function baml.time._wrap_into_day(total_ns: bigint) -> int  [expr] {
-  { let day_ns = 86400000000000n; let wrapped = total_ns Mod day_ns Add day_ns Mod day_ns } {  } wrapped.to_int() catch (e) { root.errors.InvalidArgument => {  } baml.sys.panic("unreachable: nano...") }
+  { let day_ns = 86400000000000n; let wrapped = total_ns Mod day_ns Add day_ns Mod day_ns } {  } wrapped.to_int() catch (e) { root.errors.InvalidArgument => baml.sys.panic("unreachable: nano...") }
 }
 function baml.time.add(self: ?, other: Duration) -> baml.time.PlainTime  [expr] {
   {  } baml.time.PlainTime { _nanoseconds: _wrap_into_day(self._nanoseconds Add other._nanoseconds) }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
@@ -1906,6 +1906,7 @@ function baml.sys.ok(self: ?) -> bool  [expr] {
   {  } self.exit_code Eq 0
 }
 function baml.sys.panic(message: string) -> never  [builtin]
+function baml.sys.pid() -> int  [builtin]
 function baml.sys.shell(command: string, options: baml.sys.ProcessOptions?) -> baml.sys.ShellOutput  [builtin]
 function baml.sys.sleep(delay: root.time.Duration) -> null  [builtin]
 function baml.sys.start_process(program: string, args: string[]?, options: baml.sys.ProcessOptions?) -> baml.sys.Process  [builtin]

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
@@ -706,6 +706,7 @@ class baml.fs.MkdirOptions$stream {
   recursive: bool | null
 }
 function baml.fs.bytes(self: ?) -> uint8array  [builtin]
+function baml.fs.chmod(path: string, mode: int) -> void  [builtin]
 function baml.fs.close(self: ?) -> null  [builtin]
 function baml.fs.exists(path: string) -> bool  [builtin]
 function baml.fs.mkdir(path: string, options: baml.fs.MkdirOptions) -> null  [builtin]
@@ -719,6 +720,7 @@ function baml.fs.remove_dir(path: string) -> null  [builtin]
 function baml.fs.remove_dir_all(path: string) -> null  [builtin]
 function baml.fs.seek_from(self: ?, whence: "start" | "current" | "end", offset: int) -> int  [builtin]
 function baml.fs.size(path: string) -> int  [builtin]
+function baml.fs.symlink(target: string, path: string) -> void  [builtin]
 function baml.fs.text(self: ?) -> string  [builtin]
 function baml.fs.write(self: ?, data: string) -> int  [builtin]
 function baml.fs.write(path: string, content: string) -> int  [builtin]
@@ -2139,7 +2141,7 @@ class baml.time.PlainTime$stream {
 function baml.time._from_components(hour: int, minute: int, second: int, millisecond: int, microsecond: int, nanosecond: int) -> baml.time.PlainTime  [builtin]
 function baml.time._to_string_impl(self: ?) -> string  [builtin]
 function baml.time._wrap_into_day(total_ns: bigint) -> int  [expr] {
-  { let day_ns = 86400000000000n; let wrapped = total_ns Mod day_ns Add day_ns Mod day_ns } {  } wrapped.to_int() catch (e) { root.errors.InvalidArgument => baml.sys.panic("unreachable: nano...") }
+  { let day_ns = 86400000000000n; let wrapped = total_ns Mod day_ns Add day_ns Mod day_ns } {  } wrapped.to_int() catch (e) { root.errors.InvalidArgument => {  } baml.sys.panic("unreachable: nano...") }
 }
 function baml.time.add(self: ?, other: Duration) -> baml.time.PlainTime  [expr] {
   {  } baml.time.PlainTime { _nanoseconds: _wrap_into_day(self._nanoseconds Add other._nanoseconds) }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -7533,6 +7533,8 @@ fn baml.sys.exit = builtin(vm)
 
 fn baml.sys.argv = builtin(vm)
 
+fn baml.sys.pid = builtin(io)
+
 fn baml.time.Duration.abs(self: baml.time.Duration) -> baml.time.Duration {
     // Locals:
     let _0: baml.time.Duration // _0 // return

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -2935,6 +2935,10 @@ fn baml.fs.remove_dir = builtin(io)
 
 fn baml.fs.remove_dir_all = builtin(io)
 
+fn baml.fs.chmod = builtin(io)
+
+fn baml.fs.symlink = builtin(io)
+
 fn baml.future.Future.cancel = builtin(vm)
 
 fn baml.future.Future.is_settled = builtin(vm)

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -2259,6 +2259,9 @@ function baml.fs.File.write(self: baml.fs.File, data: string) -> int {
 function baml.fs.File.write_bytes(self: baml.fs.File, data: uint8array) -> int {
 }
 
+function baml.fs.chmod(path: string, mode: int) -> void {
+}
+
 function baml.fs.exists(path: string) -> bool {
 }
 
@@ -2284,6 +2287,9 @@ function baml.fs.remove_dir_all(path: string) -> null {
 }
 
 function baml.fs.size(path: string) -> int {
+}
+
+function baml.fs.symlink(target: string, path: string) -> void {
 }
 
 function baml.fs.write(path: string, content: string) -> int {

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -5139,6 +5139,9 @@ function baml.sys.exit(code: int) -> never {
 function baml.sys.panic(message: string) -> never {
 }
 
+function baml.sys.pid() -> int {
+}
+
 function baml.sys.shell(command: string, options: baml.sys.ProcessOptions | null) -> baml.sys.ShellOutput {
 }
 

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -109,6 +109,7 @@ namespace baml.fs:
   class DirEntry { methods: [] }
   class File { methods: [text, bytes, read, read_bytes, close, seek_from, write, write_bytes] }
   class MkdirOptions { methods: [] }
+  function chmod
   function exists
   function mkdir
   function open
@@ -118,6 +119,7 @@ namespace baml.fs:
   function remove_dir
   function remove_dir_all
   function size
+  function symlink
   function write
   function write_bytes
 namespace baml.future:

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -293,6 +293,7 @@ namespace baml.sys:
   function exec
   function exit
   function panic
+  function pid
   function shell
   function sleep
   function start_process

--- a/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__sweep__s15_sweep_baml_src.snap
+++ b/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__sweep__s15_sweep_baml_src.snap
@@ -3,7 +3,7 @@ source: crates/baml_tests/src/type_spec/sweep.rs
 expression: report
 ---
 files: 119
-typed nodes: 62116
+typed nodes: 62134
 hir_ty error-channel entries: 0
 panics: 0
 

--- a/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__sweep__s15_sweep_baml_src.snap
+++ b/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__sweep__s15_sweep_baml_src.snap
@@ -3,7 +3,7 @@ source: crates/baml_tests/src/type_spec/sweep.rs
 expression: report
 ---
 files: 119
-typed nodes: 62134
+typed nodes: 62292
 hir_ty error-channel entries: 0
 panics: 0
 

--- a/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__sweep__s15_sweep_baml_src.snap
+++ b/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__sweep__s15_sweep_baml_src.snap
@@ -3,7 +3,7 @@ source: crates/baml_tests/src/type_spec/sweep.rs
 expression: report
 ---
 files: 119
-typed nodes: 62292
+typed nodes: 62297
 hir_ty error-channel entries: 0
 panics: 0
 

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -5053,20 +5053,20 @@ function claude_code.ClaudeCodeClient.new(model: string, executable: string, cwd
 }
 
 function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
-  165   0     load_type 0                        
+  163   0     load_type 0                        
         1     load_var 1                         (raw)
         2     load_const 1                       (".type")
         3     load_const 2                       ("?")
         4     call 343 ntypeargs=1               (baml.json.path_or)
         5     store_var 2                        (kind)
 
-  166   6     load_var 2                         (kind)
+  164   6     load_var 2                         (kind)
         7     load_const 3                       ("system")
         8     cmp_op ==                          
         9     pop_jump_if_false +2               (to 11)
         10    jump +183                          (to 193)
 
-  179   11    load_var 2                         (kind)
+  177   11    load_var 2                         (kind)
         12    load_const 4                       ("assistant")
         13    cmp_op ==                          
         14    jump_if_false +2                   (to 16)
@@ -5078,13 +5078,13 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         20    pop_jump_if_false +2               (to 22)
         21    jump +23                           (to 44)
 
-  197   22    load_var 2                         (kind)
+  195   22    load_var 2                         (kind)
         23    load_const 6                       ("result")
         24    cmp_op ==                          
         25    pop_jump_if_false +2               (to 27)
         26    jump +233                          (to 259)
 
-  200   27    load_type 0                        
+  198   27    load_type 0                        
         28    load_var 2                         (kind)
         29    call 138 ntypeargs=1               (baml.String.from)
         30    store_var 23                       (_88)
@@ -5102,18 +5102,18 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         42    pop 1                              
         43    jump +216                          (to 259)
 
-  180   44    load_type 0                        
+  178   44    load_type 0                        
         45    alloc_array 0                      
         46    store_var 9                        (parts)
 
-  181   47    load_type 13                       
+  179   47    load_type 13                       
         48    load_var 1                         (raw)
         49    load_const 14                      (".message.content")
         50    load_type 15                       
         51    alloc_array 0                      
         52    call 343 ntypeargs=1               (baml.json.path_or)
 
-  182   53    load_type 16                       
+  180   53    load_type 16                       
         54    load_const 17                      ("iter")
         55    virtual_call nargs=1 ntypeargs=0   
         56    store_var 10                       (_35)
@@ -5129,14 +5129,14 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         66    load_var 11                        (_36)
         67    store_var 12                       (b)
 
-  183   68    load_type 0                        
+  181   68    load_type 0                        
         69    load_var 12                        (b)
         70    load_const 21                      (".type")
         71    load_const 22                      ("?")
         72    call 343 ntypeargs=1               (baml.json.path_or)
         73    store_var 13                       (bt)
 
-  184   74    load_var 13                        (bt)
+  182   74    load_var 13                        (bt)
         75    load_const 23                      ("text")
         76    cmp_op ==                          
         77    pop_jump_if_false +2               (to 79)
@@ -5157,20 +5157,20 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         92    pop_jump_if_false +2               (to 94)
         93    jump +6                            (to 99)
 
-  193   94    load_type 0                        
+  191   94    load_type 0                        
         95    load_var2 9 13                     
         96    call 4 ntypeargs=1                 (baml.Array.push)
         97    pop 1                              
         98    jump -41                           (to 57)
 
-  192   99    load_type 0                        
+  190   99    load_type 0                        
         100   load_var 9                         (parts)
         101   load_const 27                      ("tool_result")
         102   call 4 ntypeargs=1                 (baml.Array.push)
         103   pop 1                              
         104   jump -47                           (to 57)
 
-  191   105   load_type 0                        
+  189   105   load_type 0                        
         106   load_var 12                        (b)
         107   load_const 28                      (".name")
         108   load_const 29                      ("?")
@@ -5189,7 +5189,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         121   pop 1                              
         122   jump -65                           (to 57)
 
-  188   123   load_type 0                        
+  186   123   load_type 0                        
         124   load_var 12                        (b)
         125   load_const 31                      (".thinking")
         126   load_const 32                      ("")
@@ -5201,17 +5201,17 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         132   call 138 ntypeargs=1               (baml.String.from)
         133   store_var 16                       (_55)
 
-  187   134   load_type 0                        
+  185   134   load_type 0                        
         135   load_var 9                         (parts)
 
-  188   136   load_const 33                      ("thinking: ")
+  186   136   load_const 33                      ("thinking: ")
         137   load_var 16                        (_55)
         138   bin_op +                           
         139   call 4 ntypeargs=1                 (baml.Array.push)
         140   pop 1                              
         141   jump -84                           (to 57)
 
-  185   142   load_type 0                        
+  183   142   load_type 0                        
         143   load_var 12                        (b)
         144   load_const 34                      (".text")
         145   load_const 35                      ("")
@@ -5231,7 +5231,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         159   pop 1                              
         160   jump -103                          (to 57)
 
-  196   161   load_type 0                        
+  194   161   load_type 0                        
         162   load_var 2                         (kind)
         163   call 138 ntypeargs=1               (baml.String.from)
         164   store_var 20                       (_78)
@@ -5264,20 +5264,20 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         191   pop 1                              
         192   jump +67                           (to 259)
 
-  167   193   load_type 0                        
+  165   193   load_type 0                        
         194   load_var 1                         (raw)
         195   load_const 45                      (".subtype")
         196   load_const 46                      ("?")
         197   call 343 ntypeargs=1               (baml.json.path_or)
         198   store_var 3                        (subtype)
 
-  168   199   load_var 3                         (subtype)
+  166   199   load_var 3                         (subtype)
         200   load_const 47                      ("thinking_tokens")
         201   cmp_op ==                          
         202   pop_jump_if_false +2               (to 204)
         203   jump +32                           (to 235)
 
-  176   204   load_type 0                        
+  174   204   load_type 0                        
         205   load_var 3                         (subtype)
         206   call 138 ntypeargs=1               (baml.String.from)
         207   store_var 6                        (_19)
@@ -5292,10 +5292,10 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         216   call 138 ntypeargs=1               (baml.String.from)
         217   store_var 7                        (_22)
 
-  175   218   load_const 50                      ("$baml_log")
+  173   218   load_const 50                      ("$baml_log")
         219   load_const 51                      ("info")
 
-  176   220   load_const 52                      ("cc event: system/")
+  174   220   load_const 52                      ("cc event: system/")
         221   load_var 6                         (_19)
         222   bin_op +                           
         223   load_const 53                      (" model=")
@@ -5308,11 +5308,11 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         230   load_type 12                       
         231   alloc_map 2                        
 
-  175   232   send_event                         
+  173   232   send_event                         
         233   pop 1                              
         234   jump +25                           (to 259)
 
-  172   235   load_type 56                       
+  170   235   load_type 56                       
         236   load_var 1                         (raw)
         237   load_const 57                      (".estimated_tokens")
         238   load_const 58                      (0)
@@ -5323,10 +5323,10 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         243   call 138 ntypeargs=1               (baml.String.from)
         244   store_var 4                        (_12)
 
-  171   245   load_const 59                      ("$baml_log")
+  169   245   load_const 59                      ("$baml_log")
         246   load_const 60                      ("debug")
 
-  172   247   load_const 61                      ("cc event: thinking ~")
+  170   247   load_const 61                      ("cc event: thinking ~")
         248   load_var 4                         (_12)
         249   bin_op +                           
         250   load_const 62                      (" tokens")
@@ -5337,26 +5337,26 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         255   load_type 12                       
         256   alloc_map 2                        
 
-  171   257   send_event                         
+  169   257   send_event                         
         258   pop 1                              
 
-  202   259   load_const 65                      (null)
+  200   259   load_const 65                      (null)
         260   return                             
 }
 
 function claude_code.internal._preview(text: string) -> string {
-  156   0    load_var 1             (text)
+  154   0    load_var 1             (text)
         1    call 139 ntypeargs=0   (baml.String.length)
         2    load_const 0           (120)
         3    cmp_int_op >           
         4    pop_jump_if_false +2   (to 6)
         5    jump +3                (to 8)
 
-  159   6    load_var 1             (text)
+  157   6    load_var 1             (text)
 
-  156   7    jump +11               (to 18)
+  154   7    jump +11               (to 18)
 
-  157   8    load_var 1             (text)
+  155   8    load_var 1             (text)
         9    load_const 1           (0)
         10   load_const 0           (120)
         11   call 153 ntypeargs=0   (baml.String.substring)
@@ -5370,10 +5370,10 @@ function claude_code.internal._preview(text: string) -> string {
 }
 
 function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.json {
-  129   0    load_const 0                       (null)
+  127   0    load_const 0                       (null)
         1    store_var 2                        (result)
 
-  130   2    load_var 1                         (p)
+  128   2    load_var 1                         (p)
         3    load_field 0                       (stdout)
         4    load_type 1                        
         5    load_const 2                       ("iter")
@@ -5392,29 +5392,29 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         18   call 144 ntypeargs=0               (baml.String.trim)
         19   store_var 5                        (trimmed)
 
-  132   20   load_var 5                         (trimmed)
+  130   20   load_var 5                         (trimmed)
         21   call 139 ntypeargs=0               (baml.String.length)
         22   load_const 6                       (0)
         23   cmp_int_op >                       
         24   pop_jump_if_false -16              (to 8)
 
-  133   25   load_var 5                         (trimmed)
+  131   25   load_var 5                         (trimmed)
         26   call 330 ntypeargs=0               (baml.json.parse)
         27   store_var 6                        (raw)
         28   jump +7                            (to 35)
         29   load_var 7                         (e)
         30   throw_if_panic                     
 
-  135   31   load_const 7                       ("claude-code")
+  133   31   load_const 7                       ("claude-code")
         32   load_var 5                         (trimmed)
         33   init_instance 0                    (ai.errors.ParseFailed .provider, .raw_output)
         34   throw                              
 
-  138   35   load_var 6                         (raw)
+  136   35   load_var 6                         (raw)
         36   call 924 ntypeargs=0               (claude_code.internal._log_cc_event)
         37   pop 1                              
 
-  139   38   load_type 8                        
+  137   38   load_type 8                        
         39   load_var 6                         (raw)
         40   load_const 9                       (".type")
         41   load_const 10                      ("")
@@ -5423,21 +5423,21 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         44   cmp_op ==                          
         45   pop_jump_if_false -37              (to 8)
 
-  140   46   load_var 6                         (raw)
+  138   46   load_var 6                         (raw)
         47   store_var 2                        (result)
 
-  139   48   jump -40                           (to 8)
+  137   48   jump -40                           (to 8)
 
-  146   49   load_var 2                         (result)
+  144   49   load_var 2                         (result)
         50   load_const 0                       (null)
         51   call 656 ntypeargs=0               (baml.ops.equals_equals)
         52   pop_jump_if_false +2               (to 54)
         53   jump +3                            (to 56)
 
-  152   54   load_var 2                         (result)
+  150   54   load_var 2                         (result)
         55   return                             
 
-  147   56   load_const 12                      ("claude-code")
+  145   56   load_const 12                      ("claude-code")
         57   load_const 13                      ("the Claude Code CLI stream ended without a result event")
         58   init_instance 1                    (ai.errors.ParseFailed .provider, .raw_output)
         59   throw                              
@@ -5462,7 +5462,7 @@ function claude_code.internal._type_schema(t: string) -> map<string, unknown> {
 }
 
 function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient) -> string {
-  221   0    load_type 0           
+  219   0    load_type 0           
         1    load_type 1           
         2    load_var 1            (c)
         3    load_field 6          (mcp_servers)
@@ -5473,11 +5473,11 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
         8    load_type 2           
         9    load_var 3            (_3)
 
-  222   10   make_closure 2243 0   
+  220   10   make_closure 2243 0   
         11   call 16 ntypeargs=3   (baml.Array.map)
         12   store_var 2           (_2)
 
-  221   13   load_type 0           
+  219   13   load_type 0           
         14   load_var 2            (_2)
         15   load_const 3          (",")
         16   call 15 ntypeargs=1   (baml.Array.join)
@@ -5746,29 +5746,29 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
 }
 
 function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
-  235   0     load_const 0                       ("")
+  233   0     load_const 0                       ("")
         1     load_var 2                         (input)
         2     load_field 0                       (prompt)
         3     call_indirect                      
         4     call 811 ntypeargs=0               (ai.Prompt.text)
         5     store_var 4                        (instructions)
 
-  236   6     load_var 2                         (input)
+  234   6     load_var 2                         (input)
         7     load_field 2                       (toolbox)
         8     call 826 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         9     unary_op !                         
         10    store_var_load_var 5               (has_tools)
 
-  237   11    pop_jump_if_false +2               (to 13)
+  235   11    pop_jump_if_false +2               (to 13)
         12    jump +6                            (to 18)
 
-  240   13    load_var 2                         (input)
+  238   13    load_var 2                         (input)
         14    load_field 3                       (output_type)
         15    sys_op 344                         (baml.json.schema)
         16    store_var 6                        (schema)
         17    jump +9                            (to 26)
 
-  238   18    load_var 2                         (input)
+  236   18    load_var 2                         (input)
         19    load_field 3                       (output_type)
         20    call 919 ntypeargs=0               (claude_code.internal.envelope_schema)
         21    store_var 7                        (_11)
@@ -5777,11 +5777,11 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         24    call 334 ntypeargs=1               (baml.json.to_json)
         25    store_var 6                        (schema)
 
-  242   26    load_var 5                         (has_tools)
+  240   26    load_var 5                         (has_tools)
         27    pop_jump_if_false +2               (to 29)
         28    jump +17                           (to 45)
 
-  245   29    load_type 2                        
+  243   29    load_type 2                        
         30    load_var 4                         (instructions)
         31    call 138 ntypeargs=1               (baml.String.from)
         32    store_var 14                       (_29)
@@ -5797,9 +5797,9 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         42    bin_op +                           
         43    store_var 8                        (prompt_text)
 
-  242   44    jump +26                           (to 70)
+  240   44    jump +26                           (to 70)
 
-  243   45    load_type 2                        
+  241   45    load_type 2                        
         46    load_var 4                         (instructions)
         47    call 138 ntypeargs=1               (baml.String.from)
         48    store_var 9                        (_18)
@@ -5825,7 +5825,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         68    bin_op +                           
         69    store_var 8                        (prompt_text)
 
-  249   70    load_type 2                        
+  247   70    load_type 2                        
         71    load_var 1                         (c)
         72    load_field 1                       (model)
         73    call 138 ntypeargs=1               (baml.String.from)
@@ -5847,10 +5847,10 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         89    call 138 ntypeargs=1               (baml.String.from)
         90    store_var 20                       (_47)
 
-  248   91    load_const 4                       ("$baml_log")
+  246   91    load_const 4                       ("$baml_log")
         92    load_const 5                       ("info")
 
-  249   93    load_const 6                       ("claude-code invoke: model=")
+  247   93    load_const 6                       ("claude-code invoke: model=")
         94    load_var 17                        (_41)
         95    bin_op +                           
         96    load_const 7                       (" prompt_chars=")
@@ -5867,74 +5867,74 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         107   load_type 11                       
         108   alloc_map 2                        
 
-  248   109   send_event                         
+  246   109   send_event                         
         110   pop 1                              
 
-  251   111   load_type 2                        
+  249   111   load_type 2                        
         112   alloc_array 0                      
         113   store_var 22                       (args)
 
-  252   114   load_type 2                        
+  250   114   load_type 2                        
         115   load_var 22                        (args)
         116   load_const 12                      ("-p")
         117   call 4 ntypeargs=1                 (baml.Array.push)
         118   pop 1                              
 
-  253   119   load_type 2                        
+  251   119   load_type 2                        
         120   load_var 22                        (args)
         121   load_const 13                      ("--output-format")
         122   call 4 ntypeargs=1                 (baml.Array.push)
         123   pop 1                              
 
-  254   124   load_type 2                        
+  252   124   load_type 2                        
         125   load_var 22                        (args)
         126   load_const 14                      ("stream-json")
         127   call 4 ntypeargs=1                 (baml.Array.push)
         128   pop 1                              
 
-  255   129   load_type 2                        
+  253   129   load_type 2                        
         130   load_var 22                        (args)
         131   load_const 15                      ("--verbose")
         132   call 4 ntypeargs=1                 (baml.Array.push)
         133   pop 1                              
 
-  256   134   load_type 2                        
+  254   134   load_type 2                        
         135   load_var 22                        (args)
         136   load_const 16                      ("--model")
         137   call 4 ntypeargs=1                 (baml.Array.push)
         138   pop 1                              
 
-  257   139   load_type 2                        
+  255   139   load_type 2                        
         140   load_var2 22 1                     
         141   load_field 1                       (model)
         142   call 4 ntypeargs=1                 (baml.Array.push)
         143   pop 1                              
 
-  258   144   load_type 2                        
+  256   144   load_type 2                        
         145   load_var 22                        (args)
         146   load_const 17                      ("--permission-mode")
         147   call 4 ntypeargs=1                 (baml.Array.push)
         148   pop 1                              
 
-  259   149   load_type 2                        
+  257   149   load_type 2                        
         150   load_var2 22 1                     
         151   load_field 4                       (permission_mode)
         152   call 4 ntypeargs=1                 (baml.Array.push)
         153   pop 1                              
 
-  260   154   load_type 2                        
+  258   154   load_type 2                        
         155   load_var 22                        (args)
         156   load_const 18                      ("--no-session-persistence")
         157   call 4 ntypeargs=1                 (baml.Array.push)
         158   pop 1                              
 
-  261   159   load_type 2                        
+  259   159   load_type 2                        
         160   load_var 22                        (args)
         161   load_const 19                      ("--tools")
         162   call 4 ntypeargs=1                 (baml.Array.push)
         163   pop 1                              
 
-  262   164   load_type 2                        
+  260   164   load_type 2                        
         165   load_var 1                         (c)
         166   load_field 5                       (harness_tools)
         167   load_const 20                      (",")
@@ -5945,7 +5945,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         172   call 4 ntypeargs=1                 (baml.Array.push)
         173   pop 1                              
 
-  269   174   load_var 1                         (c)
+  267   174   load_var 1                         (c)
         175   call 925 ntypeargs=0               (claude_code.internal.mcp_config_json)
         176   store_var 24                       (_81)
         177   load_var 24                        (_81)
@@ -5954,24 +5954,24 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         180   load_var 24                        (_81)
         181   store_var 25                       (mcp)
 
-  270   182   load_type 2                        
+  268   182   load_type 2                        
         183   load_var 22                        (args)
         184   load_const 22                      ("--mcp-config")
         185   call 4 ntypeargs=1                 (baml.Array.push)
         186   pop 1                              
 
-  271   187   load_type 2                        
+  269   187   load_type 2                        
         188   load_var2 22 25                    
         189   call 4 ntypeargs=1                 (baml.Array.push)
         190   pop 1                              
 
-  272   191   load_type 2                        
+  270   191   load_type 2                        
         192   load_var 22                        (args)
         193   load_const 23                      ("--strict-mcp-config")
         194   call 4 ntypeargs=1                 (baml.Array.push)
         195   pop 1                              
 
-  273   196   load_var 1                         (c)
+  271   196   load_var 1                         (c)
         197   call 926 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
         198   store_var 27                       (_93)
         199   load_type 2                        
@@ -5986,13 +5986,13 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         208   call 4 ntypeargs=1                 (baml.Array.push)
         209   pop 1                              
 
-  275   210   load_type 2                        
+  273   210   load_type 2                        
         211   load_var 22                        (args)
         212   load_const 25                      ("--json-schema")
         213   call 4 ntypeargs=1                 (baml.Array.push)
         214   pop 1                              
 
-  276   215   load_var 6                         (schema)
+  274   215   load_var 6                         (schema)
         216   call 331 ntypeargs=0               (baml.json.stringify)
         217   store_var 28                       (_99)
         218   load_type 2                        
@@ -6000,17 +6000,17 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         220   call 4 ntypeargs=1                 (baml.Array.push)
         221   pop 1                              
 
-  277   222   load_type 2                        
+  275   222   load_type 2                        
         223   load_var2 22 8                     
         224   call 4 ntypeargs=1                 (baml.Array.push)
         225   pop 1                              
 
-  280   226   load_var 1                         (c)
+  278   226   load_var 1                         (c)
         227   load_field 0                       (executable)
 
-  281   228   load_var2 22 1                     
+  279   228   load_var2 22 1                     
 
-  282   229   load_field 2                       (cwd)
+  280   229   load_field 2                       (cwd)
         230   load_const 26                      (null)
         231   load_var 1                         (c)
         232   load_field 3                       (timeout_ms)
@@ -6021,10 +6021,10 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         237   store_var 29                       (p)
         238   jump +18                           (to 256)
 
-  279   239   load_var 30                        (e)
+  277   239   load_var 30                        (e)
         240   throw_if_panic                     
 
-  287   241   load_type 27                       
+  285   241   load_type 27                       
         242   load_var 30                        (e)
         243   call 138 ntypeargs=1               (baml.String.from)
         244   store_var 32                       (_115)
@@ -6033,34 +6033,34 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         247   call 138 ntypeargs=1               (baml.String.from)
         248   store_var 31                       (_114)
 
-  285   249   load_const 28                      ("claude-code")
+  283   249   load_const 28                      ("claude-code")
 
-  287   250   load_const 29                      ("the Claude Code CLI could not start: ")
+  285   250   load_const 29                      ("the Claude Code CLI could not start: ")
         251   load_var 31                        (_114)
         252   bin_op +                           
         253   load_const 26                      (null)
         254   init_instance 1                    (ai.errors.NetworkFailure .provider, .detail, .raw_body)
         255   throw                              
 
-  296   256   load_var 29                        (p)
+  294   256   load_var 29                        (p)
         257   sys_op 248                         (baml.sys.Process.close_stdin)
         258   pop 1                              
         259   jump +3                            (to 262)
         260   load_var 35                        (e)
         261   throw_if_panic                     
 
-  301   262   load_var 29                        (p)
+  299   262   load_var 29                        (p)
         263   call 922 ntypeargs=0               (claude_code.internal._read_result)
         264   store_var 36                       (result)
 
-  302   265   load_var 29                        (p)
+  300   265   load_var 29                        (p)
         266   sys_op 249                         (baml.sys.Process.wait)
         267   store_var 37                       (exit)
         268   jump +18                           (to 286)
         269   load_var 38                        (e)
         270   throw_if_panic                     
 
-  306   271   load_type 30                       
+  304   271   load_type 30                       
         272   load_var 38                        (e)
         273   call 138 ntypeargs=1               (baml.String.from)
         274   store_var 40                       (_129)
@@ -6069,22 +6069,22 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         277   call 138 ntypeargs=1               (baml.String.from)
         278   store_var 39                       (_128)
 
-  304   279   load_const 31                      ("claude-code")
+  302   279   load_const 31                      ("claude-code")
 
-  306   280   load_const 32                      ("the Claude Code CLI did not terminate cleanly: ")
+  304   280   load_const 32                      ("the Claude Code CLI did not terminate cleanly: ")
         281   load_var 39                        (_128)
         282   bin_op +                           
         283   load_const 26                      (null)
         284   init_instance 2                    (ai.errors.NetworkFailure .provider, .detail, .raw_body)
         285   throw                              
 
-  311   286   load_var 37                        (exit)
+  309   286   load_var 37                        (exit)
         287   call 242 ntypeargs=0               (baml.sys.ProcessExit.ok)
         288   unary_op !                         
         289   pop_jump_if_false +2               (to 291)
         290   jump +251                          (to 541)
 
-  320   291   load_type 33                       
+  318   291   load_type 33                       
         292   load_var 36                        (result)
         293   load_const 34                      (".is_error")
         294   load_const 35                      (false)
@@ -6092,7 +6092,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         296   pop_jump_if_false +2               (to 298)
         297   jump +231                          (to 528)
 
-  328   298   load_type 2                        
+  326   298   load_type 2                        
         299   load_var 36                        (result)
         300   load_const 36                      (".subtype")
         301   load_const 37                      ("?")
@@ -6123,10 +6123,10 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         326   call 138 ntypeargs=1               (baml.String.from)
         327   store_var 48                       (_163)
 
-  327   328   load_const 43                      ("$baml_log")
+  325   328   load_const 43                      ("$baml_log")
         329   load_const 44                      ("info")
 
-  328   330   load_const 45                      ("claude-code result: subtype=")
+  326   330   load_const 45                      ("claude-code result: subtype=")
         331   load_var 44                        (_153)
         332   bin_op +                           
         333   load_const 46                      (" cost_usd=")
@@ -6143,10 +6143,10 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         344   load_type 11                       
         345   alloc_map 2                        
 
-  327   346   send_event                         
+  325   346   send_event                         
         347   pop 1                              
 
-  330   348   load_type 50                       
+  328   348   load_type 50                       
         349   load_var 36                        (result)
         350   load_const 51                      (".structured_output")
         351   call 342 ntypeargs=1               (baml.json.path)
@@ -6155,7 +6155,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         354   load_var 51                        (e)
         355   throw_if_panic                     
 
-  332   356   load_type 2                        
+  330   356   load_type 2                        
         357   load_var 36                        (result)
         358   load_const 52                      (".result")
         359   load_const 53                      ("")
@@ -6166,49 +6166,49 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         364   load_var 52                        (inner)
         365   throw_if_panic                     
 
-  336   366   load_var 36                        (result)
+  334   366   load_var 36                        (result)
         367   call 331 ntypeargs=0               (baml.json.stringify)
         368   store_var 53                       (_177)
 
-  334   369   load_const 54                      ("claude-code")
+  332   369   load_const 54                      ("claude-code")
         370   load_var 53                        (_177)
         371   init_instance 3                    (ai.errors.ParseFailed .provider, .raw_output)
         372   throw                              
 
-  344   373   load_type 3                        
+  342   373   load_type 3                        
         374   load_var 36                        (result)
         375   load_const 55                      (".usage.input_tokens")
         376   load_const 56                      (0)
         377   call 343 ntypeargs=1               (baml.json.path_or)
         378   store_var 54                       (_180)
 
-  345   379   load_type 3                        
+  343   379   load_type 3                        
         380   load_var 36                        (result)
         381   load_const 57                      (".usage.output_tokens")
         382   load_const 56                      (0)
         383   call 343 ntypeargs=1               (baml.json.path_or)
         384   store_var 55                       (_183)
 
-  346   385   load_type 58                       
+  344   385   load_type 58                       
         386   load_var 36                        (result)
         387   load_const 59                      (".usage.cache_read_input_tokens")
         388   load_const 26                      (null)
         389   call 343 ntypeargs=1               (baml.json.path_or)
         390   store_var 56                       (_186)
 
-  350   391   load_type 60                       
+  348   391   load_type 60                       
         392   alloc_array 0                      
         393   store_var 57                       (content)
 
-  351   394   load_const 56                      (ai.content.StopReason.Complete)
+  349   394   load_const 56                      (ai.content.StopReason.Complete)
         395   alloc_variant 436                  (ai.content.StopReason)
         396   store_var 58                       (stop)
 
-  352   397   load_var 5                         (has_tools)
+  350   397   load_var 5                         (has_tools)
         398   pop_jump_if_false +2               (to 400)
         399   jump +10                           (to 409)
 
-  380   400   load_var 50                        (structured)
+  378   400   load_var 50                        (structured)
         401   call 331 ntypeargs=0               (baml.json.stringify)
         402   store_var 74                       (_247)
         403   load_type 60                       
@@ -6218,26 +6218,26 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         407   pop 1                              
         408   jump +108                          (to 516)
 
-  353   409   load_type 50                       
+  351   409   load_type 50                       
         410   load_var 36                        (result)
         411   load_const 61                      (".structured_output.outcome")
         412   load_var 50                        (structured)
         413   call 343 ntypeargs=1               (baml.json.path_or)
         414   store_var 59                       (outcome)
 
-  354   415   load_type 62                       
+  352   415   load_type 62                       
         416   load_var 59                        (outcome)
         417   load_const 63                      (".calls")
         418   load_const 26                      (null)
         419   call 343 ntypeargs=1               (baml.json.path_or)
 
-  355   420   store_var 60                       (_199)
+  353   420   store_var 60                       (_199)
         421   load_var 60                        (_199)
         422   narrow_bind 64 60                  
         423   pop_jump_if_false +2               (to 425)
         424   jump +10                           (to 434)
 
-  377   425   load_var 59                        (outcome)
+  375   425   load_var 59                        (outcome)
         426   call 331 ntypeargs=0               (baml.json.stringify)
         427   store_var 73                       (_242)
         428   load_type 60                       
@@ -6247,16 +6247,16 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         432   pop 1                              
         433   jump +83                           (to 516)
 
-  356   434   load_const 56                      (0)
+  354   434   load_const 56                      (0)
         435   store_var 61                       (i)
 
-  355   436   load_var 60                        (_199)
+  353   436   load_var 60                        (_199)
         437   load_type 65                       
         438   load_const 66                      ("iter")
         439   virtual_call nargs=1 ntypeargs=0   
         440   store_var 62                       (_203)
 
-  357   441   load_var 62                        (_203)
+  355   441   load_var 62                        (_203)
         442   load_type 67                       
         443   load_const 68                      ("next")
         444   virtual_call nargs=1 ntypeargs=0   
@@ -6268,7 +6268,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         450   load_var 63                        (_204)
         451   store_var 64                       (raw_call)
 
-  361   452   load_var 2                         (input)
+  359   452   load_var 2                         (input)
         453   load_field 1                       (journal)
         454   call 808 ntypeargs=0               (ai.Journal.entries)
         455   container_len                      
@@ -6282,12 +6282,12 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         463   call 138 ntypeargs=1               (baml.String.from)
         464   store_var 68                       (_218)
 
-  358   465   load_type 2                        
+  356   465   load_type 2                        
 
-  359   466   load_var 64                        (raw_call)
+  357   466   load_var 64                        (raw_call)
         467   load_const 70                      (".id")
 
-  361   468   load_const 71                      ("cc_call_")
+  359   468   load_const 71                      ("cc_call_")
         469   load_var 66                        (_213)
         470   bin_op +                           
         471   load_const 72                      ("_")
@@ -6297,14 +6297,14 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         475   call 343 ntypeargs=1               (baml.json.path_or)
         476   store_var 65                       (id)
 
-  363   477   load_type 2                        
+  361   477   load_type 2                        
         478   load_var 64                        (raw_call)
         479   load_const 73                      (".name")
         480   load_const 74                      ("")
         481   call 343 ntypeargs=1               (baml.json.path_or)
         482   store_var 69                       (name)
 
-  365   483   load_type 50                       
+  363   483   load_type 50                       
         484   load_var 64                        (raw_call)
         485   load_const 75                      (".args")
         486   load_type 2                        
@@ -6313,7 +6313,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         489   call 343 ntypeargs=1               (baml.json.path_or)
         490   store_var 72                       (_227)
 
-  364   491   load_type 1                        
+  362   491   load_type 1                        
         492   load_var 72                        (_227)
         493   call 337 ntypeargs=1               (baml.json.from_json)
         494   store_var 70                       (call_args)
@@ -6321,78 +6321,78 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         496   load_var 71                        (e)
         497   throw_if_panic                     
 
-  368   498   load_type 2                        
+  366   498   load_type 2                        
         499   load_type 11                       
         500   alloc_map 0                        
         501   store_var 70                       (call_args)
 
-  372   502   load_type 60                       
+  370   502   load_type 60                       
         503   load_var2 57 65                    
         504   load_var2 69 70                    
         505   init_instance 6                    (ai.content.ToolUse .id, .name, .args)
         506   call 4 ntypeargs=1                 (baml.Array.push)
         507   pop 1                              
 
-  373   508   load_var 61                        (i)
+  371   508   load_var 61                        (i)
         509   load_const 21                      (1)
         510   add_int                            
         511   store_var 61                       (i)
 
-  357   512   jump -71                           (to 441)
+  355   512   jump -71                           (to 441)
 
-  375   513   load_const 21                      (ai.content.StopReason.ToolUse)
+  373   513   load_const 21                      (ai.content.StopReason.ToolUse)
         514   alloc_variant 436                  (ai.content.StopReason)
         515   store_var 58                       (stop)
 
-  382   516   load_var2 57 58                    
+  380   516   load_var2 57 58                    
 
-  343   517   load_var2 54 55                    
+  341   517   load_var2 54 55                    
         518   load_var 56                        (_186)
         519   load_const 26                      (null)
         520   init_instance 7                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
         521   init_instance 8                    (ai.ModelTurn .content, .stop_reason, .usage)
         522   store_var 3                        (_0)
 
-  293   523   load_var 29                        (p)
+  291   523   load_var 29                        (p)
         524   sys_op 251                         (baml.sys.Process.close)
         525   pop 1                              
         526   load_var 3                         (_0)
         527   return                             
 
-  323   528   load_type 2                        
+  321   528   load_type 2                        
         529   load_var 36                        (result)
         530   load_const 76                      (".subtype")
         531   load_const 77                      ("error")
         532   call 343 ntypeargs=1               (baml.json.path_or)
         533   store_var 42                       (_143)
 
-  324   534   load_var 36                        (result)
+  322   534   load_var 36                        (result)
         535   call 331 ntypeargs=0               (baml.json.stringify)
         536   store_var 43                       (_146)
 
-  321   537   load_const 78                      ("claude-code")
+  319   537   load_const 78                      ("claude-code")
         538   load_var2 42 43                    
         539   init_instance 9                    (ai.errors.Refused .provider, .reason, .raw_body)
         540   throw                              
 
-  315   541   load_type 3                        
+  313   541   load_type 3                        
         542   load_var 37                        (exit)
         543   load_field 0                       (exit_code)
         544   call 138 ntypeargs=1               (baml.String.from)
         545   store_var 41                       (_136)
         546   jump +6                            (to 552)
 
-  293   547   load_var 29                        (p)
+  291   547   load_var 29                        (p)
         548   sys_op 251                         (baml.sys.Process.close)
         549   pop 1                              
 
-  229   550   load_var 33                        (_118)
+  227   550   load_var 33                        (_118)
         551   rethrow                            
 
-  312   552   load_const 79                      ("claude-code")
+  310   552   load_const 79                      ("claude-code")
         553   load_const 26                      (null)
 
-  315   554   load_const 80                      ("the Claude Code CLI exited with code ")
+  313   554   load_const 80                      ("the Claude Code CLI exited with code ")
         555   load_var 41                        (_136)
         556   bin_op +                           
         557   load_const 26                      (null)
@@ -6401,7 +6401,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 }
 
 function claude_code.internal.mcp_config_json(c: claude_code.ClaudeCodeClient) -> string | null {
-  209   0    load_var 1             (c)
+  207   0    load_var 1             (c)
         1    load_field 6           (mcp_servers)
         2    container_len          
         3    store_var 2            (_3)
@@ -6411,12 +6411,12 @@ function claude_code.internal.mcp_config_json(c: claude_code.ClaudeCodeClient) -
         7    pop_jump_if_false +2   (to 9)
         8    jump +18               (to 26)
 
-  212   9    load_type 1            
+  210   9    load_type 1            
         10   load_type 2            
         11   alloc_map 0            
         12   store_var 3            (wrapper)
 
-  213   13   load_type 1            
+  211   13   load_type 1            
         14   load_type 2            
         15   load_var 3             (wrapper)
         16   load_const 3           ("mcpServers")
@@ -6425,13 +6425,13 @@ function claude_code.internal.mcp_config_json(c: claude_code.ClaudeCodeClient) -
         19   call 37 ntypeargs=2    (baml.Map.set)
         20   pop 1                  
 
-  214   21   load_type 4            
+  212   21   load_type 4            
         22   load_var 3             (wrapper)
         23   call 334 ntypeargs=1   (baml.json.to_json)
         24   call 331 ntypeargs=0   (baml.json.stringify)
         25   jump +2                (to 27)
 
-  210   26   load_const 5           (null)
+  208   26   load_const 5           (null)
         27   return                 
 }
 
@@ -6499,7 +6499,7 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         56   pop 1                              
         57   jump -48                           (to 9)
 
-  122   58   load_type 0                        
+  121   58   load_type 0                        
         59   load_var 2                         (catalog)
         60   load_const 11                      (", ")
         61   call 15 ntypeargs=1                (baml.Array.join)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -30,14 +30,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   199   24    load_type 1                                
         25    load_deref 2                               
-        26    call 806 ntypeargs=1                       (ai.Journal.new)
+        26    call 807 ntypeargs=1                       (ai.Journal.new)
         27    store_deref 5                              
 
   200   28    load_type 1                                
         29    load_deref 1                               
         30    load_deref 5                               
         31    load_const 2                               (0)
-        32    call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        32    call 846 ntypeargs=1                       (ai.Agent._emit_from)
         33    store_var 6                                (seen)
 
   201   34    load_const 2                               (0)
@@ -73,7 +73,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         59    load_deref 5                               
         60    load_var 8                                 (total)
         61    load_const 5                               (2)
-        62    call 844 ntypeargs=1                       (ai.Agent._attempt_turn)
+        62    call 845 ntypeargs=1                       (ai.Agent._attempt_turn)
         63    store_var 10                               (turn)
 
   213   64    load_var 7                                 (steps)
@@ -85,11 +85,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         69    load_deref 1                               
         70    load_deref 5                               
         71    load_var 6                                 (seen)
-        72    call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        72    call 846 ntypeargs=1                       (ai.Agent._emit_from)
         73    store_var 6                                (seen)
 
   215   74    load_var 10                                (turn)
-        75    call 825 ntypeargs=0                       (ai.ModelTurn.tool_uses)
+        75    call 826 ntypeargs=0                       (ai.ModelTurn.tool_uses)
         76    store_var 11                               (calls)
 
   216   77    load_var 11                                (calls)
@@ -102,7 +102,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         84    jump +63                                   (to 147)
 
   251   85    load_var 10                                (turn)
-        86    call 824 ntypeargs=0                       (ai.ModelTurn.terminal_text)
+        86    call 825 ntypeargs=0                       (ai.ModelTurn.terminal_text)
         87    store_var 34                               (_96)
         88    load_var 34                                (_96)
         89    store_var 33                               (candidate)
@@ -115,7 +115,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   252   96    load_type 1                                
         97    load_var 33                                (candidate)
-        98    call 426 ntypeargs=1                       (baml.sap.parse)
+        98    call 427 ntypeargs=1                       (baml.sap.parse)
         99    store_var 35                               (value)
         100   jump +11                                   (to 111)
         101   load_var 36                                (e)
@@ -132,7 +132,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   257   111   load_type 1                                
         112   load_var 35                                (value)
-        113   call 331 ntypeargs=1                       (baml.json.to_json)
+        113   call 332 ntypeargs=1                       (baml.json.to_json)
         114   jump +12                                   (to 126)
         115   load_var 38                                (e)
         116   throw_if_panic                             
@@ -147,7 +147,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         124   init_instance 3                            (baml.errors.UnknownError .data, .message)
         125   throw                                      
 
-  263   126   call 328 ntypeargs=0                       (baml.json.stringify)
+  263   126   call 329 ntypeargs=0                       (baml.json.stringify)
         127   store_var 40                               (_117)
 
   262   128   load_deref 5                               
@@ -156,14 +156,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         130   init_instance 4                            (ai.events.FinalProduced .value_json)
         131   load_type 11                               
         132   alloc_array 1                              
-        133   call 807 ntypeargs=0                       (ai.Journal.append_all)
+        133   call 808 ntypeargs=0                       (ai.Journal.append_all)
         134   pop 1                                      
 
   265   135   load_type 1                                
         136   load_deref 1                               
         137   load_deref 5                               
         138   load_var 6                                 (seen)
-        139   call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        139   call 846 ntypeargs=1                       (ai.Agent._emit_from)
         140   store_var 6                                (seen)
 
   266   141   load_var 35                                (value)
@@ -174,7 +174,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         146   return                                     
 
   217   147   load_deref 5                               
-        148   call 805 ntypeargs=0                       (ai.Journal.entries)
+        148   call 806 ntypeargs=0                       (ai.Journal.entries)
         149   container_len                              
         150   store_var 13                               (before)
 
@@ -185,14 +185,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         155   load_type 1                                
         156   load_var2 1 2                              
         157   load_var 5                                 (j)
-        158   make_closure 1738 captures=3 ntypeargs=1   
+        158   make_closure 1739 captures=3 ntypeargs=1   
         159   call 16 ntypeargs=3                        (baml.Array.map)
         160   store_var 14                               (futures)
 
   222   161   load_type 15                               
         162   load_type 16                               
         163   load_var 14                                (futures)
-        164   call 483 ntypeargs=2                       (baml.future.all)
+        164   call 484 ntypeargs=2                       (baml.future.all)
         165   await                                      
         166   pop 1                                      
 
@@ -200,11 +200,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         168   load_deref 1                               
         169   load_deref 5                               
         170   load_var 6                                 (seen)
-        171   call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        171   call 846 ntypeargs=1                       (ai.Agent._emit_from)
         172   store_var 6                                (seen)
 
   227   173   load_deref 5                               
-        174   call 805 ntypeargs=0                       (ai.Journal.entries)
+        174   call 806 ntypeargs=0                       (ai.Journal.entries)
         175   store_var 15                               (entries)
 
   228   176   load_var 13                                (before)
@@ -234,7 +234,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         197   load_var 11                                (calls)
         198   load_type 1                                
         199   load_var 20                                (f)
-        200   make_closure 1739 captures=1 ntypeargs=1   
+        200   make_closure 1740 captures=1 ntypeargs=1   
         201   call 19 ntypeargs=2                        (baml.Array.find)
 
   234   202   store_var 21                               (_58)
@@ -338,12 +338,12 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   126   3     load_type 0                        
         4     load_var 3                         (spec)
-        5     call 816 ntypeargs=1               (ai.FunctionSpec.tools)
+        5     call 817 ntypeargs=1               (ai.FunctionSpec.tools)
         6     store_var 9                        (_10)
 
   127   7     load_type 0                        
         8     load_var 3                         (spec)
-        9     call 814 ntypeargs=1               (ai.FunctionSpec.output_type)
+        9     call 815 ntypeargs=1               (ai.FunctionSpec.output_type)
         10    store_var 10                       (_12)
 
   122   11    load_var2 2 8                      
@@ -446,7 +446,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         99    store_var 21                       (batch)
 
   142   100   load_var 7                         (turn)
-        101   call 825 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        101   call 826 ntypeargs=0               (ai.ModelTurn.tool_uses)
         102   load_type 8                        
         103   load_const 9                       ("iter")
         104   virtual_call nargs=1 ntypeargs=0   
@@ -489,7 +489,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         137   pop 1                              
 
   148   138   load_var 7                         (turn)
-        139   call 824 ntypeargs=0               (ai.ModelTurn.terminal_text)
+        139   call 825 ntypeargs=0               (ai.ModelTurn.terminal_text)
         140   store_var 29                       (_56)
         141   load_var 29                        (_56)
         142   store_var 28                       (candidate)
@@ -501,7 +501,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         148   store_var 28                       (candidate)
 
   149   149   load_var 7                         (turn)
-        150   call 825 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        150   call 826 ntypeargs=0               (ai.ModelTurn.tool_uses)
         151   container_len                      
         152   store_var 30                       (_62)
         153   load_var 30                        (_62)
@@ -515,7 +515,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         160   load_field 1                       (stop_reason)
         161   load_const 14                      (ai.content.StopReason.MaxTokens)
         162   alloc_variant 436                  (ai.content.StopReason)
-        163   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        163   call 654 ntypeargs=0               (baml.ops.equals_equals)
 
   149   164   jump_if_false +2                   (to 166)
         165   jump +7                            (to 172)
@@ -525,7 +525,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         168   load_field 1                       (stop_reason)
         169   load_const 15                      (ai.content.StopReason.Refused)
         170   alloc_variant 436                  (ai.content.StopReason)
-        171   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        171   call 654 ntypeargs=0               (baml.ops.equals_equals)
 
   149   172   jump_if_false +2                   (to 174)
         173   jump +5                            (to 178)
@@ -533,7 +533,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   152   175   load_type 0                        
         176   load_var2 1 28                     
-        177   call 843 ntypeargs=1               (ai.Agent._parses)
+        177   call 844 ntypeargs=1               (ai.Agent._parses)
 
   153   178   pop_jump_if_false +2               (to 180)
         179   jump +34                           (to 213)
@@ -545,7 +545,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         184   jump +12                           (to 196)
 
   175   185   load_var2 4 21                     
-        186   call 807 ntypeargs=0               (ai.Journal.append_all)
+        186   call 808 ntypeargs=0               (ai.Journal.append_all)
         187   pop 1                              
 
   176   188   load_var 2                         (c)
@@ -566,7 +566,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         201   pop 1                              
 
   172   202   load_var2 4 21                     
-        203   call 807 ntypeargs=0               (ai.Journal.append_all)
+        203   call 808 ntypeargs=0               (ai.Journal.append_all)
         204   pop 1                              
 
   173   205   load_type 0                        
@@ -575,11 +575,11 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         208   load_var2 5 6                      
         209   load_const 16                      (1)
         210   sub_int                            
-        211   call 844 ntypeargs=1               (ai.Agent._attempt_turn)
+        211   call 845 ntypeargs=1               (ai.Agent._attempt_turn)
         212   jump +19                           (to 231)
 
   154   213   load_var2 4 21                     
-        214   call 807 ntypeargs=0               (ai.Journal.append_all)
+        214   call 808 ntypeargs=0               (ai.Journal.append_all)
         215   pop 1                              
 
   156   216   load_var 7                         (turn)
@@ -623,7 +623,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
 function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> int {
   182   0    load_var 2             (j)
-        1    call 805 ntypeargs=0   (ai.Journal.entries)
+        1    call 806 ntypeargs=0   (ai.Journal.entries)
         2    store_var 4            (entries)
 
   183   3    load_var 3             (seen)
@@ -695,7 +695,7 @@ function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> in
 function ai.Agent._parses(self: ai.Agent<#0>, candidate: string) -> bool {
   100   0    load_type 0            
         1    load_var 2             (candidate)
-        2    call 426 ntypeargs=1   (baml.sap.parse)
+        2    call 427 ntypeargs=1   (baml.sap.parse)
         3    pop 1                  
         4    jump +5                (to 9)
         5    load_var 3             (e)
@@ -711,7 +711,7 @@ function ai.Agent._parses(self: ai.Agent<#0>, candidate: string) -> bool {
 function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: ai.content.ToolUse, j: ai.Journal) -> null {
   56   0     load_var2 2 3          
        1     load_field 1           (name)
-       2     call 822 ntypeargs=0   (ai.tools.Toolbox.get)
+       2     call 823 ntypeargs=0   (ai.tools.Toolbox.get)
        3     store_var 5            (_7)
        4     load_var 5             (_7)
        5     narrow_bind 0 5        
@@ -736,7 +736,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        20    init_instance 0        (ai.events.ToolFailed .id, .message)
        21    load_type 3            
        22    alloc_array 1          
-       23    call 807 ntypeargs=0   (ai.Journal.append_all)
+       23    call 808 ntypeargs=0   (ai.Journal.append_all)
        24    pop 1                  
 
   94   25    load_const 4           (null)
@@ -747,7 +747,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
 
   58   29    load_var2 6 3          
        30    load_field 2           (args)
-       31    call 817 ntypeargs=0   (ai.tools.Tool.call)
+       31    call 818 ntypeargs=0   (ai.tools.Tool.call)
        32    store_var 7            (outcome)
        33    jump +63               (to 96)
        34    load_var 8             (e)
@@ -767,7 +767,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        45    init_instance 1        (ai.events.ToolFailed .id, .message)
        46    load_type 3            
        47    alloc_array 1          
-       48    call 807 ntypeargs=0   (ai.Journal.append_all)
+       48    call 808 ntypeargs=0   (ai.Journal.append_all)
        49    pop 1                  
 
   64   50    load_var 6             (t)
@@ -785,7 +785,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        62    load_var 11            (_19)
        63    load_const 6           (ai.tools.ErrorMode.Raise)
        64    alloc_variant 437      (ai.tools.ErrorMode)
-       65    call 653 ntypeargs=0   (baml.ops.equals_equals)
+       65    call 654 ntypeargs=0   (baml.ops.equals_equals)
        66    pop_jump_if_false +2   (to 68)
        67    jump +4                (to 71)
 
@@ -840,7 +840,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        104   init_instance 3        (ai.events.ToolCompleted .id, .output)
        105   load_type 3            
        106   alloc_array 1          
-       107   call 807 ntypeargs=0   (ai.Journal.append_all)
+       107   call 808 ntypeargs=0   (ai.Journal.append_all)
        108   pop 1                  
 
   83   109   load_const 4           (null)
@@ -886,7 +886,7 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
        30   pop_jump_if_false +4                       (to 34)
 
   41   31   load_type 4                                
-       32   make_closure 1720 captures=0 ntypeargs=1   
+       32   make_closure 1721 captures=0 ntypeargs=1   
        33   store_var 5                                (_9)
 
   35   34   load_var2 1 2                              
@@ -972,11 +972,11 @@ function ai.Journal.entries(self: ai.Journal) -> (ai.events.RunStarted | ai.even
 function ai.Journal.new(spec: ai.FunctionSpec<#0>) -> ai.Journal {
   21   0    load_type 0            
        1    load_var 1             (spec)
-       2    call 812 ntypeargs=1   (ai.FunctionSpec.name)
+       2    call 813 ntypeargs=1   (ai.FunctionSpec.name)
        3    store_var 2            (_4)
        4    load_type 0            
        5    load_var 1             (spec)
-       6    call 813 ntypeargs=1   (ai.FunctionSpec.arguments)
+       6    call 814 ntypeargs=1   (ai.FunctionSpec.arguments)
        7    store_var 3            (_6)
        8    load_var2 2 3          
        9    init_instance 0        (ai.events.RunStarted .spec_name, .arguments)
@@ -1060,7 +1060,7 @@ function ai.ModelTurn.tool_uses(self: ai.ModelTurn) -> ai.content.ToolUse[] {
 
 function ai.Prompt.baml.ToString.to_string(self: ai.Prompt) -> string {
   35   0   load_var 1             (self)
-       1   call 808 ntypeargs=0   (ai.Prompt.text)
+       1   call 809 ntypeargs=0   (ai.Prompt.text)
        2   return                 
 }
 
@@ -1218,7 +1218,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         47   load_var 10                        (_17)
         48   load_const 6                       (ai.errors.RetrySafety.Safe)
         49   alloc_variant 438                  (ai.errors.RetrySafety)
-        50   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        50   call 654 ntypeargs=0               (baml.ops.equals_equals)
 
   155   51   pop_jump_if_false +2               (to 53)
         52   jump +3                            (to 55)
@@ -1230,7 +1230,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         56   load_var 3                         (index)
         57   load_const 4                       (1)
         58   add_int                            
-        59   call 838 ntypeargs=0               (ai.clients.Fallback._try)
+        59   call 839 ntypeargs=0               (ai.clients.Fallback._try)
         60   return                             
 }
 
@@ -1262,13 +1262,13 @@ function ai.clients.Fallback.root.Client.id(self: ai.clients.Fallback) -> string
 function ai.clients.Fallback.root.Client.invoke(self: ai.clients.Fallback, input: ai.ModelTurnInput) -> ai.ModelTurn {
   185   0   load_var2 1 2          
         1   load_const 0           (0)
-        2   call 838 ntypeargs=0   (ai.clients.Fallback._try)
+        2   call 839 ntypeargs=0   (ai.clients.Fallback._try)
         3   jump +6                (to 9)
         4   load_var 3             (e)
         5   throw_if_panic         
 
   186   6   load_var 3             (e)
-        7   call 856 ntypeargs=0   (ai.errors.normalize)
+        7   call 857 ntypeargs=0   (ai.errors.normalize)
         8   throw                  
         9   return                 
 }
@@ -1310,7 +1310,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        29   load_var 7                         (_11)
        30   load_const 5                       (ai.errors.RetrySafety.Safe)
        31   alloc_variant 438                  (ai.errors.RetrySafety)
-       32   call 653 ntypeargs=0               (baml.ops.equals_equals)
+       32   call 654 ntypeargs=0               (baml.ops.equals_equals)
 
   74   33   jump_if_false +5                   (to 38)
        34   pop 1                              
@@ -1336,8 +1336,8 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        49   add_int                            
 
   80   50   load_var 6                         (f)
-       51   call 830 ntypeargs=0               (ai.clients.Backoff.delay_ms)
-       52   call 502 ntypeargs=0               (baml.time.Duration.from_milliseconds)
+       51   call 831 ntypeargs=0               (ai.clients.Backoff.delay_ms)
+       52   call 503 ntypeargs=0               (baml.time.Duration.from_milliseconds)
 
   79   53   sys_op 255                         (baml.sys.sleep)
        54   pop 1                              
@@ -1349,7 +1349,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        59   load_var 3                         (remaining)
        60   load_const 3                       (1)
        61   sub_int                            
-       62   call 832 ntypeargs=0               (ai.clients.Retry._attempt)
+       62   call 833 ntypeargs=0               (ai.clients.Retry._attempt)
        63   return                             
 }
 
@@ -1394,7 +1394,7 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
        32   load_const 0           (<omitted>)
        33   load_const 0           (<omitted>)
        34   load_const 0           (<omitted>)
-       35   call 829 ntypeargs=0   (ai.clients.Backoff.new)
+       35   call 830 ntypeargs=0   (ai.clients.Backoff.new)
        36   store_var 6            (_10)
 
   61   37   load_var2 1 2          
@@ -1418,13 +1418,13 @@ function ai.clients.Retry.root.Client.invoke(self: ai.clients.Retry, input: ai.M
   99    0    load_var2 1 2          
         1    load_var 1             (self)
         2    load_field 1           (max_attempts)
-        3    call 832 ntypeargs=0   (ai.clients.Retry._attempt)
+        3    call 833 ntypeargs=0   (ai.clients.Retry._attempt)
         4    jump +6                (to 10)
         5    load_var 3             (e)
         6    throw_if_panic         
 
   100   7    load_var 3             (e)
-        8    call 856 ntypeargs=0   (ai.errors.normalize)
+        8    call 857 ntypeargs=0   (ai.errors.normalize)
         9    throw                  
         10   return                 
 }
@@ -1518,7 +1518,7 @@ function ai.clients.RoundRobin.root.Client.invoke(self: ai.clients.RoundRobin, i
         33   throw_if_panic                     
 
   141   34   load_var 4                         (e)
-        35   call 856 ntypeargs=0               (ai.errors.normalize)
+        35   call 857 ntypeargs=0               (ai.errors.normalize)
         36   throw                              
         37   load_var 3                         (_0)
         38   return                             
@@ -1694,7 +1694,7 @@ function ai.errors.normalize(error: unknown) -> ai.errors.Failure | baml.errors.
 
 function ai.internal._schema_for_signature(handler: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> map<string, unknown> {
   6    0    load_var 1                         (handler)
-       1    call 739 ntypeargs=0               (reflect.signature)
+       1    call 740 ntypeargs=0               (reflect.signature)
        2    store_var 2                        (sig)
 
   7    3    load_type 0                        
@@ -1729,7 +1729,7 @@ function ai.internal._schema_for_signature(handler: baml.AnyFunction<Returns = u
        29   store_var 8                        (_12)
        30   load_var 7                         (a)
        31   load_field 1                       (type)
-       32   sys_op 341                         (baml.json.schema)
+       32   sys_op 342                         (baml.json.schema)
        33   store_var 9                        (_13)
        34   load_type 0                        
        35   load_type 1                        
@@ -1775,10 +1775,10 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
 
   102   9     load_var2 4 2                      
         10    load_var 3                         (params)
-        11    call 926 ntypeargs=0               (ai.mcp.rpc_line)
+        11    call 927 ntypeargs=0               (ai.mcp.rpc_line)
         12    store_var 5                        (_6)
         13    load_var2 1 5                      
-        14    call 928 ntypeargs=0               (ai.mcp.McpConnection._send)
+        14    call 929 ntypeargs=0               (ai.mcp.McpConnection._send)
         15    pop 1                              
 
   103   16    load_const 1                       (true)
@@ -1884,7 +1884,7 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         100   pop_jump_if_false -84              (to 16)
 
   118   101   load_var 12                        (trimmed)
-        102   call 327 ntypeargs=0               (baml.json.parse)
+        102   call 328 ntypeargs=0               (baml.json.parse)
         103   store_var 13                       (msg)
         104   jump +5                            (to 109)
         105   load_var 14                        (e)
@@ -1898,7 +1898,7 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         111   load_const 15                      (".id")
         112   load_const 0                       (1)
         113   unary_op -                         
-        114   call 340 ntypeargs=1               (baml.json.path_or)
+        114   call 341 ntypeargs=1               (baml.json.path_or)
         115   load_var 4                         (id)
         116   cmp_int_op ==                      
         117   pop_jump_if_false -101             (to 16)
@@ -1907,12 +1907,12 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         119   load_var 13                        (msg)
         120   load_const 17                      (".error")
         121   load_const 5                       (null)
-        122   call 340 ntypeargs=1               (baml.json.path_or)
+        122   call 341 ntypeargs=1               (baml.json.path_or)
         123   store_var 15                       (err)
 
   123   124   load_var 15                        (err)
         125   load_const 5                       (null)
-        126   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        126   call 654 ntypeargs=0               (baml.ops.equals_equals)
         127   unary_op !                         
         128   pop_jump_if_false +2               (to 130)
         129   jump +7                            (to 136)
@@ -1921,7 +1921,7 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         131   load_var 13                        (msg)
         132   load_const 18                      (".result")
         133   load_const 5                       (null)
-        134   call 340 ntypeargs=1               (baml.json.path_or)
+        134   call 341 ntypeargs=1               (baml.json.path_or)
         135   return                             
 
   125   136   load_type 2                        
@@ -1934,18 +1934,18 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         142   load_var 15                        (err)
         143   load_const 20                      (".code")
         144   load_const 5                       (null)
-        145   call 340 ntypeargs=1               (baml.json.path_or)
+        145   call 341 ntypeargs=1               (baml.json.path_or)
         146   store_var 17                       (_46)
 
   127   147   load_type 2                        
         148   load_var 15                        (err)
         149   load_const 21                      (".message")
         150   load_const 22                      ("MCP error")
-        151   call 340 ntypeargs=1               (baml.json.path_or)
+        151   call 341 ntypeargs=1               (baml.json.path_or)
         152   store_var 18                       (_49)
 
   128   153   load_var 15                        (err)
-        154   call 328 ntypeargs=0               (baml.json.stringify)
+        154   call 329 ntypeargs=0               (baml.json.stringify)
         155   store_var 19                       (_52)
 
   125   156   load_const 23                      ("mcp/")
@@ -2016,7 +2016,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         5    load_type 3                        
         6    load_type 4                        
         7    alloc_map 2                        
-        8    call 929 ntypeargs=0               (ai.mcp.McpConnection._request)
+        8    call 930 ntypeargs=0               (ai.mcp.McpConnection._request)
         9    store_var 4                        (result)
 
   185   10   load_type 3                        
@@ -2028,7 +2028,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         15   load_const 6                       (".content")
         16   load_type 7                        
         17   alloc_array 0                      
-        18   call 340 ntypeargs=1               (baml.json.path_or)
+        18   call 341 ntypeargs=1               (baml.json.path_or)
         19   load_type 8                        
         20   load_const 9                       ("iter")
         21   virtual_call nargs=1 ntypeargs=0   
@@ -2049,7 +2049,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         35   load_var 8                         (item)
         36   load_const 13                      (".type")
         37   load_const 14                      ("")
-        38   call 340 ntypeargs=1               (baml.json.path_or)
+        38   call 341 ntypeargs=1               (baml.json.path_or)
         39   load_const 15                      ("text")
         40   cmp_op ==                          
         41   pop_jump_if_false -18              (to 23)
@@ -2058,7 +2058,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         43   load_var 8                         (item)
         44   load_const 16                      (".text")
         45   load_const 17                      ("")
-        46   call 340 ntypeargs=1               (baml.json.path_or)
+        46   call 341 ntypeargs=1               (baml.json.path_or)
         47   store_var 9                        (_22)
         48   load_type 3                        
         49   load_var2 5 9                      
@@ -2076,7 +2076,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         59   load_var 4                         (result)
         60   load_const 20                      (".isError")
         61   load_const 21                      (false)
-        62   call 340 ntypeargs=1               (baml.json.path_or)
+        62   call 341 ntypeargs=1               (baml.json.path_or)
         63   pop_jump_if_false +2               (to 65)
         64   jump +3                            (to 67)
 
@@ -2185,16 +2185,16 @@ function ai.mcp.McpConnection.connect(name: string, command: string, args: strin
        59   load_type 4            
        60   load_type 11           
        61   alloc_map 3            
-       62   call 929 ntypeargs=0   (ai.mcp.McpConnection._request)
+       62   call 930 ntypeargs=0   (ai.mcp.McpConnection._request)
        63   pop 1                  
 
   76   64   load_const 2           (null)
        65   load_const 19          ("notifications/initialized")
        66   load_const 2           (null)
-       67   call 926 ntypeargs=0   (ai.mcp.rpc_line)
+       67   call 927 ntypeargs=0   (ai.mcp.rpc_line)
        68   store_var 11           (_26)
        69   load_var2 10 11        
-       70   call 928 ntypeargs=0   (ai.mcp.McpConnection._send)
+       70   call 929 ntypeargs=0   (ai.mcp.McpConnection._send)
        71   pop 1                  
 
   77   72   load_var 10            (conn)
@@ -2207,7 +2207,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         2    load_type 1                        
         3    load_type 2                        
         4    alloc_map 0                        
-        5    call 929 ntypeargs=0               (ai.mcp.McpConnection._request)
+        5    call 930 ntypeargs=0               (ai.mcp.McpConnection._request)
         6    store_var 2                        (result)
 
   157   7    load_type 3                        
@@ -2219,7 +2219,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         12   load_const 5                       (".tools")
         13   load_type 6                        
         14   alloc_array 0                      
-        15   call 340 ntypeargs=1               (baml.json.path_or)
+        15   call 341 ntypeargs=1               (baml.json.path_or)
         16   load_type 7                        
         17   load_const 8                       ("iter")
         18   virtual_call nargs=1 ntypeargs=0   
@@ -2240,7 +2240,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         32   load_var 6                         (t)
         33   load_const 12                      (".name")
         34   load_const 13                      ("")
-        35   call 340 ntypeargs=1               (baml.json.path_or)
+        35   call 341 ntypeargs=1               (baml.json.path_or)
         36   store_var 7                        (tool_name)
 
   161   37   load_type 6                        
@@ -2249,12 +2249,12 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         40   load_type 1                        
         41   load_type 6                        
         42   alloc_map 0                        
-        43   call 340 ntypeargs=1               (baml.json.path_or)
+        43   call 341 ntypeargs=1               (baml.json.path_or)
         44   store_var 10                       (_19)
 
   160   45   load_type 15                       
         46   load_var 10                        (_19)
-        47   call 334 ntypeargs=1               (baml.json.from_json)
+        47   call 335 ntypeargs=1               (baml.json.from_json)
         48   store_var 8                        (schema)
         49   jump +7                            (to 56)
         50   load_var 9                         (e)
@@ -2269,20 +2269,20 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         57   load_var 6                         (t)
         58   load_const 16                      (".description")
         59   load_const 17                      ("")
-        60   call 340 ntypeargs=1               (baml.json.path_or)
+        60   call 341 ntypeargs=1               (baml.json.path_or)
         61   store_var 12                       (_28)
 
   172   62   load_var 8                         (schema)
         63   store_var 13                       (_31)
 
   173   64   load_var2 1 7                      
-        65   call 925 ntypeargs=0               (ai.mcp._proxy)
+        65   call 926 ntypeargs=0               (ai.mcp._proxy)
         66   store_var 14                       (_32)
 
   170   67   load_var2 7 12                     
         68   load_var2 13 14                    
         69   load_const 18                      (<omitted>)
-        70   call 819 ntypeargs=0               (ai.tools.raw_tool)
+        70   call 820 ntypeargs=0               (ai.tools.raw_tool)
         71   store_var 11                       (_26)
 
   168   72   load_type 3                        
@@ -2304,7 +2304,7 @@ function ai.mcp._proxy(conn: ai.mcp.McpConnection, name: string) -> (map<string,
        5   store_var 2           
 
   20   6   load_var2 1 2         
-       7   make_closure 2304 2   
+       7   make_closure 2305 2   
        8   return                
 }
 
@@ -2350,8 +2350,8 @@ function ai.mcp.rpc_line(id: int | null, method: string, params: map<string, unk
 
   34   32   load_type 7            
        33   load_var 4             (m)
-       34   call 331 ntypeargs=1   (baml.json.to_json)
-       35   call 328 ntypeargs=0   (baml.json.stringify)
+       34   call 332 ntypeargs=1   (baml.json.to_json)
+       35   call 329 ntypeargs=0   (baml.json.stringify)
        36   return                 
 }
 
@@ -2361,7 +2361,7 @@ function ai.prompt(body: ((string) -> baml.prompt.Role throws never, baml.prompt
        2   store_var 1           
 
   49   3   load_var 1            (body)
-       4   make_closure 1654 1   
+       4   make_closure 1655 1   
        5   return                
 }
 
@@ -2378,7 +2378,7 @@ function ai.stream.Stream.final(self: ai.stream.Stream<#0, #1>) -> #1 {
         8    load_field 1           (_cache)
         9    load_type 0            
         10   load_type 1            
-        11   sys_op 424             (baml.sap.__parse_final)
+        11   sys_op 425             (baml.sap.__parse_final)
         12   return                 
 
   279   13   load_var 1             (self)
@@ -2443,7 +2443,7 @@ function ai.stream.Stream.next(self: ai.stream.Stream<#0, #1>) -> #0 | ai.stream
         27   load_field 1                     (_cache)
         28   load_type 3                      
         29   load_type 4                      
-        30   sys_op 425                       (baml.sap.__parse_partial)
+        30   sys_op 426                       (baml.sap.__parse_partial)
         31   store_var 3                      (parsed)
 
   264   32   load_var 3                       (parsed)
@@ -2491,7 +2491,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         1    pop_jump_if_false +7   (to 8)
 
   216   2    load_var 1             (self)
-        3    call 851 ntypeargs=0   (ai.stream.TurnStream.next)
+        3    call 852 ntypeargs=0   (ai.stream.TurnStream.next)
         4    store_var 2            (_3)
         5    load_var 2             (_3)
         6    narrow_bind 1 2        
@@ -2500,7 +2500,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
   223   8    load_var 1             (self)
         9    load_field 8           (_input_tokens)
         10   load_const 2           (null)
-        11   call 653 ntypeargs=0   (baml.ops.equals_equals)
+        11   call 654 ntypeargs=0   (baml.ops.equals_equals)
         12   unary_op !             
         13   jump_if_false +2       (to 15)
         14   jump +7                (to 21)
@@ -2508,7 +2508,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         16   load_var 1             (self)
         17   load_field 9           (_output_tokens)
         18   load_const 2           (null)
-        19   call 653 ntypeargs=0   (baml.ops.equals_equals)
+        19   call 654 ntypeargs=0   (baml.ops.equals_equals)
         20   unary_op !             
         21   pop_jump_if_false +2   (to 23)
         22   jump +4                (to 26)
@@ -2656,7 +2656,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         38    jump +6                            (to 44)
 
   202   39    load_var 1                         (self)
-        40    call 850 ntypeargs=0               (ai.stream.TurnStream._finish)
+        40    call 851 ntypeargs=0               (ai.stream.TurnStream._finish)
         41    pop 1                              
 
   203   42    alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2734,7 +2734,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         102   jump -15                           (to 87)
 
   176   103   load_var 1                         (self)
-        104   call 850 ntypeargs=0               (ai.stream.TurnStream._finish)
+        104   call 851 ntypeargs=0               (ai.stream.TurnStream._finish)
         105   pop 1                              
 
   177   106   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2774,7 +2774,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         137   pop_jump_if_false -137             (to 0)
 
   165   138   load_var 1                         (self)
-        139   call 850 ntypeargs=0               (ai.stream.TurnStream._finish)
+        139   call 851 ntypeargs=0               (ai.stream.TurnStream._finish)
         140   pop 1                              
 
   166   141   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2845,7 +2845,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
 function ai.stream.decode_sse_batch(batch: string) -> ai.stream.SseEvent[] {
   27   0   load_type 0            
        1   load_var 1             (batch)
-       2   call 333 ntypeargs=1   (baml.json.from_string)
+       2   call 334 ntypeargs=1   (baml.json.from_string)
        3   return                 
 }
 
@@ -2863,8 +2863,8 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   306   9     load_type 2                                
         10    load_var 1                                 (spec)
-        11    call 816 ntypeargs=1                       (ai.FunctionSpec.tools)
-        12    call 823 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
+        11    call 817 ntypeargs=1                       (ai.FunctionSpec.tools)
+        12    call 824 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
         13    unary_op !                                 
         14    pop_jump_if_false +2                       (to 16)
         15    jump +71                                   (to 86)
@@ -2914,17 +2914,17 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   331   51    load_type 2                                
         52    load_var 1                                 (spec)
-        53    call 806 ntypeargs=1                       (ai.Journal.new)
+        53    call 807 ntypeargs=1                       (ai.Journal.new)
         54    store_var 12                               (_29)
 
   332   55    load_type 2                                
         56    load_var 1                                 (spec)
-        57    call 816 ntypeargs=1                       (ai.FunctionSpec.tools)
+        57    call 817 ntypeargs=1                       (ai.FunctionSpec.tools)
         58    store_var 13                               (_31)
 
   333   59    load_type 2                                
         60    load_var 1                                 (spec)
-        61    call 814 ntypeargs=1                       (ai.FunctionSpec.output_type)
+        61    call 815 ntypeargs=1                       (ai.FunctionSpec.output_type)
         62    store_var 14                               (_33)
 
   328   63    load_var2 5 11                             
@@ -2939,13 +2939,13 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   346   71    load_type 8                                
         72    load_type 2                                
-        73    call 423 ntypeargs=2                       (baml.sap.__new_parse_cache)
+        73    call 424 ntypeargs=2                       (baml.sap.__new_parse_cache)
         74    store_var 15                               (_36)
 
   340   75    load_type 8                                
         76    load_type 2                                
         77    load_var 10                                (turns)
-        78    make_closure 1760 captures=1 ntypeargs=2   
+        78    make_closure 1761 captures=1 ntypeargs=2   
         79    load_var 15                                (_36)
         80    load_const 9                               ("")
         81    load_const 10                              (false)
@@ -2956,7 +2956,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   308   86    load_type 2                                
         87    load_var 1                                 (spec)
-        88    call 812 ntypeargs=1                       (ai.FunctionSpec.name)
+        88    call 813 ntypeargs=1                       (ai.FunctionSpec.name)
         89    store_var 4                                (_12)
         90    load_type 11                               
         91    load_var 4                                 (_12)
@@ -3005,7 +3005,7 @@ function ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> 
        27   load_type 5            
 
   29   28   load_var2 4 2          
-       29   call 740 ntypeargs=2   (reflect.call_any)
+       29   call 741 ntypeargs=2   (reflect.call_any)
        30   store_var 5            (value)
        31   jump +33               (to 64)
 
@@ -3045,8 +3045,8 @@ function ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> 
 
   35   64   load_type 5            
        65   load_var 5             (value)
-       66   call 331 ntypeargs=1   (baml.json.to_json)
-       67   call 328 ntypeargs=0   (baml.json.stringify)
+       66   call 332 ntypeargs=1   (baml.json.to_json)
+       67   call 329 ntypeargs=0   (baml.json.stringify)
        68   jump +3                (to 71)
 
   27   69   load_var2 2 3          
@@ -3065,7 +3065,7 @@ function ai.tools.Toolbox.get(self: ai.tools.Toolbox, name: string) -> ai.tools.
         5    load_var 1            (self)
         6    load_field 0          (entries)
         7    load_var 2            (name)
-        8    make_closure 1680 1   
+        8    make_closure 1681 1   
         9    call 19 ntypeargs=2   (baml.Array.find)
         10   return                
 }
@@ -3190,7 +3190,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        17   store_var 4            (on_error)
 
   49   18   load_var 1             (handler)
-       19   call 739 ntypeargs=0   (reflect.signature)
+       19   call 740 ntypeargs=0   (reflect.signature)
        20   store_var 5            (sig)
 
   50   21   load_var 2             (name)
@@ -3241,7 +3241,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        61   store_var 9            (_17)
 
   58   62   load_var 1             (handler)
-       63   call 866 ntypeargs=0   (ai.internal._schema_for_signature)
+       63   call 867 ntypeargs=0   (ai.internal._schema_for_signature)
        64   store_var 11           (_21)
 
   56   65   load_var2 8 9          
@@ -3258,7 +3258,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
 
 function ai.wire.render_output_format(t: type) -> string {
   37   0   load_var 1   (t)
-       1   sys_op 418   (baml.prompt.render_output_format)
+       1   sys_op 419   (baml.prompt.render_output_format)
        2   return       
 }
 
@@ -3310,7 +3310,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
 
   29   38   load_type 6            
        39   load_var 7             (text)
-       40   call 333 ntypeargs=1   (baml.json.from_string)
+       40   call 334 ntypeargs=1   (baml.json.from_string)
        41   jump +6                (to 47)
        42   load_var 9             (e)
        43   throw_if_panic         
@@ -3323,7 +3323,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
   27   48   load_var2 2 3          
        49   load_field 0           (status_code)
        50   load_var 7             (text)
-       51   call 865 ntypeargs=0   (ai.errors.classify_http)
+       51   call 866 ntypeargs=0   (ai.errors.classify_http)
        52   throw                  
 }
 
@@ -3341,20 +3341,20 @@ function anthropic.AnthropicClient.ai.Client.id(self: anthropic.AnthropicClient)
 
 function anthropic.AnthropicClient.ai.Client.invoke(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   32   0   load_var2 1 2          
-       1   call 893 ntypeargs=0   (anthropic.internal.invoke)
+       1   call 894 ntypeargs=0   (anthropic.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   33   5   load_var 3             (e)
-       6   call 856 ntypeargs=0   (ai.errors.normalize)
+       6   call 857 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function anthropic.AnthropicClient.ai.stream.StreamingClient.invoke_stream(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   40   0   load_var2 1 2          
-       1   call 895 ntypeargs=0   (anthropic.internal.invoke_stream)
+       1   call 896 ntypeargs=0   (anthropic.internal.invoke_stream)
        2   return                 
 }
 
@@ -3518,7 +3518,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         2     store_var 2                        (out)
 
   349   3     load_var 1                         (batch)
-        4     call 847 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 848 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -3544,7 +3544,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
   351   25    load_type 7                        
 
   350   26    load_var 6                         (_10)
-        27    call 333 ntypeargs=1               (baml.json.from_string)
+        27    call 334 ntypeargs=1               (baml.json.from_string)
         28    jump +4                            (to 32)
 
   351   29    load_var 7                         (e)
@@ -3629,7 +3629,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         99    pop_jump_if_false +2               (to 101)
         100   jump +5                            (to 105)
         101   load_var 21                        (_67)
-        102   call 892 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+        102   call 893 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         103   store_var 20                       (stop)
         104   jump +3                            (to 107)
 
@@ -3792,7 +3792,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         2     store_var 2                        (msgs)
 
   132   3     load_var 1                         (j)
-        4     call 805 ntypeargs=0               (ai.Journal.entries)
+        4     call 806 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -3840,7 +3840,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         47    load_var 14                        (f)
         48    load_field 1                       (message)
         49    load_const 10                      (true)
-        50    call 888 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        50    call 889 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         51    pop 1                              
         52    jump -43                           (to 9)
 
@@ -3852,13 +3852,13 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         57    load_var 12                        (c)
         58    load_field 1                       (output)
         59    load_const 11                      (false)
-        60    call 888 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        60    call 889 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         61    pop 1                              
         62    jump -53                           (to 9)
 
   133   63    load_var 9                         (_25)
         64    load_field 0                       (content)
-        65    call 887 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
+        65    call 888 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
         66    store_var 10                       (_29)
 
   142   67    load_type 0                        
@@ -3923,7 +3923,7 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
        5    store_var 3                        (messages)
 
   53   6    load_var 1                         (prompt)
-       7    call 809 ntypeargs=0               (ai.Prompt.messages)
+       7    call 810 ntypeargs=0               (ai.Prompt.messages)
        8    load_type 2                        
        9    load_const 3                       ("iter")
        10   virtual_call nargs=1 ntypeargs=0   
@@ -4166,11 +4166,11 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         2     store_var 4                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 827 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 828 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 4                         (_5)
         7     call_indirect                      
 
-  183   8     call 886 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
+  183   8     call 887 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
         9     store_var 5                        (prompt_parts)
 
   184   10    load_var 5                         (prompt_parts)
@@ -4183,7 +4183,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   186   16    load_var 2                         (input)
         17    load_field 1                       (journal)
-        18    call 889 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
+        18    call 890 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
         19    load_type 0                        
         20    load_const 1                       ("iter")
         21    virtual_call nargs=1 ntypeargs=0   
@@ -4285,7 +4285,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         108   pop 1                              
 
   210   109   load_var 7                         (lowered)
-        110   call 890 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        110   call 891 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         111   store_var 16                       (_61)
         112   load_type 6                        
         113   load_type 7                        
@@ -4307,7 +4307,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   201   127   load_var 7                         (lowered)
         128   call 7 ntypeargs=1                 (baml.Array.concat)
-        129   call 890 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        129   call 891 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         130   store_var 14                       (_46)
         131   load_type 6                        
         132   load_type 7                        
@@ -4319,7 +4319,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   213   138   load_var 2                         (input)
         139   load_field 2                       (toolbox)
-        140   call 823 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        140   call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         141   unary_op !                         
         142   pop_jump_if_false +80              (to 222)
 
@@ -4329,7 +4329,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   215   146   load_var 2                         (input)
         147   load_field 2                       (toolbox)
-        148   call 821 ntypeargs=0               (ai.tools.Toolbox.list)
+        148   call 822 ntypeargs=0               (ai.tools.Toolbox.list)
         149   load_type 20                       
         150   load_const 21                      ("iter")
         151   virtual_call nargs=1 ntypeargs=0   
@@ -4463,8 +4463,8 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   247   264   load_type 19                       
         265   load_var 10                        (body)
-        266   call 331 ntypeargs=1               (baml.json.to_json)
-        267   call 328 ntypeargs=0               (baml.json.stringify)
+        266   call 332 ntypeargs=1               (baml.json.to_json)
+        267   call 329 ntypeargs=0               (baml.json.stringify)
         268   store_var 28                       (_118)
 
   239   269   load_const 40                      ("POST")
@@ -4519,13 +4519,13 @@ function anthropic.internal._anthropic_stop_reason(s: string) -> ai.content.Stop
 function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   266   0     load_var2 1 2                      
         1     load_const 0                       (false)
-        2     call 891 ntypeargs=0               (anthropic.internal._anthropic_request)
+        2     call 892 ntypeargs=0               (anthropic.internal._anthropic_request)
         3     store_var 3                        (req)
 
   267   4     load_type 1                        
         5     load_var 3                         (req)
         6     load_const 2                       ("anthropic")
-        7     call 826 ntypeargs=1               (ai.wire.send_as)
+        7     call 827 ntypeargs=1               (ai.wire.send_as)
         8     store_var 4                        (resp)
 
   269   9     load_type 3                        
@@ -4661,7 +4661,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         126   pop_jump_if_false +2               (to 128)
         127   jump +5                            (to 132)
         128   load_var 20                        (_46)
-        129   call 892 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+        129   call 893 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         130   store_var 19                       (stop)
         131   jump +4                            (to 135)
 
@@ -4702,7 +4702,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
 function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   415   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 891 ntypeargs=0   (anthropic.internal._anthropic_request)
+        2    call 892 ntypeargs=0   (anthropic.internal._anthropic_request)
 
   416   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -4728,7 +4728,7 @@ function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: a
         21   throw                  
 
   425   22   load_const 6           (anthropic.internal._anthropic_decode_batch)
-        23   call 848 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 849 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -4822,7 +4822,7 @@ function assert.contains(haystack: string, needle: string) -> null {
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   59   0    load_var2 1 2          
-       1    call 653 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 654 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -4832,14 +4832,14 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   59   6    jump +23               (to 29)
 
   61   7    load_var 1             (actual)
-       8    call 800 ntypeargs=0   (assert.format_operand)
+       8    call 801 ntypeargs=0   (assert.format_operand)
        9    store_var 4            (_9)
        10   load_type 1            
        11   load_var 4             (_9)
        12   call 138 ntypeargs=1   (baml.String.from)
        13   store_var 3            (_8)
        14   load_var 2             (expected)
-       15   call 800 ntypeargs=0   (assert.format_operand)
+       15   call 801 ntypeargs=0   (assert.format_operand)
        16   store_var 6            (_12)
        17   load_type 1            
        18   load_var 6             (_12)
@@ -4933,7 +4933,7 @@ function assert.is_type(actual: unknown) -> #0 {
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 653 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 654 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -4969,13 +4969,13 @@ function claude_code.ClaudeCodeClient.ai.Client.id(self: claude_code.ClaudeCodeC
 
 function claude_code.ClaudeCodeClient.ai.Client.invoke(self: claude_code.ClaudeCodeClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   44   0   load_var2 1 2          
-       1   call 924 ntypeargs=0   (claude_code.internal.invoke)
+       1   call 925 ntypeargs=0   (claude_code.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   45   5   load_var 3             (e)
-       6   call 856 ntypeargs=0   (ai.errors.normalize)
+       6   call 857 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
@@ -5057,7 +5057,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         1     load_var 1                         (raw)
         2     load_const 1                       (".type")
         3     load_const 2                       ("?")
-        4     call 340 ntypeargs=1               (baml.json.path_or)
+        4     call 341 ntypeargs=1               (baml.json.path_or)
         5     store_var 2                        (kind)
 
   164   6     load_var 2                         (kind)
@@ -5111,7 +5111,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         49    load_const 14                      (".message.content")
         50    load_type 15                       
         51    alloc_array 0                      
-        52    call 340 ntypeargs=1               (baml.json.path_or)
+        52    call 341 ntypeargs=1               (baml.json.path_or)
 
   180   53    load_type 16                       
         54    load_const 17                      ("iter")
@@ -5133,7 +5133,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         69    load_var 12                        (b)
         70    load_const 21                      (".type")
         71    load_const 22                      ("?")
-        72    call 340 ntypeargs=1               (baml.json.path_or)
+        72    call 341 ntypeargs=1               (baml.json.path_or)
         73    store_var 13                       (bt)
 
   182   74    load_var 13                        (bt)
@@ -5174,7 +5174,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         106   load_var 12                        (b)
         107   load_const 28                      (".name")
         108   load_const 29                      ("?")
-        109   call 340 ntypeargs=1               (baml.json.path_or)
+        109   call 341 ntypeargs=1               (baml.json.path_or)
         110   store_var 19                       (_65)
         111   load_type 0                        
         112   load_var 19                        (_65)
@@ -5193,8 +5193,8 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         124   load_var 12                        (b)
         125   load_const 31                      (".thinking")
         126   load_const 32                      ("")
-        127   call 340 ntypeargs=1               (baml.json.path_or)
-        128   call 920 ntypeargs=0               (claude_code.internal._preview)
+        127   call 341 ntypeargs=1               (baml.json.path_or)
+        128   call 921 ntypeargs=0               (claude_code.internal._preview)
         129   store_var 17                       (_56)
         130   load_type 0                        
         131   load_var 17                        (_56)
@@ -5215,8 +5215,8 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         143   load_var 12                        (b)
         144   load_const 34                      (".text")
         145   load_const 35                      ("")
-        146   call 340 ntypeargs=1               (baml.json.path_or)
-        147   call 920 ntypeargs=0               (claude_code.internal._preview)
+        146   call 341 ntypeargs=1               (baml.json.path_or)
+        147   call 921 ntypeargs=0               (claude_code.internal._preview)
         148   store_var 15                       (_47)
         149   load_type 0                        
         150   load_var 15                        (_47)
@@ -5268,7 +5268,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         194   load_var 1                         (raw)
         195   load_const 45                      (".subtype")
         196   load_const 46                      ("?")
-        197   call 340 ntypeargs=1               (baml.json.path_or)
+        197   call 341 ntypeargs=1               (baml.json.path_or)
         198   store_var 3                        (subtype)
 
   166   199   load_var 3                         (subtype)
@@ -5285,7 +5285,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         209   load_var 1                         (raw)
         210   load_const 48                      (".model")
         211   load_const 49                      ("?")
-        212   call 340 ntypeargs=1               (baml.json.path_or)
+        212   call 341 ntypeargs=1               (baml.json.path_or)
         213   store_var 8                        (_23)
         214   load_type 0                        
         215   load_var 8                         (_23)
@@ -5316,7 +5316,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         236   load_var 1                         (raw)
         237   load_const 57                      (".estimated_tokens")
         238   load_const 58                      (0)
-        239   call 340 ntypeargs=1               (baml.json.path_or)
+        239   call 341 ntypeargs=1               (baml.json.path_or)
         240   store_var 5                        (_13)
         241   load_type 56                       
         242   load_var 5                         (_13)
@@ -5399,7 +5399,7 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         24   pop_jump_if_false -16              (to 8)
 
   131   25   load_var 5                         (trimmed)
-        26   call 327 ntypeargs=0               (baml.json.parse)
+        26   call 328 ntypeargs=0               (baml.json.parse)
         27   store_var 6                        (raw)
         28   jump +7                            (to 35)
         29   load_var 7                         (e)
@@ -5411,14 +5411,14 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         34   throw                              
 
   136   35   load_var 6                         (raw)
-        36   call 921 ntypeargs=0               (claude_code.internal._log_cc_event)
+        36   call 922 ntypeargs=0               (claude_code.internal._log_cc_event)
         37   pop 1                              
 
   137   38   load_type 8                        
         39   load_var 6                         (raw)
         40   load_const 9                       (".type")
         41   load_const 10                      ("")
-        42   call 340 ntypeargs=1               (baml.json.path_or)
+        42   call 341 ntypeargs=1               (baml.json.path_or)
         43   load_const 11                      ("result")
         44   cmp_op ==                          
         45   pop_jump_if_false -37              (to 8)
@@ -5430,7 +5430,7 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
 
   144   49   load_var 2                         (result)
         50   load_const 0                       (null)
-        51   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        51   call 654 ntypeargs=0               (baml.ops.equals_equals)
         52   pop_jump_if_false +2               (to 54)
         53   jump +3                            (to 56)
 
@@ -5473,7 +5473,7 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
         8    load_type 2           
         9    load_var 3            (_3)
 
-  220   10   make_closure 2240 0   
+  220   10   make_closure 2241 0   
         11   call 16 ntypeargs=3   (baml.Array.map)
         12   store_var 2           (_2)
 
@@ -5486,11 +5486,11 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
 
 function claude_code.internal.envelope_schema(output_type: type) -> map<string, unknown> {
   52   0     load_var 1             (output_type)
-       1     sys_op 341             (baml.json.schema)
+       1     sys_op 342             (baml.json.schema)
        2     store_var 3            (_3)
        3     load_type 0            
        4     load_var 3             (_3)
-       5     call 334 ntypeargs=1   (baml.json.from_json)
+       5     call 335 ntypeargs=1   (baml.json.from_json)
        6     store_var 2            (final_root)
 
   53   7     load_type 1            
@@ -5506,7 +5506,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        16    store_var 5            (call_props)
 
   55   17    load_const 4           ("string")
-       18    call 917 ntypeargs=0   (claude_code.internal._type_schema)
+       18    call 918 ntypeargs=0   (claude_code.internal._type_schema)
        19    store_var 6            (_10)
        20    load_type 1            
        21    load_type 2            
@@ -5517,7 +5517,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        26    pop 1                  
 
   56   27    load_const 6           ("string")
-       28    call 917 ntypeargs=0   (claude_code.internal._type_schema)
+       28    call 918 ntypeargs=0   (claude_code.internal._type_schema)
        29    store_var 7            (_14)
        30    load_type 1            
        31    load_type 2            
@@ -5528,7 +5528,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        36    pop 1                  
 
   57   37    load_const 8           ("object")
-       38    call 917 ntypeargs=0   (claude_code.internal._type_schema)
+       38    call 918 ntypeargs=0   (claude_code.internal._type_schema)
        39    store_var 8            (_18)
        40    load_type 1            
        41    load_type 2            
@@ -5659,11 +5659,11 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
 
   74   150   load_type 0            
        151   load_var 2             (final_root)
-       152   call 331 ntypeargs=1   (baml.json.to_json)
+       152   call 332 ntypeargs=1   (baml.json.to_json)
        153   store_var 14           (_67)
        154   load_type 0            
        155   load_var 12            (calls_schema)
-       156   call 331 ntypeargs=1   (baml.json.to_json)
+       156   call 332 ntypeargs=1   (baml.json.to_json)
        157   store_var 15           (_70)
        158   load_type 1            
        159   load_type 2            
@@ -5729,7 +5729,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
 
   82   212   load_var 4             (definitions)
        213   load_const 38          (null)
-       214   call 653 ntypeargs=0   (baml.ops.equals_equals)
+       214   call 654 ntypeargs=0   (baml.ops.equals_equals)
        215   unary_op !             
        216   pop_jump_if_false +8   (to 224)
 
@@ -5750,12 +5750,12 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         1     load_var 2                         (input)
         2     load_field 0                       (prompt)
         3     call_indirect                      
-        4     call 808 ntypeargs=0               (ai.Prompt.text)
+        4     call 809 ntypeargs=0               (ai.Prompt.text)
         5     store_var 4                        (instructions)
 
   234   6     load_var 2                         (input)
         7     load_field 2                       (toolbox)
-        8     call 823 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        8     call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         9     unary_op !                         
         10    store_var_load_var 5               (has_tools)
 
@@ -5764,17 +5764,17 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 
   238   13    load_var 2                         (input)
         14    load_field 3                       (output_type)
-        15    sys_op 341                         (baml.json.schema)
+        15    sys_op 342                         (baml.json.schema)
         16    store_var 6                        (schema)
         17    jump +9                            (to 26)
 
   236   18    load_var 2                         (input)
         19    load_field 3                       (output_type)
-        20    call 916 ntypeargs=0               (claude_code.internal.envelope_schema)
+        20    call 917 ntypeargs=0               (claude_code.internal.envelope_schema)
         21    store_var 7                        (_11)
         22    load_type 1                        
         23    load_var 7                         (_11)
-        24    call 331 ntypeargs=1               (baml.json.to_json)
+        24    call 332 ntypeargs=1               (baml.json.to_json)
         25    store_var 6                        (schema)
 
   240   26    load_var 5                         (has_tools)
@@ -5787,7 +5787,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         32    store_var 14                       (_29)
         33    load_var 2                         (input)
         34    load_field 1                       (journal)
-        35    call 915 ntypeargs=0               (claude_code.internal.transcript_text)
+        35    call 916 ntypeargs=0               (claude_code.internal.transcript_text)
         36    store_var 16                       (_33)
         37    load_type 2                        
         38    load_var 16                        (_33)
@@ -5805,7 +5805,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         48    store_var 9                        (_18)
         49    load_var 2                         (input)
         50    load_field 1                       (journal)
-        51    call 915 ntypeargs=0               (claude_code.internal.transcript_text)
+        51    call 916 ntypeargs=0               (claude_code.internal.transcript_text)
         52    store_var 11                       (_22)
         53    load_type 2                        
         54    load_var 11                        (_22)
@@ -5813,7 +5813,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         56    store_var 10                       (_21)
         57    load_var 2                         (input)
         58    load_field 2                       (toolbox)
-        59    call 918 ntypeargs=0               (claude_code.internal.tool_protocol)
+        59    call 919 ntypeargs=0               (claude_code.internal.tool_protocol)
         60    store_var 13                       (_26)
         61    load_type 2                        
         62    load_var 13                        (_26)
@@ -5839,7 +5839,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         81    store_var 18                       (_44)
         82    load_var 2                         (input)
         83    load_field 2                       (toolbox)
-        84    call 821 ntypeargs=0               (ai.tools.Toolbox.list)
+        84    call 822 ntypeargs=0               (ai.tools.Toolbox.list)
         85    container_len                      
         86    store_var 21                       (_48)
         87    load_type 3                        
@@ -5946,7 +5946,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         173   pop 1                              
 
   267   174   load_var 1                         (c)
-        175   call 922 ntypeargs=0               (claude_code.internal.mcp_config_json)
+        175   call 923 ntypeargs=0               (claude_code.internal.mcp_config_json)
         176   store_var 24                       (_81)
         177   load_var 24                        (_81)
         178   narrow_bind 21 24                  
@@ -5972,7 +5972,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         195   pop 1                              
 
   271   196   load_var 1                         (c)
-        197   call 923 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
+        197   call 924 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
         198   store_var 27                       (_93)
         199   load_type 2                        
         200   load_var 27                        (_93)
@@ -5993,7 +5993,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         214   pop 1                              
 
   274   215   load_var 6                         (schema)
-        216   call 328 ntypeargs=0               (baml.json.stringify)
+        216   call 329 ntypeargs=0               (baml.json.stringify)
         217   store_var 28                       (_99)
         218   load_type 2                        
         219   load_var2 22 28                    
@@ -6050,7 +6050,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         261   throw_if_panic                     
 
   299   262   load_var 29                        (p)
-        263   call 919 ntypeargs=0               (claude_code.internal._read_result)
+        263   call 920 ntypeargs=0               (claude_code.internal._read_result)
         264   store_var 36                       (result)
 
   300   265   load_var 29                        (p)
@@ -6088,7 +6088,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         292   load_var 36                        (result)
         293   load_const 34                      (".is_error")
         294   load_const 35                      (false)
-        295   call 340 ntypeargs=1               (baml.json.path_or)
+        295   call 341 ntypeargs=1               (baml.json.path_or)
         296   pop_jump_if_false +2               (to 298)
         297   jump +231                          (to 528)
 
@@ -6096,7 +6096,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         299   load_var 36                        (result)
         300   load_const 36                      (".subtype")
         301   load_const 37                      ("?")
-        302   call 340 ntypeargs=1               (baml.json.path_or)
+        302   call 341 ntypeargs=1               (baml.json.path_or)
         303   store_var 45                       (_154)
         304   load_type 2                        
         305   load_var 45                        (_154)
@@ -6106,7 +6106,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         309   load_var 36                        (result)
         310   load_const 39                      (".total_cost_usd")
         311   load_const 40                      (0.0)
-        312   call 340 ntypeargs=1               (baml.json.path_or)
+        312   call 341 ntypeargs=1               (baml.json.path_or)
         313   store_var 47                       (_159)
         314   load_type 38                       
         315   load_var 47                        (_159)
@@ -6116,7 +6116,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         319   load_var 36                        (result)
         320   load_const 41                      (".session_id")
         321   load_const 42                      ("?")
-        322   call 340 ntypeargs=1               (baml.json.path_or)
+        322   call 341 ntypeargs=1               (baml.json.path_or)
         323   store_var 49                       (_164)
         324   load_type 2                        
         325   load_var 49                        (_164)
@@ -6149,7 +6149,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
   328   348   load_type 50                       
         349   load_var 36                        (result)
         350   load_const 51                      (".structured_output")
-        351   call 339 ntypeargs=1               (baml.json.path)
+        351   call 340 ntypeargs=1               (baml.json.path)
         352   store_var 50                       (structured)
         353   jump +20                           (to 373)
         354   load_var 51                        (e)
@@ -6159,15 +6159,15 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         357   load_var 36                        (result)
         358   load_const 52                      (".result")
         359   load_const 53                      ("")
-        360   call 340 ntypeargs=1               (baml.json.path_or)
-        361   call 327 ntypeargs=0               (baml.json.parse)
+        360   call 341 ntypeargs=1               (baml.json.path_or)
+        361   call 328 ntypeargs=0               (baml.json.parse)
         362   store_var 50                       (structured)
         363   jump +10                           (to 373)
         364   load_var 52                        (inner)
         365   throw_if_panic                     
 
   334   366   load_var 36                        (result)
-        367   call 328 ntypeargs=0               (baml.json.stringify)
+        367   call 329 ntypeargs=0               (baml.json.stringify)
         368   store_var 53                       (_177)
 
   332   369   load_const 54                      ("claude-code")
@@ -6179,21 +6179,21 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         374   load_var 36                        (result)
         375   load_const 55                      (".usage.input_tokens")
         376   load_const 56                      (0)
-        377   call 340 ntypeargs=1               (baml.json.path_or)
+        377   call 341 ntypeargs=1               (baml.json.path_or)
         378   store_var 54                       (_180)
 
   343   379   load_type 3                        
         380   load_var 36                        (result)
         381   load_const 57                      (".usage.output_tokens")
         382   load_const 56                      (0)
-        383   call 340 ntypeargs=1               (baml.json.path_or)
+        383   call 341 ntypeargs=1               (baml.json.path_or)
         384   store_var 55                       (_183)
 
   344   385   load_type 58                       
         386   load_var 36                        (result)
         387   load_const 59                      (".usage.cache_read_input_tokens")
         388   load_const 26                      (null)
-        389   call 340 ntypeargs=1               (baml.json.path_or)
+        389   call 341 ntypeargs=1               (baml.json.path_or)
         390   store_var 56                       (_186)
 
   348   391   load_type 60                       
@@ -6209,7 +6209,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         399   jump +10                           (to 409)
 
   378   400   load_var 50                        (structured)
-        401   call 328 ntypeargs=0               (baml.json.stringify)
+        401   call 329 ntypeargs=0               (baml.json.stringify)
         402   store_var 74                       (_247)
         403   load_type 60                       
         404   load_var2 57 74                    
@@ -6222,14 +6222,14 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         410   load_var 36                        (result)
         411   load_const 61                      (".structured_output.outcome")
         412   load_var 50                        (structured)
-        413   call 340 ntypeargs=1               (baml.json.path_or)
+        413   call 341 ntypeargs=1               (baml.json.path_or)
         414   store_var 59                       (outcome)
 
   352   415   load_type 62                       
         416   load_var 59                        (outcome)
         417   load_const 63                      (".calls")
         418   load_const 26                      (null)
-        419   call 340 ntypeargs=1               (baml.json.path_or)
+        419   call 341 ntypeargs=1               (baml.json.path_or)
 
   353   420   store_var 60                       (_199)
         421   load_var 60                        (_199)
@@ -6238,7 +6238,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         424   jump +10                           (to 434)
 
   375   425   load_var 59                        (outcome)
-        426   call 328 ntypeargs=0               (baml.json.stringify)
+        426   call 329 ntypeargs=0               (baml.json.stringify)
         427   store_var 73                       (_242)
         428   load_type 60                       
         429   load_var2 57 73                    
@@ -6270,7 +6270,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 
   359   452   load_var 2                         (input)
         453   load_field 1                       (journal)
-        454   call 805 ntypeargs=0               (ai.Journal.entries)
+        454   call 806 ntypeargs=0               (ai.Journal.entries)
         455   container_len                      
         456   store_var 67                       (_214)
         457   load_type 3                        
@@ -6294,14 +6294,14 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         472   bin_op +                           
         473   load_var 68                        (_218)
         474   bin_op +                           
-        475   call 340 ntypeargs=1               (baml.json.path_or)
+        475   call 341 ntypeargs=1               (baml.json.path_or)
         476   store_var 65                       (id)
 
   361   477   load_type 2                        
         478   load_var 64                        (raw_call)
         479   load_const 73                      (".name")
         480   load_const 74                      ("")
-        481   call 340 ntypeargs=1               (baml.json.path_or)
+        481   call 341 ntypeargs=1               (baml.json.path_or)
         482   store_var 69                       (name)
 
   363   483   load_type 50                       
@@ -6310,12 +6310,12 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         486   load_type 2                        
         487   load_type 50                       
         488   alloc_map 0                        
-        489   call 340 ntypeargs=1               (baml.json.path_or)
+        489   call 341 ntypeargs=1               (baml.json.path_or)
         490   store_var 72                       (_227)
 
   362   491   load_type 1                        
         492   load_var 72                        (_227)
-        493   call 334 ntypeargs=1               (baml.json.from_json)
+        493   call 335 ntypeargs=1               (baml.json.from_json)
         494   store_var 70                       (call_args)
         495   jump +7                            (to 502)
         496   load_var 71                        (e)
@@ -6363,11 +6363,11 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         529   load_var 36                        (result)
         530   load_const 76                      (".subtype")
         531   load_const 77                      ("error")
-        532   call 340 ntypeargs=1               (baml.json.path_or)
+        532   call 341 ntypeargs=1               (baml.json.path_or)
         533   store_var 42                       (_143)
 
   322   534   load_var 36                        (result)
-        535   call 328 ntypeargs=0               (baml.json.stringify)
+        535   call 329 ntypeargs=0               (baml.json.stringify)
         536   store_var 43                       (_146)
 
   319   537   load_const 78                      ("claude-code")
@@ -6427,8 +6427,8 @@ function claude_code.internal.mcp_config_json(c: claude_code.ClaudeCodeClient) -
 
   212   21   load_type 4            
         22   load_var 3             (wrapper)
-        23   call 331 ntypeargs=1   (baml.json.to_json)
-        24   call 328 ntypeargs=0   (baml.json.stringify)
+        23   call 332 ntypeargs=1   (baml.json.to_json)
+        24   call 329 ntypeargs=0   (baml.json.stringify)
         25   jump +2                (to 27)
 
   208   26   load_const 5           (null)
@@ -6441,7 +6441,7 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         2    store_var 2                        (catalog)
 
   100   3    load_var 1                         (tb)
-        4    call 821 ntypeargs=0               (ai.tools.Toolbox.list)
+        4    call 822 ntypeargs=0               (ai.tools.Toolbox.list)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -6471,8 +6471,8 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         30   load_type 6                        
         31   load_var 5                         (t)
         32   load_field 2                       (input_schema)
-        33   call 331 ntypeargs=1               (baml.json.to_json)
-        34   call 328 ntypeargs=0               (baml.json.stringify)
+        33   call 332 ntypeargs=1               (baml.json.to_json)
+        34   call 329 ntypeargs=0               (baml.json.stringify)
         35   store_var 9                        (_23)
         36   load_type 0                        
         37   load_var 9                         (_23)
@@ -6523,7 +6523,7 @@ function claude_code.internal.transcript_text(j: ai.Journal) -> string {
        2     store_var 2                        (lines)
 
   8    3     load_var 1                         (j)
-       4     call 805 ntypeargs=0               (ai.Journal.entries)
+       4     call 806 ntypeargs=0               (ai.Journal.entries)
        5     load_type 1                        
        6     load_const 2                       ("iter")
        7     virtual_call nargs=1 ntypeargs=0   
@@ -6661,8 +6661,8 @@ function claude_code.internal.transcript_text(j: ai.Journal) -> string {
        131   load_type 20                       
        132   load_var 15                        (c)
        133   load_field 2                       (args)
-       134   call 331 ntypeargs=1               (baml.json.to_json)
-       135   call 328 ntypeargs=0               (baml.json.stringify)
+       134   call 332 ntypeargs=1               (baml.json.to_json)
+       135   call 329 ntypeargs=0               (baml.json.stringify)
        136   store_var 19                       (_49)
        137   load_type 0                        
        138   load_var 19                        (_49)
@@ -6763,20 +6763,20 @@ function google.GoogleClient.ai.Client.id(self: google.GoogleClient) -> string {
 
 function google.GoogleClient.ai.Client.invoke(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   22   0   load_var2 1 2          
-       1   call 909 ntypeargs=0   (google.internal.invoke)
+       1   call 910 ntypeargs=0   (google.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   23   5   load_var 3             (e)
-       6   call 856 ntypeargs=0   (ai.errors.normalize)
+       6   call 857 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function google.GoogleClient.ai.stream.StreamingClient.invoke_stream(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   30   0   load_var2 1 2          
-       1   call 911 ntypeargs=0   (google.internal.invoke_stream)
+       1   call 912 ntypeargs=0   (google.internal.invoke_stream)
        2   return                 
 }
 
@@ -6897,7 +6897,7 @@ function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string 
         1    store_var 3                        (name)
 
   110   2    load_var 1                         (j)
-        3    call 805 ntypeargs=0               (ai.Journal.entries)
+        3    call 806 ntypeargs=0               (ai.Journal.entries)
         4    load_type 1                        
         5    load_const 2                       ("iter")
         6    virtual_call nargs=1 ntypeargs=0   
@@ -6963,7 +6963,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         2     store_var 2                        (out)
 
   368   3     load_var 1                         (batch)
-        4     call 847 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 848 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -6988,7 +6988,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
   370   24    load_type 7                        
 
   369   25    load_var 5                         (_10)
-        26    call 333 ntypeargs=1               (baml.json.from_string)
+        26    call 334 ntypeargs=1               (baml.json.from_string)
         27    jump +4                            (to 31)
 
   370   28    load_var 6                         (e)
@@ -7130,7 +7130,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         154   jump +2                            (to 156)
         155   load_const 8                       (null)
         156   load_const 8                       (null)
-        157   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        157   call 654 ntypeargs=0               (baml.ops.equals_equals)
         158   store_var 21                       (_62)
 
   390   159   load_var 19                        (finish)
@@ -7201,14 +7201,14 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
 
   405   208   load_var 22                        (stop)
         209   load_const 8                       (null)
-        210   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        210   call 654 ntypeargs=0               (baml.ops.equals_equals)
         211   unary_op !                         
         212   jump_if_false +2                   (to 214)
         213   jump +6                            (to 219)
         214   pop 1                              
         215   load_var 23                        (usage)
         216   load_const 8                       (null)
-        217   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        217   call 654 ntypeargs=0               (baml.ops.equals_equals)
         218   unary_op !                         
         219   pop_jump_if_false -210             (to 9)
 
@@ -7258,11 +7258,11 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         2     store_var 4                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 827 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 828 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 4                         (_5)
         7     call_indirect                      
 
-  227   8     call 903 ntypeargs=0               (google.internal.google_lower_prompt)
+  227   8     call 904 ntypeargs=0               (google.internal.google_lower_prompt)
         9     store_var 5                        (prompt_parts)
 
   228   10    load_var 5                         (prompt_parts)
@@ -7271,7 +7271,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   229   13    load_var 2                         (input)
         14    load_field 1                       (journal)
-        15    call 905 ntypeargs=0               (google.internal.google_lower_journal)
+        15    call 906 ntypeargs=0               (google.internal.google_lower_journal)
         16    load_type 0                        
         17    load_const 1                       ("iter")
         18    virtual_call nargs=1 ntypeargs=0   
@@ -7350,7 +7350,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
   239   81    load_const 12                      ("user")
         82    load_var 5                         (prompt_parts)
         83    load_field 0                       (system_parts)
-        84    call 900 ntypeargs=0               (google.internal._gm_content)
+        84    call 901 ntypeargs=0               (google.internal._gm_content)
         85    store_var 11                       (_29)
         86    load_type 5                        
         87    load_var 11                        (_29)
@@ -7370,7 +7370,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   250   100   load_var 2                         (input)
         101   load_field 2                       (toolbox)
-        102   call 823 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        102   call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         103   unary_op !                         
         104   pop_jump_if_false +104             (to 208)
 
@@ -7380,7 +7380,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   252   108   load_var 2                         (input)
         109   load_field 2                       (toolbox)
-        110   call 821 ntypeargs=0               (ai.tools.Toolbox.list)
+        110   call 822 ntypeargs=0               (ai.tools.Toolbox.list)
         111   load_type 14                       
         112   load_const 15                      ("iter")
         113   virtual_call nargs=1 ntypeargs=0   
@@ -7549,8 +7549,8 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   283   256   load_type 5                        
         257   load_var 9                         (body)
-        258   call 331 ntypeargs=1               (baml.json.to_json)
-        259   call 328 ntypeargs=0               (baml.json.stringify)
+        258   call 332 ntypeargs=1               (baml.json.to_json)
+        259   call 329 ntypeargs=0               (baml.json.stringify)
         260   store_var 30                       (_118)
 
   276   261   load_const 35                      ("POST")
@@ -7577,7 +7577,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         5     store_var 3                        (pending)
 
   141   6     load_var 1                         (j)
-        7     call 805 ntypeargs=0               (ai.Journal.entries)
+        7     call 806 ntypeargs=0               (ai.Journal.entries)
         8     load_type 1                        
         9     load_const 2                       ("iter")
         10    virtual_call nargs=1 ntypeargs=0   
@@ -7636,9 +7636,9 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   199   60    load_var2 1 34                     
         61    load_field 0                       (id)
-        62    call 904 ntypeargs=0               (google.internal._gm_tool_name_for)
+        62    call 905 ntypeargs=0               (google.internal._gm_tool_name_for)
         63    load_var 35                        (response)
-        64    call 902 ntypeargs=0               (google.internal._gm_function_response)
+        64    call 903 ntypeargs=0               (google.internal._gm_function_response)
         65    store_var 36                       (_91)
         66    load_type 0                        
         67    load_var2 3 36                     
@@ -7665,9 +7665,9 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   193   85    load_var2 1 30                     
         86    load_field 0                       (id)
-        87    call 904 ntypeargs=0               (google.internal._gm_tool_name_for)
+        87    call 905 ntypeargs=0               (google.internal._gm_tool_name_for)
         88    load_var 31                        (response)
-        89    call 902 ntypeargs=0               (google.internal._gm_function_response)
+        89    call 903 ntypeargs=0               (google.internal._gm_function_response)
         90    store_var 32                       (_78)
         91    load_type 0                        
         92    load_var2 3 32                     
@@ -7688,7 +7688,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   156   105   load_const 15                      ("user")
         106   load_var 3                         (pending)
-        107   call 900 ntypeargs=0               (google.internal._gm_content)
+        107   call 901 ntypeargs=0               (google.internal._gm_content)
         108   store_var 16                       (_29)
         109   load_type 0                        
         110   load_var2 2 16                     
@@ -7779,7 +7779,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   164   185   load_var 21                        (_39)
         186   load_field 0                       (text)
-        187   call 901 ntypeargs=0               (google.internal._gm_text_part)
+        187   call 902 ntypeargs=0               (google.internal._gm_text_part)
         188   store_var 22                       (_42)
 
   166   189   load_type 0                        
@@ -7798,7 +7798,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   183   201   load_const 25                      ("model")
         202   load_var 17                        (parts)
-        203   call 900 ntypeargs=0               (google.internal._gm_content)
+        203   call 901 ntypeargs=0               (google.internal._gm_content)
         204   store_var 28                       (_67)
         205   load_type 0                        
         206   load_var2 2 28                     
@@ -7819,7 +7819,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   145   219   load_const 26                      ("user")
         220   load_var 3                         (pending)
-        221   call 900 ntypeargs=0               (google.internal._gm_content)
+        221   call 901 ntypeargs=0               (google.internal._gm_content)
         222   store_var 10                       (_15)
         223   load_type 0                        
         224   load_var2 2 10                     
@@ -7832,13 +7832,13 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   151   230   load_var 8                         (u)
         231   load_field 0                       (content)
-        232   call 901 ntypeargs=0               (google.internal._gm_text_part)
+        232   call 902 ntypeargs=0               (google.internal._gm_text_part)
         233   store_var 12                       (_21)
         234   load_const 27                      ("user")
         235   load_var 12                        (_21)
         236   load_type 0                        
         237   alloc_array 1                      
-        238   call 900 ntypeargs=0               (google.internal._gm_content)
+        238   call 901 ntypeargs=0               (google.internal._gm_content)
         239   store_var 11                       (_19)
         240   load_type 0                        
         241   load_var2 2 11                     
@@ -7856,7 +7856,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   206   252   load_const 28                      ("user")
         253   load_var 3                         (pending)
-        254   call 900 ntypeargs=0               (google.internal._gm_content)
+        254   call 901 ntypeargs=0               (google.internal._gm_content)
         255   store_var 38                       (_99)
         256   load_type 0                        
         257   load_var2 2 38                     
@@ -7880,7 +7880,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
         7    store_var 4                        (first_role)
 
   82    8    load_var 1                         (prompt)
-        9    call 809 ntypeargs=0               (ai.Prompt.messages)
+        9    call 810 ntypeargs=0               (ai.Prompt.messages)
         10   load_type 2                        
         11   load_const 3                       ("iter")
         12   virtual_call nargs=1 ntypeargs=0   
@@ -7898,7 +7898,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
         24   store_var_load_var 7               (message)
 
   83    25   load_field 1                       (content)
-        26   call 901 ntypeargs=0               (google.internal._gm_text_part)
+        26   call 902 ntypeargs=0               (google.internal._gm_text_part)
         27   store_var 8                        (part)
 
   84    28   load_var 7                         (message)
@@ -7934,7 +7934,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
   99    51   load_var2 9 8                      
         52   load_type 0                        
         53   alloc_array 1                      
-        54   call 900 ntypeargs=0               (google.internal._gm_content)
+        54   call 901 ntypeargs=0               (google.internal._gm_content)
         55   store_var 10                       (_24)
         56   load_type 0                        
         57   load_var2 3 10                     
@@ -8161,7 +8161,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         182   jump +2                            (to 184)
         183   load_const 3                       (null)
         184   load_const 3                       (null)
-        185   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        185   call 654 ntypeargs=0               (baml.ops.equals_equals)
         186   store_var 24                       (_74)
 
   324   187   load_var 4                         (has_call)
@@ -8274,35 +8274,35 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
 function google.internal.google_render(c: google.GoogleClient, input: ai.ModelTurnInput) -> baml.http.Request {
   216   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 907 ntypeargs=0   (google.internal._google_request)
+        2   call 908 ntypeargs=0   (google.internal._google_request)
         3   return                 
 }
 
 function google.internal.invoke(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   351   0    load_var 2             (input)
         1    load_field 1           (journal)
-        2    call 805 ntypeargs=0   (ai.Journal.entries)
+        2    call 806 ntypeargs=0   (ai.Journal.entries)
         3    container_len          
         4    store_var 3            (seq)
 
   352   5    load_var2 1 2          
-        6    call 906 ntypeargs=0   (google.internal.google_render)
+        6    call 907 ntypeargs=0   (google.internal.google_render)
         7    store_var 4            (req)
 
   353   8    load_type 0            
         9    load_var 4             (req)
         10   load_const 1           ("google")
-        11   call 826 ntypeargs=1   (ai.wire.send_as)
+        11   call 827 ntypeargs=1   (ai.wire.send_as)
 
   354   12   load_var 3             (seq)
-        13   call 908 ntypeargs=0   (google.internal.google_parse)
+        13   call 909 ntypeargs=0   (google.internal.google_parse)
         14   return                 
 }
 
 function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   432   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 907 ntypeargs=0   (google.internal._google_request)
+        2    call 908 ntypeargs=0   (google.internal._google_request)
 
   433   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -8328,7 +8328,7 @@ function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTu
         21   throw                  
 
   442   22   load_const 6           (google.internal._google_decode_batch)
-        23   call 848 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 849 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -8346,20 +8346,20 @@ function openai.OpenAiClient.ai.Client.id(self: openai.OpenAiClient) -> string {
 
 function openai.OpenAiClient.ai.Client.invoke(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   62   0   load_var2 1 2          
-       1   call 879 ntypeargs=0   (openai.internal.invoke)
+       1   call 880 ntypeargs=0   (openai.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   63   5   load_var 3             (e)
-       6   call 856 ntypeargs=0   (ai.errors.normalize)
+       6   call 857 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function openai.OpenAiClient.ai.stream.StreamingClient.invoke_stream(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   70   0   load_var2 1 2          
-       1   call 881 ntypeargs=0   (openai.internal.invoke_stream)
+       1   call 882 ntypeargs=0   (openai.internal.invoke_stream)
        2   return                 
 }
 
@@ -8477,7 +8477,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         2     store_var 2                        (out)
 
   255   3     load_var 1                         (batch)
-        4     call 847 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 848 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -8503,7 +8503,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
   257   25    load_type 7                        
 
   256   26    load_var 6                         (_10)
-        27    call 333 ntypeargs=1               (baml.json.from_string)
+        27    call 334 ntypeargs=1               (baml.json.from_string)
         28    jump +4                            (to 32)
 
   257   29    load_var 7                         (e)
@@ -8569,7 +8569,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         83    narrow_bind 15 14                  
         84    pop_jump_if_false +39              (to 123)
         85    load_var 14                        (_39)
-        86    call 878 ntypeargs=0               (openai.internal.openai_parse)
+        86    call 879 ntypeargs=0               (openai.internal.openai_parse)
         87    store_var 15                       (turn)
 
   275   88    load_var 15                        (turn)
@@ -8644,16 +8644,16 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         2     store_var 4                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 827 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 828 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 4                         (_5)
         7     call_indirect                      
 
-  129   8     call 874 ntypeargs=0               (openai.internal.openai_lower_prompt)
+  129   8     call 875 ntypeargs=0               (openai.internal.openai_lower_prompt)
         9     store_var 5                        (items)
 
   130   10    load_var 2                         (input)
         11    load_field 1                       (journal)
-        12    call 875 ntypeargs=0               (openai.internal.openai_lower_journal)
+        12    call 876 ntypeargs=0               (openai.internal.openai_lower_journal)
         13    load_type 0                        
         14    load_const 1                       ("iter")
         15    virtual_call nargs=1 ntypeargs=0   
@@ -8707,7 +8707,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   137   57    load_var 2                         (input)
         58    load_field 2                       (toolbox)
-        59    call 823 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        59    call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         60    unary_op !                         
         61    pop_jump_if_false +83              (to 144)
 
@@ -8717,7 +8717,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   139   65    load_var 2                         (input)
         66    load_field 2                       (toolbox)
-        67    call 821 ntypeargs=0               (ai.tools.Toolbox.list)
+        67    call 822 ntypeargs=0               (ai.tools.Toolbox.list)
         68    load_type 12                       
         69    load_const 13                      ("iter")
         70    virtual_call nargs=1 ntypeargs=0   
@@ -8816,7 +8816,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         152   pop 1                              
 
   162   153   load_var 1                         (c)
-        154   call 870 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
+        154   call 871 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
         155   store_var 16                       (_78)
         156   load_var 16                        (_78)
         157   store_var 15                       (_77)
@@ -8832,7 +8832,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         167   store_var 14                       (_76)
 
   163   168   load_var 1                         (c)
-        169   call 869 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
+        169   call 870 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
         170   store_var 18                       (_84)
         171   load_type 6                        
         172   load_var 18                        (_84)
@@ -8841,8 +8841,8 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   164   175   load_type 5                        
         176   load_var 8                         (body)
-        177   call 331 ntypeargs=1               (baml.json.to_json)
-        178   call 328 ntypeargs=0               (baml.json.stringify)
+        177   call 332 ntypeargs=1               (baml.json.to_json)
+        178   call 329 ntypeargs=0               (baml.json.stringify)
         179   store_var 19                       (_86)
 
   160   180   load_const 29                      ("POST")
@@ -8867,22 +8867,22 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
 function openai.internal.invoke(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   231   0   load_var2 1 2          
-        1   call 876 ntypeargs=0   (openai.internal.openai_render)
+        1   call 877 ntypeargs=0   (openai.internal.openai_render)
         2   store_var 3            (req)
 
   232   3   load_type 0            
         4   load_var 3             (req)
         5   load_const 1           ("openai")
-        6   call 826 ntypeargs=1   (ai.wire.send_as)
+        6   call 827 ntypeargs=1   (ai.wire.send_as)
 
-  233   7   call 878 ntypeargs=0   (openai.internal.openai_parse)
+  233   7   call 879 ntypeargs=0   (openai.internal.openai_parse)
         8   return                 
 }
 
 function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   304   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 877 ntypeargs=0   (openai.internal._openai_request)
+        2    call 878 ntypeargs=0   (openai.internal._openai_request)
 
   305   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -8908,7 +8908,7 @@ function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTu
         21   throw                  
 
   314   22   load_const 6           (openai.internal._openai_decode_batch)
-        23   call 848 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 849 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -8918,7 +8918,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         2     store_var 2                        (items)
 
   58    3     load_var 1                         (j)
-        4     call 805 ntypeargs=0               (ai.Journal.entries)
+        4     call 806 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -8999,8 +8999,8 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
 
   106   76    load_type 0                        
         77    load_var 25                        (err)
-        78    call 331 ntypeargs=1               (baml.json.to_json)
-        79    call 328 ntypeargs=0               (baml.json.stringify)
+        78    call 332 ntypeargs=1               (baml.json.to_json)
+        79    call 329 ntypeargs=0               (baml.json.stringify)
         80    store_var 27                       (_100)
         81    load_type 10                       
         82    load_type 11                       
@@ -9123,8 +9123,8 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
   82    184   load_type 0                        
         185   load_var 17                        (use)
         186   load_field 2                       (args)
-        187   call 331 ntypeargs=1               (baml.json.to_json)
-        188   call 328 ntypeargs=0               (baml.json.stringify)
+        187   call 332 ntypeargs=1               (baml.json.to_json)
+        188   call 329 ntypeargs=0               (baml.json.stringify)
         189   store_var 19                       (_58)
         190   load_type 10                       
         191   load_type 11                       
@@ -9212,7 +9212,7 @@ function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> map<string, u
        2    store_var 2                        (items)
 
   38   3    load_var 1                         (prompt)
-       4    call 809 ntypeargs=0               (ai.Prompt.messages)
+       4    call 810 ntypeargs=0               (ai.Prompt.messages)
        5    load_type 1                        
        6    load_const 2                       ("iter")
        7    virtual_call nargs=1 ntypeargs=0   
@@ -9458,7 +9458,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
   177   148   load_type 25                       
 
   176   149   load_var 8                         (_14)
-        150   call 333 ntypeargs=1               (baml.json.from_string)
+        150   call 334 ntypeargs=1               (baml.json.from_string)
         151   store_var 7                        (args)
 
   180   152   load_var 6                         (item)
@@ -9563,7 +9563,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
 function openai.internal.openai_render(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> baml.http.Request {
   118   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 877 ntypeargs=0   (openai.internal._openai_request)
+        2   call 878 ntypeargs=0   (openai.internal._openai_request)
         3   return                 
 }
 
@@ -9580,7 +9580,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  104   0   make_closure 1614 0   
+  104   0   make_closure 1615 0   
         1   return                
 }
 
@@ -9605,7 +9605,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   76   16   load_var 1             (threshold)
-       17   make_closure 1609 1    
+       17   make_closure 1610 1    
        18   return                 
 }
 
@@ -9644,7 +9644,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1593 2    
+       29   make_closure 1594 2    
        30   return                 
 }
 
@@ -9663,12 +9663,12 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   42   10   load_var 1             (max_attempts)
-       11   make_closure 1603 1    
+       11   make_closure 1604 1    
        12   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  98   0   make_closure 1612 0   
+  98   0   make_closure 1613 0   
        1   return                
 }
 
@@ -9872,7 +9872,7 @@ function testing.TestCollector.register_test_at(self: testing.TestCollector, own
         4   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
         5   load_var2 3 4          
         6   load_var 5             (runner)
-        7   call 742 ntypeargs=0   (testing.TestCollector.register_test)
+        7   call 743 ntypeargs=0   (testing.TestCollector.register_test)
         8   return                 
 }
 
@@ -10001,7 +10001,7 @@ function testing.TestCollector.register_test_set_at(self: testing.TestCollector,
         4   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
         5   load_var2 3 4          
         6   load_var 5             (runner)
-        7   call 743 ntypeargs=0   (testing.TestCollector.register_test_set)
+        7   call 744 ntypeargs=0   (testing.TestCollector.register_test_set)
         8   return                 
 }
 
@@ -10031,11 +10031,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   290   22   load_var2 1 5                      
-        23   call 758 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 759 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   291   25   load_var 1                         (self)
-        26   call 750 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 751 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   295   28   load_type 5                        
@@ -10072,7 +10072,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   298   58   load_var2 9 2                      
-        59   call 757 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 758 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   301   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -10095,7 +10095,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         10   pop_jump_if_false +2   (to 12)
         11   jump +51               (to 62)
 
-  308   12   sys_op 520             (baml.time.Instant.now)
+  308   12   sys_op 521             (baml.time.Instant.now)
         13   store_var 4            (start)
 
   309   14   load_var 2             (ts)
@@ -10113,8 +10113,8 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         25   pop 1                  
 
   315   26   load_var 4             (start)
-        27   call 521 ntypeargs=0   (baml.time.Instant.elapsed)
-        28   call 508 ntypeargs=0   (baml.time.Duration.to_milliseconds)
+        27   call 522 ntypeargs=0   (baml.time.Instant.elapsed)
+        28   call 509 ntypeargs=0   (baml.time.Duration.to_milliseconds)
         29   call 92 ntypeargs=0    (baml.Bigint.to_int)
         30   store_var 6            (elapsed)
         31   jump +13               (to 44)
@@ -10162,7 +10162,7 @@ function testing.TestRegistry.list_filtered(self: testing.TestRegistry, profile_
   281   0   load_var2 1 2          
         1   load_var2 3 4          
         2   load_var 5             (cli_exclude)
-        3   call 778 ntypeargs=0   (testing.select_names_layered)
+        3   call 779 ntypeargs=0   (testing.select_names_layered)
         4   return                 
 }
 
@@ -10178,9 +10178,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   237   0   load_var 1             (self)
-        1   call 759 ntypeargs=0   (testing.testset_children)
+        1   call 760 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 769 ntypeargs=0   (testing.run_testset)
+        3   call 770 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -10188,7 +10188,7 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
   259   0    load_var2 1 2          
         1    load_var2 3 4          
         2    load_var 5             (cli_exclude)
-        3    call 778 ntypeargs=0   (testing.select_names_layered)
+        3    call 779 ntypeargs=0   (testing.select_names_layered)
         4    store_var 6            (selected_names)
 
   261   5    load_var 2             (profile_include)
@@ -10231,22 +10231,22 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
         36   jump +4                (to 40)
 
   268   37   load_var2 1 6          
-        38   call 754 ntypeargs=0   (testing.TestRegistry.run_selected)
+        38   call 755 ntypeargs=0   (testing.TestRegistry.run_selected)
         39   jump +3                (to 42)
 
   266   40   load_var 1             (self)
-        41   call 753 ntypeargs=0   (testing.TestRegistry.run_all)
+        41   call 754 ntypeargs=0   (testing.TestRegistry.run_all)
 
   270   42   load_var 6             (selected_names)
-        43   call 784 ntypeargs=0   (testing.flatten_with_tolerated)
+        43   call 785 ntypeargs=0   (testing.flatten_with_tolerated)
         44   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   241   0   load_var2 1 2          
-        1   call 760 ntypeargs=0   (testing.testset_children_selected)
+        1   call 761 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 769 ntypeargs=0   (testing.run_testset)
+        3   call 770 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -10279,7 +10279,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 768 ntypeargs=0               (testing.run_test)
+        26   call 769 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   211   28   load_type 5                        
@@ -10316,7 +10316,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   215   58   load_var2 9 2                      
-        59   call 751 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 752 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   218   61   load_const 12                      ("Test not found: ")
@@ -10351,11 +10351,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   224   22   load_var2 1 5                      
-        23   call 758 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 759 ntypeargs=0               (testing.testset_children)
+        23   call 759 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 760 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 769 ntypeargs=0               (testing.run_testset)
+        27   call 770 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   227   29   load_type 5                        
@@ -10392,7 +10392,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   230   59   load_var2 9 2                      
-        60   call 752 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 753 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   233   62   load_const 12                      ("TestSet not found: ")
@@ -10485,7 +10485,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         71   store_var 10                       (_28)
 
   189   72   load_var 9                         (sub)
-        73   call 750 ntypeargs=0               (testing.TestRegistry.serialize)
+        73   call 751 ntypeargs=0               (testing.TestRegistry.serialize)
         74   store_var 11                       (_29)
 
   186   75   load_type 0                        
@@ -10643,7 +10643,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   441   56    load_var 12                        (outcome)
         57    load_const 10                      ("pass")
-        58    call 653 ntypeargs=0               (baml.ops.equals_equals)
+        58    call 654 ntypeargs=0               (baml.ops.equals_equals)
         59    pop_jump_if_false +2               (to 61)
         60    jump +58                           (to 118)
 
@@ -10710,7 +10710,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   458   111   load_var 12                        (outcome)
         112   load_const 16                      ("error")
-        113   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        113   call 654 ntypeargs=0               (baml.ops.equals_equals)
         114   pop_jump_if_false -94              (to 20)
 
   459   115   load_const 17                      (true)
@@ -10785,7 +10785,7 @@ function testing.any_pattern_matches(pats: string[], canonical_id: string) -> bo
 
   608   14   load_var2 2 4                      
 
-  607   15   call 771 ntypeargs=0               (testing.glob_match)
+  607   15   call 772 ntypeargs=0               (testing.glob_match)
 
   608   16   pop_jump_if_false -11              (to 5)
 
@@ -10824,7 +10824,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         23   store_var_load_var 7               (name)
 
   949   24   load_var 3                         (all_failed_names)
-        25   call 787 ntypeargs=0               (testing.failure_matches_selected)
+        25   call 788 ntypeargs=0               (testing.failure_matches_selected)
         26   pop_jump_if_false +2               (to 28)
         27   jump +8                            (to 35)
 
@@ -10837,7 +10837,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         34   jump -21                           (to 13)
 
   950   35   load_var2 7 2                      
-        36   call 787 ntypeargs=0               (testing.failure_matches_selected)
+        36   call 788 ntypeargs=0               (testing.failure_matches_selected)
         37   pop_jump_if_false +2               (to 39)
         38   jump +8                            (to 46)
 
@@ -10881,7 +10881,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          16   store_var_load_var 5               (name)
 
   1050   17   load_var 2                         (out)
-         18   call 786 ntypeargs=0               (testing.name_in)
+         18   call 787 ntypeargs=0               (testing.name_in)
          19   unary_op !                         
          20   pop_jump_if_false -14              (to 6)
 
@@ -10913,7 +10913,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          44   pop_jump_if_false +2               (to 46)
          45   jump -13                           (to 32)
          46   load_var2 8 2                      
-         47   call 789 ntypeargs=0               (testing.collect_all_failed_names)
+         47   call 790 ntypeargs=0               (testing.collect_all_failed_names)
          48   pop 1                              
          49   jump -17                           (to 32)
 
@@ -10991,7 +10991,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
          57    load_var 14             (nested)
          58    load_field 0            (outcome)
          59    load_const 3            ("pass")
-         60    call 653 ntypeargs=0    (baml.ops.equals_equals)
+         60    call 654 ntypeargs=0    (baml.ops.equals_equals)
          61    store_var 15            (nested_tolerated)
 
   1015   62    load_var 14             (nested)
@@ -11016,7 +11016,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
          79    store_var_load_var 17   (sentinel)
 
   1024   80    load_var 3              (selected_names)
-         81    call 786 ntypeargs=0    (testing.name_in)
+         81    call 787 ntypeargs=0    (testing.name_in)
          82    pop_jump_if_false +2    (to 84)
          83    jump +21                (to 104)
 
@@ -11071,14 +11071,14 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
   1017   123   load_var2 14 15         
 
   1018   124   load_var2 3 4           
-         125   call 788 ntypeargs=0    (testing.collect_leaf_identities)
+         125   call 789 ntypeargs=0    (testing.collect_leaf_identities)
          126   pop 1                   
          127   jump +30                (to 157)
 
   1003   128   load_var 13             (_25)
          129   load_field 0            (outcome)
          130   load_const 7            ("pass")
-         131   call 653 ntypeargs=0    (baml.ops.equals_equals)
+         131   call 654 ntypeargs=0    (baml.ops.equals_equals)
 
   1005   132   pop_jump_if_false +2    (to 134)
          133   jump +18                (to 151)
@@ -11147,7 +11147,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
          22   load_var 5                         (r)
          23   load_field 5                       (results)
          24   load_var 2                         (out)
-         25   call 790 ntypeargs=0               (testing.collect_leaf_messages)
+         25   call 791 ntypeargs=0               (testing.collect_leaf_messages)
          26   pop 1                              
          27   jump -22                           (to 5)
          28   load_var 6                         (_8)
@@ -11171,7 +11171,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   1069   45   load_field 0                       (outcome)
          46   load_const 10                      ("pass")
-         47   call 653 ntypeargs=0               (baml.ops.equals_equals)
+         47   call 654 ntypeargs=0               (baml.ops.equals_equals)
          48   unary_op !                         
          49   pop_jump_if_false -15              (to 34)
 
@@ -11242,7 +11242,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
   749   41   load_var2 1 6                      
 
-  748   42   call 781 ntypeargs=0               (testing.collect_subtree_names)
+  748   42   call 782 ntypeargs=0               (testing.collect_subtree_names)
 
   749   43   load_type 10                       
         44   load_const 11                      ("iter")
@@ -11271,8 +11271,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   762   0    load_var2 1 2          
-        1    call 758 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 780 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 759 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 781 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +89               (to 92)
         4    load_var 3             (e)
         5    store_var 4            (_5)
@@ -11371,11 +11371,11 @@ function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testi
 
 function testing.collect_subtree_names_layered(registry: testing.TestRegistry, ts: testing.TestSetRegistration, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> string[] {
   778   0     load_var2 1 2           
-        1     call 758 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
+        1     call 759 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
 
   777   2     load_var2 3 4           
         3     load_var2 5 6           
-        4     call 778 ntypeargs=0    (testing.select_names_layered)
+        4     call 779 ntypeargs=0    (testing.select_names_layered)
         5     jump +109               (to 114)
         6     load_var 7              (e)
         7     store_var 8             (_9)
@@ -11458,7 +11458,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   805   83    load_var2 3 4           
         84    load_var2 5 6           
-        85    call 774 ntypeargs=0    (testing.leaf_selected_layered)
+        85    call 775 ntypeargs=0    (testing.leaf_selected_layered)
 
   803   86    pop_jump_if_false +2    (to 88)
         87    jump +4                 (to 91)
@@ -11482,7 +11482,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   789   100   load_var2 3 4           
         101   load_var2 5 6           
-        102   call 774 ntypeargs=0    (testing.leaf_selected_layered)
+        102   call 775 ntypeargs=0    (testing.leaf_selected_layered)
 
   787   103   pop_jump_if_false +2    (to 105)
         104   jump +4                 (to 108)
@@ -11550,7 +11550,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         37    load_var 12                        (tsr)
         38    load_field 0                       (outcome)
         39    load_const 7                       ("pass")
-        40    call 653 ntypeargs=0               (baml.ops.equals_equals)
+        40    call 654 ntypeargs=0               (baml.ops.equals_equals)
         41    store_var 13                       (ft)
 
   855   42    load_var 12                        (tsr)
@@ -11598,14 +11598,14 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   856   74    load_var 12                        (tsr)
         75    load_field 5                       (results)
         76    load_var 13                        (ft)
-        77    call 783 ntypeargs=0               (testing.count_leaves)
+        77    call 784 ntypeargs=0               (testing.count_leaves)
         78    store_var 10                       (delta)
         79    jump +30                           (to 109)
 
   843   80    load_var 11                        (_13)
         81    load_field 0                       (outcome)
         82    load_const 8                       ("pass")
-        83    call 653 ntypeargs=0               (baml.ops.equals_equals)
+        83    call 654 ntypeargs=0               (baml.ops.equals_equals)
 
   845   84    pop_jump_if_false +2               (to 86)
         85    jump +18                           (to 103)
@@ -11690,7 +11690,7 @@ function testing.expansion_error_report(name: string) -> testing.TestSetReport {
 
 function testing.failure_matches_selected(selected: string, failed_names: string[]) -> bool {
   972   0    load_var2 1 2                      
-        1    call 786 ntypeargs=0               (testing.name_in)
+        1    call 787 ntypeargs=0               (testing.name_in)
         2    pop_jump_if_false +2               (to 4)
         3    jump +40                           (to 43)
 
@@ -11752,7 +11752,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   887   0     load_var 1             (report)
         1     load_field 0           (outcome)
         2     load_const 0           ("pass")
-        3     call 653 ntypeargs=0   (baml.ops.equals_equals)
+        3     call 654 ntypeargs=0   (baml.ops.equals_equals)
         4     store_var 3            (top_tolerated)
 
   888   5     load_var 1             (report)
@@ -11800,7 +11800,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   889   37    load_var 1             (report)
         38    load_field 5           (results)
         39    load_var 3             (top_tolerated)
-        40    call 783 ntypeargs=0   (testing.count_leaves)
+        40    call 784 ntypeargs=0   (testing.count_leaves)
         41    store_var 4            (counts)
 
   905   42    load_type 2            
@@ -11810,7 +11810,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   906   45    load_var 1             (report)
         46    load_field 5           (results)
         47    load_var 6             (messages)
-        48    call 790 ntypeargs=0   (testing.collect_leaf_messages)
+        48    call 791 ntypeargs=0   (testing.collect_leaf_messages)
         49    pop 1                  
 
   907   50    load_type 2            
@@ -11818,7 +11818,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
         52    store_var 7            (all_failed_names)
 
   908   53    load_var2 1 7          
-        54    call 789 ntypeargs=0   (testing.collect_all_failed_names)
+        54    call 790 ntypeargs=0   (testing.collect_all_failed_names)
         55    pop 1                  
 
   909   56    load_type 2            
@@ -11832,7 +11832,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
 
   910   64    load_var2 1 3          
         65    load_var2 2 8          
-        66    call 788 ntypeargs=0   (testing.collect_leaf_identities)
+        66    call 789 ntypeargs=0   (testing.collect_leaf_identities)
         67    pop 1                  
 
   916   68    load_var 8             (executed)
@@ -11890,7 +11890,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   922   112   load_var2 2 1          
         113   load_field 4           (failed_names)
         114   load_var 7             (all_failed_names)
-        115   call 785 ntypeargs=0   (testing.classify_selected_names)
+        115   call 786 ntypeargs=0   (testing.classify_selected_names)
         116   store_var 9            (identities)
         117   jump +3                (to 120)
 
@@ -12050,14 +12050,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
   577   96    load_var2 1 2           
         97    call 155 ntypeargs=0    (baml.String.index_of)
         98    load_const 6            (null)
-        99    call 653 ntypeargs=0    (baml.ops.equals_equals)
+        99    call 654 ntypeargs=0    (baml.ops.equals_equals)
         100   unary_op !              
         101   return                  
 }
 
 function testing.leaf_selected(name: string, include: string[], exclude: string[]) -> bool {
   618   0    load_var2 3 1          
-        1    call 772 ntypeargs=0   (testing.any_pattern_matches)
+        1    call 773 ntypeargs=0   (testing.any_pattern_matches)
         2    pop_jump_if_false +2   (to 4)
         3    jump +14               (to 17)
 
@@ -12071,7 +12071,7 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
         11   jump +4                (to 15)
 
   624   12   load_var2 2 1          
-        13   call 772 ntypeargs=0   (testing.any_pattern_matches)
+        13   call 773 ntypeargs=0   (testing.any_pattern_matches)
         14   jump +4                (to 18)
 
   622   15   load_const 1           (true)
@@ -12084,13 +12084,13 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
 function testing.leaf_selected_layered(name: string, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> bool {
   637   0   load_var2 1 2          
         1   load_var 3             (profile_exclude)
-        2   call 773 ntypeargs=0   (testing.leaf_selected)
+        2   call 774 ntypeargs=0   (testing.leaf_selected)
         3   jump_if_false +5       (to 8)
         4   pop 1                  
 
   638   5   load_var2 1 4          
         6   load_var 5             (cli_exclude)
-        7   call 773 ntypeargs=0   (testing.leaf_selected)
+        7   call 774 ntypeargs=0   (testing.leaf_selected)
         8   return                 
 }
 
@@ -12186,7 +12186,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   486   25   load_var 5                         (child)
-        26   make_closure 1493 1                
+        26   make_closure 1494 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   load_type 7                        
@@ -12202,10 +12202,10 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
   490   38   load_type 7                        
         39   load_type 8                        
         40   load_var 2                         (futures)
-        41   call 482 ntypeargs=2               (baml.future.all_complete)
+        41   call 483 ntypeargs=2               (baml.future.all_complete)
         42   await                              
 
-  491   43   call 766 ntypeargs=0               (testing.aggregate_reports)
+  491   43   call 767 ntypeargs=0               (testing.aggregate_reports)
         44   return                             
 }
 
@@ -12262,16 +12262,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         44   pop 1                              
         45   load_var 8                         (outcome)
         46   load_const 7                       ("pass")
-        47   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        47   call 654 ntypeargs=0               (baml.ops.equals_equals)
         48   unary_op !                         
         49   pop_jump_if_false -41              (to 8)
 
   119   50   load_var 3                         (named_results)
-        51   call 766 ntypeargs=0               (testing.aggregate_reports)
+        51   call 767 ntypeargs=0               (testing.aggregate_reports)
         52   jump +3                            (to 55)
 
   124   53   load_var 3                         (named_results)
-        54   call 766 ntypeargs=0               (testing.aggregate_reports)
+        54   call 767 ntypeargs=0               (testing.aggregate_reports)
         55   return                             
 }
 
@@ -12281,7 +12281,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   496   3    load_var 1             (body)
-        4    make_closure 1505 1    
+        4    make_closure 1506 1    
         5    store_var 3            (base_run)
 
   527   6    load_var 2             (runner)
@@ -12313,7 +12313,7 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         7    jump +3                (to 10)
 
   539   8    load_var 1             (children)
-        9    call 767 ntypeargs=0   (testing.run_children_parallel)
+        9    call 768 ntypeargs=0   (testing.run_children_parallel)
         10   return                 
 }
 
@@ -12324,7 +12324,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         3   load_type 0            
         4   alloc_array 0          
         5   load_var2 2 3          
-        6   call 778 ntypeargs=0   (testing.select_names_layered)
+        6   call 779 ntypeargs=0   (testing.select_names_layered)
         7   return                 
 }
 
@@ -12355,7 +12355,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
   704   21   load_field 0                       (name)
         22   load_var2 2 3                      
         23   load_var2 4 5                      
-        24   call 774 ntypeargs=0               (testing.leaf_selected_layered)
+        24   call 775 ntypeargs=0               (testing.leaf_selected_layered)
 
   702   25   pop_jump_if_false -15              (to 10)
 
@@ -12387,14 +12387,14 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   718   50   load_field 0                       (name)
         51   load_var2 2 3                      
-        52   call 777 ntypeargs=0               (testing.subtree_may_be_selected)
+        52   call 778 ntypeargs=0               (testing.subtree_may_be_selected)
         53   jump_if_false +6                   (to 59)
         54   pop 1                              
 
   719   55   load_var 12                        (ts)
         56   load_field 0                       (name)
         57   load_var2 4 5                      
-        58   call 777 ntypeargs=0               (testing.subtree_may_be_selected)
+        58   call 778 ntypeargs=0               (testing.subtree_may_be_selected)
 
   717   59   pop_jump_if_false -20              (to 39)
 
@@ -12402,7 +12402,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   723   61   load_var2 2 3                      
         62   load_var2 4 5                      
-        63   call 782 ntypeargs=0               (testing.collect_subtree_names_layered)
+        63   call 783 ntypeargs=0               (testing.collect_subtree_names_layered)
 
   729   64   load_type 10                       
         65   load_const 11                      ("iter")
@@ -12456,13 +12456,13 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         21   load_const 6                       ("*")
         22   call 155 ntypeargs=0               (baml.String.index_of)
         23   load_const 7                       (null)
-        24   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        24   call 654 ntypeargs=0               (baml.ops.equals_equals)
         25   jump_if_false +7                   (to 32)
         26   pop 1                              
         27   load_var2 3 6                      
         28   call 155 ntypeargs=0               (baml.String.index_of)
         29   load_const 7                       (null)
-        30   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        30   call 654 ntypeargs=0               (baml.ops.equals_equals)
         31   unary_op !                         
         32   pop_jump_if_false +2               (to 34)
         33   jump +11                           (to 44)
@@ -12473,7 +12473,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         37   jump_if_false +4                   (to 41)
         38   pop 1                              
         39   load_var2 3 6                      
-        40   call 771 ntypeargs=0               (testing.glob_match)
+        40   call 772 ntypeargs=0               (testing.glob_match)
         41   pop_jump_if_false -32              (to 9)
 
   655   42   load_const 9                       (true)
@@ -12488,7 +12488,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
 
 function testing.subtree_may_be_selected(prefix: string, include: string[], exclude: string[]) -> bool {
   677   0    load_var2 1 3                      
-        1    call 775 ntypeargs=0               (testing.subtree_excluded)
+        1    call 776 ntypeargs=0               (testing.subtree_excluded)
         2    pop_jump_if_false +2               (to 4)
         3    jump +32                           (to 35)
 
@@ -12516,7 +12516,7 @@ function testing.subtree_may_be_selected(prefix: string, include: string[], excl
         24   pop_jump_if_false +2               (to 26)
         25   jump +6                            (to 31)
         26   load_var2 6 1                      
-        27   call 776 ntypeargs=0               (testing.pattern_may_match_descendant)
+        27   call 777 ntypeargs=0               (testing.pattern_may_match_descendant)
 
   684   28   pop_jump_if_false -11              (to 17)
 
@@ -12544,7 +12544,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   364   6    load_var2 1 2         
 
   366   7    load_var 3            (runner)
-        8    make_closure 1470 2   
+        8    make_closure 1471 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   return                
 }
@@ -12561,7 +12561,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   375   8    load_var2 1 2         
-        9    make_closure 1472 2   
+        9    make_closure 1473 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   return                
 }
@@ -12582,7 +12582,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   391   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1474 3   
+        13   make_closure 1475 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   return                
 }
@@ -12616,7 +12616,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 761 ntypeargs=0               (testing.test_child)
+        26   call 762 ntypeargs=0               (testing.test_child)
         27   store_var 6                        (_10)
         28   load_type 0                        
         29   load_var2 2 6                      
@@ -12643,7 +12643,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
 
   334   49   load_var2 1 8                      
 
-  333   50   call 762 ntypeargs=0               (testing.testset_child)
+  333   50   call 763 ntypeargs=0               (testing.testset_child)
         51   store_var 9                        (_22)
 
   334   52   load_type 0                        
@@ -12682,7 +12682,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   342   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 764 ntypeargs=0               (testing._name_selected)
+        23   call 765 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   343   25   load_var 6                         (t)
@@ -12691,7 +12691,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 6                         (t)
         30   load_field 2                       (runner)
-        31   call 761 ntypeargs=0               (testing.test_child)
+        31   call 762 ntypeargs=0               (testing.test_child)
         32   store_var 7                        (_13)
         33   load_type 0                        
         34   load_var2 3 7                      
@@ -12720,12 +12720,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   354   56   load_field 0                       (name)
         57   load_var 2                         (names)
-        58   call 765 ntypeargs=0               (testing._has_selected_descendant)
+        58   call 766 ntypeargs=0               (testing._has_selected_descendant)
         59   pop_jump_if_false -14              (to 45)
 
   355   60   load_var2 1 10                     
         61   load_var 2                         (names)
-        62   call 763 ntypeargs=0               (testing.testset_child_selected)
+        62   call 764 ntypeargs=0               (testing.testset_child_selected)
         63   store_var 11                       (_27)
         64   load_type 0                        
         65   load_var2 3 11                     
@@ -12746,7 +12746,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 934 ntypeargs=0   (user.score)
+       7    call 935 ntypeargs=0   (user.score)
        8    store_var 3            (base)
 
   11   9    load_var 3             (base)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -30,14 +30,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   199   24    load_type 1                                
         25    load_deref 2                               
-        26    call 807 ntypeargs=1                       (ai.Journal.new)
+        26    call 809 ntypeargs=1                       (ai.Journal.new)
         27    store_deref 5                              
 
   200   28    load_type 1                                
         29    load_deref 1                               
         30    load_deref 5                               
         31    load_const 2                               (0)
-        32    call 846 ntypeargs=1                       (ai.Agent._emit_from)
+        32    call 848 ntypeargs=1                       (ai.Agent._emit_from)
         33    store_var 6                                (seen)
 
   201   34    load_const 2                               (0)
@@ -73,7 +73,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         59    load_deref 5                               
         60    load_var 8                                 (total)
         61    load_const 5                               (2)
-        62    call 845 ntypeargs=1                       (ai.Agent._attempt_turn)
+        62    call 847 ntypeargs=1                       (ai.Agent._attempt_turn)
         63    store_var 10                               (turn)
 
   213   64    load_var 7                                 (steps)
@@ -85,11 +85,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         69    load_deref 1                               
         70    load_deref 5                               
         71    load_var 6                                 (seen)
-        72    call 846 ntypeargs=1                       (ai.Agent._emit_from)
+        72    call 848 ntypeargs=1                       (ai.Agent._emit_from)
         73    store_var 6                                (seen)
 
   215   74    load_var 10                                (turn)
-        75    call 826 ntypeargs=0                       (ai.ModelTurn.tool_uses)
+        75    call 828 ntypeargs=0                       (ai.ModelTurn.tool_uses)
         76    store_var 11                               (calls)
 
   216   77    load_var 11                                (calls)
@@ -102,7 +102,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         84    jump +63                                   (to 147)
 
   251   85    load_var 10                                (turn)
-        86    call 825 ntypeargs=0                       (ai.ModelTurn.terminal_text)
+        86    call 827 ntypeargs=0                       (ai.ModelTurn.terminal_text)
         87    store_var 34                               (_96)
         88    load_var 34                                (_96)
         89    store_var 33                               (candidate)
@@ -115,7 +115,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   252   96    load_type 1                                
         97    load_var 33                                (candidate)
-        98    call 427 ntypeargs=1                       (baml.sap.parse)
+        98    call 429 ntypeargs=1                       (baml.sap.parse)
         99    store_var 35                               (value)
         100   jump +11                                   (to 111)
         101   load_var 36                                (e)
@@ -132,7 +132,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   257   111   load_type 1                                
         112   load_var 35                                (value)
-        113   call 332 ntypeargs=1                       (baml.json.to_json)
+        113   call 334 ntypeargs=1                       (baml.json.to_json)
         114   jump +12                                   (to 126)
         115   load_var 38                                (e)
         116   throw_if_panic                             
@@ -147,7 +147,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         124   init_instance 3                            (baml.errors.UnknownError .data, .message)
         125   throw                                      
 
-  263   126   call 329 ntypeargs=0                       (baml.json.stringify)
+  263   126   call 331 ntypeargs=0                       (baml.json.stringify)
         127   store_var 40                               (_117)
 
   262   128   load_deref 5                               
@@ -156,14 +156,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         130   init_instance 4                            (ai.events.FinalProduced .value_json)
         131   load_type 11                               
         132   alloc_array 1                              
-        133   call 808 ntypeargs=0                       (ai.Journal.append_all)
+        133   call 810 ntypeargs=0                       (ai.Journal.append_all)
         134   pop 1                                      
 
   265   135   load_type 1                                
         136   load_deref 1                               
         137   load_deref 5                               
         138   load_var 6                                 (seen)
-        139   call 846 ntypeargs=1                       (ai.Agent._emit_from)
+        139   call 848 ntypeargs=1                       (ai.Agent._emit_from)
         140   store_var 6                                (seen)
 
   266   141   load_var 35                                (value)
@@ -174,7 +174,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         146   return                                     
 
   217   147   load_deref 5                               
-        148   call 806 ntypeargs=0                       (ai.Journal.entries)
+        148   call 808 ntypeargs=0                       (ai.Journal.entries)
         149   container_len                              
         150   store_var 13                               (before)
 
@@ -185,14 +185,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         155   load_type 1                                
         156   load_var2 1 2                              
         157   load_var 5                                 (j)
-        158   make_closure 1739 captures=3 ntypeargs=1   
+        158   make_closure 1741 captures=3 ntypeargs=1   
         159   call 16 ntypeargs=3                        (baml.Array.map)
         160   store_var 14                               (futures)
 
   222   161   load_type 15                               
         162   load_type 16                               
         163   load_var 14                                (futures)
-        164   call 484 ntypeargs=2                       (baml.future.all)
+        164   call 486 ntypeargs=2                       (baml.future.all)
         165   await                                      
         166   pop 1                                      
 
@@ -200,11 +200,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         168   load_deref 1                               
         169   load_deref 5                               
         170   load_var 6                                 (seen)
-        171   call 846 ntypeargs=1                       (ai.Agent._emit_from)
+        171   call 848 ntypeargs=1                       (ai.Agent._emit_from)
         172   store_var 6                                (seen)
 
   227   173   load_deref 5                               
-        174   call 806 ntypeargs=0                       (ai.Journal.entries)
+        174   call 808 ntypeargs=0                       (ai.Journal.entries)
         175   store_var 15                               (entries)
 
   228   176   load_var 13                                (before)
@@ -234,7 +234,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         197   load_var 11                                (calls)
         198   load_type 1                                
         199   load_var 20                                (f)
-        200   make_closure 1740 captures=1 ntypeargs=1   
+        200   make_closure 1742 captures=1 ntypeargs=1   
         201   call 19 ntypeargs=2                        (baml.Array.find)
 
   234   202   store_var 21                               (_58)
@@ -338,12 +338,12 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   126   3     load_type 0                        
         4     load_var 3                         (spec)
-        5     call 817 ntypeargs=1               (ai.FunctionSpec.tools)
+        5     call 819 ntypeargs=1               (ai.FunctionSpec.tools)
         6     store_var 9                        (_10)
 
   127   7     load_type 0                        
         8     load_var 3                         (spec)
-        9     call 815 ntypeargs=1               (ai.FunctionSpec.output_type)
+        9     call 817 ntypeargs=1               (ai.FunctionSpec.output_type)
         10    store_var 10                       (_12)
 
   122   11    load_var2 2 8                      
@@ -446,7 +446,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         99    store_var 21                       (batch)
 
   142   100   load_var 7                         (turn)
-        101   call 826 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        101   call 828 ntypeargs=0               (ai.ModelTurn.tool_uses)
         102   load_type 8                        
         103   load_const 9                       ("iter")
         104   virtual_call nargs=1 ntypeargs=0   
@@ -489,7 +489,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         137   pop 1                              
 
   148   138   load_var 7                         (turn)
-        139   call 825 ntypeargs=0               (ai.ModelTurn.terminal_text)
+        139   call 827 ntypeargs=0               (ai.ModelTurn.terminal_text)
         140   store_var 29                       (_56)
         141   load_var 29                        (_56)
         142   store_var 28                       (candidate)
@@ -501,7 +501,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         148   store_var 28                       (candidate)
 
   149   149   load_var 7                         (turn)
-        150   call 826 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        150   call 828 ntypeargs=0               (ai.ModelTurn.tool_uses)
         151   container_len                      
         152   store_var 30                       (_62)
         153   load_var 30                        (_62)
@@ -515,7 +515,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         160   load_field 1                       (stop_reason)
         161   load_const 14                      (ai.content.StopReason.MaxTokens)
         162   alloc_variant 436                  (ai.content.StopReason)
-        163   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        163   call 656 ntypeargs=0               (baml.ops.equals_equals)
 
   149   164   jump_if_false +2                   (to 166)
         165   jump +7                            (to 172)
@@ -525,7 +525,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         168   load_field 1                       (stop_reason)
         169   load_const 15                      (ai.content.StopReason.Refused)
         170   alloc_variant 436                  (ai.content.StopReason)
-        171   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        171   call 656 ntypeargs=0               (baml.ops.equals_equals)
 
   149   172   jump_if_false +2                   (to 174)
         173   jump +5                            (to 178)
@@ -533,7 +533,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   152   175   load_type 0                        
         176   load_var2 1 28                     
-        177   call 844 ntypeargs=1               (ai.Agent._parses)
+        177   call 846 ntypeargs=1               (ai.Agent._parses)
 
   153   178   pop_jump_if_false +2               (to 180)
         179   jump +34                           (to 213)
@@ -545,7 +545,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         184   jump +12                           (to 196)
 
   175   185   load_var2 4 21                     
-        186   call 808 ntypeargs=0               (ai.Journal.append_all)
+        186   call 810 ntypeargs=0               (ai.Journal.append_all)
         187   pop 1                              
 
   176   188   load_var 2                         (c)
@@ -566,7 +566,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         201   pop 1                              
 
   172   202   load_var2 4 21                     
-        203   call 808 ntypeargs=0               (ai.Journal.append_all)
+        203   call 810 ntypeargs=0               (ai.Journal.append_all)
         204   pop 1                              
 
   173   205   load_type 0                        
@@ -575,11 +575,11 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         208   load_var2 5 6                      
         209   load_const 16                      (1)
         210   sub_int                            
-        211   call 845 ntypeargs=1               (ai.Agent._attempt_turn)
+        211   call 847 ntypeargs=1               (ai.Agent._attempt_turn)
         212   jump +19                           (to 231)
 
   154   213   load_var2 4 21                     
-        214   call 808 ntypeargs=0               (ai.Journal.append_all)
+        214   call 810 ntypeargs=0               (ai.Journal.append_all)
         215   pop 1                              
 
   156   216   load_var 7                         (turn)
@@ -623,7 +623,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
 function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> int {
   182   0    load_var 2             (j)
-        1    call 806 ntypeargs=0   (ai.Journal.entries)
+        1    call 808 ntypeargs=0   (ai.Journal.entries)
         2    store_var 4            (entries)
 
   183   3    load_var 3             (seen)
@@ -695,7 +695,7 @@ function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> in
 function ai.Agent._parses(self: ai.Agent<#0>, candidate: string) -> bool {
   100   0    load_type 0            
         1    load_var 2             (candidate)
-        2    call 427 ntypeargs=1   (baml.sap.parse)
+        2    call 429 ntypeargs=1   (baml.sap.parse)
         3    pop 1                  
         4    jump +5                (to 9)
         5    load_var 3             (e)
@@ -711,7 +711,7 @@ function ai.Agent._parses(self: ai.Agent<#0>, candidate: string) -> bool {
 function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: ai.content.ToolUse, j: ai.Journal) -> null {
   56   0     load_var2 2 3          
        1     load_field 1           (name)
-       2     call 823 ntypeargs=0   (ai.tools.Toolbox.get)
+       2     call 825 ntypeargs=0   (ai.tools.Toolbox.get)
        3     store_var 5            (_7)
        4     load_var 5             (_7)
        5     narrow_bind 0 5        
@@ -736,7 +736,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        20    init_instance 0        (ai.events.ToolFailed .id, .message)
        21    load_type 3            
        22    alloc_array 1          
-       23    call 808 ntypeargs=0   (ai.Journal.append_all)
+       23    call 810 ntypeargs=0   (ai.Journal.append_all)
        24    pop 1                  
 
   94   25    load_const 4           (null)
@@ -747,7 +747,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
 
   58   29    load_var2 6 3          
        30    load_field 2           (args)
-       31    call 818 ntypeargs=0   (ai.tools.Tool.call)
+       31    call 820 ntypeargs=0   (ai.tools.Tool.call)
        32    store_var 7            (outcome)
        33    jump +63               (to 96)
        34    load_var 8             (e)
@@ -767,7 +767,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        45    init_instance 1        (ai.events.ToolFailed .id, .message)
        46    load_type 3            
        47    alloc_array 1          
-       48    call 808 ntypeargs=0   (ai.Journal.append_all)
+       48    call 810 ntypeargs=0   (ai.Journal.append_all)
        49    pop 1                  
 
   64   50    load_var 6             (t)
@@ -785,7 +785,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        62    load_var 11            (_19)
        63    load_const 6           (ai.tools.ErrorMode.Raise)
        64    alloc_variant 437      (ai.tools.ErrorMode)
-       65    call 654 ntypeargs=0   (baml.ops.equals_equals)
+       65    call 656 ntypeargs=0   (baml.ops.equals_equals)
        66    pop_jump_if_false +2   (to 68)
        67    jump +4                (to 71)
 
@@ -840,7 +840,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        104   init_instance 3        (ai.events.ToolCompleted .id, .output)
        105   load_type 3            
        106   alloc_array 1          
-       107   call 808 ntypeargs=0   (ai.Journal.append_all)
+       107   call 810 ntypeargs=0   (ai.Journal.append_all)
        108   pop 1                  
 
   83   109   load_const 4           (null)
@@ -886,7 +886,7 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
        30   pop_jump_if_false +4                       (to 34)
 
   41   31   load_type 4                                
-       32   make_closure 1721 captures=0 ntypeargs=1   
+       32   make_closure 1723 captures=0 ntypeargs=1   
        33   store_var 5                                (_9)
 
   35   34   load_var2 1 2                              
@@ -972,11 +972,11 @@ function ai.Journal.entries(self: ai.Journal) -> (ai.events.RunStarted | ai.even
 function ai.Journal.new(spec: ai.FunctionSpec<#0>) -> ai.Journal {
   21   0    load_type 0            
        1    load_var 1             (spec)
-       2    call 813 ntypeargs=1   (ai.FunctionSpec.name)
+       2    call 815 ntypeargs=1   (ai.FunctionSpec.name)
        3    store_var 2            (_4)
        4    load_type 0            
        5    load_var 1             (spec)
-       6    call 814 ntypeargs=1   (ai.FunctionSpec.arguments)
+       6    call 816 ntypeargs=1   (ai.FunctionSpec.arguments)
        7    store_var 3            (_6)
        8    load_var2 2 3          
        9    init_instance 0        (ai.events.RunStarted .spec_name, .arguments)
@@ -1060,7 +1060,7 @@ function ai.ModelTurn.tool_uses(self: ai.ModelTurn) -> ai.content.ToolUse[] {
 
 function ai.Prompt.baml.ToString.to_string(self: ai.Prompt) -> string {
   35   0   load_var 1             (self)
-       1   call 809 ntypeargs=0   (ai.Prompt.text)
+       1   call 811 ntypeargs=0   (ai.Prompt.text)
        2   return                 
 }
 
@@ -1218,7 +1218,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         47   load_var 10                        (_17)
         48   load_const 6                       (ai.errors.RetrySafety.Safe)
         49   alloc_variant 438                  (ai.errors.RetrySafety)
-        50   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        50   call 656 ntypeargs=0               (baml.ops.equals_equals)
 
   155   51   pop_jump_if_false +2               (to 53)
         52   jump +3                            (to 55)
@@ -1230,7 +1230,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         56   load_var 3                         (index)
         57   load_const 4                       (1)
         58   add_int                            
-        59   call 839 ntypeargs=0               (ai.clients.Fallback._try)
+        59   call 841 ntypeargs=0               (ai.clients.Fallback._try)
         60   return                             
 }
 
@@ -1262,13 +1262,13 @@ function ai.clients.Fallback.root.Client.id(self: ai.clients.Fallback) -> string
 function ai.clients.Fallback.root.Client.invoke(self: ai.clients.Fallback, input: ai.ModelTurnInput) -> ai.ModelTurn {
   185   0   load_var2 1 2          
         1   load_const 0           (0)
-        2   call 839 ntypeargs=0   (ai.clients.Fallback._try)
+        2   call 841 ntypeargs=0   (ai.clients.Fallback._try)
         3   jump +6                (to 9)
         4   load_var 3             (e)
         5   throw_if_panic         
 
   186   6   load_var 3             (e)
-        7   call 857 ntypeargs=0   (ai.errors.normalize)
+        7   call 859 ntypeargs=0   (ai.errors.normalize)
         8   throw                  
         9   return                 
 }
@@ -1310,7 +1310,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        29   load_var 7                         (_11)
        30   load_const 5                       (ai.errors.RetrySafety.Safe)
        31   alloc_variant 438                  (ai.errors.RetrySafety)
-       32   call 654 ntypeargs=0               (baml.ops.equals_equals)
+       32   call 656 ntypeargs=0               (baml.ops.equals_equals)
 
   74   33   jump_if_false +5                   (to 38)
        34   pop 1                              
@@ -1336,8 +1336,8 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        49   add_int                            
 
   80   50   load_var 6                         (f)
-       51   call 831 ntypeargs=0               (ai.clients.Backoff.delay_ms)
-       52   call 503 ntypeargs=0               (baml.time.Duration.from_milliseconds)
+       51   call 833 ntypeargs=0               (ai.clients.Backoff.delay_ms)
+       52   call 505 ntypeargs=0               (baml.time.Duration.from_milliseconds)
 
   79   53   sys_op 255                         (baml.sys.sleep)
        54   pop 1                              
@@ -1349,7 +1349,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        59   load_var 3                         (remaining)
        60   load_const 3                       (1)
        61   sub_int                            
-       62   call 833 ntypeargs=0               (ai.clients.Retry._attempt)
+       62   call 835 ntypeargs=0               (ai.clients.Retry._attempt)
        63   return                             
 }
 
@@ -1394,7 +1394,7 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
        32   load_const 0           (<omitted>)
        33   load_const 0           (<omitted>)
        34   load_const 0           (<omitted>)
-       35   call 830 ntypeargs=0   (ai.clients.Backoff.new)
+       35   call 832 ntypeargs=0   (ai.clients.Backoff.new)
        36   store_var 6            (_10)
 
   61   37   load_var2 1 2          
@@ -1418,13 +1418,13 @@ function ai.clients.Retry.root.Client.invoke(self: ai.clients.Retry, input: ai.M
   99    0    load_var2 1 2          
         1    load_var 1             (self)
         2    load_field 1           (max_attempts)
-        3    call 833 ntypeargs=0   (ai.clients.Retry._attempt)
+        3    call 835 ntypeargs=0   (ai.clients.Retry._attempt)
         4    jump +6                (to 10)
         5    load_var 3             (e)
         6    throw_if_panic         
 
   100   7    load_var 3             (e)
-        8    call 857 ntypeargs=0   (ai.errors.normalize)
+        8    call 859 ntypeargs=0   (ai.errors.normalize)
         9    throw                  
         10   return                 
 }
@@ -1518,7 +1518,7 @@ function ai.clients.RoundRobin.root.Client.invoke(self: ai.clients.RoundRobin, i
         33   throw_if_panic                     
 
   141   34   load_var 4                         (e)
-        35   call 857 ntypeargs=0               (ai.errors.normalize)
+        35   call 859 ntypeargs=0               (ai.errors.normalize)
         36   throw                              
         37   load_var 3                         (_0)
         38   return                             
@@ -1694,7 +1694,7 @@ function ai.errors.normalize(error: unknown) -> ai.errors.Failure | baml.errors.
 
 function ai.internal._schema_for_signature(handler: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> map<string, unknown> {
   6    0    load_var 1                         (handler)
-       1    call 740 ntypeargs=0               (reflect.signature)
+       1    call 742 ntypeargs=0               (reflect.signature)
        2    store_var 2                        (sig)
 
   7    3    load_type 0                        
@@ -1729,7 +1729,7 @@ function ai.internal._schema_for_signature(handler: baml.AnyFunction<Returns = u
        29   store_var 8                        (_12)
        30   load_var 7                         (a)
        31   load_field 1                       (type)
-       32   sys_op 342                         (baml.json.schema)
+       32   sys_op 344                         (baml.json.schema)
        33   store_var 9                        (_13)
        34   load_type 0                        
        35   load_type 1                        
@@ -1775,10 +1775,10 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
 
   102   9     load_var2 4 2                      
         10    load_var 3                         (params)
-        11    call 927 ntypeargs=0               (ai.mcp.rpc_line)
+        11    call 929 ntypeargs=0               (ai.mcp.rpc_line)
         12    store_var 5                        (_6)
         13    load_var2 1 5                      
-        14    call 929 ntypeargs=0               (ai.mcp.McpConnection._send)
+        14    call 931 ntypeargs=0               (ai.mcp.McpConnection._send)
         15    pop 1                              
 
   103   16    load_const 1                       (true)
@@ -1884,7 +1884,7 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         100   pop_jump_if_false -84              (to 16)
 
   118   101   load_var 12                        (trimmed)
-        102   call 328 ntypeargs=0               (baml.json.parse)
+        102   call 330 ntypeargs=0               (baml.json.parse)
         103   store_var 13                       (msg)
         104   jump +5                            (to 109)
         105   load_var 14                        (e)
@@ -1898,7 +1898,7 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         111   load_const 15                      (".id")
         112   load_const 0                       (1)
         113   unary_op -                         
-        114   call 341 ntypeargs=1               (baml.json.path_or)
+        114   call 343 ntypeargs=1               (baml.json.path_or)
         115   load_var 4                         (id)
         116   cmp_int_op ==                      
         117   pop_jump_if_false -101             (to 16)
@@ -1907,12 +1907,12 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         119   load_var 13                        (msg)
         120   load_const 17                      (".error")
         121   load_const 5                       (null)
-        122   call 341 ntypeargs=1               (baml.json.path_or)
+        122   call 343 ntypeargs=1               (baml.json.path_or)
         123   store_var 15                       (err)
 
   123   124   load_var 15                        (err)
         125   load_const 5                       (null)
-        126   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        126   call 656 ntypeargs=0               (baml.ops.equals_equals)
         127   unary_op !                         
         128   pop_jump_if_false +2               (to 130)
         129   jump +7                            (to 136)
@@ -1921,7 +1921,7 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         131   load_var 13                        (msg)
         132   load_const 18                      (".result")
         133   load_const 5                       (null)
-        134   call 341 ntypeargs=1               (baml.json.path_or)
+        134   call 343 ntypeargs=1               (baml.json.path_or)
         135   return                             
 
   125   136   load_type 2                        
@@ -1934,18 +1934,18 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         142   load_var 15                        (err)
         143   load_const 20                      (".code")
         144   load_const 5                       (null)
-        145   call 341 ntypeargs=1               (baml.json.path_or)
+        145   call 343 ntypeargs=1               (baml.json.path_or)
         146   store_var 17                       (_46)
 
   127   147   load_type 2                        
         148   load_var 15                        (err)
         149   load_const 21                      (".message")
         150   load_const 22                      ("MCP error")
-        151   call 341 ntypeargs=1               (baml.json.path_or)
+        151   call 343 ntypeargs=1               (baml.json.path_or)
         152   store_var 18                       (_49)
 
   128   153   load_var 15                        (err)
-        154   call 329 ntypeargs=0               (baml.json.stringify)
+        154   call 331 ntypeargs=0               (baml.json.stringify)
         155   store_var 19                       (_52)
 
   125   156   load_const 23                      ("mcp/")
@@ -2016,7 +2016,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         5    load_type 3                        
         6    load_type 4                        
         7    alloc_map 2                        
-        8    call 930 ntypeargs=0               (ai.mcp.McpConnection._request)
+        8    call 932 ntypeargs=0               (ai.mcp.McpConnection._request)
         9    store_var 4                        (result)
 
   185   10   load_type 3                        
@@ -2028,7 +2028,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         15   load_const 6                       (".content")
         16   load_type 7                        
         17   alloc_array 0                      
-        18   call 341 ntypeargs=1               (baml.json.path_or)
+        18   call 343 ntypeargs=1               (baml.json.path_or)
         19   load_type 8                        
         20   load_const 9                       ("iter")
         21   virtual_call nargs=1 ntypeargs=0   
@@ -2049,7 +2049,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         35   load_var 8                         (item)
         36   load_const 13                      (".type")
         37   load_const 14                      ("")
-        38   call 341 ntypeargs=1               (baml.json.path_or)
+        38   call 343 ntypeargs=1               (baml.json.path_or)
         39   load_const 15                      ("text")
         40   cmp_op ==                          
         41   pop_jump_if_false -18              (to 23)
@@ -2058,7 +2058,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         43   load_var 8                         (item)
         44   load_const 16                      (".text")
         45   load_const 17                      ("")
-        46   call 341 ntypeargs=1               (baml.json.path_or)
+        46   call 343 ntypeargs=1               (baml.json.path_or)
         47   store_var 9                        (_22)
         48   load_type 3                        
         49   load_var2 5 9                      
@@ -2076,7 +2076,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         59   load_var 4                         (result)
         60   load_const 20                      (".isError")
         61   load_const 21                      (false)
-        62   call 341 ntypeargs=1               (baml.json.path_or)
+        62   call 343 ntypeargs=1               (baml.json.path_or)
         63   pop_jump_if_false +2               (to 65)
         64   jump +3                            (to 67)
 
@@ -2185,16 +2185,16 @@ function ai.mcp.McpConnection.connect(name: string, command: string, args: strin
        59   load_type 4            
        60   load_type 11           
        61   alloc_map 3            
-       62   call 930 ntypeargs=0   (ai.mcp.McpConnection._request)
+       62   call 932 ntypeargs=0   (ai.mcp.McpConnection._request)
        63   pop 1                  
 
   76   64   load_const 2           (null)
        65   load_const 19          ("notifications/initialized")
        66   load_const 2           (null)
-       67   call 927 ntypeargs=0   (ai.mcp.rpc_line)
+       67   call 929 ntypeargs=0   (ai.mcp.rpc_line)
        68   store_var 11           (_26)
        69   load_var2 10 11        
-       70   call 929 ntypeargs=0   (ai.mcp.McpConnection._send)
+       70   call 931 ntypeargs=0   (ai.mcp.McpConnection._send)
        71   pop 1                  
 
   77   72   load_var 10            (conn)
@@ -2207,7 +2207,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         2    load_type 1                        
         3    load_type 2                        
         4    alloc_map 0                        
-        5    call 930 ntypeargs=0               (ai.mcp.McpConnection._request)
+        5    call 932 ntypeargs=0               (ai.mcp.McpConnection._request)
         6    store_var 2                        (result)
 
   157   7    load_type 3                        
@@ -2219,7 +2219,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         12   load_const 5                       (".tools")
         13   load_type 6                        
         14   alloc_array 0                      
-        15   call 341 ntypeargs=1               (baml.json.path_or)
+        15   call 343 ntypeargs=1               (baml.json.path_or)
         16   load_type 7                        
         17   load_const 8                       ("iter")
         18   virtual_call nargs=1 ntypeargs=0   
@@ -2240,7 +2240,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         32   load_var 6                         (t)
         33   load_const 12                      (".name")
         34   load_const 13                      ("")
-        35   call 341 ntypeargs=1               (baml.json.path_or)
+        35   call 343 ntypeargs=1               (baml.json.path_or)
         36   store_var 7                        (tool_name)
 
   161   37   load_type 6                        
@@ -2249,12 +2249,12 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         40   load_type 1                        
         41   load_type 6                        
         42   alloc_map 0                        
-        43   call 341 ntypeargs=1               (baml.json.path_or)
+        43   call 343 ntypeargs=1               (baml.json.path_or)
         44   store_var 10                       (_19)
 
   160   45   load_type 15                       
         46   load_var 10                        (_19)
-        47   call 335 ntypeargs=1               (baml.json.from_json)
+        47   call 337 ntypeargs=1               (baml.json.from_json)
         48   store_var 8                        (schema)
         49   jump +7                            (to 56)
         50   load_var 9                         (e)
@@ -2269,20 +2269,20 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         57   load_var 6                         (t)
         58   load_const 16                      (".description")
         59   load_const 17                      ("")
-        60   call 341 ntypeargs=1               (baml.json.path_or)
+        60   call 343 ntypeargs=1               (baml.json.path_or)
         61   store_var 12                       (_28)
 
   172   62   load_var 8                         (schema)
         63   store_var 13                       (_31)
 
   173   64   load_var2 1 7                      
-        65   call 926 ntypeargs=0               (ai.mcp._proxy)
+        65   call 928 ntypeargs=0               (ai.mcp._proxy)
         66   store_var 14                       (_32)
 
   170   67   load_var2 7 12                     
         68   load_var2 13 14                    
         69   load_const 18                      (<omitted>)
-        70   call 820 ntypeargs=0               (ai.tools.raw_tool)
+        70   call 822 ntypeargs=0               (ai.tools.raw_tool)
         71   store_var 11                       (_26)
 
   168   72   load_type 3                        
@@ -2304,7 +2304,7 @@ function ai.mcp._proxy(conn: ai.mcp.McpConnection, name: string) -> (map<string,
        5   store_var 2           
 
   20   6   load_var2 1 2         
-       7   make_closure 2305 2   
+       7   make_closure 2307 2   
        8   return                
 }
 
@@ -2350,8 +2350,8 @@ function ai.mcp.rpc_line(id: int | null, method: string, params: map<string, unk
 
   34   32   load_type 7            
        33   load_var 4             (m)
-       34   call 332 ntypeargs=1   (baml.json.to_json)
-       35   call 329 ntypeargs=0   (baml.json.stringify)
+       34   call 334 ntypeargs=1   (baml.json.to_json)
+       35   call 331 ntypeargs=0   (baml.json.stringify)
        36   return                 
 }
 
@@ -2361,7 +2361,7 @@ function ai.prompt(body: ((string) -> baml.prompt.Role throws never, baml.prompt
        2   store_var 1           
 
   49   3   load_var 1            (body)
-       4   make_closure 1655 1   
+       4   make_closure 1657 1   
        5   return                
 }
 
@@ -2378,7 +2378,7 @@ function ai.stream.Stream.final(self: ai.stream.Stream<#0, #1>) -> #1 {
         8    load_field 1           (_cache)
         9    load_type 0            
         10   load_type 1            
-        11   sys_op 425             (baml.sap.__parse_final)
+        11   sys_op 427             (baml.sap.__parse_final)
         12   return                 
 
   279   13   load_var 1             (self)
@@ -2443,7 +2443,7 @@ function ai.stream.Stream.next(self: ai.stream.Stream<#0, #1>) -> #0 | ai.stream
         27   load_field 1                     (_cache)
         28   load_type 3                      
         29   load_type 4                      
-        30   sys_op 426                       (baml.sap.__parse_partial)
+        30   sys_op 428                       (baml.sap.__parse_partial)
         31   store_var 3                      (parsed)
 
   264   32   load_var 3                       (parsed)
@@ -2491,7 +2491,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         1    pop_jump_if_false +7   (to 8)
 
   216   2    load_var 1             (self)
-        3    call 852 ntypeargs=0   (ai.stream.TurnStream.next)
+        3    call 854 ntypeargs=0   (ai.stream.TurnStream.next)
         4    store_var 2            (_3)
         5    load_var 2             (_3)
         6    narrow_bind 1 2        
@@ -2500,7 +2500,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
   223   8    load_var 1             (self)
         9    load_field 8           (_input_tokens)
         10   load_const 2           (null)
-        11   call 654 ntypeargs=0   (baml.ops.equals_equals)
+        11   call 656 ntypeargs=0   (baml.ops.equals_equals)
         12   unary_op !             
         13   jump_if_false +2       (to 15)
         14   jump +7                (to 21)
@@ -2508,7 +2508,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         16   load_var 1             (self)
         17   load_field 9           (_output_tokens)
         18   load_const 2           (null)
-        19   call 654 ntypeargs=0   (baml.ops.equals_equals)
+        19   call 656 ntypeargs=0   (baml.ops.equals_equals)
         20   unary_op !             
         21   pop_jump_if_false +2   (to 23)
         22   jump +4                (to 26)
@@ -2656,7 +2656,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         38    jump +6                            (to 44)
 
   202   39    load_var 1                         (self)
-        40    call 851 ntypeargs=0               (ai.stream.TurnStream._finish)
+        40    call 853 ntypeargs=0               (ai.stream.TurnStream._finish)
         41    pop 1                              
 
   203   42    alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2734,7 +2734,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         102   jump -15                           (to 87)
 
   176   103   load_var 1                         (self)
-        104   call 851 ntypeargs=0               (ai.stream.TurnStream._finish)
+        104   call 853 ntypeargs=0               (ai.stream.TurnStream._finish)
         105   pop 1                              
 
   177   106   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2774,7 +2774,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         137   pop_jump_if_false -137             (to 0)
 
   165   138   load_var 1                         (self)
-        139   call 851 ntypeargs=0               (ai.stream.TurnStream._finish)
+        139   call 853 ntypeargs=0               (ai.stream.TurnStream._finish)
         140   pop 1                              
 
   166   141   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2845,7 +2845,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
 function ai.stream.decode_sse_batch(batch: string) -> ai.stream.SseEvent[] {
   27   0   load_type 0            
        1   load_var 1             (batch)
-       2   call 334 ntypeargs=1   (baml.json.from_string)
+       2   call 336 ntypeargs=1   (baml.json.from_string)
        3   return                 
 }
 
@@ -2863,8 +2863,8 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   306   9     load_type 2                                
         10    load_var 1                                 (spec)
-        11    call 817 ntypeargs=1                       (ai.FunctionSpec.tools)
-        12    call 824 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
+        11    call 819 ntypeargs=1                       (ai.FunctionSpec.tools)
+        12    call 826 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
         13    unary_op !                                 
         14    pop_jump_if_false +2                       (to 16)
         15    jump +71                                   (to 86)
@@ -2914,17 +2914,17 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   331   51    load_type 2                                
         52    load_var 1                                 (spec)
-        53    call 807 ntypeargs=1                       (ai.Journal.new)
+        53    call 809 ntypeargs=1                       (ai.Journal.new)
         54    store_var 12                               (_29)
 
   332   55    load_type 2                                
         56    load_var 1                                 (spec)
-        57    call 817 ntypeargs=1                       (ai.FunctionSpec.tools)
+        57    call 819 ntypeargs=1                       (ai.FunctionSpec.tools)
         58    store_var 13                               (_31)
 
   333   59    load_type 2                                
         60    load_var 1                                 (spec)
-        61    call 815 ntypeargs=1                       (ai.FunctionSpec.output_type)
+        61    call 817 ntypeargs=1                       (ai.FunctionSpec.output_type)
         62    store_var 14                               (_33)
 
   328   63    load_var2 5 11                             
@@ -2939,13 +2939,13 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   346   71    load_type 8                                
         72    load_type 2                                
-        73    call 424 ntypeargs=2                       (baml.sap.__new_parse_cache)
+        73    call 426 ntypeargs=2                       (baml.sap.__new_parse_cache)
         74    store_var 15                               (_36)
 
   340   75    load_type 8                                
         76    load_type 2                                
         77    load_var 10                                (turns)
-        78    make_closure 1761 captures=1 ntypeargs=2   
+        78    make_closure 1763 captures=1 ntypeargs=2   
         79    load_var 15                                (_36)
         80    load_const 9                               ("")
         81    load_const 10                              (false)
@@ -2956,7 +2956,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   308   86    load_type 2                                
         87    load_var 1                                 (spec)
-        88    call 813 ntypeargs=1                       (ai.FunctionSpec.name)
+        88    call 815 ntypeargs=1                       (ai.FunctionSpec.name)
         89    store_var 4                                (_12)
         90    load_type 11                               
         91    load_var 4                                 (_12)
@@ -3005,7 +3005,7 @@ function ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> 
        27   load_type 5            
 
   29   28   load_var2 4 2          
-       29   call 741 ntypeargs=2   (reflect.call_any)
+       29   call 743 ntypeargs=2   (reflect.call_any)
        30   store_var 5            (value)
        31   jump +33               (to 64)
 
@@ -3045,8 +3045,8 @@ function ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> 
 
   35   64   load_type 5            
        65   load_var 5             (value)
-       66   call 332 ntypeargs=1   (baml.json.to_json)
-       67   call 329 ntypeargs=0   (baml.json.stringify)
+       66   call 334 ntypeargs=1   (baml.json.to_json)
+       67   call 331 ntypeargs=0   (baml.json.stringify)
        68   jump +3                (to 71)
 
   27   69   load_var2 2 3          
@@ -3065,7 +3065,7 @@ function ai.tools.Toolbox.get(self: ai.tools.Toolbox, name: string) -> ai.tools.
         5    load_var 1            (self)
         6    load_field 0          (entries)
         7    load_var 2            (name)
-        8    make_closure 1681 1   
+        8    make_closure 1683 1   
         9    call 19 ntypeargs=2   (baml.Array.find)
         10   return                
 }
@@ -3190,7 +3190,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        17   store_var 4            (on_error)
 
   49   18   load_var 1             (handler)
-       19   call 740 ntypeargs=0   (reflect.signature)
+       19   call 742 ntypeargs=0   (reflect.signature)
        20   store_var 5            (sig)
 
   50   21   load_var 2             (name)
@@ -3241,7 +3241,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        61   store_var 9            (_17)
 
   58   62   load_var 1             (handler)
-       63   call 867 ntypeargs=0   (ai.internal._schema_for_signature)
+       63   call 869 ntypeargs=0   (ai.internal._schema_for_signature)
        64   store_var 11           (_21)
 
   56   65   load_var2 8 9          
@@ -3258,7 +3258,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
 
 function ai.wire.render_output_format(t: type) -> string {
   37   0   load_var 1   (t)
-       1   sys_op 419   (baml.prompt.render_output_format)
+       1   sys_op 421   (baml.prompt.render_output_format)
        2   return       
 }
 
@@ -3310,7 +3310,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
 
   29   38   load_type 6            
        39   load_var 7             (text)
-       40   call 334 ntypeargs=1   (baml.json.from_string)
+       40   call 336 ntypeargs=1   (baml.json.from_string)
        41   jump +6                (to 47)
        42   load_var 9             (e)
        43   throw_if_panic         
@@ -3323,7 +3323,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
   27   48   load_var2 2 3          
        49   load_field 0           (status_code)
        50   load_var 7             (text)
-       51   call 866 ntypeargs=0   (ai.errors.classify_http)
+       51   call 868 ntypeargs=0   (ai.errors.classify_http)
        52   throw                  
 }
 
@@ -3341,20 +3341,20 @@ function anthropic.AnthropicClient.ai.Client.id(self: anthropic.AnthropicClient)
 
 function anthropic.AnthropicClient.ai.Client.invoke(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   32   0   load_var2 1 2          
-       1   call 894 ntypeargs=0   (anthropic.internal.invoke)
+       1   call 896 ntypeargs=0   (anthropic.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   33   5   load_var 3             (e)
-       6   call 857 ntypeargs=0   (ai.errors.normalize)
+       6   call 859 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function anthropic.AnthropicClient.ai.stream.StreamingClient.invoke_stream(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   40   0   load_var2 1 2          
-       1   call 896 ntypeargs=0   (anthropic.internal.invoke_stream)
+       1   call 898 ntypeargs=0   (anthropic.internal.invoke_stream)
        2   return                 
 }
 
@@ -3518,7 +3518,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         2     store_var 2                        (out)
 
   349   3     load_var 1                         (batch)
-        4     call 848 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 850 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -3544,7 +3544,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
   351   25    load_type 7                        
 
   350   26    load_var 6                         (_10)
-        27    call 334 ntypeargs=1               (baml.json.from_string)
+        27    call 336 ntypeargs=1               (baml.json.from_string)
         28    jump +4                            (to 32)
 
   351   29    load_var 7                         (e)
@@ -3629,7 +3629,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         99    pop_jump_if_false +2               (to 101)
         100   jump +5                            (to 105)
         101   load_var 21                        (_67)
-        102   call 893 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+        102   call 895 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         103   store_var 20                       (stop)
         104   jump +3                            (to 107)
 
@@ -3792,7 +3792,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         2     store_var 2                        (msgs)
 
   132   3     load_var 1                         (j)
-        4     call 806 ntypeargs=0               (ai.Journal.entries)
+        4     call 808 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -3840,7 +3840,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         47    load_var 14                        (f)
         48    load_field 1                       (message)
         49    load_const 10                      (true)
-        50    call 889 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        50    call 891 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         51    pop 1                              
         52    jump -43                           (to 9)
 
@@ -3852,13 +3852,13 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         57    load_var 12                        (c)
         58    load_field 1                       (output)
         59    load_const 11                      (false)
-        60    call 889 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        60    call 891 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         61    pop 1                              
         62    jump -53                           (to 9)
 
   133   63    load_var 9                         (_25)
         64    load_field 0                       (content)
-        65    call 888 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
+        65    call 890 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
         66    store_var 10                       (_29)
 
   142   67    load_type 0                        
@@ -3923,7 +3923,7 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
        5    store_var 3                        (messages)
 
   53   6    load_var 1                         (prompt)
-       7    call 810 ntypeargs=0               (ai.Prompt.messages)
+       7    call 812 ntypeargs=0               (ai.Prompt.messages)
        8    load_type 2                        
        9    load_const 3                       ("iter")
        10   virtual_call nargs=1 ntypeargs=0   
@@ -4166,11 +4166,11 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         2     store_var 4                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 828 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 830 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 4                         (_5)
         7     call_indirect                      
 
-  183   8     call 887 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
+  183   8     call 889 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
         9     store_var 5                        (prompt_parts)
 
   184   10    load_var 5                         (prompt_parts)
@@ -4183,7 +4183,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   186   16    load_var 2                         (input)
         17    load_field 1                       (journal)
-        18    call 890 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
+        18    call 892 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
         19    load_type 0                        
         20    load_const 1                       ("iter")
         21    virtual_call nargs=1 ntypeargs=0   
@@ -4285,7 +4285,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         108   pop 1                              
 
   210   109   load_var 7                         (lowered)
-        110   call 891 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        110   call 893 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         111   store_var 16                       (_61)
         112   load_type 6                        
         113   load_type 7                        
@@ -4307,7 +4307,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   201   127   load_var 7                         (lowered)
         128   call 7 ntypeargs=1                 (baml.Array.concat)
-        129   call 891 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        129   call 893 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         130   store_var 14                       (_46)
         131   load_type 6                        
         132   load_type 7                        
@@ -4319,7 +4319,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   213   138   load_var 2                         (input)
         139   load_field 2                       (toolbox)
-        140   call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        140   call 826 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         141   unary_op !                         
         142   pop_jump_if_false +80              (to 222)
 
@@ -4329,7 +4329,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   215   146   load_var 2                         (input)
         147   load_field 2                       (toolbox)
-        148   call 822 ntypeargs=0               (ai.tools.Toolbox.list)
+        148   call 824 ntypeargs=0               (ai.tools.Toolbox.list)
         149   load_type 20                       
         150   load_const 21                      ("iter")
         151   virtual_call nargs=1 ntypeargs=0   
@@ -4463,8 +4463,8 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   247   264   load_type 19                       
         265   load_var 10                        (body)
-        266   call 332 ntypeargs=1               (baml.json.to_json)
-        267   call 329 ntypeargs=0               (baml.json.stringify)
+        266   call 334 ntypeargs=1               (baml.json.to_json)
+        267   call 331 ntypeargs=0               (baml.json.stringify)
         268   store_var 28                       (_118)
 
   239   269   load_const 40                      ("POST")
@@ -4519,13 +4519,13 @@ function anthropic.internal._anthropic_stop_reason(s: string) -> ai.content.Stop
 function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   266   0     load_var2 1 2                      
         1     load_const 0                       (false)
-        2     call 892 ntypeargs=0               (anthropic.internal._anthropic_request)
+        2     call 894 ntypeargs=0               (anthropic.internal._anthropic_request)
         3     store_var 3                        (req)
 
   267   4     load_type 1                        
         5     load_var 3                         (req)
         6     load_const 2                       ("anthropic")
-        7     call 827 ntypeargs=1               (ai.wire.send_as)
+        7     call 829 ntypeargs=1               (ai.wire.send_as)
         8     store_var 4                        (resp)
 
   269   9     load_type 3                        
@@ -4661,7 +4661,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         126   pop_jump_if_false +2               (to 128)
         127   jump +5                            (to 132)
         128   load_var 20                        (_46)
-        129   call 893 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+        129   call 895 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         130   store_var 19                       (stop)
         131   jump +4                            (to 135)
 
@@ -4702,7 +4702,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
 function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   415   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 892 ntypeargs=0   (anthropic.internal._anthropic_request)
+        2    call 894 ntypeargs=0   (anthropic.internal._anthropic_request)
 
   416   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -4728,7 +4728,7 @@ function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: a
         21   throw                  
 
   425   22   load_const 6           (anthropic.internal._anthropic_decode_batch)
-        23   call 849 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 851 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -4822,7 +4822,7 @@ function assert.contains(haystack: string, needle: string) -> null {
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   59   0    load_var2 1 2          
-       1    call 654 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 656 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -4832,14 +4832,14 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   59   6    jump +23               (to 29)
 
   61   7    load_var 1             (actual)
-       8    call 801 ntypeargs=0   (assert.format_operand)
+       8    call 803 ntypeargs=0   (assert.format_operand)
        9    store_var 4            (_9)
        10   load_type 1            
        11   load_var 4             (_9)
        12   call 138 ntypeargs=1   (baml.String.from)
        13   store_var 3            (_8)
        14   load_var 2             (expected)
-       15   call 801 ntypeargs=0   (assert.format_operand)
+       15   call 803 ntypeargs=0   (assert.format_operand)
        16   store_var 6            (_12)
        17   load_type 1            
        18   load_var 6             (_12)
@@ -4933,7 +4933,7 @@ function assert.is_type(actual: unknown) -> #0 {
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 654 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 656 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -4969,13 +4969,13 @@ function claude_code.ClaudeCodeClient.ai.Client.id(self: claude_code.ClaudeCodeC
 
 function claude_code.ClaudeCodeClient.ai.Client.invoke(self: claude_code.ClaudeCodeClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   44   0   load_var2 1 2          
-       1   call 925 ntypeargs=0   (claude_code.internal.invoke)
+       1   call 927 ntypeargs=0   (claude_code.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   45   5   load_var 3             (e)
-       6   call 857 ntypeargs=0   (ai.errors.normalize)
+       6   call 859 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
@@ -5053,20 +5053,20 @@ function claude_code.ClaudeCodeClient.new(model: string, executable: string, cwd
 }
 
 function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
-  163   0     load_type 0                        
+  165   0     load_type 0                        
         1     load_var 1                         (raw)
         2     load_const 1                       (".type")
         3     load_const 2                       ("?")
-        4     call 341 ntypeargs=1               (baml.json.path_or)
+        4     call 343 ntypeargs=1               (baml.json.path_or)
         5     store_var 2                        (kind)
 
-  164   6     load_var 2                         (kind)
+  166   6     load_var 2                         (kind)
         7     load_const 3                       ("system")
         8     cmp_op ==                          
         9     pop_jump_if_false +2               (to 11)
         10    jump +183                          (to 193)
 
-  177   11    load_var 2                         (kind)
+  179   11    load_var 2                         (kind)
         12    load_const 4                       ("assistant")
         13    cmp_op ==                          
         14    jump_if_false +2                   (to 16)
@@ -5078,13 +5078,13 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         20    pop_jump_if_false +2               (to 22)
         21    jump +23                           (to 44)
 
-  195   22    load_var 2                         (kind)
+  197   22    load_var 2                         (kind)
         23    load_const 6                       ("result")
         24    cmp_op ==                          
         25    pop_jump_if_false +2               (to 27)
         26    jump +233                          (to 259)
 
-  198   27    load_type 0                        
+  200   27    load_type 0                        
         28    load_var 2                         (kind)
         29    call 138 ntypeargs=1               (baml.String.from)
         30    store_var 23                       (_88)
@@ -5102,18 +5102,18 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         42    pop 1                              
         43    jump +216                          (to 259)
 
-  178   44    load_type 0                        
+  180   44    load_type 0                        
         45    alloc_array 0                      
         46    store_var 9                        (parts)
 
-  179   47    load_type 13                       
+  181   47    load_type 13                       
         48    load_var 1                         (raw)
         49    load_const 14                      (".message.content")
         50    load_type 15                       
         51    alloc_array 0                      
-        52    call 341 ntypeargs=1               (baml.json.path_or)
+        52    call 343 ntypeargs=1               (baml.json.path_or)
 
-  180   53    load_type 16                       
+  182   53    load_type 16                       
         54    load_const 17                      ("iter")
         55    virtual_call nargs=1 ntypeargs=0   
         56    store_var 10                       (_35)
@@ -5129,14 +5129,14 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         66    load_var 11                        (_36)
         67    store_var 12                       (b)
 
-  181   68    load_type 0                        
+  183   68    load_type 0                        
         69    load_var 12                        (b)
         70    load_const 21                      (".type")
         71    load_const 22                      ("?")
-        72    call 341 ntypeargs=1               (baml.json.path_or)
+        72    call 343 ntypeargs=1               (baml.json.path_or)
         73    store_var 13                       (bt)
 
-  182   74    load_var 13                        (bt)
+  184   74    load_var 13                        (bt)
         75    load_const 23                      ("text")
         76    cmp_op ==                          
         77    pop_jump_if_false +2               (to 79)
@@ -5157,24 +5157,24 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         92    pop_jump_if_false +2               (to 94)
         93    jump +6                            (to 99)
 
-  191   94    load_type 0                        
+  193   94    load_type 0                        
         95    load_var2 9 13                     
         96    call 4 ntypeargs=1                 (baml.Array.push)
         97    pop 1                              
         98    jump -41                           (to 57)
 
-  190   99    load_type 0                        
+  192   99    load_type 0                        
         100   load_var 9                         (parts)
         101   load_const 27                      ("tool_result")
         102   call 4 ntypeargs=1                 (baml.Array.push)
         103   pop 1                              
         104   jump -47                           (to 57)
 
-  189   105   load_type 0                        
+  191   105   load_type 0                        
         106   load_var 12                        (b)
         107   load_const 28                      (".name")
         108   load_const 29                      ("?")
-        109   call 341 ntypeargs=1               (baml.json.path_or)
+        109   call 343 ntypeargs=1               (baml.json.path_or)
         110   store_var 19                       (_65)
         111   load_type 0                        
         112   load_var 19                        (_65)
@@ -5189,34 +5189,34 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         121   pop 1                              
         122   jump -65                           (to 57)
 
-  186   123   load_type 0                        
+  188   123   load_type 0                        
         124   load_var 12                        (b)
         125   load_const 31                      (".thinking")
         126   load_const 32                      ("")
-        127   call 341 ntypeargs=1               (baml.json.path_or)
-        128   call 921 ntypeargs=0               (claude_code.internal._preview)
+        127   call 343 ntypeargs=1               (baml.json.path_or)
+        128   call 923 ntypeargs=0               (claude_code.internal._preview)
         129   store_var 17                       (_56)
         130   load_type 0                        
         131   load_var 17                        (_56)
         132   call 138 ntypeargs=1               (baml.String.from)
         133   store_var 16                       (_55)
 
-  185   134   load_type 0                        
+  187   134   load_type 0                        
         135   load_var 9                         (parts)
 
-  186   136   load_const 33                      ("thinking: ")
+  188   136   load_const 33                      ("thinking: ")
         137   load_var 16                        (_55)
         138   bin_op +                           
         139   call 4 ntypeargs=1                 (baml.Array.push)
         140   pop 1                              
         141   jump -84                           (to 57)
 
-  183   142   load_type 0                        
+  185   142   load_type 0                        
         143   load_var 12                        (b)
         144   load_const 34                      (".text")
         145   load_const 35                      ("")
-        146   call 341 ntypeargs=1               (baml.json.path_or)
-        147   call 921 ntypeargs=0               (claude_code.internal._preview)
+        146   call 343 ntypeargs=1               (baml.json.path_or)
+        147   call 923 ntypeargs=0               (claude_code.internal._preview)
         148   store_var 15                       (_47)
         149   load_type 0                        
         150   load_var 15                        (_47)
@@ -5231,7 +5231,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         159   pop 1                              
         160   jump -103                          (to 57)
 
-  194   161   load_type 0                        
+  196   161   load_type 0                        
         162   load_var 2                         (kind)
         163   call 138 ntypeargs=1               (baml.String.from)
         164   store_var 20                       (_78)
@@ -5264,20 +5264,20 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         191   pop 1                              
         192   jump +67                           (to 259)
 
-  165   193   load_type 0                        
+  167   193   load_type 0                        
         194   load_var 1                         (raw)
         195   load_const 45                      (".subtype")
         196   load_const 46                      ("?")
-        197   call 341 ntypeargs=1               (baml.json.path_or)
+        197   call 343 ntypeargs=1               (baml.json.path_or)
         198   store_var 3                        (subtype)
 
-  166   199   load_var 3                         (subtype)
+  168   199   load_var 3                         (subtype)
         200   load_const 47                      ("thinking_tokens")
         201   cmp_op ==                          
         202   pop_jump_if_false +2               (to 204)
         203   jump +32                           (to 235)
 
-  174   204   load_type 0                        
+  176   204   load_type 0                        
         205   load_var 3                         (subtype)
         206   call 138 ntypeargs=1               (baml.String.from)
         207   store_var 6                        (_19)
@@ -5285,17 +5285,17 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         209   load_var 1                         (raw)
         210   load_const 48                      (".model")
         211   load_const 49                      ("?")
-        212   call 341 ntypeargs=1               (baml.json.path_or)
+        212   call 343 ntypeargs=1               (baml.json.path_or)
         213   store_var 8                        (_23)
         214   load_type 0                        
         215   load_var 8                         (_23)
         216   call 138 ntypeargs=1               (baml.String.from)
         217   store_var 7                        (_22)
 
-  173   218   load_const 50                      ("$baml_log")
+  175   218   load_const 50                      ("$baml_log")
         219   load_const 51                      ("info")
 
-  174   220   load_const 52                      ("cc event: system/")
+  176   220   load_const 52                      ("cc event: system/")
         221   load_var 6                         (_19)
         222   bin_op +                           
         223   load_const 53                      (" model=")
@@ -5308,25 +5308,25 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         230   load_type 12                       
         231   alloc_map 2                        
 
-  173   232   send_event                         
+  175   232   send_event                         
         233   pop 1                              
         234   jump +25                           (to 259)
 
-  170   235   load_type 56                       
+  172   235   load_type 56                       
         236   load_var 1                         (raw)
         237   load_const 57                      (".estimated_tokens")
         238   load_const 58                      (0)
-        239   call 341 ntypeargs=1               (baml.json.path_or)
+        239   call 343 ntypeargs=1               (baml.json.path_or)
         240   store_var 5                        (_13)
         241   load_type 56                       
         242   load_var 5                         (_13)
         243   call 138 ntypeargs=1               (baml.String.from)
         244   store_var 4                        (_12)
 
-  169   245   load_const 59                      ("$baml_log")
+  171   245   load_const 59                      ("$baml_log")
         246   load_const 60                      ("debug")
 
-  170   247   load_const 61                      ("cc event: thinking ~")
+  172   247   load_const 61                      ("cc event: thinking ~")
         248   load_var 4                         (_12)
         249   bin_op +                           
         250   load_const 62                      (" tokens")
@@ -5337,26 +5337,26 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         255   load_type 12                       
         256   alloc_map 2                        
 
-  169   257   send_event                         
+  171   257   send_event                         
         258   pop 1                              
 
-  200   259   load_const 65                      (null)
+  202   259   load_const 65                      (null)
         260   return                             
 }
 
 function claude_code.internal._preview(text: string) -> string {
-  154   0    load_var 1             (text)
+  156   0    load_var 1             (text)
         1    call 139 ntypeargs=0   (baml.String.length)
         2    load_const 0           (120)
         3    cmp_int_op >           
         4    pop_jump_if_false +2   (to 6)
         5    jump +3                (to 8)
 
-  157   6    load_var 1             (text)
+  159   6    load_var 1             (text)
 
-  154   7    jump +11               (to 18)
+  156   7    jump +11               (to 18)
 
-  155   8    load_var 1             (text)
+  157   8    load_var 1             (text)
         9    load_const 1           (0)
         10   load_const 0           (120)
         11   call 153 ntypeargs=0   (baml.String.substring)
@@ -5370,10 +5370,10 @@ function claude_code.internal._preview(text: string) -> string {
 }
 
 function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.json {
-  127   0    load_const 0                       (null)
+  129   0    load_const 0                       (null)
         1    store_var 2                        (result)
 
-  128   2    load_var 1                         (p)
+  130   2    load_var 1                         (p)
         3    load_field 0                       (stdout)
         4    load_type 1                        
         5    load_const 2                       ("iter")
@@ -5392,52 +5392,52 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         18   call 144 ntypeargs=0               (baml.String.trim)
         19   store_var 5                        (trimmed)
 
-  130   20   load_var 5                         (trimmed)
+  132   20   load_var 5                         (trimmed)
         21   call 139 ntypeargs=0               (baml.String.length)
         22   load_const 6                       (0)
         23   cmp_int_op >                       
         24   pop_jump_if_false -16              (to 8)
 
-  131   25   load_var 5                         (trimmed)
-        26   call 328 ntypeargs=0               (baml.json.parse)
+  133   25   load_var 5                         (trimmed)
+        26   call 330 ntypeargs=0               (baml.json.parse)
         27   store_var 6                        (raw)
         28   jump +7                            (to 35)
         29   load_var 7                         (e)
         30   throw_if_panic                     
 
-  133   31   load_const 7                       ("claude-code")
+  135   31   load_const 7                       ("claude-code")
         32   load_var 5                         (trimmed)
         33   init_instance 0                    (ai.errors.ParseFailed .provider, .raw_output)
         34   throw                              
 
-  136   35   load_var 6                         (raw)
-        36   call 922 ntypeargs=0               (claude_code.internal._log_cc_event)
+  138   35   load_var 6                         (raw)
+        36   call 924 ntypeargs=0               (claude_code.internal._log_cc_event)
         37   pop 1                              
 
-  137   38   load_type 8                        
+  139   38   load_type 8                        
         39   load_var 6                         (raw)
         40   load_const 9                       (".type")
         41   load_const 10                      ("")
-        42   call 341 ntypeargs=1               (baml.json.path_or)
+        42   call 343 ntypeargs=1               (baml.json.path_or)
         43   load_const 11                      ("result")
         44   cmp_op ==                          
         45   pop_jump_if_false -37              (to 8)
 
-  138   46   load_var 6                         (raw)
+  140   46   load_var 6                         (raw)
         47   store_var 2                        (result)
 
-  137   48   jump -40                           (to 8)
+  139   48   jump -40                           (to 8)
 
-  144   49   load_var 2                         (result)
+  146   49   load_var 2                         (result)
         50   load_const 0                       (null)
-        51   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        51   call 656 ntypeargs=0               (baml.ops.equals_equals)
         52   pop_jump_if_false +2               (to 54)
         53   jump +3                            (to 56)
 
-  150   54   load_var 2                         (result)
+  152   54   load_var 2                         (result)
         55   return                             
 
-  145   56   load_const 12                      ("claude-code")
+  147   56   load_const 12                      ("claude-code")
         57   load_const 13                      ("the Claude Code CLI stream ended without a result event")
         58   init_instance 1                    (ai.errors.ParseFailed .provider, .raw_output)
         59   throw                              
@@ -5462,7 +5462,7 @@ function claude_code.internal._type_schema(t: string) -> map<string, unknown> {
 }
 
 function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient) -> string {
-  219   0    load_type 0           
+  221   0    load_type 0           
         1    load_type 1           
         2    load_var 1            (c)
         3    load_field 6          (mcp_servers)
@@ -5473,11 +5473,11 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
         8    load_type 2           
         9    load_var 3            (_3)
 
-  220   10   make_closure 2241 0   
+  222   10   make_closure 2243 0   
         11   call 16 ntypeargs=3   (baml.Array.map)
         12   store_var 2           (_2)
 
-  219   13   load_type 0           
+  221   13   load_type 0           
         14   load_var 2            (_2)
         15   load_const 3          (",")
         16   call 15 ntypeargs=1   (baml.Array.join)
@@ -5486,11 +5486,11 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
 
 function claude_code.internal.envelope_schema(output_type: type) -> map<string, unknown> {
   52   0     load_var 1             (output_type)
-       1     sys_op 342             (baml.json.schema)
+       1     sys_op 344             (baml.json.schema)
        2     store_var 3            (_3)
        3     load_type 0            
        4     load_var 3             (_3)
-       5     call 335 ntypeargs=1   (baml.json.from_json)
+       5     call 337 ntypeargs=1   (baml.json.from_json)
        6     store_var 2            (final_root)
 
   53   7     load_type 1            
@@ -5506,7 +5506,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        16    store_var 5            (call_props)
 
   55   17    load_const 4           ("string")
-       18    call 918 ntypeargs=0   (claude_code.internal._type_schema)
+       18    call 920 ntypeargs=0   (claude_code.internal._type_schema)
        19    store_var 6            (_10)
        20    load_type 1            
        21    load_type 2            
@@ -5517,7 +5517,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        26    pop 1                  
 
   56   27    load_const 6           ("string")
-       28    call 918 ntypeargs=0   (claude_code.internal._type_schema)
+       28    call 920 ntypeargs=0   (claude_code.internal._type_schema)
        29    store_var 7            (_14)
        30    load_type 1            
        31    load_type 2            
@@ -5528,7 +5528,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        36    pop 1                  
 
   57   37    load_const 8           ("object")
-       38    call 918 ntypeargs=0   (claude_code.internal._type_schema)
+       38    call 920 ntypeargs=0   (claude_code.internal._type_schema)
        39    store_var 8            (_18)
        40    load_type 1            
        41    load_type 2            
@@ -5659,11 +5659,11 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
 
   74   150   load_type 0            
        151   load_var 2             (final_root)
-       152   call 332 ntypeargs=1   (baml.json.to_json)
+       152   call 334 ntypeargs=1   (baml.json.to_json)
        153   store_var 14           (_67)
        154   load_type 0            
        155   load_var 12            (calls_schema)
-       156   call 332 ntypeargs=1   (baml.json.to_json)
+       156   call 334 ntypeargs=1   (baml.json.to_json)
        157   store_var 15           (_70)
        158   load_type 1            
        159   load_type 2            
@@ -5729,7 +5729,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
 
   82   212   load_var 4             (definitions)
        213   load_const 38          (null)
-       214   call 654 ntypeargs=0   (baml.ops.equals_equals)
+       214   call 656 ntypeargs=0   (baml.ops.equals_equals)
        215   unary_op !             
        216   pop_jump_if_false +8   (to 224)
 
@@ -5746,48 +5746,48 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
 }
 
 function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
-  233   0     load_const 0                       ("")
+  235   0     load_const 0                       ("")
         1     load_var 2                         (input)
         2     load_field 0                       (prompt)
         3     call_indirect                      
-        4     call 809 ntypeargs=0               (ai.Prompt.text)
+        4     call 811 ntypeargs=0               (ai.Prompt.text)
         5     store_var 4                        (instructions)
 
-  234   6     load_var 2                         (input)
+  236   6     load_var 2                         (input)
         7     load_field 2                       (toolbox)
-        8     call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        8     call 826 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         9     unary_op !                         
         10    store_var_load_var 5               (has_tools)
 
-  235   11    pop_jump_if_false +2               (to 13)
+  237   11    pop_jump_if_false +2               (to 13)
         12    jump +6                            (to 18)
 
-  238   13    load_var 2                         (input)
+  240   13    load_var 2                         (input)
         14    load_field 3                       (output_type)
-        15    sys_op 342                         (baml.json.schema)
+        15    sys_op 344                         (baml.json.schema)
         16    store_var 6                        (schema)
         17    jump +9                            (to 26)
 
-  236   18    load_var 2                         (input)
+  238   18    load_var 2                         (input)
         19    load_field 3                       (output_type)
-        20    call 917 ntypeargs=0               (claude_code.internal.envelope_schema)
+        20    call 919 ntypeargs=0               (claude_code.internal.envelope_schema)
         21    store_var 7                        (_11)
         22    load_type 1                        
         23    load_var 7                         (_11)
-        24    call 332 ntypeargs=1               (baml.json.to_json)
+        24    call 334 ntypeargs=1               (baml.json.to_json)
         25    store_var 6                        (schema)
 
-  240   26    load_var 5                         (has_tools)
+  242   26    load_var 5                         (has_tools)
         27    pop_jump_if_false +2               (to 29)
         28    jump +17                           (to 45)
 
-  243   29    load_type 2                        
+  245   29    load_type 2                        
         30    load_var 4                         (instructions)
         31    call 138 ntypeargs=1               (baml.String.from)
         32    store_var 14                       (_29)
         33    load_var 2                         (input)
         34    load_field 1                       (journal)
-        35    call 916 ntypeargs=0               (claude_code.internal.transcript_text)
+        35    call 918 ntypeargs=0               (claude_code.internal.transcript_text)
         36    store_var 16                       (_33)
         37    load_type 2                        
         38    load_var 16                        (_33)
@@ -5797,15 +5797,15 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         42    bin_op +                           
         43    store_var 8                        (prompt_text)
 
-  240   44    jump +26                           (to 70)
+  242   44    jump +26                           (to 70)
 
-  241   45    load_type 2                        
+  243   45    load_type 2                        
         46    load_var 4                         (instructions)
         47    call 138 ntypeargs=1               (baml.String.from)
         48    store_var 9                        (_18)
         49    load_var 2                         (input)
         50    load_field 1                       (journal)
-        51    call 916 ntypeargs=0               (claude_code.internal.transcript_text)
+        51    call 918 ntypeargs=0               (claude_code.internal.transcript_text)
         52    store_var 11                       (_22)
         53    load_type 2                        
         54    load_var 11                        (_22)
@@ -5813,7 +5813,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         56    store_var 10                       (_21)
         57    load_var 2                         (input)
         58    load_field 2                       (toolbox)
-        59    call 919 ntypeargs=0               (claude_code.internal.tool_protocol)
+        59    call 921 ntypeargs=0               (claude_code.internal.tool_protocol)
         60    store_var 13                       (_26)
         61    load_type 2                        
         62    load_var 13                        (_26)
@@ -5825,7 +5825,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         68    bin_op +                           
         69    store_var 8                        (prompt_text)
 
-  247   70    load_type 2                        
+  249   70    load_type 2                        
         71    load_var 1                         (c)
         72    load_field 1                       (model)
         73    call 138 ntypeargs=1               (baml.String.from)
@@ -5839,7 +5839,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         81    store_var 18                       (_44)
         82    load_var 2                         (input)
         83    load_field 2                       (toolbox)
-        84    call 822 ntypeargs=0               (ai.tools.Toolbox.list)
+        84    call 824 ntypeargs=0               (ai.tools.Toolbox.list)
         85    container_len                      
         86    store_var 21                       (_48)
         87    load_type 3                        
@@ -5847,10 +5847,10 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         89    call 138 ntypeargs=1               (baml.String.from)
         90    store_var 20                       (_47)
 
-  246   91    load_const 4                       ("$baml_log")
+  248   91    load_const 4                       ("$baml_log")
         92    load_const 5                       ("info")
 
-  247   93    load_const 6                       ("claude-code invoke: model=")
+  249   93    load_const 6                       ("claude-code invoke: model=")
         94    load_var 17                        (_41)
         95    bin_op +                           
         96    load_const 7                       (" prompt_chars=")
@@ -5867,74 +5867,74 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         107   load_type 11                       
         108   alloc_map 2                        
 
-  246   109   send_event                         
+  248   109   send_event                         
         110   pop 1                              
 
-  249   111   load_type 2                        
+  251   111   load_type 2                        
         112   alloc_array 0                      
         113   store_var 22                       (args)
 
-  250   114   load_type 2                        
+  252   114   load_type 2                        
         115   load_var 22                        (args)
         116   load_const 12                      ("-p")
         117   call 4 ntypeargs=1                 (baml.Array.push)
         118   pop 1                              
 
-  251   119   load_type 2                        
+  253   119   load_type 2                        
         120   load_var 22                        (args)
         121   load_const 13                      ("--output-format")
         122   call 4 ntypeargs=1                 (baml.Array.push)
         123   pop 1                              
 
-  252   124   load_type 2                        
+  254   124   load_type 2                        
         125   load_var 22                        (args)
         126   load_const 14                      ("stream-json")
         127   call 4 ntypeargs=1                 (baml.Array.push)
         128   pop 1                              
 
-  253   129   load_type 2                        
+  255   129   load_type 2                        
         130   load_var 22                        (args)
         131   load_const 15                      ("--verbose")
         132   call 4 ntypeargs=1                 (baml.Array.push)
         133   pop 1                              
 
-  254   134   load_type 2                        
+  256   134   load_type 2                        
         135   load_var 22                        (args)
         136   load_const 16                      ("--model")
         137   call 4 ntypeargs=1                 (baml.Array.push)
         138   pop 1                              
 
-  255   139   load_type 2                        
+  257   139   load_type 2                        
         140   load_var2 22 1                     
         141   load_field 1                       (model)
         142   call 4 ntypeargs=1                 (baml.Array.push)
         143   pop 1                              
 
-  256   144   load_type 2                        
+  258   144   load_type 2                        
         145   load_var 22                        (args)
         146   load_const 17                      ("--permission-mode")
         147   call 4 ntypeargs=1                 (baml.Array.push)
         148   pop 1                              
 
-  257   149   load_type 2                        
+  259   149   load_type 2                        
         150   load_var2 22 1                     
         151   load_field 4                       (permission_mode)
         152   call 4 ntypeargs=1                 (baml.Array.push)
         153   pop 1                              
 
-  258   154   load_type 2                        
+  260   154   load_type 2                        
         155   load_var 22                        (args)
         156   load_const 18                      ("--no-session-persistence")
         157   call 4 ntypeargs=1                 (baml.Array.push)
         158   pop 1                              
 
-  259   159   load_type 2                        
+  261   159   load_type 2                        
         160   load_var 22                        (args)
         161   load_const 19                      ("--tools")
         162   call 4 ntypeargs=1                 (baml.Array.push)
         163   pop 1                              
 
-  260   164   load_type 2                        
+  262   164   load_type 2                        
         165   load_var 1                         (c)
         166   load_field 5                       (harness_tools)
         167   load_const 20                      (",")
@@ -5945,8 +5945,8 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         172   call 4 ntypeargs=1                 (baml.Array.push)
         173   pop 1                              
 
-  267   174   load_var 1                         (c)
-        175   call 923 ntypeargs=0               (claude_code.internal.mcp_config_json)
+  269   174   load_var 1                         (c)
+        175   call 925 ntypeargs=0               (claude_code.internal.mcp_config_json)
         176   store_var 24                       (_81)
         177   load_var 24                        (_81)
         178   narrow_bind 21 24                  
@@ -5954,25 +5954,25 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         180   load_var 24                        (_81)
         181   store_var 25                       (mcp)
 
-  268   182   load_type 2                        
+  270   182   load_type 2                        
         183   load_var 22                        (args)
         184   load_const 22                      ("--mcp-config")
         185   call 4 ntypeargs=1                 (baml.Array.push)
         186   pop 1                              
 
-  269   187   load_type 2                        
+  271   187   load_type 2                        
         188   load_var2 22 25                    
         189   call 4 ntypeargs=1                 (baml.Array.push)
         190   pop 1                              
 
-  270   191   load_type 2                        
+  272   191   load_type 2                        
         192   load_var 22                        (args)
         193   load_const 23                      ("--strict-mcp-config")
         194   call 4 ntypeargs=1                 (baml.Array.push)
         195   pop 1                              
 
-  271   196   load_var 1                         (c)
-        197   call 924 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
+  273   196   load_var 1                         (c)
+        197   call 926 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
         198   store_var 27                       (_93)
         199   load_type 2                        
         200   load_var 27                        (_93)
@@ -5986,31 +5986,31 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         208   call 4 ntypeargs=1                 (baml.Array.push)
         209   pop 1                              
 
-  273   210   load_type 2                        
+  275   210   load_type 2                        
         211   load_var 22                        (args)
         212   load_const 25                      ("--json-schema")
         213   call 4 ntypeargs=1                 (baml.Array.push)
         214   pop 1                              
 
-  274   215   load_var 6                         (schema)
-        216   call 329 ntypeargs=0               (baml.json.stringify)
+  276   215   load_var 6                         (schema)
+        216   call 331 ntypeargs=0               (baml.json.stringify)
         217   store_var 28                       (_99)
         218   load_type 2                        
         219   load_var2 22 28                    
         220   call 4 ntypeargs=1                 (baml.Array.push)
         221   pop 1                              
 
-  275   222   load_type 2                        
+  277   222   load_type 2                        
         223   load_var2 22 8                     
         224   call 4 ntypeargs=1                 (baml.Array.push)
         225   pop 1                              
 
-  278   226   load_var 1                         (c)
+  280   226   load_var 1                         (c)
         227   load_field 0                       (executable)
 
-  279   228   load_var2 22 1                     
+  281   228   load_var2 22 1                     
 
-  280   229   load_field 2                       (cwd)
+  282   229   load_field 2                       (cwd)
         230   load_const 26                      (null)
         231   load_var 1                         (c)
         232   load_field 3                       (timeout_ms)
@@ -6021,10 +6021,10 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         237   store_var 29                       (p)
         238   jump +18                           (to 256)
 
-  277   239   load_var 30                        (e)
+  279   239   load_var 30                        (e)
         240   throw_if_panic                     
 
-  285   241   load_type 27                       
+  287   241   load_type 27                       
         242   load_var 30                        (e)
         243   call 138 ntypeargs=1               (baml.String.from)
         244   store_var 32                       (_115)
@@ -6033,34 +6033,34 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         247   call 138 ntypeargs=1               (baml.String.from)
         248   store_var 31                       (_114)
 
-  283   249   load_const 28                      ("claude-code")
+  285   249   load_const 28                      ("claude-code")
 
-  285   250   load_const 29                      ("the Claude Code CLI could not start: ")
+  287   250   load_const 29                      ("the Claude Code CLI could not start: ")
         251   load_var 31                        (_114)
         252   bin_op +                           
         253   load_const 26                      (null)
         254   init_instance 1                    (ai.errors.NetworkFailure .provider, .detail, .raw_body)
         255   throw                              
 
-  294   256   load_var 29                        (p)
+  296   256   load_var 29                        (p)
         257   sys_op 248                         (baml.sys.Process.close_stdin)
         258   pop 1                              
         259   jump +3                            (to 262)
         260   load_var 35                        (e)
         261   throw_if_panic                     
 
-  299   262   load_var 29                        (p)
-        263   call 920 ntypeargs=0               (claude_code.internal._read_result)
+  301   262   load_var 29                        (p)
+        263   call 922 ntypeargs=0               (claude_code.internal._read_result)
         264   store_var 36                       (result)
 
-  300   265   load_var 29                        (p)
+  302   265   load_var 29                        (p)
         266   sys_op 249                         (baml.sys.Process.wait)
         267   store_var 37                       (exit)
         268   jump +18                           (to 286)
         269   load_var 38                        (e)
         270   throw_if_panic                     
 
-  304   271   load_type 30                       
+  306   271   load_type 30                       
         272   load_var 38                        (e)
         273   call 138 ntypeargs=1               (baml.String.from)
         274   store_var 40                       (_129)
@@ -6069,34 +6069,34 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         277   call 138 ntypeargs=1               (baml.String.from)
         278   store_var 39                       (_128)
 
-  302   279   load_const 31                      ("claude-code")
+  304   279   load_const 31                      ("claude-code")
 
-  304   280   load_const 32                      ("the Claude Code CLI did not terminate cleanly: ")
+  306   280   load_const 32                      ("the Claude Code CLI did not terminate cleanly: ")
         281   load_var 39                        (_128)
         282   bin_op +                           
         283   load_const 26                      (null)
         284   init_instance 2                    (ai.errors.NetworkFailure .provider, .detail, .raw_body)
         285   throw                              
 
-  309   286   load_var 37                        (exit)
+  311   286   load_var 37                        (exit)
         287   call 242 ntypeargs=0               (baml.sys.ProcessExit.ok)
         288   unary_op !                         
         289   pop_jump_if_false +2               (to 291)
         290   jump +251                          (to 541)
 
-  318   291   load_type 33                       
+  320   291   load_type 33                       
         292   load_var 36                        (result)
         293   load_const 34                      (".is_error")
         294   load_const 35                      (false)
-        295   call 341 ntypeargs=1               (baml.json.path_or)
+        295   call 343 ntypeargs=1               (baml.json.path_or)
         296   pop_jump_if_false +2               (to 298)
         297   jump +231                          (to 528)
 
-  326   298   load_type 2                        
+  328   298   load_type 2                        
         299   load_var 36                        (result)
         300   load_const 36                      (".subtype")
         301   load_const 37                      ("?")
-        302   call 341 ntypeargs=1               (baml.json.path_or)
+        302   call 343 ntypeargs=1               (baml.json.path_or)
         303   store_var 45                       (_154)
         304   load_type 2                        
         305   load_var 45                        (_154)
@@ -6106,7 +6106,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         309   load_var 36                        (result)
         310   load_const 39                      (".total_cost_usd")
         311   load_const 40                      (0.0)
-        312   call 341 ntypeargs=1               (baml.json.path_or)
+        312   call 343 ntypeargs=1               (baml.json.path_or)
         313   store_var 47                       (_159)
         314   load_type 38                       
         315   load_var 47                        (_159)
@@ -6116,17 +6116,17 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         319   load_var 36                        (result)
         320   load_const 41                      (".session_id")
         321   load_const 42                      ("?")
-        322   call 341 ntypeargs=1               (baml.json.path_or)
+        322   call 343 ntypeargs=1               (baml.json.path_or)
         323   store_var 49                       (_164)
         324   load_type 2                        
         325   load_var 49                        (_164)
         326   call 138 ntypeargs=1               (baml.String.from)
         327   store_var 48                       (_163)
 
-  325   328   load_const 43                      ("$baml_log")
+  327   328   load_const 43                      ("$baml_log")
         329   load_const 44                      ("info")
 
-  326   330   load_const 45                      ("claude-code result: subtype=")
+  328   330   load_const 45                      ("claude-code result: subtype=")
         331   load_var 44                        (_153)
         332   bin_op +                           
         333   load_const 46                      (" cost_usd=")
@@ -6143,73 +6143,73 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         344   load_type 11                       
         345   alloc_map 2                        
 
-  325   346   send_event                         
+  327   346   send_event                         
         347   pop 1                              
 
-  328   348   load_type 50                       
+  330   348   load_type 50                       
         349   load_var 36                        (result)
         350   load_const 51                      (".structured_output")
-        351   call 340 ntypeargs=1               (baml.json.path)
+        351   call 342 ntypeargs=1               (baml.json.path)
         352   store_var 50                       (structured)
         353   jump +20                           (to 373)
         354   load_var 51                        (e)
         355   throw_if_panic                     
 
-  330   356   load_type 2                        
+  332   356   load_type 2                        
         357   load_var 36                        (result)
         358   load_const 52                      (".result")
         359   load_const 53                      ("")
-        360   call 341 ntypeargs=1               (baml.json.path_or)
-        361   call 328 ntypeargs=0               (baml.json.parse)
+        360   call 343 ntypeargs=1               (baml.json.path_or)
+        361   call 330 ntypeargs=0               (baml.json.parse)
         362   store_var 50                       (structured)
         363   jump +10                           (to 373)
         364   load_var 52                        (inner)
         365   throw_if_panic                     
 
-  334   366   load_var 36                        (result)
-        367   call 329 ntypeargs=0               (baml.json.stringify)
+  336   366   load_var 36                        (result)
+        367   call 331 ntypeargs=0               (baml.json.stringify)
         368   store_var 53                       (_177)
 
-  332   369   load_const 54                      ("claude-code")
+  334   369   load_const 54                      ("claude-code")
         370   load_var 53                        (_177)
         371   init_instance 3                    (ai.errors.ParseFailed .provider, .raw_output)
         372   throw                              
 
-  342   373   load_type 3                        
+  344   373   load_type 3                        
         374   load_var 36                        (result)
         375   load_const 55                      (".usage.input_tokens")
         376   load_const 56                      (0)
-        377   call 341 ntypeargs=1               (baml.json.path_or)
+        377   call 343 ntypeargs=1               (baml.json.path_or)
         378   store_var 54                       (_180)
 
-  343   379   load_type 3                        
+  345   379   load_type 3                        
         380   load_var 36                        (result)
         381   load_const 57                      (".usage.output_tokens")
         382   load_const 56                      (0)
-        383   call 341 ntypeargs=1               (baml.json.path_or)
+        383   call 343 ntypeargs=1               (baml.json.path_or)
         384   store_var 55                       (_183)
 
-  344   385   load_type 58                       
+  346   385   load_type 58                       
         386   load_var 36                        (result)
         387   load_const 59                      (".usage.cache_read_input_tokens")
         388   load_const 26                      (null)
-        389   call 341 ntypeargs=1               (baml.json.path_or)
+        389   call 343 ntypeargs=1               (baml.json.path_or)
         390   store_var 56                       (_186)
 
-  348   391   load_type 60                       
+  350   391   load_type 60                       
         392   alloc_array 0                      
         393   store_var 57                       (content)
 
-  349   394   load_const 56                      (ai.content.StopReason.Complete)
+  351   394   load_const 56                      (ai.content.StopReason.Complete)
         395   alloc_variant 436                  (ai.content.StopReason)
         396   store_var 58                       (stop)
 
-  350   397   load_var 5                         (has_tools)
+  352   397   load_var 5                         (has_tools)
         398   pop_jump_if_false +2               (to 400)
         399   jump +10                           (to 409)
 
-  378   400   load_var 50                        (structured)
-        401   call 329 ntypeargs=0               (baml.json.stringify)
+  380   400   load_var 50                        (structured)
+        401   call 331 ntypeargs=0               (baml.json.stringify)
         402   store_var 74                       (_247)
         403   load_type 60                       
         404   load_var2 57 74                    
@@ -6218,27 +6218,27 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         407   pop 1                              
         408   jump +108                          (to 516)
 
-  351   409   load_type 50                       
+  353   409   load_type 50                       
         410   load_var 36                        (result)
         411   load_const 61                      (".structured_output.outcome")
         412   load_var 50                        (structured)
-        413   call 341 ntypeargs=1               (baml.json.path_or)
+        413   call 343 ntypeargs=1               (baml.json.path_or)
         414   store_var 59                       (outcome)
 
-  352   415   load_type 62                       
+  354   415   load_type 62                       
         416   load_var 59                        (outcome)
         417   load_const 63                      (".calls")
         418   load_const 26                      (null)
-        419   call 341 ntypeargs=1               (baml.json.path_or)
+        419   call 343 ntypeargs=1               (baml.json.path_or)
 
-  353   420   store_var 60                       (_199)
+  355   420   store_var 60                       (_199)
         421   load_var 60                        (_199)
         422   narrow_bind 64 60                  
         423   pop_jump_if_false +2               (to 425)
         424   jump +10                           (to 434)
 
-  375   425   load_var 59                        (outcome)
-        426   call 329 ntypeargs=0               (baml.json.stringify)
+  377   425   load_var 59                        (outcome)
+        426   call 331 ntypeargs=0               (baml.json.stringify)
         427   store_var 73                       (_242)
         428   load_type 60                       
         429   load_var2 57 73                    
@@ -6247,16 +6247,16 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         432   pop 1                              
         433   jump +83                           (to 516)
 
-  354   434   load_const 56                      (0)
+  356   434   load_const 56                      (0)
         435   store_var 61                       (i)
 
-  353   436   load_var 60                        (_199)
+  355   436   load_var 60                        (_199)
         437   load_type 65                       
         438   load_const 66                      ("iter")
         439   virtual_call nargs=1 ntypeargs=0   
         440   store_var 62                       (_203)
 
-  355   441   load_var 62                        (_203)
+  357   441   load_var 62                        (_203)
         442   load_type 67                       
         443   load_const 68                      ("next")
         444   virtual_call nargs=1 ntypeargs=0   
@@ -6268,9 +6268,9 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         450   load_var 63                        (_204)
         451   store_var 64                       (raw_call)
 
-  359   452   load_var 2                         (input)
+  361   452   load_var 2                         (input)
         453   load_field 1                       (journal)
-        454   call 806 ntypeargs=0               (ai.Journal.entries)
+        454   call 808 ntypeargs=0               (ai.Journal.entries)
         455   container_len                      
         456   store_var 67                       (_214)
         457   load_type 3                        
@@ -6282,117 +6282,117 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         463   call 138 ntypeargs=1               (baml.String.from)
         464   store_var 68                       (_218)
 
-  356   465   load_type 2                        
+  358   465   load_type 2                        
 
-  357   466   load_var 64                        (raw_call)
+  359   466   load_var 64                        (raw_call)
         467   load_const 70                      (".id")
 
-  359   468   load_const 71                      ("cc_call_")
+  361   468   load_const 71                      ("cc_call_")
         469   load_var 66                        (_213)
         470   bin_op +                           
         471   load_const 72                      ("_")
         472   bin_op +                           
         473   load_var 68                        (_218)
         474   bin_op +                           
-        475   call 341 ntypeargs=1               (baml.json.path_or)
+        475   call 343 ntypeargs=1               (baml.json.path_or)
         476   store_var 65                       (id)
 
-  361   477   load_type 2                        
+  363   477   load_type 2                        
         478   load_var 64                        (raw_call)
         479   load_const 73                      (".name")
         480   load_const 74                      ("")
-        481   call 341 ntypeargs=1               (baml.json.path_or)
+        481   call 343 ntypeargs=1               (baml.json.path_or)
         482   store_var 69                       (name)
 
-  363   483   load_type 50                       
+  365   483   load_type 50                       
         484   load_var 64                        (raw_call)
         485   load_const 75                      (".args")
         486   load_type 2                        
         487   load_type 50                       
         488   alloc_map 0                        
-        489   call 341 ntypeargs=1               (baml.json.path_or)
+        489   call 343 ntypeargs=1               (baml.json.path_or)
         490   store_var 72                       (_227)
 
-  362   491   load_type 1                        
+  364   491   load_type 1                        
         492   load_var 72                        (_227)
-        493   call 335 ntypeargs=1               (baml.json.from_json)
+        493   call 337 ntypeargs=1               (baml.json.from_json)
         494   store_var 70                       (call_args)
         495   jump +7                            (to 502)
         496   load_var 71                        (e)
         497   throw_if_panic                     
 
-  366   498   load_type 2                        
+  368   498   load_type 2                        
         499   load_type 11                       
         500   alloc_map 0                        
         501   store_var 70                       (call_args)
 
-  370   502   load_type 60                       
+  372   502   load_type 60                       
         503   load_var2 57 65                    
         504   load_var2 69 70                    
         505   init_instance 6                    (ai.content.ToolUse .id, .name, .args)
         506   call 4 ntypeargs=1                 (baml.Array.push)
         507   pop 1                              
 
-  371   508   load_var 61                        (i)
+  373   508   load_var 61                        (i)
         509   load_const 21                      (1)
         510   add_int                            
         511   store_var 61                       (i)
 
-  355   512   jump -71                           (to 441)
+  357   512   jump -71                           (to 441)
 
-  373   513   load_const 21                      (ai.content.StopReason.ToolUse)
+  375   513   load_const 21                      (ai.content.StopReason.ToolUse)
         514   alloc_variant 436                  (ai.content.StopReason)
         515   store_var 58                       (stop)
 
-  380   516   load_var2 57 58                    
+  382   516   load_var2 57 58                    
 
-  341   517   load_var2 54 55                    
+  343   517   load_var2 54 55                    
         518   load_var 56                        (_186)
         519   load_const 26                      (null)
         520   init_instance 7                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
         521   init_instance 8                    (ai.ModelTurn .content, .stop_reason, .usage)
         522   store_var 3                        (_0)
 
-  291   523   load_var 29                        (p)
+  293   523   load_var 29                        (p)
         524   sys_op 251                         (baml.sys.Process.close)
         525   pop 1                              
         526   load_var 3                         (_0)
         527   return                             
 
-  321   528   load_type 2                        
+  323   528   load_type 2                        
         529   load_var 36                        (result)
         530   load_const 76                      (".subtype")
         531   load_const 77                      ("error")
-        532   call 341 ntypeargs=1               (baml.json.path_or)
+        532   call 343 ntypeargs=1               (baml.json.path_or)
         533   store_var 42                       (_143)
 
-  322   534   load_var 36                        (result)
-        535   call 329 ntypeargs=0               (baml.json.stringify)
+  324   534   load_var 36                        (result)
+        535   call 331 ntypeargs=0               (baml.json.stringify)
         536   store_var 43                       (_146)
 
-  319   537   load_const 78                      ("claude-code")
+  321   537   load_const 78                      ("claude-code")
         538   load_var2 42 43                    
         539   init_instance 9                    (ai.errors.Refused .provider, .reason, .raw_body)
         540   throw                              
 
-  313   541   load_type 3                        
+  315   541   load_type 3                        
         542   load_var 37                        (exit)
         543   load_field 0                       (exit_code)
         544   call 138 ntypeargs=1               (baml.String.from)
         545   store_var 41                       (_136)
         546   jump +6                            (to 552)
 
-  291   547   load_var 29                        (p)
+  293   547   load_var 29                        (p)
         548   sys_op 251                         (baml.sys.Process.close)
         549   pop 1                              
 
-  227   550   load_var 33                        (_118)
+  229   550   load_var 33                        (_118)
         551   rethrow                            
 
-  310   552   load_const 79                      ("claude-code")
+  312   552   load_const 79                      ("claude-code")
         553   load_const 26                      (null)
 
-  313   554   load_const 80                      ("the Claude Code CLI exited with code ")
+  315   554   load_const 80                      ("the Claude Code CLI exited with code ")
         555   load_var 41                        (_136)
         556   bin_op +                           
         557   load_const 26                      (null)
@@ -6401,7 +6401,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 }
 
 function claude_code.internal.mcp_config_json(c: claude_code.ClaudeCodeClient) -> string | null {
-  207   0    load_var 1             (c)
+  209   0    load_var 1             (c)
         1    load_field 6           (mcp_servers)
         2    container_len          
         3    store_var 2            (_3)
@@ -6411,12 +6411,12 @@ function claude_code.internal.mcp_config_json(c: claude_code.ClaudeCodeClient) -
         7    pop_jump_if_false +2   (to 9)
         8    jump +18               (to 26)
 
-  210   9    load_type 1            
+  212   9    load_type 1            
         10   load_type 2            
         11   alloc_map 0            
         12   store_var 3            (wrapper)
 
-  211   13   load_type 1            
+  213   13   load_type 1            
         14   load_type 2            
         15   load_var 3             (wrapper)
         16   load_const 3           ("mcpServers")
@@ -6425,13 +6425,13 @@ function claude_code.internal.mcp_config_json(c: claude_code.ClaudeCodeClient) -
         19   call 37 ntypeargs=2    (baml.Map.set)
         20   pop 1                  
 
-  212   21   load_type 4            
+  214   21   load_type 4            
         22   load_var 3             (wrapper)
-        23   call 332 ntypeargs=1   (baml.json.to_json)
-        24   call 329 ntypeargs=0   (baml.json.stringify)
+        23   call 334 ntypeargs=1   (baml.json.to_json)
+        24   call 331 ntypeargs=0   (baml.json.stringify)
         25   jump +2                (to 27)
 
-  208   26   load_const 5           (null)
+  210   26   load_const 5           (null)
         27   return                 
 }
 
@@ -6441,7 +6441,7 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         2    store_var 2                        (catalog)
 
   100   3    load_var 1                         (tb)
-        4    call 822 ntypeargs=0               (ai.tools.Toolbox.list)
+        4    call 824 ntypeargs=0               (ai.tools.Toolbox.list)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -6471,8 +6471,8 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         30   load_type 6                        
         31   load_var 5                         (t)
         32   load_field 2                       (input_schema)
-        33   call 332 ntypeargs=1               (baml.json.to_json)
-        34   call 329 ntypeargs=0               (baml.json.stringify)
+        33   call 334 ntypeargs=1               (baml.json.to_json)
+        34   call 331 ntypeargs=0               (baml.json.stringify)
         35   store_var 9                        (_23)
         36   load_type 0                        
         37   load_var 9                         (_23)
@@ -6499,7 +6499,7 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         56   pop 1                              
         57   jump -48                           (to 9)
 
-  121   58   load_type 0                        
+  122   58   load_type 0                        
         59   load_var 2                         (catalog)
         60   load_const 11                      (", ")
         61   call 15 ntypeargs=1                (baml.Array.join)
@@ -6523,7 +6523,7 @@ function claude_code.internal.transcript_text(j: ai.Journal) -> string {
        2     store_var 2                        (lines)
 
   8    3     load_var 1                         (j)
-       4     call 806 ntypeargs=0               (ai.Journal.entries)
+       4     call 808 ntypeargs=0               (ai.Journal.entries)
        5     load_type 1                        
        6     load_const 2                       ("iter")
        7     virtual_call nargs=1 ntypeargs=0   
@@ -6661,8 +6661,8 @@ function claude_code.internal.transcript_text(j: ai.Journal) -> string {
        131   load_type 20                       
        132   load_var 15                        (c)
        133   load_field 2                       (args)
-       134   call 332 ntypeargs=1               (baml.json.to_json)
-       135   call 329 ntypeargs=0               (baml.json.stringify)
+       134   call 334 ntypeargs=1               (baml.json.to_json)
+       135   call 331 ntypeargs=0               (baml.json.stringify)
        136   store_var 19                       (_49)
        137   load_type 0                        
        138   load_var 19                        (_49)
@@ -6763,20 +6763,20 @@ function google.GoogleClient.ai.Client.id(self: google.GoogleClient) -> string {
 
 function google.GoogleClient.ai.Client.invoke(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   22   0   load_var2 1 2          
-       1   call 910 ntypeargs=0   (google.internal.invoke)
+       1   call 912 ntypeargs=0   (google.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   23   5   load_var 3             (e)
-       6   call 857 ntypeargs=0   (ai.errors.normalize)
+       6   call 859 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function google.GoogleClient.ai.stream.StreamingClient.invoke_stream(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   30   0   load_var2 1 2          
-       1   call 912 ntypeargs=0   (google.internal.invoke_stream)
+       1   call 914 ntypeargs=0   (google.internal.invoke_stream)
        2   return                 
 }
 
@@ -6897,7 +6897,7 @@ function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string 
         1    store_var 3                        (name)
 
   110   2    load_var 1                         (j)
-        3    call 806 ntypeargs=0               (ai.Journal.entries)
+        3    call 808 ntypeargs=0               (ai.Journal.entries)
         4    load_type 1                        
         5    load_const 2                       ("iter")
         6    virtual_call nargs=1 ntypeargs=0   
@@ -6963,7 +6963,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         2     store_var 2                        (out)
 
   368   3     load_var 1                         (batch)
-        4     call 848 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 850 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -6988,7 +6988,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
   370   24    load_type 7                        
 
   369   25    load_var 5                         (_10)
-        26    call 334 ntypeargs=1               (baml.json.from_string)
+        26    call 336 ntypeargs=1               (baml.json.from_string)
         27    jump +4                            (to 31)
 
   370   28    load_var 6                         (e)
@@ -7130,7 +7130,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         154   jump +2                            (to 156)
         155   load_const 8                       (null)
         156   load_const 8                       (null)
-        157   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        157   call 656 ntypeargs=0               (baml.ops.equals_equals)
         158   store_var 21                       (_62)
 
   390   159   load_var 19                        (finish)
@@ -7201,14 +7201,14 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
 
   405   208   load_var 22                        (stop)
         209   load_const 8                       (null)
-        210   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        210   call 656 ntypeargs=0               (baml.ops.equals_equals)
         211   unary_op !                         
         212   jump_if_false +2                   (to 214)
         213   jump +6                            (to 219)
         214   pop 1                              
         215   load_var 23                        (usage)
         216   load_const 8                       (null)
-        217   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        217   call 656 ntypeargs=0               (baml.ops.equals_equals)
         218   unary_op !                         
         219   pop_jump_if_false -210             (to 9)
 
@@ -7258,11 +7258,11 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         2     store_var 4                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 828 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 830 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 4                         (_5)
         7     call_indirect                      
 
-  227   8     call 904 ntypeargs=0               (google.internal.google_lower_prompt)
+  227   8     call 906 ntypeargs=0               (google.internal.google_lower_prompt)
         9     store_var 5                        (prompt_parts)
 
   228   10    load_var 5                         (prompt_parts)
@@ -7271,7 +7271,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   229   13    load_var 2                         (input)
         14    load_field 1                       (journal)
-        15    call 906 ntypeargs=0               (google.internal.google_lower_journal)
+        15    call 908 ntypeargs=0               (google.internal.google_lower_journal)
         16    load_type 0                        
         17    load_const 1                       ("iter")
         18    virtual_call nargs=1 ntypeargs=0   
@@ -7350,7 +7350,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
   239   81    load_const 12                      ("user")
         82    load_var 5                         (prompt_parts)
         83    load_field 0                       (system_parts)
-        84    call 901 ntypeargs=0               (google.internal._gm_content)
+        84    call 903 ntypeargs=0               (google.internal._gm_content)
         85    store_var 11                       (_29)
         86    load_type 5                        
         87    load_var 11                        (_29)
@@ -7370,7 +7370,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   250   100   load_var 2                         (input)
         101   load_field 2                       (toolbox)
-        102   call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        102   call 826 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         103   unary_op !                         
         104   pop_jump_if_false +104             (to 208)
 
@@ -7380,7 +7380,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   252   108   load_var 2                         (input)
         109   load_field 2                       (toolbox)
-        110   call 822 ntypeargs=0               (ai.tools.Toolbox.list)
+        110   call 824 ntypeargs=0               (ai.tools.Toolbox.list)
         111   load_type 14                       
         112   load_const 15                      ("iter")
         113   virtual_call nargs=1 ntypeargs=0   
@@ -7549,8 +7549,8 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   283   256   load_type 5                        
         257   load_var 9                         (body)
-        258   call 332 ntypeargs=1               (baml.json.to_json)
-        259   call 329 ntypeargs=0               (baml.json.stringify)
+        258   call 334 ntypeargs=1               (baml.json.to_json)
+        259   call 331 ntypeargs=0               (baml.json.stringify)
         260   store_var 30                       (_118)
 
   276   261   load_const 35                      ("POST")
@@ -7577,7 +7577,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         5     store_var 3                        (pending)
 
   141   6     load_var 1                         (j)
-        7     call 806 ntypeargs=0               (ai.Journal.entries)
+        7     call 808 ntypeargs=0               (ai.Journal.entries)
         8     load_type 1                        
         9     load_const 2                       ("iter")
         10    virtual_call nargs=1 ntypeargs=0   
@@ -7636,9 +7636,9 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   199   60    load_var2 1 34                     
         61    load_field 0                       (id)
-        62    call 905 ntypeargs=0               (google.internal._gm_tool_name_for)
+        62    call 907 ntypeargs=0               (google.internal._gm_tool_name_for)
         63    load_var 35                        (response)
-        64    call 903 ntypeargs=0               (google.internal._gm_function_response)
+        64    call 905 ntypeargs=0               (google.internal._gm_function_response)
         65    store_var 36                       (_91)
         66    load_type 0                        
         67    load_var2 3 36                     
@@ -7665,9 +7665,9 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   193   85    load_var2 1 30                     
         86    load_field 0                       (id)
-        87    call 905 ntypeargs=0               (google.internal._gm_tool_name_for)
+        87    call 907 ntypeargs=0               (google.internal._gm_tool_name_for)
         88    load_var 31                        (response)
-        89    call 903 ntypeargs=0               (google.internal._gm_function_response)
+        89    call 905 ntypeargs=0               (google.internal._gm_function_response)
         90    store_var 32                       (_78)
         91    load_type 0                        
         92    load_var2 3 32                     
@@ -7688,7 +7688,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   156   105   load_const 15                      ("user")
         106   load_var 3                         (pending)
-        107   call 901 ntypeargs=0               (google.internal._gm_content)
+        107   call 903 ntypeargs=0               (google.internal._gm_content)
         108   store_var 16                       (_29)
         109   load_type 0                        
         110   load_var2 2 16                     
@@ -7779,7 +7779,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   164   185   load_var 21                        (_39)
         186   load_field 0                       (text)
-        187   call 902 ntypeargs=0               (google.internal._gm_text_part)
+        187   call 904 ntypeargs=0               (google.internal._gm_text_part)
         188   store_var 22                       (_42)
 
   166   189   load_type 0                        
@@ -7798,7 +7798,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   183   201   load_const 25                      ("model")
         202   load_var 17                        (parts)
-        203   call 901 ntypeargs=0               (google.internal._gm_content)
+        203   call 903 ntypeargs=0               (google.internal._gm_content)
         204   store_var 28                       (_67)
         205   load_type 0                        
         206   load_var2 2 28                     
@@ -7819,7 +7819,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   145   219   load_const 26                      ("user")
         220   load_var 3                         (pending)
-        221   call 901 ntypeargs=0               (google.internal._gm_content)
+        221   call 903 ntypeargs=0               (google.internal._gm_content)
         222   store_var 10                       (_15)
         223   load_type 0                        
         224   load_var2 2 10                     
@@ -7832,13 +7832,13 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   151   230   load_var 8                         (u)
         231   load_field 0                       (content)
-        232   call 902 ntypeargs=0               (google.internal._gm_text_part)
+        232   call 904 ntypeargs=0               (google.internal._gm_text_part)
         233   store_var 12                       (_21)
         234   load_const 27                      ("user")
         235   load_var 12                        (_21)
         236   load_type 0                        
         237   alloc_array 1                      
-        238   call 901 ntypeargs=0               (google.internal._gm_content)
+        238   call 903 ntypeargs=0               (google.internal._gm_content)
         239   store_var 11                       (_19)
         240   load_type 0                        
         241   load_var2 2 11                     
@@ -7856,7 +7856,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   206   252   load_const 28                      ("user")
         253   load_var 3                         (pending)
-        254   call 901 ntypeargs=0               (google.internal._gm_content)
+        254   call 903 ntypeargs=0               (google.internal._gm_content)
         255   store_var 38                       (_99)
         256   load_type 0                        
         257   load_var2 2 38                     
@@ -7880,7 +7880,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
         7    store_var 4                        (first_role)
 
   82    8    load_var 1                         (prompt)
-        9    call 810 ntypeargs=0               (ai.Prompt.messages)
+        9    call 812 ntypeargs=0               (ai.Prompt.messages)
         10   load_type 2                        
         11   load_const 3                       ("iter")
         12   virtual_call nargs=1 ntypeargs=0   
@@ -7898,7 +7898,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
         24   store_var_load_var 7               (message)
 
   83    25   load_field 1                       (content)
-        26   call 902 ntypeargs=0               (google.internal._gm_text_part)
+        26   call 904 ntypeargs=0               (google.internal._gm_text_part)
         27   store_var 8                        (part)
 
   84    28   load_var 7                         (message)
@@ -7934,7 +7934,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
   99    51   load_var2 9 8                      
         52   load_type 0                        
         53   alloc_array 1                      
-        54   call 901 ntypeargs=0               (google.internal._gm_content)
+        54   call 903 ntypeargs=0               (google.internal._gm_content)
         55   store_var 10                       (_24)
         56   load_type 0                        
         57   load_var2 3 10                     
@@ -8161,7 +8161,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         182   jump +2                            (to 184)
         183   load_const 3                       (null)
         184   load_const 3                       (null)
-        185   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        185   call 656 ntypeargs=0               (baml.ops.equals_equals)
         186   store_var 24                       (_74)
 
   324   187   load_var 4                         (has_call)
@@ -8274,35 +8274,35 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
 function google.internal.google_render(c: google.GoogleClient, input: ai.ModelTurnInput) -> baml.http.Request {
   216   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 908 ntypeargs=0   (google.internal._google_request)
+        2   call 910 ntypeargs=0   (google.internal._google_request)
         3   return                 
 }
 
 function google.internal.invoke(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   351   0    load_var 2             (input)
         1    load_field 1           (journal)
-        2    call 806 ntypeargs=0   (ai.Journal.entries)
+        2    call 808 ntypeargs=0   (ai.Journal.entries)
         3    container_len          
         4    store_var 3            (seq)
 
   352   5    load_var2 1 2          
-        6    call 907 ntypeargs=0   (google.internal.google_render)
+        6    call 909 ntypeargs=0   (google.internal.google_render)
         7    store_var 4            (req)
 
   353   8    load_type 0            
         9    load_var 4             (req)
         10   load_const 1           ("google")
-        11   call 827 ntypeargs=1   (ai.wire.send_as)
+        11   call 829 ntypeargs=1   (ai.wire.send_as)
 
   354   12   load_var 3             (seq)
-        13   call 909 ntypeargs=0   (google.internal.google_parse)
+        13   call 911 ntypeargs=0   (google.internal.google_parse)
         14   return                 
 }
 
 function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   432   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 908 ntypeargs=0   (google.internal._google_request)
+        2    call 910 ntypeargs=0   (google.internal._google_request)
 
   433   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -8328,7 +8328,7 @@ function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTu
         21   throw                  
 
   442   22   load_const 6           (google.internal._google_decode_batch)
-        23   call 849 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 851 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -8346,20 +8346,20 @@ function openai.OpenAiClient.ai.Client.id(self: openai.OpenAiClient) -> string {
 
 function openai.OpenAiClient.ai.Client.invoke(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   62   0   load_var2 1 2          
-       1   call 880 ntypeargs=0   (openai.internal.invoke)
+       1   call 882 ntypeargs=0   (openai.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   63   5   load_var 3             (e)
-       6   call 857 ntypeargs=0   (ai.errors.normalize)
+       6   call 859 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function openai.OpenAiClient.ai.stream.StreamingClient.invoke_stream(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   70   0   load_var2 1 2          
-       1   call 882 ntypeargs=0   (openai.internal.invoke_stream)
+       1   call 884 ntypeargs=0   (openai.internal.invoke_stream)
        2   return                 
 }
 
@@ -8477,7 +8477,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         2     store_var 2                        (out)
 
   255   3     load_var 1                         (batch)
-        4     call 848 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 850 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -8503,7 +8503,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
   257   25    load_type 7                        
 
   256   26    load_var 6                         (_10)
-        27    call 334 ntypeargs=1               (baml.json.from_string)
+        27    call 336 ntypeargs=1               (baml.json.from_string)
         28    jump +4                            (to 32)
 
   257   29    load_var 7                         (e)
@@ -8569,7 +8569,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         83    narrow_bind 15 14                  
         84    pop_jump_if_false +39              (to 123)
         85    load_var 14                        (_39)
-        86    call 879 ntypeargs=0               (openai.internal.openai_parse)
+        86    call 881 ntypeargs=0               (openai.internal.openai_parse)
         87    store_var 15                       (turn)
 
   275   88    load_var 15                        (turn)
@@ -8644,16 +8644,16 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         2     store_var 4                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 828 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 830 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 4                         (_5)
         7     call_indirect                      
 
-  129   8     call 875 ntypeargs=0               (openai.internal.openai_lower_prompt)
+  129   8     call 877 ntypeargs=0               (openai.internal.openai_lower_prompt)
         9     store_var 5                        (items)
 
   130   10    load_var 2                         (input)
         11    load_field 1                       (journal)
-        12    call 876 ntypeargs=0               (openai.internal.openai_lower_journal)
+        12    call 878 ntypeargs=0               (openai.internal.openai_lower_journal)
         13    load_type 0                        
         14    load_const 1                       ("iter")
         15    virtual_call nargs=1 ntypeargs=0   
@@ -8707,7 +8707,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   137   57    load_var 2                         (input)
         58    load_field 2                       (toolbox)
-        59    call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        59    call 826 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         60    unary_op !                         
         61    pop_jump_if_false +83              (to 144)
 
@@ -8717,7 +8717,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   139   65    load_var 2                         (input)
         66    load_field 2                       (toolbox)
-        67    call 822 ntypeargs=0               (ai.tools.Toolbox.list)
+        67    call 824 ntypeargs=0               (ai.tools.Toolbox.list)
         68    load_type 12                       
         69    load_const 13                      ("iter")
         70    virtual_call nargs=1 ntypeargs=0   
@@ -8816,7 +8816,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         152   pop 1                              
 
   162   153   load_var 1                         (c)
-        154   call 871 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
+        154   call 873 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
         155   store_var 16                       (_78)
         156   load_var 16                        (_78)
         157   store_var 15                       (_77)
@@ -8832,7 +8832,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         167   store_var 14                       (_76)
 
   163   168   load_var 1                         (c)
-        169   call 870 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
+        169   call 872 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
         170   store_var 18                       (_84)
         171   load_type 6                        
         172   load_var 18                        (_84)
@@ -8841,8 +8841,8 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   164   175   load_type 5                        
         176   load_var 8                         (body)
-        177   call 332 ntypeargs=1               (baml.json.to_json)
-        178   call 329 ntypeargs=0               (baml.json.stringify)
+        177   call 334 ntypeargs=1               (baml.json.to_json)
+        178   call 331 ntypeargs=0               (baml.json.stringify)
         179   store_var 19                       (_86)
 
   160   180   load_const 29                      ("POST")
@@ -8867,22 +8867,22 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
 function openai.internal.invoke(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   231   0   load_var2 1 2          
-        1   call 877 ntypeargs=0   (openai.internal.openai_render)
+        1   call 879 ntypeargs=0   (openai.internal.openai_render)
         2   store_var 3            (req)
 
   232   3   load_type 0            
         4   load_var 3             (req)
         5   load_const 1           ("openai")
-        6   call 827 ntypeargs=1   (ai.wire.send_as)
+        6   call 829 ntypeargs=1   (ai.wire.send_as)
 
-  233   7   call 879 ntypeargs=0   (openai.internal.openai_parse)
+  233   7   call 881 ntypeargs=0   (openai.internal.openai_parse)
         8   return                 
 }
 
 function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   304   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 878 ntypeargs=0   (openai.internal._openai_request)
+        2    call 880 ntypeargs=0   (openai.internal._openai_request)
 
   305   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -8908,7 +8908,7 @@ function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTu
         21   throw                  
 
   314   22   load_const 6           (openai.internal._openai_decode_batch)
-        23   call 849 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 851 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -8918,7 +8918,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         2     store_var 2                        (items)
 
   58    3     load_var 1                         (j)
-        4     call 806 ntypeargs=0               (ai.Journal.entries)
+        4     call 808 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -8999,8 +8999,8 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
 
   106   76    load_type 0                        
         77    load_var 25                        (err)
-        78    call 332 ntypeargs=1               (baml.json.to_json)
-        79    call 329 ntypeargs=0               (baml.json.stringify)
+        78    call 334 ntypeargs=1               (baml.json.to_json)
+        79    call 331 ntypeargs=0               (baml.json.stringify)
         80    store_var 27                       (_100)
         81    load_type 10                       
         82    load_type 11                       
@@ -9123,8 +9123,8 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
   82    184   load_type 0                        
         185   load_var 17                        (use)
         186   load_field 2                       (args)
-        187   call 332 ntypeargs=1               (baml.json.to_json)
-        188   call 329 ntypeargs=0               (baml.json.stringify)
+        187   call 334 ntypeargs=1               (baml.json.to_json)
+        188   call 331 ntypeargs=0               (baml.json.stringify)
         189   store_var 19                       (_58)
         190   load_type 10                       
         191   load_type 11                       
@@ -9212,7 +9212,7 @@ function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> map<string, u
        2    store_var 2                        (items)
 
   38   3    load_var 1                         (prompt)
-       4    call 810 ntypeargs=0               (ai.Prompt.messages)
+       4    call 812 ntypeargs=0               (ai.Prompt.messages)
        5    load_type 1                        
        6    load_const 2                       ("iter")
        7    virtual_call nargs=1 ntypeargs=0   
@@ -9458,7 +9458,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
   177   148   load_type 25                       
 
   176   149   load_var 8                         (_14)
-        150   call 334 ntypeargs=1               (baml.json.from_string)
+        150   call 336 ntypeargs=1               (baml.json.from_string)
         151   store_var 7                        (args)
 
   180   152   load_var 6                         (item)
@@ -9563,7 +9563,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
 function openai.internal.openai_render(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> baml.http.Request {
   118   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 878 ntypeargs=0   (openai.internal._openai_request)
+        2   call 880 ntypeargs=0   (openai.internal._openai_request)
         3   return                 
 }
 
@@ -9580,7 +9580,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  104   0   make_closure 1615 0   
+  104   0   make_closure 1617 0   
         1   return                
 }
 
@@ -9605,7 +9605,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   76   16   load_var 1             (threshold)
-       17   make_closure 1610 1    
+       17   make_closure 1612 1    
        18   return                 
 }
 
@@ -9644,7 +9644,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1594 2    
+       29   make_closure 1596 2    
        30   return                 
 }
 
@@ -9663,12 +9663,12 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   42   10   load_var 1             (max_attempts)
-       11   make_closure 1604 1    
+       11   make_closure 1606 1    
        12   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  98   0   make_closure 1613 0   
+  98   0   make_closure 1615 0   
        1   return                
 }
 
@@ -9872,7 +9872,7 @@ function testing.TestCollector.register_test_at(self: testing.TestCollector, own
         4   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
         5   load_var2 3 4          
         6   load_var 5             (runner)
-        7   call 743 ntypeargs=0   (testing.TestCollector.register_test)
+        7   call 745 ntypeargs=0   (testing.TestCollector.register_test)
         8   return                 
 }
 
@@ -10001,7 +10001,7 @@ function testing.TestCollector.register_test_set_at(self: testing.TestCollector,
         4   init_instance 0        (testing.TestCollector .prefix, .tests, .testsets)
         5   load_var2 3 4          
         6   load_var 5             (runner)
-        7   call 744 ntypeargs=0   (testing.TestCollector.register_test_set)
+        7   call 746 ntypeargs=0   (testing.TestCollector.register_test_set)
         8   return                 
 }
 
@@ -10031,11 +10031,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   290   22   load_var2 1 5                      
-        23   call 759 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 761 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   291   25   load_var 1                         (self)
-        26   call 751 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 753 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   295   28   load_type 5                        
@@ -10072,7 +10072,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   298   58   load_var2 9 2                      
-        59   call 758 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 760 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   301   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -10095,7 +10095,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         10   pop_jump_if_false +2   (to 12)
         11   jump +51               (to 62)
 
-  308   12   sys_op 521             (baml.time.Instant.now)
+  308   12   sys_op 523             (baml.time.Instant.now)
         13   store_var 4            (start)
 
   309   14   load_var 2             (ts)
@@ -10113,8 +10113,8 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         25   pop 1                  
 
   315   26   load_var 4             (start)
-        27   call 522 ntypeargs=0   (baml.time.Instant.elapsed)
-        28   call 509 ntypeargs=0   (baml.time.Duration.to_milliseconds)
+        27   call 524 ntypeargs=0   (baml.time.Instant.elapsed)
+        28   call 511 ntypeargs=0   (baml.time.Duration.to_milliseconds)
         29   call 92 ntypeargs=0    (baml.Bigint.to_int)
         30   store_var 6            (elapsed)
         31   jump +13               (to 44)
@@ -10162,7 +10162,7 @@ function testing.TestRegistry.list_filtered(self: testing.TestRegistry, profile_
   281   0   load_var2 1 2          
         1   load_var2 3 4          
         2   load_var 5             (cli_exclude)
-        3   call 779 ntypeargs=0   (testing.select_names_layered)
+        3   call 781 ntypeargs=0   (testing.select_names_layered)
         4   return                 
 }
 
@@ -10178,9 +10178,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   237   0   load_var 1             (self)
-        1   call 760 ntypeargs=0   (testing.testset_children)
+        1   call 762 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 770 ntypeargs=0   (testing.run_testset)
+        3   call 772 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -10188,7 +10188,7 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
   259   0    load_var2 1 2          
         1    load_var2 3 4          
         2    load_var 5             (cli_exclude)
-        3    call 779 ntypeargs=0   (testing.select_names_layered)
+        3    call 781 ntypeargs=0   (testing.select_names_layered)
         4    store_var 6            (selected_names)
 
   261   5    load_var 2             (profile_include)
@@ -10231,22 +10231,22 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
         36   jump +4                (to 40)
 
   268   37   load_var2 1 6          
-        38   call 755 ntypeargs=0   (testing.TestRegistry.run_selected)
+        38   call 757 ntypeargs=0   (testing.TestRegistry.run_selected)
         39   jump +3                (to 42)
 
   266   40   load_var 1             (self)
-        41   call 754 ntypeargs=0   (testing.TestRegistry.run_all)
+        41   call 756 ntypeargs=0   (testing.TestRegistry.run_all)
 
   270   42   load_var 6             (selected_names)
-        43   call 785 ntypeargs=0   (testing.flatten_with_tolerated)
+        43   call 787 ntypeargs=0   (testing.flatten_with_tolerated)
         44   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   241   0   load_var2 1 2          
-        1   call 761 ntypeargs=0   (testing.testset_children_selected)
+        1   call 763 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 770 ntypeargs=0   (testing.run_testset)
+        3   call 772 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -10279,7 +10279,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 769 ntypeargs=0               (testing.run_test)
+        26   call 771 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   211   28   load_type 5                        
@@ -10316,7 +10316,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   215   58   load_var2 9 2                      
-        59   call 752 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 754 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   218   61   load_const 12                      ("Test not found: ")
@@ -10351,11 +10351,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   224   22   load_var2 1 5                      
-        23   call 759 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 760 ntypeargs=0               (testing.testset_children)
+        23   call 761 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 762 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 770 ntypeargs=0               (testing.run_testset)
+        27   call 772 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   227   29   load_type 5                        
@@ -10392,7 +10392,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   230   59   load_var2 9 2                      
-        60   call 753 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 755 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   233   62   load_const 12                      ("TestSet not found: ")
@@ -10485,7 +10485,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         71   store_var 10                       (_28)
 
   189   72   load_var 9                         (sub)
-        73   call 751 ntypeargs=0               (testing.TestRegistry.serialize)
+        73   call 753 ntypeargs=0               (testing.TestRegistry.serialize)
         74   store_var 11                       (_29)
 
   186   75   load_type 0                        
@@ -10643,7 +10643,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   441   56    load_var 12                        (outcome)
         57    load_const 10                      ("pass")
-        58    call 654 ntypeargs=0               (baml.ops.equals_equals)
+        58    call 656 ntypeargs=0               (baml.ops.equals_equals)
         59    pop_jump_if_false +2               (to 61)
         60    jump +58                           (to 118)
 
@@ -10710,7 +10710,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   458   111   load_var 12                        (outcome)
         112   load_const 16                      ("error")
-        113   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        113   call 656 ntypeargs=0               (baml.ops.equals_equals)
         114   pop_jump_if_false -94              (to 20)
 
   459   115   load_const 17                      (true)
@@ -10785,7 +10785,7 @@ function testing.any_pattern_matches(pats: string[], canonical_id: string) -> bo
 
   608   14   load_var2 2 4                      
 
-  607   15   call 772 ntypeargs=0               (testing.glob_match)
+  607   15   call 774 ntypeargs=0               (testing.glob_match)
 
   608   16   pop_jump_if_false -11              (to 5)
 
@@ -10824,7 +10824,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         23   store_var_load_var 7               (name)
 
   949   24   load_var 3                         (all_failed_names)
-        25   call 788 ntypeargs=0               (testing.failure_matches_selected)
+        25   call 790 ntypeargs=0               (testing.failure_matches_selected)
         26   pop_jump_if_false +2               (to 28)
         27   jump +8                            (to 35)
 
@@ -10837,7 +10837,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         34   jump -21                           (to 13)
 
   950   35   load_var2 7 2                      
-        36   call 788 ntypeargs=0               (testing.failure_matches_selected)
+        36   call 790 ntypeargs=0               (testing.failure_matches_selected)
         37   pop_jump_if_false +2               (to 39)
         38   jump +8                            (to 46)
 
@@ -10881,7 +10881,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          16   store_var_load_var 5               (name)
 
   1050   17   load_var 2                         (out)
-         18   call 787 ntypeargs=0               (testing.name_in)
+         18   call 789 ntypeargs=0               (testing.name_in)
          19   unary_op !                         
          20   pop_jump_if_false -14              (to 6)
 
@@ -10913,7 +10913,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          44   pop_jump_if_false +2               (to 46)
          45   jump -13                           (to 32)
          46   load_var2 8 2                      
-         47   call 790 ntypeargs=0               (testing.collect_all_failed_names)
+         47   call 792 ntypeargs=0               (testing.collect_all_failed_names)
          48   pop 1                              
          49   jump -17                           (to 32)
 
@@ -10991,7 +10991,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
          57    load_var 14             (nested)
          58    load_field 0            (outcome)
          59    load_const 3            ("pass")
-         60    call 654 ntypeargs=0    (baml.ops.equals_equals)
+         60    call 656 ntypeargs=0    (baml.ops.equals_equals)
          61    store_var 15            (nested_tolerated)
 
   1015   62    load_var 14             (nested)
@@ -11016,7 +11016,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
          79    store_var_load_var 17   (sentinel)
 
   1024   80    load_var 3              (selected_names)
-         81    call 787 ntypeargs=0    (testing.name_in)
+         81    call 789 ntypeargs=0    (testing.name_in)
          82    pop_jump_if_false +2    (to 84)
          83    jump +21                (to 104)
 
@@ -11071,14 +11071,14 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
   1017   123   load_var2 14 15         
 
   1018   124   load_var2 3 4           
-         125   call 789 ntypeargs=0    (testing.collect_leaf_identities)
+         125   call 791 ntypeargs=0    (testing.collect_leaf_identities)
          126   pop 1                   
          127   jump +30                (to 157)
 
   1003   128   load_var 13             (_25)
          129   load_field 0            (outcome)
          130   load_const 7            ("pass")
-         131   call 654 ntypeargs=0    (baml.ops.equals_equals)
+         131   call 656 ntypeargs=0    (baml.ops.equals_equals)
 
   1005   132   pop_jump_if_false +2    (to 134)
          133   jump +18                (to 151)
@@ -11147,7 +11147,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
          22   load_var 5                         (r)
          23   load_field 5                       (results)
          24   load_var 2                         (out)
-         25   call 791 ntypeargs=0               (testing.collect_leaf_messages)
+         25   call 793 ntypeargs=0               (testing.collect_leaf_messages)
          26   pop 1                              
          27   jump -22                           (to 5)
          28   load_var 6                         (_8)
@@ -11171,7 +11171,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   1069   45   load_field 0                       (outcome)
          46   load_const 10                      ("pass")
-         47   call 654 ntypeargs=0               (baml.ops.equals_equals)
+         47   call 656 ntypeargs=0               (baml.ops.equals_equals)
          48   unary_op !                         
          49   pop_jump_if_false -15              (to 34)
 
@@ -11242,7 +11242,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
   749   41   load_var2 1 6                      
 
-  748   42   call 782 ntypeargs=0               (testing.collect_subtree_names)
+  748   42   call 784 ntypeargs=0               (testing.collect_subtree_names)
 
   749   43   load_type 10                       
         44   load_const 11                      ("iter")
@@ -11271,8 +11271,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   762   0    load_var2 1 2          
-        1    call 759 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 781 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 761 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 783 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +89               (to 92)
         4    load_var 3             (e)
         5    store_var 4            (_5)
@@ -11371,11 +11371,11 @@ function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testi
 
 function testing.collect_subtree_names_layered(registry: testing.TestRegistry, ts: testing.TestSetRegistration, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> string[] {
   778   0     load_var2 1 2           
-        1     call 759 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
+        1     call 761 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
 
   777   2     load_var2 3 4           
         3     load_var2 5 6           
-        4     call 779 ntypeargs=0    (testing.select_names_layered)
+        4     call 781 ntypeargs=0    (testing.select_names_layered)
         5     jump +109               (to 114)
         6     load_var 7              (e)
         7     store_var 8             (_9)
@@ -11458,7 +11458,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   805   83    load_var2 3 4           
         84    load_var2 5 6           
-        85    call 775 ntypeargs=0    (testing.leaf_selected_layered)
+        85    call 777 ntypeargs=0    (testing.leaf_selected_layered)
 
   803   86    pop_jump_if_false +2    (to 88)
         87    jump +4                 (to 91)
@@ -11482,7 +11482,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   789   100   load_var2 3 4           
         101   load_var2 5 6           
-        102   call 775 ntypeargs=0    (testing.leaf_selected_layered)
+        102   call 777 ntypeargs=0    (testing.leaf_selected_layered)
 
   787   103   pop_jump_if_false +2    (to 105)
         104   jump +4                 (to 108)
@@ -11550,7 +11550,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         37    load_var 12                        (tsr)
         38    load_field 0                       (outcome)
         39    load_const 7                       ("pass")
-        40    call 654 ntypeargs=0               (baml.ops.equals_equals)
+        40    call 656 ntypeargs=0               (baml.ops.equals_equals)
         41    store_var 13                       (ft)
 
   855   42    load_var 12                        (tsr)
@@ -11598,14 +11598,14 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   856   74    load_var 12                        (tsr)
         75    load_field 5                       (results)
         76    load_var 13                        (ft)
-        77    call 784 ntypeargs=0               (testing.count_leaves)
+        77    call 786 ntypeargs=0               (testing.count_leaves)
         78    store_var 10                       (delta)
         79    jump +30                           (to 109)
 
   843   80    load_var 11                        (_13)
         81    load_field 0                       (outcome)
         82    load_const 8                       ("pass")
-        83    call 654 ntypeargs=0               (baml.ops.equals_equals)
+        83    call 656 ntypeargs=0               (baml.ops.equals_equals)
 
   845   84    pop_jump_if_false +2               (to 86)
         85    jump +18                           (to 103)
@@ -11690,7 +11690,7 @@ function testing.expansion_error_report(name: string) -> testing.TestSetReport {
 
 function testing.failure_matches_selected(selected: string, failed_names: string[]) -> bool {
   972   0    load_var2 1 2                      
-        1    call 787 ntypeargs=0               (testing.name_in)
+        1    call 789 ntypeargs=0               (testing.name_in)
         2    pop_jump_if_false +2               (to 4)
         3    jump +40                           (to 43)
 
@@ -11752,7 +11752,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   887   0     load_var 1             (report)
         1     load_field 0           (outcome)
         2     load_const 0           ("pass")
-        3     call 654 ntypeargs=0   (baml.ops.equals_equals)
+        3     call 656 ntypeargs=0   (baml.ops.equals_equals)
         4     store_var 3            (top_tolerated)
 
   888   5     load_var 1             (report)
@@ -11800,7 +11800,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   889   37    load_var 1             (report)
         38    load_field 5           (results)
         39    load_var 3             (top_tolerated)
-        40    call 784 ntypeargs=0   (testing.count_leaves)
+        40    call 786 ntypeargs=0   (testing.count_leaves)
         41    store_var 4            (counts)
 
   905   42    load_type 2            
@@ -11810,7 +11810,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   906   45    load_var 1             (report)
         46    load_field 5           (results)
         47    load_var 6             (messages)
-        48    call 791 ntypeargs=0   (testing.collect_leaf_messages)
+        48    call 793 ntypeargs=0   (testing.collect_leaf_messages)
         49    pop 1                  
 
   907   50    load_type 2            
@@ -11818,7 +11818,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
         52    store_var 7            (all_failed_names)
 
   908   53    load_var2 1 7          
-        54    call 790 ntypeargs=0   (testing.collect_all_failed_names)
+        54    call 792 ntypeargs=0   (testing.collect_all_failed_names)
         55    pop 1                  
 
   909   56    load_type 2            
@@ -11832,7 +11832,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
 
   910   64    load_var2 1 3          
         65    load_var2 2 8          
-        66    call 789 ntypeargs=0   (testing.collect_leaf_identities)
+        66    call 791 ntypeargs=0   (testing.collect_leaf_identities)
         67    pop 1                  
 
   916   68    load_var 8             (executed)
@@ -11890,7 +11890,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   922   112   load_var2 2 1          
         113   load_field 4           (failed_names)
         114   load_var 7             (all_failed_names)
-        115   call 786 ntypeargs=0   (testing.classify_selected_names)
+        115   call 788 ntypeargs=0   (testing.classify_selected_names)
         116   store_var 9            (identities)
         117   jump +3                (to 120)
 
@@ -12050,14 +12050,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
   577   96    load_var2 1 2           
         97    call 155 ntypeargs=0    (baml.String.index_of)
         98    load_const 6            (null)
-        99    call 654 ntypeargs=0    (baml.ops.equals_equals)
+        99    call 656 ntypeargs=0    (baml.ops.equals_equals)
         100   unary_op !              
         101   return                  
 }
 
 function testing.leaf_selected(name: string, include: string[], exclude: string[]) -> bool {
   618   0    load_var2 3 1          
-        1    call 773 ntypeargs=0   (testing.any_pattern_matches)
+        1    call 775 ntypeargs=0   (testing.any_pattern_matches)
         2    pop_jump_if_false +2   (to 4)
         3    jump +14               (to 17)
 
@@ -12071,7 +12071,7 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
         11   jump +4                (to 15)
 
   624   12   load_var2 2 1          
-        13   call 773 ntypeargs=0   (testing.any_pattern_matches)
+        13   call 775 ntypeargs=0   (testing.any_pattern_matches)
         14   jump +4                (to 18)
 
   622   15   load_const 1           (true)
@@ -12084,13 +12084,13 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
 function testing.leaf_selected_layered(name: string, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> bool {
   637   0   load_var2 1 2          
         1   load_var 3             (profile_exclude)
-        2   call 774 ntypeargs=0   (testing.leaf_selected)
+        2   call 776 ntypeargs=0   (testing.leaf_selected)
         3   jump_if_false +5       (to 8)
         4   pop 1                  
 
   638   5   load_var2 1 4          
         6   load_var 5             (cli_exclude)
-        7   call 774 ntypeargs=0   (testing.leaf_selected)
+        7   call 776 ntypeargs=0   (testing.leaf_selected)
         8   return                 
 }
 
@@ -12186,7 +12186,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   486   25   load_var 5                         (child)
-        26   make_closure 1494 1                
+        26   make_closure 1496 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   load_type 7                        
@@ -12202,10 +12202,10 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
   490   38   load_type 7                        
         39   load_type 8                        
         40   load_var 2                         (futures)
-        41   call 483 ntypeargs=2               (baml.future.all_complete)
+        41   call 485 ntypeargs=2               (baml.future.all_complete)
         42   await                              
 
-  491   43   call 767 ntypeargs=0               (testing.aggregate_reports)
+  491   43   call 769 ntypeargs=0               (testing.aggregate_reports)
         44   return                             
 }
 
@@ -12262,16 +12262,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         44   pop 1                              
         45   load_var 8                         (outcome)
         46   load_const 7                       ("pass")
-        47   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        47   call 656 ntypeargs=0               (baml.ops.equals_equals)
         48   unary_op !                         
         49   pop_jump_if_false -41              (to 8)
 
   119   50   load_var 3                         (named_results)
-        51   call 767 ntypeargs=0               (testing.aggregate_reports)
+        51   call 769 ntypeargs=0               (testing.aggregate_reports)
         52   jump +3                            (to 55)
 
   124   53   load_var 3                         (named_results)
-        54   call 767 ntypeargs=0               (testing.aggregate_reports)
+        54   call 769 ntypeargs=0               (testing.aggregate_reports)
         55   return                             
 }
 
@@ -12281,7 +12281,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   496   3    load_var 1             (body)
-        4    make_closure 1506 1    
+        4    make_closure 1508 1    
         5    store_var 3            (base_run)
 
   527   6    load_var 2             (runner)
@@ -12313,7 +12313,7 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         7    jump +3                (to 10)
 
   539   8    load_var 1             (children)
-        9    call 768 ntypeargs=0   (testing.run_children_parallel)
+        9    call 770 ntypeargs=0   (testing.run_children_parallel)
         10   return                 
 }
 
@@ -12324,7 +12324,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         3   load_type 0            
         4   alloc_array 0          
         5   load_var2 2 3          
-        6   call 779 ntypeargs=0   (testing.select_names_layered)
+        6   call 781 ntypeargs=0   (testing.select_names_layered)
         7   return                 
 }
 
@@ -12355,7 +12355,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
   704   21   load_field 0                       (name)
         22   load_var2 2 3                      
         23   load_var2 4 5                      
-        24   call 775 ntypeargs=0               (testing.leaf_selected_layered)
+        24   call 777 ntypeargs=0               (testing.leaf_selected_layered)
 
   702   25   pop_jump_if_false -15              (to 10)
 
@@ -12387,14 +12387,14 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   718   50   load_field 0                       (name)
         51   load_var2 2 3                      
-        52   call 778 ntypeargs=0               (testing.subtree_may_be_selected)
+        52   call 780 ntypeargs=0               (testing.subtree_may_be_selected)
         53   jump_if_false +6                   (to 59)
         54   pop 1                              
 
   719   55   load_var 12                        (ts)
         56   load_field 0                       (name)
         57   load_var2 4 5                      
-        58   call 778 ntypeargs=0               (testing.subtree_may_be_selected)
+        58   call 780 ntypeargs=0               (testing.subtree_may_be_selected)
 
   717   59   pop_jump_if_false -20              (to 39)
 
@@ -12402,7 +12402,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   723   61   load_var2 2 3                      
         62   load_var2 4 5                      
-        63   call 783 ntypeargs=0               (testing.collect_subtree_names_layered)
+        63   call 785 ntypeargs=0               (testing.collect_subtree_names_layered)
 
   729   64   load_type 10                       
         65   load_const 11                      ("iter")
@@ -12456,13 +12456,13 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         21   load_const 6                       ("*")
         22   call 155 ntypeargs=0               (baml.String.index_of)
         23   load_const 7                       (null)
-        24   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        24   call 656 ntypeargs=0               (baml.ops.equals_equals)
         25   jump_if_false +7                   (to 32)
         26   pop 1                              
         27   load_var2 3 6                      
         28   call 155 ntypeargs=0               (baml.String.index_of)
         29   load_const 7                       (null)
-        30   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        30   call 656 ntypeargs=0               (baml.ops.equals_equals)
         31   unary_op !                         
         32   pop_jump_if_false +2               (to 34)
         33   jump +11                           (to 44)
@@ -12473,7 +12473,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         37   jump_if_false +4                   (to 41)
         38   pop 1                              
         39   load_var2 3 6                      
-        40   call 772 ntypeargs=0               (testing.glob_match)
+        40   call 774 ntypeargs=0               (testing.glob_match)
         41   pop_jump_if_false -32              (to 9)
 
   655   42   load_const 9                       (true)
@@ -12488,7 +12488,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
 
 function testing.subtree_may_be_selected(prefix: string, include: string[], exclude: string[]) -> bool {
   677   0    load_var2 1 3                      
-        1    call 776 ntypeargs=0               (testing.subtree_excluded)
+        1    call 778 ntypeargs=0               (testing.subtree_excluded)
         2    pop_jump_if_false +2               (to 4)
         3    jump +32                           (to 35)
 
@@ -12516,7 +12516,7 @@ function testing.subtree_may_be_selected(prefix: string, include: string[], excl
         24   pop_jump_if_false +2               (to 26)
         25   jump +6                            (to 31)
         26   load_var2 6 1                      
-        27   call 777 ntypeargs=0               (testing.pattern_may_match_descendant)
+        27   call 779 ntypeargs=0               (testing.pattern_may_match_descendant)
 
   684   28   pop_jump_if_false -11              (to 17)
 
@@ -12544,7 +12544,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   364   6    load_var2 1 2         
 
   366   7    load_var 3            (runner)
-        8    make_closure 1471 2   
+        8    make_closure 1473 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   return                
 }
@@ -12561,7 +12561,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   375   8    load_var2 1 2         
-        9    make_closure 1473 2   
+        9    make_closure 1475 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   return                
 }
@@ -12582,7 +12582,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   391   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1475 3   
+        13   make_closure 1477 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   return                
 }
@@ -12616,7 +12616,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 762 ntypeargs=0               (testing.test_child)
+        26   call 764 ntypeargs=0               (testing.test_child)
         27   store_var 6                        (_10)
         28   load_type 0                        
         29   load_var2 2 6                      
@@ -12643,7 +12643,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
 
   334   49   load_var2 1 8                      
 
-  333   50   call 763 ntypeargs=0               (testing.testset_child)
+  333   50   call 765 ntypeargs=0               (testing.testset_child)
         51   store_var 9                        (_22)
 
   334   52   load_type 0                        
@@ -12682,7 +12682,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   342   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 765 ntypeargs=0               (testing._name_selected)
+        23   call 767 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   343   25   load_var 6                         (t)
@@ -12691,7 +12691,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 6                         (t)
         30   load_field 2                       (runner)
-        31   call 762 ntypeargs=0               (testing.test_child)
+        31   call 764 ntypeargs=0               (testing.test_child)
         32   store_var 7                        (_13)
         33   load_type 0                        
         34   load_var2 3 7                      
@@ -12720,12 +12720,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   354   56   load_field 0                       (name)
         57   load_var 2                         (names)
-        58   call 766 ntypeargs=0               (testing._has_selected_descendant)
+        58   call 768 ntypeargs=0               (testing._has_selected_descendant)
         59   pop_jump_if_false -14              (to 45)
 
   355   60   load_var2 1 10                     
         61   load_var 2                         (names)
-        62   call 764 ntypeargs=0               (testing.testset_child_selected)
+        62   call 766 ntypeargs=0               (testing.testset_child_selected)
         63   store_var 11                       (_27)
         64   load_type 0                        
         65   load_var2 3 11                     
@@ -12746,7 +12746,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 935 ntypeargs=0   (user.score)
+       7    call 937 ntypeargs=0   (user.score)
        8    store_var 3            (base)
 
   11   9    load_var 3             (base)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -30,14 +30,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   199   24    load_type 1                                
         25    load_deref 2                               
-        26    call 806 ntypeargs=1                       (ai.Journal.new)
+        26    call 807 ntypeargs=1                       (ai.Journal.new)
         27    store_deref 6                              
 
   200   28    load_type 1                                
         29    load_deref 1                               
         30    load_deref 6                               
         31    load_const 2                               (0)
-        32    call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        32    call 846 ntypeargs=1                       (ai.Agent._emit_from)
         33    store_var 7                                (seen)
 
   201   34    load_const 2                               (0)
@@ -73,7 +73,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         59    load_deref 6                               
         60    load_var 9                                 (total)
         61    load_const 5                               (2)
-        62    call 844 ntypeargs=1                       (ai.Agent._attempt_turn)
+        62    call 845 ntypeargs=1                       (ai.Agent._attempt_turn)
         63    store_var 11                               (turn)
 
   213   64    load_var 8                                 (steps)
@@ -85,11 +85,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         69    load_deref 1                               
         70    load_deref 6                               
         71    load_var 7                                 (seen)
-        72    call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        72    call 846 ntypeargs=1                       (ai.Agent._emit_from)
         73    store_var 7                                (seen)
 
   215   74    load_var 11                                (turn)
-        75    call 825 ntypeargs=0                       (ai.ModelTurn.tool_uses)
+        75    call 826 ntypeargs=0                       (ai.ModelTurn.tool_uses)
         76    store_var 12                               (calls)
 
   216   77    load_var 12                                (calls)
@@ -102,7 +102,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         84    jump +65                                   (to 149)
 
   251   85    load_var 11                                (turn)
-        86    call 824 ntypeargs=0                       (ai.ModelTurn.terminal_text)
+        86    call 825 ntypeargs=0                       (ai.ModelTurn.terminal_text)
         87    store_var 35                               (_96)
         88    load_var 35                                (_96)
         89    store_var 34                               (candidate)
@@ -115,7 +115,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   252   96    load_type 1                                
         97    load_var 34                                (candidate)
-        98    call 426 ntypeargs=1                       (baml.sap.parse)
+        98    call 427 ntypeargs=1                       (baml.sap.parse)
         99    store_var 36                               (value)
         100   jump +11                                   (to 111)
         101   load_var 37                                (e)
@@ -132,7 +132,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   257   111   load_type 1                                
         112   load_var 36                                (value)
-        113   call 331 ntypeargs=1                       (baml.json.to_json)
+        113   call 332 ntypeargs=1                       (baml.json.to_json)
         114   jump +12                                   (to 126)
         115   load_var 39                                (e)
         116   throw_if_panic                             
@@ -147,7 +147,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         124   init_instance 3                            (baml.errors.UnknownError .data, .message)
         125   throw                                      
 
-  263   126   call 328 ntypeargs=0                       (baml.json.stringify)
+  263   126   call 329 ntypeargs=0                       (baml.json.stringify)
         127   store_var 41                               (_117)
 
   262   128   load_deref 6                               
@@ -156,14 +156,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         130   init_instance 4                            (ai.events.FinalProduced .value_json)
         131   load_type 11                               
         132   alloc_array 1                              
-        133   call 807 ntypeargs=0                       (ai.Journal.append_all)
+        133   call 808 ntypeargs=0                       (ai.Journal.append_all)
         134   pop 1                                      
 
   265   135   load_type 1                                
         136   load_deref 1                               
         137   load_deref 6                               
         138   load_var 7                                 (seen)
-        139   call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        139   call 846 ntypeargs=1                       (ai.Agent._emit_from)
         140   store_var 7                                (seen)
 
   266   141   load_var 36                                (value)
@@ -176,7 +176,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         148   return                                     
 
   217   149   load_deref 6                               
-        150   call 805 ntypeargs=0                       (ai.Journal.entries)
+        150   call 806 ntypeargs=0                       (ai.Journal.entries)
         151   container_len                              
         152   store_var 14                               (before)
 
@@ -187,14 +187,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         157   load_type 1                                
         158   load_var2 1 2                              
         159   load_var 6                                 (j)
-        160   make_closure 1735 captures=3 ntypeargs=1   
+        160   make_closure 1736 captures=3 ntypeargs=1   
         161   call 16 ntypeargs=3                        (baml.Array.map)
         162   store_var 15                               (futures)
 
   222   163   load_type 15                               
         164   load_type 16                               
         165   load_var 15                                (futures)
-        166   call 483 ntypeargs=2                       (baml.future.all)
+        166   call 484 ntypeargs=2                       (baml.future.all)
         167   await                                      
         168   pop 1                                      
 
@@ -202,11 +202,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         170   load_deref 1                               
         171   load_deref 6                               
         172   load_var 7                                 (seen)
-        173   call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        173   call 846 ntypeargs=1                       (ai.Agent._emit_from)
         174   store_var 7                                (seen)
 
   227   175   load_deref 6                               
-        176   call 805 ntypeargs=0                       (ai.Journal.entries)
+        176   call 806 ntypeargs=0                       (ai.Journal.entries)
         177   store_var 16                               (entries)
 
   228   178   load_var 14                                (before)
@@ -236,7 +236,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         199   load_var 12                                (calls)
         200   load_type 1                                
         201   load_var 21                                (f)
-        202   make_closure 1736 captures=1 ntypeargs=1   
+        202   make_closure 1737 captures=1 ntypeargs=1   
         203   call 19 ntypeargs=2                        (baml.Array.find)
 
   234   204   store_var 22                               (_58)
@@ -340,12 +340,12 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   126   3     load_type 0                        
         4     load_var 3                         (spec)
-        5     call 816 ntypeargs=1               (ai.FunctionSpec.tools)
+        5     call 817 ntypeargs=1               (ai.FunctionSpec.tools)
         6     store_var 9                        (_10)
 
   127   7     load_type 0                        
         8     load_var 3                         (spec)
-        9     call 814 ntypeargs=1               (ai.FunctionSpec.output_type)
+        9     call 815 ntypeargs=1               (ai.FunctionSpec.output_type)
         10    store_var 10                       (_12)
 
   122   11    load_var2 2 8                      
@@ -448,7 +448,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         99    store_var 21                       (batch)
 
   142   100   load_var 7                         (turn)
-        101   call 825 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        101   call 826 ntypeargs=0               (ai.ModelTurn.tool_uses)
         102   load_type 8                        
         103   load_const 9                       ("iter")
         104   virtual_call nargs=1 ntypeargs=0   
@@ -492,7 +492,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         139   pop 1                              
 
   148   140   load_var 7                         (turn)
-        141   call 824 ntypeargs=0               (ai.ModelTurn.terminal_text)
+        141   call 825 ntypeargs=0               (ai.ModelTurn.terminal_text)
         142   store_var 30                       (_56)
         143   load_var 30                        (_56)
         144   store_var 29                       (candidate)
@@ -504,7 +504,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         150   store_var 29                       (candidate)
 
   149   151   load_var 7                         (turn)
-        152   call 825 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        152   call 826 ntypeargs=0               (ai.ModelTurn.tool_uses)
         153   container_len                      
         154   store_var 31                       (_62)
         155   load_var 31                        (_62)
@@ -518,7 +518,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         162   load_field 1                       (stop_reason)
         163   load_const 14                      (ai.content.StopReason.MaxTokens)
         164   alloc_variant 436                  (ai.content.StopReason)
-        165   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        165   call 654 ntypeargs=0               (baml.ops.equals_equals)
 
   149   166   jump_if_false +2                   (to 168)
         167   jump +7                            (to 174)
@@ -528,7 +528,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         170   load_field 1                       (stop_reason)
         171   load_const 15                      (ai.content.StopReason.Refused)
         172   alloc_variant 436                  (ai.content.StopReason)
-        173   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        173   call 654 ntypeargs=0               (baml.ops.equals_equals)
 
   149   174   jump_if_false +2                   (to 176)
         175   jump +5                            (to 180)
@@ -536,7 +536,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   152   177   load_type 0                        
         178   load_var2 1 29                     
-        179   call 843 ntypeargs=1               (ai.Agent._parses)
+        179   call 844 ntypeargs=1               (ai.Agent._parses)
 
   153   180   pop_jump_if_false +2               (to 182)
         181   jump +34                           (to 215)
@@ -548,7 +548,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         186   jump +12                           (to 198)
 
   175   187   load_var2 4 21                     
-        188   call 807 ntypeargs=0               (ai.Journal.append_all)
+        188   call 808 ntypeargs=0               (ai.Journal.append_all)
         189   pop 1                              
 
   176   190   load_var 2                         (c)
@@ -569,7 +569,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         203   pop 1                              
 
   172   204   load_var2 4 21                     
-        205   call 807 ntypeargs=0               (ai.Journal.append_all)
+        205   call 808 ntypeargs=0               (ai.Journal.append_all)
         206   pop 1                              
 
   173   207   load_type 0                        
@@ -578,11 +578,11 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         210   load_var2 5 6                      
         211   load_const 16                      (1)
         212   sub_int                            
-        213   call 844 ntypeargs=1               (ai.Agent._attempt_turn)
+        213   call 845 ntypeargs=1               (ai.Agent._attempt_turn)
         214   jump +19                           (to 233)
 
   154   215   load_var2 4 21                     
-        216   call 807 ntypeargs=0               (ai.Journal.append_all)
+        216   call 808 ntypeargs=0               (ai.Journal.append_all)
         217   pop 1                              
 
   156   218   load_var 7                         (turn)
@@ -626,7 +626,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
 function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> int {
   182   0    load_var 2             (j)
-        1    call 805 ntypeargs=0   (ai.Journal.entries)
+        1    call 806 ntypeargs=0   (ai.Journal.entries)
         2    store_var 4            (entries)
 
   183   3    load_var 3             (seen)
@@ -700,7 +700,7 @@ function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> in
 function ai.Agent._parses(self: ai.Agent<#0>, candidate: string) -> bool {
   100   0    load_type 0            
         1    load_var 2             (candidate)
-        2    call 426 ntypeargs=1   (baml.sap.parse)
+        2    call 427 ntypeargs=1   (baml.sap.parse)
         3    pop 1                  
         4    jump +5                (to 9)
         5    load_var 3             (e)
@@ -716,7 +716,7 @@ function ai.Agent._parses(self: ai.Agent<#0>, candidate: string) -> bool {
 function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: ai.content.ToolUse, j: ai.Journal) -> null {
   56   0     load_var2 2 3           
        1     load_field 1            (name)
-       2     call 822 ntypeargs=0    (ai.tools.Toolbox.get)
+       2     call 823 ntypeargs=0    (ai.tools.Toolbox.get)
        3     store_var 5             (_7)
        4     load_var 5              (_7)
        5     narrow_bind 0 5         
@@ -741,7 +741,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        20    init_instance 0         (ai.events.ToolFailed .id, .message)
        21    load_type 3             
        22    alloc_array 1           
-       23    call 807 ntypeargs=0    (ai.Journal.append_all)
+       23    call 808 ntypeargs=0    (ai.Journal.append_all)
        24    pop 1                   
 
   94   25    load_const 4            (null)
@@ -752,7 +752,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
 
   58   29    load_var2 6 3           
        30    load_field 2            (args)
-       31    call 817 ntypeargs=0    (ai.tools.Tool.call)
+       31    call 818 ntypeargs=0    (ai.tools.Tool.call)
        32    store_var 7             (outcome)
        33    jump +65                (to 98)
        34    load_var 8              (e)
@@ -772,7 +772,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        45    init_instance 1         (ai.events.ToolFailed .id, .message)
        46    load_type 3             
        47    alloc_array 1           
-       48    call 807 ntypeargs=0    (ai.Journal.append_all)
+       48    call 808 ntypeargs=0    (ai.Journal.append_all)
        49    pop 1                   
 
   64   50    load_var 6              (t)
@@ -790,7 +790,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        62    load_var 11             (_19)
        63    load_const 6            (ai.tools.ErrorMode.Raise)
        64    alloc_variant 437       (ai.tools.ErrorMode)
-       65    call 653 ntypeargs=0    (baml.ops.equals_equals)
+       65    call 654 ntypeargs=0    (baml.ops.equals_equals)
        66    pop_jump_if_false +2    (to 68)
        67    jump +4                 (to 71)
 
@@ -849,7 +849,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        108   init_instance 3         (ai.events.ToolCompleted .id, .output)
        109   load_type 3             
        110   alloc_array 1           
-       111   call 807 ntypeargs=0    (ai.Journal.append_all)
+       111   call 808 ntypeargs=0    (ai.Journal.append_all)
        112   pop 1                   
 
   83   113   load_const 4            (null)
@@ -895,7 +895,7 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
        30   pop_jump_if_false +4                       (to 34)
 
   41   31   load_type 4                                
-       32   make_closure 1717 captures=0 ntypeargs=1   
+       32   make_closure 1718 captures=0 ntypeargs=1   
        33   store_var 5                                (_9)
 
   35   34   load_var2 1 2                              
@@ -986,11 +986,11 @@ function ai.Journal.entries(self: ai.Journal) -> (ai.events.RunStarted | ai.even
 function ai.Journal.new(spec: ai.FunctionSpec<#0>) -> ai.Journal {
   21   0    load_type 0            
        1    load_var 1             (spec)
-       2    call 812 ntypeargs=1   (ai.FunctionSpec.name)
+       2    call 813 ntypeargs=1   (ai.FunctionSpec.name)
        3    store_var 3            (_4)
        4    load_type 0            
        5    load_var 1             (spec)
-       6    call 813 ntypeargs=1   (ai.FunctionSpec.arguments)
+       6    call 814 ntypeargs=1   (ai.FunctionSpec.arguments)
        7    store_var 4            (_6)
        8    load_var2 3 4          
        9    init_instance 0        (ai.events.RunStarted .spec_name, .arguments)
@@ -1087,7 +1087,7 @@ function ai.ModelTurn.tool_uses(self: ai.ModelTurn) -> ai.content.ToolUse[] {
 
 function ai.Prompt.baml.ToString.to_string(self: ai.Prompt) -> string {
   35   0   load_var 1             (self)
-       1   call 808 ntypeargs=0   (ai.Prompt.text)
+       1   call 809 ntypeargs=0   (ai.Prompt.text)
        2   return                 
 }
 
@@ -1253,7 +1253,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         49   load_var 11                        (_17)
         50   load_const 6                       (ai.errors.RetrySafety.Safe)
         51   alloc_variant 438                  (ai.errors.RetrySafety)
-        52   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        52   call 654 ntypeargs=0               (baml.ops.equals_equals)
 
   155   53   pop_jump_if_false +2               (to 55)
         54   jump +3                            (to 57)
@@ -1265,7 +1265,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         58   load_var 3                         (index)
         59   load_const 4                       (1)
         60   add_int                            
-        61   call 838 ntypeargs=0               (ai.clients.Fallback._try)
+        61   call 839 ntypeargs=0               (ai.clients.Fallback._try)
         62   return                             
 }
 
@@ -1300,13 +1300,13 @@ function ai.clients.Fallback.root.Client.id(self: ai.clients.Fallback) -> string
 function ai.clients.Fallback.root.Client.invoke(self: ai.clients.Fallback, input: ai.ModelTurnInput) -> ai.ModelTurn {
   185   0   load_var2 1 2          
         1   load_const 0           (0)
-        2   call 838 ntypeargs=0   (ai.clients.Fallback._try)
+        2   call 839 ntypeargs=0   (ai.clients.Fallback._try)
         3   jump +6                (to 9)
         4   load_var 3             (e)
         5   throw_if_panic         
 
   186   6   load_var 3             (e)
-        7   call 856 ntypeargs=0   (ai.errors.normalize)
+        7   call 857 ntypeargs=0   (ai.errors.normalize)
         8   throw                  
         9   return                 
 }
@@ -1348,7 +1348,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        29   load_var 7                         (_11)
        30   load_const 5                       (ai.errors.RetrySafety.Safe)
        31   alloc_variant 438                  (ai.errors.RetrySafety)
-       32   call 653 ntypeargs=0               (baml.ops.equals_equals)
+       32   call 654 ntypeargs=0               (baml.ops.equals_equals)
 
   74   33   jump_if_false +5                   (to 38)
        34   pop 1                              
@@ -1374,8 +1374,8 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
   80   49   load_var 1                         (self)
        50   load_field 3                       (backoff)
        51   load_var2 8 6                      
-       52   call 830 ntypeargs=0               (ai.clients.Backoff.delay_ms)
-       53   call 502 ntypeargs=0               (baml.time.Duration.from_milliseconds)
+       52   call 831 ntypeargs=0               (ai.clients.Backoff.delay_ms)
+       53   call 503 ntypeargs=0               (baml.time.Duration.from_milliseconds)
 
   79   54   sys_op 255                         (baml.sys.sleep)
        55   pop 1                              
@@ -1387,7 +1387,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        60   load_var 3                         (remaining)
        61   load_const 3                       (1)
        62   sub_int                            
-       63   call 832 ntypeargs=0               (ai.clients.Retry._attempt)
+       63   call 833 ntypeargs=0               (ai.clients.Retry._attempt)
        64   return                             
 }
 
@@ -1432,7 +1432,7 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
        32   load_const 0           (<omitted>)
        33   load_const 0           (<omitted>)
        34   load_const 0           (<omitted>)
-       35   call 829 ntypeargs=0   (ai.clients.Backoff.new)
+       35   call 830 ntypeargs=0   (ai.clients.Backoff.new)
        36   store_var 6            (_10)
 
   61   37   load_var2 1 2          
@@ -1456,13 +1456,13 @@ function ai.clients.Retry.root.Client.invoke(self: ai.clients.Retry, input: ai.M
   99    0    load_var2 1 2          
         1    load_var 1             (self)
         2    load_field 1           (max_attempts)
-        3    call 832 ntypeargs=0   (ai.clients.Retry._attempt)
+        3    call 833 ntypeargs=0   (ai.clients.Retry._attempt)
         4    jump +6                (to 10)
         5    load_var 3             (e)
         6    throw_if_panic         
 
   100   7    load_var 3             (e)
-        8    call 856 ntypeargs=0   (ai.errors.normalize)
+        8    call 857 ntypeargs=0   (ai.errors.normalize)
         9    throw                  
         10   return                 
 }
@@ -1564,7 +1564,7 @@ function ai.clients.RoundRobin.root.Client.invoke(self: ai.clients.RoundRobin, i
         37   throw_if_panic                     
 
   141   38   load_var 4                         (e)
-        39   call 856 ntypeargs=0               (ai.errors.normalize)
+        39   call 857 ntypeargs=0               (ai.errors.normalize)
         40   throw                              
         41   load_var 3                         (_0)
         42   return                             
@@ -1763,7 +1763,7 @@ function ai.errors.normalize(error: unknown) -> ai.errors.Failure | baml.errors.
 
 function ai.internal._schema_for_signature(handler: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> map<string, unknown> {
   6    0    load_var 1                         (handler)
-       1    call 739 ntypeargs=0               (reflect.signature)
+       1    call 740 ntypeargs=0               (reflect.signature)
        2    store_var 3                        (sig)
 
   7    3    load_type 0                        
@@ -1798,7 +1798,7 @@ function ai.internal._schema_for_signature(handler: baml.AnyFunction<Returns = u
        29   store_var 9                        (_12)
        30   load_var 8                         (a)
        31   load_field 1                       (type)
-       32   sys_op 341                         (baml.json.schema)
+       32   sys_op 342                         (baml.json.schema)
        33   store_var 10                       (_13)
        34   load_type 0                        
        35   load_type 1                        
@@ -1846,10 +1846,10 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
 
   102   9     load_var2 4 2                      
         10    load_var 3                         (params)
-        11    call 926 ntypeargs=0               (ai.mcp.rpc_line)
+        11    call 927 ntypeargs=0               (ai.mcp.rpc_line)
         12    store_var 5                        (_6)
         13    load_var2 1 5                      
-        14    call 928 ntypeargs=0               (ai.mcp.McpConnection._send)
+        14    call 929 ntypeargs=0               (ai.mcp.McpConnection._send)
         15    pop 1                              
 
   103   16    load_const 1                       (true)
@@ -1958,7 +1958,7 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         102   pop_jump_if_false -86              (to 16)
 
   118   103   load_var 13                        (trimmed)
-        104   call 327 ntypeargs=0               (baml.json.parse)
+        104   call 328 ntypeargs=0               (baml.json.parse)
         105   store_var 14                       (msg)
         106   jump +5                            (to 111)
         107   load_var 15                        (e)
@@ -1972,7 +1972,7 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         113   load_const 15                      (".id")
         114   load_const 0                       (1)
         115   unary_op -                         
-        116   call 340 ntypeargs=1               (baml.json.path_or)
+        116   call 341 ntypeargs=1               (baml.json.path_or)
         117   load_var 4                         (id)
         118   cmp_int_op ==                      
         119   pop_jump_if_false -103             (to 16)
@@ -1981,12 +1981,12 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         121   load_var 14                        (msg)
         122   load_const 17                      (".error")
         123   load_const 5                       (null)
-        124   call 340 ntypeargs=1               (baml.json.path_or)
+        124   call 341 ntypeargs=1               (baml.json.path_or)
         125   store_var 16                       (err)
 
   123   126   load_var 16                        (err)
         127   load_const 5                       (null)
-        128   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        128   call 654 ntypeargs=0               (baml.ops.equals_equals)
         129   unary_op !                         
         130   pop_jump_if_false +2               (to 132)
         131   jump +7                            (to 138)
@@ -1995,7 +1995,7 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         133   load_var 14                        (msg)
         134   load_const 18                      (".result")
         135   load_const 5                       (null)
-        136   call 340 ntypeargs=1               (baml.json.path_or)
+        136   call 341 ntypeargs=1               (baml.json.path_or)
         137   return                             
 
   125   138   load_type 2                        
@@ -2008,18 +2008,18 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         144   load_var 16                        (err)
         145   load_const 20                      (".code")
         146   load_const 5                       (null)
-        147   call 340 ntypeargs=1               (baml.json.path_or)
+        147   call 341 ntypeargs=1               (baml.json.path_or)
         148   store_var 18                       (_46)
 
   127   149   load_type 2                        
         150   load_var 16                        (err)
         151   load_const 21                      (".message")
         152   load_const 22                      ("MCP error")
-        153   call 340 ntypeargs=1               (baml.json.path_or)
+        153   call 341 ntypeargs=1               (baml.json.path_or)
         154   store_var 19                       (_49)
 
   128   155   load_var 16                        (err)
-        156   call 328 ntypeargs=0               (baml.json.stringify)
+        156   call 329 ntypeargs=0               (baml.json.stringify)
         157   store_var 20                       (_52)
 
   125   158   load_const 23                      ("mcp/")
@@ -2094,7 +2094,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
   184   7    load_var 1                         (self)
         8    load_const 4                       ("tools/call")
         9    load_var 5                         (params)
-        10   call 929 ntypeargs=0               (ai.mcp.McpConnection._request)
+        10   call 930 ntypeargs=0               (ai.mcp.McpConnection._request)
         11   store_var 6                        (result)
 
   185   12   load_type 2                        
@@ -2106,7 +2106,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         17   load_const 6                       (".content")
         18   load_type 7                        
         19   alloc_array 0                      
-        20   call 340 ntypeargs=1               (baml.json.path_or)
+        20   call 341 ntypeargs=1               (baml.json.path_or)
         21   load_type 8                        
         22   load_const 9                       ("iter")
         23   virtual_call nargs=1 ntypeargs=0   
@@ -2127,7 +2127,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         37   load_var 10                        (item)
         38   load_const 13                      (".type")
         39   load_const 14                      ("")
-        40   call 340 ntypeargs=1               (baml.json.path_or)
+        40   call 341 ntypeargs=1               (baml.json.path_or)
         41   load_const 15                      ("text")
         42   cmp_op ==                          
         43   pop_jump_if_false -18              (to 25)
@@ -2136,7 +2136,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         45   load_var 10                        (item)
         46   load_const 16                      (".text")
         47   load_const 17                      ("")
-        48   call 340 ntypeargs=1               (baml.json.path_or)
+        48   call 341 ntypeargs=1               (baml.json.path_or)
         49   store_var 11                       (_22)
         50   load_type 2                        
         51   load_var2 7 11                     
@@ -2154,7 +2154,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         61   load_var 6                         (result)
         62   load_const 20                      (".isError")
         63   load_const 21                      (false)
-        64   call 340 ntypeargs=1               (baml.json.path_or)
+        64   call 341 ntypeargs=1               (baml.json.path_or)
         65   pop_jump_if_false +2               (to 67)
         66   jump +5                            (to 71)
 
@@ -2267,16 +2267,16 @@ function ai.mcp.McpConnection.connect(name: string, command: string, args: strin
   75   61   load_var 11            (conn)
        62   load_const 18          ("initialize")
        63   load_var 12            (init)
-       64   call 929 ntypeargs=0   (ai.mcp.McpConnection._request)
+       64   call 930 ntypeargs=0   (ai.mcp.McpConnection._request)
        65   pop 1                  
 
   76   66   load_const 2           (null)
        67   load_const 19          ("notifications/initialized")
        68   load_const 2           (null)
-       69   call 926 ntypeargs=0   (ai.mcp.rpc_line)
+       69   call 927 ntypeargs=0   (ai.mcp.rpc_line)
        70   store_var 13           (_26)
        71   load_var2 11 13        
-       72   call 928 ntypeargs=0   (ai.mcp.McpConnection._send)
+       72   call 929 ntypeargs=0   (ai.mcp.McpConnection._send)
        73   pop 1                  
 
   77   74   load_var 11            (conn)
@@ -2291,7 +2291,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         2    load_type 1                        
         3    load_type 2                        
         4    alloc_map 0                        
-        5    call 929 ntypeargs=0               (ai.mcp.McpConnection._request)
+        5    call 930 ntypeargs=0               (ai.mcp.McpConnection._request)
         6    store_var 3                        (result)
 
   157   7    load_type 3                        
@@ -2303,7 +2303,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         12   load_const 5                       (".tools")
         13   load_type 6                        
         14   alloc_array 0                      
-        15   call 340 ntypeargs=1               (baml.json.path_or)
+        15   call 341 ntypeargs=1               (baml.json.path_or)
         16   load_type 7                        
         17   load_const 8                       ("iter")
         18   virtual_call nargs=1 ntypeargs=0   
@@ -2324,7 +2324,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         32   load_var 7                         (t)
         33   load_const 12                      (".name")
         34   load_const 13                      ("")
-        35   call 340 ntypeargs=1               (baml.json.path_or)
+        35   call 341 ntypeargs=1               (baml.json.path_or)
         36   store_var 8                        (tool_name)
 
   161   37   load_type 6                        
@@ -2333,12 +2333,12 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         40   load_type 1                        
         41   load_type 6                        
         42   alloc_map 0                        
-        43   call 340 ntypeargs=1               (baml.json.path_or)
+        43   call 341 ntypeargs=1               (baml.json.path_or)
         44   store_var 11                       (_19)
 
   160   45   load_type 15                       
         46   load_var 11                        (_19)
-        47   call 334 ntypeargs=1               (baml.json.from_json)
+        47   call 335 ntypeargs=1               (baml.json.from_json)
         48   store_var 9                        (schema)
         49   jump +9                            (to 58)
         50   load_var 10                        (e)
@@ -2356,20 +2356,20 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         59   load_var 7                         (t)
         60   load_const 16                      (".description")
         61   load_const 17                      ("")
-        62   call 340 ntypeargs=1               (baml.json.path_or)
+        62   call 341 ntypeargs=1               (baml.json.path_or)
         63   store_var 14                       (_28)
 
   172   64   load_var 9                         (schema)
         65   store_var 15                       (_31)
 
   173   66   load_var2 1 8                      
-        67   call 925 ntypeargs=0               (ai.mcp._proxy)
+        67   call 926 ntypeargs=0               (ai.mcp._proxy)
         68   store_var 16                       (_32)
 
   170   69   load_var2 8 14                     
         70   load_var2 15 16                    
         71   load_const 18                      (<omitted>)
-        72   call 819 ntypeargs=0               (ai.tools.raw_tool)
+        72   call 820 ntypeargs=0               (ai.tools.raw_tool)
         73   store_var 13                       (_26)
 
   168   74   load_type 3                        
@@ -2393,7 +2393,7 @@ function ai.mcp._proxy(conn: ai.mcp.McpConnection, name: string) -> (map<string,
        5    store_var 2           
 
   20   6    load_var2 1 2         
-       7    make_closure 2301 2   
+       7    make_closure 2302 2   
        8    store_var 3           (_0)
        9    load_var 3            (_0)
        10   return                
@@ -2443,8 +2443,8 @@ function ai.mcp.rpc_line(id: int | null, method: string, params: map<string, unk
 
   34   36   load_type 7             
        37   load_var 4              (m)
-       38   call 331 ntypeargs=1    (baml.json.to_json)
-       39   call 328 ntypeargs=0    (baml.json.stringify)
+       38   call 332 ntypeargs=1    (baml.json.to_json)
+       39   call 329 ntypeargs=0    (baml.json.stringify)
        40   return                  
 }
 
@@ -2454,7 +2454,7 @@ function ai.prompt(body: ((string) -> baml.prompt.Role throws never, baml.prompt
        2   store_var 1           
 
   49   3   load_var 1            (body)
-       4   make_closure 1651 1   
+       4   make_closure 1652 1   
        5   store_var 3           (render)
 
   53   6   load_var 3            (render)
@@ -2476,7 +2476,7 @@ function ai.stream.Stream.final(self: ai.stream.Stream<#0, #1>) -> #1 {
         8    load_field 1           (_cache)
         9    load_type 0            
         10   load_type 1            
-        11   sys_op 424             (baml.sap.__parse_final)
+        11   sys_op 425             (baml.sap.__parse_final)
         12   return                 
 
   279   13   load_var 1             (self)
@@ -2544,7 +2544,7 @@ function ai.stream.Stream.next(self: ai.stream.Stream<#0, #1>) -> #0 | ai.stream
         29   load_field 1                     (_cache)
         30   load_type 3                      
         31   load_type 4                      
-        32   sys_op 425                       (baml.sap.__parse_partial)
+        32   sys_op 426                       (baml.sap.__parse_partial)
         33   store_var 4                      (parsed)
 
   264   34   load_var 4                       (parsed)
@@ -2597,7 +2597,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         1    pop_jump_if_false +7   (to 8)
 
   216   2    load_var 1             (self)
-        3    call 851 ntypeargs=0   (ai.stream.TurnStream.next)
+        3    call 852 ntypeargs=0   (ai.stream.TurnStream.next)
         4    store_var 2            (_3)
         5    load_var 2             (_3)
         6    narrow_bind 1 2        
@@ -2606,7 +2606,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
   223   8    load_var 1             (self)
         9    load_field 8           (_input_tokens)
         10   load_const 2           (null)
-        11   call 653 ntypeargs=0   (baml.ops.equals_equals)
+        11   call 654 ntypeargs=0   (baml.ops.equals_equals)
         12   unary_op !             
         13   jump_if_false +2       (to 15)
         14   jump +7                (to 21)
@@ -2614,7 +2614,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         16   load_var 1             (self)
         17   load_field 9           (_output_tokens)
         18   load_const 2           (null)
-        19   call 653 ntypeargs=0   (baml.ops.equals_equals)
+        19   call 654 ntypeargs=0   (baml.ops.equals_equals)
         20   unary_op !             
         21   pop_jump_if_false +2   (to 23)
         22   jump +4                (to 26)
@@ -2766,7 +2766,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         38    jump +6                            (to 44)
 
   202   39    load_var 1                         (self)
-        40    call 850 ntypeargs=0               (ai.stream.TurnStream._finish)
+        40    call 851 ntypeargs=0               (ai.stream.TurnStream._finish)
         41    pop 1                              
 
   203   42    alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2849,7 +2849,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         110   jump -17                           (to 93)
 
   176   111   load_var 1                         (self)
-        112   call 850 ntypeargs=0               (ai.stream.TurnStream._finish)
+        112   call 851 ntypeargs=0               (ai.stream.TurnStream._finish)
         113   pop 1                              
 
   177   114   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2889,7 +2889,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         145   pop_jump_if_false -145             (to 0)
 
   165   146   load_var 1                         (self)
-        147   call 850 ntypeargs=0               (ai.stream.TurnStream._finish)
+        147   call 851 ntypeargs=0               (ai.stream.TurnStream._finish)
         148   pop 1                              
 
   166   149   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2964,7 +2964,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
 function ai.stream.decode_sse_batch(batch: string) -> ai.stream.SseEvent[] {
   27   0   load_type 0            
        1   load_var 1             (batch)
-       2   call 333 ntypeargs=1   (baml.json.from_string)
+       2   call 334 ntypeargs=1   (baml.json.from_string)
        3   return                 
 }
 
@@ -2982,8 +2982,8 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   306   9     load_type 2                                
         10    load_var 1                                 (spec)
-        11    call 816 ntypeargs=1                       (ai.FunctionSpec.tools)
-        12    call 823 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
+        11    call 817 ntypeargs=1                       (ai.FunctionSpec.tools)
+        12    call 824 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
         13    unary_op !                                 
         14    pop_jump_if_false +2                       (to 16)
         15    jump +79                                   (to 94)
@@ -3043,17 +3043,17 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   331   57    load_type 2                                
         58    load_var 1                                 (spec)
-        59    call 806 ntypeargs=1                       (ai.Journal.new)
+        59    call 807 ntypeargs=1                       (ai.Journal.new)
         60    store_var 16                               (_29)
 
   332   61    load_type 2                                
         62    load_var 1                                 (spec)
-        63    call 816 ntypeargs=1                       (ai.FunctionSpec.tools)
+        63    call 817 ntypeargs=1                       (ai.FunctionSpec.tools)
         64    store_var 17                               (_31)
 
   333   65    load_type 2                                
         66    load_var 1                                 (spec)
-        67    call 814 ntypeargs=1                       (ai.FunctionSpec.output_type)
+        67    call 815 ntypeargs=1                       (ai.FunctionSpec.output_type)
         68    store_var 18                               (_33)
 
   328   69    load_var2 6 15                             
@@ -3068,13 +3068,13 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   346   77    load_type 8                                
         78    load_type 2                                
-        79    call 423 ntypeargs=2                       (baml.sap.__new_parse_cache)
+        79    call 424 ntypeargs=2                       (baml.sap.__new_parse_cache)
         80    store_var 19                               (_36)
 
   340   81    load_type 8                                
         82    load_type 2                                
         83    load_var 14                                (turns)
-        84    make_closure 1757 captures=1 ntypeargs=2   
+        84    make_closure 1758 captures=1 ntypeargs=2   
         85    load_var 19                                (_36)
         86    load_const 9                               ("")
         87    load_const 10                              (false)
@@ -3087,7 +3087,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   308   94    load_type 2                                
         95    load_var 1                                 (spec)
-        96    call 812 ntypeargs=1                       (ai.FunctionSpec.name)
+        96    call 813 ntypeargs=1                       (ai.FunctionSpec.name)
         97    store_var 5                                (_12)
         98    load_type 11                               
         99    load_var 5                                 (_12)
@@ -3138,7 +3138,7 @@ function ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> 
   30   28   load_type 5            
        29   load_type 5            
        30   load_var2 6 2          
-       31   call 740 ntypeargs=2   (reflect.call_any)
+       31   call 741 ntypeargs=2   (reflect.call_any)
        32   store_var 7            (value)
        33   jump +33               (to 66)
        34   load_var 8             (e)
@@ -3177,8 +3177,8 @@ function ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> 
 
   35   66   load_type 5            
        67   load_var 7             (value)
-       68   call 331 ntypeargs=1   (baml.json.to_json)
-       69   call 328 ntypeargs=0   (baml.json.stringify)
+       68   call 332 ntypeargs=1   (baml.json.to_json)
+       69   call 329 ntypeargs=0   (baml.json.stringify)
        70   jump +5                (to 75)
 
   26   71   load_var 3             (_4)
@@ -3199,7 +3199,7 @@ function ai.tools.Toolbox.get(self: ai.tools.Toolbox, name: string) -> ai.tools.
         5    load_var 1            (self)
         6    load_field 0          (entries)
         7    load_var 2            (name)
-        8    make_closure 1677 1   
+        8    make_closure 1678 1   
         9    call 19 ntypeargs=2   (baml.Array.find)
         10   return                
 }
@@ -3328,7 +3328,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        17   store_var 4            (on_error)
 
   49   18   load_var 1             (handler)
-       19   call 739 ntypeargs=0   (reflect.signature)
+       19   call 740 ntypeargs=0   (reflect.signature)
        20   store_var 5            (sig)
 
   50   21   load_var 2             (name)
@@ -3379,7 +3379,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        61   store_var 9            (_17)
 
   58   62   load_var 1             (handler)
-       63   call 866 ntypeargs=0   (ai.internal._schema_for_signature)
+       63   call 867 ntypeargs=0   (ai.internal._schema_for_signature)
        64   store_var 11           (_21)
 
   56   65   load_var2 8 9          
@@ -3396,7 +3396,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
 
 function ai.wire.render_output_format(t: type) -> string {
   37   0   load_var 1   (t)
-       1   sys_op 418   (baml.prompt.render_output_format)
+       1   sys_op 419   (baml.prompt.render_output_format)
        2   return       
 }
 
@@ -3448,7 +3448,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
 
   29   38   load_type 6            
        39   load_var 7             (text)
-       40   call 333 ntypeargs=1   (baml.json.from_string)
+       40   call 334 ntypeargs=1   (baml.json.from_string)
        41   jump +6                (to 47)
        42   load_var 9             (e)
        43   throw_if_panic         
@@ -3461,7 +3461,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
   27   48   load_var2 2 3          
        49   load_field 0           (status_code)
        50   load_var 7             (text)
-       51   call 865 ntypeargs=0   (ai.errors.classify_http)
+       51   call 866 ntypeargs=0   (ai.errors.classify_http)
        52   throw                  
 }
 
@@ -3481,20 +3481,20 @@ function anthropic.AnthropicClient.ai.Client.id(self: anthropic.AnthropicClient)
 
 function anthropic.AnthropicClient.ai.Client.invoke(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   32   0   load_var2 1 2          
-       1   call 893 ntypeargs=0   (anthropic.internal.invoke)
+       1   call 894 ntypeargs=0   (anthropic.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   33   5   load_var 3             (e)
-       6   call 856 ntypeargs=0   (ai.errors.normalize)
+       6   call 857 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function anthropic.AnthropicClient.ai.stream.StreamingClient.invoke_stream(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   40   0   load_var2 1 2          
-       1   call 895 ntypeargs=0   (anthropic.internal.invoke_stream)
+       1   call 896 ntypeargs=0   (anthropic.internal.invoke_stream)
        2   return                 
 }
 
@@ -3660,7 +3660,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         2     store_var 3                        (out)
 
   349   3     load_var 1                         (batch)
-        4     call 847 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 848 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -3687,7 +3687,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
 
   351   27    load_type 7                        
         28    load_var 8                         (data)
-        29    call 333 ntypeargs=1               (baml.json.from_string)
+        29    call 334 ntypeargs=1               (baml.json.from_string)
         30    jump +4                            (to 34)
         31    load_var 9                         (e)
         32    throw_if_panic                     
@@ -3773,7 +3773,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         103   load_var 24                        (_67)
         104   store_var_load_var 25              (s)
 
-  384   105   call 892 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+  384   105   call 893 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         106   store_var 23                       (stop)
         107   jump +3                            (to 110)
 
@@ -3939,7 +3939,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         2     store_var 3                        (msgs)
 
   132   3     load_var 1                         (j)
-        4     call 805 ntypeargs=0               (ai.Journal.entries)
+        4     call 806 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -3987,7 +3987,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         47    load_var 16                        (f)
         48    load_field 1                       (message)
         49    load_const 10                      (true)
-        50    call 888 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        50    call 889 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         51    pop 1                              
         52    jump -43                           (to 9)
 
@@ -3999,7 +3999,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         57    load_var 14                        (c)
         58    load_field 1                       (output)
         59    load_const 11                      (false)
-        60    call 888 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        60    call 889 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         61    pop 1                              
         62    jump -53                           (to 9)
 
@@ -4007,7 +4007,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         64    store_var_load_var 11              (m)
 
   146   65    load_field 0                       (content)
-        66    call 887 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
+        66    call 888 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
         67    store_var 12                       (_29)
 
   142   68    load_type 0                        
@@ -4074,7 +4074,7 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
        5    store_var 4                        (messages)
 
   53   6    load_var 1                         (prompt)
-       7    call 809 ntypeargs=0               (ai.Prompt.messages)
+       7    call 810 ntypeargs=0               (ai.Prompt.messages)
        8    load_type 2                        
        9    load_const 3                       ("iter")
        10   virtual_call nargs=1 ntypeargs=0   
@@ -4321,11 +4321,11 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         2     store_var 5                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 827 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 828 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 5                         (_5)
         7     call_indirect                      
 
-  183   8     call 886 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
+  183   8     call 887 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
         9     store_var 6                        (prompt_parts)
 
   184   10    load_var 6                         (prompt_parts)
@@ -4338,7 +4338,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   186   16    load_var 2                         (input)
         17    load_field 1                       (journal)
-        18    call 889 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
+        18    call 890 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
         19    load_type 0                        
         20    load_const 1                       ("iter")
         21    virtual_call nargs=1 ntypeargs=0   
@@ -4441,7 +4441,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         110   pop 1                              
 
   210   111   load_var 8                         (lowered)
-        112   call 890 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        112   call 891 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         113   store_var 19                       (_61)
         114   load_type 6                        
         115   load_type 7                        
@@ -4464,7 +4464,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         130   alloc_array 1                      
         131   load_var 8                         (lowered)
         132   call 7 ntypeargs=1                 (baml.Array.concat)
-        133   call 890 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        133   call 891 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         134   store_var 17                       (_46)
         135   load_type 6                        
         136   load_type 7                        
@@ -4476,7 +4476,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   213   142   load_var 2                         (input)
         143   load_field 2                       (toolbox)
-        144   call 823 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        144   call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         145   unary_op !                         
         146   pop_jump_if_false +80              (to 226)
 
@@ -4486,7 +4486,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   215   150   load_var 2                         (input)
         151   load_field 2                       (toolbox)
-        152   call 821 ntypeargs=0               (ai.tools.Toolbox.list)
+        152   call 822 ntypeargs=0               (ai.tools.Toolbox.list)
         153   load_type 20                       
         154   load_const 21                      ("iter")
         155   virtual_call nargs=1 ntypeargs=0   
@@ -4620,8 +4620,8 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   247   268   load_type 19                       
         269   load_var 12                        (body)
-        270   call 331 ntypeargs=1               (baml.json.to_json)
-        271   call 328 ntypeargs=0               (baml.json.stringify)
+        270   call 332 ntypeargs=1               (baml.json.to_json)
+        271   call 329 ntypeargs=0               (baml.json.stringify)
         272   store_var 31                       (_118)
 
   239   273   load_const 40                      ("POST")
@@ -4678,13 +4678,13 @@ function anthropic.internal._anthropic_stop_reason(s: string) -> ai.content.Stop
 function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   266   0     load_var2 1 2                      
         1     load_const 0                       (false)
-        2     call 891 ntypeargs=0               (anthropic.internal._anthropic_request)
+        2     call 892 ntypeargs=0               (anthropic.internal._anthropic_request)
         3     store_var 3                        (req)
 
   267   4     load_type 1                        
         5     load_var 3                         (req)
         6     load_const 2                       ("anthropic")
-        7     call 826 ntypeargs=1               (ai.wire.send_as)
+        7     call 827 ntypeargs=1               (ai.wire.send_as)
         8     store_var 4                        (resp)
 
   269   9     load_type 3                        
@@ -4824,7 +4824,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         130   load_var 21                        (_46)
         131   store_var_load_var 22              (s)
 
-  294   132   call 892 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+  294   132   call 893 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         133   store_var 20                       (stop)
         134   jump +4                            (to 138)
 
@@ -4865,7 +4865,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
 function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   415   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 891 ntypeargs=0   (anthropic.internal._anthropic_request)
+        2    call 892 ntypeargs=0   (anthropic.internal._anthropic_request)
 
   416   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -4891,7 +4891,7 @@ function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: a
         21   throw                  
 
   425   22   load_const 6           (anthropic.internal._anthropic_decode_batch)
-        23   call 848 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 849 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -4985,7 +4985,7 @@ function assert.contains(haystack: string, needle: string) -> null {
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   59   0    load_var2 1 2          
-       1    call 653 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 654 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -4995,14 +4995,14 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   59   6    jump +23               (to 29)
 
   61   7    load_var 1             (actual)
-       8    call 800 ntypeargs=0   (assert.format_operand)
+       8    call 801 ntypeargs=0   (assert.format_operand)
        9    store_var 4            (_9)
        10   load_type 1            
        11   load_var 4             (_9)
        12   call 138 ntypeargs=1   (baml.String.from)
        13   store_var 3            (_8)
        14   load_var 2             (expected)
-       15   call 800 ntypeargs=0   (assert.format_operand)
+       15   call 801 ntypeargs=0   (assert.format_operand)
        16   store_var 6            (_12)
        17   load_type 1            
        18   load_var 6             (_12)
@@ -5098,7 +5098,7 @@ function assert.is_type(actual: unknown) -> #0 {
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 653 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 654 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -5136,13 +5136,13 @@ function claude_code.ClaudeCodeClient.ai.Client.id(self: claude_code.ClaudeCodeC
 
 function claude_code.ClaudeCodeClient.ai.Client.invoke(self: claude_code.ClaudeCodeClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   44   0   load_var2 1 2          
-       1   call 924 ntypeargs=0   (claude_code.internal.invoke)
+       1   call 925 ntypeargs=0   (claude_code.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   45   5   load_var 3             (e)
-       6   call 856 ntypeargs=0   (ai.errors.normalize)
+       6   call 857 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
@@ -5226,7 +5226,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         1     load_var 1                         (raw)
         2     load_const 1                       (".type")
         3     load_const 2                       ("?")
-        4     call 340 ntypeargs=1               (baml.json.path_or)
+        4     call 341 ntypeargs=1               (baml.json.path_or)
         5     store_var 3                        (kind)
 
   164   6     load_var 3                         (kind)
@@ -5280,7 +5280,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         49    load_const 14                      (".message.content")
         50    load_type 15                       
         51    alloc_array 0                      
-        52    call 340 ntypeargs=1               (baml.json.path_or)
+        52    call 341 ntypeargs=1               (baml.json.path_or)
 
   180   53    load_type 16                       
         54    load_const 17                      ("iter")
@@ -5302,7 +5302,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         69    load_var 13                        (b)
         70    load_const 21                      (".type")
         71    load_const 22                      ("?")
-        72    call 340 ntypeargs=1               (baml.json.path_or)
+        72    call 341 ntypeargs=1               (baml.json.path_or)
         73    store_var 14                       (bt)
 
   182   74    load_var 14                        (bt)
@@ -5343,7 +5343,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         106   load_var 13                        (b)
         107   load_const 28                      (".name")
         108   load_const 29                      ("?")
-        109   call 340 ntypeargs=1               (baml.json.path_or)
+        109   call 341 ntypeargs=1               (baml.json.path_or)
         110   store_var 20                       (_65)
         111   load_type 0                        
         112   load_var 20                        (_65)
@@ -5362,8 +5362,8 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         124   load_var 13                        (b)
         125   load_const 31                      (".thinking")
         126   load_const 32                      ("")
-        127   call 340 ntypeargs=1               (baml.json.path_or)
-        128   call 920 ntypeargs=0               (claude_code.internal._preview)
+        127   call 341 ntypeargs=1               (baml.json.path_or)
+        128   call 921 ntypeargs=0               (claude_code.internal._preview)
         129   store_var 18                       (_56)
         130   load_type 0                        
         131   load_var 18                        (_56)
@@ -5384,8 +5384,8 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         143   load_var 13                        (b)
         144   load_const 34                      (".text")
         145   load_const 35                      ("")
-        146   call 340 ntypeargs=1               (baml.json.path_or)
-        147   call 920 ntypeargs=0               (claude_code.internal._preview)
+        146   call 341 ntypeargs=1               (baml.json.path_or)
+        147   call 921 ntypeargs=0               (claude_code.internal._preview)
         148   store_var 16                       (_47)
         149   load_type 0                        
         150   load_var 16                        (_47)
@@ -5437,7 +5437,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         194   load_var 1                         (raw)
         195   load_const 45                      (".subtype")
         196   load_const 46                      ("?")
-        197   call 340 ntypeargs=1               (baml.json.path_or)
+        197   call 341 ntypeargs=1               (baml.json.path_or)
         198   store_var 4                        (subtype)
 
   166   199   load_var 4                         (subtype)
@@ -5454,7 +5454,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         209   load_var 1                         (raw)
         210   load_const 48                      (".model")
         211   load_const 49                      ("?")
-        212   call 340 ntypeargs=1               (baml.json.path_or)
+        212   call 341 ntypeargs=1               (baml.json.path_or)
         213   store_var 9                        (_23)
         214   load_type 0                        
         215   load_var 9                         (_23)
@@ -5485,7 +5485,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         236   load_var 1                         (raw)
         237   load_const 57                      (".estimated_tokens")
         238   load_const 58                      (0)
-        239   call 340 ntypeargs=1               (baml.json.path_or)
+        239   call 341 ntypeargs=1               (baml.json.path_or)
         240   store_var 6                        (_13)
         241   load_type 56                       
         242   load_var 6                         (_13)
@@ -5573,7 +5573,7 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         26   pop_jump_if_false -18              (to 8)
 
   131   27   load_var 6                         (trimmed)
-        28   call 327 ntypeargs=0               (baml.json.parse)
+        28   call 328 ntypeargs=0               (baml.json.parse)
         29   store_var 7                        (raw)
         30   jump +7                            (to 37)
         31   load_var 8                         (e)
@@ -5585,14 +5585,14 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         36   throw                              
 
   136   37   load_var 7                         (raw)
-        38   call 921 ntypeargs=0               (claude_code.internal._log_cc_event)
+        38   call 922 ntypeargs=0               (claude_code.internal._log_cc_event)
         39   pop 1                              
 
   137   40   load_type 8                        
         41   load_var 7                         (raw)
         42   load_const 9                       (".type")
         43   load_const 10                      ("")
-        44   call 340 ntypeargs=1               (baml.json.path_or)
+        44   call 341 ntypeargs=1               (baml.json.path_or)
         45   load_const 11                      ("result")
         46   cmp_op ==                          
         47   pop_jump_if_false -39              (to 8)
@@ -5604,7 +5604,7 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
 
   144   51   load_var 2                         (result)
         52   load_const 0                       (null)
-        53   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        53   call 654 ntypeargs=0               (baml.ops.equals_equals)
         54   pop_jump_if_false +2               (to 56)
         55   jump +3                            (to 58)
 
@@ -5649,7 +5649,7 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
         8    load_type 2           
         9    load_var 3            (_3)
 
-  220   10   make_closure 2237 0   
+  220   10   make_closure 2238 0   
         11   call 16 ntypeargs=3   (baml.Array.map)
         12   store_var 2           (_2)
 
@@ -5662,11 +5662,11 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
 
 function claude_code.internal.envelope_schema(output_type: type) -> map<string, unknown> {
   52   0     load_var 1             (output_type)
-       1     sys_op 341             (baml.json.schema)
+       1     sys_op 342             (baml.json.schema)
        2     store_var 4            (_3)
        3     load_type 0            
        4     load_var 4             (_3)
-       5     call 334 ntypeargs=1   (baml.json.from_json)
+       5     call 335 ntypeargs=1   (baml.json.from_json)
        6     store_var 3            (final_root)
 
   53   7     load_type 1            
@@ -5682,7 +5682,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        16    store_var 6            (call_props)
 
   55   17    load_const 4           ("string")
-       18    call 917 ntypeargs=0   (claude_code.internal._type_schema)
+       18    call 918 ntypeargs=0   (claude_code.internal._type_schema)
        19    store_var 7            (_10)
        20    load_type 1            
        21    load_type 2            
@@ -5693,7 +5693,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        26    pop 1                  
 
   56   27    load_const 6           ("string")
-       28    call 917 ntypeargs=0   (claude_code.internal._type_schema)
+       28    call 918 ntypeargs=0   (claude_code.internal._type_schema)
        29    store_var 8            (_14)
        30    load_type 1            
        31    load_type 2            
@@ -5704,7 +5704,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        36    pop 1                  
 
   57   37    load_const 8           ("object")
-       38    call 917 ntypeargs=0   (claude_code.internal._type_schema)
+       38    call 918 ntypeargs=0   (claude_code.internal._type_schema)
        39    store_var 9            (_18)
        40    load_type 1            
        41    load_type 2            
@@ -5835,11 +5835,11 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
 
   74   150   load_type 0            
        151   load_var 3             (final_root)
-       152   call 331 ntypeargs=1   (baml.json.to_json)
+       152   call 332 ntypeargs=1   (baml.json.to_json)
        153   store_var 15           (_67)
        154   load_type 0            
        155   load_var 13            (calls_schema)
-       156   call 331 ntypeargs=1   (baml.json.to_json)
+       156   call 332 ntypeargs=1   (baml.json.to_json)
        157   store_var 16           (_70)
        158   load_type 1            
        159   load_type 2            
@@ -5905,7 +5905,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
 
   82   212   load_var 5             (definitions)
        213   load_const 38          (null)
-       214   call 653 ntypeargs=0   (baml.ops.equals_equals)
+       214   call 654 ntypeargs=0   (baml.ops.equals_equals)
        215   unary_op !             
        216   pop_jump_if_false +8   (to 224)
 
@@ -5928,12 +5928,12 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         1     load_var 2                         (input)
         2     load_field 0                       (prompt)
         3     call_indirect                      
-        4     call 808 ntypeargs=0               (ai.Prompt.text)
+        4     call 809 ntypeargs=0               (ai.Prompt.text)
         5     store_var 4                        (instructions)
 
   234   6     load_var 2                         (input)
         7     load_field 2                       (toolbox)
-        8     call 823 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        8     call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         9     unary_op !                         
         10    store_var_load_var 5               (has_tools)
 
@@ -5942,17 +5942,17 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 
   238   13    load_var 2                         (input)
         14    load_field 3                       (output_type)
-        15    sys_op 341                         (baml.json.schema)
+        15    sys_op 342                         (baml.json.schema)
         16    store_var 6                        (schema)
         17    jump +9                            (to 26)
 
   236   18    load_var 2                         (input)
         19    load_field 3                       (output_type)
-        20    call 916 ntypeargs=0               (claude_code.internal.envelope_schema)
+        20    call 917 ntypeargs=0               (claude_code.internal.envelope_schema)
         21    store_var 7                        (_11)
         22    load_type 1                        
         23    load_var 7                         (_11)
-        24    call 331 ntypeargs=1               (baml.json.to_json)
+        24    call 332 ntypeargs=1               (baml.json.to_json)
         25    store_var 6                        (schema)
 
   240   26    load_var 5                         (has_tools)
@@ -5965,7 +5965,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         32    store_var 14                       (_29)
         33    load_var 2                         (input)
         34    load_field 1                       (journal)
-        35    call 915 ntypeargs=0               (claude_code.internal.transcript_text)
+        35    call 916 ntypeargs=0               (claude_code.internal.transcript_text)
         36    store_var 16                       (_33)
         37    load_type 2                        
         38    load_var 16                        (_33)
@@ -5983,7 +5983,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         48    store_var 9                        (_18)
         49    load_var 2                         (input)
         50    load_field 1                       (journal)
-        51    call 915 ntypeargs=0               (claude_code.internal.transcript_text)
+        51    call 916 ntypeargs=0               (claude_code.internal.transcript_text)
         52    store_var 11                       (_22)
         53    load_type 2                        
         54    load_var 11                        (_22)
@@ -5991,7 +5991,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         56    store_var 10                       (_21)
         57    load_var 2                         (input)
         58    load_field 2                       (toolbox)
-        59    call 918 ntypeargs=0               (claude_code.internal.tool_protocol)
+        59    call 919 ntypeargs=0               (claude_code.internal.tool_protocol)
         60    store_var 13                       (_26)
         61    load_type 2                        
         62    load_var 13                        (_26)
@@ -6017,7 +6017,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         81    store_var 18                       (_44)
         82    load_var 2                         (input)
         83    load_field 2                       (toolbox)
-        84    call 821 ntypeargs=0               (ai.tools.Toolbox.list)
+        84    call 822 ntypeargs=0               (ai.tools.Toolbox.list)
         85    container_len                      
         86    store_var 21                       (_48)
         87    load_type 3                        
@@ -6124,7 +6124,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         173   pop 1                              
 
   267   174   load_var 1                         (c)
-        175   call 922 ntypeargs=0               (claude_code.internal.mcp_config_json)
+        175   call 923 ntypeargs=0               (claude_code.internal.mcp_config_json)
         176   store_var 24                       (_81)
         177   load_var 24                        (_81)
         178   narrow_bind 21 24                  
@@ -6150,7 +6150,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         195   pop 1                              
 
   271   196   load_var 1                         (c)
-        197   call 923 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
+        197   call 924 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
         198   store_var 27                       (_93)
         199   load_type 2                        
         200   load_var 27                        (_93)
@@ -6171,7 +6171,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         214   pop 1                              
 
   274   215   load_var 6                         (schema)
-        216   call 328 ntypeargs=0               (baml.json.stringify)
+        216   call 329 ntypeargs=0               (baml.json.stringify)
         217   store_var 28                       (_99)
         218   load_type 2                        
         219   load_var2 22 28                    
@@ -6228,7 +6228,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         261   throw_if_panic                     
 
   299   262   load_var 29                        (p)
-        263   call 919 ntypeargs=0               (claude_code.internal._read_result)
+        263   call 920 ntypeargs=0               (claude_code.internal._read_result)
         264   store_var 36                       (result)
 
   300   265   load_var 29                        (p)
@@ -6266,7 +6266,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         292   load_var 36                        (result)
         293   load_const 34                      (".is_error")
         294   load_const 35                      (false)
-        295   call 340 ntypeargs=1               (baml.json.path_or)
+        295   call 341 ntypeargs=1               (baml.json.path_or)
         296   pop_jump_if_false +2               (to 298)
         297   jump +237                          (to 534)
 
@@ -6274,7 +6274,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         299   load_var 36                        (result)
         300   load_const 36                      (".subtype")
         301   load_const 37                      ("?")
-        302   call 340 ntypeargs=1               (baml.json.path_or)
+        302   call 341 ntypeargs=1               (baml.json.path_or)
         303   store_var 45                       (_154)
         304   load_type 2                        
         305   load_var 45                        (_154)
@@ -6284,7 +6284,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         309   load_var 36                        (result)
         310   load_const 39                      (".total_cost_usd")
         311   load_const 40                      (0.0)
-        312   call 340 ntypeargs=1               (baml.json.path_or)
+        312   call 341 ntypeargs=1               (baml.json.path_or)
         313   store_var 47                       (_159)
         314   load_type 38                       
         315   load_var 47                        (_159)
@@ -6294,7 +6294,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         319   load_var 36                        (result)
         320   load_const 41                      (".session_id")
         321   load_const 42                      ("?")
-        322   call 340 ntypeargs=1               (baml.json.path_or)
+        322   call 341 ntypeargs=1               (baml.json.path_or)
         323   store_var 49                       (_164)
         324   load_type 2                        
         325   load_var 49                        (_164)
@@ -6327,7 +6327,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
   328   348   load_type 50                       
         349   load_var 36                        (result)
         350   load_const 51                      (".structured_output")
-        351   call 339 ntypeargs=1               (baml.json.path)
+        351   call 340 ntypeargs=1               (baml.json.path)
         352   store_var 50                       (structured)
         353   jump +20                           (to 373)
         354   load_var 51                        (e)
@@ -6337,15 +6337,15 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         357   load_var 36                        (result)
         358   load_const 52                      (".result")
         359   load_const 53                      ("")
-        360   call 340 ntypeargs=1               (baml.json.path_or)
-        361   call 327 ntypeargs=0               (baml.json.parse)
+        360   call 341 ntypeargs=1               (baml.json.path_or)
+        361   call 328 ntypeargs=0               (baml.json.parse)
         362   store_var 50                       (structured)
         363   jump +10                           (to 373)
         364   load_var 52                        (inner)
         365   throw_if_panic                     
 
   334   366   load_var 36                        (result)
-        367   call 328 ntypeargs=0               (baml.json.stringify)
+        367   call 329 ntypeargs=0               (baml.json.stringify)
         368   store_var 53                       (_177)
 
   332   369   load_const 54                      ("claude-code")
@@ -6357,21 +6357,21 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         374   load_var 36                        (result)
         375   load_const 55                      (".usage.input_tokens")
         376   load_const 56                      (0)
-        377   call 340 ntypeargs=1               (baml.json.path_or)
+        377   call 341 ntypeargs=1               (baml.json.path_or)
         378   store_var 55                       (_180)
 
   343   379   load_type 3                        
         380   load_var 36                        (result)
         381   load_const 57                      (".usage.output_tokens")
         382   load_const 56                      (0)
-        383   call 340 ntypeargs=1               (baml.json.path_or)
+        383   call 341 ntypeargs=1               (baml.json.path_or)
         384   store_var 56                       (_183)
 
   344   385   load_type 58                       
         386   load_var 36                        (result)
         387   load_const 59                      (".usage.cache_read_input_tokens")
         388   load_const 26                      (null)
-        389   call 340 ntypeargs=1               (baml.json.path_or)
+        389   call 341 ntypeargs=1               (baml.json.path_or)
         390   store_var 57                       (_186)
 
   341   391   load_var2 55 56                    
@@ -6393,7 +6393,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         404   jump +10                           (to 414)
 
   378   405   load_var 50                        (structured)
-        406   call 328 ntypeargs=0               (baml.json.stringify)
+        406   call 329 ntypeargs=0               (baml.json.stringify)
         407   store_var 77                       (_247)
         408   load_type 60                       
         409   load_var2 58 77                    
@@ -6406,14 +6406,14 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         415   load_var 36                        (result)
         416   load_const 61                      (".structured_output.outcome")
         417   load_var 50                        (structured)
-        418   call 340 ntypeargs=1               (baml.json.path_or)
+        418   call 341 ntypeargs=1               (baml.json.path_or)
         419   store_var 60                       (outcome)
 
   352   420   load_type 62                       
         421   load_var 60                        (outcome)
         422   load_const 63                      (".calls")
         423   load_const 26                      (null)
-        424   call 340 ntypeargs=1               (baml.json.path_or)
+        424   call 341 ntypeargs=1               (baml.json.path_or)
 
   353   425   store_var 61                       (_199)
         426   load_var 61                        (_199)
@@ -6422,7 +6422,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         429   jump +10                           (to 439)
 
   375   430   load_var 60                        (outcome)
-        431   call 328 ntypeargs=0               (baml.json.stringify)
+        431   call 329 ntypeargs=0               (baml.json.stringify)
         432   store_var 76                       (_242)
         433   load_type 60                       
         434   load_var2 58 76                    
@@ -6456,7 +6456,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 
   359   459   load_var 2                         (input)
         460   load_field 1                       (journal)
-        461   call 805 ntypeargs=0               (ai.Journal.entries)
+        461   call 806 ntypeargs=0               (ai.Journal.entries)
         462   container_len                      
         463   store_var 69                       (_214)
         464   load_type 3                        
@@ -6480,14 +6480,14 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         479   bin_op +                           
         480   load_var 70                        (_218)
         481   bin_op +                           
-        482   call 340 ntypeargs=1               (baml.json.path_or)
+        482   call 341 ntypeargs=1               (baml.json.path_or)
         483   store_var 67                       (id)
 
   361   484   load_type 2                        
         485   load_var 66                        (raw_call)
         486   load_const 73                      (".name")
         487   load_const 74                      ("")
-        488   call 340 ntypeargs=1               (baml.json.path_or)
+        488   call 341 ntypeargs=1               (baml.json.path_or)
         489   store_var 71                       (name)
 
   363   490   load_type 50                       
@@ -6496,12 +6496,12 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         493   load_type 2                        
         494   load_type 50                       
         495   alloc_map 0                        
-        496   call 340 ntypeargs=1               (baml.json.path_or)
+        496   call 341 ntypeargs=1               (baml.json.path_or)
         497   store_var 74                       (_227)
 
   362   498   load_type 1                        
         499   load_var 74                        (_227)
-        500   call 334 ntypeargs=1               (baml.json.from_json)
+        500   call 335 ntypeargs=1               (baml.json.from_json)
         501   store_var 72                       (call_args)
         502   jump +9                            (to 511)
         503   load_var 73                        (e)
@@ -6548,11 +6548,11 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         535   load_var 36                        (result)
         536   load_const 76                      (".subtype")
         537   load_const 77                      ("error")
-        538   call 340 ntypeargs=1               (baml.json.path_or)
+        538   call 341 ntypeargs=1               (baml.json.path_or)
         539   store_var 42                       (_143)
 
   322   540   load_var 36                        (result)
-        541   call 328 ntypeargs=0               (baml.json.stringify)
+        541   call 329 ntypeargs=0               (baml.json.stringify)
         542   store_var 43                       (_146)
 
   319   543   load_const 78                      ("claude-code")
@@ -6612,8 +6612,8 @@ function claude_code.internal.mcp_config_json(c: claude_code.ClaudeCodeClient) -
 
   212   21   load_type 4            
         22   load_var 3             (wrapper)
-        23   call 331 ntypeargs=1   (baml.json.to_json)
-        24   call 328 ntypeargs=0   (baml.json.stringify)
+        23   call 332 ntypeargs=1   (baml.json.to_json)
+        24   call 329 ntypeargs=0   (baml.json.stringify)
         25   jump +2                (to 27)
 
   208   26   load_const 5           (null)
@@ -6626,7 +6626,7 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         2    store_var 3                        (catalog)
 
   100   3    load_var 1                         (tb)
-        4    call 821 ntypeargs=0               (ai.tools.Toolbox.list)
+        4    call 822 ntypeargs=0               (ai.tools.Toolbox.list)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -6656,8 +6656,8 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         30   load_type 6                        
         31   load_var 6                         (t)
         32   load_field 2                       (input_schema)
-        33   call 331 ntypeargs=1               (baml.json.to_json)
-        34   call 328 ntypeargs=0               (baml.json.stringify)
+        33   call 332 ntypeargs=1               (baml.json.to_json)
+        34   call 329 ntypeargs=0               (baml.json.stringify)
         35   store_var 10                       (_23)
         36   load_type 0                        
         37   load_var 10                        (_23)
@@ -6710,7 +6710,7 @@ function claude_code.internal.transcript_text(j: ai.Journal) -> string {
        2     store_var 2                        (lines)
 
   8    3     load_var 1                         (j)
-       4     call 805 ntypeargs=0               (ai.Journal.entries)
+       4     call 806 ntypeargs=0               (ai.Journal.entries)
        5     load_type 1                        
        6     load_const 2                       ("iter")
        7     virtual_call nargs=1 ntypeargs=0   
@@ -6849,8 +6849,8 @@ function claude_code.internal.transcript_text(j: ai.Journal) -> string {
        132   load_type 20                       
        133   load_var 18                        (c)
        134   load_field 2                       (args)
-       135   call 331 ntypeargs=1               (baml.json.to_json)
-       136   call 328 ntypeargs=0               (baml.json.stringify)
+       135   call 332 ntypeargs=1               (baml.json.to_json)
+       136   call 329 ntypeargs=0               (baml.json.stringify)
        137   store_var 22                       (_49)
        138   load_type 0                        
        139   load_var 22                        (_49)
@@ -6955,20 +6955,20 @@ function google.GoogleClient.ai.Client.id(self: google.GoogleClient) -> string {
 
 function google.GoogleClient.ai.Client.invoke(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   22   0   load_var2 1 2          
-       1   call 909 ntypeargs=0   (google.internal.invoke)
+       1   call 910 ntypeargs=0   (google.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   23   5   load_var 3             (e)
-       6   call 856 ntypeargs=0   (ai.errors.normalize)
+       6   call 857 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function google.GoogleClient.ai.stream.StreamingClient.invoke_stream(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   30   0   load_var2 1 2          
-       1   call 911 ntypeargs=0   (google.internal.invoke_stream)
+       1   call 912 ntypeargs=0   (google.internal.invoke_stream)
        2   return                 
 }
 
@@ -7095,7 +7095,7 @@ function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string 
         1    store_var 3                        (name)
 
   110   2    load_var 1                         (j)
-        3    call 805 ntypeargs=0               (ai.Journal.entries)
+        3    call 806 ntypeargs=0               (ai.Journal.entries)
         4    load_type 1                        
         5    load_const 2                       ("iter")
         6    virtual_call nargs=1 ntypeargs=0   
@@ -7166,7 +7166,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         2     store_var 3                        (out)
 
   368   3     load_var 1                         (batch)
-        4     call 847 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 848 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -7193,7 +7193,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
 
   370   27    load_type 7                        
         28    load_var 8                         (data)
-        29    call 333 ntypeargs=1               (baml.json.from_string)
+        29    call 334 ntypeargs=1               (baml.json.from_string)
         30    jump +4                            (to 34)
         31    load_var 9                         (e)
         32    throw_if_panic                     
@@ -7334,7 +7334,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         157   jump +2                            (to 159)
         158   load_const 8                       (null)
         159   load_const 8                       (null)
-        160   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        160   call 654 ntypeargs=0               (baml.ops.equals_equals)
         161   unary_op !                         
         162   store_var 24                       (blocked)
 
@@ -7405,14 +7405,14 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
 
   405   211   load_var 25                        (stop)
         212   load_const 8                       (null)
-        213   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        213   call 654 ntypeargs=0               (baml.ops.equals_equals)
         214   unary_op !                         
         215   jump_if_false +2                   (to 217)
         216   jump +6                            (to 222)
         217   pop 1                              
         218   load_var 26                        (usage)
         219   load_const 8                       (null)
-        220   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        220   call 654 ntypeargs=0               (baml.ops.equals_equals)
         221   unary_op !                         
         222   pop_jump_if_false -213             (to 9)
 
@@ -7464,11 +7464,11 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         2     store_var 5                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 827 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 828 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 5                         (_5)
         7     call_indirect                      
 
-  227   8     call 903 ntypeargs=0               (google.internal.google_lower_prompt)
+  227   8     call 904 ntypeargs=0               (google.internal.google_lower_prompt)
         9     store_var 6                        (prompt_parts)
 
   228   10    load_var 6                         (prompt_parts)
@@ -7477,7 +7477,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   229   13    load_var 2                         (input)
         14    load_field 1                       (journal)
-        15    call 905 ntypeargs=0               (google.internal.google_lower_journal)
+        15    call 906 ntypeargs=0               (google.internal.google_lower_journal)
         16    load_type 0                        
         17    load_const 1                       ("iter")
         18    virtual_call nargs=1 ntypeargs=0   
@@ -7558,7 +7558,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
   239   84    load_const 12                      ("user")
         85    load_var 6                         (prompt_parts)
         86    load_field 0                       (system_parts)
-        87    call 900 ntypeargs=0               (google.internal._gm_content)
+        87    call 901 ntypeargs=0               (google.internal._gm_content)
         88    store_var 14                       (_29)
         89    load_type 5                        
         90    load_var 14                        (_29)
@@ -7578,7 +7578,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   250   103   load_var 2                         (input)
         104   load_field 2                       (toolbox)
-        105   call 823 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        105   call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         106   unary_op !                         
         107   pop_jump_if_false +104             (to 211)
 
@@ -7588,7 +7588,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   252   111   load_var 2                         (input)
         112   load_field 2                       (toolbox)
-        113   call 821 ntypeargs=0               (ai.tools.Toolbox.list)
+        113   call 822 ntypeargs=0               (ai.tools.Toolbox.list)
         114   load_type 14                       
         115   load_const 15                      ("iter")
         116   virtual_call nargs=1 ntypeargs=0   
@@ -7757,8 +7757,8 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   283   259   load_type 5                        
         260   load_var 11                        (body)
-        261   call 331 ntypeargs=1               (baml.json.to_json)
-        262   call 328 ntypeargs=0               (baml.json.stringify)
+        261   call 332 ntypeargs=1               (baml.json.to_json)
+        262   call 329 ntypeargs=0               (baml.json.stringify)
         263   store_var 33                       (_118)
 
   276   264   load_const 35                      ("POST")
@@ -7787,7 +7787,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         5     store_var 4                        (pending)
 
   141   6     load_var 1                         (j)
-        7     call 805 ntypeargs=0               (ai.Journal.entries)
+        7     call 806 ntypeargs=0               (ai.Journal.entries)
         8     load_type 1                        
         9     load_const 2                       ("iter")
         10    virtual_call nargs=1 ntypeargs=0   
@@ -7846,9 +7846,9 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   199   60    load_var2 1 36                     
         61    load_field 0                       (id)
-        62    call 904 ntypeargs=0               (google.internal._gm_tool_name_for)
+        62    call 905 ntypeargs=0               (google.internal._gm_tool_name_for)
         63    load_var 37                        (response)
-        64    call 902 ntypeargs=0               (google.internal._gm_function_response)
+        64    call 903 ntypeargs=0               (google.internal._gm_function_response)
         65    store_var 38                       (_91)
         66    load_type 0                        
         67    load_var2 4 38                     
@@ -7875,9 +7875,9 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   193   85    load_var2 1 32                     
         86    load_field 0                       (id)
-        87    call 904 ntypeargs=0               (google.internal._gm_tool_name_for)
+        87    call 905 ntypeargs=0               (google.internal._gm_tool_name_for)
         88    load_var 33                        (response)
-        89    call 902 ntypeargs=0               (google.internal._gm_function_response)
+        89    call 903 ntypeargs=0               (google.internal._gm_function_response)
         90    store_var 34                       (_78)
         91    load_type 0                        
         92    load_var2 4 34                     
@@ -7898,7 +7898,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   156   105   load_const 15                      ("user")
         106   load_var 4                         (pending)
-        107   call 900 ntypeargs=0               (google.internal._gm_content)
+        107   call 901 ntypeargs=0               (google.internal._gm_content)
         108   store_var 17                       (_29)
         109   load_type 0                        
         110   load_var2 3 17                     
@@ -7991,7 +7991,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         186   store_var_load_var 23              (t)
 
   166   187   load_field 0                       (text)
-        188   call 901 ntypeargs=0               (google.internal._gm_text_part)
+        188   call 902 ntypeargs=0               (google.internal._gm_text_part)
         189   store_var 24                       (_42)
         190   load_type 0                        
         191   load_var2 18 24                    
@@ -8009,7 +8009,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   183   202   load_const 25                      ("model")
         203   load_var 18                        (parts)
-        204   call 900 ntypeargs=0               (google.internal._gm_content)
+        204   call 901 ntypeargs=0               (google.internal._gm_content)
         205   store_var 30                       (_67)
         206   load_type 0                        
         207   load_var2 3 30                     
@@ -8030,7 +8030,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   145   220   load_const 26                      ("user")
         221   load_var 4                         (pending)
-        222   call 900 ntypeargs=0               (google.internal._gm_content)
+        222   call 901 ntypeargs=0               (google.internal._gm_content)
         223   store_var 11                       (_15)
         224   load_type 0                        
         225   load_var2 3 11                     
@@ -8043,13 +8043,13 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   151   231   load_var 9                         (u)
         232   load_field 0                       (content)
-        233   call 901 ntypeargs=0               (google.internal._gm_text_part)
+        233   call 902 ntypeargs=0               (google.internal._gm_text_part)
         234   store_var 13                       (_21)
         235   load_const 27                      ("user")
         236   load_var 13                        (_21)
         237   load_type 0                        
         238   alloc_array 1                      
-        239   call 900 ntypeargs=0               (google.internal._gm_content)
+        239   call 901 ntypeargs=0               (google.internal._gm_content)
         240   store_var 12                       (_19)
         241   load_type 0                        
         242   load_var2 3 12                     
@@ -8067,7 +8067,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   206   253   load_const 28                      ("user")
         254   load_var 4                         (pending)
-        255   call 900 ntypeargs=0               (google.internal._gm_content)
+        255   call 901 ntypeargs=0               (google.internal._gm_content)
         256   store_var 40                       (_99)
         257   load_type 0                        
         258   load_var2 3 40                     
@@ -8093,7 +8093,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
         7    store_var 4                        (first_role)
 
   82    8    load_var 1                         (prompt)
-        9    call 809 ntypeargs=0               (ai.Prompt.messages)
+        9    call 810 ntypeargs=0               (ai.Prompt.messages)
         10   load_type 2                        
         11   load_const 3                       ("iter")
         12   virtual_call nargs=1 ntypeargs=0   
@@ -8111,7 +8111,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
         24   store_var_load_var 7               (message)
 
   83    25   load_field 1                       (content)
-        26   call 901 ntypeargs=0               (google.internal._gm_text_part)
+        26   call 902 ntypeargs=0               (google.internal._gm_text_part)
         27   store_var 8                        (part)
 
   84    28   load_var 7                         (message)
@@ -8147,7 +8147,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
   99    51   load_var2 9 8                      
         52   load_type 0                        
         53   alloc_array 1                      
-        54   call 900 ntypeargs=0               (google.internal._gm_content)
+        54   call 901 ntypeargs=0               (google.internal._gm_content)
         55   store_var 10                       (_24)
         56   load_type 0                        
         57   load_var2 3 10                     
@@ -8377,7 +8377,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         184   jump +2                            (to 186)
         185   load_const 3                       (null)
         186   load_const 3                       (null)
-        187   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        187   call 654 ntypeargs=0               (baml.ops.equals_equals)
         188   unary_op !                         
         189   store_var 25                       (blocked)
 
@@ -8489,35 +8489,35 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
 function google.internal.google_render(c: google.GoogleClient, input: ai.ModelTurnInput) -> baml.http.Request {
   216   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 907 ntypeargs=0   (google.internal._google_request)
+        2   call 908 ntypeargs=0   (google.internal._google_request)
         3   return                 
 }
 
 function google.internal.invoke(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   351   0    load_var 2             (input)
         1    load_field 1           (journal)
-        2    call 805 ntypeargs=0   (ai.Journal.entries)
+        2    call 806 ntypeargs=0   (ai.Journal.entries)
         3    container_len          
         4    store_var 3            (seq)
 
   352   5    load_var2 1 2          
-        6    call 906 ntypeargs=0   (google.internal.google_render)
+        6    call 907 ntypeargs=0   (google.internal.google_render)
         7    store_var 4            (req)
 
   353   8    load_type 0            
         9    load_var 4             (req)
         10   load_const 1           ("google")
-        11   call 826 ntypeargs=1   (ai.wire.send_as)
+        11   call 827 ntypeargs=1   (ai.wire.send_as)
 
   354   12   load_var 3             (seq)
-        13   call 908 ntypeargs=0   (google.internal.google_parse)
+        13   call 909 ntypeargs=0   (google.internal.google_parse)
         14   return                 
 }
 
 function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   432   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 907 ntypeargs=0   (google.internal._google_request)
+        2    call 908 ntypeargs=0   (google.internal._google_request)
 
   433   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -8543,7 +8543,7 @@ function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTu
         21   throw                  
 
   442   22   load_const 6           (google.internal._google_decode_batch)
-        23   call 848 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 849 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -8563,20 +8563,20 @@ function openai.OpenAiClient.ai.Client.id(self: openai.OpenAiClient) -> string {
 
 function openai.OpenAiClient.ai.Client.invoke(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   62   0   load_var2 1 2          
-       1   call 879 ntypeargs=0   (openai.internal.invoke)
+       1   call 880 ntypeargs=0   (openai.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   63   5   load_var 3             (e)
-       6   call 856 ntypeargs=0   (ai.errors.normalize)
+       6   call 857 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function openai.OpenAiClient.ai.stream.StreamingClient.invoke_stream(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   70   0   load_var2 1 2          
-       1   call 881 ntypeargs=0   (openai.internal.invoke_stream)
+       1   call 882 ntypeargs=0   (openai.internal.invoke_stream)
        2   return                 
 }
 
@@ -8705,7 +8705,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         2     store_var 3                        (out)
 
   255   3     load_var 1                         (batch)
-        4     call 847 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 848 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -8732,7 +8732,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
 
   257   27    load_type 7                        
         28    load_var 8                         (data)
-        29    call 333 ntypeargs=1               (baml.json.from_string)
+        29    call 334 ntypeargs=1               (baml.json.from_string)
         30    jump +4                            (to 34)
         31    load_var 9                         (e)
         32    throw_if_panic                     
@@ -8799,7 +8799,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         87    load_var 17                        (_39)
         88    store_var_load_var 18              (r)
 
-  272   89    call 878 ntypeargs=0               (openai.internal.openai_parse)
+  272   89    call 879 ntypeargs=0               (openai.internal.openai_parse)
         90    store_var 19                       (turn)
 
   275   91    load_var 19                        (turn)
@@ -8877,16 +8877,16 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         2     store_var 5                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 827 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 828 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 5                         (_5)
         7     call_indirect                      
 
-  129   8     call 874 ntypeargs=0               (openai.internal.openai_lower_prompt)
+  129   8     call 875 ntypeargs=0               (openai.internal.openai_lower_prompt)
         9     store_var 6                        (items)
 
   130   10    load_var 2                         (input)
         11    load_field 1                       (journal)
-        12    call 875 ntypeargs=0               (openai.internal.openai_lower_journal)
+        12    call 876 ntypeargs=0               (openai.internal.openai_lower_journal)
         13    load_type 0                        
         14    load_const 1                       ("iter")
         15    virtual_call nargs=1 ntypeargs=0   
@@ -8941,7 +8941,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   137   59    load_var 2                         (input)
         60    load_field 2                       (toolbox)
-        61    call 823 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        61    call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         62    unary_op !                         
         63    pop_jump_if_false +83              (to 146)
 
@@ -8951,7 +8951,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   139   67    load_var 2                         (input)
         68    load_field 2                       (toolbox)
-        69    call 821 ntypeargs=0               (ai.tools.Toolbox.list)
+        69    call 822 ntypeargs=0               (ai.tools.Toolbox.list)
         70    load_type 12                       
         71    load_const 13                      ("iter")
         72    virtual_call nargs=1 ntypeargs=0   
@@ -9050,7 +9050,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         154   pop 1                              
 
   162   155   load_var 1                         (c)
-        156   call 870 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
+        156   call 871 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
         157   store_var 18                       (_78)
         158   load_var 18                        (_78)
         159   store_var 17                       (_77)
@@ -9066,7 +9066,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         169   store_var 16                       (_76)
 
   163   170   load_var 1                         (c)
-        171   call 869 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
+        171   call 870 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
         172   store_var 20                       (_84)
         173   load_type 6                        
         174   load_var 20                        (_84)
@@ -9075,8 +9075,8 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   164   177   load_type 5                        
         178   load_var 10                        (body)
-        179   call 331 ntypeargs=1               (baml.json.to_json)
-        180   call 328 ntypeargs=0               (baml.json.stringify)
+        179   call 332 ntypeargs=1               (baml.json.to_json)
+        180   call 329 ntypeargs=0               (baml.json.stringify)
         181   store_var 21                       (_86)
 
   160   182   load_const 29                      ("POST")
@@ -9103,22 +9103,22 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
 function openai.internal.invoke(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   231   0   load_var2 1 2          
-        1   call 876 ntypeargs=0   (openai.internal.openai_render)
+        1   call 877 ntypeargs=0   (openai.internal.openai_render)
         2   store_var 3            (req)
 
   232   3   load_type 0            
         4   load_var 3             (req)
         5   load_const 1           ("openai")
-        6   call 826 ntypeargs=1   (ai.wire.send_as)
+        6   call 827 ntypeargs=1   (ai.wire.send_as)
 
-  233   7   call 878 ntypeargs=0   (openai.internal.openai_parse)
+  233   7   call 879 ntypeargs=0   (openai.internal.openai_parse)
         8   return                 
 }
 
 function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   304   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 877 ntypeargs=0   (openai.internal._openai_request)
+        2    call 878 ntypeargs=0   (openai.internal._openai_request)
 
   305   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -9144,7 +9144,7 @@ function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTu
         21   throw                  
 
   314   22   load_const 6           (openai.internal._openai_decode_batch)
-        23   call 848 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 849 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -9154,7 +9154,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         2     store_var 3                        (items)
 
   58    3     load_var 1                         (j)
-        4     call 805 ntypeargs=0               (ai.Journal.entries)
+        4     call 806 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -9235,8 +9235,8 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
 
   106   76    load_type 0                        
         77    load_var 27                        (err)
-        78    call 331 ntypeargs=1               (baml.json.to_json)
-        79    call 328 ntypeargs=0               (baml.json.stringify)
+        78    call 332 ntypeargs=1               (baml.json.to_json)
+        79    call 329 ntypeargs=0               (baml.json.stringify)
         80    store_var 29                       (_100)
         81    load_type 10                       
         82    load_type 11                       
@@ -9360,8 +9360,8 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
   82    185   load_type 0                        
         186   load_var 19                        (use)
         187   load_field 2                       (args)
-        188   call 331 ntypeargs=1               (baml.json.to_json)
-        189   call 328 ntypeargs=0               (baml.json.stringify)
+        188   call 332 ntypeargs=1               (baml.json.to_json)
+        189   call 329 ntypeargs=0               (baml.json.stringify)
         190   store_var 21                       (_58)
         191   load_type 10                       
         192   load_type 11                       
@@ -9451,7 +9451,7 @@ function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> map<string, u
        2    store_var 3                        (items)
 
   38   3    load_var 1                         (prompt)
-       4    call 809 ntypeargs=0               (ai.Prompt.messages)
+       4    call 810 ntypeargs=0               (ai.Prompt.messages)
        5    load_type 1                        
        6    load_const 2                       ("iter")
        7    virtual_call nargs=1 ntypeargs=0   
@@ -9702,7 +9702,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
 
   177   153   load_type 25                       
         154   load_var 9                         (s)
-        155   call 333 ntypeargs=1               (baml.json.from_string)
+        155   call 334 ntypeargs=1               (baml.json.from_string)
         156   store_var 7                        (args)
 
   180   157   load_var 6                         (item)
@@ -9807,7 +9807,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
 function openai.internal.openai_render(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> baml.http.Request {
   118   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 877 ntypeargs=0   (openai.internal._openai_request)
+        2   call 878 ntypeargs=0   (openai.internal._openai_request)
         3   return                 
 }
 
@@ -9824,7 +9824,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  104   0   make_closure 1611 0   
+  104   0   make_closure 1612 0   
         1   store_var 1           (_0)
         2   load_var 1            (_0)
         3   return                
@@ -9851,7 +9851,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   76   16   load_var 1             (threshold)
-       17   make_closure 1606 1    
+       17   make_closure 1607 1    
        18   store_var 2            (_0)
        19   load_var 2             (_0)
        20   return                 
@@ -9892,7 +9892,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1590 2    
+       29   make_closure 1591 2    
        30   store_var 3            (_0)
        31   load_var 3             (_0)
        32   return                 
@@ -9913,14 +9913,14 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   42   10   load_var 1             (max_attempts)
-       11   make_closure 1600 1    
+       11   make_closure 1601 1    
        12   store_var 2            (_0)
        13   load_var 2             (_0)
        14   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  98   0   make_closure 1609 0   
+  98   0   make_closure 1610 0   
        1   store_var 1           (_0)
        2   load_var 1            (_0)
        3   return                
@@ -10136,7 +10136,7 @@ function testing.TestCollector.register_test_at(self: testing.TestCollector, own
 
   107   6   load_var2 6 3          
         7   load_var2 4 5          
-        8   call 742 ntypeargs=0   (testing.TestCollector.register_test)
+        8   call 743 ntypeargs=0   (testing.TestCollector.register_test)
         9   return                 
 }
 
@@ -10269,7 +10269,7 @@ function testing.TestCollector.register_test_set_at(self: testing.TestCollector,
 
   118   6   load_var2 6 3          
         7   load_var2 4 5          
-        8   call 743 ntypeargs=0   (testing.TestCollector.register_test_set)
+        8   call 744 ntypeargs=0   (testing.TestCollector.register_test_set)
         9   return                 
 }
 
@@ -10299,11 +10299,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   290   22   load_var2 1 5                      
-        23   call 758 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 759 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   291   25   load_var 1                         (self)
-        26   call 750 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 751 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   295   28   load_type 5                        
@@ -10340,7 +10340,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   298   58   load_var2 9 2                      
-        59   call 757 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 758 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   301   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -10363,7 +10363,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         10   pop_jump_if_false +2   (to 12)
         11   jump +53               (to 64)
 
-  308   12   sys_op 520             (baml.time.Instant.now)
+  308   12   sys_op 521             (baml.time.Instant.now)
         13   store_var 5            (start)
 
   309   14   load_var 2             (ts)
@@ -10381,8 +10381,8 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         25   pop 1                  
 
   315   26   load_var 5             (start)
-        27   call 521 ntypeargs=0   (baml.time.Instant.elapsed)
-        28   call 508 ntypeargs=0   (baml.time.Duration.to_milliseconds)
+        27   call 522 ntypeargs=0   (baml.time.Instant.elapsed)
+        28   call 509 ntypeargs=0   (baml.time.Duration.to_milliseconds)
         29   call 92 ntypeargs=0    (baml.Bigint.to_int)
         30   store_var 7            (elapsed)
         31   jump +15               (to 46)
@@ -10434,7 +10434,7 @@ function testing.TestRegistry.list_filtered(self: testing.TestRegistry, profile_
   281   0   load_var2 1 2          
         1   load_var2 3 4          
         2   load_var 5             (cli_exclude)
-        3   call 778 ntypeargs=0   (testing.select_names_layered)
+        3   call 779 ntypeargs=0   (testing.select_names_layered)
         4   return                 
 }
 
@@ -10452,9 +10452,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   237   0   load_var 1             (self)
-        1   call 759 ntypeargs=0   (testing.testset_children)
+        1   call 760 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 769 ntypeargs=0   (testing.run_testset)
+        3   call 770 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -10462,7 +10462,7 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
   259   0    load_var2 1 2          
         1    load_var2 3 4          
         2    load_var 5             (cli_exclude)
-        3    call 778 ntypeargs=0   (testing.select_names_layered)
+        3    call 779 ntypeargs=0   (testing.select_names_layered)
         4    store_var 6            (selected_names)
 
   261   5    load_var 2             (profile_include)
@@ -10505,22 +10505,22 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
         36   jump +4                (to 40)
 
   268   37   load_var2 1 6          
-        38   call 754 ntypeargs=0   (testing.TestRegistry.run_selected)
+        38   call 755 ntypeargs=0   (testing.TestRegistry.run_selected)
         39   jump +3                (to 42)
 
   266   40   load_var 1             (self)
-        41   call 753 ntypeargs=0   (testing.TestRegistry.run_all)
+        41   call 754 ntypeargs=0   (testing.TestRegistry.run_all)
 
   270   42   load_var 6             (selected_names)
-        43   call 784 ntypeargs=0   (testing.flatten_with_tolerated)
+        43   call 785 ntypeargs=0   (testing.flatten_with_tolerated)
         44   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   241   0   load_var2 1 2          
-        1   call 760 ntypeargs=0   (testing.testset_children_selected)
+        1   call 761 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 769 ntypeargs=0   (testing.run_testset)
+        3   call 770 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -10553,7 +10553,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 768 ntypeargs=0               (testing.run_test)
+        26   call 769 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   211   28   load_type 5                        
@@ -10590,7 +10590,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   215   58   load_var2 9 2                      
-        59   call 751 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 752 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   218   61   load_const 12                      ("Test not found: ")
@@ -10625,11 +10625,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   224   22   load_var2 1 5                      
-        23   call 758 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 759 ntypeargs=0               (testing.testset_children)
+        23   call 759 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 760 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 769 ntypeargs=0               (testing.run_testset)
+        27   call 770 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   227   29   load_type 5                        
@@ -10666,7 +10666,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   230   59   load_var2 9 2                      
-        60   call 752 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 753 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   233   62   load_const 12                      ("TestSet not found: ")
@@ -10760,7 +10760,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         73   store_var 12                       (_28)
 
   189   74   load_var 11                        (sub)
-        75   call 750 ntypeargs=0               (testing.TestRegistry.serialize)
+        75   call 751 ntypeargs=0               (testing.TestRegistry.serialize)
         76   store_var 13                       (_29)
 
   186   77   load_type 0                        
@@ -10934,7 +10934,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   441   60    load_var 13                        (outcome)
         61    load_const 10                      ("pass")
-        62    call 653 ntypeargs=0               (baml.ops.equals_equals)
+        62    call 654 ntypeargs=0               (baml.ops.equals_equals)
         63    pop_jump_if_false +2               (to 65)
         64    jump +60                           (to 124)
 
@@ -11002,7 +11002,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   458   117   load_var 13                        (outcome)
         118   load_const 16                      ("error")
-        119   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        119   call 654 ntypeargs=0               (baml.ops.equals_equals)
         120   pop_jump_if_false -100             (to 20)
 
   459   121   load_const 17                      (true)
@@ -11080,7 +11080,7 @@ function testing.any_pattern_matches(pats: string[], canonical_id: string) -> bo
         15   store_var 5                        (p)
 
   608   16   load_var2 2 5                      
-        17   call 771 ntypeargs=0               (testing.glob_match)
+        17   call 772 ntypeargs=0               (testing.glob_match)
         18   pop_jump_if_false -13              (to 5)
 
   609   19   load_const 5                       (true)
@@ -11118,7 +11118,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         23   store_var_load_var 8               (name)
 
   949   24   load_var 3                         (all_failed_names)
-        25   call 787 ntypeargs=0               (testing.failure_matches_selected)
+        25   call 788 ntypeargs=0               (testing.failure_matches_selected)
         26   pop_jump_if_false +2               (to 28)
         27   jump +8                            (to 35)
 
@@ -11131,7 +11131,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         34   jump -21                           (to 13)
 
   950   35   load_var2 8 2                      
-        36   call 787 ntypeargs=0               (testing.failure_matches_selected)
+        36   call 788 ntypeargs=0               (testing.failure_matches_selected)
         37   pop_jump_if_false +2               (to 39)
         38   jump +8                            (to 46)
 
@@ -11177,7 +11177,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          16   store_var_load_var 6               (name)
 
   1050   17   load_var 2                         (out)
-         18   call 786 ntypeargs=0               (testing.name_in)
+         18   call 787 ntypeargs=0               (testing.name_in)
          19   unary_op !                         
          20   pop_jump_if_false -14              (to 6)
 
@@ -11212,7 +11212,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          47   store_var_load_var 10              (nested)
 
   1057   48   load_var 2                         (out)
-         49   call 789 ntypeargs=0               (testing.collect_all_failed_names)
+         49   call 790 ntypeargs=0               (testing.collect_all_failed_names)
          50   pop 1                              
          51   jump -19                           (to 32)
 
@@ -11292,7 +11292,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
          57    load_var 15             (nested)
          58    load_field 0            (outcome)
          59    load_const 3            ("pass")
-         60    call 653 ntypeargs=0    (baml.ops.equals_equals)
+         60    call 654 ntypeargs=0    (baml.ops.equals_equals)
          61    store_var 16            (nested_tolerated)
 
   1015   62    load_var 15             (nested)
@@ -11317,7 +11317,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
          79    store_var_load_var 18   (sentinel)
 
   1024   80    load_var 3              (selected_names)
-         81    call 786 ntypeargs=0    (testing.name_in)
+         81    call 787 ntypeargs=0    (testing.name_in)
          82    pop_jump_if_false +2    (to 84)
          83    jump +21                (to 104)
 
@@ -11372,7 +11372,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
   1017   123   load_var2 15 16         
 
   1018   124   load_var2 3 4           
-         125   call 788 ntypeargs=0    (testing.collect_leaf_identities)
+         125   call 789 ntypeargs=0    (testing.collect_leaf_identities)
          126   pop 1                   
          127   jump +31                (to 158)
 
@@ -11381,7 +11381,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
 
   1005   130   load_field 0            (outcome)
          131   load_const 7            ("pass")
-         132   call 653 ntypeargs=0    (baml.ops.equals_equals)
+         132   call 654 ntypeargs=0    (baml.ops.equals_equals)
          133   pop_jump_if_false +2    (to 135)
          134   jump +18                (to 152)
 
@@ -11451,7 +11451,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   1077   24   load_field 5                       (results)
          25   load_var 2                         (out)
-         26   call 790 ntypeargs=0               (testing.collect_leaf_messages)
+         26   call 791 ntypeargs=0               (testing.collect_leaf_messages)
          27   pop 1                              
          28   jump -23                           (to 5)
 
@@ -11477,7 +11477,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   1069   47   load_field 0                       (outcome)
          48   load_const 10                      ("pass")
-         49   call 653 ntypeargs=0               (baml.ops.equals_equals)
+         49   call 654 ntypeargs=0               (baml.ops.equals_equals)
          50   unary_op !                         
          51   pop_jump_if_false -15              (to 36)
 
@@ -11553,7 +11553,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         44   store_var 9                        (ts)
 
   749   45   load_var2 1 9                      
-        46   call 781 ntypeargs=0               (testing.collect_subtree_names)
+        46   call 782 ntypeargs=0               (testing.collect_subtree_names)
         47   load_type 10                       
         48   load_const 11                      ("iter")
         49   virtual_call nargs=1 ntypeargs=0   
@@ -11584,8 +11584,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   762   0    load_var2 1 2          
-        1    call 758 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 780 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 759 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 781 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +91               (to 94)
         4    load_var 3             (e)
         5    store_var 4            (_5)
@@ -11687,11 +11687,11 @@ function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testi
 
 function testing.collect_subtree_names_layered(registry: testing.TestRegistry, ts: testing.TestSetRegistration, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> string[] {
   778   0     load_var2 1 2           
-        1     call 758 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
+        1     call 759 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
 
   777   2     load_var2 3 4           
         3     load_var2 5 6           
-        4     call 778 ntypeargs=0    (testing.select_names_layered)
+        4     call 779 ntypeargs=0    (testing.select_names_layered)
         5     jump +111               (to 116)
         6     load_var 7              (e)
         7     store_var 8             (_9)
@@ -11774,7 +11774,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   805   83    load_var2 3 4           
         84    load_var2 5 6           
-        85    call 774 ntypeargs=0    (testing.leaf_selected_layered)
+        85    call 775 ntypeargs=0    (testing.leaf_selected_layered)
 
   803   86    pop_jump_if_false +2    (to 88)
         87    jump +4                 (to 91)
@@ -11798,7 +11798,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   789   100   load_var2 3 4           
         101   load_var2 5 6           
-        102   call 774 ntypeargs=0    (testing.leaf_selected_layered)
+        102   call 775 ntypeargs=0    (testing.leaf_selected_layered)
 
   787   103   pop_jump_if_false +2    (to 105)
         104   jump +4                 (to 108)
@@ -11869,7 +11869,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         37    load_var 13                        (tsr)
         38    load_field 0                       (outcome)
         39    load_const 7                       ("pass")
-        40    call 653 ntypeargs=0               (baml.ops.equals_equals)
+        40    call 654 ntypeargs=0               (baml.ops.equals_equals)
         41    store_var 14                       (ft)
 
   855   42    load_var 13                        (tsr)
@@ -11917,7 +11917,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   856   74    load_var 13                        (tsr)
         75    load_field 5                       (results)
         76    load_var 14                        (ft)
-        77    call 783 ntypeargs=0               (testing.count_leaves)
+        77    call 784 ntypeargs=0               (testing.count_leaves)
         78    store_var 10                       (delta)
         79    jump +31                           (to 110)
 
@@ -11926,7 +11926,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
 
   845   82    load_field 0                       (outcome)
         83    load_const 8                       ("pass")
-        84    call 653 ntypeargs=0               (baml.ops.equals_equals)
+        84    call 654 ntypeargs=0               (baml.ops.equals_equals)
         85    pop_jump_if_false +2               (to 87)
         86    jump +18                           (to 104)
 
@@ -12012,7 +12012,7 @@ function testing.expansion_error_report(name: string) -> testing.TestSetReport {
 
 function testing.failure_matches_selected(selected: string, failed_names: string[]) -> bool {
   972   0    load_var2 1 2                      
-        1    call 786 ntypeargs=0               (testing.name_in)
+        1    call 787 ntypeargs=0               (testing.name_in)
         2    pop_jump_if_false +2               (to 4)
         3    jump +43                           (to 46)
 
@@ -12073,7 +12073,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   887   0     load_var 1             (report)
         1     load_field 0           (outcome)
         2     load_const 0           ("pass")
-        3     call 653 ntypeargs=0   (baml.ops.equals_equals)
+        3     call 654 ntypeargs=0   (baml.ops.equals_equals)
         4     store_var 3            (top_tolerated)
 
   888   5     load_var 1             (report)
@@ -12121,7 +12121,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   889   37    load_var 1             (report)
         38    load_field 5           (results)
         39    load_var 3             (top_tolerated)
-        40    call 783 ntypeargs=0   (testing.count_leaves)
+        40    call 784 ntypeargs=0   (testing.count_leaves)
         41    store_var 4            (counts)
 
   905   42    load_type 2            
@@ -12131,7 +12131,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   906   45    load_var 1             (report)
         46    load_field 5           (results)
         47    load_var 6             (messages)
-        48    call 790 ntypeargs=0   (testing.collect_leaf_messages)
+        48    call 791 ntypeargs=0   (testing.collect_leaf_messages)
         49    pop 1                  
 
   907   50    load_type 2            
@@ -12139,7 +12139,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
         52    store_var 7            (all_failed_names)
 
   908   53    load_var2 1 7          
-        54    call 789 ntypeargs=0   (testing.collect_all_failed_names)
+        54    call 790 ntypeargs=0   (testing.collect_all_failed_names)
         55    pop 1                  
 
   909   56    load_type 2            
@@ -12153,7 +12153,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
 
   910   64    load_var2 1 3          
         65    load_var2 2 8          
-        66    call 788 ntypeargs=0   (testing.collect_leaf_identities)
+        66    call 789 ntypeargs=0   (testing.collect_leaf_identities)
         67    pop 1                  
 
   916   68    load_var 8             (executed)
@@ -12211,7 +12211,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   922   112   load_var2 2 1          
         113   load_field 4           (failed_names)
         114   load_var 7             (all_failed_names)
-        115   call 785 ntypeargs=0   (testing.classify_selected_names)
+        115   call 786 ntypeargs=0   (testing.classify_selected_names)
         116   store_var 9            (identities)
         117   jump +3                (to 120)
 
@@ -12372,14 +12372,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
   577   98    load_var2 1 2           
         99    call 155 ntypeargs=0    (baml.String.index_of)
         100   load_const 6            (null)
-        101   call 653 ntypeargs=0    (baml.ops.equals_equals)
+        101   call 654 ntypeargs=0    (baml.ops.equals_equals)
         102   unary_op !              
         103   return                  
 }
 
 function testing.leaf_selected(name: string, include: string[], exclude: string[]) -> bool {
   618   0    load_var2 3 1          
-        1    call 772 ntypeargs=0   (testing.any_pattern_matches)
+        1    call 773 ntypeargs=0   (testing.any_pattern_matches)
         2    pop_jump_if_false +2   (to 4)
         3    jump +14               (to 17)
 
@@ -12393,7 +12393,7 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
         11   jump +4                (to 15)
 
   624   12   load_var2 2 1          
-        13   call 772 ntypeargs=0   (testing.any_pattern_matches)
+        13   call 773 ntypeargs=0   (testing.any_pattern_matches)
         14   jump +4                (to 18)
 
   622   15   load_const 1           (true)
@@ -12406,13 +12406,13 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
 function testing.leaf_selected_layered(name: string, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> bool {
   637   0   load_var2 1 2          
         1   load_var 3             (profile_exclude)
-        2   call 773 ntypeargs=0   (testing.leaf_selected)
+        2   call 774 ntypeargs=0   (testing.leaf_selected)
         3   jump_if_false +5       (to 8)
         4   pop 1                  
 
   638   5   load_var2 1 4          
         6   load_var 5             (cli_exclude)
-        7   call 773 ntypeargs=0   (testing.leaf_selected)
+        7   call 774 ntypeargs=0   (testing.leaf_selected)
         8   return                 
 }
 
@@ -12512,7 +12512,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   486   25   load_var 5                         (child)
-        26   make_closure 1491 1                
+        26   make_closure 1492 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   load_type 7                        
@@ -12528,10 +12528,10 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
   490   38   load_type 7                        
         39   load_type 8                        
         40   load_var 2                         (futures)
-        41   call 482 ntypeargs=2               (baml.future.all_complete)
+        41   call 483 ntypeargs=2               (baml.future.all_complete)
         42   await                              
 
-  491   43   call 766 ntypeargs=0               (testing.aggregate_reports)
+  491   43   call 767 ntypeargs=0               (testing.aggregate_reports)
         44   return                             
 }
 
@@ -12595,16 +12595,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         48   pop 1                              
         49   load_var 8                         (outcome)
         50   load_const 7                       ("pass")
-        51   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        51   call 654 ntypeargs=0               (baml.ops.equals_equals)
         52   unary_op !                         
         53   pop_jump_if_false -45              (to 8)
 
   119   54   load_var 3                         (named_results)
-        55   call 766 ntypeargs=0               (testing.aggregate_reports)
+        55   call 767 ntypeargs=0               (testing.aggregate_reports)
         56   jump +3                            (to 59)
 
   124   57   load_var 3                         (named_results)
-        58   call 766 ntypeargs=0               (testing.aggregate_reports)
+        58   call 767 ntypeargs=0               (testing.aggregate_reports)
         59   return                             
 }
 
@@ -12614,7 +12614,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   496   3    load_var 1             (body)
-        4    make_closure 1503 1    
+        4    make_closure 1504 1    
         5    store_var 3            (base_run)
 
   527   6    load_var 2             (runner)
@@ -12650,7 +12650,7 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         9    jump +3                (to 12)
 
   539   10   load_var 1             (children)
-        11   call 767 ntypeargs=0   (testing.run_children_parallel)
+        11   call 768 ntypeargs=0   (testing.run_children_parallel)
         12   return                 
 }
 
@@ -12661,7 +12661,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         3   load_type 0            
         4   alloc_array 0          
         5   load_var2 2 3          
-        6   call 778 ntypeargs=0   (testing.select_names_layered)
+        6   call 779 ntypeargs=0   (testing.select_names_layered)
         7   return                 
 }
 
@@ -12692,7 +12692,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
   704   21   load_field 0                       (name)
         22   load_var2 2 3                      
         23   load_var2 4 5                      
-        24   call 774 ntypeargs=0               (testing.leaf_selected_layered)
+        24   call 775 ntypeargs=0               (testing.leaf_selected_layered)
 
   702   25   pop_jump_if_false -15              (to 10)
 
@@ -12724,14 +12724,14 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   718   50   load_field 0                       (name)
         51   load_var2 2 3                      
-        52   call 777 ntypeargs=0               (testing.subtree_may_be_selected)
+        52   call 778 ntypeargs=0               (testing.subtree_may_be_selected)
         53   jump_if_false +6                   (to 59)
         54   pop 1                              
 
   719   55   load_var 13                        (ts)
         56   load_field 0                       (name)
         57   load_var2 4 5                      
-        58   call 777 ntypeargs=0               (testing.subtree_may_be_selected)
+        58   call 778 ntypeargs=0               (testing.subtree_may_be_selected)
 
   717   59   pop_jump_if_false -20              (to 39)
 
@@ -12739,7 +12739,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   723   61   load_var2 2 3                      
         62   load_var2 4 5                      
-        63   call 782 ntypeargs=0               (testing.collect_subtree_names_layered)
+        63   call 783 ntypeargs=0               (testing.collect_subtree_names_layered)
 
   729   64   load_type 10                       
         65   load_const 11                      ("iter")
@@ -12796,13 +12796,13 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         21   load_const 6                       ("*")
         22   call 155 ntypeargs=0               (baml.String.index_of)
         23   load_const 7                       (null)
-        24   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        24   call 654 ntypeargs=0               (baml.ops.equals_equals)
         25   jump_if_false +7                   (to 32)
         26   pop 1                              
         27   load_var2 3 6                      
         28   call 155 ntypeargs=0               (baml.String.index_of)
         29   load_const 7                       (null)
-        30   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        30   call 654 ntypeargs=0               (baml.ops.equals_equals)
         31   unary_op !                         
         32   pop_jump_if_false +2               (to 34)
         33   jump +11                           (to 44)
@@ -12813,7 +12813,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         37   jump_if_false +4                   (to 41)
         38   pop 1                              
         39   load_var2 3 6                      
-        40   call 771 ntypeargs=0               (testing.glob_match)
+        40   call 772 ntypeargs=0               (testing.glob_match)
         41   pop_jump_if_false -32              (to 9)
 
   655   42   load_const 9                       (true)
@@ -12828,7 +12828,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
 
 function testing.subtree_may_be_selected(prefix: string, include: string[], exclude: string[]) -> bool {
   677   0    load_var2 1 3                      
-        1    call 775 ntypeargs=0               (testing.subtree_excluded)
+        1    call 776 ntypeargs=0               (testing.subtree_excluded)
         2    pop_jump_if_false +2               (to 4)
         3    jump +34                           (to 37)
 
@@ -12859,7 +12859,7 @@ function testing.subtree_may_be_selected(prefix: string, include: string[], excl
         27   store_var_load_var 7               (pattern)
 
   684   28   load_var 1                         (prefix)
-        29   call 776 ntypeargs=0               (testing.pattern_may_match_descendant)
+        29   call 777 ntypeargs=0               (testing.pattern_may_match_descendant)
         30   pop_jump_if_false -13              (to 17)
 
   685   31   load_const 6                       (true)
@@ -12886,7 +12886,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   364   6    load_var2 1 2         
 
   366   7    load_var 3            (runner)
-        8    make_closure 1468 2   
+        8    make_closure 1469 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   store_var 4           (_0)
         11   load_var 4            (_0)
@@ -12905,7 +12905,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   375   8    load_var2 1 2         
-        9    make_closure 1470 2   
+        9    make_closure 1471 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   store_var 3           (_0)
         12   load_var 3            (_0)
@@ -12928,7 +12928,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   391   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1472 3   
+        13   make_closure 1473 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   store_var 4           (_0)
         16   load_var 4            (_0)
@@ -12964,7 +12964,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 6                         (t)
         25   load_field 2                       (runner)
-        26   call 761 ntypeargs=0               (testing.test_child)
+        26   call 762 ntypeargs=0               (testing.test_child)
         27   store_var 7                        (_10)
         28   load_type 0                        
         29   load_var2 3 7                      
@@ -12992,7 +12992,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         50   store_var 10                       (ts)
 
   334   51   load_var2 1 10                     
-        52   call 762 ntypeargs=0               (testing.testset_child)
+        52   call 763 ntypeargs=0               (testing.testset_child)
         53   store_var 11                       (_22)
         54   load_type 0                        
         55   load_var2 3 11                     
@@ -13032,7 +13032,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   342   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 764 ntypeargs=0               (testing._name_selected)
+        23   call 765 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   343   25   load_var 7                         (t)
@@ -13041,7 +13041,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 7                         (t)
         30   load_field 2                       (runner)
-        31   call 761 ntypeargs=0               (testing.test_child)
+        31   call 762 ntypeargs=0               (testing.test_child)
         32   store_var 8                        (_13)
         33   load_type 0                        
         34   load_var2 4 8                      
@@ -13070,12 +13070,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   354   56   load_field 0                       (name)
         57   load_var 2                         (names)
-        58   call 765 ntypeargs=0               (testing._has_selected_descendant)
+        58   call 766 ntypeargs=0               (testing._has_selected_descendant)
         59   pop_jump_if_false -14              (to 45)
 
   355   60   load_var2 1 11                     
         61   load_var 2                         (names)
-        62   call 763 ntypeargs=0               (testing.testset_child_selected)
+        62   call 764 ntypeargs=0               (testing.testset_child_selected)
         63   store_var 12                       (_27)
         64   load_type 0                        
         65   load_var2 4 12                     
@@ -13098,7 +13098,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 934 ntypeargs=0   (user.score)
+       7    call 935 ntypeargs=0   (user.score)
        8    store_var 4            (base)
 
   11   9    load_var 4             (base)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -30,14 +30,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   199   24    load_type 1                                
         25    load_deref 2                               
-        26    call 807 ntypeargs=1                       (ai.Journal.new)
+        26    call 809 ntypeargs=1                       (ai.Journal.new)
         27    store_deref 6                              
 
   200   28    load_type 1                                
         29    load_deref 1                               
         30    load_deref 6                               
         31    load_const 2                               (0)
-        32    call 846 ntypeargs=1                       (ai.Agent._emit_from)
+        32    call 848 ntypeargs=1                       (ai.Agent._emit_from)
         33    store_var 7                                (seen)
 
   201   34    load_const 2                               (0)
@@ -73,7 +73,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         59    load_deref 6                               
         60    load_var 9                                 (total)
         61    load_const 5                               (2)
-        62    call 845 ntypeargs=1                       (ai.Agent._attempt_turn)
+        62    call 847 ntypeargs=1                       (ai.Agent._attempt_turn)
         63    store_var 11                               (turn)
 
   213   64    load_var 8                                 (steps)
@@ -85,11 +85,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         69    load_deref 1                               
         70    load_deref 6                               
         71    load_var 7                                 (seen)
-        72    call 846 ntypeargs=1                       (ai.Agent._emit_from)
+        72    call 848 ntypeargs=1                       (ai.Agent._emit_from)
         73    store_var 7                                (seen)
 
   215   74    load_var 11                                (turn)
-        75    call 826 ntypeargs=0                       (ai.ModelTurn.tool_uses)
+        75    call 828 ntypeargs=0                       (ai.ModelTurn.tool_uses)
         76    store_var 12                               (calls)
 
   216   77    load_var 12                                (calls)
@@ -102,7 +102,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         84    jump +65                                   (to 149)
 
   251   85    load_var 11                                (turn)
-        86    call 825 ntypeargs=0                       (ai.ModelTurn.terminal_text)
+        86    call 827 ntypeargs=0                       (ai.ModelTurn.terminal_text)
         87    store_var 35                               (_96)
         88    load_var 35                                (_96)
         89    store_var 34                               (candidate)
@@ -115,7 +115,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   252   96    load_type 1                                
         97    load_var 34                                (candidate)
-        98    call 427 ntypeargs=1                       (baml.sap.parse)
+        98    call 429 ntypeargs=1                       (baml.sap.parse)
         99    store_var 36                               (value)
         100   jump +11                                   (to 111)
         101   load_var 37                                (e)
@@ -132,7 +132,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   257   111   load_type 1                                
         112   load_var 36                                (value)
-        113   call 332 ntypeargs=1                       (baml.json.to_json)
+        113   call 334 ntypeargs=1                       (baml.json.to_json)
         114   jump +12                                   (to 126)
         115   load_var 39                                (e)
         116   throw_if_panic                             
@@ -147,7 +147,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         124   init_instance 3                            (baml.errors.UnknownError .data, .message)
         125   throw                                      
 
-  263   126   call 329 ntypeargs=0                       (baml.json.stringify)
+  263   126   call 331 ntypeargs=0                       (baml.json.stringify)
         127   store_var 41                               (_117)
 
   262   128   load_deref 6                               
@@ -156,14 +156,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         130   init_instance 4                            (ai.events.FinalProduced .value_json)
         131   load_type 11                               
         132   alloc_array 1                              
-        133   call 808 ntypeargs=0                       (ai.Journal.append_all)
+        133   call 810 ntypeargs=0                       (ai.Journal.append_all)
         134   pop 1                                      
 
   265   135   load_type 1                                
         136   load_deref 1                               
         137   load_deref 6                               
         138   load_var 7                                 (seen)
-        139   call 846 ntypeargs=1                       (ai.Agent._emit_from)
+        139   call 848 ntypeargs=1                       (ai.Agent._emit_from)
         140   store_var 7                                (seen)
 
   266   141   load_var 36                                (value)
@@ -176,7 +176,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         148   return                                     
 
   217   149   load_deref 6                               
-        150   call 806 ntypeargs=0                       (ai.Journal.entries)
+        150   call 808 ntypeargs=0                       (ai.Journal.entries)
         151   container_len                              
         152   store_var 14                               (before)
 
@@ -187,14 +187,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         157   load_type 1                                
         158   load_var2 1 2                              
         159   load_var 6                                 (j)
-        160   make_closure 1736 captures=3 ntypeargs=1   
+        160   make_closure 1738 captures=3 ntypeargs=1   
         161   call 16 ntypeargs=3                        (baml.Array.map)
         162   store_var 15                               (futures)
 
   222   163   load_type 15                               
         164   load_type 16                               
         165   load_var 15                                (futures)
-        166   call 484 ntypeargs=2                       (baml.future.all)
+        166   call 486 ntypeargs=2                       (baml.future.all)
         167   await                                      
         168   pop 1                                      
 
@@ -202,11 +202,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         170   load_deref 1                               
         171   load_deref 6                               
         172   load_var 7                                 (seen)
-        173   call 846 ntypeargs=1                       (ai.Agent._emit_from)
+        173   call 848 ntypeargs=1                       (ai.Agent._emit_from)
         174   store_var 7                                (seen)
 
   227   175   load_deref 6                               
-        176   call 806 ntypeargs=0                       (ai.Journal.entries)
+        176   call 808 ntypeargs=0                       (ai.Journal.entries)
         177   store_var 16                               (entries)
 
   228   178   load_var 14                                (before)
@@ -236,7 +236,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         199   load_var 12                                (calls)
         200   load_type 1                                
         201   load_var 21                                (f)
-        202   make_closure 1737 captures=1 ntypeargs=1   
+        202   make_closure 1739 captures=1 ntypeargs=1   
         203   call 19 ntypeargs=2                        (baml.Array.find)
 
   234   204   store_var 22                               (_58)
@@ -340,12 +340,12 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   126   3     load_type 0                        
         4     load_var 3                         (spec)
-        5     call 817 ntypeargs=1               (ai.FunctionSpec.tools)
+        5     call 819 ntypeargs=1               (ai.FunctionSpec.tools)
         6     store_var 9                        (_10)
 
   127   7     load_type 0                        
         8     load_var 3                         (spec)
-        9     call 815 ntypeargs=1               (ai.FunctionSpec.output_type)
+        9     call 817 ntypeargs=1               (ai.FunctionSpec.output_type)
         10    store_var 10                       (_12)
 
   122   11    load_var2 2 8                      
@@ -448,7 +448,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         99    store_var 21                       (batch)
 
   142   100   load_var 7                         (turn)
-        101   call 826 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        101   call 828 ntypeargs=0               (ai.ModelTurn.tool_uses)
         102   load_type 8                        
         103   load_const 9                       ("iter")
         104   virtual_call nargs=1 ntypeargs=0   
@@ -492,7 +492,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         139   pop 1                              
 
   148   140   load_var 7                         (turn)
-        141   call 825 ntypeargs=0               (ai.ModelTurn.terminal_text)
+        141   call 827 ntypeargs=0               (ai.ModelTurn.terminal_text)
         142   store_var 30                       (_56)
         143   load_var 30                        (_56)
         144   store_var 29                       (candidate)
@@ -504,7 +504,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         150   store_var 29                       (candidate)
 
   149   151   load_var 7                         (turn)
-        152   call 826 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        152   call 828 ntypeargs=0               (ai.ModelTurn.tool_uses)
         153   container_len                      
         154   store_var 31                       (_62)
         155   load_var 31                        (_62)
@@ -518,7 +518,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         162   load_field 1                       (stop_reason)
         163   load_const 14                      (ai.content.StopReason.MaxTokens)
         164   alloc_variant 436                  (ai.content.StopReason)
-        165   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        165   call 656 ntypeargs=0               (baml.ops.equals_equals)
 
   149   166   jump_if_false +2                   (to 168)
         167   jump +7                            (to 174)
@@ -528,7 +528,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         170   load_field 1                       (stop_reason)
         171   load_const 15                      (ai.content.StopReason.Refused)
         172   alloc_variant 436                  (ai.content.StopReason)
-        173   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        173   call 656 ntypeargs=0               (baml.ops.equals_equals)
 
   149   174   jump_if_false +2                   (to 176)
         175   jump +5                            (to 180)
@@ -536,7 +536,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   152   177   load_type 0                        
         178   load_var2 1 29                     
-        179   call 844 ntypeargs=1               (ai.Agent._parses)
+        179   call 846 ntypeargs=1               (ai.Agent._parses)
 
   153   180   pop_jump_if_false +2               (to 182)
         181   jump +34                           (to 215)
@@ -548,7 +548,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         186   jump +12                           (to 198)
 
   175   187   load_var2 4 21                     
-        188   call 808 ntypeargs=0               (ai.Journal.append_all)
+        188   call 810 ntypeargs=0               (ai.Journal.append_all)
         189   pop 1                              
 
   176   190   load_var 2                         (c)
@@ -569,7 +569,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         203   pop 1                              
 
   172   204   load_var2 4 21                     
-        205   call 808 ntypeargs=0               (ai.Journal.append_all)
+        205   call 810 ntypeargs=0               (ai.Journal.append_all)
         206   pop 1                              
 
   173   207   load_type 0                        
@@ -578,11 +578,11 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         210   load_var2 5 6                      
         211   load_const 16                      (1)
         212   sub_int                            
-        213   call 845 ntypeargs=1               (ai.Agent._attempt_turn)
+        213   call 847 ntypeargs=1               (ai.Agent._attempt_turn)
         214   jump +19                           (to 233)
 
   154   215   load_var2 4 21                     
-        216   call 808 ntypeargs=0               (ai.Journal.append_all)
+        216   call 810 ntypeargs=0               (ai.Journal.append_all)
         217   pop 1                              
 
   156   218   load_var 7                         (turn)
@@ -626,7 +626,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
 function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> int {
   182   0    load_var 2             (j)
-        1    call 806 ntypeargs=0   (ai.Journal.entries)
+        1    call 808 ntypeargs=0   (ai.Journal.entries)
         2    store_var 4            (entries)
 
   183   3    load_var 3             (seen)
@@ -700,7 +700,7 @@ function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> in
 function ai.Agent._parses(self: ai.Agent<#0>, candidate: string) -> bool {
   100   0    load_type 0            
         1    load_var 2             (candidate)
-        2    call 427 ntypeargs=1   (baml.sap.parse)
+        2    call 429 ntypeargs=1   (baml.sap.parse)
         3    pop 1                  
         4    jump +5                (to 9)
         5    load_var 3             (e)
@@ -716,7 +716,7 @@ function ai.Agent._parses(self: ai.Agent<#0>, candidate: string) -> bool {
 function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: ai.content.ToolUse, j: ai.Journal) -> null {
   56   0     load_var2 2 3           
        1     load_field 1            (name)
-       2     call 823 ntypeargs=0    (ai.tools.Toolbox.get)
+       2     call 825 ntypeargs=0    (ai.tools.Toolbox.get)
        3     store_var 5             (_7)
        4     load_var 5              (_7)
        5     narrow_bind 0 5         
@@ -741,7 +741,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        20    init_instance 0         (ai.events.ToolFailed .id, .message)
        21    load_type 3             
        22    alloc_array 1           
-       23    call 808 ntypeargs=0    (ai.Journal.append_all)
+       23    call 810 ntypeargs=0    (ai.Journal.append_all)
        24    pop 1                   
 
   94   25    load_const 4            (null)
@@ -752,7 +752,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
 
   58   29    load_var2 6 3           
        30    load_field 2            (args)
-       31    call 818 ntypeargs=0    (ai.tools.Tool.call)
+       31    call 820 ntypeargs=0    (ai.tools.Tool.call)
        32    store_var 7             (outcome)
        33    jump +65                (to 98)
        34    load_var 8              (e)
@@ -772,7 +772,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        45    init_instance 1         (ai.events.ToolFailed .id, .message)
        46    load_type 3             
        47    alloc_array 1           
-       48    call 808 ntypeargs=0    (ai.Journal.append_all)
+       48    call 810 ntypeargs=0    (ai.Journal.append_all)
        49    pop 1                   
 
   64   50    load_var 6              (t)
@@ -790,7 +790,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        62    load_var 11             (_19)
        63    load_const 6            (ai.tools.ErrorMode.Raise)
        64    alloc_variant 437       (ai.tools.ErrorMode)
-       65    call 654 ntypeargs=0    (baml.ops.equals_equals)
+       65    call 656 ntypeargs=0    (baml.ops.equals_equals)
        66    pop_jump_if_false +2    (to 68)
        67    jump +4                 (to 71)
 
@@ -849,7 +849,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        108   init_instance 3         (ai.events.ToolCompleted .id, .output)
        109   load_type 3             
        110   alloc_array 1           
-       111   call 808 ntypeargs=0    (ai.Journal.append_all)
+       111   call 810 ntypeargs=0    (ai.Journal.append_all)
        112   pop 1                   
 
   83   113   load_const 4            (null)
@@ -895,7 +895,7 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
        30   pop_jump_if_false +4                       (to 34)
 
   41   31   load_type 4                                
-       32   make_closure 1718 captures=0 ntypeargs=1   
+       32   make_closure 1720 captures=0 ntypeargs=1   
        33   store_var 5                                (_9)
 
   35   34   load_var2 1 2                              
@@ -986,11 +986,11 @@ function ai.Journal.entries(self: ai.Journal) -> (ai.events.RunStarted | ai.even
 function ai.Journal.new(spec: ai.FunctionSpec<#0>) -> ai.Journal {
   21   0    load_type 0            
        1    load_var 1             (spec)
-       2    call 813 ntypeargs=1   (ai.FunctionSpec.name)
+       2    call 815 ntypeargs=1   (ai.FunctionSpec.name)
        3    store_var 3            (_4)
        4    load_type 0            
        5    load_var 1             (spec)
-       6    call 814 ntypeargs=1   (ai.FunctionSpec.arguments)
+       6    call 816 ntypeargs=1   (ai.FunctionSpec.arguments)
        7    store_var 4            (_6)
        8    load_var2 3 4          
        9    init_instance 0        (ai.events.RunStarted .spec_name, .arguments)
@@ -1087,7 +1087,7 @@ function ai.ModelTurn.tool_uses(self: ai.ModelTurn) -> ai.content.ToolUse[] {
 
 function ai.Prompt.baml.ToString.to_string(self: ai.Prompt) -> string {
   35   0   load_var 1             (self)
-       1   call 809 ntypeargs=0   (ai.Prompt.text)
+       1   call 811 ntypeargs=0   (ai.Prompt.text)
        2   return                 
 }
 
@@ -1253,7 +1253,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         49   load_var 11                        (_17)
         50   load_const 6                       (ai.errors.RetrySafety.Safe)
         51   alloc_variant 438                  (ai.errors.RetrySafety)
-        52   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        52   call 656 ntypeargs=0               (baml.ops.equals_equals)
 
   155   53   pop_jump_if_false +2               (to 55)
         54   jump +3                            (to 57)
@@ -1265,7 +1265,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         58   load_var 3                         (index)
         59   load_const 4                       (1)
         60   add_int                            
-        61   call 839 ntypeargs=0               (ai.clients.Fallback._try)
+        61   call 841 ntypeargs=0               (ai.clients.Fallback._try)
         62   return                             
 }
 
@@ -1300,13 +1300,13 @@ function ai.clients.Fallback.root.Client.id(self: ai.clients.Fallback) -> string
 function ai.clients.Fallback.root.Client.invoke(self: ai.clients.Fallback, input: ai.ModelTurnInput) -> ai.ModelTurn {
   185   0   load_var2 1 2          
         1   load_const 0           (0)
-        2   call 839 ntypeargs=0   (ai.clients.Fallback._try)
+        2   call 841 ntypeargs=0   (ai.clients.Fallback._try)
         3   jump +6                (to 9)
         4   load_var 3             (e)
         5   throw_if_panic         
 
   186   6   load_var 3             (e)
-        7   call 857 ntypeargs=0   (ai.errors.normalize)
+        7   call 859 ntypeargs=0   (ai.errors.normalize)
         8   throw                  
         9   return                 
 }
@@ -1348,7 +1348,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        29   load_var 7                         (_11)
        30   load_const 5                       (ai.errors.RetrySafety.Safe)
        31   alloc_variant 438                  (ai.errors.RetrySafety)
-       32   call 654 ntypeargs=0               (baml.ops.equals_equals)
+       32   call 656 ntypeargs=0               (baml.ops.equals_equals)
 
   74   33   jump_if_false +5                   (to 38)
        34   pop 1                              
@@ -1374,8 +1374,8 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
   80   49   load_var 1                         (self)
        50   load_field 3                       (backoff)
        51   load_var2 8 6                      
-       52   call 831 ntypeargs=0               (ai.clients.Backoff.delay_ms)
-       53   call 503 ntypeargs=0               (baml.time.Duration.from_milliseconds)
+       52   call 833 ntypeargs=0               (ai.clients.Backoff.delay_ms)
+       53   call 505 ntypeargs=0               (baml.time.Duration.from_milliseconds)
 
   79   54   sys_op 255                         (baml.sys.sleep)
        55   pop 1                              
@@ -1387,7 +1387,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
        60   load_var 3                         (remaining)
        61   load_const 3                       (1)
        62   sub_int                            
-       63   call 833 ntypeargs=0               (ai.clients.Retry._attempt)
+       63   call 835 ntypeargs=0               (ai.clients.Retry._attempt)
        64   return                             
 }
 
@@ -1432,7 +1432,7 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
        32   load_const 0           (<omitted>)
        33   load_const 0           (<omitted>)
        34   load_const 0           (<omitted>)
-       35   call 830 ntypeargs=0   (ai.clients.Backoff.new)
+       35   call 832 ntypeargs=0   (ai.clients.Backoff.new)
        36   store_var 6            (_10)
 
   61   37   load_var2 1 2          
@@ -1456,13 +1456,13 @@ function ai.clients.Retry.root.Client.invoke(self: ai.clients.Retry, input: ai.M
   99    0    load_var2 1 2          
         1    load_var 1             (self)
         2    load_field 1           (max_attempts)
-        3    call 833 ntypeargs=0   (ai.clients.Retry._attempt)
+        3    call 835 ntypeargs=0   (ai.clients.Retry._attempt)
         4    jump +6                (to 10)
         5    load_var 3             (e)
         6    throw_if_panic         
 
   100   7    load_var 3             (e)
-        8    call 857 ntypeargs=0   (ai.errors.normalize)
+        8    call 859 ntypeargs=0   (ai.errors.normalize)
         9    throw                  
         10   return                 
 }
@@ -1564,7 +1564,7 @@ function ai.clients.RoundRobin.root.Client.invoke(self: ai.clients.RoundRobin, i
         37   throw_if_panic                     
 
   141   38   load_var 4                         (e)
-        39   call 857 ntypeargs=0               (ai.errors.normalize)
+        39   call 859 ntypeargs=0               (ai.errors.normalize)
         40   throw                              
         41   load_var 3                         (_0)
         42   return                             
@@ -1763,7 +1763,7 @@ function ai.errors.normalize(error: unknown) -> ai.errors.Failure | baml.errors.
 
 function ai.internal._schema_for_signature(handler: baml.AnyFunction<Returns = unknown, Throws = unknown>) -> map<string, unknown> {
   6    0    load_var 1                         (handler)
-       1    call 740 ntypeargs=0               (reflect.signature)
+       1    call 742 ntypeargs=0               (reflect.signature)
        2    store_var 3                        (sig)
 
   7    3    load_type 0                        
@@ -1798,7 +1798,7 @@ function ai.internal._schema_for_signature(handler: baml.AnyFunction<Returns = u
        29   store_var 9                        (_12)
        30   load_var 8                         (a)
        31   load_field 1                       (type)
-       32   sys_op 342                         (baml.json.schema)
+       32   sys_op 344                         (baml.json.schema)
        33   store_var 10                       (_13)
        34   load_type 0                        
        35   load_type 1                        
@@ -1846,10 +1846,10 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
 
   102   9     load_var2 4 2                      
         10    load_var 3                         (params)
-        11    call 927 ntypeargs=0               (ai.mcp.rpc_line)
+        11    call 929 ntypeargs=0               (ai.mcp.rpc_line)
         12    store_var 5                        (_6)
         13    load_var2 1 5                      
-        14    call 929 ntypeargs=0               (ai.mcp.McpConnection._send)
+        14    call 931 ntypeargs=0               (ai.mcp.McpConnection._send)
         15    pop 1                              
 
   103   16    load_const 1                       (true)
@@ -1958,7 +1958,7 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         102   pop_jump_if_false -86              (to 16)
 
   118   103   load_var 13                        (trimmed)
-        104   call 328 ntypeargs=0               (baml.json.parse)
+        104   call 330 ntypeargs=0               (baml.json.parse)
         105   store_var 14                       (msg)
         106   jump +5                            (to 111)
         107   load_var 15                        (e)
@@ -1972,7 +1972,7 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         113   load_const 15                      (".id")
         114   load_const 0                       (1)
         115   unary_op -                         
-        116   call 341 ntypeargs=1               (baml.json.path_or)
+        116   call 343 ntypeargs=1               (baml.json.path_or)
         117   load_var 4                         (id)
         118   cmp_int_op ==                      
         119   pop_jump_if_false -103             (to 16)
@@ -1981,12 +1981,12 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         121   load_var 14                        (msg)
         122   load_const 17                      (".error")
         123   load_const 5                       (null)
-        124   call 341 ntypeargs=1               (baml.json.path_or)
+        124   call 343 ntypeargs=1               (baml.json.path_or)
         125   store_var 16                       (err)
 
   123   126   load_var 16                        (err)
         127   load_const 5                       (null)
-        128   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        128   call 656 ntypeargs=0               (baml.ops.equals_equals)
         129   unary_op !                         
         130   pop_jump_if_false +2               (to 132)
         131   jump +7                            (to 138)
@@ -1995,7 +1995,7 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         133   load_var 14                        (msg)
         134   load_const 18                      (".result")
         135   load_const 5                       (null)
-        136   call 341 ntypeargs=1               (baml.json.path_or)
+        136   call 343 ntypeargs=1               (baml.json.path_or)
         137   return                             
 
   125   138   load_type 2                        
@@ -2008,18 +2008,18 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
         144   load_var 16                        (err)
         145   load_const 20                      (".code")
         146   load_const 5                       (null)
-        147   call 341 ntypeargs=1               (baml.json.path_or)
+        147   call 343 ntypeargs=1               (baml.json.path_or)
         148   store_var 18                       (_46)
 
   127   149   load_type 2                        
         150   load_var 16                        (err)
         151   load_const 21                      (".message")
         152   load_const 22                      ("MCP error")
-        153   call 341 ntypeargs=1               (baml.json.path_or)
+        153   call 343 ntypeargs=1               (baml.json.path_or)
         154   store_var 19                       (_49)
 
   128   155   load_var 16                        (err)
-        156   call 329 ntypeargs=0               (baml.json.stringify)
+        156   call 331 ntypeargs=0               (baml.json.stringify)
         157   store_var 20                       (_52)
 
   125   158   load_const 23                      ("mcp/")
@@ -2094,7 +2094,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
   184   7    load_var 1                         (self)
         8    load_const 4                       ("tools/call")
         9    load_var 5                         (params)
-        10   call 930 ntypeargs=0               (ai.mcp.McpConnection._request)
+        10   call 932 ntypeargs=0               (ai.mcp.McpConnection._request)
         11   store_var 6                        (result)
 
   185   12   load_type 2                        
@@ -2106,7 +2106,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         17   load_const 6                       (".content")
         18   load_type 7                        
         19   alloc_array 0                      
-        20   call 341 ntypeargs=1               (baml.json.path_or)
+        20   call 343 ntypeargs=1               (baml.json.path_or)
         21   load_type 8                        
         22   load_const 9                       ("iter")
         23   virtual_call nargs=1 ntypeargs=0   
@@ -2127,7 +2127,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         37   load_var 10                        (item)
         38   load_const 13                      (".type")
         39   load_const 14                      ("")
-        40   call 341 ntypeargs=1               (baml.json.path_or)
+        40   call 343 ntypeargs=1               (baml.json.path_or)
         41   load_const 15                      ("text")
         42   cmp_op ==                          
         43   pop_jump_if_false -18              (to 25)
@@ -2136,7 +2136,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         45   load_var 10                        (item)
         46   load_const 16                      (".text")
         47   load_const 17                      ("")
-        48   call 341 ntypeargs=1               (baml.json.path_or)
+        48   call 343 ntypeargs=1               (baml.json.path_or)
         49   store_var 11                       (_22)
         50   load_type 2                        
         51   load_var2 7 11                     
@@ -2154,7 +2154,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         61   load_var 6                         (result)
         62   load_const 20                      (".isError")
         63   load_const 21                      (false)
-        64   call 341 ntypeargs=1               (baml.json.path_or)
+        64   call 343 ntypeargs=1               (baml.json.path_or)
         65   pop_jump_if_false +2               (to 67)
         66   jump +5                            (to 71)
 
@@ -2267,16 +2267,16 @@ function ai.mcp.McpConnection.connect(name: string, command: string, args: strin
   75   61   load_var 11            (conn)
        62   load_const 18          ("initialize")
        63   load_var 12            (init)
-       64   call 930 ntypeargs=0   (ai.mcp.McpConnection._request)
+       64   call 932 ntypeargs=0   (ai.mcp.McpConnection._request)
        65   pop 1                  
 
   76   66   load_const 2           (null)
        67   load_const 19          ("notifications/initialized")
        68   load_const 2           (null)
-       69   call 927 ntypeargs=0   (ai.mcp.rpc_line)
+       69   call 929 ntypeargs=0   (ai.mcp.rpc_line)
        70   store_var 13           (_26)
        71   load_var2 11 13        
-       72   call 929 ntypeargs=0   (ai.mcp.McpConnection._send)
+       72   call 931 ntypeargs=0   (ai.mcp.McpConnection._send)
        73   pop 1                  
 
   77   74   load_var 11            (conn)
@@ -2291,7 +2291,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         2    load_type 1                        
         3    load_type 2                        
         4    alloc_map 0                        
-        5    call 930 ntypeargs=0               (ai.mcp.McpConnection._request)
+        5    call 932 ntypeargs=0               (ai.mcp.McpConnection._request)
         6    store_var 3                        (result)
 
   157   7    load_type 3                        
@@ -2303,7 +2303,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         12   load_const 5                       (".tools")
         13   load_type 6                        
         14   alloc_array 0                      
-        15   call 341 ntypeargs=1               (baml.json.path_or)
+        15   call 343 ntypeargs=1               (baml.json.path_or)
         16   load_type 7                        
         17   load_const 8                       ("iter")
         18   virtual_call nargs=1 ntypeargs=0   
@@ -2324,7 +2324,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         32   load_var 7                         (t)
         33   load_const 12                      (".name")
         34   load_const 13                      ("")
-        35   call 341 ntypeargs=1               (baml.json.path_or)
+        35   call 343 ntypeargs=1               (baml.json.path_or)
         36   store_var 8                        (tool_name)
 
   161   37   load_type 6                        
@@ -2333,12 +2333,12 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         40   load_type 1                        
         41   load_type 6                        
         42   alloc_map 0                        
-        43   call 341 ntypeargs=1               (baml.json.path_or)
+        43   call 343 ntypeargs=1               (baml.json.path_or)
         44   store_var 11                       (_19)
 
   160   45   load_type 15                       
         46   load_var 11                        (_19)
-        47   call 335 ntypeargs=1               (baml.json.from_json)
+        47   call 337 ntypeargs=1               (baml.json.from_json)
         48   store_var 9                        (schema)
         49   jump +9                            (to 58)
         50   load_var 10                        (e)
@@ -2356,20 +2356,20 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         59   load_var 7                         (t)
         60   load_const 16                      (".description")
         61   load_const 17                      ("")
-        62   call 341 ntypeargs=1               (baml.json.path_or)
+        62   call 343 ntypeargs=1               (baml.json.path_or)
         63   store_var 14                       (_28)
 
   172   64   load_var 9                         (schema)
         65   store_var 15                       (_31)
 
   173   66   load_var2 1 8                      
-        67   call 926 ntypeargs=0               (ai.mcp._proxy)
+        67   call 928 ntypeargs=0               (ai.mcp._proxy)
         68   store_var 16                       (_32)
 
   170   69   load_var2 8 14                     
         70   load_var2 15 16                    
         71   load_const 18                      (<omitted>)
-        72   call 820 ntypeargs=0               (ai.tools.raw_tool)
+        72   call 822 ntypeargs=0               (ai.tools.raw_tool)
         73   store_var 13                       (_26)
 
   168   74   load_type 3                        
@@ -2393,7 +2393,7 @@ function ai.mcp._proxy(conn: ai.mcp.McpConnection, name: string) -> (map<string,
        5    store_var 2           
 
   20   6    load_var2 1 2         
-       7    make_closure 2302 2   
+       7    make_closure 2304 2   
        8    store_var 3           (_0)
        9    load_var 3            (_0)
        10   return                
@@ -2443,8 +2443,8 @@ function ai.mcp.rpc_line(id: int | null, method: string, params: map<string, unk
 
   34   36   load_type 7             
        37   load_var 4              (m)
-       38   call 332 ntypeargs=1    (baml.json.to_json)
-       39   call 329 ntypeargs=0    (baml.json.stringify)
+       38   call 334 ntypeargs=1    (baml.json.to_json)
+       39   call 331 ntypeargs=0    (baml.json.stringify)
        40   return                  
 }
 
@@ -2454,7 +2454,7 @@ function ai.prompt(body: ((string) -> baml.prompt.Role throws never, baml.prompt
        2   store_var 1           
 
   49   3   load_var 1            (body)
-       4   make_closure 1652 1   
+       4   make_closure 1654 1   
        5   store_var 3           (render)
 
   53   6   load_var 3            (render)
@@ -2476,7 +2476,7 @@ function ai.stream.Stream.final(self: ai.stream.Stream<#0, #1>) -> #1 {
         8    load_field 1           (_cache)
         9    load_type 0            
         10   load_type 1            
-        11   sys_op 425             (baml.sap.__parse_final)
+        11   sys_op 427             (baml.sap.__parse_final)
         12   return                 
 
   279   13   load_var 1             (self)
@@ -2544,7 +2544,7 @@ function ai.stream.Stream.next(self: ai.stream.Stream<#0, #1>) -> #0 | ai.stream
         29   load_field 1                     (_cache)
         30   load_type 3                      
         31   load_type 4                      
-        32   sys_op 426                       (baml.sap.__parse_partial)
+        32   sys_op 428                       (baml.sap.__parse_partial)
         33   store_var 4                      (parsed)
 
   264   34   load_var 4                       (parsed)
@@ -2597,7 +2597,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         1    pop_jump_if_false +7   (to 8)
 
   216   2    load_var 1             (self)
-        3    call 852 ntypeargs=0   (ai.stream.TurnStream.next)
+        3    call 854 ntypeargs=0   (ai.stream.TurnStream.next)
         4    store_var 2            (_3)
         5    load_var 2             (_3)
         6    narrow_bind 1 2        
@@ -2606,7 +2606,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
   223   8    load_var 1             (self)
         9    load_field 8           (_input_tokens)
         10   load_const 2           (null)
-        11   call 654 ntypeargs=0   (baml.ops.equals_equals)
+        11   call 656 ntypeargs=0   (baml.ops.equals_equals)
         12   unary_op !             
         13   jump_if_false +2       (to 15)
         14   jump +7                (to 21)
@@ -2614,7 +2614,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         16   load_var 1             (self)
         17   load_field 9           (_output_tokens)
         18   load_const 2           (null)
-        19   call 654 ntypeargs=0   (baml.ops.equals_equals)
+        19   call 656 ntypeargs=0   (baml.ops.equals_equals)
         20   unary_op !             
         21   pop_jump_if_false +2   (to 23)
         22   jump +4                (to 26)
@@ -2766,7 +2766,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         38    jump +6                            (to 44)
 
   202   39    load_var 1                         (self)
-        40    call 851 ntypeargs=0               (ai.stream.TurnStream._finish)
+        40    call 853 ntypeargs=0               (ai.stream.TurnStream._finish)
         41    pop 1                              
 
   203   42    alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2849,7 +2849,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         110   jump -17                           (to 93)
 
   176   111   load_var 1                         (self)
-        112   call 851 ntypeargs=0               (ai.stream.TurnStream._finish)
+        112   call 853 ntypeargs=0               (ai.stream.TurnStream._finish)
         113   pop 1                              
 
   177   114   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2889,7 +2889,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         145   pop_jump_if_false -145             (to 0)
 
   165   146   load_var 1                         (self)
-        147   call 851 ntypeargs=0               (ai.stream.TurnStream._finish)
+        147   call 853 ntypeargs=0               (ai.stream.TurnStream._finish)
         148   pop 1                              
 
   166   149   alloc_instance 359 ntypeargs=0     (ai.stream.Done)
@@ -2964,7 +2964,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
 function ai.stream.decode_sse_batch(batch: string) -> ai.stream.SseEvent[] {
   27   0   load_type 0            
        1   load_var 1             (batch)
-       2   call 334 ntypeargs=1   (baml.json.from_string)
+       2   call 336 ntypeargs=1   (baml.json.from_string)
        3   return                 
 }
 
@@ -2982,8 +2982,8 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   306   9     load_type 2                                
         10    load_var 1                                 (spec)
-        11    call 817 ntypeargs=1                       (ai.FunctionSpec.tools)
-        12    call 824 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
+        11    call 819 ntypeargs=1                       (ai.FunctionSpec.tools)
+        12    call 826 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
         13    unary_op !                                 
         14    pop_jump_if_false +2                       (to 16)
         15    jump +79                                   (to 94)
@@ -3043,17 +3043,17 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   331   57    load_type 2                                
         58    load_var 1                                 (spec)
-        59    call 807 ntypeargs=1                       (ai.Journal.new)
+        59    call 809 ntypeargs=1                       (ai.Journal.new)
         60    store_var 16                               (_29)
 
   332   61    load_type 2                                
         62    load_var 1                                 (spec)
-        63    call 817 ntypeargs=1                       (ai.FunctionSpec.tools)
+        63    call 819 ntypeargs=1                       (ai.FunctionSpec.tools)
         64    store_var 17                               (_31)
 
   333   65    load_type 2                                
         66    load_var 1                                 (spec)
-        67    call 815 ntypeargs=1                       (ai.FunctionSpec.output_type)
+        67    call 817 ntypeargs=1                       (ai.FunctionSpec.output_type)
         68    store_var 18                               (_33)
 
   328   69    load_var2 6 15                             
@@ -3068,13 +3068,13 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   346   77    load_type 8                                
         78    load_type 2                                
-        79    call 424 ntypeargs=2                       (baml.sap.__new_parse_cache)
+        79    call 426 ntypeargs=2                       (baml.sap.__new_parse_cache)
         80    store_var 19                               (_36)
 
   340   81    load_type 8                                
         82    load_type 2                                
         83    load_var 14                                (turns)
-        84    make_closure 1758 captures=1 ntypeargs=2   
+        84    make_closure 1760 captures=1 ntypeargs=2   
         85    load_var 19                                (_36)
         86    load_const 9                               ("")
         87    load_const 10                              (false)
@@ -3087,7 +3087,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   308   94    load_type 2                                
         95    load_var 1                                 (spec)
-        96    call 813 ntypeargs=1                       (ai.FunctionSpec.name)
+        96    call 815 ntypeargs=1                       (ai.FunctionSpec.name)
         97    store_var 5                                (_12)
         98    load_type 11                               
         99    load_var 5                                 (_12)
@@ -3138,7 +3138,7 @@ function ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> 
   30   28   load_type 5            
        29   load_type 5            
        30   load_var2 6 2          
-       31   call 741 ntypeargs=2   (reflect.call_any)
+       31   call 743 ntypeargs=2   (reflect.call_any)
        32   store_var 7            (value)
        33   jump +33               (to 66)
        34   load_var 8             (e)
@@ -3177,8 +3177,8 @@ function ai.tools.Tool.call(self: ai.tools.Tool, args: map<string, unknown>) -> 
 
   35   66   load_type 5            
        67   load_var 7             (value)
-       68   call 332 ntypeargs=1   (baml.json.to_json)
-       69   call 329 ntypeargs=0   (baml.json.stringify)
+       68   call 334 ntypeargs=1   (baml.json.to_json)
+       69   call 331 ntypeargs=0   (baml.json.stringify)
        70   jump +5                (to 75)
 
   26   71   load_var 3             (_4)
@@ -3199,7 +3199,7 @@ function ai.tools.Toolbox.get(self: ai.tools.Toolbox, name: string) -> ai.tools.
         5    load_var 1            (self)
         6    load_field 0          (entries)
         7    load_var 2            (name)
-        8    make_closure 1678 1   
+        8    make_closure 1680 1   
         9    call 19 ntypeargs=2   (baml.Array.find)
         10   return                
 }
@@ -3328,7 +3328,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        17   store_var 4            (on_error)
 
   49   18   load_var 1             (handler)
-       19   call 740 ntypeargs=0   (reflect.signature)
+       19   call 742 ntypeargs=0   (reflect.signature)
        20   store_var 5            (sig)
 
   50   21   load_var 2             (name)
@@ -3379,7 +3379,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        61   store_var 9            (_17)
 
   58   62   load_var 1             (handler)
-       63   call 867 ntypeargs=0   (ai.internal._schema_for_signature)
+       63   call 869 ntypeargs=0   (ai.internal._schema_for_signature)
        64   store_var 11           (_21)
 
   56   65   load_var2 8 9          
@@ -3396,7 +3396,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
 
 function ai.wire.render_output_format(t: type) -> string {
   37   0   load_var 1   (t)
-       1   sys_op 419   (baml.prompt.render_output_format)
+       1   sys_op 421   (baml.prompt.render_output_format)
        2   return       
 }
 
@@ -3448,7 +3448,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
 
   29   38   load_type 6            
        39   load_var 7             (text)
-       40   call 334 ntypeargs=1   (baml.json.from_string)
+       40   call 336 ntypeargs=1   (baml.json.from_string)
        41   jump +6                (to 47)
        42   load_var 9             (e)
        43   throw_if_panic         
@@ -3461,7 +3461,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
   27   48   load_var2 2 3          
        49   load_field 0           (status_code)
        50   load_var 7             (text)
-       51   call 866 ntypeargs=0   (ai.errors.classify_http)
+       51   call 868 ntypeargs=0   (ai.errors.classify_http)
        52   throw                  
 }
 
@@ -3481,20 +3481,20 @@ function anthropic.AnthropicClient.ai.Client.id(self: anthropic.AnthropicClient)
 
 function anthropic.AnthropicClient.ai.Client.invoke(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   32   0   load_var2 1 2          
-       1   call 894 ntypeargs=0   (anthropic.internal.invoke)
+       1   call 896 ntypeargs=0   (anthropic.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   33   5   load_var 3             (e)
-       6   call 857 ntypeargs=0   (ai.errors.normalize)
+       6   call 859 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function anthropic.AnthropicClient.ai.stream.StreamingClient.invoke_stream(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   40   0   load_var2 1 2          
-       1   call 896 ntypeargs=0   (anthropic.internal.invoke_stream)
+       1   call 898 ntypeargs=0   (anthropic.internal.invoke_stream)
        2   return                 
 }
 
@@ -3660,7 +3660,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         2     store_var 3                        (out)
 
   349   3     load_var 1                         (batch)
-        4     call 848 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 850 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -3687,7 +3687,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
 
   351   27    load_type 7                        
         28    load_var 8                         (data)
-        29    call 334 ntypeargs=1               (baml.json.from_string)
+        29    call 336 ntypeargs=1               (baml.json.from_string)
         30    jump +4                            (to 34)
         31    load_var 9                         (e)
         32    throw_if_panic                     
@@ -3773,7 +3773,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         103   load_var 24                        (_67)
         104   store_var_load_var 25              (s)
 
-  384   105   call 893 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+  384   105   call 895 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         106   store_var 23                       (stop)
         107   jump +3                            (to 110)
 
@@ -3939,7 +3939,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         2     store_var 3                        (msgs)
 
   132   3     load_var 1                         (j)
-        4     call 806 ntypeargs=0               (ai.Journal.entries)
+        4     call 808 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -3987,7 +3987,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         47    load_var 16                        (f)
         48    load_field 1                       (message)
         49    load_const 10                      (true)
-        50    call 889 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        50    call 891 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         51    pop 1                              
         52    jump -43                           (to 9)
 
@@ -3999,7 +3999,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         57    load_var 14                        (c)
         58    load_field 1                       (output)
         59    load_const 11                      (false)
-        60    call 889 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
+        60    call 891 ntypeargs=0               (anthropic.internal._anthropic_push_tool_result)
         61    pop 1                              
         62    jump -53                           (to 9)
 
@@ -4007,7 +4007,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         64    store_var_load_var 11              (m)
 
   146   65    load_field 0                       (content)
-        66    call 888 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
+        66    call 890 ntypeargs=0               (anthropic.internal._anthropic_assistant_blocks)
         67    store_var 12                       (_29)
 
   142   68    load_type 0                        
@@ -4074,7 +4074,7 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
        5    store_var 4                        (messages)
 
   53   6    load_var 1                         (prompt)
-       7    call 810 ntypeargs=0               (ai.Prompt.messages)
+       7    call 812 ntypeargs=0               (ai.Prompt.messages)
        8    load_type 2                        
        9    load_const 3                       ("iter")
        10   virtual_call nargs=1 ntypeargs=0   
@@ -4321,11 +4321,11 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         2     store_var 5                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 828 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 830 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 5                         (_5)
         7     call_indirect                      
 
-  183   8     call 887 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
+  183   8     call 889 ntypeargs=0               (anthropic.internal._anthropic_lower_prompt)
         9     store_var 6                        (prompt_parts)
 
   184   10    load_var 6                         (prompt_parts)
@@ -4338,7 +4338,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   186   16    load_var 2                         (input)
         17    load_field 1                       (journal)
-        18    call 890 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
+        18    call 892 ntypeargs=0               (anthropic.internal._anthropic_lower_journal)
         19    load_type 0                        
         20    load_const 1                       ("iter")
         21    virtual_call nargs=1 ntypeargs=0   
@@ -4441,7 +4441,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         110   pop 1                              
 
   210   111   load_var 8                         (lowered)
-        112   call 891 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        112   call 893 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         113   store_var 19                       (_61)
         114   load_type 6                        
         115   load_type 7                        
@@ -4464,7 +4464,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         130   alloc_array 1                      
         131   load_var 8                         (lowered)
         132   call 7 ntypeargs=1                 (baml.Array.concat)
-        133   call 891 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        133   call 893 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
         134   store_var 17                       (_46)
         135   load_type 6                        
         136   load_type 7                        
@@ -4476,7 +4476,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   213   142   load_var 2                         (input)
         143   load_field 2                       (toolbox)
-        144   call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        144   call 826 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         145   unary_op !                         
         146   pop_jump_if_false +80              (to 226)
 
@@ -4486,7 +4486,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   215   150   load_var 2                         (input)
         151   load_field 2                       (toolbox)
-        152   call 822 ntypeargs=0               (ai.tools.Toolbox.list)
+        152   call 824 ntypeargs=0               (ai.tools.Toolbox.list)
         153   load_type 20                       
         154   load_const 21                      ("iter")
         155   virtual_call nargs=1 ntypeargs=0   
@@ -4620,8 +4620,8 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
 
   247   268   load_type 19                       
         269   load_var 12                        (body)
-        270   call 332 ntypeargs=1               (baml.json.to_json)
-        271   call 329 ntypeargs=0               (baml.json.stringify)
+        270   call 334 ntypeargs=1               (baml.json.to_json)
+        271   call 331 ntypeargs=0               (baml.json.stringify)
         272   store_var 31                       (_118)
 
   239   273   load_const 40                      ("POST")
@@ -4678,13 +4678,13 @@ function anthropic.internal._anthropic_stop_reason(s: string) -> ai.content.Stop
 function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   266   0     load_var2 1 2                      
         1     load_const 0                       (false)
-        2     call 892 ntypeargs=0               (anthropic.internal._anthropic_request)
+        2     call 894 ntypeargs=0               (anthropic.internal._anthropic_request)
         3     store_var 3                        (req)
 
   267   4     load_type 1                        
         5     load_var 3                         (req)
         6     load_const 2                       ("anthropic")
-        7     call 827 ntypeargs=1               (ai.wire.send_as)
+        7     call 829 ntypeargs=1               (ai.wire.send_as)
         8     store_var 4                        (resp)
 
   269   9     load_type 3                        
@@ -4824,7 +4824,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         130   load_var 21                        (_46)
         131   store_var_load_var 22              (s)
 
-  294   132   call 893 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+  294   132   call 895 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
         133   store_var 20                       (stop)
         134   jump +4                            (to 138)
 
@@ -4865,7 +4865,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
 function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   415   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 892 ntypeargs=0   (anthropic.internal._anthropic_request)
+        2    call 894 ntypeargs=0   (anthropic.internal._anthropic_request)
 
   416   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -4891,7 +4891,7 @@ function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: a
         21   throw                  
 
   425   22   load_const 6           (anthropic.internal._anthropic_decode_batch)
-        23   call 849 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 851 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -4985,7 +4985,7 @@ function assert.contains(haystack: string, needle: string) -> null {
 
 function assert.equal(actual: unknown, expected: unknown) -> null {
   59   0    load_var2 1 2          
-       1    call 654 ntypeargs=0   (baml.ops.equals_equals)
+       1    call 656 ntypeargs=0   (baml.ops.equals_equals)
        2    unary_op !             
        3    pop_jump_if_false +2   (to 5)
        4    jump +3                (to 7)
@@ -4995,14 +4995,14 @@ function assert.equal(actual: unknown, expected: unknown) -> null {
   59   6    jump +23               (to 29)
 
   61   7    load_var 1             (actual)
-       8    call 801 ntypeargs=0   (assert.format_operand)
+       8    call 803 ntypeargs=0   (assert.format_operand)
        9    store_var 4            (_9)
        10   load_type 1            
        11   load_var 4             (_9)
        12   call 138 ntypeargs=1   (baml.String.from)
        13   store_var 3            (_8)
        14   load_var 2             (expected)
-       15   call 801 ntypeargs=0   (assert.format_operand)
+       15   call 803 ntypeargs=0   (assert.format_operand)
        16   store_var 6            (_12)
        17   load_type 1            
        18   load_var 6             (_12)
@@ -5098,7 +5098,7 @@ function assert.is_type(actual: unknown) -> #0 {
 function assert.not_null(value: unknown | null) -> null {
   14   0   load_var 1             (value)
        1   load_const 0           (null)
-       2   call 654 ntypeargs=0   (baml.ops.equals_equals)
+       2   call 656 ntypeargs=0   (baml.ops.equals_equals)
        3   pop_jump_if_false +2   (to 5)
        4   jump +3                (to 7)
 
@@ -5136,13 +5136,13 @@ function claude_code.ClaudeCodeClient.ai.Client.id(self: claude_code.ClaudeCodeC
 
 function claude_code.ClaudeCodeClient.ai.Client.invoke(self: claude_code.ClaudeCodeClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   44   0   load_var2 1 2          
-       1   call 925 ntypeargs=0   (claude_code.internal.invoke)
+       1   call 927 ntypeargs=0   (claude_code.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   45   5   load_var 3             (e)
-       6   call 857 ntypeargs=0   (ai.errors.normalize)
+       6   call 859 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
@@ -5222,20 +5222,20 @@ function claude_code.ClaudeCodeClient.new(model: string, executable: string, cwd
 }
 
 function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
-  163   0     load_type 0                        
+  165   0     load_type 0                        
         1     load_var 1                         (raw)
         2     load_const 1                       (".type")
         3     load_const 2                       ("?")
-        4     call 341 ntypeargs=1               (baml.json.path_or)
+        4     call 343 ntypeargs=1               (baml.json.path_or)
         5     store_var 3                        (kind)
 
-  164   6     load_var 3                         (kind)
+  166   6     load_var 3                         (kind)
         7     load_const 3                       ("system")
         8     cmp_op ==                          
         9     pop_jump_if_false +2               (to 11)
         10    jump +183                          (to 193)
 
-  177   11    load_var 3                         (kind)
+  179   11    load_var 3                         (kind)
         12    load_const 4                       ("assistant")
         13    cmp_op ==                          
         14    jump_if_false +2                   (to 16)
@@ -5247,13 +5247,13 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         20    pop_jump_if_false +2               (to 22)
         21    jump +23                           (to 44)
 
-  195   22    load_var 3                         (kind)
+  197   22    load_var 3                         (kind)
         23    load_const 6                       ("result")
         24    cmp_op ==                          
         25    pop_jump_if_false +2               (to 27)
         26    jump +233                          (to 259)
 
-  198   27    load_type 0                        
+  200   27    load_type 0                        
         28    load_var 3                         (kind)
         29    call 138 ntypeargs=1               (baml.String.from)
         30    store_var 24                       (_88)
@@ -5271,18 +5271,18 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         42    pop 1                              
         43    jump +216                          (to 259)
 
-  178   44    load_type 0                        
+  180   44    load_type 0                        
         45    alloc_array 0                      
         46    store_var 10                       (parts)
 
-  179   47    load_type 13                       
+  181   47    load_type 13                       
         48    load_var 1                         (raw)
         49    load_const 14                      (".message.content")
         50    load_type 15                       
         51    alloc_array 0                      
-        52    call 341 ntypeargs=1               (baml.json.path_or)
+        52    call 343 ntypeargs=1               (baml.json.path_or)
 
-  180   53    load_type 16                       
+  182   53    load_type 16                       
         54    load_const 17                      ("iter")
         55    virtual_call nargs=1 ntypeargs=0   
         56    store_var 11                       (_35)
@@ -5298,14 +5298,14 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         66    load_var 12                        (_36)
         67    store_var 13                       (b)
 
-  181   68    load_type 0                        
+  183   68    load_type 0                        
         69    load_var 13                        (b)
         70    load_const 21                      (".type")
         71    load_const 22                      ("?")
-        72    call 341 ntypeargs=1               (baml.json.path_or)
+        72    call 343 ntypeargs=1               (baml.json.path_or)
         73    store_var 14                       (bt)
 
-  182   74    load_var 14                        (bt)
+  184   74    load_var 14                        (bt)
         75    load_const 23                      ("text")
         76    cmp_op ==                          
         77    pop_jump_if_false +2               (to 79)
@@ -5326,24 +5326,24 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         92    pop_jump_if_false +2               (to 94)
         93    jump +6                            (to 99)
 
-  191   94    load_type 0                        
+  193   94    load_type 0                        
         95    load_var2 10 14                    
         96    call 4 ntypeargs=1                 (baml.Array.push)
         97    pop 1                              
         98    jump -41                           (to 57)
 
-  190   99    load_type 0                        
+  192   99    load_type 0                        
         100   load_var 10                        (parts)
         101   load_const 27                      ("tool_result")
         102   call 4 ntypeargs=1                 (baml.Array.push)
         103   pop 1                              
         104   jump -47                           (to 57)
 
-  189   105   load_type 0                        
+  191   105   load_type 0                        
         106   load_var 13                        (b)
         107   load_const 28                      (".name")
         108   load_const 29                      ("?")
-        109   call 341 ntypeargs=1               (baml.json.path_or)
+        109   call 343 ntypeargs=1               (baml.json.path_or)
         110   store_var 20                       (_65)
         111   load_type 0                        
         112   load_var 20                        (_65)
@@ -5358,34 +5358,34 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         121   pop 1                              
         122   jump -65                           (to 57)
 
-  186   123   load_type 0                        
+  188   123   load_type 0                        
         124   load_var 13                        (b)
         125   load_const 31                      (".thinking")
         126   load_const 32                      ("")
-        127   call 341 ntypeargs=1               (baml.json.path_or)
-        128   call 921 ntypeargs=0               (claude_code.internal._preview)
+        127   call 343 ntypeargs=1               (baml.json.path_or)
+        128   call 923 ntypeargs=0               (claude_code.internal._preview)
         129   store_var 18                       (_56)
         130   load_type 0                        
         131   load_var 18                        (_56)
         132   call 138 ntypeargs=1               (baml.String.from)
         133   store_var 17                       (_55)
 
-  185   134   load_type 0                        
+  187   134   load_type 0                        
         135   load_var 10                        (parts)
 
-  186   136   load_const 33                      ("thinking: ")
+  188   136   load_const 33                      ("thinking: ")
         137   load_var 17                        (_55)
         138   bin_op +                           
         139   call 4 ntypeargs=1                 (baml.Array.push)
         140   pop 1                              
         141   jump -84                           (to 57)
 
-  183   142   load_type 0                        
+  185   142   load_type 0                        
         143   load_var 13                        (b)
         144   load_const 34                      (".text")
         145   load_const 35                      ("")
-        146   call 341 ntypeargs=1               (baml.json.path_or)
-        147   call 921 ntypeargs=0               (claude_code.internal._preview)
+        146   call 343 ntypeargs=1               (baml.json.path_or)
+        147   call 923 ntypeargs=0               (claude_code.internal._preview)
         148   store_var 16                       (_47)
         149   load_type 0                        
         150   load_var 16                        (_47)
@@ -5400,7 +5400,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         159   pop 1                              
         160   jump -103                          (to 57)
 
-  194   161   load_type 0                        
+  196   161   load_type 0                        
         162   load_var 3                         (kind)
         163   call 138 ntypeargs=1               (baml.String.from)
         164   store_var 21                       (_78)
@@ -5433,20 +5433,20 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         191   pop 1                              
         192   jump +67                           (to 259)
 
-  165   193   load_type 0                        
+  167   193   load_type 0                        
         194   load_var 1                         (raw)
         195   load_const 45                      (".subtype")
         196   load_const 46                      ("?")
-        197   call 341 ntypeargs=1               (baml.json.path_or)
+        197   call 343 ntypeargs=1               (baml.json.path_or)
         198   store_var 4                        (subtype)
 
-  166   199   load_var 4                         (subtype)
+  168   199   load_var 4                         (subtype)
         200   load_const 47                      ("thinking_tokens")
         201   cmp_op ==                          
         202   pop_jump_if_false +2               (to 204)
         203   jump +32                           (to 235)
 
-  174   204   load_type 0                        
+  176   204   load_type 0                        
         205   load_var 4                         (subtype)
         206   call 138 ntypeargs=1               (baml.String.from)
         207   store_var 7                        (_19)
@@ -5454,17 +5454,17 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         209   load_var 1                         (raw)
         210   load_const 48                      (".model")
         211   load_const 49                      ("?")
-        212   call 341 ntypeargs=1               (baml.json.path_or)
+        212   call 343 ntypeargs=1               (baml.json.path_or)
         213   store_var 9                        (_23)
         214   load_type 0                        
         215   load_var 9                         (_23)
         216   call 138 ntypeargs=1               (baml.String.from)
         217   store_var 8                        (_22)
 
-  173   218   load_const 50                      ("$baml_log")
+  175   218   load_const 50                      ("$baml_log")
         219   load_const 51                      ("info")
 
-  174   220   load_const 52                      ("cc event: system/")
+  176   220   load_const 52                      ("cc event: system/")
         221   load_var 7                         (_19)
         222   bin_op +                           
         223   load_const 53                      (" model=")
@@ -5477,25 +5477,25 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         230   load_type 12                       
         231   alloc_map 2                        
 
-  173   232   send_event                         
+  175   232   send_event                         
         233   pop 1                              
         234   jump +25                           (to 259)
 
-  170   235   load_type 56                       
+  172   235   load_type 56                       
         236   load_var 1                         (raw)
         237   load_const 57                      (".estimated_tokens")
         238   load_const 58                      (0)
-        239   call 341 ntypeargs=1               (baml.json.path_or)
+        239   call 343 ntypeargs=1               (baml.json.path_or)
         240   store_var 6                        (_13)
         241   load_type 56                       
         242   load_var 6                         (_13)
         243   call 138 ntypeargs=1               (baml.String.from)
         244   store_var 5                        (_12)
 
-  169   245   load_const 59                      ("$baml_log")
+  171   245   load_const 59                      ("$baml_log")
         246   load_const 60                      ("debug")
 
-  170   247   load_const 61                      ("cc event: thinking ~")
+  172   247   load_const 61                      ("cc event: thinking ~")
         248   load_var 5                         (_12)
         249   bin_op +                           
         250   load_const 62                      (" tokens")
@@ -5506,28 +5506,28 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         255   load_type 12                       
         256   alloc_map 2                        
 
-  169   257   send_event                         
+  171   257   send_event                         
         258   pop 1                              
 
-  200   259   load_const 65                      (null)
+  202   259   load_const 65                      (null)
         260   store_var 2                        (_0)
         261   load_var 2                         (_0)
         262   return                             
 }
 
 function claude_code.internal._preview(text: string) -> string {
-  154   0    load_var 1             (text)
+  156   0    load_var 1             (text)
         1    call 139 ntypeargs=0   (baml.String.length)
         2    load_const 0           (120)
         3    cmp_int_op >           
         4    pop_jump_if_false +2   (to 6)
         5    jump +3                (to 8)
 
-  157   6    load_var 1             (text)
+  159   6    load_var 1             (text)
 
-  154   7    jump +11               (to 18)
+  156   7    jump +11               (to 18)
 
-  155   8    load_var 1             (text)
+  157   8    load_var 1             (text)
         9    load_const 1           (0)
         10   load_const 0           (120)
         11   call 153 ntypeargs=0   (baml.String.substring)
@@ -5541,10 +5541,10 @@ function claude_code.internal._preview(text: string) -> string {
 }
 
 function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.json {
-  127   0    load_const 0                       (null)
+  129   0    load_const 0                       (null)
         1    store_var 2                        (result)
 
-  128   2    load_var 1                         (p)
+  130   2    load_var 1                         (p)
         3    load_field 0                       (stdout)
         4    load_type 1                        
         5    load_const 2                       ("iter")
@@ -5562,56 +5562,56 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         17   load_var 4                         (_5)
         18   store_var 5                        (line)
 
-  129   19   load_var 5                         (line)
+  131   19   load_var 5                         (line)
         20   call 144 ntypeargs=0               (baml.String.trim)
         21   store_var 6                        (trimmed)
 
-  130   22   load_var 6                         (trimmed)
+  132   22   load_var 6                         (trimmed)
         23   call 139 ntypeargs=0               (baml.String.length)
         24   load_const 6                       (0)
         25   cmp_int_op >                       
         26   pop_jump_if_false -18              (to 8)
 
-  131   27   load_var 6                         (trimmed)
-        28   call 328 ntypeargs=0               (baml.json.parse)
+  133   27   load_var 6                         (trimmed)
+        28   call 330 ntypeargs=0               (baml.json.parse)
         29   store_var 7                        (raw)
         30   jump +7                            (to 37)
         31   load_var 8                         (e)
         32   throw_if_panic                     
 
-  133   33   load_const 7                       ("claude-code")
+  135   33   load_const 7                       ("claude-code")
         34   load_var 6                         (trimmed)
         35   init_instance 0                    (ai.errors.ParseFailed .provider, .raw_output)
         36   throw                              
 
-  136   37   load_var 7                         (raw)
-        38   call 922 ntypeargs=0               (claude_code.internal._log_cc_event)
+  138   37   load_var 7                         (raw)
+        38   call 924 ntypeargs=0               (claude_code.internal._log_cc_event)
         39   pop 1                              
 
-  137   40   load_type 8                        
+  139   40   load_type 8                        
         41   load_var 7                         (raw)
         42   load_const 9                       (".type")
         43   load_const 10                      ("")
-        44   call 341 ntypeargs=1               (baml.json.path_or)
+        44   call 343 ntypeargs=1               (baml.json.path_or)
         45   load_const 11                      ("result")
         46   cmp_op ==                          
         47   pop_jump_if_false -39              (to 8)
 
-  138   48   load_var 7                         (raw)
+  140   48   load_var 7                         (raw)
         49   store_var 2                        (result)
 
-  137   50   jump -42                           (to 8)
+  139   50   jump -42                           (to 8)
 
-  144   51   load_var 2                         (result)
+  146   51   load_var 2                         (result)
         52   load_const 0                       (null)
-        53   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        53   call 656 ntypeargs=0               (baml.ops.equals_equals)
         54   pop_jump_if_false +2               (to 56)
         55   jump +3                            (to 58)
 
-  150   56   load_var 2                         (result)
+  152   56   load_var 2                         (result)
         57   return                             
 
-  145   58   load_const 12                      ("claude-code")
+  147   58   load_const 12                      ("claude-code")
         59   load_const 13                      ("the Claude Code CLI stream ended without a result event")
         60   init_instance 1                    (ai.errors.ParseFailed .provider, .raw_output)
         61   throw                              
@@ -5638,7 +5638,7 @@ function claude_code.internal._type_schema(t: string) -> map<string, unknown> {
 }
 
 function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient) -> string {
-  219   0    load_type 0           
+  221   0    load_type 0           
         1    load_type 1           
         2    load_var 1            (c)
         3    load_field 6          (mcp_servers)
@@ -5649,11 +5649,11 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
         8    load_type 2           
         9    load_var 3            (_3)
 
-  220   10   make_closure 2238 0   
+  222   10   make_closure 2240 0   
         11   call 16 ntypeargs=3   (baml.Array.map)
         12   store_var 2           (_2)
 
-  219   13   load_type 0           
+  221   13   load_type 0           
         14   load_var 2            (_2)
         15   load_const 3          (",")
         16   call 15 ntypeargs=1   (baml.Array.join)
@@ -5662,11 +5662,11 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
 
 function claude_code.internal.envelope_schema(output_type: type) -> map<string, unknown> {
   52   0     load_var 1             (output_type)
-       1     sys_op 342             (baml.json.schema)
+       1     sys_op 344             (baml.json.schema)
        2     store_var 4            (_3)
        3     load_type 0            
        4     load_var 4             (_3)
-       5     call 335 ntypeargs=1   (baml.json.from_json)
+       5     call 337 ntypeargs=1   (baml.json.from_json)
        6     store_var 3            (final_root)
 
   53   7     load_type 1            
@@ -5682,7 +5682,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        16    store_var 6            (call_props)
 
   55   17    load_const 4           ("string")
-       18    call 918 ntypeargs=0   (claude_code.internal._type_schema)
+       18    call 920 ntypeargs=0   (claude_code.internal._type_schema)
        19    store_var 7            (_10)
        20    load_type 1            
        21    load_type 2            
@@ -5693,7 +5693,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        26    pop 1                  
 
   56   27    load_const 6           ("string")
-       28    call 918 ntypeargs=0   (claude_code.internal._type_schema)
+       28    call 920 ntypeargs=0   (claude_code.internal._type_schema)
        29    store_var 8            (_14)
        30    load_type 1            
        31    load_type 2            
@@ -5704,7 +5704,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        36    pop 1                  
 
   57   37    load_const 8           ("object")
-       38    call 918 ntypeargs=0   (claude_code.internal._type_schema)
+       38    call 920 ntypeargs=0   (claude_code.internal._type_schema)
        39    store_var 9            (_18)
        40    load_type 1            
        41    load_type 2            
@@ -5835,11 +5835,11 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
 
   74   150   load_type 0            
        151   load_var 3             (final_root)
-       152   call 332 ntypeargs=1   (baml.json.to_json)
+       152   call 334 ntypeargs=1   (baml.json.to_json)
        153   store_var 15           (_67)
        154   load_type 0            
        155   load_var 13            (calls_schema)
-       156   call 332 ntypeargs=1   (baml.json.to_json)
+       156   call 334 ntypeargs=1   (baml.json.to_json)
        157   store_var 16           (_70)
        158   load_type 1            
        159   load_type 2            
@@ -5905,7 +5905,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
 
   82   212   load_var 5             (definitions)
        213   load_const 38          (null)
-       214   call 654 ntypeargs=0   (baml.ops.equals_equals)
+       214   call 656 ntypeargs=0   (baml.ops.equals_equals)
        215   unary_op !             
        216   pop_jump_if_false +8   (to 224)
 
@@ -5924,48 +5924,48 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
 }
 
 function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
-  233   0     load_const 0                       ("")
+  235   0     load_const 0                       ("")
         1     load_var 2                         (input)
         2     load_field 0                       (prompt)
         3     call_indirect                      
-        4     call 809 ntypeargs=0               (ai.Prompt.text)
+        4     call 811 ntypeargs=0               (ai.Prompt.text)
         5     store_var 4                        (instructions)
 
-  234   6     load_var 2                         (input)
+  236   6     load_var 2                         (input)
         7     load_field 2                       (toolbox)
-        8     call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        8     call 826 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         9     unary_op !                         
         10    store_var_load_var 5               (has_tools)
 
-  235   11    pop_jump_if_false +2               (to 13)
+  237   11    pop_jump_if_false +2               (to 13)
         12    jump +6                            (to 18)
 
-  238   13    load_var 2                         (input)
+  240   13    load_var 2                         (input)
         14    load_field 3                       (output_type)
-        15    sys_op 342                         (baml.json.schema)
+        15    sys_op 344                         (baml.json.schema)
         16    store_var 6                        (schema)
         17    jump +9                            (to 26)
 
-  236   18    load_var 2                         (input)
+  238   18    load_var 2                         (input)
         19    load_field 3                       (output_type)
-        20    call 917 ntypeargs=0               (claude_code.internal.envelope_schema)
+        20    call 919 ntypeargs=0               (claude_code.internal.envelope_schema)
         21    store_var 7                        (_11)
         22    load_type 1                        
         23    load_var 7                         (_11)
-        24    call 332 ntypeargs=1               (baml.json.to_json)
+        24    call 334 ntypeargs=1               (baml.json.to_json)
         25    store_var 6                        (schema)
 
-  240   26    load_var 5                         (has_tools)
+  242   26    load_var 5                         (has_tools)
         27    pop_jump_if_false +2               (to 29)
         28    jump +17                           (to 45)
 
-  243   29    load_type 2                        
+  245   29    load_type 2                        
         30    load_var 4                         (instructions)
         31    call 138 ntypeargs=1               (baml.String.from)
         32    store_var 14                       (_29)
         33    load_var 2                         (input)
         34    load_field 1                       (journal)
-        35    call 916 ntypeargs=0               (claude_code.internal.transcript_text)
+        35    call 918 ntypeargs=0               (claude_code.internal.transcript_text)
         36    store_var 16                       (_33)
         37    load_type 2                        
         38    load_var 16                        (_33)
@@ -5975,15 +5975,15 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         42    bin_op +                           
         43    store_var 8                        (prompt_text)
 
-  240   44    jump +26                           (to 70)
+  242   44    jump +26                           (to 70)
 
-  241   45    load_type 2                        
+  243   45    load_type 2                        
         46    load_var 4                         (instructions)
         47    call 138 ntypeargs=1               (baml.String.from)
         48    store_var 9                        (_18)
         49    load_var 2                         (input)
         50    load_field 1                       (journal)
-        51    call 916 ntypeargs=0               (claude_code.internal.transcript_text)
+        51    call 918 ntypeargs=0               (claude_code.internal.transcript_text)
         52    store_var 11                       (_22)
         53    load_type 2                        
         54    load_var 11                        (_22)
@@ -5991,7 +5991,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         56    store_var 10                       (_21)
         57    load_var 2                         (input)
         58    load_field 2                       (toolbox)
-        59    call 919 ntypeargs=0               (claude_code.internal.tool_protocol)
+        59    call 921 ntypeargs=0               (claude_code.internal.tool_protocol)
         60    store_var 13                       (_26)
         61    load_type 2                        
         62    load_var 13                        (_26)
@@ -6003,7 +6003,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         68    bin_op +                           
         69    store_var 8                        (prompt_text)
 
-  247   70    load_type 2                        
+  249   70    load_type 2                        
         71    load_var 1                         (c)
         72    load_field 1                       (model)
         73    call 138 ntypeargs=1               (baml.String.from)
@@ -6017,7 +6017,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         81    store_var 18                       (_44)
         82    load_var 2                         (input)
         83    load_field 2                       (toolbox)
-        84    call 822 ntypeargs=0               (ai.tools.Toolbox.list)
+        84    call 824 ntypeargs=0               (ai.tools.Toolbox.list)
         85    container_len                      
         86    store_var 21                       (_48)
         87    load_type 3                        
@@ -6025,10 +6025,10 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         89    call 138 ntypeargs=1               (baml.String.from)
         90    store_var 20                       (_47)
 
-  246   91    load_const 4                       ("$baml_log")
+  248   91    load_const 4                       ("$baml_log")
         92    load_const 5                       ("info")
 
-  247   93    load_const 6                       ("claude-code invoke: model=")
+  249   93    load_const 6                       ("claude-code invoke: model=")
         94    load_var 17                        (_41)
         95    bin_op +                           
         96    load_const 7                       (" prompt_chars=")
@@ -6045,74 +6045,74 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         107   load_type 11                       
         108   alloc_map 2                        
 
-  246   109   send_event                         
+  248   109   send_event                         
         110   pop 1                              
 
-  249   111   load_type 2                        
+  251   111   load_type 2                        
         112   alloc_array 0                      
         113   store_var 22                       (args)
 
-  250   114   load_type 2                        
+  252   114   load_type 2                        
         115   load_var 22                        (args)
         116   load_const 12                      ("-p")
         117   call 4 ntypeargs=1                 (baml.Array.push)
         118   pop 1                              
 
-  251   119   load_type 2                        
+  253   119   load_type 2                        
         120   load_var 22                        (args)
         121   load_const 13                      ("--output-format")
         122   call 4 ntypeargs=1                 (baml.Array.push)
         123   pop 1                              
 
-  252   124   load_type 2                        
+  254   124   load_type 2                        
         125   load_var 22                        (args)
         126   load_const 14                      ("stream-json")
         127   call 4 ntypeargs=1                 (baml.Array.push)
         128   pop 1                              
 
-  253   129   load_type 2                        
+  255   129   load_type 2                        
         130   load_var 22                        (args)
         131   load_const 15                      ("--verbose")
         132   call 4 ntypeargs=1                 (baml.Array.push)
         133   pop 1                              
 
-  254   134   load_type 2                        
+  256   134   load_type 2                        
         135   load_var 22                        (args)
         136   load_const 16                      ("--model")
         137   call 4 ntypeargs=1                 (baml.Array.push)
         138   pop 1                              
 
-  255   139   load_type 2                        
+  257   139   load_type 2                        
         140   load_var2 22 1                     
         141   load_field 1                       (model)
         142   call 4 ntypeargs=1                 (baml.Array.push)
         143   pop 1                              
 
-  256   144   load_type 2                        
+  258   144   load_type 2                        
         145   load_var 22                        (args)
         146   load_const 17                      ("--permission-mode")
         147   call 4 ntypeargs=1                 (baml.Array.push)
         148   pop 1                              
 
-  257   149   load_type 2                        
+  259   149   load_type 2                        
         150   load_var2 22 1                     
         151   load_field 4                       (permission_mode)
         152   call 4 ntypeargs=1                 (baml.Array.push)
         153   pop 1                              
 
-  258   154   load_type 2                        
+  260   154   load_type 2                        
         155   load_var 22                        (args)
         156   load_const 18                      ("--no-session-persistence")
         157   call 4 ntypeargs=1                 (baml.Array.push)
         158   pop 1                              
 
-  259   159   load_type 2                        
+  261   159   load_type 2                        
         160   load_var 22                        (args)
         161   load_const 19                      ("--tools")
         162   call 4 ntypeargs=1                 (baml.Array.push)
         163   pop 1                              
 
-  260   164   load_type 2                        
+  262   164   load_type 2                        
         165   load_var 1                         (c)
         166   load_field 5                       (harness_tools)
         167   load_const 20                      (",")
@@ -6123,8 +6123,8 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         172   call 4 ntypeargs=1                 (baml.Array.push)
         173   pop 1                              
 
-  267   174   load_var 1                         (c)
-        175   call 923 ntypeargs=0               (claude_code.internal.mcp_config_json)
+  269   174   load_var 1                         (c)
+        175   call 925 ntypeargs=0               (claude_code.internal.mcp_config_json)
         176   store_var 24                       (_81)
         177   load_var 24                        (_81)
         178   narrow_bind 21 24                  
@@ -6132,25 +6132,25 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         180   load_var 24                        (_81)
         181   store_var 25                       (mcp)
 
-  268   182   load_type 2                        
+  270   182   load_type 2                        
         183   load_var 22                        (args)
         184   load_const 22                      ("--mcp-config")
         185   call 4 ntypeargs=1                 (baml.Array.push)
         186   pop 1                              
 
-  269   187   load_type 2                        
+  271   187   load_type 2                        
         188   load_var2 22 25                    
         189   call 4 ntypeargs=1                 (baml.Array.push)
         190   pop 1                              
 
-  270   191   load_type 2                        
+  272   191   load_type 2                        
         192   load_var 22                        (args)
         193   load_const 23                      ("--strict-mcp-config")
         194   call 4 ntypeargs=1                 (baml.Array.push)
         195   pop 1                              
 
-  271   196   load_var 1                         (c)
-        197   call 924 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
+  273   196   load_var 1                         (c)
+        197   call 926 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
         198   store_var 27                       (_93)
         199   load_type 2                        
         200   load_var 27                        (_93)
@@ -6164,31 +6164,31 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         208   call 4 ntypeargs=1                 (baml.Array.push)
         209   pop 1                              
 
-  273   210   load_type 2                        
+  275   210   load_type 2                        
         211   load_var 22                        (args)
         212   load_const 25                      ("--json-schema")
         213   call 4 ntypeargs=1                 (baml.Array.push)
         214   pop 1                              
 
-  274   215   load_var 6                         (schema)
-        216   call 329 ntypeargs=0               (baml.json.stringify)
+  276   215   load_var 6                         (schema)
+        216   call 331 ntypeargs=0               (baml.json.stringify)
         217   store_var 28                       (_99)
         218   load_type 2                        
         219   load_var2 22 28                    
         220   call 4 ntypeargs=1                 (baml.Array.push)
         221   pop 1                              
 
-  275   222   load_type 2                        
+  277   222   load_type 2                        
         223   load_var2 22 8                     
         224   call 4 ntypeargs=1                 (baml.Array.push)
         225   pop 1                              
 
-  278   226   load_var 1                         (c)
+  280   226   load_var 1                         (c)
         227   load_field 0                       (executable)
 
-  279   228   load_var2 22 1                     
+  281   228   load_var2 22 1                     
 
-  280   229   load_field 2                       (cwd)
+  282   229   load_field 2                       (cwd)
         230   load_const 26                      (null)
         231   load_var 1                         (c)
         232   load_field 3                       (timeout_ms)
@@ -6199,10 +6199,10 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         237   store_var 29                       (p)
         238   jump +18                           (to 256)
 
-  277   239   load_var 30                        (e)
+  279   239   load_var 30                        (e)
         240   throw_if_panic                     
 
-  285   241   load_type 27                       
+  287   241   load_type 27                       
         242   load_var 30                        (e)
         243   call 138 ntypeargs=1               (baml.String.from)
         244   store_var 32                       (_115)
@@ -6211,34 +6211,34 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         247   call 138 ntypeargs=1               (baml.String.from)
         248   store_var 31                       (_114)
 
-  283   249   load_const 28                      ("claude-code")
+  285   249   load_const 28                      ("claude-code")
 
-  285   250   load_const 29                      ("the Claude Code CLI could not start: ")
+  287   250   load_const 29                      ("the Claude Code CLI could not start: ")
         251   load_var 31                        (_114)
         252   bin_op +                           
         253   load_const 26                      (null)
         254   init_instance 1                    (ai.errors.NetworkFailure .provider, .detail, .raw_body)
         255   throw                              
 
-  294   256   load_var 29                        (p)
+  296   256   load_var 29                        (p)
         257   sys_op 248                         (baml.sys.Process.close_stdin)
         258   pop 1                              
         259   jump +3                            (to 262)
         260   load_var 35                        (e)
         261   throw_if_panic                     
 
-  299   262   load_var 29                        (p)
-        263   call 920 ntypeargs=0               (claude_code.internal._read_result)
+  301   262   load_var 29                        (p)
+        263   call 922 ntypeargs=0               (claude_code.internal._read_result)
         264   store_var 36                       (result)
 
-  300   265   load_var 29                        (p)
+  302   265   load_var 29                        (p)
         266   sys_op 249                         (baml.sys.Process.wait)
         267   store_var 37                       (exit)
         268   jump +18                           (to 286)
         269   load_var 38                        (e)
         270   throw_if_panic                     
 
-  304   271   load_type 30                       
+  306   271   load_type 30                       
         272   load_var 38                        (e)
         273   call 138 ntypeargs=1               (baml.String.from)
         274   store_var 40                       (_129)
@@ -6247,34 +6247,34 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         277   call 138 ntypeargs=1               (baml.String.from)
         278   store_var 39                       (_128)
 
-  302   279   load_const 31                      ("claude-code")
+  304   279   load_const 31                      ("claude-code")
 
-  304   280   load_const 32                      ("the Claude Code CLI did not terminate cleanly: ")
+  306   280   load_const 32                      ("the Claude Code CLI did not terminate cleanly: ")
         281   load_var 39                        (_128)
         282   bin_op +                           
         283   load_const 26                      (null)
         284   init_instance 2                    (ai.errors.NetworkFailure .provider, .detail, .raw_body)
         285   throw                              
 
-  309   286   load_var 37                        (exit)
+  311   286   load_var 37                        (exit)
         287   call 242 ntypeargs=0               (baml.sys.ProcessExit.ok)
         288   unary_op !                         
         289   pop_jump_if_false +2               (to 291)
         290   jump +257                          (to 547)
 
-  318   291   load_type 33                       
+  320   291   load_type 33                       
         292   load_var 36                        (result)
         293   load_const 34                      (".is_error")
         294   load_const 35                      (false)
-        295   call 341 ntypeargs=1               (baml.json.path_or)
+        295   call 343 ntypeargs=1               (baml.json.path_or)
         296   pop_jump_if_false +2               (to 298)
         297   jump +237                          (to 534)
 
-  326   298   load_type 2                        
+  328   298   load_type 2                        
         299   load_var 36                        (result)
         300   load_const 36                      (".subtype")
         301   load_const 37                      ("?")
-        302   call 341 ntypeargs=1               (baml.json.path_or)
+        302   call 343 ntypeargs=1               (baml.json.path_or)
         303   store_var 45                       (_154)
         304   load_type 2                        
         305   load_var 45                        (_154)
@@ -6284,7 +6284,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         309   load_var 36                        (result)
         310   load_const 39                      (".total_cost_usd")
         311   load_const 40                      (0.0)
-        312   call 341 ntypeargs=1               (baml.json.path_or)
+        312   call 343 ntypeargs=1               (baml.json.path_or)
         313   store_var 47                       (_159)
         314   load_type 38                       
         315   load_var 47                        (_159)
@@ -6294,17 +6294,17 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         319   load_var 36                        (result)
         320   load_const 41                      (".session_id")
         321   load_const 42                      ("?")
-        322   call 341 ntypeargs=1               (baml.json.path_or)
+        322   call 343 ntypeargs=1               (baml.json.path_or)
         323   store_var 49                       (_164)
         324   load_type 2                        
         325   load_var 49                        (_164)
         326   call 138 ntypeargs=1               (baml.String.from)
         327   store_var 48                       (_163)
 
-  325   328   load_const 43                      ("$baml_log")
+  327   328   load_const 43                      ("$baml_log")
         329   load_const 44                      ("info")
 
-  326   330   load_const 45                      ("claude-code result: subtype=")
+  328   330   load_const 45                      ("claude-code result: subtype=")
         331   load_var 44                        (_153)
         332   bin_op +                           
         333   load_const 46                      (" cost_usd=")
@@ -6321,79 +6321,79 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         344   load_type 11                       
         345   alloc_map 2                        
 
-  325   346   send_event                         
+  327   346   send_event                         
         347   pop 1                              
 
-  328   348   load_type 50                       
+  330   348   load_type 50                       
         349   load_var 36                        (result)
         350   load_const 51                      (".structured_output")
-        351   call 340 ntypeargs=1               (baml.json.path)
+        351   call 342 ntypeargs=1               (baml.json.path)
         352   store_var 50                       (structured)
         353   jump +20                           (to 373)
         354   load_var 51                        (e)
         355   throw_if_panic                     
 
-  330   356   load_type 2                        
+  332   356   load_type 2                        
         357   load_var 36                        (result)
         358   load_const 52                      (".result")
         359   load_const 53                      ("")
-        360   call 341 ntypeargs=1               (baml.json.path_or)
-        361   call 328 ntypeargs=0               (baml.json.parse)
+        360   call 343 ntypeargs=1               (baml.json.path_or)
+        361   call 330 ntypeargs=0               (baml.json.parse)
         362   store_var 50                       (structured)
         363   jump +10                           (to 373)
         364   load_var 52                        (inner)
         365   throw_if_panic                     
 
-  334   366   load_var 36                        (result)
-        367   call 329 ntypeargs=0               (baml.json.stringify)
+  336   366   load_var 36                        (result)
+        367   call 331 ntypeargs=0               (baml.json.stringify)
         368   store_var 53                       (_177)
 
-  332   369   load_const 54                      ("claude-code")
+  334   369   load_const 54                      ("claude-code")
         370   load_var 53                        (_177)
         371   init_instance 3                    (ai.errors.ParseFailed .provider, .raw_output)
         372   throw                              
 
-  342   373   load_type 3                        
+  344   373   load_type 3                        
         374   load_var 36                        (result)
         375   load_const 55                      (".usage.input_tokens")
         376   load_const 56                      (0)
-        377   call 341 ntypeargs=1               (baml.json.path_or)
+        377   call 343 ntypeargs=1               (baml.json.path_or)
         378   store_var 55                       (_180)
 
-  343   379   load_type 3                        
+  345   379   load_type 3                        
         380   load_var 36                        (result)
         381   load_const 57                      (".usage.output_tokens")
         382   load_const 56                      (0)
-        383   call 341 ntypeargs=1               (baml.json.path_or)
+        383   call 343 ntypeargs=1               (baml.json.path_or)
         384   store_var 56                       (_183)
 
-  344   385   load_type 58                       
+  346   385   load_type 58                       
         386   load_var 36                        (result)
         387   load_const 59                      (".usage.cache_read_input_tokens")
         388   load_const 26                      (null)
-        389   call 341 ntypeargs=1               (baml.json.path_or)
+        389   call 343 ntypeargs=1               (baml.json.path_or)
         390   store_var 57                       (_186)
 
-  341   391   load_var2 55 56                    
+  343   391   load_var2 55 56                    
         392   load_var 57                        (_186)
         393   load_const 26                      (null)
         394   init_instance 4                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
         395   store_var 54                       (usage)
 
-  348   396   load_type 60                       
+  350   396   load_type 60                       
         397   alloc_array 0                      
         398   store_var 58                       (content)
 
-  349   399   load_const 56                      (ai.content.StopReason.Complete)
+  351   399   load_const 56                      (ai.content.StopReason.Complete)
         400   alloc_variant 436                  (ai.content.StopReason)
         401   store_var 59                       (stop)
 
-  350   402   load_var 5                         (has_tools)
+  352   402   load_var 5                         (has_tools)
         403   pop_jump_if_false +2               (to 405)
         404   jump +10                           (to 414)
 
-  378   405   load_var 50                        (structured)
-        406   call 329 ntypeargs=0               (baml.json.stringify)
+  380   405   load_var 50                        (structured)
+        406   call 331 ntypeargs=0               (baml.json.stringify)
         407   store_var 77                       (_247)
         408   load_type 60                       
         409   load_var2 58 77                    
@@ -6402,27 +6402,27 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         412   pop 1                              
         413   jump +112                          (to 525)
 
-  351   414   load_type 50                       
+  353   414   load_type 50                       
         415   load_var 36                        (result)
         416   load_const 61                      (".structured_output.outcome")
         417   load_var 50                        (structured)
-        418   call 341 ntypeargs=1               (baml.json.path_or)
+        418   call 343 ntypeargs=1               (baml.json.path_or)
         419   store_var 60                       (outcome)
 
-  352   420   load_type 62                       
+  354   420   load_type 62                       
         421   load_var 60                        (outcome)
         422   load_const 63                      (".calls")
         423   load_const 26                      (null)
-        424   call 341 ntypeargs=1               (baml.json.path_or)
+        424   call 343 ntypeargs=1               (baml.json.path_or)
 
-  353   425   store_var 61                       (_199)
+  355   425   store_var 61                       (_199)
         426   load_var 61                        (_199)
         427   narrow_bind 64 61                  
         428   pop_jump_if_false +2               (to 430)
         429   jump +10                           (to 439)
 
-  375   430   load_var 60                        (outcome)
-        431   call 329 ntypeargs=0               (baml.json.stringify)
+  377   430   load_var 60                        (outcome)
+        431   call 331 ntypeargs=0               (baml.json.stringify)
         432   store_var 76                       (_242)
         433   load_type 60                       
         434   load_var2 58 76                    
@@ -6431,13 +6431,13 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         437   pop 1                              
         438   jump +87                           (to 525)
 
-  353   439   load_var 61                        (_199)
+  355   439   load_var 61                        (_199)
         440   store_var 62                       (call_list)
 
-  354   441   load_const 56                      (0)
+  356   441   load_const 56                      (0)
         442   store_var 63                       (i)
 
-  355   443   load_var 62                        (call_list)
+  357   443   load_var 62                        (call_list)
         444   load_type 65                       
         445   load_const 66                      ("iter")
         446   virtual_call nargs=1 ntypeargs=0   
@@ -6454,9 +6454,9 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         457   load_var 65                        (_204)
         458   store_var 66                       (raw_call)
 
-  359   459   load_var 2                         (input)
+  361   459   load_var 2                         (input)
         460   load_field 1                       (journal)
-        461   call 806 ntypeargs=0               (ai.Journal.entries)
+        461   call 808 ntypeargs=0               (ai.Journal.entries)
         462   container_len                      
         463   store_var 69                       (_214)
         464   load_type 3                        
@@ -6468,116 +6468,116 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         470   call 138 ntypeargs=1               (baml.String.from)
         471   store_var 70                       (_218)
 
-  356   472   load_type 2                        
+  358   472   load_type 2                        
 
-  357   473   load_var 66                        (raw_call)
+  359   473   load_var 66                        (raw_call)
         474   load_const 70                      (".id")
 
-  359   475   load_const 71                      ("cc_call_")
+  361   475   load_const 71                      ("cc_call_")
         476   load_var 68                        (_213)
         477   bin_op +                           
         478   load_const 72                      ("_")
         479   bin_op +                           
         480   load_var 70                        (_218)
         481   bin_op +                           
-        482   call 341 ntypeargs=1               (baml.json.path_or)
+        482   call 343 ntypeargs=1               (baml.json.path_or)
         483   store_var 67                       (id)
 
-  361   484   load_type 2                        
+  363   484   load_type 2                        
         485   load_var 66                        (raw_call)
         486   load_const 73                      (".name")
         487   load_const 74                      ("")
-        488   call 341 ntypeargs=1               (baml.json.path_or)
+        488   call 343 ntypeargs=1               (baml.json.path_or)
         489   store_var 71                       (name)
 
-  363   490   load_type 50                       
+  365   490   load_type 50                       
         491   load_var 66                        (raw_call)
         492   load_const 75                      (".args")
         493   load_type 2                        
         494   load_type 50                       
         495   alloc_map 0                        
-        496   call 341 ntypeargs=1               (baml.json.path_or)
+        496   call 343 ntypeargs=1               (baml.json.path_or)
         497   store_var 74                       (_227)
 
-  362   498   load_type 1                        
+  364   498   load_type 1                        
         499   load_var 74                        (_227)
-        500   call 335 ntypeargs=1               (baml.json.from_json)
+        500   call 337 ntypeargs=1               (baml.json.from_json)
         501   store_var 72                       (call_args)
         502   jump +9                            (to 511)
         503   load_var 73                        (e)
         504   throw_if_panic                     
 
-  366   505   load_type 2                        
+  368   505   load_type 2                        
         506   load_type 11                       
         507   alloc_map 0                        
         508   store_var 75                       (empty)
 
-  367   509   load_var 75                        (empty)
+  369   509   load_var 75                        (empty)
         510   store_var 72                       (call_args)
 
-  370   511   load_type 60                       
+  372   511   load_type 60                       
         512   load_var2 58 67                    
         513   load_var2 71 72                    
         514   init_instance 7                    (ai.content.ToolUse .id, .name, .args)
         515   call 4 ntypeargs=1                 (baml.Array.push)
         516   pop 1                              
 
-  371   517   load_var 63                        (i)
+  373   517   load_var 63                        (i)
         518   load_const 21                      (1)
         519   add_int                            
         520   store_var 63                       (i)
 
-  355   521   jump -73                           (to 448)
+  357   521   jump -73                           (to 448)
 
-  373   522   load_const 21                      (ai.content.StopReason.ToolUse)
+  375   522   load_const 21                      (ai.content.StopReason.ToolUse)
         523   alloc_variant 436                  (ai.content.StopReason)
         524   store_var 59                       (stop)
 
-  380   525   load_var2 58 59                    
+  382   525   load_var2 58 59                    
         526   load_var 54                        (usage)
         527   init_instance 8                    (ai.ModelTurn .content, .stop_reason, .usage)
         528   store_var 3                        (_0)
 
-  291   529   load_var 29                        (p)
+  293   529   load_var 29                        (p)
         530   sys_op 251                         (baml.sys.Process.close)
         531   pop 1                              
         532   load_var 3                         (_0)
         533   return                             
 
-  321   534   load_type 2                        
+  323   534   load_type 2                        
         535   load_var 36                        (result)
         536   load_const 76                      (".subtype")
         537   load_const 77                      ("error")
-        538   call 341 ntypeargs=1               (baml.json.path_or)
+        538   call 343 ntypeargs=1               (baml.json.path_or)
         539   store_var 42                       (_143)
 
-  322   540   load_var 36                        (result)
-        541   call 329 ntypeargs=0               (baml.json.stringify)
+  324   540   load_var 36                        (result)
+        541   call 331 ntypeargs=0               (baml.json.stringify)
         542   store_var 43                       (_146)
 
-  319   543   load_const 78                      ("claude-code")
+  321   543   load_const 78                      ("claude-code")
         544   load_var2 42 43                    
         545   init_instance 9                    (ai.errors.Refused .provider, .reason, .raw_body)
         546   throw                              
 
-  313   547   load_type 3                        
+  315   547   load_type 3                        
         548   load_var 37                        (exit)
         549   load_field 0                       (exit_code)
         550   call 138 ntypeargs=1               (baml.String.from)
         551   store_var 41                       (_136)
         552   jump +6                            (to 558)
 
-  291   553   load_var 29                        (p)
+  293   553   load_var 29                        (p)
         554   sys_op 251                         (baml.sys.Process.close)
         555   pop 1                              
 
-  227   556   load_var 33                        (_118)
+  229   556   load_var 33                        (_118)
         557   rethrow                            
 
-  310   558   load_const 79                      ("claude-code")
+  312   558   load_const 79                      ("claude-code")
         559   load_const 26                      (null)
 
-  313   560   load_const 80                      ("the Claude Code CLI exited with code ")
+  315   560   load_const 80                      ("the Claude Code CLI exited with code ")
         561   load_var 41                        (_136)
         562   bin_op +                           
         563   load_const 26                      (null)
@@ -6586,7 +6586,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 }
 
 function claude_code.internal.mcp_config_json(c: claude_code.ClaudeCodeClient) -> string | null {
-  207   0    load_var 1             (c)
+  209   0    load_var 1             (c)
         1    load_field 6           (mcp_servers)
         2    container_len          
         3    store_var 2            (_3)
@@ -6596,12 +6596,12 @@ function claude_code.internal.mcp_config_json(c: claude_code.ClaudeCodeClient) -
         7    pop_jump_if_false +2   (to 9)
         8    jump +18               (to 26)
 
-  210   9    load_type 1            
+  212   9    load_type 1            
         10   load_type 2            
         11   alloc_map 0            
         12   store_var 3            (wrapper)
 
-  211   13   load_type 1            
+  213   13   load_type 1            
         14   load_type 2            
         15   load_var 3             (wrapper)
         16   load_const 3           ("mcpServers")
@@ -6610,13 +6610,13 @@ function claude_code.internal.mcp_config_json(c: claude_code.ClaudeCodeClient) -
         19   call 37 ntypeargs=2    (baml.Map.set)
         20   pop 1                  
 
-  212   21   load_type 4            
+  214   21   load_type 4            
         22   load_var 3             (wrapper)
-        23   call 332 ntypeargs=1   (baml.json.to_json)
-        24   call 329 ntypeargs=0   (baml.json.stringify)
+        23   call 334 ntypeargs=1   (baml.json.to_json)
+        24   call 331 ntypeargs=0   (baml.json.stringify)
         25   jump +2                (to 27)
 
-  208   26   load_const 5           (null)
+  210   26   load_const 5           (null)
         27   return                 
 }
 
@@ -6626,7 +6626,7 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         2    store_var 3                        (catalog)
 
   100   3    load_var 1                         (tb)
-        4    call 822 ntypeargs=0               (ai.tools.Toolbox.list)
+        4    call 824 ntypeargs=0               (ai.tools.Toolbox.list)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -6656,8 +6656,8 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         30   load_type 6                        
         31   load_var 6                         (t)
         32   load_field 2                       (input_schema)
-        33   call 332 ntypeargs=1               (baml.json.to_json)
-        34   call 329 ntypeargs=0               (baml.json.stringify)
+        33   call 334 ntypeargs=1               (baml.json.to_json)
+        34   call 331 ntypeargs=0               (baml.json.stringify)
         35   store_var 10                       (_23)
         36   load_type 0                        
         37   load_var 10                        (_23)
@@ -6684,7 +6684,7 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         56   pop 1                              
         57   jump -48                           (to 9)
 
-  121   58   load_type 0                        
+  122   58   load_type 0                        
         59   load_var 3                         (catalog)
         60   load_const 11                      (", ")
         61   call 15 ntypeargs=1                (baml.Array.join)
@@ -6710,7 +6710,7 @@ function claude_code.internal.transcript_text(j: ai.Journal) -> string {
        2     store_var 2                        (lines)
 
   8    3     load_var 1                         (j)
-       4     call 806 ntypeargs=0               (ai.Journal.entries)
+       4     call 808 ntypeargs=0               (ai.Journal.entries)
        5     load_type 1                        
        6     load_const 2                       ("iter")
        7     virtual_call nargs=1 ntypeargs=0   
@@ -6849,8 +6849,8 @@ function claude_code.internal.transcript_text(j: ai.Journal) -> string {
        132   load_type 20                       
        133   load_var 18                        (c)
        134   load_field 2                       (args)
-       135   call 332 ntypeargs=1               (baml.json.to_json)
-       136   call 329 ntypeargs=0               (baml.json.stringify)
+       135   call 334 ntypeargs=1               (baml.json.to_json)
+       136   call 331 ntypeargs=0               (baml.json.stringify)
        137   store_var 22                       (_49)
        138   load_type 0                        
        139   load_var 22                        (_49)
@@ -6955,20 +6955,20 @@ function google.GoogleClient.ai.Client.id(self: google.GoogleClient) -> string {
 
 function google.GoogleClient.ai.Client.invoke(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   22   0   load_var2 1 2          
-       1   call 910 ntypeargs=0   (google.internal.invoke)
+       1   call 912 ntypeargs=0   (google.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   23   5   load_var 3             (e)
-       6   call 857 ntypeargs=0   (ai.errors.normalize)
+       6   call 859 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function google.GoogleClient.ai.stream.StreamingClient.invoke_stream(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   30   0   load_var2 1 2          
-       1   call 912 ntypeargs=0   (google.internal.invoke_stream)
+       1   call 914 ntypeargs=0   (google.internal.invoke_stream)
        2   return                 
 }
 
@@ -7095,7 +7095,7 @@ function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string 
         1    store_var 3                        (name)
 
   110   2    load_var 1                         (j)
-        3    call 806 ntypeargs=0               (ai.Journal.entries)
+        3    call 808 ntypeargs=0               (ai.Journal.entries)
         4    load_type 1                        
         5    load_const 2                       ("iter")
         6    virtual_call nargs=1 ntypeargs=0   
@@ -7166,7 +7166,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         2     store_var 3                        (out)
 
   368   3     load_var 1                         (batch)
-        4     call 848 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 850 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -7193,7 +7193,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
 
   370   27    load_type 7                        
         28    load_var 8                         (data)
-        29    call 334 ntypeargs=1               (baml.json.from_string)
+        29    call 336 ntypeargs=1               (baml.json.from_string)
         30    jump +4                            (to 34)
         31    load_var 9                         (e)
         32    throw_if_panic                     
@@ -7334,7 +7334,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         157   jump +2                            (to 159)
         158   load_const 8                       (null)
         159   load_const 8                       (null)
-        160   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        160   call 656 ntypeargs=0               (baml.ops.equals_equals)
         161   unary_op !                         
         162   store_var 24                       (blocked)
 
@@ -7405,14 +7405,14 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
 
   405   211   load_var 25                        (stop)
         212   load_const 8                       (null)
-        213   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        213   call 656 ntypeargs=0               (baml.ops.equals_equals)
         214   unary_op !                         
         215   jump_if_false +2                   (to 217)
         216   jump +6                            (to 222)
         217   pop 1                              
         218   load_var 26                        (usage)
         219   load_const 8                       (null)
-        220   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        220   call 656 ntypeargs=0               (baml.ops.equals_equals)
         221   unary_op !                         
         222   pop_jump_if_false -213             (to 9)
 
@@ -7464,11 +7464,11 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
         2     store_var 5                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 828 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 830 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 5                         (_5)
         7     call_indirect                      
 
-  227   8     call 904 ntypeargs=0               (google.internal.google_lower_prompt)
+  227   8     call 906 ntypeargs=0               (google.internal.google_lower_prompt)
         9     store_var 6                        (prompt_parts)
 
   228   10    load_var 6                         (prompt_parts)
@@ -7477,7 +7477,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   229   13    load_var 2                         (input)
         14    load_field 1                       (journal)
-        15    call 906 ntypeargs=0               (google.internal.google_lower_journal)
+        15    call 908 ntypeargs=0               (google.internal.google_lower_journal)
         16    load_type 0                        
         17    load_const 1                       ("iter")
         18    virtual_call nargs=1 ntypeargs=0   
@@ -7558,7 +7558,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
   239   84    load_const 12                      ("user")
         85    load_var 6                         (prompt_parts)
         86    load_field 0                       (system_parts)
-        87    call 901 ntypeargs=0               (google.internal._gm_content)
+        87    call 903 ntypeargs=0               (google.internal._gm_content)
         88    store_var 14                       (_29)
         89    load_type 5                        
         90    load_var 14                        (_29)
@@ -7578,7 +7578,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   250   103   load_var 2                         (input)
         104   load_field 2                       (toolbox)
-        105   call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        105   call 826 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         106   unary_op !                         
         107   pop_jump_if_false +104             (to 211)
 
@@ -7588,7 +7588,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   252   111   load_var 2                         (input)
         112   load_field 2                       (toolbox)
-        113   call 822 ntypeargs=0               (ai.tools.Toolbox.list)
+        113   call 824 ntypeargs=0               (ai.tools.Toolbox.list)
         114   load_type 14                       
         115   load_const 15                      ("iter")
         116   virtual_call nargs=1 ntypeargs=0   
@@ -7757,8 +7757,8 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   283   259   load_type 5                        
         260   load_var 11                        (body)
-        261   call 332 ntypeargs=1               (baml.json.to_json)
-        262   call 329 ntypeargs=0               (baml.json.stringify)
+        261   call 334 ntypeargs=1               (baml.json.to_json)
+        262   call 331 ntypeargs=0               (baml.json.stringify)
         263   store_var 33                       (_118)
 
   276   264   load_const 35                      ("POST")
@@ -7787,7 +7787,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         5     store_var 4                        (pending)
 
   141   6     load_var 1                         (j)
-        7     call 806 ntypeargs=0               (ai.Journal.entries)
+        7     call 808 ntypeargs=0               (ai.Journal.entries)
         8     load_type 1                        
         9     load_const 2                       ("iter")
         10    virtual_call nargs=1 ntypeargs=0   
@@ -7846,9 +7846,9 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   199   60    load_var2 1 36                     
         61    load_field 0                       (id)
-        62    call 905 ntypeargs=0               (google.internal._gm_tool_name_for)
+        62    call 907 ntypeargs=0               (google.internal._gm_tool_name_for)
         63    load_var 37                        (response)
-        64    call 903 ntypeargs=0               (google.internal._gm_function_response)
+        64    call 905 ntypeargs=0               (google.internal._gm_function_response)
         65    store_var 38                       (_91)
         66    load_type 0                        
         67    load_var2 4 38                     
@@ -7875,9 +7875,9 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   193   85    load_var2 1 32                     
         86    load_field 0                       (id)
-        87    call 905 ntypeargs=0               (google.internal._gm_tool_name_for)
+        87    call 907 ntypeargs=0               (google.internal._gm_tool_name_for)
         88    load_var 33                        (response)
-        89    call 903 ntypeargs=0               (google.internal._gm_function_response)
+        89    call 905 ntypeargs=0               (google.internal._gm_function_response)
         90    store_var 34                       (_78)
         91    load_type 0                        
         92    load_var2 4 34                     
@@ -7898,7 +7898,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   156   105   load_const 15                      ("user")
         106   load_var 4                         (pending)
-        107   call 901 ntypeargs=0               (google.internal._gm_content)
+        107   call 903 ntypeargs=0               (google.internal._gm_content)
         108   store_var 17                       (_29)
         109   load_type 0                        
         110   load_var2 3 17                     
@@ -7991,7 +7991,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
         186   store_var_load_var 23              (t)
 
   166   187   load_field 0                       (text)
-        188   call 902 ntypeargs=0               (google.internal._gm_text_part)
+        188   call 904 ntypeargs=0               (google.internal._gm_text_part)
         189   store_var 24                       (_42)
         190   load_type 0                        
         191   load_var2 18 24                    
@@ -8009,7 +8009,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   183   202   load_const 25                      ("model")
         203   load_var 18                        (parts)
-        204   call 901 ntypeargs=0               (google.internal._gm_content)
+        204   call 903 ntypeargs=0               (google.internal._gm_content)
         205   store_var 30                       (_67)
         206   load_type 0                        
         207   load_var2 3 30                     
@@ -8030,7 +8030,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   145   220   load_const 26                      ("user")
         221   load_var 4                         (pending)
-        222   call 901 ntypeargs=0               (google.internal._gm_content)
+        222   call 903 ntypeargs=0               (google.internal._gm_content)
         223   store_var 11                       (_15)
         224   load_type 0                        
         225   load_var2 3 11                     
@@ -8043,13 +8043,13 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   151   231   load_var 9                         (u)
         232   load_field 0                       (content)
-        233   call 902 ntypeargs=0               (google.internal._gm_text_part)
+        233   call 904 ntypeargs=0               (google.internal._gm_text_part)
         234   store_var 13                       (_21)
         235   load_const 27                      ("user")
         236   load_var 13                        (_21)
         237   load_type 0                        
         238   alloc_array 1                      
-        239   call 901 ntypeargs=0               (google.internal._gm_content)
+        239   call 903 ntypeargs=0               (google.internal._gm_content)
         240   store_var 12                       (_19)
         241   load_type 0                        
         242   load_var2 3 12                     
@@ -8067,7 +8067,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unkn
 
   206   253   load_const 28                      ("user")
         254   load_var 4                         (pending)
-        255   call 901 ntypeargs=0               (google.internal._gm_content)
+        255   call 903 ntypeargs=0               (google.internal._gm_content)
         256   store_var 40                       (_99)
         257   load_type 0                        
         258   load_var2 3 40                     
@@ -8093,7 +8093,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
         7    store_var 4                        (first_role)
 
   82    8    load_var 1                         (prompt)
-        9    call 810 ntypeargs=0               (ai.Prompt.messages)
+        9    call 812 ntypeargs=0               (ai.Prompt.messages)
         10   load_type 2                        
         11   load_const 3                       ("iter")
         12   virtual_call nargs=1 ntypeargs=0   
@@ -8111,7 +8111,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
         24   store_var_load_var 7               (message)
 
   83    25   load_field 1                       (content)
-        26   call 902 ntypeargs=0               (google.internal._gm_text_part)
+        26   call 904 ntypeargs=0               (google.internal._gm_text_part)
         27   store_var 8                        (part)
 
   84    28   load_var 7                         (message)
@@ -8147,7 +8147,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt) -> google.intern
   99    51   load_var2 9 8                      
         52   load_type 0                        
         53   alloc_array 1                      
-        54   call 901 ntypeargs=0               (google.internal._gm_content)
+        54   call 903 ntypeargs=0               (google.internal._gm_content)
         55   store_var 10                       (_24)
         56   load_type 0                        
         57   load_var2 3 10                     
@@ -8377,7 +8377,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         184   jump +2                            (to 186)
         185   load_const 3                       (null)
         186   load_const 3                       (null)
-        187   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        187   call 656 ntypeargs=0               (baml.ops.equals_equals)
         188   unary_op !                         
         189   store_var 25                       (blocked)
 
@@ -8489,35 +8489,35 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
 function google.internal.google_render(c: google.GoogleClient, input: ai.ModelTurnInput) -> baml.http.Request {
   216   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 908 ntypeargs=0   (google.internal._google_request)
+        2   call 910 ntypeargs=0   (google.internal._google_request)
         3   return                 
 }
 
 function google.internal.invoke(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   351   0    load_var 2             (input)
         1    load_field 1           (journal)
-        2    call 806 ntypeargs=0   (ai.Journal.entries)
+        2    call 808 ntypeargs=0   (ai.Journal.entries)
         3    container_len          
         4    store_var 3            (seq)
 
   352   5    load_var2 1 2          
-        6    call 907 ntypeargs=0   (google.internal.google_render)
+        6    call 909 ntypeargs=0   (google.internal.google_render)
         7    store_var 4            (req)
 
   353   8    load_type 0            
         9    load_var 4             (req)
         10   load_const 1           ("google")
-        11   call 827 ntypeargs=1   (ai.wire.send_as)
+        11   call 829 ntypeargs=1   (ai.wire.send_as)
 
   354   12   load_var 3             (seq)
-        13   call 909 ntypeargs=0   (google.internal.google_parse)
+        13   call 911 ntypeargs=0   (google.internal.google_parse)
         14   return                 
 }
 
 function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   432   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 908 ntypeargs=0   (google.internal._google_request)
+        2    call 910 ntypeargs=0   (google.internal._google_request)
 
   433   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -8543,7 +8543,7 @@ function google.internal.invoke_stream(c: google.GoogleClient, input: ai.ModelTu
         21   throw                  
 
   442   22   load_const 6           (google.internal._google_decode_batch)
-        23   call 849 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 851 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -8563,20 +8563,20 @@ function openai.OpenAiClient.ai.Client.id(self: openai.OpenAiClient) -> string {
 
 function openai.OpenAiClient.ai.Client.invoke(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   62   0   load_var2 1 2          
-       1   call 880 ntypeargs=0   (openai.internal.invoke)
+       1   call 882 ntypeargs=0   (openai.internal.invoke)
        2   jump +6                (to 8)
        3   load_var 3             (e)
        4   throw_if_panic         
 
   63   5   load_var 3             (e)
-       6   call 857 ntypeargs=0   (ai.errors.normalize)
+       6   call 859 ntypeargs=0   (ai.errors.normalize)
        7   throw                  
        8   return                 
 }
 
 function openai.OpenAiClient.ai.stream.StreamingClient.invoke_stream(self: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   70   0   load_var2 1 2          
-       1   call 882 ntypeargs=0   (openai.internal.invoke_stream)
+       1   call 884 ntypeargs=0   (openai.internal.invoke_stream)
        2   return                 
 }
 
@@ -8705,7 +8705,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         2     store_var 3                        (out)
 
   255   3     load_var 1                         (batch)
-        4     call 848 ntypeargs=0               (ai.stream.decode_sse_batch)
+        4     call 850 ntypeargs=0               (ai.stream.decode_sse_batch)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -8732,7 +8732,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
 
   257   27    load_type 7                        
         28    load_var 8                         (data)
-        29    call 334 ntypeargs=1               (baml.json.from_string)
+        29    call 336 ntypeargs=1               (baml.json.from_string)
         30    jump +4                            (to 34)
         31    load_var 9                         (e)
         32    throw_if_panic                     
@@ -8799,7 +8799,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         87    load_var 17                        (_39)
         88    store_var_load_var 18              (r)
 
-  272   89    call 879 ntypeargs=0               (openai.internal.openai_parse)
+  272   89    call 881 ntypeargs=0               (openai.internal.openai_parse)
         90    store_var 19                       (turn)
 
   275   91    load_var 19                        (turn)
@@ -8877,16 +8877,16 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         2     store_var 5                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 828 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 830 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 5                         (_5)
         7     call_indirect                      
 
-  129   8     call 875 ntypeargs=0               (openai.internal.openai_lower_prompt)
+  129   8     call 877 ntypeargs=0               (openai.internal.openai_lower_prompt)
         9     store_var 6                        (items)
 
   130   10    load_var 2                         (input)
         11    load_field 1                       (journal)
-        12    call 876 ntypeargs=0               (openai.internal.openai_lower_journal)
+        12    call 878 ntypeargs=0               (openai.internal.openai_lower_journal)
         13    load_type 0                        
         14    load_const 1                       ("iter")
         15    virtual_call nargs=1 ntypeargs=0   
@@ -8941,7 +8941,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   137   59    load_var 2                         (input)
         60    load_field 2                       (toolbox)
-        61    call 824 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        61    call 826 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         62    unary_op !                         
         63    pop_jump_if_false +83              (to 146)
 
@@ -8951,7 +8951,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   139   67    load_var 2                         (input)
         68    load_field 2                       (toolbox)
-        69    call 822 ntypeargs=0               (ai.tools.Toolbox.list)
+        69    call 824 ntypeargs=0               (ai.tools.Toolbox.list)
         70    load_type 12                       
         71    load_const 13                      ("iter")
         72    virtual_call nargs=1 ntypeargs=0   
@@ -9050,7 +9050,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         154   pop 1                              
 
   162   155   load_var 1                         (c)
-        156   call 871 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
+        156   call 873 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
         157   store_var 18                       (_78)
         158   load_var 18                        (_78)
         159   store_var 17                       (_77)
@@ -9066,7 +9066,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
         169   store_var 16                       (_76)
 
   163   170   load_var 1                         (c)
-        171   call 870 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
+        171   call 872 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
         172   store_var 20                       (_84)
         173   load_type 6                        
         174   load_var 20                        (_84)
@@ -9075,8 +9075,8 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   164   177   load_type 5                        
         178   load_var 10                        (body)
-        179   call 332 ntypeargs=1               (baml.json.to_json)
-        180   call 329 ntypeargs=0               (baml.json.stringify)
+        179   call 334 ntypeargs=1               (baml.json.to_json)
+        180   call 331 ntypeargs=0               (baml.json.stringify)
         181   store_var 21                       (_86)
 
   160   182   load_const 29                      ("POST")
@@ -9103,22 +9103,22 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
 function openai.internal.invoke(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   231   0   load_var2 1 2          
-        1   call 877 ntypeargs=0   (openai.internal.openai_render)
+        1   call 879 ntypeargs=0   (openai.internal.openai_render)
         2   store_var 3            (req)
 
   232   3   load_type 0            
         4   load_var 3             (req)
         5   load_const 1           ("openai")
-        6   call 827 ntypeargs=1   (ai.wire.send_as)
+        6   call 829 ntypeargs=1   (ai.wire.send_as)
 
-  233   7   call 879 ntypeargs=0   (openai.internal.openai_parse)
+  233   7   call 881 ntypeargs=0   (openai.internal.openai_parse)
         8   return                 
 }
 
 function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   304   0    load_var2 1 2          
         1    load_const 0           (true)
-        2    call 878 ntypeargs=0   (openai.internal._openai_request)
+        2    call 880 ntypeargs=0   (openai.internal._openai_request)
 
   305   3    sys_op 232             (baml.http.fetch_sse)
         4    jump +18               (to 22)
@@ -9144,7 +9144,7 @@ function openai.internal.invoke_stream(c: openai.OpenAiClient, input: ai.ModelTu
         21   throw                  
 
   314   22   load_const 6           (openai.internal._openai_decode_batch)
-        23   call 849 ntypeargs=0   (ai.stream.TurnStream.from_sse)
+        23   call 851 ntypeargs=0   (ai.stream.TurnStream.from_sse)
         24   return                 
 }
 
@@ -9154,7 +9154,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
         2     store_var 3                        (items)
 
   58    3     load_var 1                         (j)
-        4     call 806 ntypeargs=0               (ai.Journal.entries)
+        4     call 808 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -9235,8 +9235,8 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
 
   106   76    load_type 0                        
         77    load_var 27                        (err)
-        78    call 332 ntypeargs=1               (baml.json.to_json)
-        79    call 329 ntypeargs=0               (baml.json.stringify)
+        78    call 334 ntypeargs=1               (baml.json.to_json)
+        79    call 331 ntypeargs=0               (baml.json.stringify)
         80    store_var 29                       (_100)
         81    load_type 10                       
         82    load_type 11                       
@@ -9360,8 +9360,8 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> map<string, unkn
   82    185   load_type 0                        
         186   load_var 19                        (use)
         187   load_field 2                       (args)
-        188   call 332 ntypeargs=1               (baml.json.to_json)
-        189   call 329 ntypeargs=0               (baml.json.stringify)
+        188   call 334 ntypeargs=1               (baml.json.to_json)
+        189   call 331 ntypeargs=0               (baml.json.stringify)
         190   store_var 21                       (_58)
         191   load_type 10                       
         192   load_type 11                       
@@ -9451,7 +9451,7 @@ function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> map<string, u
        2    store_var 3                        (items)
 
   38   3    load_var 1                         (prompt)
-       4    call 810 ntypeargs=0               (ai.Prompt.messages)
+       4    call 812 ntypeargs=0               (ai.Prompt.messages)
        5    load_type 1                        
        6    load_const 2                       ("iter")
        7    virtual_call nargs=1 ntypeargs=0   
@@ -9702,7 +9702,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
 
   177   153   load_type 25                       
         154   load_var 9                         (s)
-        155   call 334 ntypeargs=1               (baml.json.from_string)
+        155   call 336 ntypeargs=1               (baml.json.from_string)
         156   store_var 7                        (args)
 
   180   157   load_var 6                         (item)
@@ -9807,7 +9807,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
 function openai.internal.openai_render(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> baml.http.Request {
   118   0   load_var2 1 2          
         1   load_const 0           (false)
-        2   call 878 ntypeargs=0   (openai.internal._openai_request)
+        2   call 880 ntypeargs=0   (openai.internal._openai_request)
         3   return                 
 }
 
@@ -9824,7 +9824,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  104   0   make_closure 1612 0   
+  104   0   make_closure 1614 0   
         1   store_var 1           (_0)
         2   load_var 1            (_0)
         3   return                
@@ -9851,7 +9851,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   76   16   load_var 1             (threshold)
-       17   make_closure 1607 1    
+       17   make_closure 1609 1    
        18   store_var 2            (_0)
        19   load_var 2             (_0)
        20   return                 
@@ -9892,7 +9892,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 1591 2    
+       29   make_closure 1593 2    
        30   store_var 3            (_0)
        31   load_var 3             (_0)
        32   return                 
@@ -9913,14 +9913,14 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   42   10   load_var 1             (max_attempts)
-       11   make_closure 1601 1    
+       11   make_closure 1603 1    
        12   store_var 2            (_0)
        13   load_var 2             (_0)
        14   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  98   0   make_closure 1610 0   
+  98   0   make_closure 1612 0   
        1   store_var 1           (_0)
        2   load_var 1            (_0)
        3   return                
@@ -10136,7 +10136,7 @@ function testing.TestCollector.register_test_at(self: testing.TestCollector, own
 
   107   6   load_var2 6 3          
         7   load_var2 4 5          
-        8   call 743 ntypeargs=0   (testing.TestCollector.register_test)
+        8   call 745 ntypeargs=0   (testing.TestCollector.register_test)
         9   return                 
 }
 
@@ -10269,7 +10269,7 @@ function testing.TestCollector.register_test_set_at(self: testing.TestCollector,
 
   118   6   load_var2 6 3          
         7   load_var2 4 5          
-        8   call 744 ntypeargs=0   (testing.TestCollector.register_test_set)
+        8   call 746 ntypeargs=0   (testing.TestCollector.register_test_set)
         9   return                 
 }
 
@@ -10299,11 +10299,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   290   22   load_var2 1 5                      
-        23   call 759 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 761 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   291   25   load_var 1                         (self)
-        26   call 751 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 753 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   295   28   load_type 5                        
@@ -10340,7 +10340,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   298   58   load_var2 9 2                      
-        59   call 758 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 760 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   301   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -10363,7 +10363,7 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         10   pop_jump_if_false +2   (to 12)
         11   jump +53               (to 64)
 
-  308   12   sys_op 521             (baml.time.Instant.now)
+  308   12   sys_op 523             (baml.time.Instant.now)
         13   store_var 5            (start)
 
   309   14   load_var 2             (ts)
@@ -10381,8 +10381,8 @@ function testing.TestRegistry.expand_testset_registry(self: testing.TestRegistry
         25   pop 1                  
 
   315   26   load_var 5             (start)
-        27   call 522 ntypeargs=0   (baml.time.Instant.elapsed)
-        28   call 509 ntypeargs=0   (baml.time.Duration.to_milliseconds)
+        27   call 524 ntypeargs=0   (baml.time.Instant.elapsed)
+        28   call 511 ntypeargs=0   (baml.time.Duration.to_milliseconds)
         29   call 92 ntypeargs=0    (baml.Bigint.to_int)
         30   store_var 7            (elapsed)
         31   jump +15               (to 46)
@@ -10434,7 +10434,7 @@ function testing.TestRegistry.list_filtered(self: testing.TestRegistry, profile_
   281   0   load_var2 1 2          
         1   load_var2 3 4          
         2   load_var 5             (cli_exclude)
-        3   call 779 ntypeargs=0   (testing.select_names_layered)
+        3   call 781 ntypeargs=0   (testing.select_names_layered)
         4   return                 
 }
 
@@ -10452,9 +10452,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   237   0   load_var 1             (self)
-        1   call 760 ntypeargs=0   (testing.testset_children)
+        1   call 762 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 770 ntypeargs=0   (testing.run_testset)
+        3   call 772 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -10462,7 +10462,7 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
   259   0    load_var2 1 2          
         1    load_var2 3 4          
         2    load_var 5             (cli_exclude)
-        3    call 779 ntypeargs=0   (testing.select_names_layered)
+        3    call 781 ntypeargs=0   (testing.select_names_layered)
         4    store_var 6            (selected_names)
 
   261   5    load_var 2             (profile_include)
@@ -10505,22 +10505,22 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
         36   jump +4                (to 40)
 
   268   37   load_var2 1 6          
-        38   call 755 ntypeargs=0   (testing.TestRegistry.run_selected)
+        38   call 757 ntypeargs=0   (testing.TestRegistry.run_selected)
         39   jump +3                (to 42)
 
   266   40   load_var 1             (self)
-        41   call 754 ntypeargs=0   (testing.TestRegistry.run_all)
+        41   call 756 ntypeargs=0   (testing.TestRegistry.run_all)
 
   270   42   load_var 6             (selected_names)
-        43   call 785 ntypeargs=0   (testing.flatten_with_tolerated)
+        43   call 787 ntypeargs=0   (testing.flatten_with_tolerated)
         44   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   241   0   load_var2 1 2          
-        1   call 761 ntypeargs=0   (testing.testset_children_selected)
+        1   call 763 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 770 ntypeargs=0   (testing.run_testset)
+        3   call 772 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -10553,7 +10553,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 769 ntypeargs=0               (testing.run_test)
+        26   call 771 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   211   28   load_type 5                        
@@ -10590,7 +10590,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   215   58   load_var2 9 2                      
-        59   call 752 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 754 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   218   61   load_const 12                      ("Test not found: ")
@@ -10625,11 +10625,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   224   22   load_var2 1 5                      
-        23   call 759 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 760 ntypeargs=0               (testing.testset_children)
+        23   call 761 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 762 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 770 ntypeargs=0               (testing.run_testset)
+        27   call 772 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   227   29   load_type 5                        
@@ -10666,7 +10666,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   230   59   load_var2 9 2                      
-        60   call 753 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 755 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   233   62   load_const 12                      ("TestSet not found: ")
@@ -10760,7 +10760,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         73   store_var 12                       (_28)
 
   189   74   load_var 11                        (sub)
-        75   call 751 ntypeargs=0               (testing.TestRegistry.serialize)
+        75   call 753 ntypeargs=0               (testing.TestRegistry.serialize)
         76   store_var 13                       (_29)
 
   186   77   load_type 0                        
@@ -10934,7 +10934,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   441   60    load_var 13                        (outcome)
         61    load_const 10                      ("pass")
-        62    call 654 ntypeargs=0               (baml.ops.equals_equals)
+        62    call 656 ntypeargs=0               (baml.ops.equals_equals)
         63    pop_jump_if_false +2               (to 65)
         64    jump +60                           (to 124)
 
@@ -11002,7 +11002,7 @@ function testing.aggregate_reports(named_results: testing.NamedChildReport[]) ->
 
   458   117   load_var 13                        (outcome)
         118   load_const 16                      ("error")
-        119   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        119   call 656 ntypeargs=0               (baml.ops.equals_equals)
         120   pop_jump_if_false -100             (to 20)
 
   459   121   load_const 17                      (true)
@@ -11080,7 +11080,7 @@ function testing.any_pattern_matches(pats: string[], canonical_id: string) -> bo
         15   store_var 5                        (p)
 
   608   16   load_var2 2 5                      
-        17   call 772 ntypeargs=0               (testing.glob_match)
+        17   call 774 ntypeargs=0               (testing.glob_match)
         18   pop_jump_if_false -13              (to 5)
 
   609   19   load_const 5                       (true)
@@ -11118,7 +11118,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         23   store_var_load_var 8               (name)
 
   949   24   load_var 3                         (all_failed_names)
-        25   call 788 ntypeargs=0               (testing.failure_matches_selected)
+        25   call 790 ntypeargs=0               (testing.failure_matches_selected)
         26   pop_jump_if_false +2               (to 28)
         27   jump +8                            (to 35)
 
@@ -11131,7 +11131,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         34   jump -21                           (to 13)
 
   950   35   load_var2 8 2                      
-        36   call 788 ntypeargs=0               (testing.failure_matches_selected)
+        36   call 790 ntypeargs=0               (testing.failure_matches_selected)
         37   pop_jump_if_false +2               (to 39)
         38   jump +8                            (to 46)
 
@@ -11177,7 +11177,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          16   store_var_load_var 6               (name)
 
   1050   17   load_var 2                         (out)
-         18   call 787 ntypeargs=0               (testing.name_in)
+         18   call 789 ntypeargs=0               (testing.name_in)
          19   unary_op !                         
          20   pop_jump_if_false -14              (to 6)
 
@@ -11212,7 +11212,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          47   store_var_load_var 10              (nested)
 
   1057   48   load_var 2                         (out)
-         49   call 790 ntypeargs=0               (testing.collect_all_failed_names)
+         49   call 792 ntypeargs=0               (testing.collect_all_failed_names)
          50   pop 1                              
          51   jump -19                           (to 32)
 
@@ -11292,7 +11292,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
          57    load_var 15             (nested)
          58    load_field 0            (outcome)
          59    load_const 3            ("pass")
-         60    call 654 ntypeargs=0    (baml.ops.equals_equals)
+         60    call 656 ntypeargs=0    (baml.ops.equals_equals)
          61    store_var 16            (nested_tolerated)
 
   1015   62    load_var 15             (nested)
@@ -11317,7 +11317,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
          79    store_var_load_var 18   (sentinel)
 
   1024   80    load_var 3              (selected_names)
-         81    call 787 ntypeargs=0    (testing.name_in)
+         81    call 789 ntypeargs=0    (testing.name_in)
          82    pop_jump_if_false +2    (to 84)
          83    jump +21                (to 104)
 
@@ -11372,7 +11372,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
   1017   123   load_var2 15 16         
 
   1018   124   load_var2 3 4           
-         125   call 789 ntypeargs=0    (testing.collect_leaf_identities)
+         125   call 791 ntypeargs=0    (testing.collect_leaf_identities)
          126   pop 1                   
          127   jump +31                (to 158)
 
@@ -11381,7 +11381,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
 
   1005   130   load_field 0            (outcome)
          131   load_const 7            ("pass")
-         132   call 654 ntypeargs=0    (baml.ops.equals_equals)
+         132   call 656 ntypeargs=0    (baml.ops.equals_equals)
          133   pop_jump_if_false +2    (to 135)
          134   jump +18                (to 152)
 
@@ -11451,7 +11451,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   1077   24   load_field 5                       (results)
          25   load_var 2                         (out)
-         26   call 791 ntypeargs=0               (testing.collect_leaf_messages)
+         26   call 793 ntypeargs=0               (testing.collect_leaf_messages)
          27   pop 1                              
          28   jump -23                           (to 5)
 
@@ -11477,7 +11477,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   1069   47   load_field 0                       (outcome)
          48   load_const 10                      ("pass")
-         49   call 654 ntypeargs=0               (baml.ops.equals_equals)
+         49   call 656 ntypeargs=0               (baml.ops.equals_equals)
          50   unary_op !                         
          51   pop_jump_if_false -15              (to 36)
 
@@ -11553,7 +11553,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         44   store_var 9                        (ts)
 
   749   45   load_var2 1 9                      
-        46   call 782 ntypeargs=0               (testing.collect_subtree_names)
+        46   call 784 ntypeargs=0               (testing.collect_subtree_names)
         47   load_type 10                       
         48   load_const 11                      ("iter")
         49   virtual_call nargs=1 ntypeargs=0   
@@ -11584,8 +11584,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   762   0    load_var2 1 2          
-        1    call 759 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 781 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 761 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 783 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +91               (to 94)
         4    load_var 3             (e)
         5    store_var 4            (_5)
@@ -11687,11 +11687,11 @@ function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testi
 
 function testing.collect_subtree_names_layered(registry: testing.TestRegistry, ts: testing.TestSetRegistration, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> string[] {
   778   0     load_var2 1 2           
-        1     call 759 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
+        1     call 761 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
 
   777   2     load_var2 3 4           
         3     load_var2 5 6           
-        4     call 779 ntypeargs=0    (testing.select_names_layered)
+        4     call 781 ntypeargs=0    (testing.select_names_layered)
         5     jump +111               (to 116)
         6     load_var 7              (e)
         7     store_var 8             (_9)
@@ -11774,7 +11774,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   805   83    load_var2 3 4           
         84    load_var2 5 6           
-        85    call 775 ntypeargs=0    (testing.leaf_selected_layered)
+        85    call 777 ntypeargs=0    (testing.leaf_selected_layered)
 
   803   86    pop_jump_if_false +2    (to 88)
         87    jump +4                 (to 91)
@@ -11798,7 +11798,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
 
   789   100   load_var2 3 4           
         101   load_var2 5 6           
-        102   call 775 ntypeargs=0    (testing.leaf_selected_layered)
+        102   call 777 ntypeargs=0    (testing.leaf_selected_layered)
 
   787   103   pop_jump_if_false +2    (to 105)
         104   jump +4                 (to 108)
@@ -11869,7 +11869,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
         37    load_var 13                        (tsr)
         38    load_field 0                       (outcome)
         39    load_const 7                       ("pass")
-        40    call 654 ntypeargs=0               (baml.ops.equals_equals)
+        40    call 656 ntypeargs=0               (baml.ops.equals_equals)
         41    store_var 14                       (ft)
 
   855   42    load_var 13                        (tsr)
@@ -11917,7 +11917,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   856   74    load_var 13                        (tsr)
         75    load_field 5                       (results)
         76    load_var 14                        (ft)
-        77    call 784 ntypeargs=0               (testing.count_leaves)
+        77    call 786 ntypeargs=0               (testing.count_leaves)
         78    store_var 10                       (delta)
         79    jump +31                           (to 110)
 
@@ -11926,7 +11926,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
 
   845   82    load_field 0                       (outcome)
         83    load_const 8                       ("pass")
-        84    call 654 ntypeargs=0               (baml.ops.equals_equals)
+        84    call 656 ntypeargs=0               (baml.ops.equals_equals)
         85    pop_jump_if_false +2               (to 87)
         86    jump +18                           (to 104)
 
@@ -12012,7 +12012,7 @@ function testing.expansion_error_report(name: string) -> testing.TestSetReport {
 
 function testing.failure_matches_selected(selected: string, failed_names: string[]) -> bool {
   972   0    load_var2 1 2                      
-        1    call 787 ntypeargs=0               (testing.name_in)
+        1    call 789 ntypeargs=0               (testing.name_in)
         2    pop_jump_if_false +2               (to 4)
         3    jump +43                           (to 46)
 
@@ -12073,7 +12073,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   887   0     load_var 1             (report)
         1     load_field 0           (outcome)
         2     load_const 0           ("pass")
-        3     call 654 ntypeargs=0   (baml.ops.equals_equals)
+        3     call 656 ntypeargs=0   (baml.ops.equals_equals)
         4     store_var 3            (top_tolerated)
 
   888   5     load_var 1             (report)
@@ -12121,7 +12121,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   889   37    load_var 1             (report)
         38    load_field 5           (results)
         39    load_var 3             (top_tolerated)
-        40    call 784 ntypeargs=0   (testing.count_leaves)
+        40    call 786 ntypeargs=0   (testing.count_leaves)
         41    store_var 4            (counts)
 
   905   42    load_type 2            
@@ -12131,7 +12131,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   906   45    load_var 1             (report)
         46    load_field 5           (results)
         47    load_var 6             (messages)
-        48    call 791 ntypeargs=0   (testing.collect_leaf_messages)
+        48    call 793 ntypeargs=0   (testing.collect_leaf_messages)
         49    pop 1                  
 
   907   50    load_type 2            
@@ -12139,7 +12139,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
         52    store_var 7            (all_failed_names)
 
   908   53    load_var2 1 7          
-        54    call 790 ntypeargs=0   (testing.collect_all_failed_names)
+        54    call 792 ntypeargs=0   (testing.collect_all_failed_names)
         55    pop 1                  
 
   909   56    load_type 2            
@@ -12153,7 +12153,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
 
   910   64    load_var2 1 3          
         65    load_var2 2 8          
-        66    call 789 ntypeargs=0   (testing.collect_leaf_identities)
+        66    call 791 ntypeargs=0   (testing.collect_leaf_identities)
         67    pop 1                  
 
   916   68    load_var 8             (executed)
@@ -12211,7 +12211,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   922   112   load_var2 2 1          
         113   load_field 4           (failed_names)
         114   load_var 7             (all_failed_names)
-        115   call 786 ntypeargs=0   (testing.classify_selected_names)
+        115   call 788 ntypeargs=0   (testing.classify_selected_names)
         116   store_var 9            (identities)
         117   jump +3                (to 120)
 
@@ -12372,14 +12372,14 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
   577   98    load_var2 1 2           
         99    call 155 ntypeargs=0    (baml.String.index_of)
         100   load_const 6            (null)
-        101   call 654 ntypeargs=0    (baml.ops.equals_equals)
+        101   call 656 ntypeargs=0    (baml.ops.equals_equals)
         102   unary_op !              
         103   return                  
 }
 
 function testing.leaf_selected(name: string, include: string[], exclude: string[]) -> bool {
   618   0    load_var2 3 1          
-        1    call 773 ntypeargs=0   (testing.any_pattern_matches)
+        1    call 775 ntypeargs=0   (testing.any_pattern_matches)
         2    pop_jump_if_false +2   (to 4)
         3    jump +14               (to 17)
 
@@ -12393,7 +12393,7 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
         11   jump +4                (to 15)
 
   624   12   load_var2 2 1          
-        13   call 773 ntypeargs=0   (testing.any_pattern_matches)
+        13   call 775 ntypeargs=0   (testing.any_pattern_matches)
         14   jump +4                (to 18)
 
   622   15   load_const 1           (true)
@@ -12406,13 +12406,13 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
 function testing.leaf_selected_layered(name: string, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> bool {
   637   0   load_var2 1 2          
         1   load_var 3             (profile_exclude)
-        2   call 774 ntypeargs=0   (testing.leaf_selected)
+        2   call 776 ntypeargs=0   (testing.leaf_selected)
         3   jump_if_false +5       (to 8)
         4   pop 1                  
 
   638   5   load_var2 1 4          
         6   load_var 5             (cli_exclude)
-        7   call 774 ntypeargs=0   (testing.leaf_selected)
+        7   call 776 ntypeargs=0   (testing.leaf_selected)
         8   return                 
 }
 
@@ -12512,7 +12512,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   486   25   load_var 5                         (child)
-        26   make_closure 1492 1                
+        26   make_closure 1494 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   load_type 7                        
@@ -12528,10 +12528,10 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
   490   38   load_type 7                        
         39   load_type 8                        
         40   load_var 2                         (futures)
-        41   call 483 ntypeargs=2               (baml.future.all_complete)
+        41   call 485 ntypeargs=2               (baml.future.all_complete)
         42   await                              
 
-  491   43   call 767 ntypeargs=0               (testing.aggregate_reports)
+  491   43   call 769 ntypeargs=0               (testing.aggregate_reports)
         44   return                             
 }
 
@@ -12595,16 +12595,16 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         48   pop 1                              
         49   load_var 8                         (outcome)
         50   load_const 7                       ("pass")
-        51   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        51   call 656 ntypeargs=0               (baml.ops.equals_equals)
         52   unary_op !                         
         53   pop_jump_if_false -45              (to 8)
 
   119   54   load_var 3                         (named_results)
-        55   call 767 ntypeargs=0               (testing.aggregate_reports)
+        55   call 769 ntypeargs=0               (testing.aggregate_reports)
         56   jump +3                            (to 59)
 
   124   57   load_var 3                         (named_results)
-        58   call 767 ntypeargs=0               (testing.aggregate_reports)
+        58   call 769 ntypeargs=0               (testing.aggregate_reports)
         59   return                             
 }
 
@@ -12614,7 +12614,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   496   3    load_var 1             (body)
-        4    make_closure 1504 1    
+        4    make_closure 1506 1    
         5    store_var 3            (base_run)
 
   527   6    load_var 2             (runner)
@@ -12650,7 +12650,7 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         9    jump +3                (to 12)
 
   539   10   load_var 1             (children)
-        11   call 768 ntypeargs=0   (testing.run_children_parallel)
+        11   call 770 ntypeargs=0   (testing.run_children_parallel)
         12   return                 
 }
 
@@ -12661,7 +12661,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         3   load_type 0            
         4   alloc_array 0          
         5   load_var2 2 3          
-        6   call 779 ntypeargs=0   (testing.select_names_layered)
+        6   call 781 ntypeargs=0   (testing.select_names_layered)
         7   return                 
 }
 
@@ -12692,7 +12692,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
   704   21   load_field 0                       (name)
         22   load_var2 2 3                      
         23   load_var2 4 5                      
-        24   call 775 ntypeargs=0               (testing.leaf_selected_layered)
+        24   call 777 ntypeargs=0               (testing.leaf_selected_layered)
 
   702   25   pop_jump_if_false -15              (to 10)
 
@@ -12724,14 +12724,14 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   718   50   load_field 0                       (name)
         51   load_var2 2 3                      
-        52   call 778 ntypeargs=0               (testing.subtree_may_be_selected)
+        52   call 780 ntypeargs=0               (testing.subtree_may_be_selected)
         53   jump_if_false +6                   (to 59)
         54   pop 1                              
 
   719   55   load_var 13                        (ts)
         56   load_field 0                       (name)
         57   load_var2 4 5                      
-        58   call 778 ntypeargs=0               (testing.subtree_may_be_selected)
+        58   call 780 ntypeargs=0               (testing.subtree_may_be_selected)
 
   717   59   pop_jump_if_false -20              (to 39)
 
@@ -12739,7 +12739,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   723   61   load_var2 2 3                      
         62   load_var2 4 5                      
-        63   call 783 ntypeargs=0               (testing.collect_subtree_names_layered)
+        63   call 785 ntypeargs=0               (testing.collect_subtree_names_layered)
 
   729   64   load_type 10                       
         65   load_const 11                      ("iter")
@@ -12796,13 +12796,13 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         21   load_const 6                       ("*")
         22   call 155 ntypeargs=0               (baml.String.index_of)
         23   load_const 7                       (null)
-        24   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        24   call 656 ntypeargs=0               (baml.ops.equals_equals)
         25   jump_if_false +7                   (to 32)
         26   pop 1                              
         27   load_var2 3 6                      
         28   call 155 ntypeargs=0               (baml.String.index_of)
         29   load_const 7                       (null)
-        30   call 654 ntypeargs=0               (baml.ops.equals_equals)
+        30   call 656 ntypeargs=0               (baml.ops.equals_equals)
         31   unary_op !                         
         32   pop_jump_if_false +2               (to 34)
         33   jump +11                           (to 44)
@@ -12813,7 +12813,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         37   jump_if_false +4                   (to 41)
         38   pop 1                              
         39   load_var2 3 6                      
-        40   call 772 ntypeargs=0               (testing.glob_match)
+        40   call 774 ntypeargs=0               (testing.glob_match)
         41   pop_jump_if_false -32              (to 9)
 
   655   42   load_const 9                       (true)
@@ -12828,7 +12828,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
 
 function testing.subtree_may_be_selected(prefix: string, include: string[], exclude: string[]) -> bool {
   677   0    load_var2 1 3                      
-        1    call 776 ntypeargs=0               (testing.subtree_excluded)
+        1    call 778 ntypeargs=0               (testing.subtree_excluded)
         2    pop_jump_if_false +2               (to 4)
         3    jump +34                           (to 37)
 
@@ -12859,7 +12859,7 @@ function testing.subtree_may_be_selected(prefix: string, include: string[], excl
         27   store_var_load_var 7               (pattern)
 
   684   28   load_var 1                         (prefix)
-        29   call 777 ntypeargs=0               (testing.pattern_may_match_descendant)
+        29   call 779 ntypeargs=0               (testing.pattern_may_match_descendant)
         30   pop_jump_if_false -13              (to 17)
 
   685   31   load_const 6                       (true)
@@ -12886,7 +12886,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   364   6    load_var2 1 2         
 
   366   7    load_var 3            (runner)
-        8    make_closure 1469 2   
+        8    make_closure 1471 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   store_var 4           (_0)
         11   load_var 4            (_0)
@@ -12905,7 +12905,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   375   8    load_var2 1 2         
-        9    make_closure 1471 2   
+        9    make_closure 1473 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   store_var 3           (_0)
         12   load_var 3            (_0)
@@ -12928,7 +12928,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   391   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1473 3   
+        13   make_closure 1475 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   store_var 4           (_0)
         16   load_var 4            (_0)
@@ -12964,7 +12964,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 6                         (t)
         25   load_field 2                       (runner)
-        26   call 762 ntypeargs=0               (testing.test_child)
+        26   call 764 ntypeargs=0               (testing.test_child)
         27   store_var 7                        (_10)
         28   load_type 0                        
         29   load_var2 3 7                      
@@ -12992,7 +12992,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         50   store_var 10                       (ts)
 
   334   51   load_var2 1 10                     
-        52   call 763 ntypeargs=0               (testing.testset_child)
+        52   call 765 ntypeargs=0               (testing.testset_child)
         53   store_var 11                       (_22)
         54   load_type 0                        
         55   load_var2 3 11                     
@@ -13032,7 +13032,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   342   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 765 ntypeargs=0               (testing._name_selected)
+        23   call 767 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   343   25   load_var 7                         (t)
@@ -13041,7 +13041,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 7                         (t)
         30   load_field 2                       (runner)
-        31   call 762 ntypeargs=0               (testing.test_child)
+        31   call 764 ntypeargs=0               (testing.test_child)
         32   store_var 8                        (_13)
         33   load_type 0                        
         34   load_var2 4 8                      
@@ -13070,12 +13070,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   354   56   load_field 0                       (name)
         57   load_var 2                         (names)
-        58   call 766 ntypeargs=0               (testing._has_selected_descendant)
+        58   call 768 ntypeargs=0               (testing._has_selected_descendant)
         59   pop_jump_if_false -14              (to 45)
 
   355   60   load_var2 1 11                     
         61   load_var 2                         (names)
-        62   call 764 ntypeargs=0               (testing.testset_child_selected)
+        62   call 766 ntypeargs=0               (testing.testset_child_selected)
         63   store_var 12                       (_27)
         64   load_type 0                        
         65   load_var2 4 12                     
@@ -13098,7 +13098,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1          (age)
 
   10   6    load_var2 1 2          
-       7    call 935 ntypeargs=0   (user.score)
+       7    call 937 ntypeargs=0   (user.score)
        8    store_var 4            (base)
 
   11   9    load_var 4             (base)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -5222,20 +5222,20 @@ function claude_code.ClaudeCodeClient.new(model: string, executable: string, cwd
 }
 
 function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
-  165   0     load_type 0                        
+  163   0     load_type 0                        
         1     load_var 1                         (raw)
         2     load_const 1                       (".type")
         3     load_const 2                       ("?")
         4     call 343 ntypeargs=1               (baml.json.path_or)
         5     store_var 3                        (kind)
 
-  166   6     load_var 3                         (kind)
+  164   6     load_var 3                         (kind)
         7     load_const 3                       ("system")
         8     cmp_op ==                          
         9     pop_jump_if_false +2               (to 11)
         10    jump +183                          (to 193)
 
-  179   11    load_var 3                         (kind)
+  177   11    load_var 3                         (kind)
         12    load_const 4                       ("assistant")
         13    cmp_op ==                          
         14    jump_if_false +2                   (to 16)
@@ -5247,13 +5247,13 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         20    pop_jump_if_false +2               (to 22)
         21    jump +23                           (to 44)
 
-  197   22    load_var 3                         (kind)
+  195   22    load_var 3                         (kind)
         23    load_const 6                       ("result")
         24    cmp_op ==                          
         25    pop_jump_if_false +2               (to 27)
         26    jump +233                          (to 259)
 
-  200   27    load_type 0                        
+  198   27    load_type 0                        
         28    load_var 3                         (kind)
         29    call 138 ntypeargs=1               (baml.String.from)
         30    store_var 24                       (_88)
@@ -5271,18 +5271,18 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         42    pop 1                              
         43    jump +216                          (to 259)
 
-  180   44    load_type 0                        
+  178   44    load_type 0                        
         45    alloc_array 0                      
         46    store_var 10                       (parts)
 
-  181   47    load_type 13                       
+  179   47    load_type 13                       
         48    load_var 1                         (raw)
         49    load_const 14                      (".message.content")
         50    load_type 15                       
         51    alloc_array 0                      
         52    call 343 ntypeargs=1               (baml.json.path_or)
 
-  182   53    load_type 16                       
+  180   53    load_type 16                       
         54    load_const 17                      ("iter")
         55    virtual_call nargs=1 ntypeargs=0   
         56    store_var 11                       (_35)
@@ -5298,14 +5298,14 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         66    load_var 12                        (_36)
         67    store_var 13                       (b)
 
-  183   68    load_type 0                        
+  181   68    load_type 0                        
         69    load_var 13                        (b)
         70    load_const 21                      (".type")
         71    load_const 22                      ("?")
         72    call 343 ntypeargs=1               (baml.json.path_or)
         73    store_var 14                       (bt)
 
-  184   74    load_var 14                        (bt)
+  182   74    load_var 14                        (bt)
         75    load_const 23                      ("text")
         76    cmp_op ==                          
         77    pop_jump_if_false +2               (to 79)
@@ -5326,20 +5326,20 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         92    pop_jump_if_false +2               (to 94)
         93    jump +6                            (to 99)
 
-  193   94    load_type 0                        
+  191   94    load_type 0                        
         95    load_var2 10 14                    
         96    call 4 ntypeargs=1                 (baml.Array.push)
         97    pop 1                              
         98    jump -41                           (to 57)
 
-  192   99    load_type 0                        
+  190   99    load_type 0                        
         100   load_var 10                        (parts)
         101   load_const 27                      ("tool_result")
         102   call 4 ntypeargs=1                 (baml.Array.push)
         103   pop 1                              
         104   jump -47                           (to 57)
 
-  191   105   load_type 0                        
+  189   105   load_type 0                        
         106   load_var 13                        (b)
         107   load_const 28                      (".name")
         108   load_const 29                      ("?")
@@ -5358,7 +5358,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         121   pop 1                              
         122   jump -65                           (to 57)
 
-  188   123   load_type 0                        
+  186   123   load_type 0                        
         124   load_var 13                        (b)
         125   load_const 31                      (".thinking")
         126   load_const 32                      ("")
@@ -5370,17 +5370,17 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         132   call 138 ntypeargs=1               (baml.String.from)
         133   store_var 17                       (_55)
 
-  187   134   load_type 0                        
+  185   134   load_type 0                        
         135   load_var 10                        (parts)
 
-  188   136   load_const 33                      ("thinking: ")
+  186   136   load_const 33                      ("thinking: ")
         137   load_var 17                        (_55)
         138   bin_op +                           
         139   call 4 ntypeargs=1                 (baml.Array.push)
         140   pop 1                              
         141   jump -84                           (to 57)
 
-  185   142   load_type 0                        
+  183   142   load_type 0                        
         143   load_var 13                        (b)
         144   load_const 34                      (".text")
         145   load_const 35                      ("")
@@ -5400,7 +5400,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         159   pop 1                              
         160   jump -103                          (to 57)
 
-  196   161   load_type 0                        
+  194   161   load_type 0                        
         162   load_var 3                         (kind)
         163   call 138 ntypeargs=1               (baml.String.from)
         164   store_var 21                       (_78)
@@ -5433,20 +5433,20 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         191   pop 1                              
         192   jump +67                           (to 259)
 
-  167   193   load_type 0                        
+  165   193   load_type 0                        
         194   load_var 1                         (raw)
         195   load_const 45                      (".subtype")
         196   load_const 46                      ("?")
         197   call 343 ntypeargs=1               (baml.json.path_or)
         198   store_var 4                        (subtype)
 
-  168   199   load_var 4                         (subtype)
+  166   199   load_var 4                         (subtype)
         200   load_const 47                      ("thinking_tokens")
         201   cmp_op ==                          
         202   pop_jump_if_false +2               (to 204)
         203   jump +32                           (to 235)
 
-  176   204   load_type 0                        
+  174   204   load_type 0                        
         205   load_var 4                         (subtype)
         206   call 138 ntypeargs=1               (baml.String.from)
         207   store_var 7                        (_19)
@@ -5461,10 +5461,10 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         216   call 138 ntypeargs=1               (baml.String.from)
         217   store_var 8                        (_22)
 
-  175   218   load_const 50                      ("$baml_log")
+  173   218   load_const 50                      ("$baml_log")
         219   load_const 51                      ("info")
 
-  176   220   load_const 52                      ("cc event: system/")
+  174   220   load_const 52                      ("cc event: system/")
         221   load_var 7                         (_19)
         222   bin_op +                           
         223   load_const 53                      (" model=")
@@ -5477,11 +5477,11 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         230   load_type 12                       
         231   alloc_map 2                        
 
-  175   232   send_event                         
+  173   232   send_event                         
         233   pop 1                              
         234   jump +25                           (to 259)
 
-  172   235   load_type 56                       
+  170   235   load_type 56                       
         236   load_var 1                         (raw)
         237   load_const 57                      (".estimated_tokens")
         238   load_const 58                      (0)
@@ -5492,10 +5492,10 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         243   call 138 ntypeargs=1               (baml.String.from)
         244   store_var 5                        (_12)
 
-  171   245   load_const 59                      ("$baml_log")
+  169   245   load_const 59                      ("$baml_log")
         246   load_const 60                      ("debug")
 
-  172   247   load_const 61                      ("cc event: thinking ~")
+  170   247   load_const 61                      ("cc event: thinking ~")
         248   load_var 5                         (_12)
         249   bin_op +                           
         250   load_const 62                      (" tokens")
@@ -5506,28 +5506,28 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
         255   load_type 12                       
         256   alloc_map 2                        
 
-  171   257   send_event                         
+  169   257   send_event                         
         258   pop 1                              
 
-  202   259   load_const 65                      (null)
+  200   259   load_const 65                      (null)
         260   store_var 2                        (_0)
         261   load_var 2                         (_0)
         262   return                             
 }
 
 function claude_code.internal._preview(text: string) -> string {
-  156   0    load_var 1             (text)
+  154   0    load_var 1             (text)
         1    call 139 ntypeargs=0   (baml.String.length)
         2    load_const 0           (120)
         3    cmp_int_op >           
         4    pop_jump_if_false +2   (to 6)
         5    jump +3                (to 8)
 
-  159   6    load_var 1             (text)
+  157   6    load_var 1             (text)
 
-  156   7    jump +11               (to 18)
+  154   7    jump +11               (to 18)
 
-  157   8    load_var 1             (text)
+  155   8    load_var 1             (text)
         9    load_const 1           (0)
         10   load_const 0           (120)
         11   call 153 ntypeargs=0   (baml.String.substring)
@@ -5541,10 +5541,10 @@ function claude_code.internal._preview(text: string) -> string {
 }
 
 function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.json {
-  129   0    load_const 0                       (null)
+  127   0    load_const 0                       (null)
         1    store_var 2                        (result)
 
-  130   2    load_var 1                         (p)
+  128   2    load_var 1                         (p)
         3    load_field 0                       (stdout)
         4    load_type 1                        
         5    load_const 2                       ("iter")
@@ -5562,33 +5562,33 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         17   load_var 4                         (_5)
         18   store_var 5                        (line)
 
-  131   19   load_var 5                         (line)
+  129   19   load_var 5                         (line)
         20   call 144 ntypeargs=0               (baml.String.trim)
         21   store_var 6                        (trimmed)
 
-  132   22   load_var 6                         (trimmed)
+  130   22   load_var 6                         (trimmed)
         23   call 139 ntypeargs=0               (baml.String.length)
         24   load_const 6                       (0)
         25   cmp_int_op >                       
         26   pop_jump_if_false -18              (to 8)
 
-  133   27   load_var 6                         (trimmed)
+  131   27   load_var 6                         (trimmed)
         28   call 330 ntypeargs=0               (baml.json.parse)
         29   store_var 7                        (raw)
         30   jump +7                            (to 37)
         31   load_var 8                         (e)
         32   throw_if_panic                     
 
-  135   33   load_const 7                       ("claude-code")
+  133   33   load_const 7                       ("claude-code")
         34   load_var 6                         (trimmed)
         35   init_instance 0                    (ai.errors.ParseFailed .provider, .raw_output)
         36   throw                              
 
-  138   37   load_var 7                         (raw)
+  136   37   load_var 7                         (raw)
         38   call 924 ntypeargs=0               (claude_code.internal._log_cc_event)
         39   pop 1                              
 
-  139   40   load_type 8                        
+  137   40   load_type 8                        
         41   load_var 7                         (raw)
         42   load_const 9                       (".type")
         43   load_const 10                      ("")
@@ -5597,21 +5597,21 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         46   cmp_op ==                          
         47   pop_jump_if_false -39              (to 8)
 
-  140   48   load_var 7                         (raw)
+  138   48   load_var 7                         (raw)
         49   store_var 2                        (result)
 
-  139   50   jump -42                           (to 8)
+  137   50   jump -42                           (to 8)
 
-  146   51   load_var 2                         (result)
+  144   51   load_var 2                         (result)
         52   load_const 0                       (null)
         53   call 656 ntypeargs=0               (baml.ops.equals_equals)
         54   pop_jump_if_false +2               (to 56)
         55   jump +3                            (to 58)
 
-  152   56   load_var 2                         (result)
+  150   56   load_var 2                         (result)
         57   return                             
 
-  147   58   load_const 12                      ("claude-code")
+  145   58   load_const 12                      ("claude-code")
         59   load_const 13                      ("the Claude Code CLI stream ended without a result event")
         60   init_instance 1                    (ai.errors.ParseFailed .provider, .raw_output)
         61   throw                              
@@ -5638,7 +5638,7 @@ function claude_code.internal._type_schema(t: string) -> map<string, unknown> {
 }
 
 function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient) -> string {
-  221   0    load_type 0           
+  219   0    load_type 0           
         1    load_type 1           
         2    load_var 1            (c)
         3    load_field 6          (mcp_servers)
@@ -5649,11 +5649,11 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
         8    load_type 2           
         9    load_var 3            (_3)
 
-  222   10   make_closure 2240 0   
+  220   10   make_closure 2240 0   
         11   call 16 ntypeargs=3   (baml.Array.map)
         12   store_var 2           (_2)
 
-  221   13   load_type 0           
+  219   13   load_type 0           
         14   load_var 2            (_2)
         15   load_const 3          (",")
         16   call 15 ntypeargs=1   (baml.Array.join)
@@ -5924,29 +5924,29 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
 }
 
 function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
-  235   0     load_const 0                       ("")
+  233   0     load_const 0                       ("")
         1     load_var 2                         (input)
         2     load_field 0                       (prompt)
         3     call_indirect                      
         4     call 811 ntypeargs=0               (ai.Prompt.text)
         5     store_var 4                        (instructions)
 
-  236   6     load_var 2                         (input)
+  234   6     load_var 2                         (input)
         7     load_field 2                       (toolbox)
         8     call 826 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         9     unary_op !                         
         10    store_var_load_var 5               (has_tools)
 
-  237   11    pop_jump_if_false +2               (to 13)
+  235   11    pop_jump_if_false +2               (to 13)
         12    jump +6                            (to 18)
 
-  240   13    load_var 2                         (input)
+  238   13    load_var 2                         (input)
         14    load_field 3                       (output_type)
         15    sys_op 344                         (baml.json.schema)
         16    store_var 6                        (schema)
         17    jump +9                            (to 26)
 
-  238   18    load_var 2                         (input)
+  236   18    load_var 2                         (input)
         19    load_field 3                       (output_type)
         20    call 919 ntypeargs=0               (claude_code.internal.envelope_schema)
         21    store_var 7                        (_11)
@@ -5955,11 +5955,11 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         24    call 334 ntypeargs=1               (baml.json.to_json)
         25    store_var 6                        (schema)
 
-  242   26    load_var 5                         (has_tools)
+  240   26    load_var 5                         (has_tools)
         27    pop_jump_if_false +2               (to 29)
         28    jump +17                           (to 45)
 
-  245   29    load_type 2                        
+  243   29    load_type 2                        
         30    load_var 4                         (instructions)
         31    call 138 ntypeargs=1               (baml.String.from)
         32    store_var 14                       (_29)
@@ -5975,9 +5975,9 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         42    bin_op +                           
         43    store_var 8                        (prompt_text)
 
-  242   44    jump +26                           (to 70)
+  240   44    jump +26                           (to 70)
 
-  243   45    load_type 2                        
+  241   45    load_type 2                        
         46    load_var 4                         (instructions)
         47    call 138 ntypeargs=1               (baml.String.from)
         48    store_var 9                        (_18)
@@ -6003,7 +6003,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         68    bin_op +                           
         69    store_var 8                        (prompt_text)
 
-  249   70    load_type 2                        
+  247   70    load_type 2                        
         71    load_var 1                         (c)
         72    load_field 1                       (model)
         73    call 138 ntypeargs=1               (baml.String.from)
@@ -6025,10 +6025,10 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         89    call 138 ntypeargs=1               (baml.String.from)
         90    store_var 20                       (_47)
 
-  248   91    load_const 4                       ("$baml_log")
+  246   91    load_const 4                       ("$baml_log")
         92    load_const 5                       ("info")
 
-  249   93    load_const 6                       ("claude-code invoke: model=")
+  247   93    load_const 6                       ("claude-code invoke: model=")
         94    load_var 17                        (_41)
         95    bin_op +                           
         96    load_const 7                       (" prompt_chars=")
@@ -6045,74 +6045,74 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         107   load_type 11                       
         108   alloc_map 2                        
 
-  248   109   send_event                         
+  246   109   send_event                         
         110   pop 1                              
 
-  251   111   load_type 2                        
+  249   111   load_type 2                        
         112   alloc_array 0                      
         113   store_var 22                       (args)
 
-  252   114   load_type 2                        
+  250   114   load_type 2                        
         115   load_var 22                        (args)
         116   load_const 12                      ("-p")
         117   call 4 ntypeargs=1                 (baml.Array.push)
         118   pop 1                              
 
-  253   119   load_type 2                        
+  251   119   load_type 2                        
         120   load_var 22                        (args)
         121   load_const 13                      ("--output-format")
         122   call 4 ntypeargs=1                 (baml.Array.push)
         123   pop 1                              
 
-  254   124   load_type 2                        
+  252   124   load_type 2                        
         125   load_var 22                        (args)
         126   load_const 14                      ("stream-json")
         127   call 4 ntypeargs=1                 (baml.Array.push)
         128   pop 1                              
 
-  255   129   load_type 2                        
+  253   129   load_type 2                        
         130   load_var 22                        (args)
         131   load_const 15                      ("--verbose")
         132   call 4 ntypeargs=1                 (baml.Array.push)
         133   pop 1                              
 
-  256   134   load_type 2                        
+  254   134   load_type 2                        
         135   load_var 22                        (args)
         136   load_const 16                      ("--model")
         137   call 4 ntypeargs=1                 (baml.Array.push)
         138   pop 1                              
 
-  257   139   load_type 2                        
+  255   139   load_type 2                        
         140   load_var2 22 1                     
         141   load_field 1                       (model)
         142   call 4 ntypeargs=1                 (baml.Array.push)
         143   pop 1                              
 
-  258   144   load_type 2                        
+  256   144   load_type 2                        
         145   load_var 22                        (args)
         146   load_const 17                      ("--permission-mode")
         147   call 4 ntypeargs=1                 (baml.Array.push)
         148   pop 1                              
 
-  259   149   load_type 2                        
+  257   149   load_type 2                        
         150   load_var2 22 1                     
         151   load_field 4                       (permission_mode)
         152   call 4 ntypeargs=1                 (baml.Array.push)
         153   pop 1                              
 
-  260   154   load_type 2                        
+  258   154   load_type 2                        
         155   load_var 22                        (args)
         156   load_const 18                      ("--no-session-persistence")
         157   call 4 ntypeargs=1                 (baml.Array.push)
         158   pop 1                              
 
-  261   159   load_type 2                        
+  259   159   load_type 2                        
         160   load_var 22                        (args)
         161   load_const 19                      ("--tools")
         162   call 4 ntypeargs=1                 (baml.Array.push)
         163   pop 1                              
 
-  262   164   load_type 2                        
+  260   164   load_type 2                        
         165   load_var 1                         (c)
         166   load_field 5                       (harness_tools)
         167   load_const 20                      (",")
@@ -6123,7 +6123,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         172   call 4 ntypeargs=1                 (baml.Array.push)
         173   pop 1                              
 
-  269   174   load_var 1                         (c)
+  267   174   load_var 1                         (c)
         175   call 925 ntypeargs=0               (claude_code.internal.mcp_config_json)
         176   store_var 24                       (_81)
         177   load_var 24                        (_81)
@@ -6132,24 +6132,24 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         180   load_var 24                        (_81)
         181   store_var 25                       (mcp)
 
-  270   182   load_type 2                        
+  268   182   load_type 2                        
         183   load_var 22                        (args)
         184   load_const 22                      ("--mcp-config")
         185   call 4 ntypeargs=1                 (baml.Array.push)
         186   pop 1                              
 
-  271   187   load_type 2                        
+  269   187   load_type 2                        
         188   load_var2 22 25                    
         189   call 4 ntypeargs=1                 (baml.Array.push)
         190   pop 1                              
 
-  272   191   load_type 2                        
+  270   191   load_type 2                        
         192   load_var 22                        (args)
         193   load_const 23                      ("--strict-mcp-config")
         194   call 4 ntypeargs=1                 (baml.Array.push)
         195   pop 1                              
 
-  273   196   load_var 1                         (c)
+  271   196   load_var 1                         (c)
         197   call 926 ntypeargs=0               (claude_code.internal.allowed_mcp_tools)
         198   store_var 27                       (_93)
         199   load_type 2                        
@@ -6164,13 +6164,13 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         208   call 4 ntypeargs=1                 (baml.Array.push)
         209   pop 1                              
 
-  275   210   load_type 2                        
+  273   210   load_type 2                        
         211   load_var 22                        (args)
         212   load_const 25                      ("--json-schema")
         213   call 4 ntypeargs=1                 (baml.Array.push)
         214   pop 1                              
 
-  276   215   load_var 6                         (schema)
+  274   215   load_var 6                         (schema)
         216   call 331 ntypeargs=0               (baml.json.stringify)
         217   store_var 28                       (_99)
         218   load_type 2                        
@@ -6178,17 +6178,17 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         220   call 4 ntypeargs=1                 (baml.Array.push)
         221   pop 1                              
 
-  277   222   load_type 2                        
+  275   222   load_type 2                        
         223   load_var2 22 8                     
         224   call 4 ntypeargs=1                 (baml.Array.push)
         225   pop 1                              
 
-  280   226   load_var 1                         (c)
+  278   226   load_var 1                         (c)
         227   load_field 0                       (executable)
 
-  281   228   load_var2 22 1                     
+  279   228   load_var2 22 1                     
 
-  282   229   load_field 2                       (cwd)
+  280   229   load_field 2                       (cwd)
         230   load_const 26                      (null)
         231   load_var 1                         (c)
         232   load_field 3                       (timeout_ms)
@@ -6199,10 +6199,10 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         237   store_var 29                       (p)
         238   jump +18                           (to 256)
 
-  279   239   load_var 30                        (e)
+  277   239   load_var 30                        (e)
         240   throw_if_panic                     
 
-  287   241   load_type 27                       
+  285   241   load_type 27                       
         242   load_var 30                        (e)
         243   call 138 ntypeargs=1               (baml.String.from)
         244   store_var 32                       (_115)
@@ -6211,34 +6211,34 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         247   call 138 ntypeargs=1               (baml.String.from)
         248   store_var 31                       (_114)
 
-  285   249   load_const 28                      ("claude-code")
+  283   249   load_const 28                      ("claude-code")
 
-  287   250   load_const 29                      ("the Claude Code CLI could not start: ")
+  285   250   load_const 29                      ("the Claude Code CLI could not start: ")
         251   load_var 31                        (_114)
         252   bin_op +                           
         253   load_const 26                      (null)
         254   init_instance 1                    (ai.errors.NetworkFailure .provider, .detail, .raw_body)
         255   throw                              
 
-  296   256   load_var 29                        (p)
+  294   256   load_var 29                        (p)
         257   sys_op 248                         (baml.sys.Process.close_stdin)
         258   pop 1                              
         259   jump +3                            (to 262)
         260   load_var 35                        (e)
         261   throw_if_panic                     
 
-  301   262   load_var 29                        (p)
+  299   262   load_var 29                        (p)
         263   call 922 ntypeargs=0               (claude_code.internal._read_result)
         264   store_var 36                       (result)
 
-  302   265   load_var 29                        (p)
+  300   265   load_var 29                        (p)
         266   sys_op 249                         (baml.sys.Process.wait)
         267   store_var 37                       (exit)
         268   jump +18                           (to 286)
         269   load_var 38                        (e)
         270   throw_if_panic                     
 
-  306   271   load_type 30                       
+  304   271   load_type 30                       
         272   load_var 38                        (e)
         273   call 138 ntypeargs=1               (baml.String.from)
         274   store_var 40                       (_129)
@@ -6247,22 +6247,22 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         277   call 138 ntypeargs=1               (baml.String.from)
         278   store_var 39                       (_128)
 
-  304   279   load_const 31                      ("claude-code")
+  302   279   load_const 31                      ("claude-code")
 
-  306   280   load_const 32                      ("the Claude Code CLI did not terminate cleanly: ")
+  304   280   load_const 32                      ("the Claude Code CLI did not terminate cleanly: ")
         281   load_var 39                        (_128)
         282   bin_op +                           
         283   load_const 26                      (null)
         284   init_instance 2                    (ai.errors.NetworkFailure .provider, .detail, .raw_body)
         285   throw                              
 
-  311   286   load_var 37                        (exit)
+  309   286   load_var 37                        (exit)
         287   call 242 ntypeargs=0               (baml.sys.ProcessExit.ok)
         288   unary_op !                         
         289   pop_jump_if_false +2               (to 291)
         290   jump +257                          (to 547)
 
-  320   291   load_type 33                       
+  318   291   load_type 33                       
         292   load_var 36                        (result)
         293   load_const 34                      (".is_error")
         294   load_const 35                      (false)
@@ -6270,7 +6270,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         296   pop_jump_if_false +2               (to 298)
         297   jump +237                          (to 534)
 
-  328   298   load_type 2                        
+  326   298   load_type 2                        
         299   load_var 36                        (result)
         300   load_const 36                      (".subtype")
         301   load_const 37                      ("?")
@@ -6301,10 +6301,10 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         326   call 138 ntypeargs=1               (baml.String.from)
         327   store_var 48                       (_163)
 
-  327   328   load_const 43                      ("$baml_log")
+  325   328   load_const 43                      ("$baml_log")
         329   load_const 44                      ("info")
 
-  328   330   load_const 45                      ("claude-code result: subtype=")
+  326   330   load_const 45                      ("claude-code result: subtype=")
         331   load_var 44                        (_153)
         332   bin_op +                           
         333   load_const 46                      (" cost_usd=")
@@ -6321,10 +6321,10 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         344   load_type 11                       
         345   alloc_map 2                        
 
-  327   346   send_event                         
+  325   346   send_event                         
         347   pop 1                              
 
-  330   348   load_type 50                       
+  328   348   load_type 50                       
         349   load_var 36                        (result)
         350   load_const 51                      (".structured_output")
         351   call 342 ntypeargs=1               (baml.json.path)
@@ -6333,7 +6333,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         354   load_var 51                        (e)
         355   throw_if_panic                     
 
-  332   356   load_type 2                        
+  330   356   load_type 2                        
         357   load_var 36                        (result)
         358   load_const 52                      (".result")
         359   load_const 53                      ("")
@@ -6344,55 +6344,55 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         364   load_var 52                        (inner)
         365   throw_if_panic                     
 
-  336   366   load_var 36                        (result)
+  334   366   load_var 36                        (result)
         367   call 331 ntypeargs=0               (baml.json.stringify)
         368   store_var 53                       (_177)
 
-  334   369   load_const 54                      ("claude-code")
+  332   369   load_const 54                      ("claude-code")
         370   load_var 53                        (_177)
         371   init_instance 3                    (ai.errors.ParseFailed .provider, .raw_output)
         372   throw                              
 
-  344   373   load_type 3                        
+  342   373   load_type 3                        
         374   load_var 36                        (result)
         375   load_const 55                      (".usage.input_tokens")
         376   load_const 56                      (0)
         377   call 343 ntypeargs=1               (baml.json.path_or)
         378   store_var 55                       (_180)
 
-  345   379   load_type 3                        
+  343   379   load_type 3                        
         380   load_var 36                        (result)
         381   load_const 57                      (".usage.output_tokens")
         382   load_const 56                      (0)
         383   call 343 ntypeargs=1               (baml.json.path_or)
         384   store_var 56                       (_183)
 
-  346   385   load_type 58                       
+  344   385   load_type 58                       
         386   load_var 36                        (result)
         387   load_const 59                      (".usage.cache_read_input_tokens")
         388   load_const 26                      (null)
         389   call 343 ntypeargs=1               (baml.json.path_or)
         390   store_var 57                       (_186)
 
-  343   391   load_var2 55 56                    
+  341   391   load_var2 55 56                    
         392   load_var 57                        (_186)
         393   load_const 26                      (null)
         394   init_instance 4                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
         395   store_var 54                       (usage)
 
-  350   396   load_type 60                       
+  348   396   load_type 60                       
         397   alloc_array 0                      
         398   store_var 58                       (content)
 
-  351   399   load_const 56                      (ai.content.StopReason.Complete)
+  349   399   load_const 56                      (ai.content.StopReason.Complete)
         400   alloc_variant 436                  (ai.content.StopReason)
         401   store_var 59                       (stop)
 
-  352   402   load_var 5                         (has_tools)
+  350   402   load_var 5                         (has_tools)
         403   pop_jump_if_false +2               (to 405)
         404   jump +10                           (to 414)
 
-  380   405   load_var 50                        (structured)
+  378   405   load_var 50                        (structured)
         406   call 331 ntypeargs=0               (baml.json.stringify)
         407   store_var 77                       (_247)
         408   load_type 60                       
@@ -6402,26 +6402,26 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         412   pop 1                              
         413   jump +112                          (to 525)
 
-  353   414   load_type 50                       
+  351   414   load_type 50                       
         415   load_var 36                        (result)
         416   load_const 61                      (".structured_output.outcome")
         417   load_var 50                        (structured)
         418   call 343 ntypeargs=1               (baml.json.path_or)
         419   store_var 60                       (outcome)
 
-  354   420   load_type 62                       
+  352   420   load_type 62                       
         421   load_var 60                        (outcome)
         422   load_const 63                      (".calls")
         423   load_const 26                      (null)
         424   call 343 ntypeargs=1               (baml.json.path_or)
 
-  355   425   store_var 61                       (_199)
+  353   425   store_var 61                       (_199)
         426   load_var 61                        (_199)
         427   narrow_bind 64 61                  
         428   pop_jump_if_false +2               (to 430)
         429   jump +10                           (to 439)
 
-  377   430   load_var 60                        (outcome)
+  375   430   load_var 60                        (outcome)
         431   call 331 ntypeargs=0               (baml.json.stringify)
         432   store_var 76                       (_242)
         433   load_type 60                       
@@ -6431,13 +6431,13 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         437   pop 1                              
         438   jump +87                           (to 525)
 
-  355   439   load_var 61                        (_199)
+  353   439   load_var 61                        (_199)
         440   store_var 62                       (call_list)
 
-  356   441   load_const 56                      (0)
+  354   441   load_const 56                      (0)
         442   store_var 63                       (i)
 
-  357   443   load_var 62                        (call_list)
+  355   443   load_var 62                        (call_list)
         444   load_type 65                       
         445   load_const 66                      ("iter")
         446   virtual_call nargs=1 ntypeargs=0   
@@ -6454,7 +6454,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         457   load_var 65                        (_204)
         458   store_var 66                       (raw_call)
 
-  361   459   load_var 2                         (input)
+  359   459   load_var 2                         (input)
         460   load_field 1                       (journal)
         461   call 808 ntypeargs=0               (ai.Journal.entries)
         462   container_len                      
@@ -6468,12 +6468,12 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         470   call 138 ntypeargs=1               (baml.String.from)
         471   store_var 70                       (_218)
 
-  358   472   load_type 2                        
+  356   472   load_type 2                        
 
-  359   473   load_var 66                        (raw_call)
+  357   473   load_var 66                        (raw_call)
         474   load_const 70                      (".id")
 
-  361   475   load_const 71                      ("cc_call_")
+  359   475   load_const 71                      ("cc_call_")
         476   load_var 68                        (_213)
         477   bin_op +                           
         478   load_const 72                      ("_")
@@ -6483,14 +6483,14 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         482   call 343 ntypeargs=1               (baml.json.path_or)
         483   store_var 67                       (id)
 
-  363   484   load_type 2                        
+  361   484   load_type 2                        
         485   load_var 66                        (raw_call)
         486   load_const 73                      (".name")
         487   load_const 74                      ("")
         488   call 343 ntypeargs=1               (baml.json.path_or)
         489   store_var 71                       (name)
 
-  365   490   load_type 50                       
+  363   490   load_type 50                       
         491   load_var 66                        (raw_call)
         492   load_const 75                      (".args")
         493   load_type 2                        
@@ -6499,7 +6499,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         496   call 343 ntypeargs=1               (baml.json.path_or)
         497   store_var 74                       (_227)
 
-  364   498   load_type 1                        
+  362   498   load_type 1                        
         499   load_var 74                        (_227)
         500   call 337 ntypeargs=1               (baml.json.from_json)
         501   store_var 72                       (call_args)
@@ -6507,77 +6507,77 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         503   load_var 73                        (e)
         504   throw_if_panic                     
 
-  368   505   load_type 2                        
+  366   505   load_type 2                        
         506   load_type 11                       
         507   alloc_map 0                        
         508   store_var 75                       (empty)
 
-  369   509   load_var 75                        (empty)
+  367   509   load_var 75                        (empty)
         510   store_var 72                       (call_args)
 
-  372   511   load_type 60                       
+  370   511   load_type 60                       
         512   load_var2 58 67                    
         513   load_var2 71 72                    
         514   init_instance 7                    (ai.content.ToolUse .id, .name, .args)
         515   call 4 ntypeargs=1                 (baml.Array.push)
         516   pop 1                              
 
-  373   517   load_var 63                        (i)
+  371   517   load_var 63                        (i)
         518   load_const 21                      (1)
         519   add_int                            
         520   store_var 63                       (i)
 
-  357   521   jump -73                           (to 448)
+  355   521   jump -73                           (to 448)
 
-  375   522   load_const 21                      (ai.content.StopReason.ToolUse)
+  373   522   load_const 21                      (ai.content.StopReason.ToolUse)
         523   alloc_variant 436                  (ai.content.StopReason)
         524   store_var 59                       (stop)
 
-  382   525   load_var2 58 59                    
+  380   525   load_var2 58 59                    
         526   load_var 54                        (usage)
         527   init_instance 8                    (ai.ModelTurn .content, .stop_reason, .usage)
         528   store_var 3                        (_0)
 
-  293   529   load_var 29                        (p)
+  291   529   load_var 29                        (p)
         530   sys_op 251                         (baml.sys.Process.close)
         531   pop 1                              
         532   load_var 3                         (_0)
         533   return                             
 
-  323   534   load_type 2                        
+  321   534   load_type 2                        
         535   load_var 36                        (result)
         536   load_const 76                      (".subtype")
         537   load_const 77                      ("error")
         538   call 343 ntypeargs=1               (baml.json.path_or)
         539   store_var 42                       (_143)
 
-  324   540   load_var 36                        (result)
+  322   540   load_var 36                        (result)
         541   call 331 ntypeargs=0               (baml.json.stringify)
         542   store_var 43                       (_146)
 
-  321   543   load_const 78                      ("claude-code")
+  319   543   load_const 78                      ("claude-code")
         544   load_var2 42 43                    
         545   init_instance 9                    (ai.errors.Refused .provider, .reason, .raw_body)
         546   throw                              
 
-  315   547   load_type 3                        
+  313   547   load_type 3                        
         548   load_var 37                        (exit)
         549   load_field 0                       (exit_code)
         550   call 138 ntypeargs=1               (baml.String.from)
         551   store_var 41                       (_136)
         552   jump +6                            (to 558)
 
-  293   553   load_var 29                        (p)
+  291   553   load_var 29                        (p)
         554   sys_op 251                         (baml.sys.Process.close)
         555   pop 1                              
 
-  229   556   load_var 33                        (_118)
+  227   556   load_var 33                        (_118)
         557   rethrow                            
 
-  312   558   load_const 79                      ("claude-code")
+  310   558   load_const 79                      ("claude-code")
         559   load_const 26                      (null)
 
-  315   560   load_const 80                      ("the Claude Code CLI exited with code ")
+  313   560   load_const 80                      ("the Claude Code CLI exited with code ")
         561   load_var 41                        (_136)
         562   bin_op +                           
         563   load_const 26                      (null)
@@ -6586,7 +6586,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 }
 
 function claude_code.internal.mcp_config_json(c: claude_code.ClaudeCodeClient) -> string | null {
-  209   0    load_var 1             (c)
+  207   0    load_var 1             (c)
         1    load_field 6           (mcp_servers)
         2    container_len          
         3    store_var 2            (_3)
@@ -6596,12 +6596,12 @@ function claude_code.internal.mcp_config_json(c: claude_code.ClaudeCodeClient) -
         7    pop_jump_if_false +2   (to 9)
         8    jump +18               (to 26)
 
-  212   9    load_type 1            
+  210   9    load_type 1            
         10   load_type 2            
         11   alloc_map 0            
         12   store_var 3            (wrapper)
 
-  213   13   load_type 1            
+  211   13   load_type 1            
         14   load_type 2            
         15   load_var 3             (wrapper)
         16   load_const 3           ("mcpServers")
@@ -6610,13 +6610,13 @@ function claude_code.internal.mcp_config_json(c: claude_code.ClaudeCodeClient) -
         19   call 37 ntypeargs=2    (baml.Map.set)
         20   pop 1                  
 
-  214   21   load_type 4            
+  212   21   load_type 4            
         22   load_var 3             (wrapper)
         23   call 334 ntypeargs=1   (baml.json.to_json)
         24   call 331 ntypeargs=0   (baml.json.stringify)
         25   jump +2                (to 27)
 
-  210   26   load_const 5           (null)
+  208   26   load_const 5           (null)
         27   return                 
 }
 
@@ -6684,7 +6684,7 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         56   pop 1                              
         57   jump -48                           (to 9)
 
-  122   58   load_type 0                        
+  121   58   load_type 0                        
         59   load_var 3                         (catalog)
         60   load_const 11                      (", ")
         61   call 15 ntypeargs=1                (baml.Array.join)

--- a/baml_language/crates/baml_tests/tests/fs.rs
+++ b/baml_language/crates/baml_tests/tests/fs.rs
@@ -1,7 +1,15 @@
 //! Filesystem operation tests requiring host-side capabilities.
 //!
-//! Tests here need features BAML doesn't support: creating symlinks and
-//! asserting compile-time type mismatches via `#[should_panic]`.
+//! Tests here need things BAML cannot express: asserting a compile-time type
+//! mismatch via `#[should_panic]`, and inspecting host state that `baml.fs`
+//! exposes no reader for — a file's mode bits, and whether a path is a link
+//! rather than what it resolves to.
+//!
+//! The `chmod` and `symlink` tests are Unix-only by design. Windows has no mode
+//! bits (only a read-only attribute), and creating a symlink there needs
+//! Developer Mode or `SeCreateSymbolicLinkPrivilege`, which CI does not grant.
+//! The platform-independent parts of both — argument validation and the errors
+//! for a missing or already-occupied path — are covered by `baml_src/ns_fs`.
 
 use baml_tests::baml_test;
 #[cfg(unix)]
@@ -94,4 +102,148 @@ async fn fs_read_dir_reports_symlink_flag() {
         .expect("expected link.txt entry");
 
     assert_eq!(link["is_symlink"], BexExternalValue::Bool(true));
+}
+
+/// The mode is applied verbatim, not or'd into what the file already had:
+/// `0o600` then `0o644` must land on exactly those bits.
+#[cfg(unix)]
+#[tokio::test]
+async fn fs_chmod_sets_the_exact_mode() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let (_tmp, root) = tmp(indexmap! { "file.txt" => "content" });
+    let path = format!("{root}/file.txt");
+
+    let output = baml_test!(&format!(
+        r#"
+            function main() -> null {{
+                baml.fs.chmod("{path}", 0o600);
+                baml.fs.chmod("{path}", 0o644);
+                null
+            }}
+        "#
+    ));
+
+    assert!(output.result.is_ok(), "got: {:?}", output.result);
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+    assert_eq!(mode & 0o7777, 0o644, "mode was {mode:#o}");
+}
+
+/// A mode the kernel would silently mask (here the `S_IFREG` bits of a `stat`
+/// result) is rejected before any syscall, so the file keeps its old mode.
+#[cfg(unix)]
+#[tokio::test]
+async fn fs_chmod_rejects_out_of_range_mode() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let (_tmp, root) = tmp(indexmap! { "file.txt" => "content" });
+    let path = format!("{root}/file.txt");
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+
+    let output = baml_test!(&format!(
+        r#"
+            function main() -> string {{
+                {{
+                    baml.fs.chmod("{path}", 0o100644);
+                    "no error thrown"
+                }} catch (e) {{
+                    baml.errors.InvalidArgument => e.message
+                }}
+            }}
+        "#
+    ));
+
+    let Ok(BexExternalValue::String(message)) = &output.result else {
+        panic!("expected string, got: {:?}", output.result);
+    };
+    assert!(
+        message.contains("0o100644"),
+        "message should name the rejected mode, got: {message}"
+    );
+    let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+    assert_eq!(mode & 0o7777, 0o600, "mode was {mode:#o}");
+}
+
+/// The link is a real symlink (not a copy) and resolves to the target's bytes.
+#[cfg(unix)]
+#[tokio::test]
+async fn fs_symlink_creates_a_link_to_the_target() {
+    let (_tmp, root) = tmp(indexmap! { "target.txt" => "content" });
+
+    let output = baml_test!(&format!(
+        r#"
+            function main() -> string {{
+                baml.fs.symlink("{root}/target.txt", "{root}/link.txt");
+                baml.fs.read("{root}/link.txt")
+            }}
+        "#
+    ));
+
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String("content".to_string().into()))
+    );
+    let link = format!("{root}/link.txt");
+    assert!(
+        std::fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+    assert_eq!(
+        std::fs::read_link(&link).unwrap(),
+        std::path::Path::new(&format!("{root}/target.txt"))
+    );
+}
+
+/// A relative target is stored verbatim — the OS resolves it against the link's
+/// own directory, so the link keeps working regardless of the working directory.
+#[cfg(unix)]
+#[tokio::test]
+async fn fs_symlink_stores_a_relative_target_verbatim() {
+    let (_tmp, root) = tmp(indexmap! { "target.txt" => "content" });
+
+    let output = baml_test!(&format!(
+        r#"
+            function main() -> string {{
+                baml.fs.symlink("target.txt", "{root}/link.txt");
+                baml.fs.read("{root}/link.txt")
+            }}
+        "#
+    ));
+
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String("content".to_string().into()))
+    );
+    assert_eq!(
+        std::fs::read_link(format!("{root}/link.txt")).unwrap(),
+        std::path::Path::new("target.txt")
+    );
+}
+
+/// Creating a link never clobbers what is already there.
+#[cfg(unix)]
+#[tokio::test]
+async fn fs_symlink_onto_an_existing_path_errors() {
+    let (_tmp, root) = tmp(indexmap! { "target.txt" => "target", "taken.txt" => "keep me" });
+
+    let output = baml_test!(&format!(
+        r#"
+            function main() -> bool {{
+                {{
+                    baml.fs.symlink("{root}/target.txt", "{root}/taken.txt");
+                    false
+                }} catch (e) {{
+                    baml.errors.Io => true
+                }}
+            }}
+        "#
+    ));
+
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+    assert_eq!(
+        std::fs::read_to_string(format!("{root}/taken.txt")).unwrap(),
+        "keep me"
+    );
 }

--- a/baml_language/crates/baml_tests/tests/shell.rs
+++ b/baml_language/crates/baml_tests/tests/shell.rs
@@ -401,6 +401,27 @@ async fn shell_with_options() {
     }
 }
 
+// === pid() tests ===
+
+/// `baml.sys.pid` reports the ID of the process running the VM, not of any
+/// child it spawns. The test harness runs the engine in-process, so the only
+/// correct answer is this test binary's own PID.
+#[tokio::test]
+async fn pid_is_the_host_process() {
+    let output = baml_test!(
+        r#"
+            function main() -> int {
+                baml.sys.pid()
+            }
+        "#
+    );
+
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::Int(i64::from(std::process::id())))
+    );
+}
+
 // === stdout / stderr as uint8array field tests ===
 
 #[tokio::test]

--- a/baml_language/crates/bridge_wasm/src/wasm_io_fs.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_io_fs.rs
@@ -619,4 +619,35 @@ impl io::IoNamespaceFs for WasmIoFs {
             }
         }
     }
+
+    // The JS VFS contract exposes neither permissions nor links, and both are
+    // reported as `Io` rather than `Unsupported` because that is the only
+    // category these two sysops declare — an `Unsupported` would escape every
+    // typed `catch` arm the caller can write. Growing the VFS with `chmod` /
+    // `symlink` methods is what would make these real here.
+    fn chmod(
+        &self,
+        _h: &Arc<BexHeap>,
+        _c: CallId,
+        _path: String,
+        _mode: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        SysOpOutput::err(VmBamlError::Io {
+            message: "File permissions are not supported by the JavaScript filesystem".to_string(),
+        })
+    }
+
+    fn symlink(
+        &self,
+        _h: &Arc<BexHeap>,
+        _c: CallId,
+        _target: String,
+        _path: String,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        SysOpOutput::err(VmBamlError::Io {
+            message: "Symbolic links are not supported by the JavaScript filesystem".to_string(),
+        })
+    }
 }

--- a/baml_language/crates/bridge_wasm/src/wasm_sys.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_sys.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use js_sys::{Function, Promise, Reflect, Uint8Array};
 use sys_ops::io::{self, IoNamespaceSys};
 use sys_types::{
-    BexExternalValue, BexHeap, CallId, SysOpContext, SysOpOutput, VmBamlError, VmRustFnError,
+    BexExternalValue, BexHeap, CallId, SysOpContext, SysOpOutput, VmBamlError, VmPanic,
+    VmRustFnError,
 };
 use wasm_bindgen::{JsCast, prelude::*};
 use wasm_bindgen_futures::JsFuture;
@@ -306,6 +307,34 @@ impl IoNamespaceSys for WasmSys {
             Ok(())
         }))
     }
+
+    fn pid(&self, _heap: &Arc<BexHeap>, _call_id: CallId, _ctx: &SysOpContext) -> SysOpOutput<i64> {
+        // Read `globalThis.process.pid` directly rather than through an
+        // injected callback — the same feature-detection route `WasmTime`
+        // takes to `globalThis.Temporal`. Node and Node-compatible runtimes
+        // provide it; a browser does not, and neither do the `process` shims
+        // bundlers inject, which is why a non-positive or non-integral value
+        // is treated as absent (no live process ever has PID 0).
+        match host_process_pid() {
+            Some(pid) => SysOpOutput::ok(pid),
+            // `baml.sys.pid` declares `throws never`, so an environment
+            // without process IDs panics rather than throwing.
+            None => SysOpOutput::err(VmPanic::HostUnavailable {
+                resource: "process-id".to_string(),
+                message: "the host JavaScript environment does not provide process.pid".to_string(),
+            }),
+        }
+    }
+}
+
+/// `globalThis.process.pid`, or `None` when the host does not expose a usable
+/// process ID.
+fn host_process_pid() -> Option<i64> {
+    let process = Reflect::get(&js_sys::global(), &"process".into()).ok()?;
+    let pid = Reflect::get(&process, &"pid".into()).ok()?.as_f64()?;
+    // `from_f64` rejects non-finite, out-of-range, and fractional values, so
+    // only a genuine integral PID survives.
+    <i64 as num_traits::FromPrimitive>::from_f64(pid).filter(|pid| *pid > 0)
 }
 
 fn sleep_millis_from_delay(delay: BexExternalValue) -> Result<i32, VmRustFnError> {

--- a/baml_language/crates/sys_native/src/io_impls.rs
+++ b/baml_language/crates/sys_native/src/io_impls.rs
@@ -889,6 +889,129 @@ impl io::IoNamespaceFs for NativeSysOps {
             .map_err(VmRustFnError::from)
         })
     }
+
+    fn chmod(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        path: String,
+        mode: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        let mode = match permission_bits(mode) {
+            Ok(mode) => mode,
+            Err(err) => return SysOpOutput::err(err),
+        };
+        SysOpOutput::async_op(async move { chmod_path(&path, mode).await })
+    }
+
+    fn symlink(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        target: String,
+        path: String,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        SysOpOutput::async_op(async move {
+            symlink_path(&target, &path)
+                .await
+                .map_err(|e| VmBamlError::Io {
+                    message: format!("Failed to create symlink '{path}' -> '{target}': {e}"),
+                })
+                .map_err(VmRustFnError::from)
+        })
+    }
+}
+
+/// Narrow a BAML `int` mode to the POSIX permission bits.
+///
+/// The accepted range is the permission triple plus the setuid/setgid/sticky
+/// digit. Everything else — negative values, file-type bits from a `stat`
+/// result, anything past `u32` — is rejected rather than masked, because a mode
+/// outside that range is a caller mistake and the kernel would silently drop the
+/// extra bits (`chmod_common` masks with `S_IALLUGO`).
+fn permission_bits(mode: i64) -> Result<u32, VmBamlError> {
+    u32::try_from(mode)
+        .ok()
+        .filter(|mode| *mode <= 0o7777)
+        .ok_or_else(|| VmBamlError::InvalidArgument {
+            // `{:#o}` renders a negative `i64` as its 64-bit two's complement,
+            // which reads as a nonsensically large mode; show those in decimal.
+            message: match mode {
+                0.. => {
+                    format!("Invalid file mode {mode:#o}: expected a permission mask in 0..=0o7777")
+                }
+                _ => format!("Invalid file mode {mode}: expected a permission mask in 0..=0o7777"),
+            },
+        })
+}
+
+#[cfg(unix)]
+async fn chmod_path(path: &str, mode: u32) -> Result<(), VmRustFnError> {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    tokio::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+        .await
+        .map_err(|e| VmBamlError::Io {
+            message: format!("Failed to set permissions on '{path}': {e}"),
+        })
+        .map_err(VmRustFnError::from)
+}
+
+/// Windows has no mode bits — `Permissions` carries a single read-only flag —
+/// so the owner-write bit decides it and the rest of `mode` is ignored. This
+/// matches libuv (and therefore Node's `fs.chmod`), which tests exactly
+/// `_S_IWRITE`.
+///
+/// Reading the current permissions first is what makes a missing `path` fail
+/// here as it does on unix, rather than silently succeeding.
+#[cfg(windows)]
+async fn chmod_path(path: &str, mode: u32) -> Result<(), VmRustFnError> {
+    let mut permissions = tokio::fs::metadata(path)
+        .await
+        .map_err(|e| VmBamlError::Io {
+            message: format!("Failed to read permissions of '{path}': {e}"),
+        })?
+        .permissions();
+    permissions.set_readonly((mode & 0o200) == 0);
+    tokio::fs::set_permissions(path, permissions)
+        .await
+        .map_err(|e| VmBamlError::Io {
+            message: format!("Failed to set permissions on '{path}': {e}"),
+        })
+        .map_err(VmRustFnError::from)
+}
+
+#[cfg(unix)]
+async fn symlink_path(target: &str, path: &str) -> std::io::Result<()> {
+    tokio::fs::symlink(target, path).await
+}
+
+/// Windows picks the link flavor at creation time and cannot change it later,
+/// so `target` is resolved the way the OS will resolve it — a relative target
+/// hangs off the link's own directory — and a directory link is created only
+/// when that resolves to a directory today. A dangling link becomes a file
+/// link, matching Node's autodetect.
+#[cfg(windows)]
+async fn symlink_path(target: &str, path: &str) -> std::io::Result<()> {
+    let target_path = std::path::Path::new(target);
+    let resolved = if target_path.is_absolute() {
+        target_path.to_path_buf()
+    } else {
+        std::path::Path::new(path)
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new(""))
+            .join(target_path)
+    };
+    if tokio::fs::metadata(&resolved)
+        .await
+        .is_ok_and(|metadata| metadata.is_dir())
+    {
+        tokio::fs::symlink_dir(target, path).await
+    } else {
+        tokio::fs::symlink_file(target, path).await
+    }
 }
 
 // Auto-creates missing parent dirs, matching Bun's `Bun.write` behavior.

--- a/baml_language/crates/sys_native/src/io_impls.rs
+++ b/baml_language/crates/sys_native/src/io_impls.rs
@@ -1664,6 +1664,12 @@ impl io::IoNamespaceSys for NativeSysOps {
             Ok(())
         })
     }
+
+    fn pid(&self, _heap: &Arc<BexHeap>, _call_id: CallId, _ctx: &SysOpContext) -> SysOpOutput<i64> {
+        // `std::process::id` is a `u32` on every platform this crate builds
+        // for, so the widening into BAML's i63 `int` is always exact.
+        SysOpOutput::ok(i64::from(std::process::id()))
+    }
 }
 
 fn sleep_nanos_from_delay(delay: BexExternalValue) -> Result<u64, VmRustFnError> {

--- a/baml_language/crates/sys_ops/src/lib.rs
+++ b/baml_language/crates/sys_ops/src/lib.rs
@@ -1660,6 +1660,17 @@ impl io::IoNamespaceSys for DefaultIoOps {
             message: "Operation not supported on this platform".to_string(),
         })
     }
+
+    // `baml.sys.pid` declares `throws never`, so a platform without process
+    // IDs cannot report `Unsupported` as a catchable error — it panics with
+    // `baml.panics.HostUnavailable`, exactly as `SystemRandom` does when no
+    // entropy source is reachable.
+    fn pid(&self, _h: &Arc<BexHeap>, _c: CallId, _ctx: &SysOpContext) -> SysOpOutput<i64> {
+        SysOpOutput::err(VmPanic::HostUnavailable {
+            resource: "process-id".to_string(),
+            message: "Operation not supported on this platform".to_string(),
+        })
+    }
 }
 
 impl io::IoClassGlobGlob for DefaultIoOps {
@@ -2275,6 +2286,12 @@ impl IoSysOpsBuilder {
             let t = instance.clone();
             Arc::new(move |heap, permit, args, ctx, call_id| {
                 t.__glue_baml_sys_sleep(heap, permit, args, ctx, call_id)
+            })
+        };
+        self.inner.baml_sys_pid = {
+            let t = instance;
+            Arc::new(move |heap, permit, args, ctx, call_id| {
+                t.__glue_baml_sys_pid(heap, permit, args, ctx, call_id)
             })
         };
         self

--- a/baml_language/crates/sys_ops/src/lib.rs
+++ b/baml_language/crates/sys_ops/src/lib.rs
@@ -1056,6 +1056,37 @@ impl io::IoNamespaceFs for DefaultIoOps {
             message: "Operation not supported on this platform".to_string(),
         })
     }
+
+    // `chmod` and `symlink` declare `throws root.errors.Io`, so — unlike their
+    // siblings above — they report an absent platform facility as `Io` rather
+    // than `Unsupported`. An `Unsupported` here would be off-contract: nothing
+    // in the declared throw set can hold it, so it would escape every typed
+    // `catch` arm the caller can write.
+    fn chmod(
+        &self,
+        _h: &Arc<BexHeap>,
+        _c: CallId,
+        _path: String,
+        _mode: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        SysOpOutput::err(VmBamlError::Io {
+            message: "File permissions are not supported on this platform".to_string(),
+        })
+    }
+
+    fn symlink(
+        &self,
+        _h: &Arc<BexHeap>,
+        _c: CallId,
+        _target: String,
+        _path: String,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        SysOpOutput::err(VmBamlError::Io {
+            message: "Symbolic links are not supported on this platform".to_string(),
+        })
+    }
 }
 
 impl io::IoClassHttpResponse for DefaultIoOps {
@@ -1996,9 +2027,21 @@ impl IoSysOpsBuilder {
             })
         };
         self.inner.baml_fs_mkdir = {
-            let t = instance;
+            let t = instance.clone();
             Arc::new(move |heap, permit, args, ctx, call_id| {
                 t.__glue_baml_fs_mkdir(heap, permit, args, ctx, call_id)
+            })
+        };
+        self.inner.baml_fs_chmod = {
+            let t = instance.clone();
+            Arc::new(move |heap, permit, args, ctx, call_id| {
+                t.__glue_baml_fs_chmod(heap, permit, args, ctx, call_id)
+            })
+        };
+        self.inner.baml_fs_symlink = {
+            let t = instance;
+            Arc::new(move |heap, permit, args, ctx, call_id| {
+                t.__glue_baml_fs_symlink(heap, permit, args, ctx, call_id)
             })
         };
         self

--- a/baml_language/crates/sys_wasm/src/web_sysops.rs
+++ b/baml_language/crates/sys_wasm/src/web_sysops.rs
@@ -486,6 +486,36 @@ impl IoNamespaceFs for WebFs {
     ) -> SysOpOutput<()> {
         unsupported()
     }
+
+    // These two declare `throws root.errors.Io`, which cannot carry the
+    // `Unsupported` that `unsupported()` builds — an off-contract error escapes
+    // every typed `catch` arm the caller can write — so the browser's lack of a
+    // permission model and of symbolic links is reported as `Io`.
+    fn chmod(
+        &self,
+        _h: &Arc<BexHeap>,
+        _c: CallId,
+        _path: String,
+        _mode: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        SysOpOutput::err(VmBamlError::Io {
+            message: "File permissions are not supported in the browser".to_string(),
+        })
+    }
+
+    fn symlink(
+        &self,
+        _h: &Arc<BexHeap>,
+        _c: CallId,
+        _target: String,
+        _path: String,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        SysOpOutput::err(VmBamlError::Io {
+            message: "Symbolic links are not supported in the browser".to_string(),
+        })
+    }
 }
 
 fn parse_fetch_result(


### PR DESCRIPTION
- `baml.sys.pid` returns the process id
- `baml.fs.chmod` does unix `chmod`-like behavior. On windows it can only un/set read-only
- `baml.fs.symlink` creates a new symlink.

Like other sysops, all three will panic if unsupported (e.g. in the browser) or blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added filesystem APIs for changing file permissions and creating symbolic links.
  * Added `baml.sys.pid()` to retrieve the current process ID.
  * Added validation and clear errors for invalid modes, missing paths, existing link destinations, and unsupported environments.
  * Added platform-specific behavior, including documented Windows and browser limitations.

* **Tests**
  * Added coverage for permissions, symbolic links, process IDs, validation, error handling, and cross-platform behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->