### PR TITLE
Fix compiler and runtime edge-case regressions

### DIFF
--- a/baml_language/crates/baml_compiler2_ast/src/ast.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/ast.rs
@@ -629,12 +629,6 @@ pub struct AstSourceMap {
     /// For object-constructor fields, the span of the field name keyed by
     /// `(object_expr_id, value_expr_id)`.
     pub object_field_name_spans: HashMap<(ExprId, ExprId), TextRange>,
-    /// Value expressions synthesized from property shorthand. For example,
-    /// `{ options }` lowers to the same key/value shape as
-    /// `{ options: options }`, while this set preserves that the user wrote the
-    /// shorthand so diagnostics can explain its exact-name requirement.
-    pub property_shorthand_exprs: HashSet<ExprId>,
-
     /// Ids of compiler-synthesized nodes — desugarings that have no
     /// user-written source of their own (e.g. the `string.from(${…})` wrapper
     /// and the concat accumulator that backtick interpolation lowers to). Their
@@ -662,7 +656,6 @@ impl AstSourceMap {
             path_segment_spans: HashMap::new(),
             call_arg_label_spans: HashMap::new(),
             object_field_name_spans: HashMap::new(),
-            property_shorthand_exprs: HashSet::new(),
             synthetic_exprs: HashSet::new(),
             synthetic_stmts: HashSet::new(),
             synthetic_patterns: HashSet::new(),
@@ -677,12 +670,6 @@ impl AstSourceMap {
     /// Whether `id` names a compiler-synthesized statement (see `synthetic_stmts`).
     pub fn is_synthetic_stmt(&self, id: StmtId) -> bool {
         self.synthetic_stmts.contains(&id)
-    }
-
-    /// Whether `id` is the value expression synthesized for a shorthand
-    /// property such as the `options` value in `{ options }`.
-    pub fn is_property_shorthand_expr(&self, id: ExprId) -> bool {
-        self.property_shorthand_exprs.contains(&id)
     }
 
     /// Look up a span in an arena that is index-parallel to the arena `id`
@@ -768,6 +755,66 @@ impl AstSourceMap {
 impl Default for AstSourceMap {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// How a property value was written in source.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PropertySyntax {
+    /// An explicit key/value pair such as `{ "name": value }` or
+    /// `Config { name: value }`.
+    Explicit,
+    /// A shorthand property such as `{ name }` or `Config { name }`.
+    Shorthand,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectExprField {
+    pub name: Name,
+    pub value: ExprId,
+    pub syntax: PropertySyntax,
+}
+
+impl ObjectExprField {
+    pub fn explicit(name: Name, value: ExprId) -> Self {
+        Self {
+            name,
+            value,
+            syntax: PropertySyntax::Explicit,
+        }
+    }
+
+    pub fn shorthand(name: Name, value: ExprId) -> Self {
+        Self {
+            name,
+            value,
+            syntax: PropertySyntax::Shorthand,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MapExprEntry {
+    pub key: ExprId,
+    pub value: ExprId,
+    pub syntax: PropertySyntax,
+}
+
+impl MapExprEntry {
+    pub fn explicit(key: ExprId, value: ExprId) -> Self {
+        Self {
+            key,
+            value,
+            syntax: PropertySyntax::Explicit,
+        }
+    }
+
+    pub fn shorthand(key: ExprId, value: ExprId) -> Self {
+        Self {
+            key,
+            value,
+            syntax: PropertySyntax::Shorthand,
+        }
     }
 }
 
@@ -884,14 +931,14 @@ pub enum Expr {
         /// Explicit generic type args from syntax like `Foo<int> { ... }`.
         /// Empty when no `<...>` was written (e.g. bare `Foo { ... }`).
         type_args: Vec<TypeExpr>,
-        fields: Vec<(Name, ExprId)>,
+        fields: Vec<ObjectExprField>,
         spreads: Vec<SpreadField>,
     },
     Array {
         elements: Vec<ExprId>,
     },
     Map {
-        entries: Vec<(ExprId, ExprId)>,
+        entries: Vec<MapExprEntry>,
     },
     Block {
         stmts: Vec<StmtId>,

--- a/baml_language/crates/baml_compiler2_ast/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lib.rs
@@ -2417,6 +2417,58 @@ function Demo(name: string) -> string {
             Expr::Literal(baml_base::Literal::String(s)) if s == "Hello, "
         ));
     }
+
+    #[test]
+    fn property_syntax_is_structural_ast_data() {
+        let items = parse_and_lower(
+            r#"
+class Config { name string }
+function build(name: string) -> unknown {
+  let shorthand_map = { name };
+  let explicit_map = { "name": name };
+  let shorthand_object = Config { name };
+  let explicit_object = Config { name: name };
+  [shorthand_map, explicit_map, shorthand_object, explicit_object]
+}
+"#,
+        );
+        let function = first_function(items);
+        let Some(FunctionBodyDef::Expr(body, _)) = &function.body else {
+            panic!("expected expression body");
+        };
+
+        let map_syntax: Vec<_> = body
+            .exprs
+            .iter()
+            .filter_map(|(_, expr)| match expr {
+                Expr::Map { entries } => entries.first().map(|entry| entry.syntax),
+                _ => None,
+            })
+            .collect();
+        let object_syntax: Vec<_> = body
+            .exprs
+            .iter()
+            .filter_map(|(_, expr)| match expr {
+                Expr::Object { fields, .. } => fields.first().map(|field| field.syntax),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(
+            map_syntax,
+            vec![
+                crate::ast::PropertySyntax::Shorthand,
+                crate::ast::PropertySyntax::Explicit,
+            ]
+        );
+        assert_eq!(
+            object_syntax,
+            vec![
+                crate::ast::PropertySyntax::Shorthand,
+                crate::ast::PropertySyntax::Explicit,
+            ]
+        );
+    }
 }
 
 #[cfg(test)]

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -15,9 +15,9 @@ use crate::{
     ast::{
         ArrayRestPat, AssignOp, AstSourceMap, BinaryOp, CallArg, CatchArm, CatchArmId, CatchClause,
         CatchClauseKind, DefaultExprId, Expr, ExprBody, ExprId, FieldPat, FunctionDefaults,
-        LambdaDef, LambdaKind, LetOrigin, Literal, LoopOrigin, MatchArm, MatchArmId, Param, PatId,
-        Pattern, SpreadField, Stmt, StmtId, TemplateIfBranch, TemplateSegment, TemplateTag,
-        TypeAnnotId, TypeExpr, TypeExprKind, UnaryOp,
+        LambdaDef, LambdaKind, LetOrigin, Literal, LoopOrigin, MapExprEntry, MatchArm, MatchArmId,
+        ObjectExprField, Param, PatId, Pattern, SpreadField, Stmt, StmtId, TemplateIfBranch,
+        TemplateSegment, TemplateTag, TypeAnnotId, TypeExpr, TypeExprKind, UnaryOp,
     },
 };
 
@@ -329,7 +329,7 @@ pub(crate) fn synthesize_llm_spec_body(
     );
 
     // args: { "p": p, ... }
-    let entries: Vec<(ExprId, ExprId)> = param_names
+    let entries: Vec<MapExprEntry> = param_names
         .iter()
         .map(|name| {
             let key = ctx.alloc_expr(
@@ -337,7 +337,7 @@ pub(crate) fn synthesize_llm_spec_body(
                 span,
             );
             let value = ctx.alloc_expr(Expr::Path(vec![name.clone()]), span);
-            (key, value)
+            MapExprEntry::explicit(key, value)
         })
         .collect();
     let args_map = ctx.alloc_expr(Expr::Map { entries }, span);
@@ -364,7 +364,10 @@ pub(crate) fn synthesize_llm_spec_body(
         Expr::Object {
             type_name: baml_base::TypePath::from_dotted("ai.internal.SpecCtx"),
             type_args: vec![],
-            fields: vec![(Name::new("output_format"), of_ref)],
+            fields: vec![ObjectExprField::explicit(
+                Name::new("output_format"),
+                of_ref,
+            )],
             spreads: vec![],
         },
         prompt_start,
@@ -598,11 +601,11 @@ pub(crate) fn synthesize_llm_spec_body(
             type_name: baml_base::TypePath::from_dotted("ai.FunctionSpec"),
             type_args,
             fields: vec![
-                (Name::new("spec_name"), name_lit),
-                (Name::new("args"), args_map),
-                (Name::new("prompt_template"), prompt_lambda),
-                (Name::new("toolbox"), toolbox),
-                (Name::new("default_client"), default_client),
+                ObjectExprField::explicit(Name::new("spec_name"), name_lit),
+                ObjectExprField::explicit(Name::new("args"), args_map),
+                ObjectExprField::explicit(Name::new("prompt_template"), prompt_lambda),
+                ObjectExprField::explicit(Name::new("toolbox"), toolbox),
+                ObjectExprField::explicit(Name::new("default_client"), default_client),
             ],
             spreads: vec![],
         },
@@ -4116,8 +4119,8 @@ impl LoweringContext {
                 type_name: baml_base::TypePath::from_dotted("baml.TaggedString"),
                 type_args: Vec::new(),
                 fields: vec![
-                    (Name::new("parts"), parts_ref),
-                    (Name::new("values"), values_ref),
+                    ObjectExprField::explicit(Name::new("parts"), parts_ref),
+                    ObjectExprField::explicit(Name::new("values"), values_ref),
                 ],
                 spreads: Vec::new(),
             },
@@ -4706,7 +4709,6 @@ impl LoweringContext {
                     {
                         let val_id =
                             self.alloc_expr(Expr::Path(vec![Name::new(&key_segments[0])]), span);
-                        self.source_map.property_shorthand_exprs.insert(val_id);
                         val = Some(val_id);
                     }
                     let key = if key_segments.is_empty() {
@@ -4718,7 +4720,12 @@ impl LoweringContext {
                         if let Some(span) = key_span {
                             field_name_spans.push((val_id, span));
                         }
-                        fields.push((k, val_id));
+                        let field = if seen_colon {
+                            ObjectExprField::explicit(k, val_id)
+                        } else {
+                            ObjectExprField::shorthand(k, val_id)
+                        };
+                        fields.push(field);
                     }
                     position += 1;
                 }
@@ -4812,12 +4819,15 @@ impl LoweringContext {
 
                 if !seen_colon && let Some((name, span)) = shorthand_name {
                     let value = self.alloc_expr(Expr::Path(vec![name]), span);
-                    self.source_map.property_shorthand_exprs.insert(value);
                     val_expr = Some(value);
                 }
 
                 match (key_expr, val_expr) {
-                    (Some(k), Some(v)) => Some((k, v)),
+                    (Some(k), Some(v)) => Some(if seen_colon {
+                        MapExprEntry::explicit(k, v)
+                    } else {
+                        MapExprEntry::shorthand(k, v)
+                    }),
                     _ => None,
                 }
             })

--- a/baml_language/crates/baml_compiler2_ast/src/traverse.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/traverse.rs
@@ -119,16 +119,16 @@ impl ExprBody {
             Expr::Object {
                 fields, spreads, ..
             } => {
-                out.extend(fields.iter().map(|(_, expr)| BodyNode::Expr(*expr)));
+                out.extend(fields.iter().map(|field| BodyNode::Expr(field.value)));
                 out.extend(spreads.iter().map(|s| BodyNode::Expr(s.expr)));
             }
             Expr::Array { elements } => {
                 out.extend(elements.iter().copied().map(BodyNode::Expr));
             }
             Expr::Map { entries } => {
-                for (key, value) in entries {
-                    out.push(BodyNode::Expr(*key));
-                    out.push(BodyNode::Expr(*value));
+                for entry in entries {
+                    out.push(BodyNode::Expr(entry.key));
+                    out.push(BodyNode::Expr(entry.value));
                 }
             }
             Expr::Block { stmts, tail_expr } => {

--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -3424,6 +3424,7 @@ impl PullSink for StackifyCodegen<'_, '_> {
             TyTemplate::List(..)
             | TyTemplate::Map { .. }
             | TyTemplate::Future(..)
+            | TyTemplate::Media(..)
             | TyTemplate::TypeArgRef(_)
             | TyTemplate::Interface(..)
             | TyTemplate::AssociatedTypeProjection { .. }
@@ -3448,54 +3449,62 @@ impl PullSink for StackifyCodegen<'_, '_> {
             // exhaustive final `let v: unknown` arm has its test elided.)
             TyTemplate::BuiltinUnknown { .. } => emit_true(self),
 
-            // Everything else keeps its existing coarse check.
-            other => {
-                // A fully-realized leaf (primitive, enum, alias, literal, …):
+            // Fully realized leaves keep their exact identity/tag fast path,
+            // then use structural matching when no exact fast path exists.
+            // This list is exhaustive on purpose: a new template variant must
+            // choose its type-test strategy here.
+            other @ (TyTemplate::Int { .. }
+            | TyTemplate::Bigint { .. }
+            | TyTemplate::Float { .. }
+            | TyTemplate::String { .. }
+            | TyTemplate::Bool { .. }
+            | TyTemplate::Null { .. }
+            | TyTemplate::Uint8Array { .. }
+            | TyTemplate::Literal(..)
+            | TyTemplate::Enum(..)
+            | TyTemplate::EnumVariant(..)
+            | TyTemplate::RustType { .. }
+            | TyTemplate::Type { .. }
+            | TyTemplate::Resource { .. }
+            | TyTemplate::PromptAst { .. }
+            | TyTemplate::Void { .. }
+            | TyTemplate::TypeAlias(..)
+            | TyTemplate::Never { .. }) => {
+                // A fully-realized leaf (primitive, enum, alias, literal, ...):
                 // class-pointer identity for a `TypeAlias`, otherwise its type
-                // tag. Every non-realized template kind has its own arm above,
-                // so the narrowing below succeeds for everything that reaches
-                // here; the `emit_false` fallbacks guard absent objects and
-                // tagless leaves, not template residue.
-                if let Ok(realized) = <&RealizedTy>::try_from(other) {
-                    if let RealizedTy::TypeAlias(tn, _) = realized {
-                        if let Some(class_obj_idx) = self.class_object_index_for_type_name(tn) {
-                            let c = self.add_constant(ConstValue::Object(ObjectIndex::from_raw(
-                                class_obj_idx,
-                            )));
-                            let inst = self.emit(Instruction::IsType(c));
-                            self.set_operand(
-                                inst,
-                                OperandMeta::Const(tn.display_name().to_string()),
-                            );
-                        } else {
-                            emit_false(self);
-                        }
-                    } else if let RealizedTy::Enum(tn, _) = realized {
-                        // Enum-pointer identity: `is Color` tests the value's enum
-                        // object, so it discriminates `Color` from `Status` — the
-                        // shared `ENUM` type tag cannot. Falls back to constant-false
-                        // if the enum object is absent (e.g. an unreferenced enum).
-                        if let Some(enum_obj_idx) = self.enum_object_index_for_type_name(tn) {
-                            let c = self.add_constant(ConstValue::Object(ObjectIndex::from_raw(
-                                enum_obj_idx,
-                            )));
-                            let inst = self.emit(Instruction::IsType(c));
-                            self.set_operand(
-                                inst,
-                                OperandMeta::Const(tn.display_name().to_string()),
-                            );
-                        } else {
-                            emit_false(self);
-                        }
-                    } else if let Some(tag) = realized_type_tag(realized) {
-                        let c = self.add_constant(ConstValue::Int(tag));
+                // tag when one exactly represents the test. Tagless leaves use
+                // the canonical structural matcher instead of silently
+                // compiling to false.
+                let realized = <&RealizedTy>::try_from(other)
+                    .expect("exhaustive realized-leaf template classification");
+                if let RealizedTy::TypeAlias(tn, _) = realized {
+                    if let Some(class_obj_idx) = self.class_object_index_for_type_name(tn) {
+                        let c = self
+                            .add_constant(ConstValue::Object(ObjectIndex::from_raw(class_obj_idx)));
                         let inst = self.emit(Instruction::IsType(c));
-                        self.set_operand(inst, OperandMeta::Const(realized.to_string()));
+                        self.set_operand(inst, OperandMeta::Const(tn.display_name().to_string()));
                     } else {
                         emit_false(self);
                     }
+                } else if let RealizedTy::Enum(tn, _) = realized {
+                    // Enum-pointer identity: `is Color` tests the value's enum
+                    // object, so it discriminates `Color` from `Status` - the
+                    // shared `ENUM` type tag cannot. Falls back to constant-false
+                    // if the enum object is absent (e.g. an unreferenced enum).
+                    if let Some(enum_obj_idx) = self.enum_object_index_for_type_name(tn) {
+                        let c = self
+                            .add_constant(ConstValue::Object(ObjectIndex::from_raw(enum_obj_idx)));
+                        let inst = self.emit(Instruction::IsType(c));
+                        self.set_operand(inst, OperandMeta::Const(tn.display_name().to_string()));
+                    } else {
+                        emit_false(self);
+                    }
+                } else if let Some(tag) = realized_type_tag(realized) {
+                    let c = self.add_constant(ConstValue::Int(tag));
+                    let inst = self.emit(Instruction::IsType(c));
+                    self.set_operand(inst, OperandMeta::Const(realized.to_string()));
                 } else {
-                    emit_false(self);
+                    emit_structural(self, other);
                 }
             }
         }
@@ -3636,6 +3645,7 @@ fn realized_type_tag(ty: &RealizedTy) -> Option<i64> {
         RealizedTy::Map { .. } => Some(baml_type::typetag::MAP),
         RealizedTy::Function { .. } => Some(baml_type::typetag::FUNCTION),
         RealizedTy::Uint8Array { .. } => Some(baml_type::typetag::UINT8ARRAY),
+        RealizedTy::Type { .. } => Some(baml_type::typetag::TYPE),
         RealizedTy::Literal(lit, _, _) => Some(match lit {
             baml_base::Literal::Int(_) => baml_type::typetag::INT,
             baml_base::Literal::Bigint(_) => baml_type::typetag::BIGINT,
@@ -3643,7 +3653,19 @@ fn realized_type_tag(ty: &RealizedTy) -> Option<i64> {
             baml_base::Literal::String(_) => baml_type::typetag::STRING,
             baml_base::Literal::Bool(_) => baml_type::typetag::BOOL,
         }),
-        _ => None,
+        RealizedTy::Media(..)
+        | RealizedTy::Class(..)
+        | RealizedTy::Interface(..)
+        | RealizedTy::Union(..)
+        | RealizedTy::Future(..)
+        | RealizedTy::RustType { .. }
+        | RealizedTy::Resource { .. }
+        | RealizedTy::PromptAst { .. }
+        | RealizedTy::Void { .. }
+        | RealizedTy::TypeAlias(..)
+        | RealizedTy::BuiltinUnknown { .. }
+        | RealizedTy::Never { .. }
+        | RealizedTy::EnumVariant(..) => None,
     }
 }
 

--- a/baml_language/crates/baml_compiler2_hir/src/builder.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/builder.rs
@@ -689,8 +689,8 @@ impl<'db> SemanticIndexBuilder<'db> {
             ast::Expr::Object {
                 fields, spreads, ..
             } => {
-                for (_, field_expr) in fields {
-                    self.walk_expr(*field_expr, body, source_map, true);
+                for field in fields {
+                    self.walk_expr(field.value, body, source_map, true);
                 }
                 for spread in spreads {
                     self.walk_expr(spread.expr, body, source_map, true);
@@ -702,9 +702,9 @@ impl<'db> SemanticIndexBuilder<'db> {
                 }
             }
             ast::Expr::Map { entries } => {
-                for &(key, value) in entries {
-                    self.walk_expr(key, body, source_map, true);
-                    self.walk_expr(value, body, source_map, true);
+                for entry in entries {
+                    self.walk_expr(entry.key, body, source_map, true);
+                    self.walk_expr(entry.value, body, source_map, true);
                 }
             }
             ast::Expr::MemberAccess { base, .. }

--- a/baml_language/crates/baml_compiler2_hir_ty/src/defaults.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/defaults.rs
@@ -218,8 +218,14 @@ fn collect_default_expr_forward_references(
         Expr::Object {
             fields, spreads, ..
         } => {
-            for (_, expr) in fields {
-                collect_default_expr_forward_references(*expr, body, later_params, shadowed, refs);
+            for field in fields {
+                collect_default_expr_forward_references(
+                    field.value,
+                    body,
+                    later_params,
+                    shadowed,
+                    refs,
+                );
             }
             for spread in spreads {
                 collect_default_expr_forward_references(
@@ -237,9 +243,21 @@ fn collect_default_expr_forward_references(
             }
         }
         Expr::Map { entries } => {
-            for (key, value) in entries {
-                collect_default_expr_forward_references(*key, body, later_params, shadowed, refs);
-                collect_default_expr_forward_references(*value, body, later_params, shadowed, refs);
+            for entry in entries {
+                collect_default_expr_forward_references(
+                    entry.key,
+                    body,
+                    later_params,
+                    shadowed,
+                    refs,
+                );
+                collect_default_expr_forward_references(
+                    entry.value,
+                    body,
+                    later_params,
+                    shadowed,
+                    refs,
+                );
             }
         }
         Expr::Block { stmts, tail_expr } => {

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -24,7 +24,8 @@ pub mod unify;
 use std::sync::Arc;
 
 use baml_compiler2_ast::{
-    Expr, ExprBody, ExprId, PatId, Pattern, Stmt, StmtId, traverse::BodyNode,
+    Expr, ExprBody, ExprId, ObjectExprField, PatId, Pattern, PropertySyntax, Stmt, StmtId,
+    traverse::BodyNode,
 };
 use baml_compiler2_hir::{
     body::BodyOwnerId,
@@ -1143,6 +1144,7 @@ fn infer_body_impl<'db>(
         // relies on).
         let defaults = baml_compiler2_ppir::function_parameter_defaults(db, function);
         if let Some(arena) = body.expr_body() {
+            ctx.register_property_shorthands(arena);
             for (index, default) in defaults.params.iter().enumerate() {
                 let Some(default) = default else { continue };
                 match ctx.param_tys.get(index).cloned() {
@@ -1367,9 +1369,10 @@ struct InferenceContext<'db> {
     /// result - TS short-circuit semantics, where intermediate links
     /// see the non-null type.
     chain_nullable: Vec<bool>,
-    /// Value exprs whose unresolved-name diagnostic was superseded by a
-    /// more specific one (object property shorthand).
-    suppressed_unresolved: rustc_hash::FxHashSet<ExprId>,
+    /// Shorthand value expressions and the exact property name they require.
+    /// Populated from the structural AST before inference so the ordinary path
+    /// resolver can select the specialized unresolved-name diagnostic.
+    property_shorthand_values: FxHashMap<ExprId, baml_type::Name>,
     /// BEP-042: loop depth at each active `defer` entry - a
     /// `break`/`continue` at the SAME depth (or any `return`) would
     /// escape the defer body and is rejected.
@@ -1438,7 +1441,7 @@ impl<'db> InferenceContext<'db> {
             body_owner: None,
             defaults_owner: false,
             chain_nullable: Vec::new(),
-            suppressed_unresolved: rustc_hash::FxHashSet::default(),
+            property_shorthand_values: FxHashMap::default(),
             defer_loop_floors: Vec::new(),
             loop_depth: 0,
             body_root: None,
@@ -1466,6 +1469,7 @@ impl<'db> InferenceContext<'db> {
     }
 
     fn infer_expr_body(&mut self, body: &ExprBody) {
+        self.register_property_shorthands(body);
         self.body_root = body.root_expr;
         if let Some(root) = body.root_expr {
             match self.return_ty.clone() {
@@ -1504,6 +1508,39 @@ impl<'db> InferenceContext<'db> {
                 .pattern_ascription_ty(body, pat_id)
                 .unwrap_or_else(Ty::error);
             self.result.type_of_pat.insert(pat_id, ty);
+        }
+    }
+
+    fn register_property_shorthands(&mut self, body: &ExprBody) {
+        for (_, expr) in body.exprs.iter() {
+            match expr {
+                Expr::Map { entries } => {
+                    for entry in entries {
+                        if entry.syntax != PropertySyntax::Shorthand {
+                            continue;
+                        }
+                        let Expr::Path(segments) = &body.exprs[entry.value] else {
+                            debug_assert!(false, "map shorthand value must be a path");
+                            continue;
+                        };
+                        let [name] = segments.as_slice() else {
+                            debug_assert!(false, "map shorthand value must be a single name");
+                            continue;
+                        };
+                        self.property_shorthand_values
+                            .insert(entry.value, name.clone());
+                    }
+                }
+                Expr::Object { fields, .. } => {
+                    for field in fields {
+                        if field.syntax == PropertySyntax::Shorthand {
+                            self.property_shorthand_values
+                                .insert(field.value, field.name.clone());
+                        }
+                    }
+                }
+                _ => {}
+            }
         }
     }
 
@@ -2002,36 +2039,6 @@ impl<'db> InferenceContext<'db> {
                 }
             }
             Expr::Map { entries } => {
-                // Property shorthand in an UNTYPED object (`{ options }`):
-                // an entry whose key literal spells its own single-segment
-                // value path. When that name resolves nowhere, the
-                // specialized diagnostic (with in-scope near-matches)
-                // supersedes the generic unresolved-name one.
-                for (key, value) in entries {
-                    let Expr::Literal(Literal::String(key_name)) = &body.exprs[*key] else {
-                        continue;
-                    };
-                    let Expr::Path(segments) = &body.exprs[*value] else {
-                        continue;
-                    };
-                    if segments.len() != 1 || segments[0].as_str() != key_name.as_str() {
-                        continue;
-                    }
-                    let locals = self.local_binding_names();
-                    if self.lower.resolve_value(segments).is_some()
-                        || locals.iter().any(|name| name == &segments[0])
-                    {
-                        continue;
-                    }
-                    let suggestions =
-                        crate::diagnostics::similar_name_suggestions(&segments[0], locals.iter());
-                    self.suppressed_unresolved.insert(*value);
-                    self.pending_diags.push(PendingDiag::UnresolvedShorthand {
-                        expr: *value,
-                        name: segments[0].clone(),
-                        suggestions,
-                    });
-                }
                 // With an expected map type, entries are CHECKED against
                 // its key/value (the Array arm's rule; r-a's
                 // expectation-driven literal typing) - `{"input": s}` in
@@ -2039,9 +2046,9 @@ impl<'db> InferenceContext<'db> {
                 // synthesized `map<string, string>` tripping invariance.
                 let expected_entry = self.expected_map_entry(expected);
                 if let Some((key_ty, value_ty)) = expected_entry {
-                    for (key, value) in entries {
-                        self.check_expr(body, *key, &key_ty);
-                        self.check_expr(body, *value, &value_ty);
+                    for entry in entries {
+                        self.check_expr(body, entry.key, &key_ty);
+                        self.check_expr(body, entry.value, &value_ty);
                     }
                     Ty::intern(TyKind::Map {
                         key: key_ty,
@@ -2062,9 +2069,9 @@ impl<'db> InferenceContext<'db> {
                 } else {
                     let (keys, values): (Vec<Ty>, Vec<Ty>) = entries
                         .iter()
-                        .map(|(key, value)| {
-                            let key_ty = self.infer_expr(body, *key, &Expectation::None);
-                            let value_ty = self.infer_expr(body, *value, &Expectation::None);
+                        .map(|entry| {
+                            let key_ty = self.infer_expr(body, entry.key, &Expectation::None);
+                            let value_ty = self.infer_expr(body, entry.value, &Expectation::None);
                             (self.widen_fresh(&key_ty), self.widen_fresh(&value_ty))
                         })
                         .unzip();
@@ -2119,8 +2126,8 @@ impl<'db> InferenceContext<'db> {
                     && matches!(type_name.0.as_slice(), [seg] if seg.as_str() == "map")
                 {
                     if let Some((key_ty, value_ty)) = self.expected_map_entry(expected) {
-                        for (_, value) in fields {
-                            self.check_expr(body, *value, &value_ty);
+                        for field in fields {
+                            self.check_expr(body, field.value, &value_ty);
                         }
                         Ty::intern(TyKind::Map {
                             key: key_ty,
@@ -2136,8 +2143,9 @@ impl<'db> InferenceContext<'db> {
                     } else {
                         let values: Vec<Ty> = fields
                             .iter()
-                            .map(|(_, value)| {
-                                let value_ty = self.infer_expr(body, *value, &Expectation::None);
+                            .map(|field| {
+                                let value_ty =
+                                    self.infer_expr(body, field.value, &Expectation::None);
                                 self.widen_fresh(&value_ty)
                             })
                             .collect();
@@ -4981,9 +4989,7 @@ impl<'db> InferenceContext<'db> {
         // A name that RESOLVES to a definition kind this road doesn't
         // type (clients, top-level lets outside their tier) is not
         // unresolved - it stays the silent sentinel it always was.
-        if self.lower.resolve_value(segments).is_none()
-            && !self.suppressed_unresolved.contains(&expr)
-        {
+        if self.lower.resolve_value(segments).is_none() {
             // When a proper prefix resolves (`baml.media.Image.missing`
             // has the valid type `baml.media.Image`), the segment AFTER
             // the longest valid prefix is what failed - report it alone,
@@ -5004,8 +5010,19 @@ impl<'db> InferenceContext<'db> {
                         .join("."),
                 )
             });
-            self.pending_diags
-                .push(PendingDiag::UnresolvedName { expr, name });
+            if let Some(shorthand_name) = self.property_shorthand_values.get(&expr).cloned() {
+                let locals = self.local_binding_names_at(expr);
+                let suggestions =
+                    crate::diagnostics::similar_name_suggestions(&shorthand_name, locals.iter());
+                self.pending_diags.push(PendingDiag::UnresolvedShorthand {
+                    expr,
+                    name: shorthand_name,
+                    suggestions,
+                });
+            } else {
+                self.pending_diags
+                    .push(PendingDiag::UnresolvedName { expr, name });
+            }
         }
         Ty::error()
     }
@@ -5646,7 +5663,7 @@ impl<'db> InferenceContext<'db> {
         body: &ExprBody,
         object: ExprId,
         type_name: &baml_base::TypePath,
-        fields: &[(baml_type::Name, ExprId)],
+        fields: &[ObjectExprField],
         spreads: &[baml_compiler2_ast::SpreadField],
     ) -> Ty {
         let Some(baml_compiler2_hir::contributions::Definition::Class(class)) =
@@ -5673,8 +5690,8 @@ impl<'db> InferenceContext<'db> {
                     suggestions: self.lower.type_suggestions(&segments),
                 });
             }
-            for (_, value) in fields {
-                self.infer_expr(body, *value, &Expectation::None);
+            for field in fields {
+                self.infer_expr(body, field.value, &Expectation::None);
             }
             for spread in spreads {
                 self.infer_expr(body, spread.expr, &Expectation::None);
@@ -5713,11 +5730,13 @@ impl<'db> InferenceContext<'db> {
                 });
             }
         }
-        for (name, value) in fields {
+        for field in fields {
+            let name = &field.name;
+            let value = field.value;
             match field_types.iter().find(|(field, _)| field == name) {
                 Some((_, field_ty)) => {
                     let field_ty = substitute_params(field_ty, &instantiation);
-                    self.check_expr(body, *value, &field_ty);
+                    self.check_expr(body, value, &field_ty);
                 }
                 None => {
                     // An INTERFACE field of an implemented interface is not
@@ -5736,19 +5755,16 @@ impl<'db> InferenceContext<'db> {
                         match field_types.iter().find(|(field, _)| *field == class_field) {
                             Some((_, field_ty)) => {
                                 let field_ty = substitute_params(field_ty, &instantiation);
-                                self.check_expr(body, *value, &field_ty);
+                                self.check_expr(body, value, &field_ty);
                             }
                             None => {
-                                self.infer_expr(body, *value, &Expectation::None);
+                                self.infer_expr(body, value, &Expectation::None);
                             }
                         }
                         continue;
                     }
-                    self.infer_expr(body, *value, &Expectation::None);
-                    let shorthand = matches!(
-                        &body.exprs[*value],
-                        Expr::Path(segments) if segments.len() == 1 && &segments[0] == name
-                    );
+                    self.infer_expr(body, value, &Expectation::None);
+                    let shorthand = field.syntax == PropertySyntax::Shorthand;
                     let class_name = crate::lower::qualify_def(
                         db,
                         baml_compiler2_hir::contributions::Definition::Class(class),
@@ -5756,7 +5772,7 @@ impl<'db> InferenceContext<'db> {
                     );
                     self.pending_diags.push(PendingDiag::UnknownObjectField {
                         object,
-                        value: *value,
+                        value,
                         class_name,
                         declared: field_types.iter().map(|(field, _)| field.clone()).collect(),
                         name: name.clone(),
@@ -8342,12 +8358,14 @@ impl<'db> InferenceContext<'db> {
         None
     }
 
-    /// Every value name visible at the CURRENT scope (params and let
-    /// bindings through the ancestor chain) - the near-match candidate
-    /// pool for shorthand suggestions.
-    fn local_binding_names(&self) -> Vec<baml_type::Name> {
+    /// Every local value name in the expression's lexical scope and its
+    /// ancestors - the near-match candidate pool for shorthand suggestions.
+    fn local_binding_names_at(&self, expr: ExprId) -> Vec<baml_type::Name> {
         let mut names = Vec::new();
-        let Some(scope) = self.current_scope else {
+        let Some(scope) = self
+            .metadata_key(expr)
+            .and_then(|key| self.index.expression_scope(key))
+        else {
             return names;
         };
         let index = self.index;

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -5066,7 +5066,12 @@ impl LoweringContext<'_> {
             AstExpr::Map { entries } => {
                 let pairs: Vec<(Operand, Operand)> = entries
                     .iter()
-                    .map(|&(k, v)| (self.lower_to_operand(k), self.lower_to_operand(v)))
+                    .map(|entry| {
+                        (
+                            self.lower_to_operand(entry.key),
+                            self.lower_to_operand(entry.value),
+                        )
+                    })
                     .collect();
                 let (key_ty, value_ty) = self.map_kv_templates(expr_id);
                 self.builder
@@ -6533,20 +6538,22 @@ impl LoweringContext<'_> {
     /// Lower `a ?? b` — evaluate `a`, if null then evaluate `b`, otherwise use `a`.
     fn lower_null_coalesce(
         &mut self,
-        _expr_id: AstExprId,
+        expr_id: AstExprId,
         lhs: AstExprId,
         rhs: AstExprId,
         dest: Place,
     ) {
-        // Evaluate LHS and store in dest
+        let result = self.builder.temp(self.expr_ty(expr_id));
+        let result_place = Place::local(result);
+
         let lhs_op = self.lower_to_operand(lhs);
         self.builder
-            .assign(dest.clone(), Rvalue::Use(lhs_op.clone()));
+            .assign(result_place.clone(), Rvalue::Use(lhs_op));
 
         // Test: lhs == null
         let is_null = Rvalue::BinaryOp {
             op: BinOp::Eq,
-            left: lhs_op,
+            left: Operand::Copy(result_place.clone()),
             right: Operand::Constant(Constant::Null),
         };
         let test_local = self.builder.temp(RuntimeTy::Bool {
@@ -6562,12 +6569,14 @@ impl LoweringContext<'_> {
             .branch(Operand::Copy(Place::Local(test_local)), bb_rhs, bb_join);
 
         self.builder.set_current_block(bb_rhs);
-        self.lower_expr(rhs, dest);
+        self.lower_expr(rhs, result_place.clone());
         if !self.builder.is_current_terminated() {
             self.builder.goto(bb_join);
         }
 
         self.builder.set_current_block(bb_join);
+        self.builder
+            .assign(dest, Rvalue::Use(Operand::Copy(result_place)));
     }
 
     /// Lower `OptionalChain { expr }` — set up shared null exit for the entire chain.
@@ -9245,7 +9254,7 @@ impl<'db> LoweringContext<'db> {
         expr_id: AstExprId,
         type_name: &TypePath,
         type_args: &[AstTypeExpr],
-        fields: &[(Name, AstExprId)],
+        fields: &[baml_compiler2_ast::ObjectExprField],
         spreads: &[baml_compiler2_ast::SpreadField],
         dest: Place,
     ) {
@@ -9298,9 +9307,9 @@ impl<'db> LoweringContext<'db> {
                 let mut result: Vec<Operand> = (0..field_slot_count(&field_name_to_idx))
                     .map(|_| Operand::Constant(Constant::Null))
                     .collect();
-                for (name, expr) in fields {
-                    if let Some(&idx) = field_name_to_idx.get(&name.to_string()) {
-                        result[idx] = self.lower_to_operand(*expr);
+                for field in fields {
+                    if let Some(&idx) = field_name_to_idx.get(&field.name.to_string()) {
+                        result[idx] = self.lower_to_operand(field.value);
                     }
                 }
                 result
@@ -9311,7 +9320,7 @@ impl<'db> LoweringContext<'db> {
                 // matches the class definition.
                 fields
                     .iter()
-                    .map(|(_, e)| self.lower_to_operand(*e))
+                    .map(|field| self.lower_to_operand(field.value))
                     .collect()
             };
             let type_arg_templates = self.object_class_type_arg_templates(expr_id, type_args);
@@ -9360,13 +9369,17 @@ impl<'db> LoweringContext<'db> {
                 let mut pos = 0usize;
                 fields
                     .iter()
-                    .map(|(name, e)| {
+                    .map(|field| {
                         while spread_positions.contains(&pos) {
                             pos += 1;
                         }
                         let cur = pos;
                         pos += 1;
-                        (cur, name.to_string(), self.lower_to_operand(*e))
+                        (
+                            cur,
+                            field.name.to_string(),
+                            self.lower_to_operand(field.value),
+                        )
                     })
                     .collect()
             };
@@ -9382,7 +9395,7 @@ impl<'db> LoweringContext<'db> {
                     // Unknown class — just emit named fields in order.
                     let field_operands: Vec<Operand> = fields
                         .iter()
-                        .map(|(_, e)| self.lower_to_operand(*e))
+                        .map(|field| self.lower_to_operand(field.value))
                         .collect();
                     let type_arg_templates =
                         self.object_class_type_arg_templates(expr_id, type_args);

--- a/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
+++ b/baml_language/crates/baml_compiler2_visualization/src/control_flow/from_ast.rs
@@ -951,8 +951,8 @@ fn collect_callee_names_expr(body: &ast::ExprBody, id: ast::ExprId, names: &mut 
         ast::Expr::Object {
             fields, spreads, ..
         } => {
-            for (_, field_expr) in fields {
-                collect_callee_names_expr(body, *field_expr, names);
+            for field in fields {
+                collect_callee_names_expr(body, field.value, names);
             }
             for spread in spreads {
                 collect_callee_names_expr(body, spread.expr, names);
@@ -964,9 +964,9 @@ fn collect_callee_names_expr(body: &ast::ExprBody, id: ast::ExprId, names: &mut 
             }
         }
         ast::Expr::Map { entries } => {
-            for (key, value) in entries {
-                collect_callee_names_expr(body, *key, names);
-                collect_callee_names_expr(body, *value, names);
+            for entry in entries {
+                collect_callee_names_expr(body, entry.key, names);
+                collect_callee_names_expr(body, entry.value, names);
             }
         }
         ast::Expr::Block { stmts, tail_expr } => {
@@ -1862,7 +1862,7 @@ mod tests {
             let obj = exprs.alloc(ast::Expr::Object {
                 type_name: TypePath::bare("MyResponse".into()),
                 type_args: vec![],
-                fields: vec![("ok".into(), field_val)],
+                fields: vec![ast::ObjectExprField::explicit("ok".into(), field_val)],
                 spreads: vec![],
             });
             let ret = stmts.alloc(ast::Stmt::Return(Some(obj)));
@@ -2041,7 +2041,7 @@ mod tests {
             let obj_false = exprs.alloc(ast::Expr::Object {
                 type_name: TypePath::bare("Result".into()),
                 type_args: vec![],
-                fields: vec![("err".into(), err_val)],
+                fields: vec![ast::ObjectExprField::explicit("err".into(), err_val)],
                 spreads: vec![],
             });
             let ret_false = stmts.alloc(ast::Stmt::Return(Some(obj_false)));
@@ -2081,7 +2081,7 @@ mod tests {
         let obj = exprs.alloc(ast::Expr::Object {
             type_name: TypePath::bare("Resp".into()),
             type_args: vec![],
-            fields: vec![("ok".into(), field_val)],
+            fields: vec![ast::ObjectExprField::explicit("ok".into(), field_val)],
             spreads: vec![],
         });
 

--- a/baml_language/crates/baml_lsp2_actions/src/definition.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/definition.rs
@@ -490,7 +490,7 @@ fn resolve_constructor_field_at(
             // Check if cursor token matches any field key name
             let _matching_field = fields
                 .iter()
-                .find(|(name, _)| name.as_str() == token_text)?;
+                .find(|field| field.name.as_str() == token_text)?;
 
             // Get the Object's type
             let obj_ty = inference.type_of_expr.get(&expr_id)?.to_plain();

--- a/baml_language/crates/baml_lsp2_actions/src/usages.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/usages.rs
@@ -511,7 +511,7 @@ fn find_field_definition_usages(
                     // Check if any field key matches
                     let has_matching_key = fields
                         .iter()
-                        .any(|(name, _)| name.as_str() == field_name_text);
+                        .any(|field| field.name.as_str() == field_name_text);
                     if !has_matching_key {
                         continue;
                     }

--- a/baml_language/crates/baml_tests/baml_src/ns_media_json_union/media_json_union.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_media_json_union/media_json_union.baml
@@ -36,10 +36,37 @@ function media_json_union_respects_reversed_order() -> string {
     }
 }
 
+function rejects_media_json<T>(json: string) -> bool {
+    {
+        baml.json.from_string<T>(json);
+        false
+    } catch (e) {
+        baml.json.JsonDecodeError => true
+    }
+}
+
 test "media JSON unions roundtrip every kind" {
     assert.equal(media_json_union_roundtrips_every_kind(), "image,audio,video,pdf")
 }
 
 test "media JSON unions respect reversed order" {
     assert.equal(media_json_union_respects_reversed_order(), "image")
+}
+
+test "media JSON rejects missing kind" {
+    assert.is_true(rejects_media_json<image>(
+        "{\"source\":\"base64\",\"value\":\"aGk=\",\"mime\":\"image/png\"}",
+    ))
+}
+
+test "media JSON rejects mismatched concrete kind" {
+    assert.is_true(rejects_media_json<image>(
+        "{\"kind\":\"audio\",\"source\":\"base64\",\"value\":\"aGk=\",\"mime\":\"audio/mpeg\"}",
+    ))
+}
+
+test "media JSON rejects generic kind" {
+    assert.is_true(rejects_media_json<image | audio | video | pdf>(
+        "{\"kind\":\"media\",\"source\":\"base64\",\"value\":\"aGk=\"}",
+    ))
 }

--- a/baml_language/crates/baml_tests/baml_src/ns_media_json_union/media_json_union.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_media_json_union/media_json_union.baml
@@ -1,0 +1,45 @@
+function classify_media_json_union(value: image | audio | video | pdf) -> string {
+    match (value) {
+        image => "image",
+        audio => "audio",
+        video => "video",
+        pdf => "pdf",
+    }
+}
+
+function media_json_union_roundtrips_every_kind() -> string {
+    let image_json = baml.json.to_json(image.from_base64("aGk=", "image/png"));
+    let audio_json = baml.json.to_json(audio.from_base64("aGk=", "audio/mpeg"));
+    let video_json = baml.json.to_json(video.from_base64("aGk=", "video/mp4"));
+    let pdf_json = baml.json.to_json(pdf.from_base64("aGk=", "application/pdf"));
+
+    let image_value = baml.json.from_json<image | audio | video | pdf>(image_json);
+    let audio_value = baml.json.from_json<image | audio | video | pdf>(audio_json);
+    let video_value = baml.json.from_json<image | audio | video | pdf>(video_json);
+    let pdf_value = baml.json.from_json<image | audio | video | pdf>(pdf_json);
+
+    classify_media_json_union(image_value)
+        + ","
+        + classify_media_json_union(audio_value)
+        + ","
+        + classify_media_json_union(video_value)
+        + ","
+        + classify_media_json_union(pdf_value)
+}
+
+function media_json_union_respects_reversed_order() -> string {
+    let json = baml.json.to_json(image.from_base64("aGk=", "image/png"));
+    let value = baml.json.from_json<audio | image>(json);
+    match (value) {
+        audio => "audio",
+        image => "image",
+    }
+}
+
+test "media JSON unions roundtrip every kind" {
+    assert.equal(media_json_union_roundtrips_every_kind(), "image,audio,video,pdf")
+}
+
+test "media JSON unions respect reversed order" {
+    assert.equal(media_json_union_respects_reversed_order(), "image")
+}

--- a/baml_language/crates/baml_tests/baml_src/ns_null_handling/null_handling.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_null_handling/null_handling.baml
@@ -146,6 +146,28 @@ test "null_coalesce_null_lhs_evaluates_rhs" {
     assert.equal(nh_run_null_coalesce_null_lhs(), 11)
 }
 
+function nh_null_coalesce_self_local(input: int?) -> int {
+    let value = 7;
+    value = input ?? value;
+    value
+}
+
+test "null_coalesce_rhs_reads_old_local_destination" {
+    assert.equal(nh_null_coalesce_self_local(null), 7);
+    assert.equal(nh_null_coalesce_self_local(42), 42)
+}
+
+function nh_null_coalesce_self_field(input: int?) -> int {
+    let node = NhNode { value: 9, next: null, children: null, labels: null };
+    node.value = input ?? node.value;
+    node.value
+}
+
+test "null_coalesce_rhs_reads_old_field_destination" {
+    assert.equal(nh_null_coalesce_self_field(null), 9);
+    assert.equal(nh_null_coalesce_self_field(42), 42)
+}
+
 // ============================================================================
 // 3. Combined: compound assign through mixed chain with ??-provided fallback
 // ============================================================================

--- a/baml_language/crates/baml_tests/baml_src/ns_property_shorthand/property_shorthand.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_property_shorthand/property_shorthand.baml
@@ -84,3 +84,91 @@ test "shorthand works across multiple nested classes" {
         PropertyShorthandOuter { middle: PropertyShorthandMiddle { leaf: PropertyShorthandLeaf { value: "deep"}}},
     )
 }
+
+class PropertyShorthandBinder {
+    value: string,
+}
+
+class PropertyShorthandError {
+    message: string,
+}
+
+function property_shorthand_if_let(input: string?) -> string {
+    if let name: string = input {
+        let quoted: map<string, string> = { "name": name };
+        let shorthand: map<string, string> = { name };
+        (quoted.get("name") ?? "") + (shorthand.get("name") ?? "")
+    } else {
+        ""
+    }
+}
+
+function property_shorthand_match(input: string?) -> string {
+    match (input) {
+        let name: string => {
+            let shorthand: map<string, string> = { name };
+            shorthand.get("name") ?? ""
+        },
+        null => "",
+    }
+}
+
+function property_shorthand_for(names: string[]) -> string {
+    let output = "";
+    for (let name in names) {
+        let shorthand: map<string, string> = { name };
+        output = output + (shorthand.get("name") ?? "");
+    }
+    output
+}
+
+function property_shorthand_throw() -> string throws PropertyShorthandError {
+    throw PropertyShorthandError { message: "caught" }
+}
+
+function property_shorthand_catch() -> string {
+    property_shorthand_throw() catch (error) {
+        PropertyShorthandError => {
+            let shorthand = { error };
+            error.message
+        }
+    }
+}
+
+function property_shorthand_destructure() -> string {
+    let PropertyShorthandBinder { value } = PropertyShorthandBinder { value: "destructured" };
+    let shorthand: map<string, string> = { value };
+    shorthand.get("value") ?? ""
+}
+
+function property_shorthand_nested_block() -> string {
+    {
+        let name = "nested";
+        let shorthand: map<string, string> = { name };
+        shorthand.get("name") ?? ""
+    }
+}
+
+function property_shorthand_class_if_let(input: string?) -> string {
+    if let value: string = input {
+        PropertyShorthandBinder { value }.value
+    } else {
+        ""
+    }
+}
+
+test "if let binders work in explicit and shorthand map entries" {
+    assert.equal(property_shorthand_if_let("if-let"), "if-letif-let")
+}
+
+test "shorthand uses every lexical binder scope" {
+    assert.equal(property_shorthand_match("match"), "match");
+    assert.equal(property_shorthand_for(["for", "-binder"]), "for-binder");
+    assert.equal(property_shorthand_catch(), "caught");
+    assert.equal(property_shorthand_destructure(), "destructured");
+    assert.equal(property_shorthand_nested_block(), "nested")
+}
+
+test "class shorthand sees if let binders" {
+    assert.equal(property_shorthand_class_if_let("class"), "class")
+}

--- a/baml_language/crates/baml_tests/baml_src/ns_runtime_leaf_narrowing/runtime_leaf_narrowing.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_runtime_leaf_narrowing/runtime_leaf_narrowing.baml
@@ -1,0 +1,85 @@
+function is_type_runtime_value() -> bool {
+    let value: type | int = reflect.type_of<int>();
+    value is type
+}
+
+function is_type_rejects_non_type() -> bool {
+    let value: type | int = 7;
+    value is type
+}
+
+function if_let_binds_type_runtime_value() -> string {
+    let value: type | int = reflect.type_of<string>();
+    if let runtime_type: type = value {
+        runtime_type.to_string()
+    } else {
+        "not type"
+    }
+}
+
+function is_distinguishes_media_runtime_values() -> bool {
+    let image_value: image | audio | video | pdf = image.from_base64("aGk=", "image/png");
+    let audio_value: image | audio | video | pdf = audio.from_base64("aGk=", "audio/mpeg");
+    let video_value: image | audio | video | pdf = video.from_base64("aGk=", "video/mp4");
+    let pdf_value: image | audio | video | pdf = pdf.from_base64("aGk=", "application/pdf");
+    (image_value is image)
+        && !(image_value is audio)
+        && (audio_value is audio)
+        && !(audio_value is video)
+        && (video_value is video)
+        && !(video_value is pdf)
+        && (pdf_value is pdf)
+        && !(pdf_value is image)
+}
+
+function classify_type_runtime_value(value: type | int) -> string {
+    match (value) {
+        let runtime_type: type => runtime_type.to_string(),
+        int => "int",
+    }
+}
+
+function classify_media_runtime_value(value: image | audio | video | pdf) -> string {
+    match (value) {
+        image => "image",
+        audio => "audio",
+        video => "video",
+        pdf => "pdf",
+    }
+}
+
+function match_recognizes_type_runtime_values() -> bool {
+    classify_type_runtime_value(reflect.type_of<string>()) == "string"
+        && classify_type_runtime_value(7) == "int"
+}
+
+function match_distinguishes_media_runtime_values() -> bool {
+    classify_media_runtime_value(image.from_base64("aGk=", "image/png")) == "image"
+        && classify_media_runtime_value(audio.from_base64("aGk=", "audio/mpeg")) == "audio"
+        && classify_media_runtime_value(video.from_base64("aGk=", "video/mp4")) == "video"
+        && classify_media_runtime_value(pdf.from_base64("aGk=", "application/pdf")) == "pdf"
+}
+
+test "is recognizes type runtime values" {
+    assert.is_true(is_type_runtime_value())
+}
+
+test "is rejects non-type runtime values" {
+    assert.is_true(!is_type_rejects_non_type())
+}
+
+test "if let binds type runtime values" {
+    assert.equal(if_let_binds_type_runtime_value(), "string")
+}
+
+test "is distinguishes media runtime values" {
+    assert.is_true(is_distinguishes_media_runtime_values())
+}
+
+test "match recognizes type runtime values" {
+    assert.is_true(match_recognizes_type_runtime_values())
+}
+
+test "match distinguishes media runtime values" {
+    assert.is_true(match_distinguishes_media_runtime_values())
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
@@ -355,6 +355,12 @@ function $init_test(registry: unknown) -> null {
     load_var ?1
     call ?
     pop 1
+    load_var ?1
+    call ?
+    pop 1
+    load_var ?1
+    call ?
+    pop 1
     load_const ?
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/csv.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/csv.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
-assertion_line: 149
 ---
 function csv.$init_test_ns_csv_csv(registry: testing.TestCollector) -> null {
     load_var registry
@@ -728,29 +727,28 @@ function csv.csv_bom_stripped_by_default() -> string {
     load_const <omitted>
     call baml.csv.reader
     call baml.csv.CsvReader.headers
-    store_var _6
-    load_var _6
-    store_var h
-    load_var _6
+    store_var_load_var _6
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_type string
     alloc_array 0
-    store_var h
+    store_var _6
 
   L0:
+    load_var _6
+    store_var h
     load_var rows
     call user.csv.grid
-    store_var _9
+    store_var _10
     load_var h
     load_const "|"
     call user.csv.join
-    store_var _11
-    load_var _9
+    store_var _12
+    load_var _10
     load_const "/"
     bin_op +
-    load_var _11
+    load_var _12
     bin_op +
     return
 }
@@ -1048,15 +1046,12 @@ function csv.csv_decode_error_details() -> string {
     store_var _14
     load_var e
     load_field .column
-    store_var _17
-    load_var _17
-    store_var _16
-    load_var _17
+    store_var_load_var _17
     load_const null
     cmp_op ==
     pop_jump_if_false L2
     load_const "?"
-    store_var _16
+    store_var _17
 
   L2:
     load_var _10
@@ -1070,7 +1065,7 @@ function csv.csv_decode_error_details() -> string {
     bin_op +
     load_const " column="
     bin_op +
-    load_var _16
+    load_var _17
     bin_op +
     jump L4
 
@@ -1256,21 +1251,18 @@ function csv.csv_decode_missing_column_is_header_error() -> string {
     store_var _6
     load_var e
     load_field .column
-    store_var _9
-    load_var _9
-    store_var _8
-    load_var _9
+    store_var_load_var _9
     load_const null
     cmp_op ==
     pop_jump_if_false L2
     load_const "?"
-    store_var _8
+    store_var _9
 
   L2:
     load_var _6
     load_const ":"
     bin_op +
-    load_var _8
+    load_var _9
     bin_op +
     jump L4
 
@@ -1656,29 +1648,30 @@ function csv.csv_duplicate_column_matched_is_header_error() -> string {
     load_var _9
     is_type baml.iter.Done
     pop_jump_if_false L4
-    jump L5
+    jump L6
 
   L4:
     load_type string
     load_var _9
     load_const 1
     call baml.csv.CsvRecord.get_at
-    store_var _12
-    load_var _12
-    store_var positional
-    load_var _12
+    store_var_load_var _12
     load_const null
     cmp_op ==
-    pop_jump_if_false L6
+    pop_jump_if_false L5
     load_const "<null>"
-    store_var positional
-    jump L6
+    store_var _12
 
   L5:
+    load_var _12
+    store_var positional
+    jump L7
+
+  L6:
     load_const "none"
     store_var positional
 
-  L6:
+  L7:
     load_var err
     load_const "/"
     bin_op +
@@ -1902,27 +1895,28 @@ function csv.csv_file_roundtrip() -> string {
     load_const null
     cmp_op ==
     pop_jump_if_false L0
-    jump L1
+    jump L2
 
   L0:
     load_var _17
     load_field .note
-    store_var _21
-    load_var _21
-    store_var first_note
-    load_var _21
+    store_var_load_var _21
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
+    pop_jump_if_false L1
     load_const "<null>"
-    store_var first_note
-    jump L2
+    store_var _21
 
   L1:
+    load_var _21
+    store_var first_note
+    jump L3
+
+  L2:
     load_const "missing"
     store_var first_note
 
-  L2:
+  L3:
     load_var path
     sys_op baml.fs.remove
     pop 1
@@ -1930,17 +1924,17 @@ function csv.csv_file_roundtrip() -> string {
     load_const 0
     cmp_int_op >
     call baml.json.stringify
-    store_var _28
+    store_var _29
     load_var back
     container_len
-    store_var _32
-    load_var _32
+    store_var _33
+    load_var _33
     call baml.json.stringify
-    store_var _31
-    load_var _28
+    store_var _32
+    load_var _29
     load_const ":"
     bin_op +
-    load_var _31
+    load_var _32
     bin_op +
     load_const ":"
     bin_op +
@@ -2081,20 +2075,17 @@ function csv.csv_headers_variants() -> string {
     load_const <omitted>
     call baml.csv.reader
     call baml.csv.CsvReader.headers
-    store_var _3
-    load_var _3
-    store_var _2
-    load_var _3
+    store_var_load_var _3
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_const "<null>"
     load_type string
     alloc_array 1
-    store_var _2
+    store_var _3
 
   L0:
-    load_var _2
+    load_var _3
     load_const "|"
     call user.csv.join
     store_var with_header
@@ -2120,15 +2111,15 @@ function csv.csv_headers_variants() -> string {
     init_instance baml.csv.ReaderOptions .delimiter, .quote, .quoting, .escape, .has_header, .headers, .comment, .trim, .skip_lines, .skip_blank_records, .ragged, .null_values, .encoding, .bom, .on_error, .on_skip, .max_skipped, .limit
     call baml.csv.reader
     call baml.csv.CsvReader.headers
-    store_var _7
-    load_var _7
+    store_var _8
+    load_var _8
     load_const null
     cmp_op ==
     pop_jump_if_false L1
     jump L2
 
   L1:
-    load_var _7
+    load_var _8
     load_const "|"
     call user.csv.join
     store_var no_header
@@ -2143,15 +2134,15 @@ function csv.csv_headers_variants() -> string {
     load_const <omitted>
     call baml.csv.reader
     call baml.csv.CsvReader.headers
-    store_var _14
-    load_var _14
+    store_var _15
+    load_var _15
     load_const null
     cmp_op ==
     pop_jump_if_false L4
     jump L5
 
   L4:
-    load_var _14
+    load_var _15
     load_const "|"
     call user.csv.join
     store_var empty_input
@@ -2451,18 +2442,14 @@ function csv.csv_null_semantics_empty_unquoted() -> string {
 
   L0:
     load_var _3
-    store_var p
-    load_var p
+    store_var_load_var p
     load_field .so
-    store_var _13
-    load_var _13
-    store_var _12
-    load_var _13
+    store_var_load_var _13
     load_const null
     cmp_op ==
     pop_jump_if_false L1
     load_const "<null>"
-    store_var _12
+    store_var _13
 
   L1:
     load_const "s="
@@ -2471,7 +2458,7 @@ function csv.csv_null_semantics_empty_unquoted() -> string {
     bin_op +
     load_const " so="
     bin_op +
-    load_var _12
+    load_var _13
     bin_op +
     load_const " io="
     bin_op +
@@ -2480,8 +2467,8 @@ function csv.csv_null_semantics_empty_unquoted() -> string {
     load_field .io
     load_const "<null>"
     call user.csv.int_or
-    store_var _15
-    load_var2 4 7
+    store_var _16
+    load_var2 4 6
     bin_op +
     jump L3
 
@@ -2512,19 +2499,16 @@ function csv.csv_null_semantics_quoted_empty() -> string {
   L0:
     load_var _2
     load_field .so
-    store_var _9
-    load_var _9
-    store_var _8
-    load_var _9
+    store_var_load_var _9
     load_const null
     cmp_op ==
     pop_jump_if_false L1
     load_const "<null>"
-    store_var _8
+    store_var _9
 
   L1:
     load_const "so="
-    load_var _8
+    load_var _9
     bin_op +
     store_var ok
     jump L3
@@ -2610,22 +2594,18 @@ function csv.csv_null_values_option() -> string {
 
   L0:
     load_var _4
-    store_var p
-    load_var p
+    store_var_load_var p
     load_field .so
-    store_var _14
-    load_var _14
-    store_var _13
-    load_var _14
+    store_var_load_var _14
     load_const null
     cmp_op ==
     pop_jump_if_false L1
     load_const "<null>"
-    store_var _13
+    store_var _14
 
   L1:
     load_const "so="
-    load_var _13
+    load_var _14
     bin_op +
     load_const " io="
     bin_op +
@@ -2634,8 +2614,8 @@ function csv.csv_null_values_option() -> string {
     load_field .io
     load_const "<null>"
     call user.csv.int_or
-    store_var _16
-    load_var2 6 9
+    store_var _17
+    load_var2 6 8
     bin_op +
     store_var ok
     jump L3
@@ -2676,37 +2656,38 @@ function csv.csv_null_values_option() -> string {
     load_const "a,s,so,io\nx,y,\"N/A\",\n"
     load_var opts
     call baml.csv.decode
-    store_var _27
+    store_var _28
     load_type csv.NullProbe
-    load_var _27
+    load_var _28
     load_const 0
     call baml.Array.at
-    store_var _26
-    load_var _26
+    store_var _27
+    load_var _27
     load_const null
     cmp_op ==
     pop_jump_if_false L8
-    jump L9
-
-  L8:
-    load_var _26
-    load_field .so
-    store_var _33
-    load_var _33
-    store_var quoted
-    load_var _33
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L10
-    load_const "<null>"
-    store_var quoted
     jump L10
 
+  L8:
+    load_var _27
+    load_field .so
+    store_var_load_var _34
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L9
+    load_const "<null>"
+    store_var _34
+
   L9:
+    load_var _34
+    store_var quoted
+    jump L11
+
+  L10:
     load_const "missing"
     store_var quoted
 
-  L10:
+  L11:
     load_var ok
     load_const "/"
     bin_op +
@@ -3825,15 +3806,12 @@ function csv.csv_record_api() -> string {
     load_var rec
     load_const "name"
     call baml.csv.CsvRecord.get
-    store_var _16
-    load_var _16
-    store_var _15
-    load_var _16
+    store_var_load_var _16
     load_const null
     cmp_op ==
     pop_jump_if_false L1
     load_const "<null>"
-    store_var _15
+    store_var _16
 
   L1:
     load_type string
@@ -3846,54 +3824,48 @@ function csv.csv_record_api() -> string {
     call baml.csv.CsvRecord.get
     load_const "<null>"
     call user.csv.int_or
-    store_var _21
+    store_var _22
     load_type string
-    load_var2 3 8
+    load_var2 3 7
     call baml.Array.push
     pop 1
     load_type string
     load_var rec
     load_const "absent"
     call baml.csv.CsvRecord.get
-    store_var _27
-    load_var _27
-    store_var _26
-    load_var _27
+    store_var_load_var _28
     load_const null
     cmp_op ==
     pop_jump_if_false L2
     load_const "<absent-null>"
-    store_var _26
+    store_var _28
 
   L2:
     load_type string
-    load_var2 3 9
+    load_var2 3 8
     call baml.Array.push
     pop 1
     load_type string
     load_var rec
     load_const 99
     call baml.csv.CsvRecord.get_at
-    store_var _33
-    load_var _33
-    store_var _32
-    load_var _33
+    store_var_load_var _35
     load_const null
     cmp_op ==
     pop_jump_if_false L3
     load_const "<oob-null>"
-    store_var _32
+    store_var _35
 
   L3:
     load_type string
-    load_var2 3 11
+    load_var2 3 9
     call baml.Array.push
     pop 1
     load_var rec
     call baml.csv.CsvRecord.to_map
     store_var m
     load_type string
-    load_var2 3 13
+    load_var2 3 10
     load_const "name"
     load_map_element
     call baml.Array.push
@@ -3974,21 +3946,18 @@ function csv.csv_record_get_decode_error() -> string {
     store_var _10
     load_var e
     load_field .column
-    store_var _13
-    load_var _13
-    store_var _12
-    load_var _13
+    store_var_load_var _13
     load_const null
     cmp_op ==
     pop_jump_if_false L3
     load_const "?"
-    store_var _12
+    store_var _13
 
   L3:
     load_var _10
     load_const ":"
     bin_op +
-    load_var _12
+    load_var _13
     bin_op +
     jump L6
 
@@ -4863,29 +4832,30 @@ function csv.csv_smoke_typed_returns_probe() -> string {
     load_var _3
     is_type baml.iter.Done
     pop_jump_if_false L0
-    jump L1
+    jump L2
 
   L0:
     load_type string
     load_var _3
     load_const "name"
     call baml.csv.CsvRecord.get
-    store_var _6
-    load_var _6
-    store_var rec_name
-    load_var _6
+    store_var_load_var _6
     load_const null
     cmp_op ==
-    pop_jump_if_false L2
+    pop_jump_if_false L1
     load_const "<null>"
-    store_var rec_name
-    jump L2
+    store_var _6
 
   L1:
+    load_var _6
+    store_var rec_name
+    jump L3
+
+  L2:
     load_const "none"
     store_var rec_name
 
-  L2:
+  L3:
     load_const 0
     store_var total
     load_type csv.CsvSmokeIntRow
@@ -4894,34 +4864,34 @@ function csv.csv_smoke_typed_returns_probe() -> string {
     load_type baml.iter.Iterable<Error = baml.csv.CsvError | baml.errors.Io, Item = csv.CsvSmokeIntRow>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _12
+    store_var _13
 
-  L3:
-    load_var _12
+  L4:
+    load_var _13
     load_type baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = csv.CsvSmokeIntRow>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _13
-    load_var _13
+    store_var _14
+    load_var _14
     is_type baml.iter.Done
-    pop_jump_if_false L4
-    jump L5
+    pop_jump_if_false L5
+    jump L6
 
-  L4:
+  L5:
     load_var2 5 7
     load_field .n
     add_int
     store_var total
-    jump L3
+    jump L4
 
-  L5:
+  L6:
     load_var rec_name
     load_const ":"
     bin_op +
-    store_var _18
+    store_var _19
     load_var total
     call baml.json.stringify
-    store_var _20
+    store_var _21
     load_var2 8 9
     bin_op +
     return
@@ -5180,19 +5150,16 @@ function csv.csv_trim_all() -> string {
     store_var r
     load_var r
     call baml.csv.CsvReader.headers
-    store_var _4
-    load_var _4
-    store_var headers
-    load_var _4
+    store_var_load_var _4
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_type string
     alloc_array 0
-    store_var headers
+    store_var _4
 
   L0:
-    load_var headers
+    load_var _4
     load_const "|"
     call user.csv.join
     store_var h
@@ -5200,14 +5167,14 @@ function csv.csv_trim_all() -> string {
     load_type baml.iter.Iterator<Error = baml.csv.CsvError | baml.errors.Io, Item = baml.csv.CsvRecord>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _9
-    load_var _9
+    store_var _10
+    load_var _10
     is_type baml.iter.Done
     pop_jump_if_false L1
     jump L2
 
   L1:
-    load_var _9
+    load_var _10
     call baml.csv.CsvRecord.fields
     load_const "|"
     call user.csv.join

--- a/baml_language/crates/baml_tests/snapshots/baml_src/errorcontext.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/errorcontext.snap
@@ -150,48 +150,45 @@ function errorcontext.ec_deferthrow_check() -> bool {
     load_var rendered
     load_const "origin"
     call baml.String.index_of
-    store_var _3
-    load_var _3
-    store_var origin_at
-    load_var _3
+    store_var_load_var _3
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_const 1
     unary_op -
-    store_var origin_at
+    store_var _3
 
   L0:
+    load_var _3
+    store_var origin_at
     load_var rendered
     load_const "wrap"
     call baml.String.index_of
-    store_var _6
-    load_var _6
-    store_var wrap_at
-    load_var _6
+    store_var_load_var _7
     load_const null
     cmp_op ==
     pop_jump_if_false L1
     load_const 1
     unary_op -
-    store_var wrap_at
+    store_var _7
 
   L1:
+    load_var _7
+    store_var wrap_at
     load_var rendered
     load_const "cleanup"
     call baml.String.index_of
-    store_var _9
-    load_var _9
-    store_var cleanup_at
-    load_var _9
+    store_var_load_var _11
     load_const null
     cmp_op ==
     pop_jump_if_false L2
     load_const 1
     unary_op -
-    store_var cleanup_at
+    store_var _11
 
   L2:
+    load_var _11
+    store_var cleanup_at
     load_var origin_at
     load_const 0
     cmp_int_op >=

--- a/baml_language/crates/baml_tests/snapshots/baml_src/generic_union_returns.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/generic_union_returns.snap
@@ -84,26 +84,25 @@ function generic_union_returns.sap_nullable_container_types_are_preserved() -> b
     load_var empty_json
     make_bound_method baml.Array.length
     call_indirect
-    store_var _9
+    store_var _10
     jump L2
 
   L1:
     load_const null
-    store_var _9
+    store_var _10
 
   L2:
-    load_var _9
-    store_var _8
-    load_var _9
+    load_var _10
+    store_var_load_var _9
     load_const null
     cmp_op ==
     pop_jump_if_false L3
     load_const 1
     unary_op -
-    store_var _8
+    store_var _9
 
   L3:
-    load_var _8
+    load_var _9
     load_const 0
     cmp_int_op ==
     store_var empty_ok
@@ -117,25 +116,24 @@ function generic_union_returns.sap_nullable_container_types_are_preserved() -> b
     load_var metadata
     make_bound_method baml.Map.length
     call_indirect
-    store_var _17
+    store_var _19
     jump L6
 
   L5:
     load_const null
-    store_var _17
+    store_var _19
 
   L6:
-    load_var _17
-    store_var _16
-    load_var _17
+    load_var _19
+    store_var_load_var _18
     load_const null
     cmp_op ==
     pop_jump_if_false L7
     load_const 0
-    store_var _16
+    store_var _18
 
   L7:
-    load_var _16
+    load_var _18
     load_const 1
     cmp_int_op ==
     store_var map_ok
@@ -188,15 +186,15 @@ function generic_union_returns.sap_nullable_container_types_are_preserved() -> b
     load_var statuses
     make_bound_method baml.Array.at
     call_indirect
-    store_var _37
+    store_var _39
     jump L15
 
   L14:
     load_const null
-    store_var _37
+    store_var _39
 
   L15:
-    load_var _37
+    load_var _39
     load_const user.generic_union_returns.ParsedStatus.Ready
     alloc_variant user.generic_union_returns.ParsedStatus
     call baml.ops.equals_equals

--- a/baml_language/crates/baml_tests/snapshots/baml_src/maps.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/maps.snap
@@ -322,19 +322,16 @@ function maps.map_clear_then_reuse_main() -> int {
     load_var m
     load_const "b"
     call baml.Map.get
-    store_var _11
-    load_var _11
-    store_var _0
-    load_var _11
+    store_var_load_var _11
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_const 1
     unary_op -
-    store_var _0
+    store_var _11
 
   L0:
-    load_var _0
+    load_var _11
     return
 }
 
@@ -405,19 +402,16 @@ function maps.map_delete_does_not_affect_other_keys_main() -> int {
     load_var m
     load_const "b"
     call baml.Map.get
-    store_var _11
-    load_var _11
-    store_var _0
-    load_var _11
+    store_var_load_var _11
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_const 1
     unary_op -
-    store_var _0
+    store_var _11
 
   L0:
-    load_var _0
+    load_var _11
     return
 }
 
@@ -495,19 +489,16 @@ function maps.map_get_or_insert_does_not_overwrite_main() -> int {
     load_var m
     load_const "k"
     call baml.Map.get
-    store_var _8
-    load_var _8
-    store_var _0
-    load_var _8
+    store_var_load_var _8
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_const 1
     unary_op -
-    store_var _0
+    store_var _8
 
   L0:
-    load_var _0
+    load_var _8
     return
 }
 
@@ -564,19 +555,16 @@ function maps.map_get_or_insert_persists_main() -> int {
     load_var m
     load_const "k"
     call baml.Map.get
-    store_var _5
-    load_var _5
-    store_var _0
-    load_var _5
+    store_var_load_var _5
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_const 1
     unary_op -
-    store_var _0
+    store_var _5
 
   L0:
-    load_var _0
+    load_var _5
     return
 }
 
@@ -778,19 +766,16 @@ function maps.map_set_then_get_main() -> int {
     load_var m
     load_const "a"
     call baml.Map.get
-    store_var _8
-    load_var _8
-    store_var _0
-    load_var _8
+    store_var_load_var _8
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_const 1
     unary_op -
-    store_var _0
+    store_var _8
 
   L0:
-    load_var _0
+    load_var _8
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/media_json_union.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/media_json_union.snap
@@ -1,0 +1,162 @@
+---
+source: crates/baml_tests/tests/baml_src.rs
+---
+function media_json_union.$init_test_ns_media_json_union_media_json_union(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "root.media_json_union"
+    load_const "media JSON unions roundtrip every kind"
+    make_closure .<lambda($init_test_ns_media_json_union_media_json_union, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.media_json_union"
+    load_const "media JSON unions respect reversed order"
+    make_closure .<lambda($init_test_ns_media_json_union_media_json_union, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_const null
+    return
+}
+
+function media_json_union.classify_media_json_union(value: image | audio | video | pdf) -> string {
+    load_var value
+    is_type image
+    pop_jump_if_false L0
+    jump L5
+
+  L0:
+    load_var value
+    is_type audio
+    pop_jump_if_false L1
+    jump L4
+
+  L1:
+    load_var value
+    is_type video
+    pop_jump_if_false L2
+    jump L3
+
+  L2:
+    load_const "pdf"
+    jump L6
+
+  L3:
+    load_const "video"
+    jump L6
+
+  L4:
+    load_const "audio"
+    jump L6
+
+  L5:
+    load_const "image"
+
+  L6:
+    return
+}
+
+function media_json_union.media_json_union_respects_reversed_order() -> string {
+    load_const "aGk="
+    load_const "image/png"
+    call baml.media.Image.from_base64
+    store_var _2
+    load_type image
+    load_var _2
+    call baml.json.to_json
+    store_var json
+    load_type audio | image
+    load_var json
+    call baml.json.from_json
+    is_type audio
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const "image"
+    jump L2
+
+  L1:
+    load_const "audio"
+
+  L2:
+    return
+}
+
+function media_json_union.media_json_union_roundtrips_every_kind() -> string {
+    load_const "aGk="
+    load_const "image/png"
+    call baml.media.Image.from_base64
+    store_var _2
+    load_type image
+    load_var _2
+    call baml.json.to_json
+    store_var image_json
+    load_const "aGk="
+    load_const "audio/mpeg"
+    call baml.media.Audio.from_base64
+    store_var _5
+    load_type audio
+    load_var _5
+    call baml.json.to_json
+    store_var audio_json
+    load_const "aGk="
+    load_const "video/mp4"
+    call baml.media.Video.from_base64
+    store_var _8
+    load_type video
+    load_var _8
+    call baml.json.to_json
+    store_var video_json
+    load_const "aGk="
+    load_const "application/pdf"
+    call baml.media.Pdf.from_base64
+    store_var _11
+    load_type pdf
+    load_var _11
+    call baml.json.to_json
+    store_var pdf_json
+    load_type image | audio | video | pdf
+    load_var image_json
+    call baml.json.from_json
+    store_var image_value
+    load_type image | audio | video | pdf
+    load_var audio_json
+    call baml.json.from_json
+    store_var audio_value
+    load_type image | audio | video | pdf
+    load_var video_json
+    call baml.json.from_json
+    store_var video_value
+    load_type image | audio | video | pdf
+    load_var pdf_json
+    call baml.json.from_json
+    store_var pdf_value
+    load_var image_value
+    call user.media_json_union.classify_media_json_union
+    store_var _30
+    load_var audio_value
+    call user.media_json_union.classify_media_json_union
+    store_var _32
+    load_var video_value
+    call user.media_json_union.classify_media_json_union
+    store_var _34
+    load_var pdf_value
+    call user.media_json_union.classify_media_json_union
+    store_var _36
+    load_var _30
+    load_const ","
+    bin_op +
+    load_var _32
+    bin_op +
+    load_const ","
+    bin_op +
+    load_var _34
+    bin_op +
+    load_const ","
+    bin_op +
+    load_var _36
+    bin_op +
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/media_json_union.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/media_json_union.snap
@@ -16,6 +16,27 @@ function media_json_union.$init_test_ns_media_json_union_media_json_union(regist
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
+    load_var registry
+    load_const "root.media_json_union"
+    load_const "media JSON rejects missing kind"
+    make_closure .<lambda($init_test_ns_media_json_union_media_json_union, 2)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.media_json_union"
+    load_const "media JSON rejects mismatched concrete kind"
+    make_closure .<lambda($init_test_ns_media_json_union_media_json_union, 3)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.media_json_union"
+    load_const "media JSON rejects generic kind"
+    make_closure .<lambda($init_test_ns_media_json_union_media_json_union, 4)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
     load_const null
     return
 }
@@ -158,5 +179,31 @@ function media_json_union.media_json_union_roundtrips_every_kind() -> string {
     bin_op +
     load_var _36
     bin_op +
+    return
+}
+
+function media_json_union.rejects_media_json(json: string) -> bool {
+    load_type #0
+    load_var json
+    call baml.json.from_string
+    pop 1
+    jump L2
+    load_var e
+    is_type baml.json.JsonDecodeError
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var e
+    rethrow
+
+  L1:
+    load_const true
+    jump L3
+
+  L2:
+    load_const false
+
+  L3:
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/null_handling.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/null_handling.snap
@@ -60,22 +60,36 @@ function null_handling.$init_test_ns_null_handling_null_handling(registry: testi
     pop 1
     load_var registry
     load_const "root.null_handling"
-    load_const "combined_compound_assign_rhs_null_uses_fallback"
+    load_const "null_coalesce_rhs_reads_old_local_destination"
     make_closure .<lambda($init_test_ns_null_handling_null_handling, 8)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.null_handling"
-    load_const "combined_compound_assign_lhs_null_skips"
+    load_const "null_coalesce_rhs_reads_old_field_destination"
     make_closure .<lambda($init_test_ns_null_handling_null_handling, 9)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
     load_var registry
     load_const "root.null_handling"
-    load_const "multi_union_optional_access"
+    load_const "combined_compound_assign_rhs_null_uses_fallback"
     make_closure .<lambda($init_test_ns_null_handling_null_handling, 10)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.null_handling"
+    load_const "combined_compound_assign_lhs_null_skips"
+    make_closure .<lambda($init_test_ns_null_handling_null_handling, 11)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.null_handling"
+    load_const "multi_union_optional_access"
+    make_closure .<lambda($init_test_ns_null_handling_null_handling, 12)>, 0
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
@@ -101,28 +115,24 @@ function null_handling.nh_combined_lhs_null(node: null_handling.NhNode | null, i
     load_var items
     load_const 0
     load_array_element
-    store_var _6
     jump L3
 
   L2:
     load_const null
-    store_var _6
 
   L3:
-    load_var _6
-    store_var _5
-    load_var _6
+    store_var_load_var _6
     load_const null
     cmp_op ==
     pop_jump_if_false L4
     load_const 1
-    store_var _5
+    store_var _6
 
   L4:
     load_var node
     copy 0
     load_field .0
-    load_var _5
+    load_var _6
     bin_op +
     store_field .0
 
@@ -163,28 +173,24 @@ function null_handling.nh_combined_rhs_null(node: null_handling.NhNode | null, i
     load_var items
     load_const 0
     load_array_element
-    store_var _6
     jump L3
 
   L2:
     load_const null
-    store_var _6
 
   L3:
-    load_var _6
-    store_var _5
-    load_var _6
+    store_var_load_var _6
     load_const null
     cmp_op ==
     pop_jump_if_false L4
     load_const 1
-    store_var _5
+    store_var _6
 
   L4:
     load_var node
     copy 0
     load_field .0
-    load_var _5
+    load_var _6
     bin_op +
     store_field .0
 
@@ -301,15 +307,18 @@ function null_handling.nh_null_coalesce_lazy_non_null(value: int | null) -> int 
     store_var ?2
     load_const 0
     store_deref ?2
-    load_var2 1 1
+    load_var value
+    store_var_load_var _5
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_var counter
     make_closure .<lambda(nh_null_coalesce_lazy_non_null, 0)>, 1
     call_indirect
+    store_var _5
 
   L0:
+    load_var _5
     load_const 10
     mul_int
     load_deref ?2
@@ -323,19 +332,64 @@ function null_handling.nh_null_coalesce_null_lhs(value: int | null) -> int {
     store_var ?2
     load_const 0
     store_deref ?2
-    load_var2 1 1
+    load_var value
+    store_var_load_var _5
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_var counter
     make_closure .<lambda(nh_null_coalesce_null_lhs, 0)>, 1
     call_indirect
+    store_var _5
 
   L0:
+    load_var _5
     load_const 10
     mul_int
     load_deref ?2
     add_int
+    return
+}
+
+function null_handling.nh_null_coalesce_self_field(input: int | null) -> int {
+    load_const 9
+    load_const null
+    load_const null
+    load_const null
+    init_instance user.null_handling.NhNode .value, .next, .children, .labels
+    store_var node
+    load_var input
+    store_var_load_var _3
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L0
+    load_var node
+    load_field .value
+    store_var _3
+
+  L0:
+    load_var2 2 3
+    store_field .value
+    load_var node
+    load_field .value
+    return
+}
+
+function null_handling.nh_null_coalesce_self_local(input: int | null) -> int {
+    load_const 7
+    store_var value
+    load_var input
+    store_var_load_var _3
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L0
+    load_var value
+    store_var _3
+
+  L0:
+    load_var _3
+    store_var value
+    load_var value
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/property_shorthand.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/property_shorthand.snap
@@ -30,7 +30,48 @@ function property_shorthand.$init_test_ns_property_shorthand_property_shorthand(
     load_const null
     call testing.TestCollector.register_test_at
     pop 1
+    load_var registry
+    load_const "root.property_shorthand"
+    load_const "if let binders work in explicit and shorthand map entries"
+    make_closure .<lambda($init_test_ns_property_shorthand_property_shorthand, 4)>, 0
     load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.property_shorthand"
+    load_const "shorthand uses every lexical binder scope"
+    make_closure .<lambda($init_test_ns_property_shorthand_property_shorthand, 5)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.property_shorthand"
+    load_const "class shorthand sees if let binders"
+    make_closure .<lambda($init_test_ns_property_shorthand_property_shorthand, 6)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_const null
+    return
+}
+
+function property_shorthand.property_shorthand_catch() -> string {
+    call user.property_shorthand.property_shorthand_throw
+    jump L2
+    load_var error
+    is_type property_shorthand.PropertyShorthandError
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var error
+    rethrow
+
+  L1:
+    load_var error
+    load_field .message
+
+  L2:
     return
 }
 
@@ -45,6 +86,160 @@ function property_shorthand.property_shorthand_class(mode: string, retries: int,
     return
 }
 
+function property_shorthand.property_shorthand_class_if_let(input: string | null) -> string {
+    load_var input
+    store_var _2
+    load_var _2
+    narrow_bind string, slot=2
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const ""
+    jump L2
+
+  L1:
+    load_var _2
+    init_instance user.property_shorthand.PropertyShorthandBinder .value
+    load_field .value
+
+  L2:
+    return
+}
+
+function property_shorthand.property_shorthand_destructure() -> string {
+    load_type string
+    load_type string
+    load_const "destructured"
+    init_instance user.property_shorthand.PropertyShorthandBinder .value
+    load_field .value
+    load_const "value"
+    load_type string
+    load_type string
+    alloc_map 1
+    load_const "value"
+    call baml.Map.get
+    store_var_load_var _6
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L0
+    load_const ""
+    store_var _6
+
+  L0:
+    load_var _6
+    return
+}
+
+function property_shorthand.property_shorthand_for(names: string[]) -> string {
+    load_const ""
+    store_var output
+    load_var names
+    load_type baml.iter.Iterable<Error = never, Item = string>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _3
+
+  L0:
+    load_var _3
+    load_type baml.iter.Iterator<Error = never, Item = string>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _4
+    load_var _4
+    is_type baml.iter.Done
+    pop_jump_if_false L1
+    jump L3
+
+  L1:
+    load_var output
+    store_var _10
+    load_type string
+    load_type string
+    load_var _4
+    load_const "name"
+    load_type string
+    load_type string
+    alloc_map 1
+    load_const "name"
+    call baml.Map.get
+    store_var_load_var _12
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L2
+    load_const ""
+    store_var _12
+
+  L2:
+    load_var2 5 6
+    bin_op +
+    store_var output
+    jump L0
+
+  L3:
+    load_var output
+    return
+}
+
+function property_shorthand.property_shorthand_if_let(input: string | null) -> string {
+    load_var input
+    store_var _2
+    load_var _2
+    narrow_bind string, slot=2
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const ""
+    jump L4
+
+  L1:
+    load_var _2
+    store_var_load_var name
+    load_const "name"
+    load_type string
+    load_type string
+    alloc_map 1
+    store_var shorthand
+    load_type string
+    load_type string
+    load_var name
+    load_const "name"
+    load_type string
+    load_type string
+    alloc_map 1
+    load_const "name"
+    call baml.Map.get
+    store_var_load_var _9
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L2
+    load_const ""
+    store_var _9
+
+  L2:
+    load_var _9
+    store_var _8
+    load_type string
+    load_type string
+    load_var shorthand
+    load_const "name"
+    call baml.Map.get
+    store_var_load_var _15
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L3
+    load_const ""
+    store_var _15
+
+  L3:
+    load_var2 5 7
+    bin_op +
+
+  L4:
+    return
+}
+
 function property_shorthand.property_shorthand_map(count: int, retries: int) -> map<string, int> {
     load_var2 1 2
     load_const "count"
@@ -52,6 +247,42 @@ function property_shorthand.property_shorthand_map(count: int, retries: int) -> 
     load_type string
     load_type int
     alloc_map 2
+    return
+}
+
+function property_shorthand.property_shorthand_match(input: string | null) -> string {
+    load_var input
+    store_var _2
+    load_var _2
+    narrow_bind string, slot=2
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const ""
+    jump L3
+
+  L1:
+    load_type string
+    load_type string
+    load_var _2
+    load_const "name"
+    load_type string
+    load_type string
+    alloc_map 1
+    load_const "name"
+    call baml.Map.get
+    store_var_load_var _6
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L2
+    load_const ""
+    store_var _6
+
+  L2:
+    load_var _6
+
+  L3:
     return
 }
 
@@ -76,4 +307,32 @@ function property_shorthand.property_shorthand_multi_nested(value: string) -> pr
     init_instance user.property_shorthand.PropertyShorthandMiddle .leaf
     init_instance user.property_shorthand.PropertyShorthandOuter .middle
     return
+}
+
+function property_shorthand.property_shorthand_nested_block() -> string {
+    load_type string
+    load_type string
+    load_const "nested"
+    load_const "name"
+    load_type string
+    load_type string
+    alloc_map 1
+    load_const "name"
+    call baml.Map.get
+    store_var_load_var _4
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L0
+    load_const ""
+    store_var _4
+
+  L0:
+    load_var _4
+    return
+}
+
+function property_shorthand.property_shorthand_throw() -> string {
+    load_const "caught"
+    init_instance user.property_shorthand.PropertyShorthandError .message
+    throw
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/qualified_literals.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/qualified_literals.snap
@@ -29,25 +29,21 @@ function qualified_literals.first_x(points: qualified_literals.QualPoint[]) -> i
     load_const 0
     call baml.Array.at
     load_field .0
-    store_var _2
     jump L2
 
   L1:
     load_const null
-    store_var _2
 
   L2:
-    load_var _2
-    store_var _0
-    load_var _2
+    store_var_load_var _2
     load_const null
     cmp_op ==
     pop_jump_if_false L3
     load_const 1
     unary_op -
-    store_var _0
+    store_var _2
 
   L3:
-    load_var _0
+    load_var _2
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/runtime_leaf_narrowing.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/runtime_leaf_narrowing.snap
@@ -1,0 +1,366 @@
+---
+source: crates/baml_tests/tests/baml_src.rs
+---
+function runtime_leaf_narrowing.$init_test_ns_runtime_leaf_narrowing_runtime_leaf_narrowing(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "root.runtime_leaf_narrowing"
+    load_const "is recognizes type runtime values"
+    make_closure .<lambda($init_test_ns_runtime_leaf_narrowing_runtime_leaf_narrowing, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.runtime_leaf_narrowing"
+    load_const "is rejects non-type runtime values"
+    make_closure .<lambda($init_test_ns_runtime_leaf_narrowing_runtime_leaf_narrowing, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.runtime_leaf_narrowing"
+    load_const "if let binds type runtime values"
+    make_closure .<lambda($init_test_ns_runtime_leaf_narrowing_runtime_leaf_narrowing, 2)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.runtime_leaf_narrowing"
+    load_const "is distinguishes media runtime values"
+    make_closure .<lambda($init_test_ns_runtime_leaf_narrowing_runtime_leaf_narrowing, 3)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.runtime_leaf_narrowing"
+    load_const "match recognizes type runtime values"
+    make_closure .<lambda($init_test_ns_runtime_leaf_narrowing_runtime_leaf_narrowing, 4)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.runtime_leaf_narrowing"
+    load_const "match distinguishes media runtime values"
+    make_closure .<lambda($init_test_ns_runtime_leaf_narrowing_runtime_leaf_narrowing, 5)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_const null
+    return
+}
+
+function runtime_leaf_narrowing.classify_media_runtime_value(value: image | audio | video | pdf) -> string {
+    load_var value
+    is_type image
+    pop_jump_if_false L0
+    jump L5
+
+  L0:
+    load_var value
+    is_type audio
+    pop_jump_if_false L1
+    jump L4
+
+  L1:
+    load_var value
+    is_type video
+    pop_jump_if_false L2
+    jump L3
+
+  L2:
+    load_const "pdf"
+    jump L6
+
+  L3:
+    load_const "video"
+    jump L6
+
+  L4:
+    load_const "audio"
+    jump L6
+
+  L5:
+    load_const "image"
+
+  L6:
+    return
+}
+
+function runtime_leaf_narrowing.classify_type_runtime_value(value: type | int) -> string {
+    load_var value
+    store_var _2
+    load_var _2
+    narrow_bind type, slot=2
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const "int"
+    jump L2
+
+  L1:
+    load_var _2
+    call baml.TypeValue.baml.ToString.to_string
+
+  L2:
+    return
+}
+
+function runtime_leaf_narrowing.if_let_binds_type_runtime_value() -> string {
+    load_type string
+    store_var _2
+    load_var _2
+    narrow_bind type, slot=1
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const "not type"
+    jump L2
+
+  L1:
+    load_var _2
+    call baml.TypeValue.baml.ToString.to_string
+
+  L2:
+    return
+}
+
+function runtime_leaf_narrowing.is_distinguishes_media_runtime_values() -> bool {
+    load_const "aGk="
+    load_const "image/png"
+    call baml.media.Image.from_base64
+    store_var image_value
+    load_const "aGk="
+    load_const "audio/mpeg"
+    call baml.media.Audio.from_base64
+    store_var audio_value
+    load_const "aGk="
+    load_const "video/mp4"
+    call baml.media.Video.from_base64
+    store_var video_value
+    load_const "aGk="
+    load_const "application/pdf"
+    call baml.media.Pdf.from_base64
+    store_var pdf_value
+    load_var image_value
+    is_type image
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    jump L2
+
+  L1:
+    load_const true
+
+  L2:
+    jump_if_false L6
+    pop 1
+    load_var image_value
+    is_type audio
+    pop_jump_if_false L3
+    jump L4
+
+  L3:
+    load_const false
+    jump L5
+
+  L4:
+    load_const true
+
+  L5:
+    unary_op !
+
+  L6:
+    jump_if_false L9
+    pop 1
+    load_var audio_value
+    is_type audio
+    pop_jump_if_false L7
+    jump L8
+
+  L7:
+    load_const false
+    jump L9
+
+  L8:
+    load_const true
+
+  L9:
+    jump_if_false L13
+    pop 1
+    load_var audio_value
+    is_type video
+    pop_jump_if_false L10
+    jump L11
+
+  L10:
+    load_const false
+    jump L12
+
+  L11:
+    load_const true
+
+  L12:
+    unary_op !
+
+  L13:
+    jump_if_false L16
+    pop 1
+    load_var video_value
+    is_type video
+    pop_jump_if_false L14
+    jump L15
+
+  L14:
+    load_const false
+    jump L16
+
+  L15:
+    load_const true
+
+  L16:
+    jump_if_false L20
+    pop 1
+    load_var video_value
+    is_type pdf
+    pop_jump_if_false L17
+    jump L18
+
+  L17:
+    load_const false
+    jump L19
+
+  L18:
+    load_const true
+
+  L19:
+    unary_op !
+
+  L20:
+    jump_if_false L23
+    pop 1
+    load_var pdf_value
+    is_type pdf
+    pop_jump_if_false L21
+    jump L22
+
+  L21:
+    load_const false
+    jump L23
+
+  L22:
+    load_const true
+
+  L23:
+    jump_if_false L27
+    pop 1
+    load_var pdf_value
+    is_type image
+    pop_jump_if_false L24
+    jump L25
+
+  L24:
+    load_const false
+    jump L26
+
+  L25:
+    load_const true
+
+  L26:
+    unary_op !
+
+  L27:
+    return
+}
+
+function runtime_leaf_narrowing.is_type_rejects_non_type() -> bool {
+    load_const 7
+    is_type type
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    jump L2
+
+  L1:
+    load_const true
+
+  L2:
+    return
+}
+
+function runtime_leaf_narrowing.is_type_runtime_value() -> bool {
+    load_type int
+    is_type type
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    jump L2
+
+  L1:
+    load_const true
+
+  L2:
+    return
+}
+
+function runtime_leaf_narrowing.match_distinguishes_media_runtime_values() -> bool {
+    load_const "aGk="
+    load_const "image/png"
+    call baml.media.Image.from_base64
+    call user.runtime_leaf_narrowing.classify_media_runtime_value
+    load_const "image"
+    cmp_op ==
+    jump_if_false L0
+    pop 1
+    load_const "aGk="
+    load_const "audio/mpeg"
+    call baml.media.Audio.from_base64
+    call user.runtime_leaf_narrowing.classify_media_runtime_value
+    load_const "audio"
+    cmp_op ==
+
+  L0:
+    jump_if_false L1
+    pop 1
+    load_const "aGk="
+    load_const "video/mp4"
+    call baml.media.Video.from_base64
+    call user.runtime_leaf_narrowing.classify_media_runtime_value
+    load_const "video"
+    cmp_op ==
+
+  L1:
+    jump_if_false L2
+    pop 1
+    load_const "aGk="
+    load_const "application/pdf"
+    call baml.media.Pdf.from_base64
+    call user.runtime_leaf_narrowing.classify_media_runtime_value
+    load_const "pdf"
+    cmp_op ==
+
+  L2:
+    return
+}
+
+function runtime_leaf_narrowing.match_recognizes_type_runtime_values() -> bool {
+    load_type string
+    call user.runtime_leaf_narrowing.classify_type_runtime_value
+    load_const "string"
+    cmp_op ==
+    jump_if_false L0
+    pop 1
+    load_const 7
+    call user.runtime_leaf_narrowing.classify_type_runtime_value
+    load_const "int"
+    cmp_op ==
+
+  L0:
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/type_error_repro.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/type_error_repro.snap
@@ -1022,18 +1022,15 @@ function type_error_repro.map_with_repeated_string_alias_union_key_body() -> int
     load_var counts
     load_const "x"
     call baml.Map.get
-    store_var _5
-    load_var _5
-    store_var _0
-    load_var _5
+    store_var_load_var _5
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_const 0
-    store_var _0
+    store_var _5
 
   L0:
-    load_var _0
+    load_var _5
     return
 }
 
@@ -1054,18 +1051,15 @@ function type_error_repro.map_with_string_alias_key_body() -> int {
     load_var counts
     load_const "x"
     call baml.Map.get
-    store_var _5
-    load_var _5
-    store_var _0
-    load_var _5
+    store_var_load_var _5
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_const 0
-    store_var _0
+    store_var _5
 
   L0:
-    load_var _0
+    load_var _5
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____04_5_mir.snap
@@ -301,9 +301,11 @@ fn ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: null | ((
     let _6: bool
     let _7: bool
     let _8: (ai.errors.Failure) -> bool throws never
-    let _9: bool
-    let _10: ai.clients.Backoff
-    let _11: bool
+    let _9: (ai.errors.Failure) -> bool throws never
+    let _10: bool
+    let _11: ai.clients.Backoff
+    let _12: ai.clients.Backoff
+    let _13: bool
 
     bb0: {
         _5 = copy _2 == const <omitted>;
@@ -336,28 +338,30 @@ fn ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: null | ((
     }
 
     bb6: {
-        _8 = copy _3;
-        _9 = copy _3 == const null;
-        branch copy _9 -> [bb7, bb8];
+        _9 = copy _3;
+        _10 = copy _9 == const null;
+        branch copy _10 -> [bb7, bb8];
     }
 
     bb7: {
-        _8 = const fn ai.clients.default_retry_judgment;
+        _9 = const fn ai.clients.default_retry_judgment;
         goto -> bb8;
     }
 
     bb8: {
-        _10 = copy _4;
-        _11 = copy _4 == const null;
-        branch copy _11 -> [bb9, bb10];
+        _8 = copy _9;
+        _12 = copy _4;
+        _13 = copy _12 == const null;
+        branch copy _13 -> [bb9, bb10];
     }
 
     bb9: {
-        _10 = call const fn ai.clients.Backoff.new(const <omitted>, const <omitted>, const <omitted>) -> [bb10];
+        _12 = call const fn ai.clients.Backoff.new(const <omitted>, const <omitted>, const <omitted>) -> [bb10];
     }
 
     bb10: {
-        _0 = ai.clients.Retry { copy _1, copy _2, copy _8, copy _10 };
+        _11 = copy _12;
+        _0 = ai.clients.Retry { copy _1, copy _2, copy _8, copy _11 };
         goto -> bb11;
     }
 
@@ -2377,18 +2381,21 @@ fn ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.ModelTurn {
     let _9: int | null
     let _10: bool
     let _11: int
-    let _12: int | null
-    let _13: bool
-    let _14: int
-    let _15: int | null
-    let _16: bool
-    let _17: (ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[]
-    let _18: ai.content.Text
-    let _19: string
-    let _20: ai.content.StopReason
-    let _21: null | ai.content.StopReason
-    let _22: bool
-    let _23: null | ai.events.Usage
+    let _12: int
+    let _13: int | null
+    let _14: bool
+    let _15: int
+    let _16: int
+    let _17: int | null
+    let _18: bool
+    let _19: (ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[]
+    let _20: ai.content.Text
+    let _21: string
+    let _22: ai.content.StopReason
+    let _23: ai.content.StopReason
+    let _24: null | ai.content.StopReason
+    let _25: bool
+    let _26: null | ai.events.Usage
 
     bb0: {
         goto -> bb1;
@@ -2437,52 +2444,55 @@ fn ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.ModelTurn {
     }
 
     bb10: {
-        _12 = copy _1.8;
-        _11 = copy _12;
-        _13 = copy _12 == const null;
-        branch copy _13 -> [bb11, bb12];
+        _13 = copy _1.8;
+        _12 = copy _13;
+        _14 = copy _12 == const null;
+        branch copy _14 -> [bb11, bb12];
     }
 
     bb11: {
-        _11 = const 0_i64;
+        _12 = const 0_i64;
         goto -> bb12;
     }
 
     bb12: {
-        _15 = copy _1.9;
-        _14 = copy _15;
-        _16 = copy _15 == const null;
-        branch copy _16 -> [bb13, bb14];
+        _11 = copy _12;
+        _17 = copy _1.9;
+        _16 = copy _17;
+        _18 = copy _16 == const null;
+        branch copy _18 -> [bb13, bb14];
     }
 
     bb13: {
-        _14 = const 0_i64;
+        _16 = const 0_i64;
         goto -> bb14;
     }
 
     bb14: {
-        _4 = ai.events.Usage { copy _11, copy _14, const null, const null };
+        _15 = copy _16;
+        _4 = ai.events.Usage { copy _11, copy _15, const null, const null };
         goto -> bb15;
     }
 
     bb15: {
-        _19 = copy _1.6;
-        _18 = ai.content.Text { copy _19 };
-        _17 = [copy _18]: ai.content.Text | ai.content.Reasoning | ai.content.ToolUse[];
-        _21 = copy _1.7;
-        _20 = copy _21;
-        _22 = copy _21 == const null;
-        branch copy _22 -> [bb16, bb17];
+        _21 = copy _1.6;
+        _20 = ai.content.Text { copy _21 };
+        _19 = [copy _20]: ai.content.Text | ai.content.Reasoning | ai.content.ToolUse[];
+        _24 = copy _1.7;
+        _23 = copy _24;
+        _25 = copy _23 == const null;
+        branch copy _25 -> [bb16, bb17];
     }
 
     bb16: {
-        _20 = const ai.content.StopReason.Complete;
+        _23 = const ai.content.StopReason.Complete;
         goto -> bb17;
     }
 
     bb17: {
-        _23 = copy _4;
-        _0 = ai.ModelTurn { copy _17, copy _20, copy _23 };
+        _22 = copy _23;
+        _26 = copy _4;
+        _0 = ai.ModelTurn { copy _19, copy _22, copy _26 };
         goto -> bb18;
     }
 
@@ -2971,19 +2981,22 @@ fn ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unknown>,
     let _7: bool
     let _8: reflect.Signature // sig
     let _9: string | null // resolved_name
-    let _10: bool
-    let _11: string | null
-    let _12: string // n
-    let _13: bool
-    let _14: string
-    let _15: baml.errors.InvalidArgument
-    let _16: string
+    let _10: string | null
+    let _11: bool
+    let _12: string | null
+    let _13: string // n
+    let _14: bool
+    let _15: string
+    let _16: baml.errors.InvalidArgument
     let _17: string
-    let _18: string | null
-    let _19: bool
-    let _20: bool
-    let _21: map<string, unknown>
-    let _22: baml.errors.InvalidArgument
+    let _18: string
+    let _19: string
+    let _20: string | null
+    let _21: string | null
+    let _22: bool
+    let _23: bool
+    let _24: map<string, unknown>
+    let _25: baml.errors.InvalidArgument
 
     bb0: {
         _5 = copy _2 == const <omitted>;
@@ -3020,62 +3033,65 @@ fn ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unknown>,
     }
 
     bb7: {
-        _9 = copy _2;
-        _10 = copy _2 == const null;
-        branch copy _10 -> [bb8, bb9];
+        _10 = copy _2;
+        _11 = copy _10 == const null;
+        branch copy _11 -> [bb8, bb9];
     }
 
     bb8: {
-        _9 = copy _8.0;
+        _10 = copy _8.0;
         goto -> bb9;
     }
 
     bb9: {
-        _11 = copy _9;
-        _11 = narrow_bind copy _11 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb11, bb10];
+        _9 = copy _10;
+        _12 = copy _9;
+        _12 = narrow_bind copy _12 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb11, bb10];
     }
 
     bb10: {
-        _22 = baml.errors.InvalidArgument { const "anonymous tool needs a name" };
-        throw copy _22;
+        _25 = baml.errors.InvalidArgument { const "anonymous tool needs a name" };
+        throw copy _25;
     }
 
     bb11: {
-        _12 = copy _11;
-        _14 = copy _12;
-        _13 = copy _14 == const "__baml_return_output";
-        branch copy _13 -> [bb19, bb12];
+        _13 = copy _12;
+        _15 = copy _13;
+        _14 = copy _15 == const "__baml_return_output";
+        branch copy _14 -> [bb19, bb12];
     }
 
     bb12: {
-        _16 = copy _12;
-        _18 = copy _3;
-        _19 = copy _3 == const null;
-        branch copy _19 -> [bb13, bb14];
+        _17 = copy _13;
+        _21 = copy _3;
+        _22 = copy _21 == const null;
+        branch copy _22 -> [bb13, bb14];
     }
 
     bb13: {
-        _18 = copy _8.5;
+        _21 = copy _8.5;
         goto -> bb14;
     }
 
     bb14: {
-        _17 = copy _18;
-        _20 = copy _18 == const null;
-        branch copy _20 -> [bb15, bb16];
+        _20 = copy _21;
+        _19 = copy _20;
+        _23 = copy _19 == const null;
+        branch copy _23 -> [bb15, bb16];
     }
 
     bb15: {
-        _17 = const "";
+        _19 = const "";
         goto -> bb16;
     }
 
     bb16: {
-        _21 = call const fn ai.internal._schema_for_signature(copy _1) -> [bb17];
+        _18 = copy _19;
+        _24 = call const fn ai.internal._schema_for_signature(copy _1) -> [bb17];
     }
 
     bb17: {
-        _0 = ai.tools.Tool { copy _16, copy _17, copy _21, copy _1, const null, copy _4 };
+        _0 = ai.tools.Tool { copy _17, copy _18, copy _24, copy _1, const null, copy _4 };
         goto -> bb18;
     }
 
@@ -3084,8 +3100,8 @@ fn ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unknown>,
     }
 
     bb19: {
-        _15 = baml.errors.InvalidArgument { const "the tool name __baml_return_output is reserved" };
-        throw copy _15;
+        _16 = baml.errors.InvalidArgument { const "the tool name __baml_return_output is reserved" };
+        throw copy _16;
     }
 }
 
@@ -3430,7 +3446,8 @@ fn ai.Agent.new(max_steps: int, client: null | ai.Client, tool_errors: ai.tools.
     let _7: bool
     let _8: bool
     let _9: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> null throws never
-    let _10: bool
+    let _10: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage) -> null throws never
+    let _11: bool
 
     bb0: {
         _5 = copy _1 == const <omitted>;
@@ -3473,17 +3490,18 @@ fn ai.Agent.new(max_steps: int, client: null | ai.Client, tool_errors: ai.tools.
     }
 
     bb8: {
-        _9 = copy _4;
-        _10 = copy _4 == const null;
-        branch copy _10 -> [bb9, bb10];
+        _10 = copy _4;
+        _11 = copy _10 == const null;
+        branch copy _11 -> [bb9, bb10];
     }
 
     bb9: {
-        _9 = make_closure lambda[0]<1 type_args>();
+        _10 = make_closure lambda[0]<1 type_args>();
         goto -> bb10;
     }
 
     bb10: {
+        _9 = copy _10;
         _0 = ai.Agent<#0> { copy _1, copy _2, copy _3, copy _9 };
         goto -> bb11;
     }
@@ -3531,32 +3549,33 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
     let _17: type
     let _18: bool
     let _19: ai.tools.ErrorMode
-    let _20: null | ai.tools.ErrorMode
-    let _21: bool
-    let _22: null | ai.errors.Failure // classified
-    let _23: unknown
-    let _24: ai.errors.Failure // f
-    let _25: ai.errors.ToolFailedError
-    let _26: string
+    let _20: ai.tools.ErrorMode
+    let _21: null | ai.tools.ErrorMode
+    let _22: bool
+    let _23: null | ai.errors.Failure // classified
+    let _24: unknown
+    let _25: ai.errors.Failure // f
+    let _26: ai.errors.ToolFailedError
     let _27: string
     let _28: string
-    let _29: type
-    let _30: null | ai.errors.Failure
-    let _31: string | null
-    let _32: string // output
-    let _33: void
-    let _34: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
-    let _35: ai.events.ToolCompleted
-    let _36: string
+    let _29: string
+    let _30: type
+    let _31: null | ai.errors.Failure
+    let _32: string | null
+    let _33: string // output
+    let _34: void
+    let _35: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _36: ai.events.ToolCompleted
     let _37: string
-    let _38: void
-    let _39: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
-    let _40: ai.events.ToolFailed
-    let _41: string
+    let _38: string
+    let _39: void
+    let _40: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _41: ai.events.ToolFailed
     let _42: string
     let _43: string
     let _44: string
-    let _45: type
+    let _45: string
+    let _46: type
 
     bb0: {
         _6 = copy _3.1;
@@ -3569,17 +3588,17 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
     }
 
     bb2: {
-        _41 = copy _3.0;
-        _44 = copy _3.1;
-        _45 = load_type(string);
-        _43 = call const fn baml.String.from<copy _45>(copy _44) -> [bb3];
+        _42 = copy _3.0;
+        _45 = copy _3.1;
+        _46 = load_type(string);
+        _44 = call const fn baml.String.from<copy _46>(copy _45) -> [bb3];
     }
 
     bb3: {
-        _42 = const "tool is not in the active toolbox: " + copy _43;
-        _40 = ai.events.ToolFailed { copy _41, copy _42 };
-        _39 = [copy _40]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced[];
-        _38 = call const fn ai.Journal.append_all(copy _4, copy _39) -> [bb4];
+        _43 = const "tool is not in the active toolbox: " + copy _44;
+        _41 = ai.events.ToolFailed { copy _42, copy _43 };
+        _40 = [copy _41]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced[];
+        _39 = call const fn ai.Journal.append_all(copy _4, copy _40) -> [bb4];
     }
 
     bb4: {
@@ -3610,18 +3629,19 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
     }
 
     bb9: {
-        _20 = copy _8.5;
-        _19 = copy _20;
-        _21 = copy _20 == const null;
-        branch copy _21 -> [bb10, bb11];
+        _21 = copy _8.5;
+        _20 = copy _21;
+        _22 = copy _20 == const null;
+        branch copy _22 -> [bb10, bb11];
     }
 
     bb10: {
-        _19 = copy _1.2;
+        _20 = copy _1.2;
         goto -> bb11;
     }
 
     bb11: {
+        _19 = copy _20;
         _18 = call const fn baml.ops.equals_equals(copy _19, const ai.tools.ErrorMode.Raise) -> [bb12];
     }
 
@@ -3635,17 +3655,17 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
     }
 
     bb14: {
-        _31 = copy _9;
-        _31 = narrow_bind copy _31 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb15, bb16];
+        _32 = copy _9;
+        _32 = narrow_bind copy _32 as String { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb15, bb16];
     }
 
     bb15: {
-        _32 = copy _31;
-        _36 = copy _3.0;
-        _37 = copy _32;
-        _35 = ai.events.ToolCompleted { copy _36, copy _37 };
-        _34 = [copy _35]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced[];
-        _33 = call const fn ai.Journal.append_all(copy _4, copy _34) -> [bb16];
+        _33 = copy _32;
+        _37 = copy _3.0;
+        _38 = copy _33;
+        _36 = ai.events.ToolCompleted { copy _37, copy _38 };
+        _35 = [copy _36]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced[];
+        _34 = call const fn ai.Journal.append_all(copy _4, copy _35) -> [bb16];
     }
 
     bb16: {
@@ -3658,32 +3678,32 @@ fn ai.Agent._run_one_tool(self: ai.Agent, tb: ai.tools.Toolbox, call: ai.content
     }
 
     bb18: {
-        _23 = copy _10;
-        _23 = narrow_bind copy _23 as Interface(QualifiedTypeName { pkg: Dep("ai"), namespace: ["errors"], name: "Failure" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb20, bb19];
+        _24 = copy _10;
+        _24 = narrow_bind copy _24 as Interface(QualifiedTypeName { pkg: Dep("ai"), namespace: ["errors"], name: "Failure" }, [], [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb20, bb19];
     }
 
     bb19: {
-        _22 = const null;
+        _23 = const null;
         goto -> bb21;
     }
 
     bb20: {
-        _24 = copy _23;
-        _22 = copy _24;
+        _25 = copy _24;
+        _23 = copy _25;
         goto -> bb21;
     }
 
     bb21: {
-        _26 = copy _3.0;
-        _27 = copy _3.1;
-        _29 = load_type(unknown);
-        _28 = call const fn baml.String.from<copy _29>(copy _10) -> [bb22];
+        _27 = copy _3.0;
+        _28 = copy _3.1;
+        _30 = load_type(unknown);
+        _29 = call const fn baml.String.from<copy _30>(copy _10) -> [bb22];
     }
 
     bb22: {
-        _30 = copy _22;
-        _25 = ai.errors.ToolFailedError { copy _26, copy _27, copy _28, copy _30 };
-        throw copy _25;
+        _31 = copy _23;
+        _26 = ai.errors.ToolFailedError { copy _27, copy _28, copy _29, copy _31 };
+        throw copy _26;
     }
 }
 
@@ -3745,74 +3765,77 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
     let _20: int | null
     let _21: int // ci
     let _22: int
-    let _23: int | null
-    let _24: bool
-    let _25: int
-    let _26: int | null
+    let _23: int
+    let _24: int | null
+    let _25: bool
+    let _26: int
     let _27: int | null
-    let _28: int // rt
-    let _29: int
-    let _30: int | null
-    let _31: bool
-    let _32: int
-    let _33: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // batch
-    let _34: ai.events.AssistantMessage
-    let _35: (ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[]
-    let _36: string
-    let _37: ai.content.ToolUse[]
-    let _38: baml.iter.Iterator<Error = never, Item = ai.content.ToolUse>
-    let _39: unknown
-    let _40: bool
-    let _41: ai.content.ToolUse
-    let _42: ai.content.ToolUse // u
-    let _43: int
-    let _44: ai.events.ToolRequested
-    let _45: string
-    let _46: string
-    let _47: map<string, unknown>
-    let _48: type
-    let _49: null | ai.events.Usage
-    let _50: null | ai.events.Usage
-    let _51: ai.events.Usage // u
-    let _52: int
-    let _53: ai.events.Usage
-    let _54: type
-    let _55: string // candidate
-    let _56: string | null
-    let _57: bool
-    let _58: bool // accepted
-    let _59: bool
+    let _28: int | null
+    let _29: int // rt
+    let _30: int
+    let _31: int
+    let _32: int | null
+    let _33: bool
+    let _34: int
+    let _35: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // batch
+    let _36: ai.events.AssistantMessage
+    let _37: (ai.content.Reasoning | ai.content.Text | ai.content.ToolUse)[]
+    let _38: string
+    let _39: ai.content.ToolUse[]
+    let _40: baml.iter.Iterator<Error = never, Item = ai.content.ToolUse>
+    let _41: unknown
+    let _42: bool
+    let _43: ai.content.ToolUse
+    let _44: ai.content.ToolUse // u
+    let _45: int
+    let _46: ai.events.ToolRequested
+    let _47: string
+    let _48: string
+    let _49: map<string, unknown>
+    let _50: type
+    let _51: null | ai.events.Usage
+    let _52: null | ai.events.Usage
+    let _53: ai.events.Usage // u
+    let _54: int
+    let _55: ai.events.Usage
+    let _56: type
+    let _57: string // candidate
+    let _58: string
+    let _59: string | null
     let _60: bool
-    let _61: bool
-    let _62: int
-    let _63: ai.content.ToolUse[]
-    let _64: ai.content.StopReason
-    let _65: ai.content.StopReason
-    let _66: string
-    let _67: type
-    let _68: bool
-    let _69: void
-    let _70: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
-    let _71: ai.content.StopReason
-    let _72: int
-    let _73: ai.errors.ParseFailed
-    let _74: string
-    let _75: string
-    let _76: ai.errors.Refused
+    let _61: bool // accepted
+    let _62: bool
+    let _63: bool
+    let _64: bool
+    let _65: int
+    let _66: ai.content.ToolUse[]
+    let _67: ai.content.StopReason
+    let _68: ai.content.StopReason
+    let _69: string
+    let _70: type
+    let _71: bool
+    let _72: void
+    let _73: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _74: ai.content.StopReason
+    let _75: int
+    let _76: ai.errors.ParseFailed
     let _77: string
-    let _78: bool
-    let _79: int
-    let _80: ai.events.UserMessage
-    let _81: type
-    let _82: void
-    let _83: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
-    let _84: int
-    let _85: type
-    let _86: void
-    let _87: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
-    let _88: ai.errors.ParseFailed
-    let _89: string
-    let _90: string
+    let _78: string
+    let _79: ai.errors.Refused
+    let _80: string
+    let _81: bool
+    let _82: int
+    let _83: ai.events.UserMessage
+    let _84: type
+    let _85: void
+    let _86: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _87: int
+    let _88: type
+    let _89: void
+    let _90: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _91: ai.errors.ParseFailed
+    let _92: string
+    let _93: string
 
     bb0: {
         _9 = copy _3.2;
@@ -3849,201 +3872,204 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
 
     bb5: {
         _21 = copy _20;
-        _23 = copy _5.2;
-        _22 = copy _23;
-        _24 = copy _23 == const null;
-        branch copy _24 -> [bb6, bb7];
+        _24 = copy _5.2;
+        _23 = copy _24;
+        _25 = copy _23 == const null;
+        branch copy _25 -> [bb6, bb7];
     }
 
     bb6: {
-        _22 = const 0_i64;
+        _23 = const 0_i64;
         goto -> bb7;
     }
 
     bb7: {
-        _25 = copy _21;
-        _5.2 = copy _22 + copy _25;
+        _22 = copy _23;
+        _26 = copy _21;
+        _5.2 = copy _22 + copy _26;
         goto -> bb8;
     }
 
     bb8: {
-        _26 = copy _16.3;
-        _27 = copy _26;
-        _27 = narrow_bind copy _27 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb9, bb12];
+        _27 = copy _16.3;
+        _28 = copy _27;
+        _28 = narrow_bind copy _28 as Int { attr: TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset } } -> [bb9, bb12];
     }
 
     bb9: {
-        _28 = copy _27;
-        _30 = copy _5.3;
-        _29 = copy _30;
-        _31 = copy _30 == const null;
-        branch copy _31 -> [bb10, bb11];
+        _29 = copy _28;
+        _32 = copy _5.3;
+        _31 = copy _32;
+        _33 = copy _31 == const null;
+        branch copy _33 -> [bb10, bb11];
     }
 
     bb10: {
-        _29 = const 0_i64;
+        _31 = const 0_i64;
         goto -> bb11;
     }
 
     bb11: {
-        _32 = copy _28;
-        _5.3 = copy _29 + copy _32;
+        _30 = copy _31;
+        _34 = copy _29;
+        _5.3 = copy _30 + copy _34;
         goto -> bb12;
     }
 
     bb12: {
-        _35 = copy _7.0;
-        _36 = virtual_call id as ai.Client(copy _2) -> [bb13];
+        _37 = copy _7.0;
+        _38 = virtual_call id as ai.Client(copy _2) -> [bb13];
     }
 
     bb13: {
-        _34 = ai.events.AssistantMessage { copy _35, copy _36 };
-        _33 = [copy _34]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced[];
-        _37 = call const fn ai.ModelTurn.tool_uses(copy _7) -> [bb14];
+        _36 = ai.events.AssistantMessage { copy _37, copy _38 };
+        _35 = [copy _36]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced[];
+        _39 = call const fn ai.ModelTurn.tool_uses(copy _7) -> [bb14];
     }
 
     bb14: {
-        _38 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.ToolUse>(copy _37) -> [bb15];
+        _40 = virtual_call iter as baml.iter.Iterable<Error = never, Item = ai.content.ToolUse>(copy _39) -> [bb15];
     }
 
     bb15: {
-        _39 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.content.ToolUse>(copy _38) -> [bb16];
+        _41 = virtual_call next as baml.iter.Iterator<Error = never, Item = ai.content.ToolUse>(copy _40) -> [bb16];
     }
 
     bb16: {
-        _40 = is_type(copy _39, baml.iter.Done);
-        branch copy _40 -> [bb18, bb17];
+        _42 = is_type(copy _41, baml.iter.Done);
+        branch copy _42 -> [bb18, bb17];
     }
 
     bb17: {
-        _41 = copy _39;
-        fresh_cell(_42);
-        _42 = copy _41;
-        _45 = copy _42.0;
-        _46 = copy _42.1;
-        _47 = copy _42.2;
-        _44 = ai.events.ToolRequested { copy _45, copy _46, copy _47 };
-        _48 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced);
-        _43 = call const fn baml.Array.push<copy _48>(copy _33, copy _44) -> [bb15];
+        _43 = copy _41;
+        fresh_cell(_44);
+        _44 = copy _43;
+        _47 = copy _44.0;
+        _48 = copy _44.1;
+        _49 = copy _44.2;
+        _46 = ai.events.ToolRequested { copy _47, copy _48, copy _49 };
+        _50 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced);
+        _45 = call const fn baml.Array.push<copy _50>(copy _35, copy _46) -> [bb15];
     }
 
     bb18: {
-        _49 = copy _7.2;
-        _50 = copy _49;
-        _50 = narrow_bind copy _50 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb19, bb20];
+        _51 = copy _7.2;
+        _52 = copy _51;
+        _52 = narrow_bind copy _52 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "Usage" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb19, bb20];
     }
 
     bb19: {
-        _51 = copy _50;
-        _53 = copy _51;
-        _54 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced);
-        _52 = call const fn baml.Array.push<copy _54>(copy _33, copy _53) -> [bb20];
+        _53 = copy _52;
+        _55 = copy _53;
+        _56 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced);
+        _54 = call const fn baml.Array.push<copy _56>(copy _35, copy _55) -> [bb20];
     }
 
     bb20: {
-        _56 = call const fn ai.ModelTurn.terminal_text(copy _7) -> [bb21];
+        _59 = call const fn ai.ModelTurn.terminal_text(copy _7) -> [bb21];
     }
 
     bb21: {
-        _55 = copy _56;
-        _57 = copy _56 == const null;
-        branch copy _57 -> [bb22, bb23];
+        _58 = copy _59;
+        _60 = copy _58 == const null;
+        branch copy _60 -> [bb22, bb23];
     }
 
     bb22: {
-        _55 = const "";
+        _58 = const "";
         goto -> bb23;
     }
 
     bb23: {
-        _63 = call const fn ai.ModelTurn.tool_uses(copy _7) -> [bb24];
+        _57 = copy _58;
+        _66 = call const fn ai.ModelTurn.tool_uses(copy _7) -> [bb24];
     }
 
     bb24: {
-        _62 = len(_63);
+        _65 = len(_66);
         goto -> bb25;
     }
 
     bb25: {
-        _61 = copy _62 > const 0_i64;
-        _60 = short_circuit(||) copy _61 -> [eval: bb26, join: bb27];
+        _64 = copy _65 > const 0_i64;
+        _63 = short_circuit(||) copy _64 -> [eval: bb26, join: bb27];
     }
 
     bb26: {
-        _64 = copy _7.1;
-        _60 = call const fn baml.ops.equals_equals(copy _64, const ai.content.StopReason.MaxTokens) -> [bb27];
+        _67 = copy _7.1;
+        _63 = call const fn baml.ops.equals_equals(copy _67, const ai.content.StopReason.MaxTokens) -> [bb27];
     }
 
     bb27: {
-        _59 = short_circuit(||) copy _60 -> [eval: bb28, join: bb29];
+        _62 = short_circuit(||) copy _63 -> [eval: bb28, join: bb29];
     }
 
     bb28: {
-        _65 = copy _7.1;
-        _59 = call const fn baml.ops.equals_equals(copy _65, const ai.content.StopReason.Refused) -> [bb29];
+        _68 = copy _7.1;
+        _62 = call const fn baml.ops.equals_equals(copy _68, const ai.content.StopReason.Refused) -> [bb29];
     }
 
     bb29: {
-        _58 = short_circuit(||) copy _59 -> [eval: bb30, join: bb31];
+        _61 = short_circuit(||) copy _62 -> [eval: bb30, join: bb31];
     }
 
     bb30: {
-        _66 = copy _55;
-        _67 = load_type(#0);
-        _58 = call const fn ai.Agent._parses<copy _67>(copy _1, copy _66) -> [bb31];
+        _69 = copy _57;
+        _70 = load_type(#0);
+        _61 = call const fn ai.Agent._parses<copy _70>(copy _1, copy _69) -> [bb31];
     }
 
     bb31: {
-        _68 = copy _58;
-        branch copy _68 -> [bb39, bb32];
+        _71 = copy _61;
+        branch copy _71 -> [bb39, bb32];
     }
 
     bb32: {
-        _78 = copy _6 > const 1_i64;
-        branch copy _78 -> [bb36, bb33];
+        _81 = copy _6 > const 1_i64;
+        branch copy _81 -> [bb36, bb33];
     }
 
     bb33: {
-        _87 = copy _33;
-        _86 = call const fn ai.Journal.append_all(copy _4, copy _87) -> [bb34];
+        _90 = copy _35;
+        _89 = call const fn ai.Journal.append_all(copy _4, copy _90) -> [bb34];
     }
 
     bb34: {
-        _89 = virtual_call id as ai.Client(copy _2) -> [bb35];
+        _92 = virtual_call id as ai.Client(copy _2) -> [bb35];
     }
 
     bb35: {
-        _90 = copy _55;
-        _88 = ai.errors.ParseFailed { copy _89, copy _90 };
-        throw copy _88;
+        _93 = copy _57;
+        _91 = ai.errors.ParseFailed { copy _92, copy _93 };
+        throw copy _91;
     }
 
     bb36: {
-        _80 = ai.events.UserMessage { const "The reply did not match the required schema. Answer again with only the corrected value." };
-        _81 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced);
-        _79 = call const fn baml.Array.push<copy _81>(copy _33, copy _80) -> [bb37];
+        _83 = ai.events.UserMessage { const "The reply did not match the required schema. Answer again with only the corrected value." };
+        _84 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced);
+        _82 = call const fn baml.Array.push<copy _84>(copy _35, copy _83) -> [bb37];
     }
 
     bb37: {
-        _83 = copy _33;
-        _82 = call const fn ai.Journal.append_all(copy _4, copy _83) -> [bb38];
+        _86 = copy _35;
+        _85 = call const fn ai.Journal.append_all(copy _4, copy _86) -> [bb38];
     }
 
     bb38: {
-        _84 = copy _6 - const 1_i64;
-        _85 = load_type(#0);
-        _0 = call const fn ai.Agent._attempt_turn<copy _85>(copy _1, copy _2, copy _3, copy _4, copy _5, copy _84) -> [bb42];
+        _87 = copy _6 - const 1_i64;
+        _88 = load_type(#0);
+        _0 = call const fn ai.Agent._attempt_turn<copy _88>(copy _1, copy _2, copy _3, copy _4, copy _5, copy _87) -> [bb42];
     }
 
     bb39: {
-        _70 = copy _33;
-        _69 = call const fn ai.Journal.append_all(copy _4, copy _70) -> [bb40];
+        _73 = copy _35;
+        _72 = call const fn ai.Journal.append_all(copy _4, copy _73) -> [bb40];
     }
 
     bb40: {
-        _71 = copy _7.1;
-        _72 = discriminant(_71);
-        switch copy _72 [StopReason.MaxTokens: bb45, StopReason.Refused: bb43, otherwise: bb41];
+        _74 = copy _7.1;
+        _75 = discriminant(_74);
+        switch copy _75 [StopReason.MaxTokens: bb45, StopReason.Refused: bb43, otherwise: bb41];
     }
 
     bb41: {
@@ -4056,22 +4082,22 @@ fn ai.Agent._attempt_turn(self: ai.Agent, c: ai.Client, spec: ai.FunctionSpec<Ou
     }
 
     bb43: {
-        _77 = virtual_call id as ai.Client(copy _2) -> [bb44];
+        _80 = virtual_call id as ai.Client(copy _2) -> [bb44];
     }
 
     bb44: {
-        _76 = ai.errors.Refused { copy _77, const "the model declined to answer", const null };
-        throw copy _76;
+        _79 = ai.errors.Refused { copy _80, const "the model declined to answer", const null };
+        throw copy _79;
     }
 
     bb45: {
-        _74 = virtual_call id as ai.Client(copy _2) -> [bb46];
+        _77 = virtual_call id as ai.Client(copy _2) -> [bb46];
     }
 
     bb46: {
-        _75 = copy _55;
-        _73 = ai.errors.ParseFailed { copy _74, copy _75 };
-        throw copy _73;
+        _78 = copy _57;
+        _76 = ai.errors.ParseFailed { copy _77, copy _78 };
+        throw copy _76;
     }
 }
 
@@ -4184,254 +4210,259 @@ fn ai.Agent.Runner<Out>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) -> ai.Ru
     let _1: ai.Agent // self // param [captured]
     let _2: ai.FunctionSpec<Out> // spec // param [captured]
     let _3: ai.Client // selected
-    let _4: null | ai.Client
-    let _5: bool
-    let _6: ai.Journal // j [captured]
-    let _7: type
-    let _8: int // seen
-    let _9: ai.Journal
-    let _10: type
-    let _11: int // steps
-    let _12: ai.events.Usage // total
-    let _13: map<string, int> // fail_counts
-    let _14: bool
-    let _15: int
+    let _4: ai.Client
+    let _5: null | ai.Client
+    let _6: bool
+    let _7: ai.Journal // j [captured]
+    let _8: type
+    let _9: int // seen
+    let _10: ai.Journal
+    let _11: type
+    let _12: int // steps
+    let _13: ai.events.Usage // total
+    let _14: map<string, int> // fail_counts
+    let _15: bool
     let _16: int
-    let _17: ai.ModelTurn // turn
-    let _18: ai.Client
-    let _19: ai.Journal
-    let _20: ai.events.Usage
-    let _21: type
-    let _22: int
-    let _23: ai.Journal
-    let _24: int
-    let _25: type
-    let _26: ai.content.ToolUse[] // calls
-    let _27: bool
-    let _28: int
-    let _29: int // before
-    let _30: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
-    let _31: future<null, ai.errors.ToolFailedError>[] // futures
-    let _32: (ai.content.ToolUse) -> future<null, ai.errors.ToolFailedError> throws never
-    let _33: type
+    let _17: int
+    let _18: ai.ModelTurn // turn
+    let _19: ai.Client
+    let _20: ai.Journal
+    let _21: ai.events.Usage
+    let _22: type
+    let _23: int
+    let _24: ai.Journal
+    let _25: int
+    let _26: type
+    let _27: ai.content.ToolUse[] // calls
+    let _28: bool
+    let _29: int
+    let _30: int // before
+    let _31: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _32: future<null, ai.errors.ToolFailedError>[] // futures
+    let _33: (ai.content.ToolUse) -> future<null, ai.errors.ToolFailedError> throws never
     let _34: type
     let _35: type
-    let _36: null[]
-    let _37: null
-    let _38: future<null, ai.errors.ToolFailedError>[]
-    let _39: type
+    let _36: type
+    let _37: null[]
+    let _38: null
+    let _39: future<null, ai.errors.ToolFailedError>[]
     let _40: type
-    let _41: ai.Journal
-    let _42: int
-    let _43: type
-    let _44: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // entries
-    let _45: int // i
-    let _46: bool
-    let _47: int
+    let _41: type
+    let _42: ai.Journal
+    let _43: int
+    let _44: type
+    let _45: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[] // entries
+    let _46: int // i
+    let _47: bool
     let _48: int
-    let _49: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
-    let _50: int
-    let _51: type
-    let _52: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
-    let _53: ai.events.ToolFailed // f [captured]
-    let _54: null | ai.content.ToolUse // failed_call
-    let _55: (ai.content.ToolUse) -> bool throws never
-    let _56: type
+    let _49: int
+    let _50: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _51: int
+    let _52: type
+    let _53: null | ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage
+    let _54: ai.events.ToolFailed // f [captured]
+    let _55: null | ai.content.ToolUse // failed_call
+    let _56: (ai.content.ToolUse) -> bool throws never
     let _57: type
-    let _58: null | ai.content.ToolUse
-    let _59: ai.content.ToolUse // known
-    let _60: string // key
-    let _61: string
+    let _58: type
+    let _59: null | ai.content.ToolUse
+    let _60: ai.content.ToolUse // known
+    let _61: string // key
     let _62: string
     let _63: string
-    let _64: type
-    let _65: string
+    let _64: string
+    let _65: type
     let _66: string
-    let _67: type
-    let _68: int // n
-    let _69: int
-    let _70: int | null
-    let _71: string
-    let _72: type
-    let _73: type
-    let _74: bool
-    let _75: int | null
-    let _76: string
-    let _77: int
-    let _78: type
-    let _79: type
-    let _80: bool
-    let _81: int
-    let _82: ai.errors.ToolFailedError
-    let _83: string
-    let _84: string
+    let _67: string
+    let _68: type
+    let _69: int // n
+    let _70: int
+    let _71: int
+    let _72: int | null
+    let _73: string
+    let _74: type
+    let _75: type
+    let _76: bool
+    let _77: int | null
+    let _78: string
+    let _79: int
+    let _80: type
+    let _81: type
+    let _82: bool
+    let _83: int
+    let _84: ai.errors.ToolFailedError
     let _85: string
     let _86: string
     let _87: string
     let _88: string
-    let _89: int
-    let _90: type
-    let _91: string
-    let _92: string
-    let _93: type
-    let _94: int
-    let _95: string // candidate
-    let _96: string | null
-    let _97: bool
-    let _98: Out // value
-    let _99: unknown // e
-    let _100: string
-    let _101: type
-    let _102: ai.errors.ParseFailed
+    let _89: string
+    let _90: string
+    let _91: int
+    let _92: type
+    let _93: string
+    let _94: string
+    let _95: type
+    let _96: int
+    let _97: string // candidate
+    let _98: string
+    let _99: string | null
+    let _100: bool
+    let _101: Out // value
+    let _102: unknown // e
     let _103: string
-    let _104: string
-    let _105: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // value_json
-    let _106: unknown // e
-    let _107: Out
-    let _108: type
-    let _109: baml.errors.UnknownError
-    let _110: baml.json.JsonSerializationError
-    let _111: string[]
-    let _112: string
-    let _113: type
-    let _114: void
-    let _115: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
-    let _116: ai.events.FinalProduced
-    let _117: string
-    let _118: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
-    let _119: ai.Journal
-    let _120: int
-    let _121: type
-    let _122: Out
-    let _123: ai.Journal
-    let _124: ai.events.Usage
-    let _125: ai.errors.StepBudgetExceeded
-    let _126: int
+    let _104: type
+    let _105: ai.errors.ParseFailed
+    let _106: string
+    let _107: string
+    let _108: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json> // value_json
+    let _109: unknown // e
+    let _110: Out
+    let _111: type
+    let _112: baml.errors.UnknownError
+    let _113: baml.json.JsonSerializationError
+    let _114: string[]
+    let _115: string
+    let _116: type
+    let _117: void
+    let _118: (ai.events.AssistantMessage | ai.events.FinalProduced | ai.events.RunStarted | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.ToolRequested | ai.events.Usage | ai.events.UserMessage)[]
+    let _119: ai.events.FinalProduced
+    let _120: string
+    let _121: int | float | string | bool | null | baml.json.json[] | map<string, baml.json.json>
+    let _122: ai.Journal
+    let _123: int
+    let _124: type
+    let _125: Out
+    let _126: ai.Journal
+    let _127: ai.events.Usage
+    let _128: ai.errors.StepBudgetExceeded
+    let _129: int
 
     bb0: {
-        _4 = copy _1.1;
-        _3 = copy _4;
-        _5 = copy _4 == const null;
-        branch copy _5 -> [bb1, bb2];
+        _5 = copy _1.1;
+        _4 = copy _5;
+        _6 = copy _4 == const null;
+        branch copy _6 -> [bb1, bb2];
     }
 
     bb1: {
-        _3 = copy _2.4;
+        _4 = copy _2.4;
         goto -> bb2;
     }
 
     bb2: {
-        _7 = load_type(#0);
-        _6 = call const fn ai.Journal.new<copy _7>(copy _2) -> [bb3];
+        _3 = copy _4;
+        _8 = load_type(#0);
+        _7 = call const fn ai.Journal.new<copy _8>(copy _2) -> [bb3];
     }
 
     bb3: {
-        _9 = copy _6;
-        _10 = load_type(#0);
-        _8 = call const fn ai.Agent._emit_from<copy _10>(copy _1, copy _9, const 0_i64) -> [bb4];
+        _10 = copy _7;
+        _11 = load_type(#0);
+        _9 = call const fn ai.Agent._emit_from<copy _11>(copy _1, copy _10, const 0_i64) -> [bb4];
     }
 
     bb4: {
-        _11 = const 0_i64;
-        _12 = ai.events.Usage { const 0_i64, const 0_i64, const null, const null };
-        _13 = {  }: map<string, int>;
+        _12 = const 0_i64;
+        _13 = ai.events.Usage { const 0_i64, const 0_i64, const null, const null };
+        _14 = {  }: map<string, int>;
         goto -> bb5;
     }
 
     bb5: {
-        _15 = copy _11;
-        _16 = copy _1.0;
-        _14 = copy _15 < copy _16;
-        branch copy _14 -> [bb7, bb6];
+        _16 = copy _12;
+        _17 = copy _1.0;
+        _15 = copy _16 < copy _17;
+        branch copy _15 -> [bb7, bb6];
     }
 
     bb6: {
-        _126 = copy _11;
-        _125 = ai.errors.StepBudgetExceeded { copy _126 };
-        throw copy _125;
+        _129 = copy _12;
+        _128 = ai.errors.StepBudgetExceeded { copy _129 };
+        throw copy _128;
     }
 
     bb7: {
-        _18 = copy _3;
-        _19 = copy _6;
-        _20 = copy _12;
-        _21 = load_type(#0);
-        _17 = call const fn ai.Agent._attempt_turn<copy _21>(copy _1, copy _18, copy _2, copy _19, copy _20, const 2_i64) -> [bb8];
+        _19 = copy _3;
+        _20 = copy _7;
+        _21 = copy _13;
+        _22 = load_type(#0);
+        _18 = call const fn ai.Agent._attempt_turn<copy _22>(copy _1, copy _19, copy _2, copy _20, copy _21, const 2_i64) -> [bb8];
     }
 
     bb8: {
-        _22 = copy _11;
-        _11 = copy _22 + const 1_i64;
-        _23 = copy _6;
-        _24 = copy _8;
-        _25 = load_type(#0);
-        _8 = call const fn ai.Agent._emit_from<copy _25>(copy _1, copy _23, copy _24) -> [bb9];
+        _23 = copy _12;
+        _12 = copy _23 + const 1_i64;
+        _24 = copy _7;
+        _25 = copy _9;
+        _26 = load_type(#0);
+        _9 = call const fn ai.Agent._emit_from<copy _26>(copy _1, copy _24, copy _25) -> [bb9];
     }
 
     bb9: {
-        _26 = call const fn ai.ModelTurn.tool_uses(copy _17) -> [bb10];
+        _27 = call const fn ai.ModelTurn.tool_uses(copy _18) -> [bb10];
     }
 
     bb10: {
-        _28 = len(_26);
+        _29 = len(_27);
         goto -> bb11;
     }
 
     bb11: {
-        _27 = copy _28 > const 0_i64;
-        branch copy _27 -> [bb22, bb12];
+        _28 = copy _29 > const 0_i64;
+        branch copy _28 -> [bb22, bb12];
     }
 
     bb12: {
-        _96 = call const fn ai.ModelTurn.terminal_text(copy _17) -> [bb13];
+        _99 = call const fn ai.ModelTurn.terminal_text(copy _18) -> [bb13];
     }
 
     bb13: {
-        _95 = copy _96;
-        _97 = copy _96 == const null;
-        branch copy _97 -> [bb14, bb15];
+        _98 = copy _99;
+        _100 = copy _98 == const null;
+        branch copy _100 -> [bb14, bb15];
     }
 
     bb14: {
-        _95 = const "";
+        _98 = const "";
         goto -> bb15;
     }
 
     bb15: {
-        _100 = copy _95;
-        _101 = load_type(#0);
-        _98 = call const fn baml.sap.parse<copy _101>(copy _100) -> [bb16, unwind: bb47];
+        _97 = copy _98;
+        _103 = copy _97;
+        _104 = load_type(#0);
+        _101 = call const fn baml.sap.parse<copy _104>(copy _103) -> [bb16, unwind: bb47];
     }
 
     bb16: {
-        _107 = copy _98;
-        _108 = load_type(#0);
-        _105 = call const fn baml.json.to_json<copy _108>(copy _107) -> [bb17, unwind: bb50];
+        _110 = copy _101;
+        _111 = load_type(#0);
+        _108 = call const fn baml.json.to_json<copy _111>(copy _110) -> [bb17, unwind: bb50];
     }
 
     bb17: {
-        _118 = copy _105;
-        _117 = call const fn baml.json.stringify(copy _118) -> [bb18];
+        _121 = copy _108;
+        _120 = call const fn baml.json.stringify(copy _121) -> [bb18];
     }
 
     bb18: {
-        _116 = ai.events.FinalProduced { copy _117 };
-        _115 = [copy _116]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced[];
-        _114 = call const fn ai.Journal.append_all(copy _6, copy _115) -> [bb19];
+        _119 = ai.events.FinalProduced { copy _120 };
+        _118 = [copy _119]: ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced[];
+        _117 = call const fn ai.Journal.append_all(copy _7, copy _118) -> [bb19];
     }
 
     bb19: {
-        _119 = copy _6;
-        _120 = copy _8;
-        _121 = load_type(#0);
-        _8 = call const fn ai.Agent._emit_from<copy _121>(copy _1, copy _119, copy _120) -> [bb20];
+        _122 = copy _7;
+        _123 = copy _9;
+        _124 = load_type(#0);
+        _9 = call const fn ai.Agent._emit_from<copy _124>(copy _1, copy _122, copy _123) -> [bb20];
     }
 
     bb20: {
-        _122 = copy _98;
-        _123 = copy _6;
-        _124 = copy _12;
-        _0 = ai.RunResult<#0> { copy _122, copy _123, copy _124 };
+        _125 = copy _101;
+        _126 = copy _7;
+        _127 = copy _13;
+        _0 = ai.RunResult<#0> { copy _125, copy _126, copy _127 };
         goto -> bb21;
     }
 
@@ -4440,188 +4471,189 @@ fn ai.Agent.Runner<Out>.run(self: ai.Agent, spec: ai.FunctionSpec<Out>) -> ai.Ru
     }
 
     bb22: {
-        _30 = call const fn ai.Journal.entries(copy _6) -> [bb23];
+        _31 = call const fn ai.Journal.entries(copy _7) -> [bb23];
     }
 
     bb23: {
-        _29 = len(_30);
+        _30 = len(_31);
         goto -> bb24;
     }
 
     bb24: {
-        _32 = make_closure lambda[0]<1 type_args>(copy _1, copy _2, copy _6);
-        _33 = load_type(future<null, ai.errors.ToolFailedError>);
-        _34 = load_type(never);
-        _35 = load_type(ai.content.ToolUse);
-        _31 = call const fn baml.Array.map<copy _35, copy _33, copy _34>(copy _26, copy _32) -> [bb25];
+        _33 = make_closure lambda[0]<1 type_args>(copy _1, copy _2, copy _7);
+        _34 = load_type(future<null, ai.errors.ToolFailedError>);
+        _35 = load_type(never);
+        _36 = load_type(ai.content.ToolUse);
+        _32 = call const fn baml.Array.map<copy _36, copy _34, copy _35>(copy _27, copy _33) -> [bb25];
     }
 
     bb25: {
-        _38 = copy _31;
-        _39 = load_type(null);
-        _40 = load_type(ai.errors.ToolFailedError);
-        _37 = call const fn baml.future.all<copy _39, copy _40>(copy _38) -> [bb26];
+        _39 = copy _32;
+        _40 = load_type(null);
+        _41 = load_type(ai.errors.ToolFailedError);
+        _38 = call const fn baml.future.all<copy _40, copy _41>(copy _39) -> [bb26];
     }
 
     bb26: {
-        _36 = await _37 -> [bb27];
+        _37 = await _38 -> [bb27];
     }
 
     bb27: {
-        _41 = copy _6;
-        _42 = copy _8;
-        _43 = load_type(#0);
-        _8 = call const fn ai.Agent._emit_from<copy _43>(copy _1, copy _41, copy _42) -> [bb28];
+        _42 = copy _7;
+        _43 = copy _9;
+        _44 = load_type(#0);
+        _9 = call const fn ai.Agent._emit_from<copy _44>(copy _1, copy _42, copy _43) -> [bb28];
     }
 
     bb28: {
-        _44 = call const fn ai.Journal.entries(copy _6) -> [bb29];
+        _45 = call const fn ai.Journal.entries(copy _7) -> [bb29];
     }
 
     bb29: {
-        _45 = copy _29;
+        _46 = copy _30;
         goto -> bb30;
     }
 
     bb30: {
-        _47 = copy _45;
-        _48 = len(_44);
+        _48 = copy _46;
+        _49 = len(_45);
         goto -> bb31;
     }
 
     bb31: {
-        _46 = copy _47 < copy _48;
-        branch copy _46 -> [bb32, bb5];
+        _47 = copy _48 < copy _49;
+        branch copy _47 -> [bb32, bb5];
     }
 
     bb32: {
-        _50 = copy _45;
-        _51 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced);
-        _49 = call const fn baml.Array.at<copy _51>(copy _44, copy _50) -> [bb33];
+        _51 = copy _46;
+        _52 = load_type(ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced);
+        _50 = call const fn baml.Array.at<copy _52>(copy _45, copy _51) -> [bb33];
     }
 
     bb33: {
-        _52 = copy _49;
-        _52 = narrow_bind copy _52 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb34, bb43];
+        _53 = copy _50;
+        _53 = narrow_bind copy _53 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["events"], name: "ToolFailed" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb34, bb43];
     }
 
     bb34: {
-        _53 = copy _52;
-        _55 = make_closure lambda[1]<1 type_args>(copy _53);
-        _56 = load_type(never);
-        _57 = load_type(ai.content.ToolUse);
-        _54 = call const fn baml.Array.find<copy _57, copy _56>(copy _26, copy _55) -> [bb35];
+        _54 = copy _53;
+        _56 = make_closure lambda[1]<1 type_args>(copy _54);
+        _57 = load_type(never);
+        _58 = load_type(ai.content.ToolUse);
+        _55 = call const fn baml.Array.find<copy _58, copy _57>(copy _27, copy _56) -> [bb35];
     }
 
     bb35: {
-        _58 = copy _54;
-        _58 = narrow_bind copy _58 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["content"], name: "ToolUse" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb36, bb43];
+        _59 = copy _55;
+        _59 = narrow_bind copy _59 as Class(QualifiedTypeName { pkg: Dep("ai"), namespace: ["content"], name: "ToolUse" }, [], TyAttr { sap_parse_without_null: Unset, sap_pending_never: Unset, sap_in_progress_never: Unset }) -> [bb36, bb43];
     }
 
     bb36: {
-        _59 = copy _58;
-        _63 = copy _59.1;
-        _64 = load_type(string);
-        _62 = call const fn baml.String.from<copy _64>(copy _63) -> [bb37];
+        _60 = copy _59;
+        _64 = copy _60.1;
+        _65 = load_type(string);
+        _63 = call const fn baml.String.from<copy _65>(copy _64) -> [bb37];
     }
 
     bb37: {
-        _61 = copy _62 + const "|";
-        _66 = copy _53.1;
-        _67 = load_type(string);
-        _65 = call const fn baml.String.from<copy _67>(copy _66) -> [bb38];
+        _62 = copy _63 + const "|";
+        _67 = copy _54.1;
+        _68 = load_type(string);
+        _66 = call const fn baml.String.from<copy _68>(copy _67) -> [bb38];
     }
 
     bb38: {
-        _60 = copy _61 + copy _65;
-        _71 = copy _60;
-        _72 = load_type(string);
-        _73 = load_type(int);
-        _70 = call const fn baml.Map.get<copy _72, copy _73>(copy _13, copy _71) -> [bb39];
+        _61 = copy _62 + copy _66;
+        _73 = copy _61;
+        _74 = load_type(string);
+        _75 = load_type(int);
+        _72 = call const fn baml.Map.get<copy _74, copy _75>(copy _14, copy _73) -> [bb39];
     }
 
     bb39: {
-        _69 = copy _70;
-        _74 = copy _70 == const null;
-        branch copy _74 -> [bb40, bb41];
+        _71 = copy _72;
+        _76 = copy _71 == const null;
+        branch copy _76 -> [bb40, bb41];
     }
 
     bb40: {
-        _69 = const 0_i64;
+        _71 = const 0_i64;
         goto -> bb41;
     }
 
     bb41: {
-        _68 = copy _69 + const 1_i64;
-        _76 = copy _60;
-        _77 = copy _68;
-        _78 = load_type(string);
-        _79 = load_type(int);
-        _75 = call const fn baml.Map.set<copy _78, copy _79>(copy _13, copy _76, copy _77) -> [bb42];
+        _70 = copy _71;
+        _69 = copy _70 + const 1_i64;
+        _78 = copy _61;
+        _79 = copy _69;
+        _80 = load_type(string);
+        _81 = load_type(int);
+        _77 = call const fn baml.Map.set<copy _80, copy _81>(copy _14, copy _78, copy _79) -> [bb42];
     }
 
     bb42: {
-        _81 = copy _68;
-        _80 = copy _81 >= const 3_i64;
-        branch copy _80 -> [bb44, bb43];
+        _83 = copy _69;
+        _82 = copy _83 >= const 3_i64;
+        branch copy _82 -> [bb44, bb43];
     }
 
     bb43: {
-        _94 = copy _45;
-        _45 = copy _94 + const 1_i64;
+        _96 = copy _46;
+        _46 = copy _96 + const 1_i64;
         goto -> bb30;
     }
 
     bb44: {
-        _83 = copy _59.0;
-        _84 = copy _59.1;
-        _89 = copy _68;
-        _90 = load_type(int);
-        _88 = call const fn baml.String.from<copy _90>(copy _89) -> [bb45];
+        _85 = copy _60.0;
+        _86 = copy _60.1;
+        _91 = copy _69;
+        _92 = load_type(int);
+        _90 = call const fn baml.String.from<copy _92>(copy _91) -> [bb45];
     }
 
     bb45: {
-        _87 = const "the same tool call failed " + copy _88;
-        _86 = copy _87 + const " times; stopping the run: ";
-        _92 = copy _53.1;
-        _93 = load_type(string);
-        _91 = call const fn baml.String.from<copy _93>(copy _92) -> [bb46];
+        _89 = const "the same tool call failed " + copy _90;
+        _88 = copy _89 + const " times; stopping the run: ";
+        _94 = copy _54.1;
+        _95 = load_type(string);
+        _93 = call const fn baml.String.from<copy _95>(copy _94) -> [bb46];
     }
 
     bb46: {
-        _85 = copy _86 + copy _91;
-        _82 = ai.errors.ToolFailedError { copy _83, copy _84, copy _85, const null };
-        throw copy _82;
+        _87 = copy _88 + copy _93;
+        _84 = ai.errors.ToolFailedError { copy _85, copy _86, copy _87, const null };
+        throw copy _84;
     }
 
     bb47: {
-        throw_if_panic copy _99 -> bb48;
+        throw_if_panic copy _102 -> bb48;
     }
 
     bb48: {
-        _103 = virtual_call id as ai.Client(copy _3) -> [bb49];
+        _106 = virtual_call id as ai.Client(copy _3) -> [bb49];
     }
 
     bb49: {
-        _104 = copy _95;
-        _102 = ai.errors.ParseFailed { copy _103, copy _104 };
-        throw copy _102;
+        _107 = copy _97;
+        _105 = ai.errors.ParseFailed { copy _106, copy _107 };
+        throw copy _105;
     }
 
     bb50: {
-        throw_if_panic copy _106 -> bb51;
+        throw_if_panic copy _109 -> bb51;
     }
 
     bb51: {
-        _110 = copy _106;
-        _113 = load_type(baml.json.JsonSerializationError);
-        _112 = call const fn baml.String.from<copy _113>(copy _106) -> [bb52];
+        _113 = copy _109;
+        _116 = load_type(baml.json.JsonSerializationError);
+        _115 = call const fn baml.String.from<copy _116>(copy _109) -> [bb52];
     }
 
     bb52: {
-        _111 = [copy _112]: string[];
-        _109 = baml.errors.UnknownError { copy _110, copy _111 };
-        throw copy _109;
+        _114 = [copy _115]: string[];
+        _112 = baml.errors.UnknownError { copy _113, copy _114 };
+        throw copy _112;
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____06_codegen.snap
@@ -16,18 +16,17 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
     store_var ?20
     load_deref ?1
     load_field .client
-    store_var _4
-    load_var _4
-    store_var selected
-    load_var _4
+    store_var_load_var _4
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_deref ?2
     load_field .default_client
-    store_var selected
+    store_var _4
 
   L0:
+    load_var _4
+    store_var selected
     load_type #0
     load_deref ?2
     call ai.Journal.new
@@ -89,8 +88,8 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
     store_var calls
     load_var calls
     container_len
-    store_var _28
-    load_var _28
+    store_var _29
+    load_var _29
     load_const 0
     cmp_int_op >
     pop_jump_if_false L4
@@ -99,17 +98,16 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
   L4:
     load_var turn
     call ai.ModelTurn.terminal_text
-    store_var _96
-    load_var _96
-    store_var candidate
-    load_var _96
+    store_var_load_var _98
     load_const null
     cmp_op ==
     pop_jump_if_false L5
     load_const ""
-    store_var candidate
+    store_var _98
 
   L5:
+    load_var _98
+    store_var candidate
     load_type #0
     load_var candidate
     call baml.sap.parse
@@ -121,8 +119,8 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _103
-    load_var2 37 33
+    store_var _106
+    load_var2 36 32
     init_instance ai.errors.ParseFailed .provider, .raw_output
     throw
 
@@ -136,8 +134,8 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
     load_type baml.json.JsonSerializationError
     load_var e
     call baml.String.from
-    store_var _112
-    load_var2 38 39
+    store_var _115
+    load_var2 37 38
     load_type string
     alloc_array 1
     init_instance baml.errors.UnknownError .data, .message
@@ -145,9 +143,9 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   L7:
     call baml.json.stringify
-    store_var _117
+    store_var _120
     load_deref ?5
-    load_var _117
+    load_var _120
     init_instance ai.events.FinalProduced .value_json
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced
     alloc_array 1
@@ -201,21 +199,21 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   L9:
     load_var i
-    store_var _47
+    store_var _48
     load_var entries
     container_len
-    store_var _48
+    store_var _49
     load_var2 17 18
     cmp_int_op <
     pop_jump_if_false L1
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced
     load_var2 15 16
     call baml.Array.at
-    store_var _52
-    load_var _52
+    store_var _53
+    load_var _53
     narrow_bind ai.events.ToolFailed, slot=19
     pop_jump_if_false L11
-    load_var _52
+    load_var _53
     store_deref ?20
     load_type ai.content.ToolUse
     load_type never
@@ -224,44 +222,41 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
     load_var f
     make_closure .<lambda(Agent.run, 2)>, captures=1, ntypeargs=1
     call baml.Array.find
-    store_var _58
-    load_var _58
+    store_var _59
+    load_var _59
     narrow_bind ai.content.ToolUse, slot=21
     pop_jump_if_false L11
-    load_var _58
+    load_var _59
     store_var known
     load_type string
     load_var known
     load_field .name
     call baml.String.from
-    store_var _62
+    store_var _63
     load_type string
     load_deref ?20
     load_field .message
     call baml.String.from
-    store_var _65
-    load_var _62
+    store_var _66
+    load_var _63
     load_const "|"
     bin_op +
-    load_var _65
+    load_var _66
     bin_op +
     store_var key
     load_type string
     load_type int
     load_var2 9 23
     call baml.Map.get
-    store_var _70
-    load_var _70
-    store_var _69
-    load_var _70
+    store_var_load_var _71
     load_const null
     cmp_op ==
     pop_jump_if_false L10
     load_const 0
-    store_var _69
+    store_var _71
 
   L10:
-    load_var _69
+    load_var _71
     load_const 1
     add_int
     store_var n
@@ -287,26 +282,26 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
   L12:
     load_var known
     load_field .id
-    store_var _83
+    store_var _85
     load_var known
     load_field .name
-    store_var _84
+    store_var _86
     load_type int
     load_var n
     call baml.String.from
-    store_var _88
+    store_var _90
     load_type string
     load_deref ?20
     load_field .message
     call baml.String.from
-    store_var _91
-    load_var2 29 30
+    store_var _93
+    load_var2 28 29
     load_const "the same tool call failed "
-    load_var _88
+    load_var _90
     bin_op +
     load_const " times; stopping the run: "
     bin_op +
-    load_var _91
+    load_var _93
     bin_op +
     load_const null
     init_instance ai.errors.ToolFailedError .id, .name, .message, .cause
@@ -365,15 +360,12 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
     store_var ci
     load_var total
     load_field .cached_input_tokens
-    store_var _23
-    load_var _23
-    store_var _22
-    load_var _23
+    store_var_load_var _23
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_const 0
-    store_var _22
+    store_var _23
 
   L0:
     load_var2 5 15
@@ -384,26 +376,23 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
   L1:
     load_var u
     load_field .reasoning_tokens
-    store_var _27
-    load_var _27
-    narrow_bind int, slot=17
+    store_var _28
+    load_var _28
+    narrow_bind int, slot=16
     pop_jump_if_false L3
-    load_var _27
+    load_var _28
     store_var rt
     load_var total
     load_field .reasoning_tokens
-    store_var _30
-    load_var _30
-    store_var _29
-    load_var _30
+    store_var_load_var _31
     load_const null
     cmp_op ==
     pop_jump_if_false L2
     load_const 0
-    store_var _29
+    store_var _31
 
   L2:
-    load_var2 5 19
+    load_var2 5 18
     load_var rt
     bin_op +
     store_field .reasoning_tokens
@@ -411,13 +400,13 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
   L3:
     load_var turn
     load_field .content
-    store_var _35
+    store_var _37
     load_var c
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _36
-    load_var2 22 23
+    store_var _38
+    load_var2 20 21
     init_instance ai.events.AssistantMessage .content, .client_id
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced
     alloc_array 1
@@ -427,24 +416,24 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
     load_type baml.iter.Iterable<Error = never, Item = ai.content.ToolUse>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _38
+    store_var _40
 
   L4:
-    load_var _38
+    load_var _40
     load_type baml.iter.Iterator<Error = never, Item = ai.content.ToolUse>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _39
-    load_var _39
+    store_var _41
+    load_var _41
     is_type baml.iter.Done
     pop_jump_if_false L5
     jump L6
 
   L5:
-    load_var _39
+    load_var _41
     store_var u
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced
-    load_var2 21 26
+    load_var2 19 24
     load_field .id
     load_var u
     load_field .name
@@ -458,34 +447,33 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
   L6:
     load_var turn
     load_field .usage
-    store_var _50
-    load_var _50
-    narrow_bind ai.events.Usage, slot=27
+    store_var _52
+    load_var _52
+    narrow_bind ai.events.Usage, slot=25
     pop_jump_if_false L7
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced
-    load_var2 21 27
+    load_var2 19 25
     call baml.Array.push
     pop 1
 
   L7:
     load_var turn
     call ai.ModelTurn.terminal_text
-    store_var _56
-    load_var _56
-    store_var candidate
-    load_var _56
+    store_var_load_var _58
     load_const null
     cmp_op ==
     pop_jump_if_false L8
     load_const ""
-    store_var candidate
+    store_var _58
 
   L8:
+    load_var _58
+    store_var candidate
     load_var turn
     call ai.ModelTurn.tool_uses
     container_len
-    store_var _62
-    load_var _62
+    store_var _65
+    load_var _65
     load_const 0
     cmp_int_op >
     jump_if_false L9
@@ -518,7 +506,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
   L13:
     pop 1
     load_type #0
-    load_var2 1 28
+    load_var2 1 26
     call ai.Agent._parses
 
   L14:
@@ -533,15 +521,15 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
     jump L17
 
   L16:
-    load_var2 4 21
+    load_var2 4 19
     call ai.Journal.append_all
     pop 1
     load_var c
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _89
-    load_var2 33 28
+    store_var _92
+    load_var2 31 26
     init_instance ai.errors.ParseFailed .provider, .raw_output
     throw
 
@@ -552,7 +540,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
     init_instance ai.events.UserMessage .content
     call baml.Array.push
     pop 1
-    load_var2 4 21
+    load_var2 4 19
     call ai.Journal.append_all
     pop 1
     load_type #0
@@ -565,7 +553,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
     jump L21
 
   L18:
-    load_var2 4 21
+    load_var2 4 19
     call ai.Journal.append_all
     pop 1
     load_var turn
@@ -596,8 +584,8 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _77
-    load_var _77
+    store_var _80
+    load_var _80
     load_const "the model declined to answer"
     load_const null
     init_instance ai.errors.Refused .provider, .reason, .raw_body
@@ -608,8 +596,8 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _74
-    load_var2 31 28
+    store_var _77
+    load_var2 29 26
     init_instance ai.errors.ParseFailed .provider, .raw_output
     throw
 }
@@ -733,15 +721,15 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
   L0:
     load_var call
     load_field .id
-    store_var _41
+    store_var _42
     load_type string
     load_var call
     load_field .name
     call baml.String.from
-    store_var _43
-    load_var2 4 19
+    store_var _44
+    load_var2 4 18
     load_const "tool is not in the active toolbox: "
-    load_var _43
+    load_var _44
     bin_op +
     init_instance ai.events.ToolFailed .id, .message
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced
@@ -777,19 +765,16 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
     pop 1
     load_var t
     load_field .on_error
-    store_var _20
-    load_var _20
-    store_var _19
-    load_var _20
+    store_var_load_var _20
     load_const null
     cmp_op ==
     pop_jump_if_false L2
     load_var self
     load_field .tool_errors
-    store_var _19
+    store_var _20
 
   L2:
-    load_var _19
+    load_var _20
     load_const ai.tools.ErrorMode.Raise
     alloc_variant ai.tools.ErrorMode
     call baml.ops.equals_equals
@@ -803,9 +788,9 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
 
   L4:
     load_var e
-    store_var _23
-    load_var _23
-    narrow_bind ai.errors.Failure, slot=14
+    store_var _24
+    load_var _24
+    narrow_bind ai.errors.Failure, slot=13
     pop_jump_if_false L5
     jump L6
 
@@ -815,34 +800,34 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
     jump L7
 
   L6:
-    load_var _23
+    load_var _24
     store_var classified
 
   L7:
     load_var call
     load_field .id
-    store_var _26
+    store_var _27
     load_var call
     load_field .name
-    store_var _27
+    store_var _28
     load_type unknown
     load_var e
     call baml.String.from
-    store_var _28
-    load_var2 15 16
-    load_var2 17 13
+    store_var _29
+    load_var2 14 15
+    load_var2 16 12
     init_instance ai.errors.ToolFailedError .id, .name, .message, .cause
     throw
 
   L8:
     load_var outcome
-    store_var _31
-    load_var _31
-    narrow_bind string, slot=18
+    store_var _32
+    load_var _32
+    narrow_bind string, slot=17
     pop_jump_if_false L9
     load_var2 4 3
     load_field .id
-    load_var _31
+    load_var _32
     init_instance ai.events.ToolCompleted .id, .output
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced
     alloc_array 1
@@ -891,14 +876,13 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
 
   L3:
     load_var on_event
-    store_var _9
-    load_var on_event
+    store_var_load_var _10
     load_const null
     cmp_op ==
     pop_jump_if_false L4
     load_type #0
     make_closure .<lambda(Agent.new, 0)>, captures=0, ntypeargs=1
-    store_var _9
+    store_var _10
 
   L4:
     load_var2 1 2
@@ -1423,18 +1407,18 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
 
   L2:
     load_var retry_if
-    store_var _8
-    load_var retry_if
+    store_var_load_var _9
     load_const null
     cmp_op ==
     pop_jump_if_false L3
     load_const ai.clients.default_retry_judgment
-    store_var _8
+    store_var _9
 
   L3:
+    load_var _9
+    store_var _8
     load_var backoff
-    store_var _10
-    load_var backoff
+    store_var_load_var _12
     load_const null
     cmp_op ==
     pop_jump_if_false L4
@@ -1442,11 +1426,11 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
     load_const <omitted>
     load_const <omitted>
     call ai.clients.Backoff.new
-    store_var _10
+    store_var _12
 
   L4:
     load_var2 1 2
-    load_var2 5 6
+    load_var2 5 7
     init_instance ai.clients.Retry .inner, .max_attempts, .retry_if, .backoff
     return
 }
@@ -2576,28 +2560,24 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
   L5:
     load_var self
     load_field ._input_tokens
-    store_var _12
-    load_var _12
-    store_var _11
-    load_var _12
+    store_var_load_var _12
     load_const null
     cmp_op ==
     pop_jump_if_false L6
     load_const 0
-    store_var _11
+    store_var _12
 
   L6:
+    load_var _12
+    store_var _11
     load_var self
     load_field ._output_tokens
-    store_var _15
-    load_var _15
-    store_var _14
-    load_var _15
+    store_var_load_var _16
     load_const null
     cmp_op ==
     pop_jump_if_false L7
     load_const 0
-    store_var _14
+    store_var _16
 
   L7:
     load_var2 4 6
@@ -2609,16 +2589,13 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
   L8:
     load_var self
     load_field ._stop_reason
-    store_var _21
-    load_var _21
-    store_var _20
-    load_var _21
+    store_var_load_var _23
     load_const null
     cmp_op ==
     pop_jump_if_false L9
     load_const ai.content.StopReason.Complete
     alloc_variant ai.content.StopReason
-    store_var _20
+    store_var _23
 
   L9:
     load_var self
@@ -2626,7 +2603,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
     init_instance ai.content.Text .text
     load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse
     alloc_array 1
-    load_var2 8 3
+    load_var2 7 3
     init_instance ai.ModelTurn .content, .stop_reason, .usage
     return
 }
@@ -3265,19 +3242,18 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
     call reflect.signature
     store_var sig
     load_var name
-    store_var resolved_name
-    load_var name
+    store_var_load_var _10
     load_const null
     cmp_op ==
     pop_jump_if_false L3
     load_var sig
     load_field .name
-    store_var resolved_name
+    store_var _10
 
   L3:
-    load_var resolved_name
-    store_var _11
-    load_var _11
+    load_var _10
+    store_var _12
+    load_var _12
     narrow_bind string, slot=7
     pop_jump_if_false L4
     jump L5
@@ -3288,7 +3264,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
     throw
 
   L5:
-    load_var _11
+    load_var _12
     store_var_load_var n
     load_const "__baml_return_output"
     cmp_op ==
@@ -3297,31 +3273,31 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
 
   L6:
     load_var description
-    store_var _18
-    load_var description
+    store_var_load_var _21
     load_const null
     cmp_op ==
     pop_jump_if_false L7
     load_var sig
     load_field .docstring
-    store_var _18
+    store_var _21
 
   L7:
-    load_var _18
-    store_var _17
-    load_var _18
+    load_var _21
+    store_var_load_var _19
     load_const null
     cmp_op ==
     pop_jump_if_false L8
     load_const ""
-    store_var _17
+    store_var _19
 
   L8:
+    load_var _19
+    store_var _18
     load_var handler
     call ai.internal._schema_for_signature
-    store_var _21
+    store_var _24
     load_var2 8 9
-    load_var2 11 1
+    load_var2 12 1
     load_const null
     load_var on_error
     init_instance ai.tools.Tool .name, .description, .input_schema, .handler, .raw_handler, .on_error

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 3073
 ---
 === MIR2 ===
 
@@ -2776,26 +2775,32 @@ fn baml.env.get_or_panic(key: string) -> string {
     // Locals:
     let _0: string // _0 // return
     let _1: string // key // param
-    let _2: string | null
-    let _3: bool
-    let _4: string
+    let _2: string
+    let _3: string | null
+    let _4: bool
+    let _5: string
 
     bb0: {
-        _2 = sys_op const fn baml.env.get(copy _1) -> bb1;
+        _3 = sys_op const fn baml.env.get(copy _1) -> bb1;
     }
 
     bb1: {
-        _0 = copy _2;
-        _3 = copy _2 == const null;
-        branch copy _3 -> [bb2, bb3];
+        _2 = copy _3;
+        _4 = copy _2 == const null;
+        branch copy _4 -> [bb2, bb3];
     }
 
     bb2: {
-        _4 = const "env var not found: " + copy _1;
-        _0 = call const fn baml.sys.panic(copy _4) -> [bb3];
+        _5 = const "env var not found: " + copy _1;
+        _2 = call const fn baml.sys.panic(copy _5) -> [bb3];
     }
 
     bb3: {
+        _0 = copy _2;
+        goto -> bb4;
+    }
+
+    bb4: {
         return;
     }
 }
@@ -2805,33 +2810,39 @@ fn baml.env.get_or_panic_lenient(key: string, lenient: bool) -> string {
     let _0: string // _0 // return
     let _1: string // key // param
     let _2: bool // lenient // param
-    let _3: string | null
-    let _4: bool
+    let _3: string
+    let _4: string | null
+    let _5: bool
 
     bb0: {
         branch copy _2 -> [bb2, bb1];
     }
 
     bb1: {
-        _0 = call const fn baml.env.get_or_panic(copy _1) -> [bb5];
+        _0 = call const fn baml.env.get_or_panic(copy _1) -> [bb6];
     }
 
     bb2: {
-        _3 = sys_op const fn baml.env.get(copy _1) -> bb3;
+        _4 = sys_op const fn baml.env.get(copy _1) -> bb3;
     }
 
     bb3: {
-        _0 = copy _3;
-        _4 = copy _3 == const null;
-        branch copy _4 -> [bb4, bb5];
+        _3 = copy _4;
+        _5 = copy _3 == const null;
+        branch copy _5 -> [bb4, bb5];
     }
 
     bb4: {
-        _0 = const "";
+        _3 = const "";
         goto -> bb5;
     }
 
     bb5: {
+        _0 = copy _3;
+        goto -> bb6;
+    }
+
+    bb6: {
         return;
     }
 }
@@ -7365,54 +7376,60 @@ fn .<lambda(options, 0)>(params: baml.spawn.SpawnParams<T, E>) -> baml.spawn.Spa
     let _3: string | null
     let _4: null | baml.spawn.TaskGroup
     let _5: null | baml.spawn.TaskGroup
-    let _6: bool
-    let _7: null | baml.spawn.CancelToken
+    let _6: null | baml.spawn.TaskGroup
+    let _7: bool
     let _8: null | baml.spawn.CancelToken
-    let _9: bool
-    let _10: bool
-    let _11: bool | null
+    let _9: null | baml.spawn.CancelToken
+    let _10: null | baml.spawn.CancelToken
+    let _11: bool
     let _12: bool
+    let _13: bool
+    let _14: bool | null
+    let _15: bool
 
     bb0: {
         _2 = copy _1.0;
         _3 = copy _1.1;
-        _5 = copy capture[0];
-        _4 = copy _5;
-        _6 = copy _5 == const null;
-        branch copy _6 -> [bb1, bb2];
+        _6 = copy capture[0];
+        _5 = copy _6;
+        _7 = copy _5 == const null;
+        branch copy _7 -> [bb1, bb2];
     }
 
     bb1: {
-        _4 = copy _1.2;
+        _5 = copy _1.2;
         goto -> bb2;
     }
 
     bb2: {
-        _8 = copy capture[1];
-        _7 = copy _8;
-        _9 = copy _8 == const null;
-        branch copy _9 -> [bb3, bb4];
+        _4 = copy _5;
+        _10 = copy capture[1];
+        _9 = copy _10;
+        _11 = copy _9 == const null;
+        branch copy _11 -> [bb3, bb4];
     }
 
     bb3: {
-        _7 = copy _1.3;
+        _9 = copy _1.3;
         goto -> bb4;
     }
 
     bb4: {
-        _11 = copy capture[2];
-        _10 = copy _11;
-        _12 = copy _11 == const null;
-        branch copy _12 -> [bb5, bb6];
+        _8 = copy _9;
+        _14 = copy capture[2];
+        _13 = copy _14;
+        _15 = copy _13 == const null;
+        branch copy _15 -> [bb5, bb6];
     }
 
     bb5: {
-        _10 = copy _1.4;
+        _13 = copy _1.4;
         goto -> bb6;
     }
 
     bb6: {
-        _0 = baml.spawn.SpawnParams<#0, #1> { copy _2, copy _3, copy _4, copy _7, copy _10 };
+        _12 = copy _13;
+        _0 = baml.spawn.SpawnParams<#0, #1> { copy _2, copy _3, copy _4, copy _8, copy _12 };
         goto -> bb7;
     }
 
@@ -8835,18 +8852,20 @@ fn baml.time.PlainDateTime.to_zoned(self: baml.time.PlainDateTime, timezone: str
     let _22: bigint | null
     let _23: bigint | null
     let _24: bigint
-    let _25: bigint | null
-    let _26: bool
-    let _27: baml.time.AmbiguousTimeError
-    let _28: string
-    let _29: bigint | null
-    let _30: bigint
-    let _31: bool
-    let _32: baml.time.UnknownTimezoneError
-    let _33: bigint | null // resolved
-    let _34: bigint
-    let _35: bigint | null
-    let _36: bool
+    let _25: bigint
+    let _26: bigint | null
+    let _27: bool
+    let _28: baml.time.AmbiguousTimeError
+    let _29: string
+    let _30: bigint | null
+    let _31: bigint
+    let _32: bool
+    let _33: baml.time.UnknownTimezoneError
+    let _34: bigint | null // resolved
+    let _35: bigint
+    let _36: bigint
+    let _37: bigint | null
+    let _38: bool
 
     bb0: {
         _4 = copy _3 == const <omitted>;
@@ -8872,36 +8891,37 @@ fn baml.time.PlainDateTime.to_zoned(self: baml.time.PlainDateTime, timezone: str
     }
 
     bb5: {
-        _30 = copy _1.0;
-        _29 = sys_op const fn baml.time._tz_to_instant(copy _2, copy _30, copy _3) -> bb6;
+        _31 = copy _1.0;
+        _30 = sys_op const fn baml.time._tz_to_instant(copy _2, copy _31, copy _3) -> bb6;
     }
 
     bb6: {
-        _31 = copy _29 == const null;
-        branch copy _31 -> [bb10, bb7];
+        _32 = copy _30 == const null;
+        branch copy _32 -> [bb10, bb7];
     }
 
     bb7: {
-        _33 = copy _29;
-        _35 = copy _33;
-        _34 = copy _35;
-        _36 = copy _35 == const null;
-        branch copy _36 -> [bb8, bb9];
+        _34 = copy _30;
+        _37 = copy _34;
+        _36 = copy _37;
+        _38 = copy _36 == const null;
+        branch copy _38 -> [bb8, bb9];
     }
 
     bb8: {
-        _34 = const 0n;
+        _36 = const 0n;
         goto -> bb9;
     }
 
     bb9: {
-        _0 = baml.time.ZonedDateTime { copy _34, const null, copy _2 };
+        _35 = copy _36;
+        _0 = baml.time.ZonedDateTime { copy _35, const null, copy _2 };
         goto -> bb24;
     }
 
     bb10: {
-        _32 = baml.time.UnknownTimezoneError { copy _2 };
-        throw copy _32;
+        _33 = baml.time.UnknownTimezoneError { copy _2 };
+        throw copy _33;
     }
 
     bb11: {
@@ -8937,24 +8957,25 @@ fn baml.time.PlainDateTime.to_zoned(self: baml.time.PlainDateTime, timezone: str
     }
 
     bb17: {
-        _28 = const "wall-clock time is ambiguous or skipped in timezone " + copy _2;
-        _27 = baml.time.AmbiguousTimeError { copy _28 };
-        throw copy _27;
+        _29 = const "wall-clock time is ambiguous or skipped in timezone " + copy _2;
+        _28 = baml.time.AmbiguousTimeError { copy _29 };
+        throw copy _28;
     }
 
     bb18: {
-        _25 = copy _15;
-        _24 = copy _25;
-        _26 = copy _25 == const null;
-        branch copy _26 -> [bb19, bb20];
+        _26 = copy _15;
+        _25 = copy _26;
+        _27 = copy _25 == const null;
+        branch copy _27 -> [bb19, bb20];
     }
 
     bb19: {
-        _24 = const 0n;
+        _25 = const 0n;
         goto -> bb20;
     }
 
     bb20: {
+        _24 = copy _25;
         _0 = baml.time.ZonedDateTime { copy _24, const null, copy _2 };
         goto -> bb24;
     }
@@ -9704,8 +9725,9 @@ fn baml.time.TimeZoneOffset.from_timezone(timezone: string, at: baml.time.Instan
     let _6: baml.time.UnknownTimezoneError
     let _7: int | null // offset
     let _8: int
-    let _9: int | null
-    let _10: bool
+    let _9: int
+    let _10: int | null
+    let _11: bool
 
     bb0: {
         _4 = copy _2.0;
@@ -9719,18 +9741,19 @@ fn baml.time.TimeZoneOffset.from_timezone(timezone: string, at: baml.time.Instan
 
     bb2: {
         _7 = copy _3;
-        _9 = copy _7;
-        _8 = copy _9;
-        _10 = copy _9 == const null;
-        branch copy _10 -> [bb3, bb4];
+        _10 = copy _7;
+        _9 = copy _10;
+        _11 = copy _9 == const null;
+        branch copy _11 -> [bb3, bb4];
     }
 
     bb3: {
-        _8 = const 0_i64;
+        _9 = const 0_i64;
         goto -> bb4;
     }
 
     bb4: {
+        _8 = copy _9;
         _0 = baml.time.TimeZoneOffset { copy _8 };
         goto -> bb5;
     }
@@ -10168,49 +10191,57 @@ fn baml.time.ZonedDateTime.timezone(self: baml.time.ZonedDateTime) -> string | b
     let _2: string | null
     let _3: bool
     let _4: int
-    let _5: int | null
-    let _6: bool
-    let _7: string | null // iana
-    let _8: string | null
-    let _9: bool
+    let _5: int
+    let _6: int | null
+    let _7: bool
+    let _8: string | null // iana
+    let _9: string
+    let _10: string | null
+    let _11: bool
 
     bb0: {
         _2 = copy _1.2;
         _3 = copy _2 == const null;
-        branch copy _3 -> [bb3, bb1];
+        branch copy _3 -> [bb4, bb1];
     }
 
     bb1: {
-        _7 = copy _2;
-        _8 = copy _7;
-        _0 = copy _8;
-        _9 = copy _8 == const null;
-        branch copy _9 -> [bb2, bb6];
+        _8 = copy _2;
+        _10 = copy _8;
+        _9 = copy _10;
+        _11 = copy _9 == const null;
+        branch copy _11 -> [bb2, bb3];
     }
 
     bb2: {
-        _0 = const "";
-        goto -> bb6;
+        _9 = const "";
+        goto -> bb3;
     }
 
     bb3: {
-        _5 = copy _1.1;
-        _4 = copy _5;
-        _6 = copy _5 == const null;
-        branch copy _6 -> [bb4, bb5];
+        _0 = copy _9;
+        goto -> bb7;
     }
 
     bb4: {
-        _4 = const 0_i64;
-        goto -> bb5;
+        _6 = copy _1.1;
+        _5 = copy _6;
+        _7 = copy _5 == const null;
+        branch copy _7 -> [bb5, bb6];
     }
 
     bb5: {
-        _0 = baml.time.TimeZoneOffset { copy _4 };
+        _5 = const 0_i64;
         goto -> bb6;
     }
 
     bb6: {
+        _4 = copy _5;
+        _0 = baml.time.TimeZoneOffset { copy _4 };
+        goto -> bb7;
+    }
+
+    bb7: {
         return;
     }
 }
@@ -10222,23 +10253,27 @@ fn baml.time.ZonedDateTime.timezone_offset(self: baml.time.ZonedDateTime) -> bam
     let _2: string | null
     let _3: bool
     let _4: int
-    let _5: int | null
-    let _6: bool
-    let _7: string | null // iana
-    let _8: int | null
-    let _9: string
-    let _10: string | null
-    let _11: bool
-    let _12: bigint
+    let _5: int
+    let _6: int | null
+    let _7: bool
+    let _8: string | null // iana
+    let _9: int | null
+    let _10: string
+    let _11: string
+    let _12: string | null
     let _13: bool
-    let _14: baml.time.UnknownTimezoneError
-    let _15: string
-    let _16: string | null
-    let _17: bool
-    let _18: int | null // offset
-    let _19: int
-    let _20: int | null
-    let _21: bool
+    let _14: bigint
+    let _15: bool
+    let _16: baml.time.UnknownTimezoneError
+    let _17: string
+    let _18: string
+    let _19: string | null
+    let _20: bool
+    let _21: int | null // offset
+    let _22: int
+    let _23: int
+    let _24: int | null
+    let _25: bool
 
     bb0: {
         _2 = copy _1.2;
@@ -10247,76 +10282,80 @@ fn baml.time.ZonedDateTime.timezone_offset(self: baml.time.ZonedDateTime) -> bam
     }
 
     bb1: {
-        _7 = copy _2;
-        _10 = copy _7;
-        _9 = copy _10;
-        _11 = copy _10 == const null;
-        branch copy _11 -> [bb2, bb3];
+        _8 = copy _2;
+        _12 = copy _8;
+        _11 = copy _12;
+        _13 = copy _11 == const null;
+        branch copy _13 -> [bb2, bb3];
     }
 
     bb2: {
-        _9 = const "";
+        _11 = const "";
         goto -> bb3;
     }
 
     bb3: {
-        _12 = copy _1.0;
-        _8 = sys_op const fn baml.time._tz_offset_at(copy _9, copy _12) -> bb4;
+        _10 = copy _11;
+        _14 = copy _1.0;
+        _9 = sys_op const fn baml.time._tz_offset_at(copy _10, copy _14) -> bb4;
     }
 
     bb4: {
-        _13 = copy _8 == const null;
-        branch copy _13 -> [bb8, bb5];
+        _15 = copy _9 == const null;
+        branch copy _15 -> [bb8, bb5];
     }
 
     bb5: {
-        _18 = copy _8;
-        _20 = copy _18;
-        _19 = copy _20;
-        _21 = copy _20 == const null;
-        branch copy _21 -> [bb6, bb7];
+        _21 = copy _9;
+        _24 = copy _21;
+        _23 = copy _24;
+        _25 = copy _23 == const null;
+        branch copy _25 -> [bb6, bb7];
     }
 
     bb6: {
-        _19 = const 0_i64;
+        _23 = const 0_i64;
         goto -> bb7;
     }
 
     bb7: {
-        _0 = baml.time.TimeZoneOffset { copy _19 };
+        _22 = copy _23;
+        _0 = baml.time.TimeZoneOffset { copy _22 };
         goto -> bb14;
     }
 
     bb8: {
-        _16 = copy _7;
-        _15 = copy _16;
-        _17 = copy _16 == const null;
-        branch copy _17 -> [bb9, bb10];
+        _19 = copy _8;
+        _18 = copy _19;
+        _20 = copy _18 == const null;
+        branch copy _20 -> [bb9, bb10];
     }
 
     bb9: {
-        _15 = const "";
+        _18 = const "";
         goto -> bb10;
     }
 
     bb10: {
-        _14 = baml.time.UnknownTimezoneError { copy _15 };
-        throw copy _14;
+        _17 = copy _18;
+        _16 = baml.time.UnknownTimezoneError { copy _17 };
+        throw copy _16;
     }
 
     bb11: {
-        _5 = copy _1.1;
-        _4 = copy _5;
-        _6 = copy _5 == const null;
-        branch copy _6 -> [bb12, bb13];
+        _6 = copy _1.1;
+        _5 = copy _6;
+        _7 = copy _5 == const null;
+        branch copy _7 -> [bb12, bb13];
     }
 
     bb12: {
-        _4 = const 0_i64;
+        _5 = const 0_i64;
         goto -> bb13;
     }
 
     bb13: {
+        _4 = copy _5;
         _0 = baml.time.TimeZoneOffset { copy _4 };
         goto -> bb14;
     }

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 3212
 ---
 function baml.Array.at(self: #0[], index: int) -> #0 | null {
 }
@@ -2153,8 +2152,7 @@ function baml.env.get(key: string) -> string | null {
 function baml.env.get_or_panic(key: string) -> string {
     load_var key
     sys_op baml.env.get
-    store_var _2
-    load_var2 2 2
+    store_var_load_var _2
     load_const null
     cmp_op ==
     pop_jump_if_false L0
@@ -2162,8 +2160,10 @@ function baml.env.get_or_panic(key: string) -> string {
     load_var key
     bin_op +
     call baml.sys.panic
+    store_var _2
 
   L0:
+    load_var _2
     return
 }
 
@@ -2175,24 +2175,22 @@ function baml.env.get_or_panic_lenient(key: string, lenient: bool) -> string {
   L0:
     load_var key
     call baml.env.get_or_panic
-    store_var _0
-    jump L2
+    jump L3
 
   L1:
     load_var key
     sys_op baml.env.get
-    store_var _3
-    load_var _3
-    store_var _0
-    load_var _3
+    store_var_load_var _3
     load_const null
     cmp_op ==
     pop_jump_if_false L2
     load_const ""
-    store_var _0
+    store_var _3
 
   L2:
-    load_var _0
+    load_var _3
+
+  L3:
     return
 }
 
@@ -6078,27 +6076,24 @@ function baml.time.PlainDateTime.to_zoned(self: baml.time.PlainDateTime, timezon
     load_field ._nanoseconds
     load_var disambiguation
     sys_op baml.time._tz_to_instant
-    store_var _29
-    load_var _29
+    store_var _30
+    load_var _30
     load_const null
     cmp_op ==
     pop_jump_if_false L3
     jump L5
 
   L3:
-    load_var _29
-    store_var _35
-    load_var _35
-    store_var _34
-    load_var _35
+    load_var _30
+    store_var_load_var _36
     load_const null
     cmp_op ==
     pop_jump_if_false L4
     load_const 0n
-    store_var _34
+    store_var _36
 
   L4:
-    load_var _34
+    load_var _36
     load_const null
     load_var timezone
     init_instance baml.time.ZonedDateTime ._nanoseconds, ._offset_ns, ._iana
@@ -6150,18 +6145,15 @@ function baml.time.PlainDateTime.to_zoned(self: baml.time.PlainDateTime, timezon
 
   L10:
     load_var earlier
-    store_var _25
-    load_var _25
-    store_var _24
-    load_var _25
+    store_var_load_var _25
     load_const null
     cmp_op ==
     pop_jump_if_false L11
     load_const 0n
-    store_var _24
+    store_var _25
 
   L11:
-    load_var _24
+    load_var _25
     load_const null
     load_var timezone
     init_instance baml.time.ZonedDateTime ._nanoseconds, ._offset_ns, ._iana
@@ -6400,18 +6392,15 @@ function baml.time.TimeZoneOffset.from_timezone(timezone: string, at: baml.time.
 
   L0:
     load_var _3
-    store_var _9
-    load_var _9
-    store_var _8
-    load_var _9
+    store_var_load_var _9
     load_const null
     cmp_op ==
     pop_jump_if_false L1
     load_const 0
-    store_var _8
+    store_var _9
 
   L1:
-    load_var _8
+    load_var _9
     init_instance baml.time.TimeZoneOffset ._nanoseconds
     return
 
@@ -6895,41 +6884,36 @@ function baml.time.ZonedDateTime.timezone(self: baml.time.ZonedDateTime) -> baml
     load_const null
     cmp_op ==
     pop_jump_if_false L0
-    jump L1
+    jump L2
 
   L0:
     load_var _2
-    store_var _8
-    load_var _8
-    store_var _0
-    load_var _8
+    store_var_load_var _9
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L1
+    load_const ""
+    store_var _9
+
+  L1:
+    load_var _9
+    jump L4
+
+  L2:
+    load_var self
+    load_field ._offset_ns
+    store_var_load_var _5
     load_const null
     cmp_op ==
     pop_jump_if_false L3
-    load_const ""
-    store_var _0
-    jump L3
-
-  L1:
-    load_var self
-    load_field ._offset_ns
-    store_var _5
-    load_var _5
-    store_var _4
-    load_var _5
-    load_const null
-    cmp_op ==
-    pop_jump_if_false L2
     load_const 0
-    store_var _4
-
-  L2:
-    load_var _4
-    init_instance baml.time.TimeZoneOffset ._nanoseconds
-    store_var _0
+    store_var _5
 
   L3:
-    load_var _0
+    load_var _5
+    init_instance baml.time.TimeZoneOffset ._nanoseconds
+
+  L4:
     return
 }
 
@@ -6944,78 +6928,65 @@ function baml.time.ZonedDateTime.timezone_offset(self: baml.time.ZonedDateTime) 
 
   L0:
     load_var _2
-    store_var iana
-    load_var iana
-    store_var _10
-    load_var _10
-    store_var _9
-    load_var _10
+    store_var_load_var iana
+    store_var_load_var _11
     load_const null
     cmp_op ==
     pop_jump_if_false L1
     load_const ""
-    store_var _9
+    store_var _11
 
   L1:
-    load_var2 7 1
+    load_var2 6 1
     load_field ._nanoseconds
     sys_op baml.time._tz_offset_at
-    store_var _8
-    load_var _8
+    store_var _9
+    load_var _9
     load_const null
     cmp_op ==
     pop_jump_if_false L2
     jump L4
 
   L2:
-    load_var _8
-    store_var _20
-    load_var _20
-    store_var _19
-    load_var _20
+    load_var _9
+    store_var_load_var _23
     load_const null
     cmp_op ==
     pop_jump_if_false L3
     load_const 0
-    store_var _19
+    store_var _23
 
   L3:
-    load_var _19
+    load_var _23
     init_instance baml.time.TimeZoneOffset ._nanoseconds
     jump L8
 
   L4:
     load_var iana
-    store_var _16
-    load_var _16
-    store_var _15
-    load_var _16
+    store_var_load_var _18
     load_const null
     cmp_op ==
     pop_jump_if_false L5
     load_const ""
-    store_var _15
+    store_var _18
 
   L5:
-    load_var _15
+    load_var _18
     init_instance baml.time.UnknownTimezoneError .timezone
     throw
 
   L6:
     load_var self
     load_field ._offset_ns
-    store_var _5
-    load_var _5
-    store_var _4
-    load_var _5
+    store_var_load_var _5
     load_const null
     cmp_op ==
     pop_jump_if_false L7
     load_const 0
-    store_var _4
+    store_var _5
 
   L7:
-    load_var _4
+    load_var _5
     init_instance baml.time.TimeZoneOffset ._nanoseconds
 
   L8:

--- a/baml_language/crates/baml_tests/snapshots/compiles/method_explicit_type_args/baml_tests__compiles__method_explicit_type_args__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/method_explicit_type_args/baml_tests__compiles__method_explicit_type_args__04_5_mir.snap
@@ -22,28 +22,30 @@ fn user.use_method_type_args() -> int {
     let _0: int // _0 // return
     let _1: Foo // f
     let _2: int // v
-    let _3: int | null
-    let _4: type
-    let _5: bool
+    let _3: int
+    let _4: int | null
+    let _5: type
+    let _6: bool
 
     bb0: {
         _1 = user.Foo { const "x" };
-        _4 = load_type(int);
-        _3 = call const fn user.Foo.zero<copy _4>(copy _1) -> [bb1];
+        _5 = load_type(int);
+        _4 = call const fn user.Foo.zero<copy _5>(copy _1) -> [bb1];
     }
 
     bb1: {
-        _2 = copy _3;
-        _5 = copy _3 == const null;
-        branch copy _5 -> [bb2, bb3];
+        _3 = copy _4;
+        _6 = copy _3 == const null;
+        branch copy _6 -> [bb2, bb3];
     }
 
     bb2: {
-        _2 = const 5_i64;
+        _3 = const 5_i64;
         goto -> bb3;
     }
 
     bb3: {
+        _2 = copy _3;
         _0 = copy _2;
         goto -> bb4;
     }

--- a/baml_language/crates/baml_tests/snapshots/compiles/method_explicit_type_args/baml_tests__compiles__method_explicit_type_args__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/method_explicit_type_args/baml_tests__compiles__method_explicit_type_args__06_codegen.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 16131
 ---
 function user.Foo.zero(self: Foo) -> #0 | null {
     load_const null
@@ -12,17 +11,14 @@ function user.use_method_type_args() -> int {
     load_const "x"
     init_instance user.Foo .tag
     call user.Foo.zero
-    store_var _3
-    load_var _3
-    store_var v
-    load_var _3
+    store_var_load_var _3
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_const 5
-    store_var v
+    store_var _3
 
   L0:
-    load_var v
+    load_var _3
     return
 }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
@@ -264,7 +264,7 @@ pub(crate) mod support {
                 let tn = type_name.to_string();
                 let field_strs: Vec<String> = fields
                     .iter()
-                    .map(|(name, val)| format!("{name}: {}", expr_desc(*val, body)))
+                    .map(|field| format!("{}: {}", field.name, expr_desc(field.value, body)))
                     .collect();
                 format!("{tn} {{ {} }}", field_strs.join(", "))
             }
@@ -275,7 +275,13 @@ pub(crate) mod support {
             Expr::Map { entries } => {
                 let entry_strs: Vec<String> = entries
                     .iter()
-                    .map(|(k, v)| format!("{}: {}", expr_desc(*k, body), expr_desc(*v, body)))
+                    .map(|entry| {
+                        format!(
+                            "{}: {}",
+                            expr_desc(entry.key, body),
+                            expr_desc(entry.value, body)
+                        )
+                    })
                     .collect();
                 format!("map {{ {} }}", entry_strs.join(", "))
             }
@@ -1853,10 +1859,11 @@ pub(crate) mod support {
                     let tn = qualify_type_name(type_name, prefix, local_type_names);
                     let field_strs: Vec<String> = fields
                         .iter()
-                        .map(|(name, val)| {
+                        .map(|field| {
                             format!(
-                                "{name}: {}",
-                                expr_desc_hir(*val, body, prefix, local_type_names)
+                                "{}: {}",
+                                field.name,
+                                expr_desc_hir(field.value, body, prefix, local_type_names)
                             )
                         })
                         .collect();
@@ -1872,11 +1879,11 @@ pub(crate) mod support {
                 Expr::Map { entries } => {
                     let entry_strs: Vec<String> = entries
                         .iter()
-                        .map(|(k, v)| {
+                        .map(|entry| {
                             format!(
                                 "{}: {}",
-                                expr_desc_hir(*k, body, prefix, local_type_names),
-                                expr_desc_hir(*v, body, prefix, local_type_names)
+                                expr_desc_hir(entry.key, body, prefix, local_type_names),
+                                expr_desc_hir(entry.value, body, prefix, local_type_names)
                             )
                         })
                         .collect();

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
@@ -443,6 +443,96 @@ function build(option: string) -> map<string, string> {
 }
 
 #[test]
+fn property_shorthand_in_parameter_default_uses_structural_syntax() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"
+function build(option: string, config: map<string, string> = { options }) -> map<string, string> {
+  config
+}
+"#,
+    );
+    let tir = render_tir(&db, file);
+    assert!(
+        tir.contains(
+            "property shorthand `options` requires an in-scope value named `options`. Did you \
+             mean `options: option`?"
+        ),
+        "expected a shorthand diagnostic in the parameter-default arena, got:\n{tir}"
+    );
+}
+
+#[test]
+fn property_shorthand_uses_the_value_expression_scope() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"
+function build(input: string?) -> map<string, string> {
+  if let option: string = input {
+    { options }
+  } else {
+    {}
+  }
+}
+"#,
+    );
+    let tir = render_tir(&db, file);
+    assert!(
+        tir.contains(
+            "property shorthand `options` requires an in-scope value named `options`. Did you \
+             mean `options: option`?"
+        ),
+        "expected the if-let binding in shorthand suggestions, got:\n{tir}"
+    );
+}
+
+#[test]
+fn explicit_quoted_map_key_is_not_property_shorthand() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"
+function build() -> map<string, string> {
+  { "options": options }
+}
+"#,
+    );
+    let tir = render_tir(&db, file);
+    assert!(
+        tir.contains("unresolved name: options"),
+        "expected the ordinary unresolved-name diagnostic, got:\n{tir}"
+    );
+    assert!(
+        !tir.contains("property shorthand"),
+        "an explicit quoted key must not use shorthand diagnostics:\n{tir}"
+    );
+}
+
+#[test]
+fn if_let_binding_resolves_in_property_shorthand() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"
+function build(input: string?) -> map<string, string> {
+  if let options: string = input {
+    { options }
+  } else {
+    {}
+  }
+}
+"#,
+    );
+    let tir = render_tir(&db, file);
+    assert!(
+        !tir.contains("property shorthand") && !tir.contains("unresolved name"),
+        "the ordinary resolver should see the if-let binding:\n{tir}"
+    );
+}
+
+#[test]
 fn class_property_shorthand_suggests_field_to_variable_mapping() {
     let mut db = make_db();
     let file = db.add_file(
@@ -488,6 +578,29 @@ function build() -> Config {
     assert!(
         !tir.contains("property shorthand"),
         "explicit properties should use the general unknown-field diagnostic:\n{tir}"
+    );
+}
+
+#[test]
+fn explicit_same_name_unknown_class_field_is_not_shorthand() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"
+class Config { goodField int }
+function build(badField: int) -> Config {
+  Config { badField: badField }
+}
+"#,
+    );
+    let tir = render_tir(&db, file);
+    assert!(
+        tir.contains("class `Config` has no field `badField`"),
+        "expected an unknown-field diagnostic, got:\n{tir}"
+    );
+    assert!(
+        !tir.contains("property shorthand"),
+        "an explicit same-name field must not use shorthand diagnostics:\n{tir}"
     );
 }
 

--- a/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__sweep__s15_sweep_baml_src.snap
+++ b/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__sweep__s15_sweep_baml_src.snap
@@ -3,7 +3,7 @@ source: crates/baml_tests/src/type_spec/sweep.rs
 expression: report
 ---
 files: 121
-typed nodes: 62694
+typed nodes: 62729
 hir_ty error-channel entries: 0
 panics: 0
 

--- a/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__sweep__s15_sweep_baml_src.snap
+++ b/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__sweep__s15_sweep_baml_src.snap
@@ -2,8 +2,8 @@
 source: crates/baml_tests/src/type_spec/sweep.rs
 expression: report
 ---
-files: 119
-typed nodes: 62116
+files: 121
+typed nodes: 62694
 hir_ty error-channel entries: 0
 panics: 0
 

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -17,318 +17,313 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   198   12    load_deref 1                               
         13    load_field 1                               (client)
-        14    store_var 4                                (_4)
-        15    load_var 4                                 (_4)
-        16    store_var 3                                (selected)
-        17    load_var 4                                 (_4)
-        18    load_const 0                               (null)
-        19    cmp_op ==                                  
-        20    pop_jump_if_false +4                       (to 24)
-        21    load_deref 2                               
-        22    load_field 4                               (default_client)
-        23    store_var 3                                (selected)
+        14    store_var_load_var 4                       (_4)
+        15    load_const 0                               (null)
+        16    cmp_op ==                                  
+        17    pop_jump_if_false +4                       (to 21)
+        18    load_deref 2                               
+        19    load_field 4                               (default_client)
+        20    store_var 4                                (_4)
+        21    load_var 4                                 (_4)
+        22    store_var 3                                (selected)
 
-  199   24    load_type 1                                
-        25    load_deref 2                               
-        26    call 806 ntypeargs=1                       (ai.Journal.new)
-        27    store_deref 5                              
+  199   23    load_type 1                                
+        24    load_deref 2                               
+        25    call 806 ntypeargs=1                       (ai.Journal.new)
+        26    store_deref 5                              
 
-  200   28    load_type 1                                
-        29    load_deref 1                               
-        30    load_deref 5                               
-        31    load_const 2                               (0)
-        32    call 845 ntypeargs=1                       (ai.Agent._emit_from)
-        33    store_var 6                                (seen)
+  200   27    load_type 1                                
+        28    load_deref 1                               
+        29    load_deref 5                               
+        30    load_const 2                               (0)
+        31    call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        32    store_var 6                                (seen)
 
-  201   34    load_const 2                               (0)
-        35    store_var 7                                (steps)
+  201   33    load_const 2                               (0)
+        34    store_var 7                                (steps)
 
-  202   36    load_const 2                               (0)
-        37    load_const 2                               (0)
+  202   35    load_const 2                               (0)
+        36    load_const 2                               (0)
+        37    load_const 0                               (null)
         38    load_const 0                               (null)
-        39    load_const 0                               (null)
-        40    init_instance 0                            (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
-        41    store_var 8                                (total)
+        39    init_instance 0                            (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
+        40    store_var 8                                (total)
 
-  209   42    load_type 3                                
-        43    load_type 4                                
-        44    alloc_map 0                                
-        45    store_var 9                                (fail_counts)
+  209   41    load_type 3                                
+        42    load_type 4                                
+        43    alloc_map 0                                
+        44    store_var 9                                (fail_counts)
 
-  210   46    load_var 7                                 (steps)
-        47    load_deref 1                               
-        48    load_field 0                               (max_steps)
-        49    cmp_int_op <                               
-        50    pop_jump_if_false +2                       (to 52)
-        51    jump +4                                    (to 55)
+  210   45    load_var 7                                 (steps)
+        46    load_deref 1                               
+        47    load_field 0                               (max_steps)
+        48    cmp_int_op <                               
+        49    pop_jump_if_false +2                       (to 51)
+        50    jump +4                                    (to 54)
 
-  269   52    load_var 7                                 (steps)
-        53    init_instance 1                            (ai.errors.StepBudgetExceeded .steps)
-        54    throw                                      
+  269   51    load_var 7                                 (steps)
+        52    init_instance 1                            (ai.errors.StepBudgetExceeded .steps)
+        53    throw                                      
 
-  212   55    load_type 1                                
-        56    load_deref 1                               
-        57    load_var 3                                 (selected)
-        58    load_deref 2                               
-        59    load_deref 5                               
-        60    load_var 8                                 (total)
-        61    load_const 5                               (2)
-        62    call 844 ntypeargs=1                       (ai.Agent._attempt_turn)
-        63    store_var 10                               (turn)
+  212   54    load_type 1                                
+        55    load_deref 1                               
+        56    load_var 3                                 (selected)
+        57    load_deref 2                               
+        58    load_deref 5                               
+        59    load_var 8                                 (total)
+        60    load_const 5                               (2)
+        61    call 844 ntypeargs=1                       (ai.Agent._attempt_turn)
+        62    store_var 10                               (turn)
 
-  213   64    load_var 7                                 (steps)
-        65    load_const 6                               (1)
-        66    add_int                                    
-        67    store_var 7                                (steps)
+  213   63    load_var 7                                 (steps)
+        64    load_const 6                               (1)
+        65    add_int                                    
+        66    store_var 7                                (steps)
 
-  214   68    load_type 1                                
-        69    load_deref 1                               
-        70    load_deref 5                               
-        71    load_var 6                                 (seen)
-        72    call 845 ntypeargs=1                       (ai.Agent._emit_from)
-        73    store_var 6                                (seen)
+  214   67    load_type 1                                
+        68    load_deref 1                               
+        69    load_deref 5                               
+        70    load_var 6                                 (seen)
+        71    call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        72    store_var 6                                (seen)
 
-  215   74    load_var 10                                (turn)
-        75    call 825 ntypeargs=0                       (ai.ModelTurn.tool_uses)
-        76    store_var 11                               (calls)
+  215   73    load_var 10                                (turn)
+        74    call 825 ntypeargs=0                       (ai.ModelTurn.tool_uses)
+        75    store_var 11                               (calls)
 
-  216   77    load_var 11                                (calls)
-        78    container_len                              
-        79    store_var 12                               (_28)
-        80    load_var 12                                (_28)
-        81    load_const 2                               (0)
-        82    cmp_int_op >                               
-        83    pop_jump_if_false +2                       (to 85)
-        84    jump +63                                   (to 147)
+  216   76    load_var 11                                (calls)
+        77    container_len                              
+        78    store_var 12                               (_29)
+        79    load_var 12                                (_29)
+        80    load_const 2                               (0)
+        81    cmp_int_op >                               
+        82    pop_jump_if_false +2                       (to 84)
+        83    jump +62                                   (to 145)
 
-  251   85    load_var 10                                (turn)
-        86    call 824 ntypeargs=0                       (ai.ModelTurn.terminal_text)
-        87    store_var 34                               (_96)
-        88    load_var 34                                (_96)
-        89    store_var 33                               (candidate)
-        90    load_var 34                                (_96)
-        91    load_const 0                               (null)
-        92    cmp_op ==                                  
-        93    pop_jump_if_false +3                       (to 96)
-        94    load_const 7                               ("")
-        95    store_var 33                               (candidate)
+  251   84    load_var 10                                (turn)
+        85    call 824 ntypeargs=0                       (ai.ModelTurn.terminal_text)
+        86    store_var_load_var 33                      (_98)
+        87    load_const 0                               (null)
+        88    cmp_op ==                                  
+        89    pop_jump_if_false +3                       (to 92)
+        90    load_const 7                               ("")
+        91    store_var 33                               (_98)
+        92    load_var 33                                (_98)
+        93    store_var 32                               (candidate)
 
-  252   96    load_type 1                                
-        97    load_var 33                                (candidate)
-        98    call 426 ntypeargs=1                       (baml.sap.parse)
-        99    store_var 35                               (value)
-        100   jump +11                                   (to 111)
-        101   load_var 36                                (e)
-        102   throw_if_panic                             
+  252   94    load_type 1                                
+        95    load_var 32                                (candidate)
+        96    call 426 ntypeargs=1                       (baml.sap.parse)
+        97    store_var 34                               (value)
+        98    jump +11                                   (to 109)
+        99    load_var 35                                (e)
+        100   throw_if_panic                             
 
-  254   103   load_var 3                                 (selected)
-        104   load_type 8                                
-        105   load_const 9                               ("id")
-        106   virtual_call nargs=1 ntypeargs=0           
-        107   store_var 37                               (_103)
-        108   load_var2 37 33                            
-        109   init_instance 2                            (ai.errors.ParseFailed .provider, .raw_output)
-        110   throw                                      
+  254   101   load_var 3                                 (selected)
+        102   load_type 8                                
+        103   load_const 9                               ("id")
+        104   virtual_call nargs=1 ntypeargs=0           
+        105   store_var 36                               (_106)
+        106   load_var2 36 32                            
+        107   init_instance 2                            (ai.errors.ParseFailed .provider, .raw_output)
+        108   throw                                      
 
-  257   111   load_type 1                                
-        112   load_var 35                                (value)
-        113   call 331 ntypeargs=1                       (baml.json.to_json)
-        114   jump +12                                   (to 126)
-        115   load_var 38                                (e)
-        116   throw_if_panic                             
+  257   109   load_type 1                                
+        110   load_var 34                                (value)
+        111   call 331 ntypeargs=1                       (baml.json.to_json)
+        112   jump +12                                   (to 124)
+        113   load_var 37                                (e)
+        114   throw_if_panic                             
 
-  259   117   load_type 10                               
-        118   load_var 38                                (e)
-        119   call 138 ntypeargs=1                       (baml.String.from)
-        120   store_var 39                               (_112)
-        121   load_var2 38 39                            
-        122   load_type 3                                
-        123   alloc_array 1                              
-        124   init_instance 3                            (baml.errors.UnknownError .data, .message)
-        125   throw                                      
+  259   115   load_type 10                               
+        116   load_var 37                                (e)
+        117   call 138 ntypeargs=1                       (baml.String.from)
+        118   store_var 38                               (_115)
+        119   load_var2 37 38                            
+        120   load_type 3                                
+        121   alloc_array 1                              
+        122   init_instance 3                            (baml.errors.UnknownError .data, .message)
+        123   throw                                      
 
-  263   126   call 328 ntypeargs=0                       (baml.json.stringify)
-        127   store_var 40                               (_117)
+  263   124   call 328 ntypeargs=0                       (baml.json.stringify)
+        125   store_var 39                               (_120)
 
-  262   128   load_deref 5                               
+  262   126   load_deref 5                               
 
-  263   129   load_var 40                                (_117)
-        130   init_instance 4                            (ai.events.FinalProduced .value_json)
-        131   load_type 11                               
-        132   alloc_array 1                              
-        133   call 807 ntypeargs=0                       (ai.Journal.append_all)
-        134   pop 1                                      
+  263   127   load_var 39                                (_120)
+        128   init_instance 4                            (ai.events.FinalProduced .value_json)
+        129   load_type 11                               
+        130   alloc_array 1                              
+        131   call 807 ntypeargs=0                       (ai.Journal.append_all)
+        132   pop 1                                      
 
-  265   135   load_type 1                                
-        136   load_deref 1                               
-        137   load_deref 5                               
-        138   load_var 6                                 (seen)
-        139   call 845 ntypeargs=1                       (ai.Agent._emit_from)
-        140   store_var 6                                (seen)
+  265   133   load_type 1                                
+        134   load_deref 1                               
+        135   load_deref 5                               
+        136   load_var 6                                 (seen)
+        137   call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        138   store_var 6                                (seen)
 
-  266   141   load_var 35                                (value)
-        142   load_deref 5                               
-        143   load_var 8                                 (total)
-        144   load_type 1                                
-        145   init_instance 5                            (ai.RunResult .value, .journal, .usage)
-        146   return                                     
+  266   139   load_var 34                                (value)
+        140   load_deref 5                               
+        141   load_var 8                                 (total)
+        142   load_type 1                                
+        143   init_instance 5                            (ai.RunResult .value, .journal, .usage)
+        144   return                                     
 
-  217   147   load_deref 5                               
-        148   call 805 ntypeargs=0                       (ai.Journal.entries)
-        149   container_len                              
-        150   store_var 13                               (before)
+  217   145   load_deref 5                               
+        146   call 805 ntypeargs=0                       (ai.Journal.entries)
+        147   container_len                              
+        148   store_var 13                               (before)
 
-  219   151   load_type 12                               
-        152   load_type 13                               
-        153   load_type 14                               
-        154   load_var 11                                (calls)
-        155   load_type 1                                
-        156   load_var2 1 2                              
-        157   load_var 5                                 (j)
-        158   make_closure 1738 captures=3 ntypeargs=1   
-        159   call 16 ntypeargs=3                        (baml.Array.map)
-        160   store_var 14                               (futures)
+  219   149   load_type 12                               
+        150   load_type 13                               
+        151   load_type 14                               
+        152   load_var 11                                (calls)
+        153   load_type 1                                
+        154   load_var2 1 2                              
+        155   load_var 5                                 (j)
+        156   make_closure 1738 captures=3 ntypeargs=1   
+        157   call 16 ntypeargs=3                        (baml.Array.map)
+        158   store_var 14                               (futures)
 
-  222   161   load_type 15                               
-        162   load_type 16                               
-        163   load_var 14                                (futures)
-        164   call 483 ntypeargs=2                       (baml.future.all)
-        165   await                                      
-        166   pop 1                                      
+  222   159   load_type 15                               
+        160   load_type 16                               
+        161   load_var 14                                (futures)
+        162   call 483 ntypeargs=2                       (baml.future.all)
+        163   await                                      
+        164   pop 1                                      
 
-  223   167   load_type 1                                
-        168   load_deref 1                               
-        169   load_deref 5                               
-        170   load_var 6                                 (seen)
-        171   call 845 ntypeargs=1                       (ai.Agent._emit_from)
-        172   store_var 6                                (seen)
+  223   165   load_type 1                                
+        166   load_deref 1                               
+        167   load_deref 5                               
+        168   load_var 6                                 (seen)
+        169   call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        170   store_var 6                                (seen)
 
-  227   173   load_deref 5                               
-        174   call 805 ntypeargs=0                       (ai.Journal.entries)
-        175   store_var 15                               (entries)
+  227   171   load_deref 5                               
+        172   call 805 ntypeargs=0                       (ai.Journal.entries)
+        173   store_var 15                               (entries)
 
-  228   176   load_var 13                                (before)
-        177   store_var 16                               (i)
+  228   174   load_var 13                                (before)
+        175   store_var 16                               (i)
 
-  229   178   load_var 16                                (i)
-        179   store_var 17                               (_47)
-        180   load_var 15                                (entries)
-        181   container_len                              
-        182   store_var 18                               (_48)
-        183   load_var2 17 18                            
-        184   cmp_int_op <                               
-        185   pop_jump_if_false -139                     (to 46)
+  229   176   load_var 16                                (i)
+        177   store_var 17                               (_48)
+        178   load_var 15                                (entries)
+        179   container_len                              
+        180   store_var 18                               (_49)
+        181   load_var2 17 18                            
+        182   cmp_int_op <                               
+        183   pop_jump_if_false -138                     (to 45)
 
-  230   186   load_type 11                               
-        187   load_var2 15 16                            
-        188   call 3 ntypeargs=1                         (baml.Array.at)
-        189   store_var 19                               (_52)
-        190   load_var 19                                (_52)
-        191   narrow_bind 17 19                          
-        192   pop_jump_if_false +60                      (to 252)
-        193   load_var 19                                (_52)
-        194   store_deref 20                             
+  230   184   load_type 11                               
+        185   load_var2 15 16                            
+        186   call 3 ntypeargs=1                         (baml.Array.at)
+        187   store_var 19                               (_53)
+        188   load_var 19                                (_53)
+        189   narrow_bind 17 19                          
+        190   pop_jump_if_false +57                      (to 247)
+        191   load_var 19                                (_53)
+        192   store_deref 20                             
 
-  231   195   load_type 12                               
-        196   load_type 14                               
-        197   load_var 11                                (calls)
-        198   load_type 1                                
-        199   load_var 20                                (f)
-        200   make_closure 1739 captures=1 ntypeargs=1   
-        201   call 19 ntypeargs=2                        (baml.Array.find)
+  231   193   load_type 12                               
+        194   load_type 14                               
+        195   load_var 11                                (calls)
+        196   load_type 1                                
+        197   load_var 20                                (f)
+        198   make_closure 1739 captures=1 ntypeargs=1   
+        199   call 19 ntypeargs=2                        (baml.Array.find)
 
-  234   202   store_var 21                               (_58)
-        203   load_var 21                                (_58)
-        204   narrow_bind 18 21                          
-        205   pop_jump_if_false +47                      (to 252)
-        206   load_var 21                                (_58)
-        207   store_var 22                               (known)
+  234   200   store_var 21                               (_59)
+        201   load_var 21                                (_59)
+        202   narrow_bind 18 21                          
+        203   pop_jump_if_false +44                      (to 247)
+        204   load_var 21                                (_59)
+        205   store_var 22                               (known)
 
-  235   208   load_type 3                                
-        209   load_var 22                                (known)
-        210   load_field 1                               (name)
-        211   call 138 ntypeargs=1                       (baml.String.from)
-        212   store_var 24                               (_62)
-        213   load_type 3                                
-        214   load_deref 20                              
-        215   load_field 1                               (message)
-        216   call 138 ntypeargs=1                       (baml.String.from)
-        217   store_var 25                               (_65)
-        218   load_var 24                                (_62)
-        219   load_const 19                              ("|")
+  235   206   load_type 3                                
+        207   load_var 22                                (known)
+        208   load_field 1                               (name)
+        209   call 138 ntypeargs=1                       (baml.String.from)
+        210   store_var 24                               (_63)
+        211   load_type 3                                
+        212   load_deref 20                              
+        213   load_field 1                               (message)
+        214   call 138 ntypeargs=1                       (baml.String.from)
+        215   store_var 25                               (_66)
+        216   load_var 24                                (_63)
+        217   load_const 19                              ("|")
+        218   bin_op +                                   
+        219   load_var 25                                (_66)
         220   bin_op +                                   
-        221   load_var 25                                (_65)
-        222   bin_op +                                   
-        223   store_var 23                               (key)
+        221   store_var 23                               (key)
 
-  236   224   load_type 3                                
-        225   load_type 4                                
-        226   load_var2 9 23                             
-        227   call 38 ntypeargs=2                        (baml.Map.get)
-        228   store_var 28                               (_70)
-        229   load_var 28                                (_70)
-        230   store_var 27                               (_69)
-        231   load_var 28                                (_70)
-        232   load_const 0                               (null)
-        233   cmp_op ==                                  
-        234   pop_jump_if_false +3                       (to 237)
-        235   load_const 2                               (0)
-        236   store_var 27                               (_69)
-        237   load_var 27                                (_69)
-        238   load_const 6                               (1)
-        239   add_int                                    
-        240   store_var 26                               (n)
+  236   222   load_type 3                                
+        223   load_type 4                                
+        224   load_var2 9 23                             
+        225   call 38 ntypeargs=2                        (baml.Map.get)
+        226   store_var_load_var 27                      (_71)
+        227   load_const 0                               (null)
+        228   cmp_op ==                                  
+        229   pop_jump_if_false +3                       (to 232)
+        230   load_const 2                               (0)
+        231   store_var 27                               (_71)
+        232   load_var 27                                (_71)
+        233   load_const 6                               (1)
+        234   add_int                                    
+        235   store_var 26                               (n)
 
-  237   241   load_type 3                                
-        242   load_type 4                                
-        243   load_var2 9 23                             
-        244   load_var 26                                (n)
-        245   call 37 ntypeargs=2                        (baml.Map.set)
-        246   pop 1                                      
+  237   236   load_type 3                                
+        237   load_type 4                                
+        238   load_var2 9 23                             
+        239   load_var 26                                (n)
+        240   call 37 ntypeargs=2                        (baml.Map.set)
+        241   pop 1                                      
 
-  238   247   load_var 26                                (n)
-        248   load_const 20                              (3)
-        249   cmp_int_op >=                              
-        250   pop_jump_if_false +2                       (to 252)
-        251   jump +6                                    (to 257)
+  238   242   load_var 26                                (n)
+        243   load_const 20                              (3)
+        244   cmp_int_op >=                              
+        245   pop_jump_if_false +2                       (to 247)
+        246   jump +6                                    (to 252)
 
-  248   252   load_var 16                                (i)
-        253   load_const 6                               (1)
-        254   add_int                                    
-        255   store_var 16                               (i)
+  248   247   load_var 16                                (i)
+        248   load_const 6                               (1)
+        249   add_int                                    
+        250   store_var 16                               (i)
 
-  229   256   jump -78                                   (to 178)
+  229   251   jump -75                                   (to 176)
 
-  240   257   load_var 22                                (known)
-        258   load_field 0                               (id)
-        259   store_var 29                               (_83)
+  240   252   load_var 22                                (known)
+        253   load_field 0                               (id)
+        254   store_var 28                               (_85)
 
-  241   260   load_var 22                                (known)
-        261   load_field 1                               (name)
-        262   store_var 30                               (_84)
+  241   255   load_var 22                                (known)
+        256   load_field 1                               (name)
+        257   store_var 29                               (_86)
 
-  242   263   load_type 4                                
-        264   load_var 26                                (n)
+  242   258   load_type 4                                
+        259   load_var 26                                (n)
+        260   call 138 ntypeargs=1                       (baml.String.from)
+        261   store_var 30                               (_90)
+        262   load_type 3                                
+        263   load_deref 20                              
+        264   load_field 1                               (message)
         265   call 138 ntypeargs=1                       (baml.String.from)
-        266   store_var 31                               (_88)
-        267   load_type 3                                
-        268   load_deref 20                              
-        269   load_field 1                               (message)
-        270   call 138 ntypeargs=1                       (baml.String.from)
-        271   store_var 32                               (_91)
+        266   store_var 31                               (_93)
 
-  239   272   load_var2 29 30                            
+  239   267   load_var2 28 29                            
 
-  242   273   load_const 21                              ("the same tool call failed ")
-        274   load_var 31                                (_88)
-        275   bin_op +                                   
-        276   load_const 22                              (" times; stopping the run: ")
-        277   bin_op +                                   
-        278   load_var 32                                (_91)
-        279   bin_op +                                   
-        280   load_const 0                               (null)
-        281   init_instance 6                            (ai.errors.ToolFailedError .id, .name, .message, .cause)
-        282   throw                                      
+  242   268   load_const 21                              ("the same tool call failed ")
+        269   load_var 30                                (_90)
+        270   bin_op +                                   
+        271   load_const 22                              (" times; stopping the run: ")
+        272   bin_op +                                   
+        273   load_var 31                                (_93)
+        274   bin_op +                                   
+        275   load_const 0                               (null)
+        276   init_instance 6                            (ai.errors.ToolFailedError .id, .name, .message, .cause)
+        277   throw                                      
 }
 
 function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.FunctionSpec<#0>, j: ai.Journal, total: ai.events.Usage, attempts_left: int) -> ai.ModelTurn {
@@ -361,7 +356,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         21    store_var 11                       (_15)
         22    load_var 11                        (_15)
         23    narrow_bind 3 11                   
-        24    pop_jump_if_false +63              (to 87)
+        24    pop_jump_if_false +57              (to 81)
         25    load_var 11                        (_15)
         26    store_var 12                       (u)
 
@@ -386,239 +381,232 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         43    store_var 13                       (_20)
         44    load_var 13                        (_20)
         45    narrow_bind 4 13                   
-        46    pop_jump_if_false +18              (to 64)
+        46    pop_jump_if_false +15              (to 61)
         47    load_var 13                        (_20)
         48    store_var 14                       (ci)
 
   134   49    load_var 5                         (total)
         50    load_field 2                       (cached_input_tokens)
-        51    store_var 16                       (_23)
-        52    load_var 16                        (_23)
-        53    store_var 15                       (_22)
-        54    load_var 16                        (_23)
-        55    load_const 5                       (null)
-        56    cmp_op ==                          
-        57    pop_jump_if_false +3               (to 60)
-        58    load_const 4                       (0)
-        59    store_var 15                       (_22)
-        60    load_var2 5 15                     
-        61    load_var 14                        (ci)
-        62    bin_op +                           
-        63    store_field 2                      (cached_input_tokens)
+        51    store_var_load_var 15              (_23)
+        52    load_const 5                       (null)
+        53    cmp_op ==                          
+        54    pop_jump_if_false +3               (to 57)
+        55    load_const 4                       (0)
+        56    store_var 15                       (_23)
+        57    load_var2 5 15                     
+        58    load_var 14                        (ci)
+        59    bin_op +                           
+        60    store_field 2                      (cached_input_tokens)
 
-  136   64    load_var 12                        (u)
-        65    load_field 3                       (reasoning_tokens)
-        66    store_var 17                       (_27)
-        67    load_var 17                        (_27)
-        68    narrow_bind 4 17                   
-        69    pop_jump_if_false +18              (to 87)
-        70    load_var 17                        (_27)
-        71    store_var 18                       (rt)
+  136   61    load_var 12                        (u)
+        62    load_field 3                       (reasoning_tokens)
+        63    store_var 16                       (_28)
+        64    load_var 16                        (_28)
+        65    narrow_bind 4 16                   
+        66    pop_jump_if_false +15              (to 81)
+        67    load_var 16                        (_28)
+        68    store_var 17                       (rt)
 
-  137   72    load_var 5                         (total)
-        73    load_field 3                       (reasoning_tokens)
-        74    store_var 20                       (_30)
-        75    load_var 20                        (_30)
-        76    store_var 19                       (_29)
-        77    load_var 20                        (_30)
-        78    load_const 5                       (null)
-        79    cmp_op ==                          
-        80    pop_jump_if_false +3               (to 83)
-        81    load_const 4                       (0)
-        82    store_var 19                       (_29)
-        83    load_var2 5 19                     
-        84    load_var 18                        (rt)
-        85    bin_op +                           
-        86    store_field 3                      (reasoning_tokens)
+  137   69    load_var 5                         (total)
+        70    load_field 3                       (reasoning_tokens)
+        71    store_var_load_var 18              (_31)
+        72    load_const 5                       (null)
+        73    cmp_op ==                          
+        74    pop_jump_if_false +3               (to 77)
+        75    load_const 4                       (0)
+        76    store_var 18                       (_31)
+        77    load_var2 5 18                     
+        78    load_var 17                        (rt)
+        79    bin_op +                           
+        80    store_field 3                      (reasoning_tokens)
 
-  141   87    load_var 7                         (turn)
-        88    load_field 0                       (content)
-        89    store_var 22                       (_35)
-        90    load_var 2                         (c)
-        91    load_type 1                        
-        92    load_const 6                       ("id")
-        93    virtual_call nargs=1 ntypeargs=0   
-        94    store_var 23                       (_36)
-        95    load_var2 22 23                    
-        96    init_instance 1                    (ai.events.AssistantMessage .content, .client_id)
-        97    load_type 7                        
-        98    alloc_array 1                      
-        99    store_var 21                       (batch)
+  141   81    load_var 7                         (turn)
+        82    load_field 0                       (content)
+        83    store_var 20                       (_37)
+        84    load_var 2                         (c)
+        85    load_type 1                        
+        86    load_const 6                       ("id")
+        87    virtual_call nargs=1 ntypeargs=0   
+        88    store_var 21                       (_38)
+        89    load_var2 20 21                    
+        90    init_instance 1                    (ai.events.AssistantMessage .content, .client_id)
+        91    load_type 7                        
+        92    alloc_array 1                      
+        93    store_var 19                       (batch)
 
-  142   100   load_var 7                         (turn)
-        101   call 825 ntypeargs=0               (ai.ModelTurn.tool_uses)
-        102   load_type 8                        
-        103   load_const 9                       ("iter")
-        104   virtual_call nargs=1 ntypeargs=0   
-        105   store_var 24                       (_38)
-        106   load_var 24                        (_38)
-        107   load_type 10                       
-        108   load_const 11                      ("next")
-        109   virtual_call nargs=1 ntypeargs=0   
-        110   store_var 25                       (_39)
-        111   load_var 25                        (_39)
-        112   is_type 12                         
-        113   pop_jump_if_false +2               (to 115)
-        114   jump +14                           (to 128)
-        115   load_var 25                        (_39)
-        116   store_var 26                       (u)
+  142   94    load_var 7                         (turn)
+        95    call 825 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        96    load_type 8                        
+        97    load_const 9                       ("iter")
+        98    virtual_call nargs=1 ntypeargs=0   
+        99    store_var 22                       (_40)
+        100   load_var 22                        (_40)
+        101   load_type 10                       
+        102   load_const 11                      ("next")
+        103   virtual_call nargs=1 ntypeargs=0   
+        104   store_var 23                       (_41)
+        105   load_var 23                        (_41)
+        106   is_type 12                         
+        107   pop_jump_if_false +2               (to 109)
+        108   jump +14                           (to 122)
+        109   load_var 23                        (_41)
+        110   store_var 24                       (u)
 
-  143   117   load_type 7                        
-        118   load_var2 21 26                    
-        119   load_field 0                       (id)
-        120   load_var 26                        (u)
-        121   load_field 1                       (name)
-        122   load_var 26                        (u)
-        123   load_field 2                       (args)
-        124   init_instance 2                    (ai.events.ToolRequested .id, .name, .args)
-        125   call 4 ntypeargs=1                 (baml.Array.push)
-        126   pop 1                              
-        127   jump -21                           (to 106)
+  143   111   load_type 7                        
+        112   load_var2 19 24                    
+        113   load_field 0                       (id)
+        114   load_var 24                        (u)
+        115   load_field 1                       (name)
+        116   load_var 24                        (u)
+        117   load_field 2                       (args)
+        118   init_instance 2                    (ai.events.ToolRequested .id, .name, .args)
+        119   call 4 ntypeargs=1                 (baml.Array.push)
+        120   pop 1                              
+        121   jump -21                           (to 100)
 
-  145   128   load_var 7                         (turn)
-        129   load_field 2                       (usage)
-        130   store_var 27                       (_50)
-        131   load_var 27                        (_50)
-        132   narrow_bind 3 27                   
-        133   pop_jump_if_false +5               (to 138)
+  145   122   load_var 7                         (turn)
+        123   load_field 2                       (usage)
+        124   store_var 25                       (_52)
+        125   load_var 25                        (_52)
+        126   narrow_bind 3 25                   
+        127   pop_jump_if_false +5               (to 132)
 
-  146   134   load_type 7                        
-        135   load_var2 21 27                    
+  146   128   load_type 7                        
+        129   load_var2 19 25                    
 
-  145   136   call 4 ntypeargs=1                 (baml.Array.push)
-        137   pop 1                              
+  145   130   call 4 ntypeargs=1                 (baml.Array.push)
+        131   pop 1                              
 
-  148   138   load_var 7                         (turn)
-        139   call 824 ntypeargs=0               (ai.ModelTurn.terminal_text)
-        140   store_var 29                       (_56)
-        141   load_var 29                        (_56)
-        142   store_var 28                       (candidate)
-        143   load_var 29                        (_56)
-        144   load_const 5                       (null)
-        145   cmp_op ==                          
-        146   pop_jump_if_false +3               (to 149)
-        147   load_const 13                      ("")
-        148   store_var 28                       (candidate)
+  148   132   load_var 7                         (turn)
+        133   call 824 ntypeargs=0               (ai.ModelTurn.terminal_text)
+        134   store_var_load_var 27              (_58)
+        135   load_const 5                       (null)
+        136   cmp_op ==                          
+        137   pop_jump_if_false +3               (to 140)
+        138   load_const 13                      ("")
+        139   store_var 27                       (_58)
+        140   load_var 27                        (_58)
+        141   store_var 26                       (candidate)
 
-  149   149   load_var 7                         (turn)
-        150   call 825 ntypeargs=0               (ai.ModelTurn.tool_uses)
-        151   container_len                      
-        152   store_var 30                       (_62)
-        153   load_var 30                        (_62)
-        154   load_const 4                       (0)
-        155   cmp_int_op >                       
-        156   jump_if_false +2                   (to 158)
-        157   jump +7                            (to 164)
-        158   pop 1                              
+  149   142   load_var 7                         (turn)
+        143   call 825 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        144   container_len                      
+        145   store_var 28                       (_65)
+        146   load_var 28                        (_65)
+        147   load_const 4                       (0)
+        148   cmp_int_op >                       
+        149   jump_if_false +2                   (to 151)
+        150   jump +7                            (to 157)
+        151   pop 1                              
 
-  150   159   load_var 7                         (turn)
-        160   load_field 1                       (stop_reason)
-        161   load_const 14                      (ai.content.StopReason.MaxTokens)
-        162   alloc_variant 436                  (ai.content.StopReason)
-        163   call 653 ntypeargs=0               (baml.ops.equals_equals)
+  150   152   load_var 7                         (turn)
+        153   load_field 1                       (stop_reason)
+        154   load_const 14                      (ai.content.StopReason.MaxTokens)
+        155   alloc_variant 436                  (ai.content.StopReason)
+        156   call 653 ntypeargs=0               (baml.ops.equals_equals)
 
-  149   164   jump_if_false +2                   (to 166)
-        165   jump +7                            (to 172)
-        166   pop 1                              
+  149   157   jump_if_false +2                   (to 159)
+        158   jump +7                            (to 165)
+        159   pop 1                              
 
-  151   167   load_var 7                         (turn)
-        168   load_field 1                       (stop_reason)
-        169   load_const 15                      (ai.content.StopReason.Refused)
-        170   alloc_variant 436                  (ai.content.StopReason)
-        171   call 653 ntypeargs=0               (baml.ops.equals_equals)
+  151   160   load_var 7                         (turn)
+        161   load_field 1                       (stop_reason)
+        162   load_const 15                      (ai.content.StopReason.Refused)
+        163   alloc_variant 436                  (ai.content.StopReason)
+        164   call 653 ntypeargs=0               (baml.ops.equals_equals)
 
-  149   172   jump_if_false +2                   (to 174)
-        173   jump +5                            (to 178)
-        174   pop 1                              
+  149   165   jump_if_false +2                   (to 167)
+        166   jump +5                            (to 171)
+        167   pop 1                              
 
-  152   175   load_type 0                        
-        176   load_var2 1 28                     
-        177   call 843 ntypeargs=1               (ai.Agent._parses)
+  152   168   load_type 0                        
+        169   load_var2 1 26                     
+        170   call 843 ntypeargs=1               (ai.Agent._parses)
 
-  153   178   pop_jump_if_false +2               (to 180)
-        179   jump +34                           (to 213)
+  153   171   pop_jump_if_false +2               (to 173)
+        172   jump +34                           (to 206)
 
-  166   180   load_var 6                         (attempts_left)
-        181   load_const 16                      (1)
-        182   cmp_int_op >                       
-        183   pop_jump_if_false +2               (to 185)
-        184   jump +12                           (to 196)
+  166   173   load_var 6                         (attempts_left)
+        174   load_const 16                      (1)
+        175   cmp_int_op >                       
+        176   pop_jump_if_false +2               (to 178)
+        177   jump +12                           (to 189)
 
-  175   185   load_var2 4 21                     
-        186   call 807 ntypeargs=0               (ai.Journal.append_all)
-        187   pop 1                              
+  175   178   load_var2 4 19                     
+        179   call 807 ntypeargs=0               (ai.Journal.append_all)
+        180   pop 1                              
 
-  176   188   load_var 2                         (c)
-        189   load_type 1                        
-        190   load_const 17                      ("id")
-        191   virtual_call nargs=1 ntypeargs=0   
-        192   store_var 33                       (_89)
-        193   load_var2 33 28                    
-        194   init_instance 3                    (ai.errors.ParseFailed .provider, .raw_output)
-        195   throw                              
+  176   181   load_var 2                         (c)
+        182   load_type 1                        
+        183   load_const 17                      ("id")
+        184   virtual_call nargs=1 ntypeargs=0   
+        185   store_var 31                       (_92)
+        186   load_var2 31 26                    
+        187   init_instance 3                    (ai.errors.ParseFailed .provider, .raw_output)
+        188   throw                              
 
-  167   196   load_type 7                        
-        197   load_var 21                        (batch)
+  167   189   load_type 7                        
+        190   load_var 19                        (batch)
 
-  168   198   load_const 18                      ("The reply did not match the required schema. Answer again with only the corrected value.")
-        199   init_instance 4                    (ai.events.UserMessage .content)
-        200   call 4 ntypeargs=1                 (baml.Array.push)
-        201   pop 1                              
+  168   191   load_const 18                      ("The reply did not match the required schema. Answer again with only the corrected value.")
+        192   init_instance 4                    (ai.events.UserMessage .content)
+        193   call 4 ntypeargs=1                 (baml.Array.push)
+        194   pop 1                              
 
-  172   202   load_var2 4 21                     
-        203   call 807 ntypeargs=0               (ai.Journal.append_all)
-        204   pop 1                              
+  172   195   load_var2 4 19                     
+        196   call 807 ntypeargs=0               (ai.Journal.append_all)
+        197   pop 1                              
 
-  173   205   load_type 0                        
-        206   load_var2 1 2                      
-        207   load_var2 3 4                      
-        208   load_var2 5 6                      
-        209   load_const 16                      (1)
-        210   sub_int                            
-        211   call 844 ntypeargs=1               (ai.Agent._attempt_turn)
-        212   jump +19                           (to 231)
+  173   198   load_type 0                        
+        199   load_var2 1 2                      
+        200   load_var2 3 4                      
+        201   load_var2 5 6                      
+        202   load_const 16                      (1)
+        203   sub_int                            
+        204   call 844 ntypeargs=1               (ai.Agent._attempt_turn)
+        205   jump +19                           (to 224)
 
-  154   213   load_var2 4 21                     
-        214   call 807 ntypeargs=0               (ai.Journal.append_all)
-        215   pop 1                              
+  154   206   load_var2 4 19                     
+        207   call 807 ntypeargs=0               (ai.Journal.append_all)
+        208   pop 1                              
 
-  156   216   load_var 7                         (turn)
+  156   209   load_var 7                         (turn)
+        210   load_field 1                       (stop_reason)
+        211   discriminant                       
+        212   load_const 14                      (StopReason.MaxTokens)
+        213   cmp_int_op ==                      
+        214   pop_jump_if_false +2               (to 216)
+        215   jump +20                           (to 235)
+        216   load_var 7                         (turn)
         217   load_field 1                       (stop_reason)
         218   discriminant                       
-        219   load_const 14                      (StopReason.MaxTokens)
+        219   load_const 15                      (StopReason.Refused)
         220   cmp_int_op ==                      
         221   pop_jump_if_false +2               (to 223)
-        222   jump +20                           (to 242)
-        223   load_var 7                         (turn)
-        224   load_field 1                       (stop_reason)
-        225   discriminant                       
-        226   load_const 15                      (StopReason.Refused)
-        227   cmp_int_op ==                      
-        228   pop_jump_if_false +2               (to 230)
-        229   jump +3                            (to 232)
+        222   jump +3                            (to 225)
 
-  165   230   load_var 7                         (turn)
-        231   return                             
+  165   223   load_var 7                         (turn)
+        224   return                             
 
-  161   232   load_var 2                         (c)
-        233   load_type 1                        
-        234   load_const 19                      ("id")
-        235   virtual_call nargs=1 ntypeargs=0   
-        236   store_var 32                       (_77)
-        237   load_var 32                        (_77)
-        238   load_const 20                      ("the model declined to answer")
-        239   load_const 5                       (null)
-        240   init_instance 5                    (ai.errors.Refused .provider, .reason, .raw_body)
-        241   throw                              
+  161   225   load_var 2                         (c)
+        226   load_type 1                        
+        227   load_const 19                      ("id")
+        228   virtual_call nargs=1 ntypeargs=0   
+        229   store_var 30                       (_80)
+        230   load_var 30                        (_80)
+        231   load_const 20                      ("the model declined to answer")
+        232   load_const 5                       (null)
+        233   init_instance 5                    (ai.errors.Refused .provider, .reason, .raw_body)
+        234   throw                              
 
-  158   242   load_var 2                         (c)
-        243   load_type 1                        
-        244   load_const 21                      ("id")
-        245   virtual_call nargs=1 ntypeargs=0   
-        246   store_var 31                       (_74)
-        247   load_var2 31 28                    
-        248   init_instance 6                    (ai.errors.ParseFailed .provider, .raw_output)
-        249   throw                              
+  158   235   load_var 2                         (c)
+        236   load_type 1                        
+        237   load_const 21                      ("id")
+        238   virtual_call nargs=1 ntypeargs=0   
+        239   store_var 29                       (_77)
+        240   load_var2 29 26                    
+        241   init_instance 6                    (ai.errors.ParseFailed .provider, .raw_output)
+        242   throw                              
 }
 
 function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> int {
@@ -709,142 +697,139 @@ function ai.Agent._parses(self: ai.Agent<#0>, candidate: string) -> bool {
 }
 
 function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: ai.content.ToolUse, j: ai.Journal) -> null {
-  56   0     load_var2 2 3          
-       1     load_field 1           (name)
-       2     call 822 ntypeargs=0   (ai.tools.Toolbox.get)
-       3     store_var 5            (_7)
-       4     load_var 5             (_7)
-       5     narrow_bind 0 5        
-       6     pop_jump_if_false +2   (to 8)
-       7     jump +20               (to 27)
+  56   0     load_var2 2 3           
+       1     load_field 1            (name)
+       2     call 822 ntypeargs=0    (ai.tools.Toolbox.get)
+       3     store_var 5             (_7)
+       4     load_var 5              (_7)
+       5     narrow_bind 0 5         
+       6     pop_jump_if_false +2    (to 8)
+       7     jump +20                (to 27)
 
-  89   8     load_var 3             (call)
-       9     load_field 0           (id)
-       10    store_var 19           (_41)
+  89   8     load_var 3              (call)
+       9     load_field 0            (id)
+       10    store_var 18            (_42)
 
-  90   11    load_type 1            
-       12    load_var 3             (call)
-       13    load_field 1           (name)
-       14    call 138 ntypeargs=1   (baml.String.from)
-       15    store_var 20           (_43)
+  90   11    load_type 1             
+       12    load_var 3              (call)
+       13    load_field 1            (name)
+       14    call 138 ntypeargs=1    (baml.String.from)
+       15    store_var 19            (_44)
 
-  86   16    load_var2 4 19         
+  86   16    load_var2 4 18          
 
-  90   17    load_const 2           ("tool is not in the active toolbox: ")
-       18    load_var 20            (_43)
-       19    bin_op +               
-       20    init_instance 0        (ai.events.ToolFailed .id, .message)
-       21    load_type 3            
-       22    alloc_array 1          
-       23    call 807 ntypeargs=0   (ai.Journal.append_all)
-       24    pop 1                  
+  90   17    load_const 2            ("tool is not in the active toolbox: ")
+       18    load_var 19             (_44)
+       19    bin_op +                
+       20    init_instance 0         (ai.events.ToolFailed .id, .message)
+       21    load_type 3             
+       22    alloc_array 1           
+       23    call 807 ntypeargs=0    (ai.Journal.append_all)
+       24    pop 1                   
 
-  94   25    load_const 4           (null)
+  94   25    load_const 4            (null)
 
-  56   26    jump +84               (to 110)
-       27    load_var 5             (_7)
-       28    store_var 6            (t)
+  56   26    jump +81                (to 107)
+       27    load_var 5              (_7)
+       28    store_var 6             (t)
 
-  58   29    load_var2 6 3          
-       30    load_field 2           (args)
-       31    call 817 ntypeargs=0   (ai.tools.Tool.call)
-       32    store_var 7            (outcome)
-       33    jump +63               (to 96)
-       34    load_var 8             (e)
-       35    throw_if_panic         
+  58   29    load_var2 6 3           
+       30    load_field 2            (args)
+       31    call 817 ntypeargs=0    (ai.tools.Tool.call)
+       32    store_var 7             (outcome)
+       33    jump +60                (to 93)
+       34    load_var 8              (e)
+       35    throw_if_panic          
 
-  61   36    load_var 3             (call)
-       37    load_field 0           (id)
-       38    store_var 9            (_15)
-       39    load_type 5            
-       40    load_var 8             (e)
-       41    call 138 ntypeargs=1   (baml.String.from)
-       42    store_var 10           (_16)
+  61   36    load_var 3              (call)
+       37    load_field 0            (id)
+       38    store_var 9             (_15)
+       39    load_type 5             
+       40    load_var 8              (e)
+       41    call 138 ntypeargs=1    (baml.String.from)
+       42    store_var 10            (_16)
 
-  60   43    load_var2 4 9          
+  60   43    load_var2 4 9           
 
-  61   44    load_var 10            (_16)
-       45    init_instance 1        (ai.events.ToolFailed .id, .message)
-       46    load_type 3            
-       47    alloc_array 1          
-       48    call 807 ntypeargs=0   (ai.Journal.append_all)
-       49    pop 1                  
+  61   44    load_var 10             (_16)
+       45    init_instance 1         (ai.events.ToolFailed .id, .message)
+       46    load_type 3             
+       47    alloc_array 1           
+       48    call 807 ntypeargs=0    (ai.Journal.append_all)
+       49    pop 1                   
 
-  64   50    load_var 6             (t)
-       51    load_field 5           (on_error)
-       52    store_var 12           (_20)
-       53    load_var 12            (_20)
-       54    store_var 11           (_19)
-       55    load_var 12            (_20)
-       56    load_const 4           (null)
-       57    cmp_op ==              
-       58    pop_jump_if_false +4   (to 62)
-       59    load_var 1             (self)
-       60    load_field 2           (tool_errors)
-       61    store_var 11           (_19)
-       62    load_var 11            (_19)
-       63    load_const 6           (ai.tools.ErrorMode.Raise)
-       64    alloc_variant 437      (ai.tools.ErrorMode)
-       65    call 653 ntypeargs=0   (baml.ops.equals_equals)
-       66    pop_jump_if_false +2   (to 68)
-       67    jump +4                (to 71)
+  64   50    load_var 6              (t)
+       51    load_field 5            (on_error)
+       52    store_var_load_var 11   (_20)
+       53    load_const 4            (null)
+       54    cmp_op ==               
+       55    pop_jump_if_false +4    (to 59)
+       56    load_var 1              (self)
+       57    load_field 2            (tool_errors)
+       58    store_var 11            (_20)
+       59    load_var 11             (_20)
+       60    load_const 6            (ai.tools.ErrorMode.Raise)
+       61    alloc_variant 437       (ai.tools.ErrorMode)
+       62    call 653 ntypeargs=0    (baml.ops.equals_equals)
+       63    pop_jump_if_false +2    (to 65)
+       64    jump +4                 (to 68)
 
-  76   68    load_const 4           (null)
-       69    store_var 7            (outcome)
+  76   65    load_const 4            (null)
+       66    store_var 7             (outcome)
 
-  64   70    jump +26               (to 96)
+  64   67    jump +26                (to 93)
 
-  65   71    load_var 8             (e)
-       72    store_var 14           (_23)
-       73    load_var 14            (_23)
-       74    narrow_bind 7 14       
-       75    pop_jump_if_false +2   (to 77)
-       76    jump +4                (to 80)
+  65   68    load_var 8              (e)
+       69    store_var 13            (_24)
+       70    load_var 13             (_24)
+       71    narrow_bind 7 13        
+       72    pop_jump_if_false +2    (to 74)
+       73    jump +4                 (to 77)
 
-  67   77    load_const 4           (null)
-       78    store_var 13           (classified)
+  67   74    load_const 4            (null)
+       75    store_var 12            (classified)
 
-  65   79    jump +3                (to 82)
-       80    load_var 14            (_23)
-       81    store_var 13           (classified)
+  65   76    jump +3                 (to 79)
+       77    load_var 13             (_24)
+       78    store_var 12            (classified)
 
-  70   82    load_var 3             (call)
-       83    load_field 0           (id)
-       84    store_var 15           (_26)
+  70   79    load_var 3              (call)
+       80    load_field 0            (id)
+       81    store_var 14            (_27)
 
-  71   85    load_var 3             (call)
-       86    load_field 1           (name)
-       87    store_var 16           (_27)
+  71   82    load_var 3              (call)
+       83    load_field 1            (name)
+       84    store_var 15            (_28)
 
-  72   88    load_type 5            
-       89    load_var 8             (e)
-       90    call 138 ntypeargs=1   (baml.String.from)
-       91    store_var 17           (_28)
+  72   85    load_type 5             
+       86    load_var 8              (e)
+       87    call 138 ntypeargs=1    (baml.String.from)
+       88    store_var 16            (_29)
 
-  69   92    load_var2 15 16        
-       93    load_var2 17 13        
+  69   89    load_var2 14 15         
+       90    load_var2 16 12         
 
-  73   94    init_instance 2        (ai.errors.ToolFailedError .id, .name, .message, .cause)
-       95    throw                  
+  73   91    init_instance 2         (ai.errors.ToolFailedError .id, .name, .message, .cause)
+       92    throw                   
 
-  80   96    load_var 7             (outcome)
-       97    store_var 18           (_31)
-       98    load_var 18            (_31)
-       99    narrow_bind 6 18       
-       100   pop_jump_if_false +9   (to 109)
+  80   93    load_var 7              (outcome)
+       94    store_var 17            (_32)
+       95    load_var 17             (_32)
+       96    narrow_bind 6 17        
+       97    pop_jump_if_false +9    (to 106)
 
-  81   101   load_var2 4 3          
-       102   load_field 0           (id)
+  81   98    load_var2 4 3           
+       99    load_field 0            (id)
 
-  80   103   load_var 18            (_31)
-       104   init_instance 3        (ai.events.ToolCompleted .id, .output)
-       105   load_type 3            
-       106   alloc_array 1          
-       107   call 807 ntypeargs=0   (ai.Journal.append_all)
-       108   pop 1                  
+  80   100   load_var 17             (_32)
+       101   init_instance 3         (ai.events.ToolCompleted .id, .output)
+       102   load_type 3             
+       103   alloc_array 1           
+       104   call 807 ntypeargs=0    (ai.Journal.append_all)
+       105   pop 1                   
 
-  83   109   load_const 4           (null)
-       110   return                 
+  83   106   load_const 4            (null)
+       107   return                  
 }
 
 function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.tools.ErrorMode, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced) -> null throws never) | null) -> ai.Agent<#0> {
@@ -879,21 +864,21 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
        24   store_var 4                                (on_event)
 
   39   25   load_var 4                                 (on_event)
-       26   store_var 5                                (_9)
-       27   load_var 4                                 (on_event)
-       28   load_const 2                               (null)
-       29   cmp_op ==                                  
-       30   pop_jump_if_false +4                       (to 34)
+       26   store_var_load_var 5                       (_10)
+       27   load_const 2                               (null)
+       28   cmp_op ==                                  
+       29   pop_jump_if_false +4                       (to 33)
 
-  41   31   load_type 4                                
-       32   make_closure 1720 captures=0 ntypeargs=1   
-       33   store_var 5                                (_9)
+  41   30   load_type 4                                
+       31   make_closure 1720 captures=0 ntypeargs=1   
+       32   store_var 5                                (_10)
 
-  35   34   load_var2 1 2                              
-       35   load_var2 3 5                              
-       36   load_type 4                                
-       37   init_instance 0                            (ai.Agent .max_steps, .client, .tool_errors, .on_event)
-       38   return                                     
+  35   33   load_var2 1 2                              
+       34   load_var2 3 5                              
+
+  39   35   load_type 4                                
+       36   init_instance 0                            (ai.Agent .max_steps, .client, .tool_errors, .on_event)
+       37   return                                     
 }
 
 function ai.FunctionSpec.arguments(self: ai.FunctionSpec<#0>) -> map<string, unknown> {
@@ -1377,17 +1362,17 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
        17   store_var 4            (backoff)
 
   64   18   load_var 3             (retry_if)
-       19   store_var 5            (_8)
-       20   load_var 3             (retry_if)
-       21   load_const 2           (null)
-       22   cmp_op ==              
-       23   pop_jump_if_false +3   (to 26)
-       24   load_const 3           (ai.clients.default_retry_judgment)
-       25   store_var 5            (_8)
+       19   store_var_load_var 6   (_9)
+       20   load_const 2           (null)
+       21   cmp_op ==              
+       22   pop_jump_if_false +3   (to 25)
+       23   load_const 3           (ai.clients.default_retry_judgment)
+       24   store_var 6            (_9)
+       25   load_var 6             (_9)
+       26   store_var 5            (_8)
 
-  65   26   load_var 4             (backoff)
-       27   store_var 6            (_10)
-       28   load_var 4             (backoff)
+  65   27   load_var 4             (backoff)
+       28   store_var_load_var 7   (_12)
        29   load_const 2           (null)
        30   cmp_op ==              
        31   pop_jump_if_false +6   (to 37)
@@ -1395,11 +1380,12 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
        33   load_const 0           (<omitted>)
        34   load_const 0           (<omitted>)
        35   call 829 ntypeargs=0   (ai.clients.Backoff.new)
-       36   store_var 6            (_10)
+       36   store_var 7            (_12)
 
   61   37   load_var2 1 2          
-       38   load_var2 5 6          
-       39   init_instance 0        (ai.clients.Retry .inner, .max_attempts, .retry_if, .backoff)
+       38   load_var2 5 7          
+
+  65   39   init_instance 0        (ai.clients.Retry .inner, .max_attempts, .retry_if, .backoff)
        40   return                 
 }
 
@@ -2516,60 +2502,55 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
   231   23   load_const 2           (null)
         24   store_var 3            (usage)
 
-  223   25   jump +28               (to 53)
+  223   25   jump +24               (to 49)
 
   225   26   load_var 1             (self)
         27   load_field 8           (_input_tokens)
-        28   store_var 5            (_12)
-        29   load_var 5             (_12)
-        30   store_var 4            (_11)
-        31   load_var 5             (_12)
-        32   load_const 2           (null)
-        33   cmp_op ==              
-        34   pop_jump_if_false +3   (to 37)
-        35   load_const 3           (0)
-        36   store_var 4            (_11)
+        28   store_var_load_var 5   (_12)
+        29   load_const 2           (null)
+        30   cmp_op ==              
+        31   pop_jump_if_false +3   (to 34)
+        32   load_const 3           (0)
+        33   store_var 5            (_12)
+        34   load_var 5             (_12)
+        35   store_var 4            (_11)
 
-  226   37   load_var 1             (self)
-        38   load_field 9           (_output_tokens)
-        39   store_var 7            (_15)
-        40   load_var 7             (_15)
-        41   store_var 6            (_14)
-        42   load_var 7             (_15)
-        43   load_const 2           (null)
-        44   cmp_op ==              
-        45   pop_jump_if_false +3   (to 48)
-        46   load_const 3           (0)
-        47   store_var 6            (_14)
+  226   36   load_var 1             (self)
+        37   load_field 9           (_output_tokens)
+        38   store_var_load_var 6   (_16)
+        39   load_const 2           (null)
+        40   cmp_op ==              
+        41   pop_jump_if_false +3   (to 44)
+        42   load_const 3           (0)
+        43   store_var 6            (_16)
 
-  224   48   load_var2 4 6          
-        49   load_const 2           (null)
-        50   load_const 2           (null)
-        51   init_instance 0        (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
-        52   store_var 3            (usage)
+  224   44   load_var2 4 6          
 
-  235   53   load_var 1             (self)
-        54   load_field 7           (_stop_reason)
-        55   store_var 9            (_21)
-        56   load_var 9             (_21)
-        57   store_var 8            (_20)
-        58   load_var 9             (_21)
-        59   load_const 2           (null)
-        60   cmp_op ==              
-        61   pop_jump_if_false +4   (to 65)
-        62   load_const 3           (ai.content.StopReason.Complete)
-        63   alloc_variant 436      (ai.content.StopReason)
-        64   store_var 8            (_20)
+  226   45   load_const 2           (null)
+        46   load_const 2           (null)
+        47   init_instance 0        (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
+        48   store_var 3            (usage)
 
-  234   65   load_var 1             (self)
-        66   load_field 6           (_text)
-        67   init_instance 1        (ai.content.Text .text)
-        68   load_type 4            
-        69   alloc_array 1          
-        70   load_var2 8 3          
+  235   49   load_var 1             (self)
+        50   load_field 7           (_stop_reason)
+        51   store_var_load_var 7   (_23)
+        52   load_const 2           (null)
+        53   cmp_op ==              
+        54   pop_jump_if_false +4   (to 58)
+        55   load_const 3           (ai.content.StopReason.Complete)
+        56   alloc_variant 436      (ai.content.StopReason)
+        57   store_var 7            (_23)
 
-  236   71   init_instance 2        (ai.ModelTurn .content, .stop_reason, .usage)
-        72   return                 
+  234   58   load_var 1             (self)
+        59   load_field 6           (_text)
+        60   init_instance 1        (ai.content.Text .text)
+        61   load_type 4            
+        62   alloc_array 1          
+
+  235   63   load_var2 7 3          
+
+  236   64   init_instance 2        (ai.ModelTurn .content, .stop_reason, .usage)
+        65   return                 
 }
 
 function ai.stream.TurnStream.from_chunks(chunks: string[]) -> ai.stream.TurnStream {
@@ -3167,93 +3148,92 @@ function ai.tools.raw_tool(name: string, description: string, input_schema: map<
 }
 
 function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unknown>, name: string | null, description: string | null, on_error: ai.tools.ErrorMode | null) -> ai.tools.Tool {
-       0    load_var 2             (name)
-       1    load_const 0           (<omitted>)
-       2    cmp_op ==              
-       3    pop_jump_if_false +3   (to 6)
+       0    load_var 2              (name)
+       1    load_const 0            (<omitted>)
+       2    cmp_op ==               
+       3    pop_jump_if_false +3    (to 6)
 
-  45   4    load_const 1           (null)
-       5    store_var 2            (name)
-       6    load_var 3             (description)
-       7    load_const 0           (<omitted>)
-       8    cmp_op ==              
-       9    pop_jump_if_false +3   (to 12)
+  45   4    load_const 1            (null)
+       5    store_var 2             (name)
+       6    load_var 3              (description)
+       7    load_const 0            (<omitted>)
+       8    cmp_op ==               
+       9    pop_jump_if_false +3    (to 12)
 
-  46   10   load_const 1           (null)
-       11   store_var 3            (description)
-       12   load_var 4             (on_error)
-       13   load_const 0           (<omitted>)
-       14   cmp_op ==              
-       15   pop_jump_if_false +3   (to 18)
+  46   10   load_const 1            (null)
+       11   store_var 3             (description)
+       12   load_var 4              (on_error)
+       13   load_const 0            (<omitted>)
+       14   cmp_op ==               
+       15   pop_jump_if_false +3    (to 18)
 
-  47   16   load_const 1           (null)
-       17   store_var 4            (on_error)
+  47   16   load_const 1            (null)
+       17   store_var 4             (on_error)
 
-  49   18   load_var 1             (handler)
-       19   call 739 ntypeargs=0   (reflect.signature)
-       20   store_var 5            (sig)
+  49   18   load_var 1              (handler)
+       19   call 739 ntypeargs=0    (reflect.signature)
+       20   store_var 5             (sig)
 
-  50   21   load_var 2             (name)
-       22   store_var 6            (resolved_name)
-       23   load_var 2             (name)
-       24   load_const 1           (null)
-       25   cmp_op ==              
-       26   pop_jump_if_false +4   (to 30)
-       27   load_var 5             (sig)
-       28   load_field 0           (name)
-       29   store_var 6            (resolved_name)
+  50   21   load_var 2              (name)
+       22   store_var_load_var 6    (_10)
+       23   load_const 1            (null)
+       24   cmp_op ==               
+       25   pop_jump_if_false +4    (to 29)
+       26   load_var 5              (sig)
+       27   load_field 0            (name)
+       28   store_var 6             (_10)
+       29   load_var 6              (_10)
+       30   store_var 7             (_12)
 
-  51   30   load_var 6             (resolved_name)
-       31   store_var 7            (_11)
-       32   load_var 7             (_11)
-       33   narrow_bind 2 7        
-       34   pop_jump_if_false +2   (to 36)
-       35   jump +4                (to 39)
+  51   31   load_var 7              (_12)
+       32   narrow_bind 2 7         
+       33   pop_jump_if_false +2    (to 35)
+       34   jump +4                 (to 38)
 
-  64   36   load_const 3           ("anonymous tool needs a name")
-       37   init_instance 0        (baml.errors.InvalidArgument .message)
-       38   throw                  
+  64   35   load_const 3            ("anonymous tool needs a name")
+       36   init_instance 0         (baml.errors.InvalidArgument .message)
+       37   throw                   
 
-  51   39   load_var 7             (_11)
-       40   store_var_load_var 8   (n)
+  51   38   load_var 7              (_12)
+       39   store_var_load_var 8    (n)
 
-  52   41   load_const 4           ("__baml_return_output")
-       42   cmp_op ==              
-       43   pop_jump_if_false +2   (to 45)
-       44   jump +27               (to 71)
+  52   40   load_const 4            ("__baml_return_output")
+       41   cmp_op ==               
+       42   pop_jump_if_false +2    (to 44)
+       43   jump +27                (to 70)
 
-  57   45   load_var 3             (description)
-       46   store_var 10           (_18)
-       47   load_var 3             (description)
-       48   load_const 1           (null)
-       49   cmp_op ==              
-       50   pop_jump_if_false +4   (to 54)
-       51   load_var 5             (sig)
-       52   load_field 5           (docstring)
-       53   store_var 10           (_18)
-       54   load_var 10            (_18)
-       55   store_var 9            (_17)
-       56   load_var 10            (_18)
-       57   load_const 1           (null)
-       58   cmp_op ==              
-       59   pop_jump_if_false +3   (to 62)
-       60   load_const 5           ("")
-       61   store_var 9            (_17)
+  57   44   load_var 3              (description)
+       45   store_var_load_var 11   (_21)
+       46   load_const 1            (null)
+       47   cmp_op ==               
+       48   pop_jump_if_false +4    (to 52)
+       49   load_var 5              (sig)
+       50   load_field 5            (docstring)
+       51   store_var 11            (_21)
+       52   load_var 11             (_21)
+       53   store_var_load_var 10   (_19)
+       54   load_const 1            (null)
+       55   cmp_op ==               
+       56   pop_jump_if_false +3    (to 59)
+       57   load_const 5            ("")
+       58   store_var 10            (_19)
+       59   load_var 10             (_19)
+       60   store_var 9             (_18)
 
-  58   62   load_var 1             (handler)
-       63   call 866 ntypeargs=0   (ai.internal._schema_for_signature)
-       64   store_var 11           (_21)
+  58   61   load_var 1              (handler)
+       62   call 866 ntypeargs=0    (ai.internal._schema_for_signature)
+       63   store_var 12            (_24)
 
-  56   65   load_var2 8 9          
-       66   load_var2 11 1         
-       67   load_const 1           (null)
-       68   load_var 4             (on_error)
-       69   init_instance 1        (ai.tools.Tool .name, .description, .input_schema, .handler, .raw_handler, .on_error)
-       70   return                 
+  56   64   load_var2 8 9           
+       65   load_var2 12 1          
+       66   load_const 1            (null)
+       67   load_var 4              (on_error)
+       68   init_instance 1         (ai.tools.Tool .name, .description, .input_schema, .handler, .raw_handler, .on_error)
+       69   return                  
 
-  53   71   load_const 6           ("the tool name __baml_return_output is reserved")
-       72   init_instance 2        (baml.errors.InvalidArgument .message)
-       73   throw                  
+  53   70   load_const 6            ("the tool name __baml_return_output is reserved")
+       71   init_instance 2         (baml.errors.InvalidArgument .message)
+       72   throw                   
 }
 
 function ai.wire.render_output_format(t: type) -> string {
@@ -3531,7 +3511,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         14    load_var 4                         (_5)
         15    is_type 5                          
         16    pop_jump_if_false +2               (to 18)
-        17    jump +222                          (to 239)
+        17    jump +214                          (to 231)
         18    load_var 4                         (_5)
         19    store_var_load_var 5               (raw)
 
@@ -3557,233 +3537,225 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         34    narrow_bind 9 8                    
         35    pop_jump_if_false -26              (to 9)
         36    load_var 8                         (_16)
-        37    store_var 9                        (event)
+        37    store_var_load_var 9               (event)
 
-  355   38    load_var 9                         (event)
-        39    load_field 0                       (type)
-        40    store_var 12                       (_20)
-        41    load_var 12                        (_20)
-        42    store_var 11                       (_19)
-        43    load_var 12                        (_20)
-        44    load_const 8                       (null)
-        45    cmp_op ==                          
-        46    pop_jump_if_false +4               (to 50)
-        47    load_var 5                         (raw)
-        48    load_field 0                       (event)
-        49    store_var 11                       (_19)
-        50    load_var 11                        (_19)
-        51    store_var 10                       (t)
-        52    load_var 11                        (_19)
-        53    load_const 8                       (null)
-        54    cmp_op ==                          
-        55    pop_jump_if_false +3               (to 58)
-        56    load_const 10                      ("")
-        57    store_var 10                       (t)
+  355   38    load_field 0                       (type)
+        39    store_var_load_var 12              (_21)
+        40    load_const 8                       (null)
+        41    cmp_op ==                          
+        42    pop_jump_if_false +4               (to 46)
+        43    load_var 5                         (raw)
+        44    load_field 0                       (event)
+        45    store_var 12                       (_21)
+        46    load_var 12                        (_21)
+        47    store_var_load_var 11              (_19)
+        48    load_const 8                       (null)
+        49    cmp_op ==                          
+        50    pop_jump_if_false +3               (to 53)
+        51    load_const 10                      ("")
+        52    store_var 11                       (_19)
+        53    load_var 11                        (_19)
+        54    store_var_load_var 10              (t)
 
-  356   58    load_var 10                        (t)
-        59    load_const 11                      ("content_block_delta")
-        60    cmp_op ==                          
-        61    pop_jump_if_false +2               (to 63)
-        62    jump +142                          (to 204)
+  356   55    load_const 11                      ("content_block_delta")
+        56    cmp_op ==                          
+        57    pop_jump_if_false +2               (to 59)
+        58    jump +142                          (to 200)
 
-  372   63    load_var 10                        (t)
-        64    load_const 12                      ("message_start")
-        65    cmp_op ==                          
-        66    pop_jump_if_false +2               (to 68)
-        67    jump +75                           (to 142)
+  372   59    load_var 10                        (t)
+        60    load_const 12                      ("message_start")
+        61    cmp_op ==                          
+        62    pop_jump_if_false +2               (to 64)
+        63    jump +75                           (to 138)
 
-  381   68    load_var 10                        (t)
-        69    load_const 13                      ("message_delta")
-        70    cmp_op ==                          
-        71    pop_jump_if_false +2               (to 73)
-        72    jump +11                           (to 83)
+  381   64    load_var 10                        (t)
+        65    load_const 13                      ("message_delta")
+        66    cmp_op ==                          
+        67    pop_jump_if_false +2               (to 69)
+        68    jump +11                           (to 79)
 
-  394   73    load_var 10                        (t)
-        74    load_const 14                      ("message_stop")
-        75    cmp_op ==                          
-        76    pop_jump_if_false -67              (to 9)
+  394   69    load_var 10                        (t)
+        70    load_const 14                      ("message_stop")
+        71    cmp_op ==                          
+        72    pop_jump_if_false -63              (to 9)
 
-  395   77    load_type 0                        
-        78    load_var 2                         (out)
-        79    alloc_instance 358 ntypeargs=0     (ai.stream.TurnDone)
-        80    call 4 ntypeargs=1                 (baml.Array.push)
-        81    pop 1                              
-        82    jump -73                           (to 9)
+  395   73    load_type 0                        
+        74    load_var 2                         (out)
+        75    alloc_instance 358 ntypeargs=0     (ai.stream.TurnDone)
+        76    call 4 ntypeargs=1                 (baml.Array.push)
+        77    pop 1                              
+        78    jump -69                           (to 9)
 
-  382   83    load_var 9                         (event)
-        84    load_field 1                       (delta)
-        85    load_const 8                       (null)
-        86    cmp_op ==                          
-        87    pop_jump_if_false +2               (to 89)
-        88    jump +6                            (to 94)
-        89    load_var 9                         (event)
-        90    load_field 1                       (delta)
-        91    load_field 2                       (2)
-        92    store_var 21                       (_67)
-        93    jump +3                            (to 96)
-        94    load_const 8                       (null)
-        95    store_var 21                       (_67)
-        96    load_var 21                        (_67)
-        97    load_const 8                       (null)
-        98    cmp_op ==                          
-        99    pop_jump_if_false +2               (to 101)
-        100   jump +5                            (to 105)
-        101   load_var 21                        (_67)
-        102   call 892 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
-        103   store_var 20                       (stop)
-        104   jump +3                            (to 107)
+  382   79    load_var 9                         (event)
+        80    load_field 1                       (delta)
+        81    load_const 8                       (null)
+        82    cmp_op ==                          
+        83    pop_jump_if_false +2               (to 85)
+        84    jump +6                            (to 90)
+        85    load_var 9                         (event)
+        86    load_field 1                       (delta)
+        87    load_field 2                       (2)
+        88    store_var 20                       (_70)
+        89    jump +3                            (to 92)
+        90    load_const 8                       (null)
+        91    store_var 20                       (_70)
+        92    load_var 20                        (_70)
+        93    load_const 8                       (null)
+        94    cmp_op ==                          
+        95    pop_jump_if_false +2               (to 97)
+        96    jump +5                            (to 101)
+        97    load_var 20                        (_70)
+        98    call 892 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+        99    store_var 19                       (stop)
+        100   jump +3                            (to 103)
 
-  383   105   load_const 8                       (null)
-        106   store_var 20                       (stop)
+  383   101   load_const 8                       (null)
+        102   store_var 19                       (stop)
 
-  388   107   load_var 20                        (stop)
-        108   store_var 22                       (_76)
+  388   103   load_var 19                        (stop)
+        104   store_var 21                       (_79)
 
-  389   109   load_var 9                         (event)
-        110   load_field 3                       (usage)
-        111   load_const 8                       (null)
-        112   cmp_op ==                          
-        113   pop_jump_if_false +2               (to 115)
-        114   jump +6                            (to 120)
-        115   load_var 9                         (event)
-        116   load_field 3                       (usage)
-        117   load_field 0                       (0)
-        118   store_var 23                       (_77)
-        119   jump +3                            (to 122)
+  389   105   load_var 9                         (event)
+        106   load_field 3                       (usage)
+        107   load_const 8                       (null)
+        108   cmp_op ==                          
+        109   pop_jump_if_false +2               (to 111)
+        110   jump +6                            (to 116)
+        111   load_var 9                         (event)
+        112   load_field 3                       (usage)
+        113   load_field 0                       (0)
+        114   store_var 22                       (_80)
+        115   jump +3                            (to 118)
+        116   load_const 8                       (null)
+        117   store_var 22                       (_80)
+
+  390   118   load_var 9                         (event)
+        119   load_field 3                       (usage)
         120   load_const 8                       (null)
-        121   store_var 23                       (_77)
+        121   cmp_op ==                          
+        122   pop_jump_if_false +2               (to 124)
+        123   jump +6                            (to 129)
+        124   load_var 9                         (event)
+        125   load_field 3                       (usage)
+        126   load_field 1                       (1)
+        127   store_var 23                       (_84)
+        128   jump +3                            (to 131)
+        129   load_const 8                       (null)
+        130   store_var 23                       (_84)
 
-  390   122   load_var 9                         (event)
-        123   load_field 3                       (usage)
-        124   load_const 8                       (null)
-        125   cmp_op ==                          
-        126   pop_jump_if_false +2               (to 128)
-        127   jump +6                            (to 133)
-        128   load_var 9                         (event)
-        129   load_field 3                       (usage)
-        130   load_field 1                       (1)
-        131   store_var 24                       (_81)
-        132   jump +3                            (to 135)
-        133   load_const 8                       (null)
-        134   store_var 24                       (_81)
+  386   131   load_type 0                        
+        132   load_var2 2 21                     
 
-  386   135   load_type 0                        
-        136   load_var2 2 22                     
+  387   133   load_var2 22 23                    
+        134   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
+        135   call 4 ntypeargs=1                 (baml.Array.push)
+        136   pop 1                              
+        137   jump -128                          (to 9)
 
-  387   137   load_var2 23 24                    
-        138   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
-        139   call 4 ntypeargs=1                 (baml.Array.push)
-        140   pop 1                              
-        141   jump -132                          (to 9)
+  376   138   load_var 9                         (event)
+        139   load_field 2                       (message)
+        140   load_const 8                       (null)
+        141   cmp_op ==                          
+        142   pop_jump_if_false +2               (to 144)
+        143   jump +20                           (to 163)
+        144   load_var 9                         (event)
+        145   load_field 2                       (message)
+        146   load_field 0                       (0)
+        147   load_const 8                       (null)
+        148   cmp_op ==                          
+        149   pop_jump_if_false +2               (to 151)
+        150   jump +13                           (to 163)
+        151   load_var 9                         (event)
+        152   load_field 2                       (message)
+        153   load_const 8                       (null)
+        154   cmp_op ==                          
+        155   pop_jump_if_false +2               (to 157)
+        156   jump +7                            (to 163)
+        157   load_var 9                         (event)
+        158   load_field 2                       (message)
+        159   load_field 0                       (0)
+        160   load_field 0                       (0)
+        161   store_var 17                       (_46)
+        162   jump +3                            (to 165)
+        163   load_const 8                       (null)
+        164   store_var 17                       (_46)
 
-  376   142   load_var 9                         (event)
-        143   load_field 2                       (message)
-        144   load_const 8                       (null)
-        145   cmp_op ==                          
-        146   pop_jump_if_false +2               (to 148)
-        147   jump +20                           (to 167)
-        148   load_var 9                         (event)
-        149   load_field 2                       (message)
-        150   load_field 0                       (0)
-        151   load_const 8                       (null)
-        152   cmp_op ==                          
-        153   pop_jump_if_false +2               (to 155)
-        154   jump +13                           (to 167)
-        155   load_var 9                         (event)
-        156   load_field 2                       (message)
-        157   load_const 8                       (null)
-        158   cmp_op ==                          
-        159   pop_jump_if_false +2               (to 161)
-        160   jump +7                            (to 167)
-        161   load_var 9                         (event)
-        162   load_field 2                       (message)
-        163   load_field 0                       (0)
-        164   load_field 0                       (0)
-        165   store_var 18                       (_43)
-        166   jump +3                            (to 169)
+  377   165   load_var 9                         (event)
+        166   load_field 2                       (message)
         167   load_const 8                       (null)
-        168   store_var 18                       (_43)
+        168   cmp_op ==                          
+        169   pop_jump_if_false +2               (to 171)
+        170   jump +20                           (to 190)
+        171   load_var 9                         (event)
+        172   load_field 2                       (message)
+        173   load_field 0                       (0)
+        174   load_const 8                       (null)
+        175   cmp_op ==                          
+        176   pop_jump_if_false +2               (to 178)
+        177   jump +13                           (to 190)
+        178   load_var 9                         (event)
+        179   load_field 2                       (message)
+        180   load_const 8                       (null)
+        181   cmp_op ==                          
+        182   pop_jump_if_false +2               (to 184)
+        183   jump +7                            (to 190)
+        184   load_var 9                         (event)
+        185   load_field 2                       (message)
+        186   load_field 0                       (0)
+        187   load_field 1                       (1)
+        188   store_var 18                       (_56)
+        189   jump +3                            (to 192)
+        190   load_const 8                       (null)
+        191   store_var 18                       (_56)
 
-  377   169   load_var 9                         (event)
-        170   load_field 2                       (message)
-        171   load_const 8                       (null)
-        172   cmp_op ==                          
-        173   pop_jump_if_false +2               (to 175)
-        174   jump +20                           (to 194)
-        175   load_var 9                         (event)
-        176   load_field 2                       (message)
-        177   load_field 0                       (0)
-        178   load_const 8                       (null)
-        179   cmp_op ==                          
-        180   pop_jump_if_false +2               (to 182)
-        181   jump +13                           (to 194)
-        182   load_var 9                         (event)
-        183   load_field 2                       (message)
-        184   load_const 8                       (null)
-        185   cmp_op ==                          
-        186   pop_jump_if_false +2               (to 188)
-        187   jump +7                            (to 194)
-        188   load_var 9                         (event)
-        189   load_field 2                       (message)
-        190   load_field 0                       (0)
-        191   load_field 1                       (1)
-        192   store_var 19                       (_53)
-        193   jump +3                            (to 196)
-        194   load_const 8                       (null)
-        195   store_var 19                       (_53)
+  373   192   load_type 0                        
+        193   load_var 2                         (out)
 
-  373   196   load_type 0                        
-        197   load_var 2                         (out)
+  374   194   load_const 8                       (null)
+        195   load_var2 17 18                    
+        196   init_instance 1                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
+        197   call 4 ntypeargs=1                 (baml.Array.push)
+        198   pop 1                              
+        199   jump -190                          (to 9)
 
-  374   198   load_const 8                       (null)
-        199   load_var2 18 19                    
-        200   init_instance 1                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
-        201   call 4 ntypeargs=1                 (baml.Array.push)
-        202   pop 1                              
-        203   jump -194                          (to 9)
+  357   200   load_var 9                         (event)
+        201   load_field 1                       (delta)
+        202   store_var 13                       (_28)
+        203   load_var 13                        (_28)
+        204   narrow_bind 15 13                  
+        205   pop_jump_if_false -196             (to 9)
+        206   load_var 13                        (_28)
+        207   store_var_load_var 14              (d)
 
-  357   204   load_var 9                         (event)
-        205   load_field 1                       (delta)
-        206   store_var 13                       (_26)
-        207   load_var 13                        (_26)
-        208   narrow_bind 15 13                  
-        209   pop_jump_if_false -200             (to 9)
-        210   load_var 13                        (_26)
-        211   store_var 14                       (d)
+  358   208   load_field 0                       (type)
+        209   store_var_load_var 15              (_32)
+        210   load_const 8                       (null)
+        211   cmp_op ==                          
+        212   pop_jump_if_false +3               (to 215)
+        213   load_const 16                      ("")
+        214   store_var 15                       (_32)
+        215   load_var 15                        (_32)
+        216   load_const 17                      ("text_delta")
+        217   cmp_op ==                          
+        218   pop_jump_if_false -209             (to 9)
 
-  358   212   load_var 14                        (d)
-        213   load_field 0                       (type)
-        214   store_var 16                       (_30)
-        215   load_var 16                        (_30)
-        216   store_var 15                       (_29)
-        217   load_var 16                        (_30)
-        218   load_const 8                       (null)
-        219   cmp_op ==                          
-        220   pop_jump_if_false +3               (to 223)
-        221   load_const 16                      ("")
-        222   store_var 15                       (_29)
-        223   load_var 15                        (_29)
-        224   load_const 17                      ("text_delta")
-        225   cmp_op ==                          
-        226   pop_jump_if_false -217             (to 9)
+  359   219   load_var 14                        (d)
+        220   load_field 1                       (text)
+        221   store_var 16                       (_36)
+        222   load_var 16                        (_36)
+        223   narrow_bind 6 16                   
+        224   pop_jump_if_false -215             (to 9)
 
-  359   227   load_var 14                        (d)
-        228   load_field 1                       (text)
-        229   store_var 17                       (_33)
-        230   load_var 17                        (_33)
-        231   narrow_bind 6 17                   
-        232   pop_jump_if_false -223             (to 9)
+  360   225   load_type 0                        
+        226   load_var2 2 16                     
 
-  360   233   load_type 0                        
-        234   load_var2 2 17                     
+  359   227   init_instance 2                    (ai.stream.TextDelta .text)
+        228   call 4 ntypeargs=1                 (baml.Array.push)
+        229   pop 1                              
+        230   jump -221                          (to 9)
 
-  359   235   init_instance 2                    (ai.stream.TextDelta .text)
-        236   call 4 ntypeargs=1                 (baml.Array.push)
-        237   pop 1                              
-        238   jump -229                          (to 9)
-
-  409   239   load_var 2                         (out)
-        240   return                             
+  409   231   load_var 2                         (out)
+        232   return                             
 }
 
 function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic.internal.AnthropicMessage[] {
@@ -4235,246 +4207,240 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         61    load_const 11                      (null)
         62    cmp_op ==                          
         63    pop_jump_if_false +2               (to 65)
-        64    jump +8                            (to 72)
+        64    jump +7                            (to 71)
         65    load_type 5                        
         66    load_var 7                         (lowered)
         67    load_const 10                      (0)
         68    call 3 ntypeargs=1                 (baml.Array.at)
         69    load_field 0                       (0)
-        70    store_var 12                       (_32)
-        71    jump +3                            (to 74)
-        72    load_const 11                      (null)
-        73    store_var 12                       (_32)
-        74    load_var 12                        (_32)
-        75    store_var 11                       (first_role)
-        76    load_var 12                        (_32)
-        77    load_const 11                      (null)
-        78    cmp_op ==                          
-        79    pop_jump_if_false +3               (to 82)
-        80    load_const 12                      ("")
-        81    store_var 11                       (first_role)
+        70    jump +2                            (to 72)
+        71    load_const 11                      (null)
+        72    store_var_load_var 11              (_32)
+        73    load_const 11                      (null)
+        74    cmp_op ==                          
+        75    pop_jump_if_false +3               (to 78)
+        76    load_const 12                      ("")
+        77    store_var 11                       (_32)
+        78    load_var 11                        (_32)
+        79    load_const 13                      ("user")
+        80    cmp_op !=                          
+        81    jump_if_false +8                   (to 89)
+        82    pop 1                              
 
-  199   82    load_var 11                        (first_role)
-        83    load_const 13                      ("user")
-        84    cmp_op !=                          
-        85    jump_if_false +8                   (to 93)
-        86    pop 1                              
-        87    load_var 6                         (system)
-        88    container_len                      
-        89    store_var 13                       (_42)
-        90    load_var 13                        (_42)
-        91    load_const 10                      (0)
-        92    cmp_int_op >                       
-        93    pop_jump_if_false +2               (to 95)
-        94    jump +26                           (to 120)
+  199   83    load_var 6                         (system)
+        84    container_len                      
+        85    store_var 12                       (_43)
+        86    load_var 12                        (_43)
+        87    load_const 10                      (0)
+        88    cmp_int_op >                       
+        89    pop_jump_if_false +2               (to 91)
+        90    jump +26                           (to 116)
 
-  204   95    load_var 6                         (system)
-        96    container_len                      
-        97    store_var 15                       (_55)
-        98    load_var 15                        (_55)
-        99    load_const 10                      (0)
-        100   cmp_int_op >                       
-        101   pop_jump_if_false +8               (to 109)
+  204   91    load_var 6                         (system)
+        92    container_len                      
+        93    store_var 14                       (_56)
+        94    load_var 14                        (_56)
+        95    load_const 10                      (0)
+        96    cmp_int_op >                       
+        97    pop_jump_if_false +8               (to 105)
 
-  205   102   load_type 6                        
-        103   load_type 7                        
-        104   load_var 10                        (body)
-        105   load_const 14                      ("system")
-        106   load_var 6                         (system)
-        107   call 37 ntypeargs=2                (baml.Map.set)
-        108   pop 1                              
+  205   98    load_type 6                        
+        99    load_type 7                        
+        100   load_var 10                        (body)
+        101   load_const 14                      ("system")
+        102   load_var 6                         (system)
+        103   call 37 ntypeargs=2                (baml.Map.set)
+        104   pop 1                              
 
-  210   109   load_var 7                         (lowered)
-        110   call 890 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
-        111   store_var 16                       (_61)
-        112   load_type 6                        
-        113   load_type 7                        
-        114   load_var 10                        (body)
-        115   load_const 15                      ("messages")
-        116   load_var 16                        (_61)
-        117   call 37 ntypeargs=2                (baml.Map.set)
-        118   pop 1                              
-        119   jump +19                           (to 138)
+  210   105   load_var 7                         (lowered)
+        106   call 890 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        107   store_var 15                       (_62)
+        108   load_type 6                        
+        109   load_type 7                        
+        110   load_var 10                        (body)
+        111   load_const 15                      ("messages")
+        112   load_var 15                        (_62)
+        113   call 37 ntypeargs=2                (baml.Map.set)
+        114   pop 1                              
+        115   jump +19                           (to 134)
 
-  201   120   load_type 5                        
+  201   116   load_type 5                        
 
-  200   121   load_const 16                      ("user")
-        122   load_const 17                      (false)
-        123   load_var 6                         (system)
-        124   init_instance 0                    (anthropic.internal.AnthropicMessage .role, .tool_results, .blocks)
-        125   load_type 5                        
-        126   alloc_array 1                      
+  200   117   load_const 16                      ("user")
+        118   load_const 17                      (false)
+        119   load_var 6                         (system)
+        120   init_instance 0                    (anthropic.internal.AnthropicMessage .role, .tool_results, .blocks)
+        121   load_type 5                        
+        122   alloc_array 1                      
 
-  201   127   load_var 7                         (lowered)
-        128   call 7 ntypeargs=1                 (baml.Array.concat)
-        129   call 890 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
-        130   store_var 14                       (_46)
-        131   load_type 6                        
-        132   load_type 7                        
-        133   load_var 10                        (body)
-        134   load_const 18                      ("messages")
-        135   load_var 14                        (_46)
-        136   call 37 ntypeargs=2                (baml.Map.set)
-        137   pop 1                              
+  201   123   load_var 7                         (lowered)
+        124   call 7 ntypeargs=1                 (baml.Array.concat)
+        125   call 890 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        126   store_var 13                       (_47)
+        127   load_type 6                        
+        128   load_type 7                        
+        129   load_var 10                        (body)
+        130   load_const 18                      ("messages")
+        131   load_var 13                        (_47)
+        132   call 37 ntypeargs=2                (baml.Map.set)
+        133   pop 1                              
 
-  213   138   load_var 2                         (input)
-        139   load_field 2                       (toolbox)
-        140   call 823 ntypeargs=0               (ai.tools.Toolbox.is_empty)
-        141   unary_op !                         
-        142   pop_jump_if_false +80              (to 222)
+  213   134   load_var 2                         (input)
+        135   load_field 2                       (toolbox)
+        136   call 823 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        137   unary_op !                         
+        138   pop_jump_if_false +80              (to 218)
 
-  214   143   load_type 19                       
-        144   alloc_array 0                      
-        145   store_var 17                       (tools)
+  214   139   load_type 19                       
+        140   alloc_array 0                      
+        141   store_var 16                       (tools)
 
-  215   146   load_var 2                         (input)
-        147   load_field 2                       (toolbox)
-        148   call 821 ntypeargs=0               (ai.tools.Toolbox.list)
-        149   load_type 20                       
-        150   load_const 21                      ("iter")
-        151   virtual_call nargs=1 ntypeargs=0   
-        152   store_var 18                       (_71)
-        153   load_var 18                        (_71)
-        154   load_type 22                       
-        155   load_const 23                      ("next")
-        156   virtual_call nargs=1 ntypeargs=0   
-        157   store_var 19                       (_72)
-        158   load_var 19                        (_72)
-        159   is_type 4                          
-        160   pop_jump_if_false +2               (to 162)
-        161   jump +36                           (to 197)
-        162   load_var 19                        (_72)
-        163   store_var 20                       (t)
+  215   142   load_var 2                         (input)
+        143   load_field 2                       (toolbox)
+        144   call 821 ntypeargs=0               (ai.tools.Toolbox.list)
+        145   load_type 20                       
+        146   load_const 21                      ("iter")
+        147   virtual_call nargs=1 ntypeargs=0   
+        148   store_var 17                       (_72)
+        149   load_var 17                        (_72)
+        150   load_type 22                       
+        151   load_const 23                      ("next")
+        152   virtual_call nargs=1 ntypeargs=0   
+        153   store_var 18                       (_73)
+        154   load_var 18                        (_73)
+        155   is_type 4                          
+        156   pop_jump_if_false +2               (to 158)
+        157   jump +36                           (to 193)
+        158   load_var 18                        (_73)
+        159   store_var 19                       (t)
 
-  216   164   load_type 6                        
+  216   160   load_type 6                        
+        161   load_type 7                        
+        162   alloc_map 0                        
+        163   store_var 20                       (tw)
+
+  217   164   load_type 6                        
         165   load_type 7                        
-        166   alloc_map 0                        
-        167   store_var 21                       (tw)
+        166   load_var 20                        (tw)
+        167   load_const 24                      ("name")
+        168   load_var 19                        (t)
+        169   load_field 0                       (name)
+        170   call 37 ntypeargs=2                (baml.Map.set)
+        171   pop 1                              
 
-  217   168   load_type 6                        
-        169   load_type 7                        
-        170   load_var 21                        (tw)
-        171   load_const 24                      ("name")
-        172   load_var 20                        (t)
-        173   load_field 0                       (name)
-        174   call 37 ntypeargs=2                (baml.Map.set)
-        175   pop 1                              
+  218   172   load_type 6                        
+        173   load_type 7                        
+        174   load_var 20                        (tw)
+        175   load_const 25                      ("description")
+        176   load_var 19                        (t)
+        177   load_field 1                       (description)
+        178   call 37 ntypeargs=2                (baml.Map.set)
+        179   pop 1                              
 
-  218   176   load_type 6                        
-        177   load_type 7                        
-        178   load_var 21                        (tw)
-        179   load_const 25                      ("description")
-        180   load_var 20                        (t)
-        181   load_field 1                       (description)
-        182   call 37 ntypeargs=2                (baml.Map.set)
-        183   pop 1                              
+  219   180   load_type 6                        
+        181   load_type 7                        
+        182   load_var 20                        (tw)
+        183   load_const 26                      ("input_schema")
+        184   load_var 19                        (t)
+        185   load_field 2                       (input_schema)
+        186   call 37 ntypeargs=2                (baml.Map.set)
+        187   pop 1                              
 
-  219   184   load_type 6                        
-        185   load_type 7                        
-        186   load_var 21                        (tw)
-        187   load_const 26                      ("input_schema")
-        188   load_var 20                        (t)
-        189   load_field 2                       (input_schema)
-        190   call 37 ntypeargs=2                (baml.Map.set)
+  220   188   load_type 19                       
+        189   load_var2 16 20                    
+        190   call 4 ntypeargs=1                 (baml.Array.push)
         191   pop 1                              
+        192   jump -43                           (to 149)
 
-  220   192   load_type 19                       
-        193   load_var2 17 21                    
-        194   call 4 ntypeargs=1                 (baml.Array.push)
-        195   pop 1                              
-        196   jump -43                           (to 153)
+  222   193   load_type 6                        
+        194   load_type 7                        
+        195   alloc_map 0                        
+        196   store_var 21                       (tc)
 
-  222   197   load_type 6                        
+  223   197   load_type 6                        
         198   load_type 7                        
-        199   alloc_map 0                        
-        200   store_var 22                       (tc)
+        199   load_var 21                        (tc)
+        200   load_const 27                      ("type")
+        201   load_const 28                      ("auto")
+        202   call 37 ntypeargs=2                (baml.Map.set)
+        203   pop 1                              
 
-  223   201   load_type 6                        
-        202   load_type 7                        
-        203   load_var 22                        (tc)
-        204   load_const 27                      ("type")
-        205   load_const 28                      ("auto")
-        206   call 37 ntypeargs=2                (baml.Map.set)
-        207   pop 1                              
+  224   204   load_type 6                        
+        205   load_type 7                        
+        206   load_var 10                        (body)
+        207   load_const 29                      ("tools")
+        208   load_var 16                        (tools)
+        209   call 37 ntypeargs=2                (baml.Map.set)
+        210   pop 1                              
 
-  224   208   load_type 6                        
-        209   load_type 7                        
-        210   load_var 10                        (body)
-        211   load_const 29                      ("tools")
-        212   load_var 17                        (tools)
-        213   call 37 ntypeargs=2                (baml.Map.set)
-        214   pop 1                              
+  225   211   load_type 6                        
+        212   load_type 7                        
+        213   load_var 10                        (body)
+        214   load_const 30                      ("tool_choice")
+        215   load_var 21                        (tc)
+        216   call 37 ntypeargs=2                (baml.Map.set)
+        217   pop 1                              
 
-  225   215   load_type 6                        
-        216   load_type 7                        
-        217   load_var 10                        (body)
-        218   load_const 30                      ("tool_choice")
-        219   load_var 22                        (tc)
-        220   call 37 ntypeargs=2                (baml.Map.set)
-        221   pop 1                              
+  231   218   load_var 3                         (stream)
+        219   pop_jump_if_false +8               (to 227)
 
-  231   222   load_var 3                         (stream)
-        223   pop_jump_if_false +8               (to 231)
+  232   220   load_type 6                        
+        221   load_type 7                        
+        222   load_var 10                        (body)
+        223   load_const 31                      ("stream")
+        224   load_const 32                      (true)
+        225   call 37 ntypeargs=2                (baml.Map.set)
+        226   pop 1                              
 
-  232   224   load_type 6                        
-        225   load_type 7                        
-        226   load_var 10                        (body)
-        227   load_const 31                      ("stream")
-        228   load_const 32                      (true)
-        229   call 37 ntypeargs=2                (baml.Map.set)
-        230   pop 1                              
+  238   227   load_var 1                         (c)
+        228   load_field 2                       (base_url)
+        229   store_var_load_var 22              (_109)
+        230   load_const 11                      (null)
+        231   cmp_op ==                          
+        232   pop_jump_if_false +3               (to 235)
+        233   load_const 33                      ("https://api.anthropic.com")
+        234   store_var 22                       (_109)
 
-  238   231   load_var 1                         (c)
-        232   load_field 2                       (base_url)
-        233   store_var 24                       (_108)
-        234   load_var 24                        (_108)
-        235   store_var 23                       (base)
-        236   load_var 24                        (_108)
-        237   load_const 11                      (null)
-        238   cmp_op ==                          
-        239   pop_jump_if_false +3               (to 242)
-        240   load_const 33                      ("https://api.anthropic.com")
-        241   store_var 23                       (base)
+  241   235   load_type 6                        
 
-  241   242   load_type 6                        
-        243   load_var 23                        (base)
-        244   call 138 ntypeargs=1               (baml.String.from)
-        245   store_var 25                       (_111)
+  238   236   load_var 22                        (_109)
+        237   call 138 ntypeargs=1               (baml.String.from)
+        238   store_var 23                       (_113)
 
-  243   246   load_var 1                         (c)
-        247   load_field 1                       (api_key)
-        248   store_var 27                       (_116)
-        249   load_var2 27 27                    
-        250   load_const 11                      (null)
-        251   cmp_op ==                          
-        252   pop_jump_if_false +3               (to 255)
-        253   load_const 34                      ("ANTHROPIC_API_KEY")
-        254   call 211 ntypeargs=0               (baml.env.get_or_panic)
+  243   239   load_var 1                         (c)
+        240   load_field 1                       (api_key)
+        241   store_var_load_var 25              (_118)
+        242   load_const 11                      (null)
+        243   cmp_op ==                          
+        244   pop_jump_if_false +4               (to 248)
+        245   load_const 34                      ("ANTHROPIC_API_KEY")
+        246   call 211 ntypeargs=0               (baml.env.get_or_panic)
+        247   store_var 25                       (_118)
+        248   load_var 25                        (_118)
+        249   load_const 35                      ("2023-06-01")
+        250   load_const 36                      ("application/json")
+        251   load_const 37                      ("x-api-key")
+        252   load_const 38                      ("anthropic-version")
+        253   load_const 39                      ("content-type")
+        254   load_type 6                        
+        255   load_type 6                        
+        256   alloc_map 3                        
+        257   store_var 24                       (_116)
 
-  242   255   load_const 35                      ("2023-06-01")
-        256   load_const 36                      ("application/json")
-        257   load_const 37                      ("x-api-key")
-        258   load_const 38                      ("anthropic-version")
-        259   load_const 39                      ("content-type")
-        260   load_type 6                        
-        261   load_type 6                        
-        262   alloc_map 3                        
-        263   store_var 26                       (_114)
+  247   258   load_type 19                       
+        259   load_var 10                        (body)
+        260   call 331 ntypeargs=1               (baml.json.to_json)
+        261   call 328 ntypeargs=0               (baml.json.stringify)
+        262   store_var 26                       (_121)
 
-  247   264   load_type 19                       
-        265   load_var 10                        (body)
-        266   call 331 ntypeargs=1               (baml.json.to_json)
-        267   call 328 ntypeargs=0               (baml.json.stringify)
-        268   store_var 28                       (_118)
+  239   263   load_const 40                      ("POST")
 
-  239   269   load_const 40                      ("POST")
-
-  241   270   load_var 25                        (_111)
-        271   load_const 41                      ("/v1/messages")
-        272   bin_op +                           
-        273   load_var2 26 28                    
-        274   init_instance 1                    (baml.http.Request .method, .url, .headers, .body)
-        275   return                             
+  241   264   load_var 23                        (_113)
+        265   load_const 41                      ("/v1/messages")
+        266   bin_op +                           
+        267   load_var2 24 26                    
+        268   init_instance 1                    (baml.http.Request .method, .url, .headers, .body)
+        269   return                             
 }
 
 function anthropic.internal._anthropic_stop_reason(s: string) -> ai.content.StopReason {
@@ -4546,7 +4512,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         23    load_var 7                         (_10)
         24    is_type 8                          
         25    pop_jump_if_false +2               (to 27)
-        26    jump +95                           (to 121)
+        26    jump +84                           (to 110)
         27    load_var 7                         (_10)
         28    store_var_load_var 8               (b)
 
@@ -4554,14 +4520,14 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         30    load_const 9                       ("text")
         31    cmp_op ==                          
         32    pop_jump_if_false +2               (to 34)
-        33    jump +71                           (to 104)
+        33    jump +63                           (to 96)
 
   274   34    load_var 8                         (b)
         35    load_field 0                       (type)
         36    load_const 10                      ("thinking")
         37    cmp_op ==                          
         38    pop_jump_if_false +2               (to 40)
-        39    jump +48                           (to 87)
+        39    jump +43                           (to 82)
 
   277   40    load_var 8                         (b)
         41    load_field 0                       (type)
@@ -4571,132 +4537,122 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
 
   281   45    load_var 8                         (b)
         46    load_field 3                       (id)
-        47    store_var 14                       (_36)
-        48    load_var 14                        (_36)
-        49    store_var 13                       (_35)
-        50    load_var 14                        (_36)
-        51    load_const 12                      (null)
-        52    cmp_op ==                          
-        53    pop_jump_if_false +3               (to 56)
-        54    load_const 13                      ("")
-        55    store_var 13                       (_35)
+        47    store_var_load_var 12              (_38)
+        48    load_const 12                      (null)
+        49    cmp_op ==                          
+        50    pop_jump_if_false +3               (to 53)
+        51    load_const 13                      ("")
+        52    store_var 12                       (_38)
+        53    load_var 12                        (_38)
+        54    store_var 11                       (_37)
 
-  282   56    load_var 8                         (b)
-        57    load_field 4                       (name)
-        58    store_var 16                       (_39)
-        59    load_var 16                        (_39)
-        60    store_var 15                       (_38)
-        61    load_var 16                        (_39)
-        62    load_const 12                      (null)
-        63    cmp_op ==                          
-        64    pop_jump_if_false +3               (to 67)
-        65    load_const 14                      ("")
-        66    store_var 15                       (_38)
+  282   55    load_var 8                         (b)
+        56    load_field 4                       (name)
+        57    store_var_load_var 14              (_42)
+        58    load_const 12                      (null)
+        59    cmp_op ==                          
+        60    pop_jump_if_false +3               (to 63)
+        61    load_const 14                      ("")
+        62    store_var 14                       (_42)
+        63    load_var 14                        (_42)
+        64    store_var 13                       (_41)
 
-  283   67    load_var 8                         (b)
-        68    load_field 5                       (input)
-        69    store_var 18                       (_42)
-        70    load_var 18                        (_42)
-        71    store_var 17                       (_41)
-        72    load_var 18                        (_42)
-        73    load_const 12                      (null)
-        74    cmp_op ==                          
-        75    pop_jump_if_false +5               (to 80)
+  283   65    load_var 8                         (b)
+        66    load_field 5                       (input)
+        67    store_var_load_var 15              (_46)
+        68    load_const 12                      (null)
+        69    cmp_op ==                          
+        70    pop_jump_if_false +5               (to 75)
 
-  278   76    load_type 15                       
-        77    load_type 16                       
-        78    alloc_map 0                        
-        79    store_var 17                       (_41)
+  278   71    load_type 15                       
+        72    load_type 16                       
+        73    alloc_map 0                        
+        74    store_var 15                       (_46)
 
-  279   80    load_type 3                        
-        81    load_var2 5 13                     
+  279   75    load_type 3                        
+        76    load_var2 5 11                     
 
-  280   82    load_var2 15 17                    
-        83    init_instance 0                    (ai.content.ToolUse .id, .name, .args)
-        84    call 4 ntypeargs=1                 (baml.Array.push)
-        85    pop 1                              
-        86    jump -68                           (to 18)
+  280   77    load_var2 13 15                    
 
-  275   87    load_var 8                         (b)
-        88    load_field 2                       (thinking)
-        89    store_var 12                       (_27)
-        90    load_var 12                        (_27)
-        91    store_var 11                       (_26)
-        92    load_var 12                        (_27)
-        93    load_const 12                      (null)
-        94    cmp_op ==                          
-        95    pop_jump_if_false +3               (to 98)
-        96    load_const 17                      ("")
-        97    store_var 11                       (_26)
-        98    load_type 3                        
-        99    load_var2 5 11                     
-        100   init_instance 1                    (ai.content.Reasoning .summary)
-        101   call 4 ntypeargs=1                 (baml.Array.push)
-        102   pop 1                              
-        103   jump -85                           (to 18)
+  283   78    init_instance 0                    (ai.content.ToolUse .id, .name, .args)
+        79    call 4 ntypeargs=1                 (baml.Array.push)
+        80    pop 1                              
+        81    jump -63                           (to 18)
 
-  272   104   load_var 8                         (b)
-        105   load_field 1                       (text)
-        106   store_var 10                       (_19)
-        107   load_var 10                        (_19)
-        108   store_var 9                        (_18)
-        109   load_var 10                        (_19)
-        110   load_const 12                      (null)
-        111   cmp_op ==                          
-        112   pop_jump_if_false +3               (to 115)
-        113   load_const 18                      ("")
-        114   store_var 9                        (_18)
-        115   load_type 3                        
-        116   load_var2 5 9                      
-        117   init_instance 2                    (ai.content.Text .text)
-        118   call 4 ntypeargs=1                 (baml.Array.push)
-        119   pop 1                              
-        120   jump -102                          (to 18)
+  275   82    load_var 8                         (b)
+        83    load_field 2                       (thinking)
+        84    store_var_load_var 10              (_28)
+        85    load_const 12                      (null)
+        86    cmp_op ==                          
+        87    pop_jump_if_false +3               (to 90)
+        88    load_const 17                      ("")
+        89    store_var 10                       (_28)
+        90    load_type 3                        
+        91    load_var2 5 10                     
+        92    init_instance 1                    (ai.content.Reasoning .summary)
+        93    call 4 ntypeargs=1                 (baml.Array.push)
+        94    pop 1                              
+        95    jump -77                           (to 18)
 
-  292   121   load_var 4                         (resp)
-        122   load_field 1                       (stop_reason)
-        123   store_var_load_var 20              (_46)
-        124   load_const 12                      (null)
-        125   cmp_op ==                          
-        126   pop_jump_if_false +2               (to 128)
-        127   jump +5                            (to 132)
-        128   load_var 20                        (_46)
-        129   call 892 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
-        130   store_var 19                       (stop)
-        131   jump +4                            (to 135)
+  272   96    load_var 8                         (b)
+        97    load_field 1                       (text)
+        98    store_var_load_var 9               (_19)
+        99    load_const 12                      (null)
+        100   cmp_op ==                          
+        101   pop_jump_if_false +3               (to 104)
+        102   load_const 18                      ("")
+        103   store_var 9                        (_19)
+        104   load_type 3                        
+        105   load_var2 5 9                      
+        106   init_instance 2                    (ai.content.Text .text)
+        107   call 4 ntypeargs=1                 (baml.Array.push)
+        108   pop 1                              
+        109   jump -91                           (to 18)
 
-  293   132   load_const 19                      (ai.content.StopReason.Complete)
-        133   alloc_variant 436                  (ai.content.StopReason)
-        134   store_var 19                       (stop)
+  292   110   load_var 4                         (resp)
+        111   load_field 1                       (stop_reason)
+        112   store_var_load_var 17              (_51)
+        113   load_const 12                      (null)
+        114   cmp_op ==                          
+        115   pop_jump_if_false +2               (to 117)
+        116   jump +5                            (to 121)
+        117   load_var 17                        (_51)
+        118   call 892 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+        119   store_var 16                       (stop)
+        120   jump +4                            (to 124)
 
-  297   135   load_var 4                         (resp)
-        136   load_field 2                       (usage)
-        137   store_var 22                       (_52)
-        138   load_var 22                        (_52)
-        139   narrow_bind 20 22                  
-        140   pop_jump_if_false +2               (to 142)
-        141   jump +4                            (to 145)
+  293   121   load_const 19                      (ai.content.StopReason.Complete)
+        122   alloc_variant 436                  (ai.content.StopReason)
+        123   store_var 16                       (stop)
 
-  306   142   load_const 12                      (null)
-        143   store_var 21                       (usage)
+  297   124   load_var 4                         (resp)
+        125   load_field 2                       (usage)
+        126   store_var 19                       (_57)
+        127   load_var 19                        (_57)
+        128   narrow_bind 20 19                  
+        129   pop_jump_if_false +2               (to 131)
+        130   jump +4                            (to 134)
 
-  297   144   jump +10                           (to 154)
-        145   load_var 22                        (_52)
-        146   store_var_load_var 23              (u)
+  306   131   load_const 12                      (null)
+        132   store_var 18                       (usage)
 
-  300   147   load_field 0                       (input_tokens)
+  297   133   jump +10                           (to 143)
+        134   load_var 19                        (_57)
+        135   store_var_load_var 20              (u)
 
-  301   148   load_var 23                        (u)
-        149   load_field 1                       (output_tokens)
-        150   load_const 12                      (null)
-        151   load_const 12                      (null)
-        152   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
-        153   store_var 21                       (usage)
+  300   136   load_field 0                       (input_tokens)
 
-  309   154   load_var2 5 19                     
-        155   load_var 21                        (usage)
-        156   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
-        157   return                             
+  301   137   load_var 20                        (u)
+        138   load_field 1                       (output_tokens)
+        139   load_const 12                      (null)
+        140   load_const 12                      (null)
+        141   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
+        142   store_var 18                       (usage)
+
+  309   143   load_var2 5 16                     
+        144   load_var 18                        (usage)
+        145   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
+        146   return                             
 }
 
 function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
@@ -5033,23 +4989,23 @@ function claude_code.ClaudeCodeClient.new(model: string, executable: string, cwd
        42   store_var 7            (mcp_servers)
 
   34   43   load_var 7             (mcp_servers)
-       44   store_var 8            (_16)
-       45   load_var 7             (mcp_servers)
-       46   load_const 3           (null)
-       47   cmp_op ==              
-       48   pop_jump_if_false +5   (to 53)
+       44   store_var_load_var 8   (_17)
+       45   load_const 3           (null)
+       46   cmp_op ==              
+       47   pop_jump_if_false +5   (to 52)
 
-  26   49   load_type 6            
-       50   load_type 7            
-       51   alloc_map 0            
-       52   store_var 8            (_16)
+  26   48   load_type 6            
+       49   load_type 7            
+       50   alloc_map 0            
+       51   store_var 8            (_17)
 
-  27   53   load_var2 2 1          
-       54   load_var2 3 4          
-       55   load_var2 5 6          
-       56   load_var 8             (_16)
-       57   init_instance 0        (claude_code.ClaudeCodeClient .executable, .model, .cwd, .timeout_ms, .permission_mode, .harness_tools, .mcp_servers)
-       58   return                 
+  27   52   load_var2 2 1          
+       53   load_var2 3 4          
+       54   load_var2 5 6          
+
+  34   55   load_var 8             (_17)
+       56   init_instance 0        (claude_code.ClaudeCodeClient .executable, .model, .cwd, .timeout_ms, .permission_mode, .harness_tools, .mcp_servers)
+       57   return                 
 }
 
 function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
@@ -6976,7 +6932,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         14    load_var 4                         (_5)
         15    is_type 5                          
         16    pop_jump_if_false +2               (to 18)
-        17    jump +234                          (to 251)
+        17    jump +225                          (to 242)
         18    load_var 4                         (_5)
         19    load_field 1                       (data)
         20    store_var 5                        (_10)
@@ -7022,234 +6978,225 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         52    load_const 8                       (null)
         53    cmp_op ==                          
         54    pop_jump_if_false +2               (to 56)
-        55    jump +17                           (to 72)
+        55    jump +16                           (to 71)
         56    load_var 9                         (cand)
         57    load_field 0                       (0)
         58    load_const 8                       (null)
         59    cmp_op ==                          
         60    pop_jump_if_false +2               (to 62)
-        61    jump +11                           (to 72)
+        61    jump +10                           (to 71)
         62    load_var 9                         (cand)
         63    load_const 8                       (null)
         64    cmp_op ==                          
         65    pop_jump_if_false +2               (to 67)
-        66    jump +6                            (to 72)
+        66    jump +5                            (to 71)
         67    load_var 9                         (cand)
         68    load_field 0                       (0)
         69    load_field 0                       (0)
-        70    store_var 11                       (_24)
-        71    jump +3                            (to 74)
-        72    load_const 8                       (null)
-        73    store_var 11                       (_24)
-        74    load_var 11                        (_24)
-        75    store_var 10                       (parts)
-        76    load_var 11                        (_24)
-        77    load_const 8                       (null)
-        78    cmp_op ==                          
-        79    pop_jump_if_false +4               (to 83)
-        80    load_type 11                       
-        81    alloc_array 0                      
-        82    store_var 10                       (parts)
+        70    jump +2                            (to 72)
+        71    load_const 8                       (null)
+        72    store_var_load_var 10              (_24)
+        73    load_const 8                       (null)
+        74    cmp_op ==                          
+        75    pop_jump_if_false +4               (to 79)
+        76    load_type 11                       
+        77    alloc_array 0                      
+        78    store_var 10                       (_24)
+        79    load_var 10                        (_24)
+        80    load_type 12                       
+        81    load_const 13                      ("iter")
+        82    virtual_call nargs=1 ntypeargs=0   
+        83    store_var 11                       (_37)
 
-  376   83    load_var 10                        (parts)
-        84    load_type 12                       
-        85    load_const 13                      ("iter")
-        86    virtual_call nargs=1 ntypeargs=0   
-        87    store_var 12                       (_36)
-        88    load_var 12                        (_36)
-        89    load_type 14                       
-        90    load_const 15                      ("next")
-        91    virtual_call nargs=1 ntypeargs=0   
-        92    store_var 13                       (_37)
-        93    load_var 13                        (_37)
-        94    is_type 5                          
-        95    pop_jump_if_false +2               (to 97)
-        96    jump +30                           (to 126)
-        97    load_var 13                        (_37)
-        98    store_var_load_var 14              (p)
+  376   84    load_var 11                        (_37)
+        85    load_type 14                       
+        86    load_const 15                      ("next")
+        87    virtual_call nargs=1 ntypeargs=0   
+        88    store_var 12                       (_38)
+        89    load_var 12                        (_38)
+        90    is_type 5                          
+        91    pop_jump_if_false +2               (to 93)
+        92    jump +27                           (to 119)
+        93    load_var 12                        (_38)
+        94    store_var_load_var 13              (p)
 
-  377   99    load_field 0                       (text)
-        100   store_var 15                       (_42)
-        101   load_var 15                        (_42)
-        102   narrow_bind 6 15                   
-        103   pop_jump_if_false -15              (to 88)
-        104   load_var 15                        (_42)
-        105   store_var 16                       (t)
+  377   95    load_field 0                       (text)
+        96    store_var 14                       (_43)
+        97    load_var 14                        (_43)
+        98    narrow_bind 6 14                   
+        99    pop_jump_if_false -15              (to 84)
+        100   load_var 14                        (_43)
+        101   store_var 15                       (t)
 
-  378   106   load_var 14                        (p)
-        107   load_field 1                       (thought)
-        108   store_var 18                       (_45)
-        109   load_var 18                        (_45)
-        110   store_var 17                       (_44)
-        111   load_var 18                        (_45)
-        112   load_const 8                       (null)
-        113   cmp_op ==                          
-        114   pop_jump_if_false +3               (to 117)
-        115   load_const 16                      (false)
-        116   store_var 17                       (_44)
-        117   load_var 17                        (_44)
-        118   pop_jump_if_false +2               (to 120)
-        119   jump -31                           (to 88)
+  378   102   load_var 13                        (p)
+        103   load_field 1                       (thought)
+        104   store_var_load_var 16              (_46)
+        105   load_const 8                       (null)
+        106   cmp_op ==                          
+        107   pop_jump_if_false +3               (to 110)
+        108   load_const 16                      (false)
+        109   store_var 16                       (_46)
+        110   load_var 16                        (_46)
+        111   pop_jump_if_false +2               (to 113)
+        112   jump -28                           (to 84)
 
-  381   120   load_type 0                        
-        121   load_var2 2 16                     
-        122   init_instance 0                    (ai.stream.TextDelta .text)
-        123   call 4 ntypeargs=1                 (baml.Array.push)
-        124   pop 1                              
-        125   jump -37                           (to 88)
+  381   113   load_type 0                        
+        114   load_var2 2 15                     
+        115   init_instance 0                    (ai.stream.TextDelta .text)
+        116   call 4 ntypeargs=1                 (baml.Array.push)
+        117   pop 1                              
+        118   jump -34                           (to 84)
 
-  388   126   load_var 9                         (cand)
+  388   119   load_var 9                         (cand)
+        120   load_const 8                       (null)
+        121   cmp_op ==                          
+        122   pop_jump_if_false +2               (to 124)
+        123   jump +4                            (to 127)
+        124   load_var 9                         (cand)
+        125   load_field 1                       (1)
+        126   jump +2                            (to 128)
         127   load_const 8                       (null)
-        128   cmp_op ==                          
-        129   pop_jump_if_false +2               (to 131)
-        130   jump +5                            (to 135)
-        131   load_var 9                         (cand)
-        132   load_field 1                       (1)
-        133   store_var 20                       (_52)
-        134   jump +3                            (to 137)
-        135   load_const 8                       (null)
-        136   store_var 20                       (_52)
-        137   load_var 20                        (_52)
-        138   store_var 19                       (finish)
-        139   load_var 20                        (_52)
-        140   load_const 8                       (null)
-        141   cmp_op ==                          
-        142   pop_jump_if_false +3               (to 145)
-        143   load_const 17                      ("")
-        144   store_var 19                       (finish)
+        128   store_var_load_var 18              (_54)
+        129   load_const 8                       (null)
+        130   cmp_op ==                          
+        131   pop_jump_if_false +3               (to 134)
+        132   load_const 17                      ("")
+        133   store_var 18                       (_54)
+        134   load_var 18                        (_54)
+        135   store_var 17                       (finish)
 
-  389   145   load_var 8                         (resp)
-        146   load_field 2                       (promptFeedback)
+  389   136   load_var 8                         (resp)
+        137   load_field 2                       (promptFeedback)
+        138   load_const 8                       (null)
+        139   cmp_op ==                          
+        140   pop_jump_if_false +2               (to 142)
+        141   jump +5                            (to 146)
+        142   load_var 8                         (resp)
+        143   load_field 2                       (promptFeedback)
+        144   load_field 0                       (0)
+        145   jump +2                            (to 147)
+        146   load_const 8                       (null)
         147   load_const 8                       (null)
-        148   cmp_op ==                          
-        149   pop_jump_if_false +2               (to 151)
-        150   jump +5                            (to 155)
-        151   load_var 8                         (resp)
-        152   load_field 2                       (promptFeedback)
-        153   load_field 0                       (0)
-        154   jump +2                            (to 156)
-        155   load_const 8                       (null)
-        156   load_const 8                       (null)
-        157   call 653 ntypeargs=0               (baml.ops.equals_equals)
-        158   store_var 21                       (_62)
+        148   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        149   store_var 19                       (_65)
 
-  390   159   load_var 19                        (finish)
-        160   load_const 18                      ("MAX_TOKENS")
-        161   cmp_op ==                          
-        162   pop_jump_if_false +2               (to 164)
-        163   jump +39                           (to 202)
+  390   150   load_var 17                        (finish)
+        151   load_const 18                      ("MAX_TOKENS")
+        152   cmp_op ==                          
+        153   pop_jump_if_false +2               (to 155)
+        154   jump +39                           (to 193)
 
-  389   164   load_var 21                        (_62)
-        165   unary_op !                         
-        166   jump_if_false +2                   (to 168)
-        167   jump +5                            (to 172)
-        168   pop 1                              
+  389   155   load_var 19                        (_65)
+        156   unary_op !                         
+        157   jump_if_false +2                   (to 159)
+        158   jump +5                            (to 163)
+        159   pop 1                              
 
-  394   169   load_var 19                        (finish)
-        170   load_const 19                      ("SAFETY")
-        171   cmp_op ==                          
+  394   160   load_var 17                        (finish)
+        161   load_const 19                      ("SAFETY")
+        162   cmp_op ==                          
 
-  393   172   jump_if_false +2                   (to 174)
-        173   jump +5                            (to 178)
-        174   pop 1                              
+  393   163   jump_if_false +2                   (to 165)
+        164   jump +5                            (to 169)
+        165   pop 1                              
 
-  395   175   load_var 19                        (finish)
-        176   load_const 20                      ("RECITATION")
-        177   cmp_op ==                          
+  395   166   load_var 17                        (finish)
+        167   load_const 20                      ("RECITATION")
+        168   cmp_op ==                          
 
-  393   178   jump_if_false +2                   (to 180)
-        179   jump +5                            (to 184)
-        180   pop 1                              
+  393   169   jump_if_false +2                   (to 171)
+        170   jump +5                            (to 175)
+        171   pop 1                              
 
-  396   181   load_var 19                        (finish)
-        182   load_const 21                      ("PROHIBITED_CONTENT")
-        183   cmp_op ==                          
+  396   172   load_var 17                        (finish)
+        173   load_const 21                      ("PROHIBITED_CONTENT")
+        174   cmp_op ==                          
 
-  392   184   pop_jump_if_false +2               (to 186)
-        185   jump +13                           (to 198)
+  392   175   pop_jump_if_false +2               (to 177)
+        176   jump +13                           (to 189)
 
-  399   186   load_var 19                        (finish)
-        187   load_const 22                      ("")
-        188   cmp_op !=                          
-        189   pop_jump_if_false +2               (to 191)
-        190   jump +4                            (to 194)
+  399   177   load_var 17                        (finish)
+        178   load_const 22                      ("")
+        179   cmp_op !=                          
+        180   pop_jump_if_false +2               (to 182)
+        181   jump +4                            (to 185)
 
-  402   191   load_const 8                       (null)
-        192   store_var 22                       (stop)
+  402   182   load_const 8                       (null)
+        183   store_var 20                       (stop)
 
-  399   193   jump +12                           (to 205)
+  399   184   jump +12                           (to 196)
 
-  400   194   load_const 10                      (ai.content.StopReason.Complete)
-        195   alloc_variant 436                  (ai.content.StopReason)
-        196   store_var 22                       (stop)
+  400   185   load_const 10                      (ai.content.StopReason.Complete)
+        186   alloc_variant 436                  (ai.content.StopReason)
+        187   store_var 20                       (stop)
 
-  399   197   jump +8                            (to 205)
+  399   188   jump +8                            (to 196)
 
-  398   198   load_const 23                      (ai.content.StopReason.Refused)
-        199   alloc_variant 436                  (ai.content.StopReason)
-        200   store_var 22                       (stop)
+  398   189   load_const 23                      (ai.content.StopReason.Refused)
+        190   alloc_variant 436                  (ai.content.StopReason)
+        191   store_var 20                       (stop)
 
-  392   201   jump +4                            (to 205)
+  392   192   jump +4                            (to 196)
 
-  391   202   load_const 24                      (ai.content.StopReason.MaxTokens)
-        203   alloc_variant 436                  (ai.content.StopReason)
-        204   store_var 22                       (stop)
+  391   193   load_const 24                      (ai.content.StopReason.MaxTokens)
+        194   alloc_variant 436                  (ai.content.StopReason)
+        195   store_var 20                       (stop)
 
-  404   205   load_var 8                         (resp)
-        206   load_field 1                       (usageMetadata)
-        207   store_var 23                       (usage)
+  404   196   load_var 8                         (resp)
+        197   load_field 1                       (usageMetadata)
+        198   store_var 21                       (usage)
 
-  405   208   load_var 22                        (stop)
-        209   load_const 8                       (null)
-        210   call 653 ntypeargs=0               (baml.ops.equals_equals)
-        211   unary_op !                         
-        212   jump_if_false +2                   (to 214)
-        213   jump +6                            (to 219)
-        214   pop 1                              
-        215   load_var 23                        (usage)
-        216   load_const 8                       (null)
-        217   call 653 ntypeargs=0               (baml.ops.equals_equals)
-        218   unary_op !                         
-        219   pop_jump_if_false -210             (to 9)
+  405   199   load_var 20                        (stop)
+        200   load_const 8                       (null)
+        201   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        202   unary_op !                         
+        203   jump_if_false +2                   (to 205)
+        204   jump +6                            (to 210)
+        205   pop 1                              
+        206   load_var 21                        (usage)
+        207   load_const 8                       (null)
+        208   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        209   unary_op !                         
+        210   pop_jump_if_false -201             (to 9)
 
-  408   220   load_var 22                        (stop)
-        221   store_var 24                       (_84)
+  408   211   load_var 20                        (stop)
+        212   store_var 22                       (_87)
 
-  409   222   load_var 23                        (usage)
-        223   load_const 8                       (null)
-        224   cmp_op ==                          
-        225   pop_jump_if_false +2               (to 227)
-        226   jump +5                            (to 231)
-        227   load_var 23                        (usage)
-        228   load_field 0                       (0)
-        229   store_var 25                       (_85)
-        230   jump +3                            (to 233)
-        231   load_const 8                       (null)
-        232   store_var 25                       (_85)
+  409   213   load_var 21                        (usage)
+        214   load_const 8                       (null)
+        215   cmp_op ==                          
+        216   pop_jump_if_false +2               (to 218)
+        217   jump +5                            (to 222)
+        218   load_var 21                        (usage)
+        219   load_field 0                       (0)
+        220   store_var 23                       (_88)
+        221   jump +3                            (to 224)
+        222   load_const 8                       (null)
+        223   store_var 23                       (_88)
 
-  410   233   load_var 23                        (usage)
-        234   load_const 8                       (null)
-        235   cmp_op ==                          
-        236   pop_jump_if_false +2               (to 238)
-        237   jump +5                            (to 242)
-        238   load_var 23                        (usage)
-        239   load_field 1                       (1)
-        240   store_var 26                       (_89)
-        241   jump +3                            (to 244)
-        242   load_const 8                       (null)
-        243   store_var 26                       (_89)
+  410   224   load_var 21                        (usage)
+        225   load_const 8                       (null)
+        226   cmp_op ==                          
+        227   pop_jump_if_false +2               (to 229)
+        228   jump +5                            (to 233)
+        229   load_var 21                        (usage)
+        230   load_field 1                       (1)
+        231   store_var 24                       (_92)
+        232   jump +3                            (to 235)
+        233   load_const 8                       (null)
+        234   store_var 24                       (_92)
 
-  406   244   load_type 0                        
-        245   load_var2 2 24                     
+  406   235   load_type 0                        
+        236   load_var2 2 22                     
 
-  407   246   load_var2 25 26                    
-        247   init_instance 1                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
-        248   call 4 ntypeargs=1                 (baml.Array.push)
-        249   pop 1                              
-        250   jump -241                          (to 9)
+  407   237   load_var2 23 24                    
+        238   init_instance 1                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
+        239   call 4 ntypeargs=1                 (baml.Array.push)
+        240   pop 1                              
+        241   jump -232                          (to 9)
 
-  426   251   load_var 2                         (out)
-        252   return                             
+  426   242   load_var 2                         (out)
+        243   return                             
 }
 
 function google.internal._google_request(c: google.GoogleClient, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
@@ -7506,65 +7453,62 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   278   216   load_var 1                         (c)
         217   load_field 2                       (base_url)
-        218   store_var 25                       (_105)
-        219   load_var 25                        (_105)
-        220   store_var 24                       (_104)
-        221   load_var 25                        (_105)
-        222   load_const 29                      (null)
-        223   cmp_op ==                          
-        224   pop_jump_if_false +3               (to 227)
-        225   load_const 30                      ("https://generativelanguage.googleapis.com/v1beta")
-        226   store_var 24                       (_104)
-        227   load_type 6                        
-        228   load_var 24                        (_104)
-        229   call 138 ntypeargs=1               (baml.String.from)
-        230   store_var 23                       (_103)
-        231   load_type 6                        
-        232   load_var 1                         (c)
-        233   load_field 0                       (model)
-        234   call 138 ntypeargs=1               (baml.String.from)
-        235   store_var 26                       (_108)
-        236   load_type 6                        
-        237   load_var 22                        (method)
-        238   call 138 ntypeargs=1               (baml.String.from)
-        239   store_var 27                       (_111)
+        218   store_var_load_var 24              (_105)
+        219   load_const 29                      (null)
+        220   cmp_op ==                          
+        221   pop_jump_if_false +3               (to 224)
+        222   load_const 30                      ("https://generativelanguage.googleapis.com/v1beta")
+        223   store_var 24                       (_105)
+        224   load_type 6                        
+        225   load_var 24                        (_105)
+        226   call 138 ntypeargs=1               (baml.String.from)
+        227   store_var 23                       (_103)
+        228   load_type 6                        
+        229   load_var 1                         (c)
+        230   load_field 0                       (model)
+        231   call 138 ntypeargs=1               (baml.String.from)
+        232   store_var 25                       (_109)
+        233   load_type 6                        
+        234   load_var 22                        (method)
+        235   call 138 ntypeargs=1               (baml.String.from)
+        236   store_var 26                       (_112)
 
-  280   240   load_var 1                         (c)
-        241   load_field 1                       (api_key)
-        242   store_var 29                       (_116)
-        243   load_var2 29 29                    
-        244   load_const 29                      (null)
-        245   cmp_op ==                          
-        246   pop_jump_if_false +3               (to 249)
-        247   load_const 31                      ("GOOGLE_API_KEY")
-        248   call 211 ntypeargs=0               (baml.env.get_or_panic)
+  280   237   load_var 1                         (c)
+        238   load_field 1                       (api_key)
+        239   store_var_load_var 28              (_117)
+        240   load_const 29                      (null)
+        241   cmp_op ==                          
+        242   pop_jump_if_false +4               (to 246)
+        243   load_const 31                      ("GOOGLE_API_KEY")
+        244   call 211 ntypeargs=0               (baml.env.get_or_panic)
+        245   store_var 28                       (_117)
+        246   load_var 28                        (_117)
+        247   load_const 32                      ("application/json")
+        248   load_const 33                      ("x-goog-api-key")
+        249   load_const 34                      ("content-type")
+        250   load_type 6                        
+        251   load_type 6                        
+        252   alloc_map 2                        
+        253   store_var 27                       (_115)
 
-  279   249   load_const 32                      ("application/json")
-        250   load_const 33                      ("x-goog-api-key")
-        251   load_const 34                      ("content-type")
-        252   load_type 6                        
-        253   load_type 6                        
-        254   alloc_map 2                        
-        255   store_var 28                       (_114)
+  283   254   load_type 5                        
+        255   load_var 9                         (body)
+        256   call 331 ntypeargs=1               (baml.json.to_json)
+        257   call 328 ntypeargs=0               (baml.json.stringify)
+        258   store_var 29                       (_120)
 
-  283   256   load_type 5                        
-        257   load_var 9                         (body)
-        258   call 331 ntypeargs=1               (baml.json.to_json)
-        259   call 328 ntypeargs=0               (baml.json.stringify)
-        260   store_var 30                       (_118)
+  276   259   load_const 35                      ("POST")
 
-  276   261   load_const 35                      ("POST")
-
-  278   262   load_var 23                        (_103)
-        263   load_const 36                      ("/models/")
+  278   260   load_var 23                        (_103)
+        261   load_const 36                      ("/models/")
+        262   bin_op +                           
+        263   load_var 25                        (_109)
         264   bin_op +                           
-        265   load_var 26                        (_108)
+        265   load_var 26                        (_112)
         266   bin_op +                           
-        267   load_var 27                        (_111)
-        268   bin_op +                           
-        269   load_var2 28 30                    
-        270   init_instance 0                    (baml.http.Request .method, .url, .headers, .body)
-        271   return                             
+        267   load_var2 27 29                    
+        268   init_instance 0                    (baml.http.Request .method, .url, .headers, .body)
+        269   return                             
 }
 
 function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unknown>[] {
@@ -7985,290 +7929,277 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         23    load_const 3                       (null)
         24    cmp_op ==                          
         25    pop_jump_if_false +2               (to 27)
-        26    jump +5                            (to 31)
+        26    jump +4                            (to 30)
         27    load_var 6                         (cand)
         28    load_field 1                       (1)
-        29    store_var 8                        (_12)
-        30    jump +3                            (to 33)
-        31    load_const 3                       (null)
-        32    store_var 8                        (_12)
-        33    load_var 8                         (_12)
-        34    store_var 7                        (finish)
-        35    load_var 8                         (_12)
-        36    load_const 3                       (null)
-        37    cmp_op ==                          
-        38    pop_jump_if_false +3               (to 41)
-        39    load_const 4                       ("")
-        40    store_var 7                        (finish)
+        29    jump +2                            (to 31)
+        30    load_const 3                       (null)
+        31    store_var_load_var 8               (_12)
+        32    load_const 3                       (null)
+        33    cmp_op ==                          
+        34    pop_jump_if_false +3               (to 37)
+        35    load_const 4                       ("")
+        36    store_var 8                        (_12)
+        37    load_var 8                         (_12)
+        38    store_var 7                        (finish)
 
-  296   41    load_var 6                         (cand)
-        42    load_const 3                       (null)
-        43    cmp_op ==                          
-        44    pop_jump_if_false +2               (to 46)
-        45    jump +17                           (to 62)
-        46    load_var 6                         (cand)
-        47    load_field 0                       (0)
-        48    load_const 3                       (null)
-        49    cmp_op ==                          
-        50    pop_jump_if_false +2               (to 52)
-        51    jump +11                           (to 62)
-        52    load_var 6                         (cand)
-        53    load_const 3                       (null)
-        54    cmp_op ==                          
-        55    pop_jump_if_false +2               (to 57)
-        56    jump +6                            (to 62)
-        57    load_var 6                         (cand)
-        58    load_field 0                       (0)
-        59    load_field 0                       (0)
-        60    store_var 10                       (_18)
-        61    jump +3                            (to 64)
-        62    load_const 3                       (null)
-        63    store_var 10                       (_18)
-        64    load_var 10                        (_18)
-        65    store_var 9                        (parts)
-        66    load_var 10                        (_18)
-        67    load_const 3                       (null)
-        68    cmp_op ==                          
-        69    pop_jump_if_false +4               (to 73)
-        70    load_type 5                        
-        71    alloc_array 0                      
-        72    store_var 9                        (parts)
+  296   39    load_var 6                         (cand)
+        40    load_const 3                       (null)
+        41    cmp_op ==                          
+        42    pop_jump_if_false +2               (to 44)
+        43    jump +16                           (to 59)
+        44    load_var 6                         (cand)
+        45    load_field 0                       (0)
+        46    load_const 3                       (null)
+        47    cmp_op ==                          
+        48    pop_jump_if_false +2               (to 50)
+        49    jump +10                           (to 59)
+        50    load_var 6                         (cand)
+        51    load_const 3                       (null)
+        52    cmp_op ==                          
+        53    pop_jump_if_false +2               (to 55)
+        54    jump +5                            (to 59)
+        55    load_var 6                         (cand)
+        56    load_field 0                       (0)
+        57    load_field 0                       (0)
+        58    jump +2                            (to 60)
+        59    load_const 3                       (null)
+        60    store_var_load_var 9               (_19)
+        61    load_const 3                       (null)
+        62    cmp_op ==                          
+        63    pop_jump_if_false +4               (to 67)
+        64    load_type 5                        
+        65    alloc_array 0                      
+        66    store_var 9                        (_19)
+        67    load_var 9                         (_19)
+        68    load_type 6                        
+        69    load_const 7                       ("iter")
+        70    virtual_call nargs=1 ntypeargs=0   
+        71    store_var 10                       (_32)
 
-  297   73    load_var 9                         (parts)
-        74    load_type 6                        
-        75    load_const 7                       ("iter")
-        76    virtual_call nargs=1 ntypeargs=0   
-        77    store_var 11                       (_30)
-        78    load_var 11                        (_30)
-        79    load_type 8                        
-        80    load_const 9                       ("next")
-        81    virtual_call nargs=1 ntypeargs=0   
-        82    store_var 12                       (_31)
-        83    load_var 12                        (_31)
-        84    is_type 10                         
-        85    pop_jump_if_false +2               (to 87)
-        86    jump +87                           (to 173)
-        87    load_var 12                        (_31)
-        88    store_var_load_var 13              (p)
+  297   72    load_var 10                        (_32)
+        73    load_type 8                        
+        74    load_const 9                       ("next")
+        75    virtual_call nargs=1 ntypeargs=0   
+        76    store_var 11                       (_33)
+        77    load_var 11                        (_33)
+        78    is_type 10                         
+        79    pop_jump_if_false +2               (to 81)
+        80    jump +84                           (to 164)
+        81    load_var 11                        (_33)
+        82    store_var_load_var 12              (p)
 
-  298   89    load_field 2                       (functionCall)
-        90    store_var 14                       (_36)
-        91    load_var 14                        (_36)
-        92    narrow_bind 11 14                  
-        93    pop_jump_if_false +2               (to 95)
-        94    jump +35                           (to 129)
+  298   83    load_field 2                       (functionCall)
+        84    store_var 13                       (_38)
+        85    load_var 13                        (_38)
+        86    narrow_bind 11 13                  
+        87    pop_jump_if_false +2               (to 89)
+        88    jump +32                           (to 120)
 
-  310   95    load_var 13                        (p)
-        96    load_field 0                       (text)
-        97    store_var 20                       (_56)
-        98    load_var 20                        (_56)
-        99    narrow_bind 12 20                  
-        100   pop_jump_if_false -22              (to 78)
-        101   load_var 20                        (_56)
-        102   store_var 21                       (t)
+  310   89    load_var 12                        (p)
+        90    load_field 0                       (text)
+        91    store_var 19                       (_58)
+        92    load_var 19                        (_58)
+        93    narrow_bind 12 19                  
+        94    pop_jump_if_false -22              (to 72)
+        95    load_var 19                        (_58)
+        96    store_var 20                       (t)
 
-  311   103   load_var 13                        (p)
-        104   load_field 1                       (thought)
-        105   store_var 23                       (_59)
-        106   load_var 23                        (_59)
-        107   store_var 22                       (_58)
-        108   load_var 23                        (_59)
-        109   load_const 3                       (null)
-        110   cmp_op ==                          
-        111   pop_jump_if_false +3               (to 114)
-        112   load_const 1                       (false)
-        113   store_var 22                       (_58)
-        114   load_var 22                        (_58)
-        115   pop_jump_if_false +2               (to 117)
-        116   jump +7                            (to 123)
+  311   97    load_var 12                        (p)
+        98    load_field 1                       (thought)
+        99    store_var_load_var 21              (_61)
+        100   load_const 3                       (null)
+        101   cmp_op ==                          
+        102   pop_jump_if_false +3               (to 105)
+        103   load_const 1                       (false)
+        104   store_var 21                       (_61)
+        105   load_var 21                        (_61)
+        106   pop_jump_if_false +2               (to 108)
+        107   jump +7                            (to 114)
 
-  315   117   load_type 0                        
-        118   load_var2 3 21                     
-        119   init_instance 0                    (ai.content.Text .text)
-        120   call 4 ntypeargs=1                 (baml.Array.push)
-        121   pop 1                              
-        122   jump -44                           (to 78)
+  315   108   load_type 0                        
+        109   load_var2 3 20                     
+        110   init_instance 0                    (ai.content.Text .text)
+        111   call 4 ntypeargs=1                 (baml.Array.push)
+        112   pop 1                              
+        113   jump -41                           (to 72)
 
-  312   123   load_type 0                        
-        124   load_var2 3 21                     
-        125   init_instance 1                    (ai.content.Reasoning .summary)
-        126   call 4 ntypeargs=1                 (baml.Array.push)
-        127   pop 1                              
-        128   jump -50                           (to 78)
+  312   114   load_type 0                        
+        115   load_var2 3 20                     
+        116   init_instance 1                    (ai.content.Reasoning .summary)
+        117   call 4 ntypeargs=1                 (baml.Array.push)
+        118   pop 1                              
+        119   jump -47                           (to 72)
 
-  298   129   load_var 14                        (_36)
-        130   store_var 15                       (fc)
+  298   120   load_var 13                        (_38)
+        121   store_var 14                       (fc)
 
-  299   131   load_type 13                       
-        132   load_type 14                       
-        133   alloc_map 0                        
-        134   store_var 16                       (args)
+  299   122   load_type 13                       
+        123   load_type 14                       
+        124   alloc_map 0                        
+        125   store_var 15                       (args)
 
-  300   135   load_var 15                        (fc)
-        136   load_field 1                       (args)
-        137   store_var 17                       (_40)
-        138   load_var 17                        (_40)
-        139   narrow_bind 15 17                  
-        140   pop_jump_if_false +3               (to 143)
-        141   load_var 17                        (_40)
-        142   store_var 16                       (args)
+  300   126   load_var 14                        (fc)
+        127   load_field 1                       (args)
+        128   store_var 16                       (_42)
+        129   load_var 16                        (_42)
+        130   narrow_bind 15 16                  
+        131   pop_jump_if_false +3               (to 134)
+        132   load_var 16                        (_42)
+        133   store_var 15                       (args)
 
-  304   143   load_type 16                       
-        144   load_var 2                         (seq)
-        145   call 138 ntypeargs=1               (baml.String.from)
-        146   store_var 18                       (_47)
-        147   load_type 16                       
-        148   load_var 5                         (call_index)
-        149   call 138 ntypeargs=1               (baml.String.from)
-        150   store_var 19                       (_49)
+  304   134   load_type 16                       
+        135   load_var 2                         (seq)
+        136   call 138 ntypeargs=1               (baml.String.from)
+        137   store_var 17                       (_49)
+        138   load_type 16                       
+        139   load_var 5                         (call_index)
+        140   call 138 ntypeargs=1               (baml.String.from)
+        141   store_var 18                       (_51)
 
-  303   151   load_type 0                        
-        152   load_var 3                         (content)
+  303   142   load_type 0                        
+        143   load_var 3                         (content)
 
-  304   153   load_const 17                      ("call_")
-        154   load_var 18                        (_47)
-        155   bin_op +                           
-        156   load_const 18                      ("_")
-        157   bin_op +                           
-        158   load_var 19                        (_49)
-        159   bin_op +                           
-        160   load_var 15                        (fc)
-        161   load_field 0                       (name)
-        162   load_var 16                        (args)
-        163   init_instance 2                    (ai.content.ToolUse .id, .name, .args)
-        164   call 4 ntypeargs=1                 (baml.Array.push)
-        165   pop 1                              
+  304   144   load_const 17                      ("call_")
+        145   load_var 17                        (_49)
+        146   bin_op +                           
+        147   load_const 18                      ("_")
+        148   bin_op +                           
+        149   load_var 18                        (_51)
+        150   bin_op +                           
+        151   load_var 14                        (fc)
+        152   load_field 0                       (name)
+        153   load_var 15                        (args)
+        154   init_instance 2                    (ai.content.ToolUse .id, .name, .args)
+        155   call 4 ntypeargs=1                 (baml.Array.push)
+        156   pop 1                              
 
-  306   166   load_var 5                         (call_index)
-        167   load_const 12                      (1)
-        168   add_int                            
-        169   store_var 5                        (call_index)
+  306   157   load_var 5                         (call_index)
+        158   load_const 12                      (1)
+        159   add_int                            
+        160   store_var 5                        (call_index)
 
-  307   170   load_const 19                      (true)
-        171   store_var 4                        (has_call)
+  307   161   load_const 19                      (true)
+        162   store_var 4                        (has_call)
 
-  298   172   jump -94                           (to 78)
+  298   163   jump -91                           (to 72)
 
-  323   173   load_var 1                         (resp)
-        174   load_field 2                       (promptFeedback)
+  323   164   load_var 1                         (resp)
+        165   load_field 2                       (promptFeedback)
+        166   load_const 3                       (null)
+        167   cmp_op ==                          
+        168   pop_jump_if_false +2               (to 170)
+        169   jump +5                            (to 174)
+        170   load_var 1                         (resp)
+        171   load_field 2                       (promptFeedback)
+        172   load_field 0                       (0)
+        173   jump +2                            (to 175)
+        174   load_const 3                       (null)
         175   load_const 3                       (null)
-        176   cmp_op ==                          
-        177   pop_jump_if_false +2               (to 179)
-        178   jump +5                            (to 183)
-        179   load_var 1                         (resp)
-        180   load_field 2                       (promptFeedback)
-        181   load_field 0                       (0)
-        182   jump +2                            (to 184)
-        183   load_const 3                       (null)
-        184   load_const 3                       (null)
-        185   call 653 ntypeargs=0               (baml.ops.equals_equals)
-        186   store_var 24                       (_74)
+        176   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        177   store_var 22                       (_77)
 
-  324   187   load_var 4                         (has_call)
-        188   pop_jump_if_false +2               (to 190)
-        189   jump +40                           (to 229)
+  324   178   load_var 4                         (has_call)
+        179   pop_jump_if_false +2               (to 181)
+        180   jump +40                           (to 220)
 
-  326   190   load_var 7                         (finish)
-        191   load_const 20                      ("MAX_TOKENS")
-        192   cmp_op ==                          
-        193   pop_jump_if_false +2               (to 195)
-        194   jump +31                           (to 225)
+  326   181   load_var 7                         (finish)
+        182   load_const 20                      ("MAX_TOKENS")
+        183   cmp_op ==                          
+        184   pop_jump_if_false +2               (to 186)
+        185   jump +31                           (to 216)
 
-  323   195   load_var 24                        (_74)
-        196   unary_op !                         
-        197   jump_if_false +2                   (to 199)
-        198   jump +5                            (to 203)
-        199   pop 1                              
+  323   186   load_var 22                        (_77)
+        187   unary_op !                         
+        188   jump_if_false +2                   (to 190)
+        189   jump +5                            (to 194)
+        190   pop 1                              
 
-  328   200   load_var 7                         (finish)
-        201   load_const 21                      ("SAFETY")
-        202   cmp_op ==                          
-        203   jump_if_false +2                   (to 205)
-        204   jump +5                            (to 209)
-        205   pop 1                              
-        206   load_var 7                         (finish)
-        207   load_const 22                      ("RECITATION")
-        208   cmp_op ==                          
-        209   jump_if_false +2                   (to 211)
-        210   jump +5                            (to 215)
-        211   pop 1                              
-        212   load_var 7                         (finish)
-        213   load_const 23                      ("PROHIBITED_CONTENT")
-        214   cmp_op ==                          
-        215   pop_jump_if_false +2               (to 217)
-        216   jump +5                            (to 221)
+  328   191   load_var 7                         (finish)
+        192   load_const 21                      ("SAFETY")
+        193   cmp_op ==                          
+        194   jump_if_false +2                   (to 196)
+        195   jump +5                            (to 200)
+        196   pop 1                              
+        197   load_var 7                         (finish)
+        198   load_const 22                      ("RECITATION")
+        199   cmp_op ==                          
+        200   jump_if_false +2                   (to 202)
+        201   jump +5                            (to 206)
+        202   pop 1                              
+        203   load_var 7                         (finish)
+        204   load_const 23                      ("PROHIBITED_CONTENT")
+        205   cmp_op ==                          
+        206   pop_jump_if_false +2               (to 208)
+        207   jump +5                            (to 212)
 
-  331   217   load_const 2                       (ai.content.StopReason.Complete)
-        218   alloc_variant 436                  (ai.content.StopReason)
-        219   store_var 25                       (stop)
+  331   208   load_const 2                       (ai.content.StopReason.Complete)
+        209   alloc_variant 436                  (ai.content.StopReason)
+        210   store_var 23                       (stop)
 
-  328   220   jump +12                           (to 232)
+  328   211   jump +12                           (to 223)
 
-  329   221   load_const 24                      (ai.content.StopReason.Refused)
-        222   alloc_variant 436                  (ai.content.StopReason)
-        223   store_var 25                       (stop)
+  329   212   load_const 24                      (ai.content.StopReason.Refused)
+        213   alloc_variant 436                  (ai.content.StopReason)
+        214   store_var 23                       (stop)
 
-  328   224   jump +8                            (to 232)
+  328   215   jump +8                            (to 223)
 
-  327   225   load_const 25                      (ai.content.StopReason.MaxTokens)
-        226   alloc_variant 436                  (ai.content.StopReason)
-        227   store_var 25                       (stop)
+  327   216   load_const 25                      (ai.content.StopReason.MaxTokens)
+        217   alloc_variant 436                  (ai.content.StopReason)
+        218   store_var 23                       (stop)
 
-  326   228   jump +4                            (to 232)
+  326   219   jump +4                            (to 223)
 
-  325   229   load_const 12                      (ai.content.StopReason.ToolUse)
-        230   alloc_variant 436                  (ai.content.StopReason)
-        231   store_var 25                       (stop)
+  325   220   load_const 12                      (ai.content.StopReason.ToolUse)
+        221   alloc_variant 436                  (ai.content.StopReason)
+        222   store_var 23                       (stop)
 
-  333   232   load_var 1                         (resp)
-        233   load_field 1                       (usageMetadata)
-        234   store_var 27                       (_88)
-        235   load_var 27                        (_88)
-        236   narrow_bind 26 27                  
-        237   pop_jump_if_false +2               (to 239)
-        238   jump +4                            (to 242)
+  333   223   load_var 1                         (resp)
+        224   load_field 1                       (usageMetadata)
+        225   store_var 25                       (_91)
+        226   load_var 25                        (_91)
+        227   narrow_bind 26 25                  
+        228   pop_jump_if_false +2               (to 230)
+        229   jump +4                            (to 233)
 
-  341   239   load_const 3                       (null)
-        240   store_var 26                       (usage)
+  341   230   load_const 3                       (null)
+        231   store_var 24                       (usage)
 
-  333   241   jump +30                           (to 271)
-        242   load_var 27                        (_88)
-        243   store_var 28                       (um)
+  333   232   jump +25                           (to 257)
+        233   load_var 25                        (_91)
+        234   store_var_load_var 26              (um)
 
-  335   244   load_var 28                        (um)
-        245   load_field 0                       (promptTokenCount)
-        246   store_var 30                       (_91)
-        247   load_var 30                        (_91)
-        248   store_var 29                       (_90)
-        249   load_var 30                        (_91)
-        250   load_const 3                       (null)
-        251   cmp_op ==                          
-        252   pop_jump_if_false +3               (to 255)
-        253   load_const 2                       (0)
-        254   store_var 29                       (_90)
+  335   235   load_field 0                       (promptTokenCount)
+        236   store_var_load_var 28              (_94)
+        237   load_const 3                       (null)
+        238   cmp_op ==                          
+        239   pop_jump_if_false +3               (to 242)
+        240   load_const 2                       (0)
+        241   store_var 28                       (_94)
+        242   load_var 28                        (_94)
+        243   store_var 27                       (_93)
 
-  336   255   load_var 28                        (um)
-        256   load_field 1                       (candidatesTokenCount)
-        257   store_var 32                       (_94)
-        258   load_var 32                        (_94)
-        259   store_var 31                       (_93)
-        260   load_var 32                        (_94)
-        261   load_const 3                       (null)
-        262   cmp_op ==                          
-        263   pop_jump_if_false +3               (to 266)
-        264   load_const 2                       (0)
-        265   store_var 31                       (_93)
+  336   244   load_var 26                        (um)
+        245   load_field 1                       (candidatesTokenCount)
+        246   store_var_load_var 29              (_98)
+        247   load_const 3                       (null)
+        248   cmp_op ==                          
+        249   pop_jump_if_false +3               (to 252)
+        250   load_const 2                       (0)
+        251   store_var 29                       (_98)
 
-  334   266   load_var2 29 31                    
-        267   load_const 3                       (null)
-        268   load_const 3                       (null)
-        269   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
-        270   store_var 26                       (usage)
+  334   252   load_var2 27 29                    
 
-  343   271   load_var2 3 25                     
-        272   load_var 26                        (usage)
-        273   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
-        274   return                             
+  336   253   load_const 3                       (null)
+        254   load_const 3                       (null)
+        255   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
+        256   store_var 24                       (usage)
+
+  343   257   load_var2 3 23                     
+        258   load_var 24                        (usage)
+        259   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
+        260   return                             
 }
 
 function google.internal.google_render(c: google.GoogleClient, input: ai.ModelTurnInput) -> baml.http.Request {
@@ -8490,7 +8421,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         14    load_var 4                         (_5)
         15    is_type 5                          
         16    pop_jump_if_false +2               (to 18)
-        17    jump +124                          (to 141)
+        17    jump +120                          (to 137)
         18    load_var 4                         (_5)
         19    store_var_load_var 5               (raw)
 
@@ -8516,126 +8447,122 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         34    narrow_bind 9 8                    
         35    pop_jump_if_false -26              (to 9)
         36    load_var 8                         (_16)
-        37    store_var 9                        (event)
+        37    store_var_load_var 9               (event)
 
-  261   38    load_var 9                         (event)
-        39    load_field 0                       (type)
-        40    store_var 12                       (_20)
-        41    load_var 12                        (_20)
-        42    store_var 11                       (_19)
-        43    load_var 12                        (_20)
-        44    load_const 8                       (null)
-        45    cmp_op ==                          
-        46    pop_jump_if_false +4               (to 50)
-        47    load_var 5                         (raw)
-        48    load_field 0                       (event)
-        49    store_var 11                       (_19)
-        50    load_var 11                        (_19)
-        51    store_var 10                       (t)
-        52    load_var 11                        (_19)
-        53    load_const 8                       (null)
-        54    cmp_op ==                          
-        55    pop_jump_if_false +3               (to 58)
-        56    load_const 10                      ("")
-        57    store_var 10                       (t)
+  261   38    load_field 0                       (type)
+        39    store_var_load_var 12              (_21)
+        40    load_const 8                       (null)
+        41    cmp_op ==                          
+        42    pop_jump_if_false +4               (to 46)
+        43    load_var 5                         (raw)
+        44    load_field 0                       (event)
+        45    store_var 12                       (_21)
+        46    load_var 12                        (_21)
+        47    store_var_load_var 11              (_19)
+        48    load_const 8                       (null)
+        49    cmp_op ==                          
+        50    pop_jump_if_false +3               (to 53)
+        51    load_const 10                      ("")
+        52    store_var 11                       (_19)
+        53    load_var 11                        (_19)
+        54    store_var_load_var 10              (t)
 
-  262   58    load_var 10                        (t)
-        59    load_const 11                      ("response.output_text.delta")
-        60    cmp_op ==                          
-        61    pop_jump_if_false +2               (to 63)
-        62    jump +67                           (to 129)
+  262   55    load_const 11                      ("response.output_text.delta")
+        56    cmp_op ==                          
+        57    pop_jump_if_false +2               (to 59)
+        58    jump +67                           (to 125)
 
-  270   63    load_var 10                        (t)
-        64    load_const 12                      ("response.completed")
-        65    cmp_op ==                          
-        66    jump_if_false +2                   (to 68)
-        67    jump +5                            (to 72)
-        68    pop 1                              
-        69    load_var 10                        (t)
-        70    load_const 13                      ("response.incomplete")
-        71    cmp_op ==                          
-        72    jump_if_false +2                   (to 74)
-        73    jump +5                            (to 78)
-        74    pop 1                              
-        75    load_var 10                        (t)
-        76    load_const 14                      ("response.failed")
-        77    cmp_op ==                          
-        78    pop_jump_if_false -69              (to 9)
+  270   59    load_var 10                        (t)
+        60    load_const 12                      ("response.completed")
+        61    cmp_op ==                          
+        62    jump_if_false +2                   (to 64)
+        63    jump +5                            (to 68)
+        64    pop 1                              
+        65    load_var 10                        (t)
+        66    load_const 13                      ("response.incomplete")
+        67    cmp_op ==                          
+        68    jump_if_false +2                   (to 70)
+        69    jump +5                            (to 74)
+        70    pop 1                              
+        71    load_var 10                        (t)
+        72    load_const 14                      ("response.failed")
+        73    cmp_op ==                          
+        74    pop_jump_if_false -65              (to 9)
 
-  271   79    load_var 9                         (event)
-        80    load_field 2                       (response)
-        81    store_var 14                       (_39)
-        82    load_var 14                        (_39)
-        83    narrow_bind 15 14                  
-        84    pop_jump_if_false +39              (to 123)
-        85    load_var 14                        (_39)
-        86    call 878 ntypeargs=0               (openai.internal.openai_parse)
-        87    store_var 15                       (turn)
+  271   75    load_var 9                         (event)
+        76    load_field 2                       (response)
+        77    store_var 14                       (_41)
+        78    load_var 14                        (_41)
+        79    narrow_bind 15 14                  
+        80    pop_jump_if_false +39              (to 119)
+        81    load_var 14                        (_41)
+        82    call 878 ntypeargs=0               (openai.internal.openai_parse)
+        83    store_var 15                       (turn)
 
-  275   88    load_var 15                        (turn)
-        89    load_field 1                       (stop_reason)
-        90    store_var 16                       (_45)
+  275   84    load_var 15                        (turn)
+        85    load_field 1                       (stop_reason)
+        86    store_var 16                       (_47)
 
-  276   91    load_var 15                        (turn)
-        92    load_field 2                       (usage)
-        93    load_const 8                       (null)
-        94    cmp_op ==                          
-        95    pop_jump_if_false +2               (to 97)
-        96    jump +6                            (to 102)
-        97    load_var 15                        (turn)
-        98    load_field 2                       (usage)
-        99    load_field 0                       (0)
-        100   store_var 17                       (_46)
-        101   jump +3                            (to 104)
+  276   87    load_var 15                        (turn)
+        88    load_field 2                       (usage)
+        89    load_const 8                       (null)
+        90    cmp_op ==                          
+        91    pop_jump_if_false +2               (to 93)
+        92    jump +6                            (to 98)
+        93    load_var 15                        (turn)
+        94    load_field 2                       (usage)
+        95    load_field 0                       (0)
+        96    store_var 17                       (_48)
+        97    jump +3                            (to 100)
+        98    load_const 8                       (null)
+        99    store_var 17                       (_48)
+
+  277   100   load_var 15                        (turn)
+        101   load_field 2                       (usage)
         102   load_const 8                       (null)
-        103   store_var 17                       (_46)
+        103   cmp_op ==                          
+        104   pop_jump_if_false +2               (to 106)
+        105   jump +6                            (to 111)
+        106   load_var 15                        (turn)
+        107   load_field 2                       (usage)
+        108   load_field 1                       (1)
+        109   store_var 18                       (_52)
+        110   jump +3                            (to 113)
+        111   load_const 8                       (null)
+        112   store_var 18                       (_52)
 
-  277   104   load_var 15                        (turn)
-        105   load_field 2                       (usage)
-        106   load_const 8                       (null)
-        107   cmp_op ==                          
-        108   pop_jump_if_false +2               (to 110)
-        109   jump +6                            (to 115)
-        110   load_var 15                        (turn)
-        111   load_field 2                       (usage)
-        112   load_field 1                       (1)
-        113   store_var 18                       (_50)
-        114   jump +3                            (to 117)
-        115   load_const 8                       (null)
-        116   store_var 18                       (_50)
+  273   113   load_type 0                        
+        114   load_var2 2 16                     
 
-  273   117   load_type 0                        
-        118   load_var2 2 16                     
+  274   115   load_var2 17 18                    
+        116   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
+        117   call 4 ntypeargs=1                 (baml.Array.push)
+        118   pop 1                              
 
-  274   119   load_var2 17 18                    
-        120   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
-        121   call 4 ntypeargs=1                 (baml.Array.push)
-        122   pop 1                              
+  284   119   load_type 0                        
+        120   load_var 2                         (out)
+        121   alloc_instance 358 ntypeargs=0     (ai.stream.TurnDone)
+        122   call 4 ntypeargs=1                 (baml.Array.push)
+        123   pop 1                              
+        124   jump -115                          (to 9)
 
-  284   123   load_type 0                        
-        124   load_var 2                         (out)
-        125   alloc_instance 358 ntypeargs=0     (ai.stream.TurnDone)
-        126   call 4 ntypeargs=1                 (baml.Array.push)
-        127   pop 1                              
-        128   jump -119                          (to 9)
+  263   125   load_var 9                         (event)
+        126   load_field 1                       (delta)
+        127   store_var 13                       (_28)
+        128   load_var 13                        (_28)
+        129   narrow_bind 6 13                   
+        130   pop_jump_if_false -121             (to 9)
 
-  263   129   load_var 9                         (event)
-        130   load_field 1                       (delta)
-        131   store_var 13                       (_26)
-        132   load_var 13                        (_26)
-        133   narrow_bind 6 13                   
-        134   pop_jump_if_false -125             (to 9)
+  264   131   load_type 0                        
+        132   load_var2 2 13                     
 
-  264   135   load_type 0                        
-        136   load_var2 2 13                     
+  263   133   init_instance 1                    (ai.stream.TextDelta .text)
+        134   call 4 ntypeargs=1                 (baml.Array.push)
+        135   pop 1                              
+        136   jump -127                          (to 9)
 
-  263   137   init_instance 1                    (ai.stream.TextDelta .text)
-        138   call 4 ntypeargs=1                 (baml.Array.push)
-        139   pop 1                              
-        140   jump -131                          (to 9)
-
-  298   141   load_var 2                         (out)
-        142   return                             
+  298   137   load_var 2                         (out)
+        138   return                             
 }
 
 function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
@@ -8817,52 +8744,49 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   162   153   load_var 1                         (c)
         154   call 870 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
-        155   store_var 16                       (_78)
-        156   load_var 16                        (_78)
-        157   store_var 15                       (_77)
-        158   load_var 16                        (_78)
-        159   load_const 27                      (null)
-        160   cmp_op ==                          
-        161   pop_jump_if_false +3               (to 164)
-        162   load_const 28                      ("https://api.openai.com/v1")
-        163   store_var 15                       (_77)
-        164   load_type 6                        
-        165   load_var 15                        (_77)
-        166   call 138 ntypeargs=1               (baml.String.from)
-        167   store_var 14                       (_76)
+        155   store_var_load_var 15              (_78)
+        156   load_const 27                      (null)
+        157   cmp_op ==                          
+        158   pop_jump_if_false +3               (to 161)
+        159   load_const 28                      ("https://api.openai.com/v1")
+        160   store_var 15                       (_78)
+        161   load_type 6                        
+        162   load_var 15                        (_78)
+        163   call 138 ntypeargs=1               (baml.String.from)
+        164   store_var 14                       (_76)
 
-  163   168   load_var 1                         (c)
-        169   call 869 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
-        170   store_var 18                       (_84)
-        171   load_type 6                        
-        172   load_var 18                        (_84)
-        173   call 138 ntypeargs=1               (baml.String.from)
-        174   store_var 17                       (_83)
+  163   165   load_var 1                         (c)
+        166   call 869 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
+        167   store_var 17                       (_85)
+        168   load_type 6                        
+        169   load_var 17                        (_85)
+        170   call 138 ntypeargs=1               (baml.String.from)
+        171   store_var 16                       (_84)
 
-  164   175   load_type 5                        
-        176   load_var 8                         (body)
-        177   call 331 ntypeargs=1               (baml.json.to_json)
-        178   call 328 ntypeargs=0               (baml.json.stringify)
-        179   store_var 19                       (_86)
+  164   172   load_type 5                        
+        173   load_var 8                         (body)
+        174   call 331 ntypeargs=1               (baml.json.to_json)
+        175   call 328 ntypeargs=0               (baml.json.stringify)
+        176   store_var 18                       (_87)
 
-  160   180   load_const 29                      ("POST")
+  160   177   load_const 29                      ("POST")
 
-  162   181   load_var 14                        (_76)
-        182   load_const 30                      ("/responses")
+  162   178   load_var 14                        (_76)
+        179   load_const 30                      ("/responses")
+        180   bin_op +                           
+
+  163   181   load_const 31                      ("Bearer ")
+        182   load_var 16                        (_84)
         183   bin_op +                           
-
-  163   184   load_const 31                      ("Bearer ")
-        185   load_var 17                        (_83)
-        186   bin_op +                           
-        187   load_const 32                      ("application/json")
-        188   load_const 33                      ("authorization")
-        189   load_const 34                      ("content-type")
-        190   load_type 6                        
-        191   load_type 6                        
-        192   alloc_map 2                        
-        193   load_var 19                        (_86)
-        194   init_instance 0                    (baml.http.Request .method, .url, .headers, .body)
-        195   return                             
+        184   load_const 32                      ("application/json")
+        185   load_const 33                      ("authorization")
+        186   load_const 34                      ("content-type")
+        187   load_type 6                        
+        188   load_type 6                        
+        189   alloc_map 2                        
+        190   load_var 18                        (_87)
+        191   init_instance 0                    (baml.http.Request .method, .url, .headers, .body)
+        192   return                             
 }
 
 function openai.internal.invoke(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
@@ -9310,7 +9234,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         16    load_var 5                         (_6)
         17    is_type 6                          
         18    pop_jump_if_false +2               (to 20)
-        19    jump +162                          (to 181)
+        19    jump +145                          (to 164)
         20    load_var 5                         (_6)
         21    store_var_load_var 6               (item)
 
@@ -9318,14 +9242,14 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         23    load_const 7                       ("function_call")
         24    cmp_op ==                          
         25    pop_jump_if_false +2               (to 27)
-        26    jump +110                          (to 136)
+        26    jump +97                           (to 123)
 
   183   27    load_var 6                         (item)
         28    load_field 0                       (type)
         29    load_const 8                       ("message")
         30    cmp_op ==                          
         31    pop_jump_if_false +2               (to 33)
-        32    jump +44                           (to 76)
+        32    jump +41                           (to 73)
 
   194   33    load_var 6                         (item)
         34    load_field 0                       (type)
@@ -9335,229 +9259,209 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
 
   195   38    load_var 6                         (item)
         39    load_field 5                       (summary)
-        40    store_var 23                       (_52)
-        41    load_var 23                        (_52)
-        42    store_var 22                       (parts)
-        43    load_var 23                        (_52)
-        44    load_const 10                      (null)
-        45    cmp_op ==                          
-        46    pop_jump_if_false +4               (to 50)
-        47    load_type 11                       
-        48    alloc_array 0                      
-        49    store_var 22                       (parts)
+        40    store_var_load_var 18              (_57)
+        41    load_const 10                      (null)
+        42    cmp_op ==                          
+        43    pop_jump_if_false +4               (to 47)
+        44    load_type 11                       
+        45    alloc_array 0                      
+        46    store_var 18                       (_57)
+        47    load_var 18                        (_57)
+        48    load_type 12                       
+        49    load_const 13                      ("iter")
+        50    virtual_call nargs=1 ntypeargs=0   
+        51    store_var 19                       (_61)
 
-  196   50    load_var 22                        (parts)
-        51    load_type 12                       
-        52    load_const 13                      ("iter")
-        53    virtual_call nargs=1 ntypeargs=0   
-        54    store_var 24                       (_55)
-        55    load_var 24                        (_55)
-        56    load_type 14                       
-        57    load_const 15                      ("next")
-        58    virtual_call nargs=1 ntypeargs=0   
-        59    store_var 25                       (_56)
-        60    load_var 25                        (_56)
-        61    is_type 6                          
-        62    pop_jump_if_false +2               (to 64)
-        63    jump -52                           (to 11)
-        64    load_var 25                        (_56)
-        65    load_field 1                       (text)
-        66    store_var 26                       (_61)
+  196   52    load_var 19                        (_61)
+        53    load_type 14                       
+        54    load_const 15                      ("next")
+        55    virtual_call nargs=1 ntypeargs=0   
+        56    store_var 20                       (_62)
+        57    load_var 20                        (_62)
+        58    is_type 6                          
+        59    pop_jump_if_false +2               (to 61)
+        60    jump -49                           (to 11)
+        61    load_var 20                        (_62)
+        62    load_field 1                       (text)
+        63    store_var 21                       (_67)
 
-  197   67    load_var 26                        (_61)
-        68    narrow_bind 16 26                  
-        69    pop_jump_if_false -14              (to 55)
+  197   64    load_var 21                        (_67)
+        65    narrow_bind 16 21                  
+        66    pop_jump_if_false -14              (to 52)
 
-  198   70    load_type 0                        
-        71    load_var2 2 26                     
+  198   67    load_type 0                        
+        68    load_var2 2 21                     
 
-  197   72    init_instance 0                    (ai.content.Reasoning .summary)
-        73    call 4 ntypeargs=1                 (baml.Array.push)
-        74    pop 1                              
-        75    jump -20                           (to 55)
+  197   69    init_instance 0                    (ai.content.Reasoning .summary)
+        70    call 4 ntypeargs=1                 (baml.Array.push)
+        71    pop 1                              
+        72    jump -20                           (to 52)
 
-  184   76    load_var 6                         (item)
-        77    load_field 4                       (content)
-        78    store_var 14                       (_31)
-        79    load_var 14                        (_31)
-        80    store_var 13                       (parts)
-        81    load_var 14                        (_31)
-        82    load_const 10                      (null)
-        83    cmp_op ==                          
-        84    pop_jump_if_false +4               (to 88)
-        85    load_type 11                       
-        86    alloc_array 0                      
-        87    store_var 13                       (parts)
+  184   73    load_var 6                         (item)
+        74    load_field 4                       (content)
+        75    store_var_load_var 12              (_33)
+        76    load_const 10                      (null)
+        77    cmp_op ==                          
+        78    pop_jump_if_false +4               (to 82)
+        79    load_type 11                       
+        80    alloc_array 0                      
+        81    store_var 12                       (_33)
+        82    load_var 12                        (_33)
+        83    load_type 12                       
+        84    load_const 17                      ("iter")
+        85    virtual_call nargs=1 ntypeargs=0   
+        86    store_var 13                       (_37)
 
-  185   88    load_var 13                        (parts)
-        89    load_type 12                       
-        90    load_const 17                      ("iter")
-        91    virtual_call nargs=1 ntypeargs=0   
-        92    store_var 15                       (_34)
-        93    load_var 15                        (_34)
-        94    load_type 14                       
-        95    load_const 18                      ("next")
-        96    virtual_call nargs=1 ntypeargs=0   
-        97    store_var 16                       (_35)
-        98    load_var 16                        (_35)
-        99    is_type 6                          
-        100   pop_jump_if_false +2               (to 102)
-        101   jump -90                           (to 11)
-        102   load_var 16                        (_35)
-        103   store_var 17                       (part)
+  185   87    load_var 13                        (_37)
+        88    load_type 14                       
+        89    load_const 18                      ("next")
+        90    virtual_call nargs=1 ntypeargs=0   
+        91    store_var 14                       (_38)
+        92    load_var 14                        (_38)
+        93    is_type 6                          
+        94    pop_jump_if_false +2               (to 96)
+        95    jump -84                           (to 11)
+        96    load_var 14                        (_38)
+        97    store_var_load_var 15              (part)
 
-  186   104   load_var 17                        (part)
-        105   load_field 0                       (type)
-        106   store_var 19                       (_41)
-        107   load_var 19                        (_41)
-        108   store_var 18                       (_40)
-        109   load_var 19                        (_41)
-        110   load_const 10                      (null)
-        111   cmp_op ==                          
-        112   pop_jump_if_false +3               (to 115)
-        113   load_const 19                      ("")
-        114   store_var 18                       (_40)
-        115   load_var 18                        (_40)
-        116   load_const 20                      ("output_text")
-        117   cmp_op ==                          
-        118   pop_jump_if_false -25              (to 93)
+  186   98    load_field 0                       (type)
+        99    store_var_load_var 16              (_44)
+        100   load_const 10                      (null)
+        101   cmp_op ==                          
+        102   pop_jump_if_false +3               (to 105)
+        103   load_const 19                      ("")
+        104   store_var 16                       (_44)
+        105   load_var 16                        (_44)
+        106   load_const 20                      ("output_text")
+        107   cmp_op ==                          
+        108   pop_jump_if_false -21              (to 87)
 
-  187   119   load_var 17                        (part)
-        120   load_field 1                       (text)
-        121   store_var 21                       (_46)
-        122   load_var 21                        (_46)
-        123   store_var 20                       (_45)
-        124   load_var 21                        (_46)
-        125   load_const 10                      (null)
-        126   cmp_op ==                          
-        127   pop_jump_if_false +3               (to 130)
-        128   load_const 21                      ("")
-        129   store_var 20                       (_45)
-        130   load_type 0                        
-        131   load_var2 2 20                     
-        132   init_instance 1                    (ai.content.Text .text)
-        133   call 4 ntypeargs=1                 (baml.Array.push)
-        134   pop 1                              
-        135   jump -42                           (to 93)
+  187   109   load_var 15                        (part)
+        110   load_field 1                       (text)
+        111   store_var_load_var 17              (_50)
+        112   load_const 10                      (null)
+        113   cmp_op ==                          
+        114   pop_jump_if_false +3               (to 117)
+        115   load_const 21                      ("")
+        116   store_var 17                       (_50)
+        117   load_type 0                        
+        118   load_var2 2 17                     
+        119   init_instance 1                    (ai.content.Text .text)
+        120   call 4 ntypeargs=1                 (baml.Array.push)
+        121   pop 1                              
+        122   jump -35                           (to 87)
 
-  174   136   load_const 22                      (true)
-        137   store_var 3                        (has_call)
+  174   123   load_const 22                      (true)
+        124   store_var 3                        (has_call)
 
-  175   138   load_type 23                       
-        139   load_type 24                       
-        140   alloc_map 0                        
-        141   store_var 7                        (args)
+  175   125   load_type 23                       
+        126   load_type 24                       
+        127   alloc_map 0                        
+        128   store_var 7                        (args)
 
-  176   142   load_var 6                         (item)
-        143   load_field 3                       (arguments)
-        144   store_var 8                        (_14)
-        145   load_var 8                         (_14)
-        146   narrow_bind 16 8                   
-        147   pop_jump_if_false +5               (to 152)
+  176   129   load_var 6                         (item)
+        130   load_field 3                       (arguments)
+        131   store_var 8                        (_14)
+        132   load_var 8                         (_14)
+        133   narrow_bind 16 8                   
+        134   pop_jump_if_false +5               (to 139)
 
-  177   148   load_type 25                       
+  177   135   load_type 25                       
 
-  176   149   load_var 8                         (_14)
-        150   call 333 ntypeargs=1               (baml.json.from_string)
-        151   store_var 7                        (args)
+  176   136   load_var 8                         (_14)
+        137   call 333 ntypeargs=1               (baml.json.from_string)
+        138   store_var 7                        (args)
 
-  180   152   load_var 6                         (item)
-        153   load_field 1                       (call_id)
-        154   store_var 10                       (_21)
-        155   load_var 10                        (_21)
-        156   store_var 9                        (_20)
-        157   load_var 10                        (_21)
-        158   load_const 10                      (null)
-        159   cmp_op ==                          
-        160   pop_jump_if_false +3               (to 163)
-        161   load_const 26                      ("")
-        162   store_var 9                        (_20)
-        163   load_var 6                         (item)
-        164   load_field 2                       (name)
-        165   store_var 12                       (_24)
-        166   load_var 12                        (_24)
-        167   store_var 11                       (_23)
-        168   load_var 12                        (_24)
-        169   load_const 10                      (null)
-        170   cmp_op ==                          
-        171   pop_jump_if_false +3               (to 174)
-        172   load_const 27                      ("")
-        173   store_var 11                       (_23)
+  180   139   load_var 6                         (item)
+        140   load_field 1                       (call_id)
+        141   store_var_load_var 10              (_21)
+        142   load_const 10                      (null)
+        143   cmp_op ==                          
+        144   pop_jump_if_false +3               (to 147)
+        145   load_const 26                      ("")
+        146   store_var 10                       (_21)
+        147   load_var 10                        (_21)
+        148   store_var 9                        (_20)
+        149   load_var 6                         (item)
+        150   load_field 2                       (name)
+        151   store_var_load_var 11              (_25)
+        152   load_const 10                      (null)
+        153   cmp_op ==                          
+        154   pop_jump_if_false +3               (to 157)
+        155   load_const 27                      ("")
+        156   store_var 11                       (_25)
 
-  179   174   load_type 0                        
-        175   load_var2 2 9                      
+  179   157   load_type 0                        
+        158   load_var2 2 9                      
 
-  180   176   load_var2 11 7                     
-        177   init_instance 2                    (ai.content.ToolUse .id, .name, .args)
-        178   call 4 ntypeargs=1                 (baml.Array.push)
-        179   pop 1                              
-        180   jump -169                          (to 11)
+  180   159   load_var2 11 7                     
+        160   init_instance 2                    (ai.content.ToolUse .id, .name, .args)
+        161   call 4 ntypeargs=1                 (baml.Array.push)
+        162   pop 1                              
+        163   jump -152                          (to 11)
 
-  209   181   load_var 3                         (has_call)
-        182   pop_jump_if_false +2               (to 184)
-        183   jump +25                           (to 208)
+  209   164   load_var 3                         (has_call)
+        165   pop_jump_if_false +2               (to 167)
+        166   jump +22                           (to 188)
 
-  211   184   load_var 1                         (resp)
-        185   load_field 0                       (status)
-        186   store_var 29                       (_71)
-        187   load_var 29                        (_71)
-        188   store_var 28                       (_70)
-        189   load_var 29                        (_71)
-        190   load_const 10                      (null)
-        191   cmp_op ==                          
-        192   pop_jump_if_false +3               (to 195)
-        193   load_const 28                      ("")
-        194   store_var 28                       (_70)
-        195   load_var 28                        (_70)
-        196   load_const 29                      ("incomplete")
-        197   cmp_op ==                          
-        198   pop_jump_if_false +2               (to 200)
-        199   jump +5                            (to 204)
+  211   167   load_var 1                         (resp)
+        168   load_field 0                       (status)
+        169   store_var_load_var 23              (_77)
+        170   load_const 10                      (null)
+        171   cmp_op ==                          
+        172   pop_jump_if_false +3               (to 175)
+        173   load_const 28                      ("")
+        174   store_var 23                       (_77)
+        175   load_var 23                        (_77)
+        176   load_const 29                      ("incomplete")
+        177   cmp_op ==                          
+        178   pop_jump_if_false +2               (to 180)
+        179   jump +5                            (to 184)
 
-  214   200   load_const 30                      (ai.content.StopReason.Complete)
-        201   alloc_variant 436                  (ai.content.StopReason)
-        202   store_var 27                       (stop)
+  214   180   load_const 30                      (ai.content.StopReason.Complete)
+        181   alloc_variant 436                  (ai.content.StopReason)
+        182   store_var 22                       (stop)
 
-  211   203   jump +8                            (to 211)
+  211   183   jump +8                            (to 191)
 
-  212   204   load_const 31                      (ai.content.StopReason.MaxTokens)
-        205   alloc_variant 436                  (ai.content.StopReason)
-        206   store_var 27                       (stop)
+  212   184   load_const 31                      (ai.content.StopReason.MaxTokens)
+        185   alloc_variant 436                  (ai.content.StopReason)
+        186   store_var 22                       (stop)
 
-  211   207   jump +4                            (to 211)
+  211   187   jump +4                            (to 191)
 
-  210   208   load_const 16                      (ai.content.StopReason.ToolUse)
-        209   alloc_variant 436                  (ai.content.StopReason)
-        210   store_var 27                       (stop)
+  210   188   load_const 16                      (ai.content.StopReason.ToolUse)
+        189   alloc_variant 436                  (ai.content.StopReason)
+        190   store_var 22                       (stop)
 
-  216   211   load_var 1                         (resp)
-        212   load_field 2                       (usage)
-        213   store_var 31                       (_75)
-        214   load_var 31                        (_75)
-        215   narrow_bind 32 31                  
-        216   pop_jump_if_false +2               (to 218)
-        217   jump +4                            (to 221)
+  216   191   load_var 1                         (resp)
+        192   load_field 2                       (usage)
+        193   store_var 25                       (_82)
+        194   load_var 25                        (_82)
+        195   narrow_bind 32 25                  
+        196   pop_jump_if_false +2               (to 198)
+        197   jump +4                            (to 201)
 
-  224   218   load_const 10                      (null)
-        219   store_var 30                       (usage)
+  224   198   load_const 10                      (null)
+        199   store_var 24                       (usage)
 
-  216   220   jump +10                           (to 230)
-        221   load_var 31                        (_75)
-        222   store_var_load_var 32              (u)
+  216   200   jump +10                           (to 210)
+        201   load_var 25                        (_82)
+        202   store_var_load_var 26              (u)
 
-  218   223   load_field 0                       (input_tokens)
+  218   203   load_field 0                       (input_tokens)
 
-  219   224   load_var 32                        (u)
-        225   load_field 1                       (output_tokens)
-        226   load_const 10                      (null)
-        227   load_const 10                      (null)
-        228   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
-        229   store_var 30                       (usage)
+  219   204   load_var 26                        (u)
+        205   load_field 1                       (output_tokens)
+        206   load_const 10                      (null)
+        207   load_const 10                      (null)
+        208   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
+        209   store_var 24                       (usage)
 
-  226   230   load_var2 2 27                     
-        231   load_var 30                        (usage)
-        232   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
-        233   return                             
+  226   210   load_var2 2 22                     
+        211   load_var 24                        (usage)
+        212   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
+        213   return                             
 }
 
 function openai.internal.openai_render(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> baml.http.Request {

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -17,320 +17,315 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   198   12    load_deref 1                               
         13    load_field 1                               (client)
-        14    store_var 5                                (_4)
-        15    load_var 5                                 (_4)
-        16    store_var 4                                (selected)
-        17    load_var 5                                 (_4)
-        18    load_const 0                               (null)
-        19    cmp_op ==                                  
-        20    pop_jump_if_false +4                       (to 24)
-        21    load_deref 2                               
-        22    load_field 4                               (default_client)
-        23    store_var 4                                (selected)
+        14    store_var_load_var 5                       (_4)
+        15    load_const 0                               (null)
+        16    cmp_op ==                                  
+        17    pop_jump_if_false +4                       (to 21)
+        18    load_deref 2                               
+        19    load_field 4                               (default_client)
+        20    store_var 5                                (_4)
+        21    load_var 5                                 (_4)
+        22    store_var 4                                (selected)
 
-  199   24    load_type 1                                
-        25    load_deref 2                               
-        26    call 806 ntypeargs=1                       (ai.Journal.new)
-        27    store_deref 6                              
+  199   23    load_type 1                                
+        24    load_deref 2                               
+        25    call 806 ntypeargs=1                       (ai.Journal.new)
+        26    store_deref 6                              
 
-  200   28    load_type 1                                
-        29    load_deref 1                               
-        30    load_deref 6                               
-        31    load_const 2                               (0)
-        32    call 845 ntypeargs=1                       (ai.Agent._emit_from)
-        33    store_var 7                                (seen)
+  200   27    load_type 1                                
+        28    load_deref 1                               
+        29    load_deref 6                               
+        30    load_const 2                               (0)
+        31    call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        32    store_var 7                                (seen)
 
-  201   34    load_const 2                               (0)
-        35    store_var 8                                (steps)
+  201   33    load_const 2                               (0)
+        34    store_var 8                                (steps)
 
-  202   36    load_const 2                               (0)
-        37    load_const 2                               (0)
+  202   35    load_const 2                               (0)
+        36    load_const 2                               (0)
+        37    load_const 0                               (null)
         38    load_const 0                               (null)
-        39    load_const 0                               (null)
-        40    init_instance 0                            (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
-        41    store_var 9                                (total)
+        39    init_instance 0                            (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
+        40    store_var 9                                (total)
 
-  209   42    load_type 3                                
-        43    load_type 4                                
-        44    alloc_map 0                                
-        45    store_var 10                               (fail_counts)
+  209   41    load_type 3                                
+        42    load_type 4                                
+        43    alloc_map 0                                
+        44    store_var 10                               (fail_counts)
 
-  210   46    load_var 8                                 (steps)
-        47    load_deref 1                               
-        48    load_field 0                               (max_steps)
-        49    cmp_int_op <                               
-        50    pop_jump_if_false +2                       (to 52)
-        51    jump +4                                    (to 55)
+  210   45    load_var 8                                 (steps)
+        46    load_deref 1                               
+        47    load_field 0                               (max_steps)
+        48    cmp_int_op <                               
+        49    pop_jump_if_false +2                       (to 51)
+        50    jump +4                                    (to 54)
 
-  269   52    load_var 8                                 (steps)
-        53    init_instance 1                            (ai.errors.StepBudgetExceeded .steps)
-        54    throw                                      
+  269   51    load_var 8                                 (steps)
+        52    init_instance 1                            (ai.errors.StepBudgetExceeded .steps)
+        53    throw                                      
 
-  212   55    load_type 1                                
-        56    load_deref 1                               
-        57    load_var 4                                 (selected)
-        58    load_deref 2                               
-        59    load_deref 6                               
-        60    load_var 9                                 (total)
-        61    load_const 5                               (2)
-        62    call 844 ntypeargs=1                       (ai.Agent._attempt_turn)
-        63    store_var 11                               (turn)
+  212   54    load_type 1                                
+        55    load_deref 1                               
+        56    load_var 4                                 (selected)
+        57    load_deref 2                               
+        58    load_deref 6                               
+        59    load_var 9                                 (total)
+        60    load_const 5                               (2)
+        61    call 844 ntypeargs=1                       (ai.Agent._attempt_turn)
+        62    store_var 11                               (turn)
 
-  213   64    load_var 8                                 (steps)
-        65    load_const 6                               (1)
-        66    add_int                                    
-        67    store_var 8                                (steps)
+  213   63    load_var 8                                 (steps)
+        64    load_const 6                               (1)
+        65    add_int                                    
+        66    store_var 8                                (steps)
 
-  214   68    load_type 1                                
-        69    load_deref 1                               
-        70    load_deref 6                               
-        71    load_var 7                                 (seen)
-        72    call 845 ntypeargs=1                       (ai.Agent._emit_from)
-        73    store_var 7                                (seen)
+  214   67    load_type 1                                
+        68    load_deref 1                               
+        69    load_deref 6                               
+        70    load_var 7                                 (seen)
+        71    call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        72    store_var 7                                (seen)
 
-  215   74    load_var 11                                (turn)
-        75    call 825 ntypeargs=0                       (ai.ModelTurn.tool_uses)
-        76    store_var 12                               (calls)
+  215   73    load_var 11                                (turn)
+        74    call 825 ntypeargs=0                       (ai.ModelTurn.tool_uses)
+        75    store_var 12                               (calls)
 
-  216   77    load_var 12                                (calls)
-        78    container_len                              
-        79    store_var 13                               (_28)
-        80    load_var 13                                (_28)
-        81    load_const 2                               (0)
-        82    cmp_int_op >                               
-        83    pop_jump_if_false +2                       (to 85)
-        84    jump +65                                   (to 149)
+  216   76    load_var 12                                (calls)
+        77    container_len                              
+        78    store_var 13                               (_29)
+        79    load_var 13                                (_29)
+        80    load_const 2                               (0)
+        81    cmp_int_op >                               
+        82    pop_jump_if_false +2                       (to 84)
+        83    jump +64                                   (to 147)
 
-  251   85    load_var 11                                (turn)
-        86    call 824 ntypeargs=0                       (ai.ModelTurn.terminal_text)
-        87    store_var 35                               (_96)
-        88    load_var 35                                (_96)
-        89    store_var 34                               (candidate)
-        90    load_var 35                                (_96)
-        91    load_const 0                               (null)
-        92    cmp_op ==                                  
-        93    pop_jump_if_false +3                       (to 96)
-        94    load_const 7                               ("")
-        95    store_var 34                               (candidate)
+  251   84    load_var 11                                (turn)
+        85    call 824 ntypeargs=0                       (ai.ModelTurn.terminal_text)
+        86    store_var_load_var 34                      (_98)
+        87    load_const 0                               (null)
+        88    cmp_op ==                                  
+        89    pop_jump_if_false +3                       (to 92)
+        90    load_const 7                               ("")
+        91    store_var 34                               (_98)
+        92    load_var 34                                (_98)
+        93    store_var 33                               (candidate)
 
-  252   96    load_type 1                                
-        97    load_var 34                                (candidate)
-        98    call 426 ntypeargs=1                       (baml.sap.parse)
-        99    store_var 36                               (value)
-        100   jump +11                                   (to 111)
-        101   load_var 37                                (e)
-        102   throw_if_panic                             
+  252   94    load_type 1                                
+        95    load_var 33                                (candidate)
+        96    call 426 ntypeargs=1                       (baml.sap.parse)
+        97    store_var 35                               (value)
+        98    jump +11                                   (to 109)
+        99    load_var 36                                (e)
+        100   throw_if_panic                             
 
-  254   103   load_var 4                                 (selected)
-        104   load_type 8                                
-        105   load_const 9                               ("id")
-        106   virtual_call nargs=1 ntypeargs=0           
-        107   store_var 38                               (_103)
-        108   load_var2 38 34                            
-        109   init_instance 2                            (ai.errors.ParseFailed .provider, .raw_output)
-        110   throw                                      
+  254   101   load_var 4                                 (selected)
+        102   load_type 8                                
+        103   load_const 9                               ("id")
+        104   virtual_call nargs=1 ntypeargs=0           
+        105   store_var 37                               (_106)
+        106   load_var2 37 33                            
+        107   init_instance 2                            (ai.errors.ParseFailed .provider, .raw_output)
+        108   throw                                      
 
-  257   111   load_type 1                                
-        112   load_var 36                                (value)
-        113   call 331 ntypeargs=1                       (baml.json.to_json)
-        114   jump +12                                   (to 126)
-        115   load_var 39                                (e)
-        116   throw_if_panic                             
+  257   109   load_type 1                                
+        110   load_var 35                                (value)
+        111   call 331 ntypeargs=1                       (baml.json.to_json)
+        112   jump +12                                   (to 124)
+        113   load_var 38                                (e)
+        114   throw_if_panic                             
 
-  259   117   load_type 10                               
-        118   load_var 39                                (e)
-        119   call 138 ntypeargs=1                       (baml.String.from)
-        120   store_var 40                               (_112)
-        121   load_var2 39 40                            
-        122   load_type 3                                
-        123   alloc_array 1                              
-        124   init_instance 3                            (baml.errors.UnknownError .data, .message)
-        125   throw                                      
+  259   115   load_type 10                               
+        116   load_var 38                                (e)
+        117   call 138 ntypeargs=1                       (baml.String.from)
+        118   store_var 39                               (_115)
+        119   load_var2 38 39                            
+        120   load_type 3                                
+        121   alloc_array 1                              
+        122   init_instance 3                            (baml.errors.UnknownError .data, .message)
+        123   throw                                      
 
-  263   126   call 328 ntypeargs=0                       (baml.json.stringify)
-        127   store_var 41                               (_117)
+  263   124   call 328 ntypeargs=0                       (baml.json.stringify)
+        125   store_var 40                               (_120)
 
-  262   128   load_deref 6                               
+  262   126   load_deref 6                               
 
-  263   129   load_var 41                                (_117)
-        130   init_instance 4                            (ai.events.FinalProduced .value_json)
-        131   load_type 11                               
-        132   alloc_array 1                              
-        133   call 807 ntypeargs=0                       (ai.Journal.append_all)
-        134   pop 1                                      
+  263   127   load_var 40                                (_120)
+        128   init_instance 4                            (ai.events.FinalProduced .value_json)
+        129   load_type 11                               
+        130   alloc_array 1                              
+        131   call 807 ntypeargs=0                       (ai.Journal.append_all)
+        132   pop 1                                      
 
-  265   135   load_type 1                                
-        136   load_deref 1                               
-        137   load_deref 6                               
-        138   load_var 7                                 (seen)
-        139   call 845 ntypeargs=1                       (ai.Agent._emit_from)
-        140   store_var 7                                (seen)
+  265   133   load_type 1                                
+        134   load_deref 1                               
+        135   load_deref 6                               
+        136   load_var 7                                 (seen)
+        137   call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        138   store_var 7                                (seen)
 
-  266   141   load_var 36                                (value)
-        142   load_deref 6                               
-        143   load_var 9                                 (total)
-        144   load_type 1                                
-        145   init_instance 5                            (ai.RunResult .value, .journal, .usage)
-        146   store_var 3                                (_0)
-        147   load_var 3                                 (_0)
-        148   return                                     
+  266   139   load_var 35                                (value)
+        140   load_deref 6                               
+        141   load_var 9                                 (total)
+        142   load_type 1                                
+        143   init_instance 5                            (ai.RunResult .value, .journal, .usage)
+        144   store_var 3                                (_0)
+        145   load_var 3                                 (_0)
+        146   return                                     
 
-  217   149   load_deref 6                               
-        150   call 805 ntypeargs=0                       (ai.Journal.entries)
-        151   container_len                              
-        152   store_var 14                               (before)
+  217   147   load_deref 6                               
+        148   call 805 ntypeargs=0                       (ai.Journal.entries)
+        149   container_len                              
+        150   store_var 14                               (before)
 
-  219   153   load_type 12                               
-        154   load_type 13                               
-        155   load_type 14                               
-        156   load_var 12                                (calls)
-        157   load_type 1                                
-        158   load_var2 1 2                              
-        159   load_var 6                                 (j)
-        160   make_closure 1735 captures=3 ntypeargs=1   
-        161   call 16 ntypeargs=3                        (baml.Array.map)
-        162   store_var 15                               (futures)
+  219   151   load_type 12                               
+        152   load_type 13                               
+        153   load_type 14                               
+        154   load_var 12                                (calls)
+        155   load_type 1                                
+        156   load_var2 1 2                              
+        157   load_var 6                                 (j)
+        158   make_closure 1735 captures=3 ntypeargs=1   
+        159   call 16 ntypeargs=3                        (baml.Array.map)
+        160   store_var 15                               (futures)
 
-  222   163   load_type 15                               
-        164   load_type 16                               
-        165   load_var 15                                (futures)
-        166   call 483 ntypeargs=2                       (baml.future.all)
-        167   await                                      
-        168   pop 1                                      
+  222   161   load_type 15                               
+        162   load_type 16                               
+        163   load_var 15                                (futures)
+        164   call 483 ntypeargs=2                       (baml.future.all)
+        165   await                                      
+        166   pop 1                                      
 
-  223   169   load_type 1                                
-        170   load_deref 1                               
-        171   load_deref 6                               
-        172   load_var 7                                 (seen)
-        173   call 845 ntypeargs=1                       (ai.Agent._emit_from)
-        174   store_var 7                                (seen)
+  223   167   load_type 1                                
+        168   load_deref 1                               
+        169   load_deref 6                               
+        170   load_var 7                                 (seen)
+        171   call 845 ntypeargs=1                       (ai.Agent._emit_from)
+        172   store_var 7                                (seen)
 
-  227   175   load_deref 6                               
-        176   call 805 ntypeargs=0                       (ai.Journal.entries)
-        177   store_var 16                               (entries)
+  227   173   load_deref 6                               
+        174   call 805 ntypeargs=0                       (ai.Journal.entries)
+        175   store_var 16                               (entries)
 
-  228   178   load_var 14                                (before)
-        179   store_var 17                               (i)
+  228   176   load_var 14                                (before)
+        177   store_var 17                               (i)
 
-  229   180   load_var 17                                (i)
-        181   store_var 18                               (_47)
-        182   load_var 16                                (entries)
-        183   container_len                              
-        184   store_var 19                               (_48)
-        185   load_var2 18 19                            
-        186   cmp_int_op <                               
-        187   pop_jump_if_false -141                     (to 46)
+  229   178   load_var 17                                (i)
+        179   store_var 18                               (_48)
+        180   load_var 16                                (entries)
+        181   container_len                              
+        182   store_var 19                               (_49)
+        183   load_var2 18 19                            
+        184   cmp_int_op <                               
+        185   pop_jump_if_false -140                     (to 45)
 
-  230   188   load_type 11                               
-        189   load_var2 16 17                            
-        190   call 3 ntypeargs=1                         (baml.Array.at)
-        191   store_var 20                               (_52)
-        192   load_var 20                                (_52)
-        193   narrow_bind 17 20                          
-        194   pop_jump_if_false +60                      (to 254)
-        195   load_var 20                                (_52)
-        196   store_deref 21                             
+  230   186   load_type 11                               
+        187   load_var2 16 17                            
+        188   call 3 ntypeargs=1                         (baml.Array.at)
+        189   store_var 20                               (_53)
+        190   load_var 20                                (_53)
+        191   narrow_bind 17 20                          
+        192   pop_jump_if_false +57                      (to 249)
+        193   load_var 20                                (_53)
+        194   store_deref 21                             
 
-  231   197   load_type 12                               
-        198   load_type 14                               
-        199   load_var 12                                (calls)
-        200   load_type 1                                
-        201   load_var 21                                (f)
-        202   make_closure 1736 captures=1 ntypeargs=1   
-        203   call 19 ntypeargs=2                        (baml.Array.find)
+  231   195   load_type 12                               
+        196   load_type 14                               
+        197   load_var 12                                (calls)
+        198   load_type 1                                
+        199   load_var 21                                (f)
+        200   make_closure 1736 captures=1 ntypeargs=1   
+        201   call 19 ntypeargs=2                        (baml.Array.find)
 
-  234   204   store_var 22                               (_58)
-        205   load_var 22                                (_58)
-        206   narrow_bind 18 22                          
-        207   pop_jump_if_false +47                      (to 254)
-        208   load_var 22                                (_58)
-        209   store_var 23                               (known)
+  234   202   store_var 22                               (_59)
+        203   load_var 22                                (_59)
+        204   narrow_bind 18 22                          
+        205   pop_jump_if_false +44                      (to 249)
+        206   load_var 22                                (_59)
+        207   store_var 23                               (known)
 
-  235   210   load_type 3                                
-        211   load_var 23                                (known)
-        212   load_field 1                               (name)
-        213   call 138 ntypeargs=1                       (baml.String.from)
-        214   store_var 25                               (_62)
-        215   load_type 3                                
-        216   load_deref 21                              
-        217   load_field 1                               (message)
-        218   call 138 ntypeargs=1                       (baml.String.from)
-        219   store_var 26                               (_65)
-        220   load_var 25                                (_62)
-        221   load_const 19                              ("|")
+  235   208   load_type 3                                
+        209   load_var 23                                (known)
+        210   load_field 1                               (name)
+        211   call 138 ntypeargs=1                       (baml.String.from)
+        212   store_var 25                               (_63)
+        213   load_type 3                                
+        214   load_deref 21                              
+        215   load_field 1                               (message)
+        216   call 138 ntypeargs=1                       (baml.String.from)
+        217   store_var 26                               (_66)
+        218   load_var 25                                (_63)
+        219   load_const 19                              ("|")
+        220   bin_op +                                   
+        221   load_var 26                                (_66)
         222   bin_op +                                   
-        223   load_var 26                                (_65)
-        224   bin_op +                                   
-        225   store_var 24                               (key)
+        223   store_var 24                               (key)
 
-  236   226   load_type 3                                
-        227   load_type 4                                
-        228   load_var2 10 24                            
-        229   call 38 ntypeargs=2                        (baml.Map.get)
-        230   store_var 29                               (_70)
-        231   load_var 29                                (_70)
-        232   store_var 28                               (_69)
-        233   load_var 29                                (_70)
-        234   load_const 0                               (null)
-        235   cmp_op ==                                  
-        236   pop_jump_if_false +3                       (to 239)
-        237   load_const 2                               (0)
-        238   store_var 28                               (_69)
-        239   load_var 28                                (_69)
-        240   load_const 6                               (1)
-        241   add_int                                    
-        242   store_var 27                               (n)
+  236   224   load_type 3                                
+        225   load_type 4                                
+        226   load_var2 10 24                            
+        227   call 38 ntypeargs=2                        (baml.Map.get)
+        228   store_var_load_var 28                      (_71)
+        229   load_const 0                               (null)
+        230   cmp_op ==                                  
+        231   pop_jump_if_false +3                       (to 234)
+        232   load_const 2                               (0)
+        233   store_var 28                               (_71)
+        234   load_var 28                                (_71)
+        235   load_const 6                               (1)
+        236   add_int                                    
+        237   store_var 27                               (n)
 
-  237   243   load_type 3                                
-        244   load_type 4                                
-        245   load_var2 10 24                            
-        246   load_var 27                                (n)
-        247   call 37 ntypeargs=2                        (baml.Map.set)
-        248   pop 1                                      
+  237   238   load_type 3                                
+        239   load_type 4                                
+        240   load_var2 10 24                            
+        241   load_var 27                                (n)
+        242   call 37 ntypeargs=2                        (baml.Map.set)
+        243   pop 1                                      
 
-  238   249   load_var 27                                (n)
-        250   load_const 20                              (3)
-        251   cmp_int_op >=                              
-        252   pop_jump_if_false +2                       (to 254)
-        253   jump +6                                    (to 259)
+  238   244   load_var 27                                (n)
+        245   load_const 20                              (3)
+        246   cmp_int_op >=                              
+        247   pop_jump_if_false +2                       (to 249)
+        248   jump +6                                    (to 254)
 
-  248   254   load_var 17                                (i)
-        255   load_const 6                               (1)
-        256   add_int                                    
-        257   store_var 17                               (i)
+  248   249   load_var 17                                (i)
+        250   load_const 6                               (1)
+        251   add_int                                    
+        252   store_var 17                               (i)
 
-  229   258   jump -78                                   (to 180)
+  229   253   jump -75                                   (to 178)
 
-  240   259   load_var 23                                (known)
-        260   load_field 0                               (id)
-        261   store_var 30                               (_83)
+  240   254   load_var 23                                (known)
+        255   load_field 0                               (id)
+        256   store_var 29                               (_85)
 
-  241   262   load_var 23                                (known)
-        263   load_field 1                               (name)
-        264   store_var 31                               (_84)
+  241   257   load_var 23                                (known)
+        258   load_field 1                               (name)
+        259   store_var 30                               (_86)
 
-  242   265   load_type 4                                
-        266   load_var 27                                (n)
+  242   260   load_type 4                                
+        261   load_var 27                                (n)
+        262   call 138 ntypeargs=1                       (baml.String.from)
+        263   store_var 31                               (_90)
+        264   load_type 3                                
+        265   load_deref 21                              
+        266   load_field 1                               (message)
         267   call 138 ntypeargs=1                       (baml.String.from)
-        268   store_var 32                               (_88)
-        269   load_type 3                                
-        270   load_deref 21                              
-        271   load_field 1                               (message)
-        272   call 138 ntypeargs=1                       (baml.String.from)
-        273   store_var 33                               (_91)
+        268   store_var 32                               (_93)
 
-  239   274   load_var2 30 31                            
+  239   269   load_var2 29 30                            
 
-  242   275   load_const 21                              ("the same tool call failed ")
-        276   load_var 32                                (_88)
-        277   bin_op +                                   
-        278   load_const 22                              (" times; stopping the run: ")
-        279   bin_op +                                   
-        280   load_var 33                                (_91)
-        281   bin_op +                                   
-        282   load_const 0                               (null)
-        283   init_instance 6                            (ai.errors.ToolFailedError .id, .name, .message, .cause)
-        284   throw                                      
+  242   270   load_const 21                              ("the same tool call failed ")
+        271   load_var 31                                (_90)
+        272   bin_op +                                   
+        273   load_const 22                              (" times; stopping the run: ")
+        274   bin_op +                                   
+        275   load_var 32                                (_93)
+        276   bin_op +                                   
+        277   load_const 0                               (null)
+        278   init_instance 6                            (ai.errors.ToolFailedError .id, .name, .message, .cause)
+        279   throw                                      
 }
 
 function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.FunctionSpec<#0>, j: ai.Journal, total: ai.events.Usage, attempts_left: int) -> ai.ModelTurn {
@@ -363,7 +358,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         21    store_var 11                       (_15)
         22    load_var 11                        (_15)
         23    narrow_bind 3 11                   
-        24    pop_jump_if_false +63              (to 87)
+        24    pop_jump_if_false +57              (to 81)
         25    load_var 11                        (_15)
         26    store_var 12                       (u)
 
@@ -388,240 +383,233 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         43    store_var 13                       (_20)
         44    load_var 13                        (_20)
         45    narrow_bind 4 13                   
-        46    pop_jump_if_false +18              (to 64)
+        46    pop_jump_if_false +15              (to 61)
         47    load_var 13                        (_20)
         48    store_var 14                       (ci)
 
   134   49    load_var 5                         (total)
         50    load_field 2                       (cached_input_tokens)
-        51    store_var 16                       (_23)
-        52    load_var 16                        (_23)
-        53    store_var 15                       (_22)
-        54    load_var 16                        (_23)
-        55    load_const 5                       (null)
-        56    cmp_op ==                          
-        57    pop_jump_if_false +3               (to 60)
-        58    load_const 4                       (0)
-        59    store_var 15                       (_22)
-        60    load_var2 5 15                     
-        61    load_var 14                        (ci)
-        62    bin_op +                           
-        63    store_field 2                      (cached_input_tokens)
+        51    store_var_load_var 15              (_23)
+        52    load_const 5                       (null)
+        53    cmp_op ==                          
+        54    pop_jump_if_false +3               (to 57)
+        55    load_const 4                       (0)
+        56    store_var 15                       (_23)
+        57    load_var2 5 15                     
+        58    load_var 14                        (ci)
+        59    bin_op +                           
+        60    store_field 2                      (cached_input_tokens)
 
-  136   64    load_var 12                        (u)
-        65    load_field 3                       (reasoning_tokens)
-        66    store_var 17                       (_27)
-        67    load_var 17                        (_27)
-        68    narrow_bind 4 17                   
-        69    pop_jump_if_false +18              (to 87)
-        70    load_var 17                        (_27)
-        71    store_var 18                       (rt)
+  136   61    load_var 12                        (u)
+        62    load_field 3                       (reasoning_tokens)
+        63    store_var 16                       (_28)
+        64    load_var 16                        (_28)
+        65    narrow_bind 4 16                   
+        66    pop_jump_if_false +15              (to 81)
+        67    load_var 16                        (_28)
+        68    store_var 17                       (rt)
 
-  137   72    load_var 5                         (total)
-        73    load_field 3                       (reasoning_tokens)
-        74    store_var 20                       (_30)
-        75    load_var 20                        (_30)
-        76    store_var 19                       (_29)
-        77    load_var 20                        (_30)
-        78    load_const 5                       (null)
-        79    cmp_op ==                          
-        80    pop_jump_if_false +3               (to 83)
-        81    load_const 4                       (0)
-        82    store_var 19                       (_29)
-        83    load_var2 5 19                     
-        84    load_var 18                        (rt)
-        85    bin_op +                           
-        86    store_field 3                      (reasoning_tokens)
+  137   69    load_var 5                         (total)
+        70    load_field 3                       (reasoning_tokens)
+        71    store_var_load_var 18              (_31)
+        72    load_const 5                       (null)
+        73    cmp_op ==                          
+        74    pop_jump_if_false +3               (to 77)
+        75    load_const 4                       (0)
+        76    store_var 18                       (_31)
+        77    load_var2 5 18                     
+        78    load_var 17                        (rt)
+        79    bin_op +                           
+        80    store_field 3                      (reasoning_tokens)
 
-  141   87    load_var 7                         (turn)
-        88    load_field 0                       (content)
-        89    store_var 22                       (_35)
-        90    load_var 2                         (c)
-        91    load_type 1                        
-        92    load_const 6                       ("id")
-        93    virtual_call nargs=1 ntypeargs=0   
-        94    store_var 23                       (_36)
-        95    load_var2 22 23                    
-        96    init_instance 1                    (ai.events.AssistantMessage .content, .client_id)
-        97    load_type 7                        
-        98    alloc_array 1                      
-        99    store_var 21                       (batch)
+  141   81    load_var 7                         (turn)
+        82    load_field 0                       (content)
+        83    store_var 20                       (_37)
+        84    load_var 2                         (c)
+        85    load_type 1                        
+        86    load_const 6                       ("id")
+        87    virtual_call nargs=1 ntypeargs=0   
+        88    store_var 21                       (_38)
+        89    load_var2 20 21                    
+        90    init_instance 1                    (ai.events.AssistantMessage .content, .client_id)
+        91    load_type 7                        
+        92    alloc_array 1                      
+        93    store_var 19                       (batch)
 
-  142   100   load_var 7                         (turn)
-        101   call 825 ntypeargs=0               (ai.ModelTurn.tool_uses)
-        102   load_type 8                        
-        103   load_const 9                       ("iter")
-        104   virtual_call nargs=1 ntypeargs=0   
-        105   store_var 24                       (_38)
-        106   load_var 24                        (_38)
-        107   load_type 10                       
-        108   load_const 11                      ("next")
-        109   virtual_call nargs=1 ntypeargs=0   
-        110   store_var 25                       (_39)
-        111   load_var 25                        (_39)
-        112   is_type 12                         
-        113   pop_jump_if_false +2               (to 115)
-        114   jump +14                           (to 128)
-        115   load_var 25                        (_39)
-        116   store_var 26                       (u)
+  142   94    load_var 7                         (turn)
+        95    call 825 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        96    load_type 8                        
+        97    load_const 9                       ("iter")
+        98    virtual_call nargs=1 ntypeargs=0   
+        99    store_var 22                       (_40)
+        100   load_var 22                        (_40)
+        101   load_type 10                       
+        102   load_const 11                      ("next")
+        103   virtual_call nargs=1 ntypeargs=0   
+        104   store_var 23                       (_41)
+        105   load_var 23                        (_41)
+        106   is_type 12                         
+        107   pop_jump_if_false +2               (to 109)
+        108   jump +14                           (to 122)
+        109   load_var 23                        (_41)
+        110   store_var 24                       (u)
 
-  143   117   load_type 7                        
-        118   load_var2 21 26                    
-        119   load_field 0                       (id)
-        120   load_var 26                        (u)
-        121   load_field 1                       (name)
-        122   load_var 26                        (u)
-        123   load_field 2                       (args)
-        124   init_instance 2                    (ai.events.ToolRequested .id, .name, .args)
-        125   call 4 ntypeargs=1                 (baml.Array.push)
-        126   pop 1                              
-        127   jump -21                           (to 106)
+  143   111   load_type 7                        
+        112   load_var2 19 24                    
+        113   load_field 0                       (id)
+        114   load_var 24                        (u)
+        115   load_field 1                       (name)
+        116   load_var 24                        (u)
+        117   load_field 2                       (args)
+        118   init_instance 2                    (ai.events.ToolRequested .id, .name, .args)
+        119   call 4 ntypeargs=1                 (baml.Array.push)
+        120   pop 1                              
+        121   jump -21                           (to 100)
 
-  145   128   load_var 7                         (turn)
-        129   load_field 2                       (usage)
-        130   store_var 27                       (_50)
-        131   load_var 27                        (_50)
-        132   narrow_bind 3 27                   
-        133   pop_jump_if_false +7               (to 140)
-        134   load_var 27                        (_50)
-        135   store_var 28                       (u)
+  145   122   load_var 7                         (turn)
+        123   load_field 2                       (usage)
+        124   store_var 25                       (_52)
+        125   load_var 25                        (_52)
+        126   narrow_bind 3 25                   
+        127   pop_jump_if_false +7               (to 134)
+        128   load_var 25                        (_52)
+        129   store_var 26                       (u)
 
-  146   136   load_type 7                        
-        137   load_var2 21 28                    
-        138   call 4 ntypeargs=1                 (baml.Array.push)
-        139   pop 1                              
+  146   130   load_type 7                        
+        131   load_var2 19 26                    
+        132   call 4 ntypeargs=1                 (baml.Array.push)
+        133   pop 1                              
 
-  148   140   load_var 7                         (turn)
-        141   call 824 ntypeargs=0               (ai.ModelTurn.terminal_text)
-        142   store_var 30                       (_56)
-        143   load_var 30                        (_56)
-        144   store_var 29                       (candidate)
-        145   load_var 30                        (_56)
-        146   load_const 5                       (null)
-        147   cmp_op ==                          
-        148   pop_jump_if_false +3               (to 151)
-        149   load_const 13                      ("")
-        150   store_var 29                       (candidate)
+  148   134   load_var 7                         (turn)
+        135   call 824 ntypeargs=0               (ai.ModelTurn.terminal_text)
+        136   store_var_load_var 28              (_58)
+        137   load_const 5                       (null)
+        138   cmp_op ==                          
+        139   pop_jump_if_false +3               (to 142)
+        140   load_const 13                      ("")
+        141   store_var 28                       (_58)
+        142   load_var 28                        (_58)
+        143   store_var 27                       (candidate)
 
-  149   151   load_var 7                         (turn)
-        152   call 825 ntypeargs=0               (ai.ModelTurn.tool_uses)
-        153   container_len                      
-        154   store_var 31                       (_62)
-        155   load_var 31                        (_62)
-        156   load_const 4                       (0)
-        157   cmp_int_op >                       
-        158   jump_if_false +2                   (to 160)
-        159   jump +7                            (to 166)
-        160   pop 1                              
+  149   144   load_var 7                         (turn)
+        145   call 825 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        146   container_len                      
+        147   store_var 29                       (_65)
+        148   load_var 29                        (_65)
+        149   load_const 4                       (0)
+        150   cmp_int_op >                       
+        151   jump_if_false +2                   (to 153)
+        152   jump +7                            (to 159)
+        153   pop 1                              
 
-  150   161   load_var 7                         (turn)
-        162   load_field 1                       (stop_reason)
-        163   load_const 14                      (ai.content.StopReason.MaxTokens)
-        164   alloc_variant 436                  (ai.content.StopReason)
-        165   call 653 ntypeargs=0               (baml.ops.equals_equals)
+  150   154   load_var 7                         (turn)
+        155   load_field 1                       (stop_reason)
+        156   load_const 14                      (ai.content.StopReason.MaxTokens)
+        157   alloc_variant 436                  (ai.content.StopReason)
+        158   call 653 ntypeargs=0               (baml.ops.equals_equals)
 
-  149   166   jump_if_false +2                   (to 168)
-        167   jump +7                            (to 174)
-        168   pop 1                              
+  149   159   jump_if_false +2                   (to 161)
+        160   jump +7                            (to 167)
+        161   pop 1                              
 
-  151   169   load_var 7                         (turn)
-        170   load_field 1                       (stop_reason)
-        171   load_const 15                      (ai.content.StopReason.Refused)
-        172   alloc_variant 436                  (ai.content.StopReason)
-        173   call 653 ntypeargs=0               (baml.ops.equals_equals)
+  151   162   load_var 7                         (turn)
+        163   load_field 1                       (stop_reason)
+        164   load_const 15                      (ai.content.StopReason.Refused)
+        165   alloc_variant 436                  (ai.content.StopReason)
+        166   call 653 ntypeargs=0               (baml.ops.equals_equals)
 
-  149   174   jump_if_false +2                   (to 176)
-        175   jump +5                            (to 180)
-        176   pop 1                              
+  149   167   jump_if_false +2                   (to 169)
+        168   jump +5                            (to 173)
+        169   pop 1                              
 
-  152   177   load_type 0                        
-        178   load_var2 1 29                     
-        179   call 843 ntypeargs=1               (ai.Agent._parses)
+  152   170   load_type 0                        
+        171   load_var2 1 27                     
+        172   call 843 ntypeargs=1               (ai.Agent._parses)
 
-  153   180   pop_jump_if_false +2               (to 182)
-        181   jump +34                           (to 215)
+  153   173   pop_jump_if_false +2               (to 175)
+        174   jump +34                           (to 208)
 
-  166   182   load_var 6                         (attempts_left)
-        183   load_const 16                      (1)
-        184   cmp_int_op >                       
-        185   pop_jump_if_false +2               (to 187)
-        186   jump +12                           (to 198)
+  166   175   load_var 6                         (attempts_left)
+        176   load_const 16                      (1)
+        177   cmp_int_op >                       
+        178   pop_jump_if_false +2               (to 180)
+        179   jump +12                           (to 191)
 
-  175   187   load_var2 4 21                     
-        188   call 807 ntypeargs=0               (ai.Journal.append_all)
-        189   pop 1                              
+  175   180   load_var2 4 19                     
+        181   call 807 ntypeargs=0               (ai.Journal.append_all)
+        182   pop 1                              
 
-  176   190   load_var 2                         (c)
-        191   load_type 1                        
-        192   load_const 17                      ("id")
-        193   virtual_call nargs=1 ntypeargs=0   
-        194   store_var 34                       (_89)
-        195   load_var2 34 29                    
-        196   init_instance 3                    (ai.errors.ParseFailed .provider, .raw_output)
-        197   throw                              
+  176   183   load_var 2                         (c)
+        184   load_type 1                        
+        185   load_const 17                      ("id")
+        186   virtual_call nargs=1 ntypeargs=0   
+        187   store_var 32                       (_92)
+        188   load_var2 32 27                    
+        189   init_instance 3                    (ai.errors.ParseFailed .provider, .raw_output)
+        190   throw                              
 
-  167   198   load_type 7                        
-        199   load_var 21                        (batch)
+  167   191   load_type 7                        
+        192   load_var 19                        (batch)
 
-  168   200   load_const 18                      ("The reply did not match the required schema. Answer again with only the corrected value.")
-        201   init_instance 4                    (ai.events.UserMessage .content)
-        202   call 4 ntypeargs=1                 (baml.Array.push)
-        203   pop 1                              
+  168   193   load_const 18                      ("The reply did not match the required schema. Answer again with only the corrected value.")
+        194   init_instance 4                    (ai.events.UserMessage .content)
+        195   call 4 ntypeargs=1                 (baml.Array.push)
+        196   pop 1                              
 
-  172   204   load_var2 4 21                     
-        205   call 807 ntypeargs=0               (ai.Journal.append_all)
-        206   pop 1                              
+  172   197   load_var2 4 19                     
+        198   call 807 ntypeargs=0               (ai.Journal.append_all)
+        199   pop 1                              
 
-  173   207   load_type 0                        
-        208   load_var2 1 2                      
-        209   load_var2 3 4                      
-        210   load_var2 5 6                      
-        211   load_const 16                      (1)
-        212   sub_int                            
-        213   call 844 ntypeargs=1               (ai.Agent._attempt_turn)
-        214   jump +19                           (to 233)
+  173   200   load_type 0                        
+        201   load_var2 1 2                      
+        202   load_var2 3 4                      
+        203   load_var2 5 6                      
+        204   load_const 16                      (1)
+        205   sub_int                            
+        206   call 844 ntypeargs=1               (ai.Agent._attempt_turn)
+        207   jump +19                           (to 226)
 
-  154   215   load_var2 4 21                     
-        216   call 807 ntypeargs=0               (ai.Journal.append_all)
-        217   pop 1                              
+  154   208   load_var2 4 19                     
+        209   call 807 ntypeargs=0               (ai.Journal.append_all)
+        210   pop 1                              
 
-  156   218   load_var 7                         (turn)
+  156   211   load_var 7                         (turn)
+        212   load_field 1                       (stop_reason)
+        213   discriminant                       
+        214   load_const 14                      (StopReason.MaxTokens)
+        215   cmp_int_op ==                      
+        216   pop_jump_if_false +2               (to 218)
+        217   jump +20                           (to 237)
+        218   load_var 7                         (turn)
         219   load_field 1                       (stop_reason)
         220   discriminant                       
-        221   load_const 14                      (StopReason.MaxTokens)
+        221   load_const 15                      (StopReason.Refused)
         222   cmp_int_op ==                      
         223   pop_jump_if_false +2               (to 225)
-        224   jump +20                           (to 244)
-        225   load_var 7                         (turn)
-        226   load_field 1                       (stop_reason)
-        227   discriminant                       
-        228   load_const 15                      (StopReason.Refused)
-        229   cmp_int_op ==                      
-        230   pop_jump_if_false +2               (to 232)
-        231   jump +3                            (to 234)
+        224   jump +3                            (to 227)
 
-  165   232   load_var 7                         (turn)
-        233   return                             
+  165   225   load_var 7                         (turn)
+        226   return                             
 
-  161   234   load_var 2                         (c)
-        235   load_type 1                        
-        236   load_const 19                      ("id")
-        237   virtual_call nargs=1 ntypeargs=0   
-        238   store_var 33                       (_77)
-        239   load_var 33                        (_77)
-        240   load_const 20                      ("the model declined to answer")
-        241   load_const 5                       (null)
-        242   init_instance 5                    (ai.errors.Refused .provider, .reason, .raw_body)
-        243   throw                              
+  161   227   load_var 2                         (c)
+        228   load_type 1                        
+        229   load_const 19                      ("id")
+        230   virtual_call nargs=1 ntypeargs=0   
+        231   store_var 31                       (_80)
+        232   load_var 31                        (_80)
+        233   load_const 20                      ("the model declined to answer")
+        234   load_const 5                       (null)
+        235   init_instance 5                    (ai.errors.Refused .provider, .reason, .raw_body)
+        236   throw                              
 
-  158   244   load_var 2                         (c)
-        245   load_type 1                        
-        246   load_const 21                      ("id")
-        247   virtual_call nargs=1 ntypeargs=0   
-        248   store_var 32                       (_74)
-        249   load_var2 32 29                    
-        250   init_instance 6                    (ai.errors.ParseFailed .provider, .raw_output)
-        251   throw                              
+  158   237   load_var 2                         (c)
+        238   load_type 1                        
+        239   load_const 21                      ("id")
+        240   virtual_call nargs=1 ntypeargs=0   
+        241   store_var 30                       (_77)
+        242   load_var2 30 27                    
+        243   init_instance 6                    (ai.errors.ParseFailed .provider, .raw_output)
+        244   throw                              
 }
 
 function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> int {
@@ -725,18 +713,18 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
 
   89   8     load_var 3              (call)
        9     load_field 0            (id)
-       10    store_var 21            (_41)
+       10    store_var 20            (_42)
 
   90   11    load_type 1             
        12    load_var 3              (call)
        13    load_field 1            (name)
        14    call 138 ntypeargs=1    (baml.String.from)
-       15    store_var 22            (_43)
+       15    store_var 21            (_44)
 
-  86   16    load_var2 4 21          
+  86   16    load_var2 4 20          
 
   90   17    load_const 2            ("tool is not in the active toolbox: ")
-       18    load_var 22             (_43)
+       18    load_var 21             (_44)
        19    bin_op +                
        20    init_instance 0         (ai.events.ToolFailed .id, .message)
        21    load_type 3             
@@ -746,7 +734,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
 
   94   25    load_const 4            (null)
 
-  56   26    jump +88                (to 114)
+  56   26    jump +85                (to 111)
        27    load_var 5              (_7)
        28    store_var 6             (t)
 
@@ -754,7 +742,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        30    load_field 2            (args)
        31    call 817 ntypeargs=0    (ai.tools.Tool.call)
        32    store_var 7             (outcome)
-       33    jump +65                (to 98)
+       33    jump +62                (to 95)
        34    load_var 8              (e)
        35    throw_if_panic          
 
@@ -777,83 +765,80 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
 
   64   50    load_var 6              (t)
        51    load_field 5            (on_error)
-       52    store_var 12            (_20)
-       53    load_var 12             (_20)
-       54    store_var 11            (_19)
-       55    load_var 12             (_20)
-       56    load_const 4            (null)
-       57    cmp_op ==               
-       58    pop_jump_if_false +4    (to 62)
-       59    load_var 1              (self)
-       60    load_field 2            (tool_errors)
-       61    store_var 11            (_19)
-       62    load_var 11             (_19)
-       63    load_const 6            (ai.tools.ErrorMode.Raise)
-       64    alloc_variant 437       (ai.tools.ErrorMode)
-       65    call 653 ntypeargs=0    (baml.ops.equals_equals)
-       66    pop_jump_if_false +2    (to 68)
-       67    jump +4                 (to 71)
+       52    store_var_load_var 11   (_20)
+       53    load_const 4            (null)
+       54    cmp_op ==               
+       55    pop_jump_if_false +4    (to 59)
+       56    load_var 1              (self)
+       57    load_field 2            (tool_errors)
+       58    store_var 11            (_20)
+       59    load_var 11             (_20)
+       60    load_const 6            (ai.tools.ErrorMode.Raise)
+       61    alloc_variant 437       (ai.tools.ErrorMode)
+       62    call 653 ntypeargs=0    (baml.ops.equals_equals)
+       63    pop_jump_if_false +2    (to 65)
+       64    jump +4                 (to 68)
 
-  76   68    load_const 4            (null)
-       69    store_var 7             (outcome)
+  76   65    load_const 4            (null)
+       66    store_var 7             (outcome)
 
-  64   70    jump +28                (to 98)
+  64   67    jump +28                (to 95)
 
-  65   71    load_var 8              (e)
-       72    store_var 14            (_23)
-       73    load_var 14             (_23)
-       74    narrow_bind 7 14        
-       75    pop_jump_if_false +2    (to 77)
-       76    jump +4                 (to 80)
+  65   68    load_var 8              (e)
+       69    store_var 13            (_24)
+       70    load_var 13             (_24)
+       71    narrow_bind 7 13        
+       72    pop_jump_if_false +2    (to 74)
+       73    jump +4                 (to 77)
 
-  67   77    load_const 4            (null)
-       78    store_var 13            (classified)
+  67   74    load_const 4            (null)
+       75    store_var 12            (classified)
 
-  65   79    jump +5                 (to 84)
-       80    load_var 14             (_23)
-       81    store_var 15            (f)
+  65   76    jump +5                 (to 81)
+       77    load_var 13             (_24)
+       78    store_var 14            (f)
 
-  66   82    load_var 15             (f)
-       83    store_var 13            (classified)
+  66   79    load_var 14             (f)
+       80    store_var 12            (classified)
 
-  70   84    load_var 3              (call)
-       85    load_field 0            (id)
-       86    store_var 16            (_26)
+  70   81    load_var 3              (call)
+       82    load_field 0            (id)
+       83    store_var 15            (_27)
 
-  71   87    load_var 3              (call)
-       88    load_field 1            (name)
-       89    store_var 17            (_27)
+  71   84    load_var 3              (call)
+       85    load_field 1            (name)
+       86    store_var 16            (_28)
 
-  72   90    load_type 5             
-       91    load_var 8              (e)
-       92    call 138 ntypeargs=1    (baml.String.from)
-       93    store_var 18            (_28)
+  72   87    load_type 5             
+       88    load_var 8              (e)
+       89    call 138 ntypeargs=1    (baml.String.from)
+       90    store_var 17            (_29)
 
-  69   94    load_var2 16 17         
-       95    load_var2 18 13         
+  69   91    load_var2 15 16         
+       92    load_var2 17 12         
 
-  73   96    init_instance 2         (ai.errors.ToolFailedError .id, .name, .message, .cause)
-       97    throw                   
+  73   93    init_instance 2         (ai.errors.ToolFailedError .id, .name, .message, .cause)
+       94    throw                   
 
-  80   98    load_var 7              (outcome)
-       99    store_var 19            (_31)
-       100   load_var 19             (_31)
-       101   narrow_bind 6 19        
-       102   pop_jump_if_false +11   (to 113)
-       103   load_var 19             (_31)
-       104   store_var 20            (output)
+  80   95    load_var 7              (outcome)
+       96    store_var 18            (_32)
+       97    load_var 18             (_32)
+       98    narrow_bind 6 18        
+       99    pop_jump_if_false +11   (to 110)
+       100   load_var 18             (_32)
+       101   store_var 19            (output)
 
-  81   105   load_var2 4 3           
-       106   load_field 0            (id)
-       107   load_var 20             (output)
-       108   init_instance 3         (ai.events.ToolCompleted .id, .output)
-       109   load_type 3             
-       110   alloc_array 1           
-       111   call 807 ntypeargs=0    (ai.Journal.append_all)
-       112   pop 1                   
+  81   102   load_var2 4 3           
+       103   load_field 0            (id)
+       104   load_var 19             (output)
+       105   init_instance 3         (ai.events.ToolCompleted .id, .output)
+       106   load_type 3             
+       107   alloc_array 1           
+       108   call 807 ntypeargs=0    (ai.Journal.append_all)
+       109   pop 1                   
 
-  83   113   load_const 4            (null)
-       114   return                  
+  83   110   load_const 4            (null)
+       111   return                  
 }
 
 function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.tools.ErrorMode, on_event: ((ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced) -> null throws never) | null) -> ai.Agent<#0> {
@@ -888,21 +873,21 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
        24   store_var 4                                (on_event)
 
   39   25   load_var 4                                 (on_event)
-       26   store_var 5                                (_9)
-       27   load_var 4                                 (on_event)
-       28   load_const 2                               (null)
-       29   cmp_op ==                                  
-       30   pop_jump_if_false +4                       (to 34)
+       26   store_var_load_var 5                       (_10)
+       27   load_const 2                               (null)
+       28   cmp_op ==                                  
+       29   pop_jump_if_false +4                       (to 33)
 
-  41   31   load_type 4                                
-       32   make_closure 1717 captures=0 ntypeargs=1   
-       33   store_var 5                                (_9)
+  41   30   load_type 4                                
+       31   make_closure 1717 captures=0 ntypeargs=1   
+       32   store_var 5                                (_10)
 
-  35   34   load_var2 1 2                              
-       35   load_var2 3 5                              
-       36   load_type 4                                
-       37   init_instance 0                            (ai.Agent .max_steps, .client, .tool_errors, .on_event)
-       38   return                                     
+  35   33   load_var2 1 2                              
+       34   load_var2 3 5                              
+
+  39   35   load_type 4                                
+       36   init_instance 0                            (ai.Agent .max_steps, .client, .tool_errors, .on_event)
+       37   return                                     
 }
 
 function ai.FunctionSpec.arguments(self: ai.FunctionSpec<#0>) -> map<string, unknown> {
@@ -1415,17 +1400,17 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
        17   store_var 4            (backoff)
 
   64   18   load_var 3             (retry_if)
-       19   store_var 5            (_8)
-       20   load_var 3             (retry_if)
-       21   load_const 2           (null)
-       22   cmp_op ==              
-       23   pop_jump_if_false +3   (to 26)
-       24   load_const 3           (ai.clients.default_retry_judgment)
-       25   store_var 5            (_8)
+       19   store_var_load_var 6   (_9)
+       20   load_const 2           (null)
+       21   cmp_op ==              
+       22   pop_jump_if_false +3   (to 25)
+       23   load_const 3           (ai.clients.default_retry_judgment)
+       24   store_var 6            (_9)
+       25   load_var 6             (_9)
+       26   store_var 5            (_8)
 
-  65   26   load_var 4             (backoff)
-       27   store_var 6            (_10)
-       28   load_var 4             (backoff)
+  65   27   load_var 4             (backoff)
+       28   store_var_load_var 7   (_12)
        29   load_const 2           (null)
        30   cmp_op ==              
        31   pop_jump_if_false +6   (to 37)
@@ -1433,11 +1418,12 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
        33   load_const 0           (<omitted>)
        34   load_const 0           (<omitted>)
        35   call 829 ntypeargs=0   (ai.clients.Backoff.new)
-       36   store_var 6            (_10)
+       36   store_var 7            (_12)
 
   61   37   load_var2 1 2          
-       38   load_var2 5 6          
-       39   init_instance 0        (ai.clients.Retry .inner, .max_attempts, .retry_if, .backoff)
+       38   load_var2 5 7          
+
+  65   39   init_instance 0        (ai.clients.Retry .inner, .max_attempts, .retry_if, .backoff)
        40   return                 
 }
 
@@ -2622,60 +2608,55 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
   231   23   load_const 2           (null)
         24   store_var 3            (usage)
 
-  223   25   jump +28               (to 53)
+  223   25   jump +24               (to 49)
 
   225   26   load_var 1             (self)
         27   load_field 8           (_input_tokens)
-        28   store_var 5            (_12)
-        29   load_var 5             (_12)
-        30   store_var 4            (_11)
-        31   load_var 5             (_12)
-        32   load_const 2           (null)
-        33   cmp_op ==              
-        34   pop_jump_if_false +3   (to 37)
-        35   load_const 3           (0)
-        36   store_var 4            (_11)
+        28   store_var_load_var 5   (_12)
+        29   load_const 2           (null)
+        30   cmp_op ==              
+        31   pop_jump_if_false +3   (to 34)
+        32   load_const 3           (0)
+        33   store_var 5            (_12)
+        34   load_var 5             (_12)
+        35   store_var 4            (_11)
 
-  226   37   load_var 1             (self)
-        38   load_field 9           (_output_tokens)
-        39   store_var 7            (_15)
-        40   load_var 7             (_15)
-        41   store_var 6            (_14)
-        42   load_var 7             (_15)
-        43   load_const 2           (null)
-        44   cmp_op ==              
-        45   pop_jump_if_false +3   (to 48)
-        46   load_const 3           (0)
-        47   store_var 6            (_14)
+  226   36   load_var 1             (self)
+        37   load_field 9           (_output_tokens)
+        38   store_var_load_var 6   (_16)
+        39   load_const 2           (null)
+        40   cmp_op ==              
+        41   pop_jump_if_false +3   (to 44)
+        42   load_const 3           (0)
+        43   store_var 6            (_16)
 
-  224   48   load_var2 4 6          
-        49   load_const 2           (null)
-        50   load_const 2           (null)
-        51   init_instance 0        (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
-        52   store_var 3            (usage)
+  224   44   load_var2 4 6          
 
-  235   53   load_var 1             (self)
-        54   load_field 7           (_stop_reason)
-        55   store_var 9            (_21)
-        56   load_var 9             (_21)
-        57   store_var 8            (_20)
-        58   load_var 9             (_21)
-        59   load_const 2           (null)
-        60   cmp_op ==              
-        61   pop_jump_if_false +4   (to 65)
-        62   load_const 3           (ai.content.StopReason.Complete)
-        63   alloc_variant 436      (ai.content.StopReason)
-        64   store_var 8            (_20)
+  226   45   load_const 2           (null)
+        46   load_const 2           (null)
+        47   init_instance 0        (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
+        48   store_var 3            (usage)
 
-  234   65   load_var 1             (self)
-        66   load_field 6           (_text)
-        67   init_instance 1        (ai.content.Text .text)
-        68   load_type 4            
-        69   alloc_array 1          
-        70   load_var2 8 3          
+  235   49   load_var 1             (self)
+        50   load_field 7           (_stop_reason)
+        51   store_var_load_var 7   (_23)
+        52   load_const 2           (null)
+        53   cmp_op ==              
+        54   pop_jump_if_false +4   (to 58)
+        55   load_const 3           (ai.content.StopReason.Complete)
+        56   alloc_variant 436      (ai.content.StopReason)
+        57   store_var 7            (_23)
 
-  236   71   init_instance 2        (ai.ModelTurn .content, .stop_reason, .usage)
-        72   return                 
+  234   58   load_var 1             (self)
+        59   load_field 6           (_text)
+        60   init_instance 1        (ai.content.Text .text)
+        61   load_type 4            
+        62   alloc_array 1          
+
+  235   63   load_var2 7 3          
+
+  236   64   init_instance 2        (ai.ModelTurn .content, .stop_reason, .usage)
+        65   return                 
 }
 
 function ai.stream.TurnStream.from_chunks(chunks: string[]) -> ai.stream.TurnStream {
@@ -3305,93 +3286,94 @@ function ai.tools.raw_tool(name: string, description: string, input_schema: map<
 }
 
 function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unknown>, name: string | null, description: string | null, on_error: ai.tools.ErrorMode | null) -> ai.tools.Tool {
-       0    load_var 2             (name)
-       1    load_const 0           (<omitted>)
-       2    cmp_op ==              
-       3    pop_jump_if_false +3   (to 6)
+       0    load_var 2              (name)
+       1    load_const 0            (<omitted>)
+       2    cmp_op ==               
+       3    pop_jump_if_false +3    (to 6)
 
-  45   4    load_const 1           (null)
-       5    store_var 2            (name)
-       6    load_var 3             (description)
-       7    load_const 0           (<omitted>)
-       8    cmp_op ==              
-       9    pop_jump_if_false +3   (to 12)
+  45   4    load_const 1            (null)
+       5    store_var 2             (name)
+       6    load_var 3              (description)
+       7    load_const 0            (<omitted>)
+       8    cmp_op ==               
+       9    pop_jump_if_false +3    (to 12)
 
-  46   10   load_const 1           (null)
-       11   store_var 3            (description)
-       12   load_var 4             (on_error)
-       13   load_const 0           (<omitted>)
-       14   cmp_op ==              
-       15   pop_jump_if_false +3   (to 18)
+  46   10   load_const 1            (null)
+       11   store_var 3             (description)
+       12   load_var 4              (on_error)
+       13   load_const 0            (<omitted>)
+       14   cmp_op ==               
+       15   pop_jump_if_false +3    (to 18)
 
-  47   16   load_const 1           (null)
-       17   store_var 4            (on_error)
+  47   16   load_const 1            (null)
+       17   store_var 4             (on_error)
 
-  49   18   load_var 1             (handler)
-       19   call 739 ntypeargs=0   (reflect.signature)
-       20   store_var 5            (sig)
+  49   18   load_var 1              (handler)
+       19   call 739 ntypeargs=0    (reflect.signature)
+       20   store_var 5             (sig)
 
-  50   21   load_var 2             (name)
-       22   store_var 6            (resolved_name)
-       23   load_var 2             (name)
-       24   load_const 1           (null)
-       25   cmp_op ==              
-       26   pop_jump_if_false +4   (to 30)
-       27   load_var 5             (sig)
-       28   load_field 0           (name)
-       29   store_var 6            (resolved_name)
+  50   21   load_var 2              (name)
+       22   store_var_load_var 7    (_10)
+       23   load_const 1            (null)
+       24   cmp_op ==               
+       25   pop_jump_if_false +4    (to 29)
+       26   load_var 5              (sig)
+       27   load_field 0            (name)
+       28   store_var 7             (_10)
+       29   load_var 7              (_10)
+       30   store_var 6             (resolved_name)
 
-  51   30   load_var 6             (resolved_name)
-       31   store_var 7            (_11)
-       32   load_var 7             (_11)
-       33   narrow_bind 2 7        
-       34   pop_jump_if_false +2   (to 36)
-       35   jump +4                (to 39)
+  51   31   load_var 6              (resolved_name)
+       32   store_var 8             (_12)
+       33   load_var 8              (_12)
+       34   narrow_bind 2 8         
+       35   pop_jump_if_false +2    (to 37)
+       36   jump +4                 (to 40)
 
-  64   36   load_const 3           ("anonymous tool needs a name")
-       37   init_instance 0        (baml.errors.InvalidArgument .message)
-       38   throw                  
+  64   37   load_const 3            ("anonymous tool needs a name")
+       38   init_instance 0         (baml.errors.InvalidArgument .message)
+       39   throw                   
 
-  51   39   load_var 7             (_11)
-       40   store_var_load_var 8   (n)
+  51   40   load_var 8              (_12)
+       41   store_var_load_var 9    (n)
 
-  52   41   load_const 4           ("__baml_return_output")
-       42   cmp_op ==              
-       43   pop_jump_if_false +2   (to 45)
-       44   jump +27               (to 71)
+  52   42   load_const 4            ("__baml_return_output")
+       43   cmp_op ==               
+       44   pop_jump_if_false +2    (to 46)
+       45   jump +27                (to 72)
 
-  57   45   load_var 3             (description)
-       46   store_var 10           (_18)
-       47   load_var 3             (description)
-       48   load_const 1           (null)
-       49   cmp_op ==              
-       50   pop_jump_if_false +4   (to 54)
-       51   load_var 5             (sig)
-       52   load_field 5           (docstring)
-       53   store_var 10           (_18)
-       54   load_var 10            (_18)
-       55   store_var 9            (_17)
-       56   load_var 10            (_18)
-       57   load_const 1           (null)
-       58   cmp_op ==              
-       59   pop_jump_if_false +3   (to 62)
-       60   load_const 5           ("")
-       61   store_var 9            (_17)
+  57   46   load_var 3              (description)
+       47   store_var_load_var 12   (_21)
+       48   load_const 1            (null)
+       49   cmp_op ==               
+       50   pop_jump_if_false +4    (to 54)
+       51   load_var 5              (sig)
+       52   load_field 5            (docstring)
+       53   store_var 12            (_21)
+       54   load_var 12             (_21)
+       55   store_var_load_var 11   (_19)
+       56   load_const 1            (null)
+       57   cmp_op ==               
+       58   pop_jump_if_false +3    (to 61)
+       59   load_const 5            ("")
+       60   store_var 11            (_19)
+       61   load_var 11             (_19)
+       62   store_var 10            (_18)
 
-  58   62   load_var 1             (handler)
-       63   call 866 ntypeargs=0   (ai.internal._schema_for_signature)
-       64   store_var 11           (_21)
+  58   63   load_var 1              (handler)
+       64   call 866 ntypeargs=0    (ai.internal._schema_for_signature)
+       65   store_var 13            (_24)
 
-  56   65   load_var2 8 9          
-       66   load_var2 11 1         
-       67   load_const 1           (null)
-       68   load_var 4             (on_error)
-       69   init_instance 1        (ai.tools.Tool .name, .description, .input_schema, .handler, .raw_handler, .on_error)
-       70   return                 
+  56   66   load_var2 9 10          
+       67   load_var2 13 1          
+       68   load_const 1            (null)
+       69   load_var 4              (on_error)
+       70   init_instance 1         (ai.tools.Tool .name, .description, .input_schema, .handler, .raw_handler, .on_error)
+       71   return                  
 
-  53   71   load_const 6           ("the tool name __baml_return_output is reserved")
-       72   init_instance 2        (baml.errors.InvalidArgument .message)
-       73   throw                  
+  53   72   load_const 6            ("the tool name __baml_return_output is reserved")
+       73   init_instance 2         (baml.errors.InvalidArgument .message)
+       74   throw                   
 }
 
 function ai.wire.render_output_format(t: type) -> string {
@@ -3673,7 +3655,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         14    load_var 5                         (_5)
         15    is_type 5                          
         16    pop_jump_if_false +2               (to 18)
-        17    jump +227                          (to 244)
+        17    jump +219                          (to 236)
         18    load_var 5                         (_5)
         19    store_var_load_var 6               (raw)
 
@@ -3699,238 +3681,230 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
         36    narrow_bind 9 10                   
         37    pop_jump_if_false -28              (to 9)
         38    load_var 10                        (_16)
-        39    store_var 11                       (event)
+        39    store_var_load_var 11              (event)
 
-  355   40    load_var 11                        (event)
-        41    load_field 0                       (type)
-        42    store_var 14                       (_20)
-        43    load_var 14                        (_20)
-        44    store_var 13                       (_19)
-        45    load_var 14                        (_20)
-        46    load_const 8                       (null)
-        47    cmp_op ==                          
-        48    pop_jump_if_false +4               (to 52)
-        49    load_var 6                         (raw)
-        50    load_field 0                       (event)
-        51    store_var 13                       (_19)
-        52    load_var 13                        (_19)
-        53    store_var 12                       (t)
-        54    load_var 13                        (_19)
-        55    load_const 8                       (null)
-        56    cmp_op ==                          
-        57    pop_jump_if_false +3               (to 60)
-        58    load_const 10                      ("")
-        59    store_var 12                       (t)
+  355   40    load_field 0                       (type)
+        41    store_var_load_var 14              (_21)
+        42    load_const 8                       (null)
+        43    cmp_op ==                          
+        44    pop_jump_if_false +4               (to 48)
+        45    load_var 6                         (raw)
+        46    load_field 0                       (event)
+        47    store_var 14                       (_21)
+        48    load_var 14                        (_21)
+        49    store_var_load_var 13              (_19)
+        50    load_const 8                       (null)
+        51    cmp_op ==                          
+        52    pop_jump_if_false +3               (to 55)
+        53    load_const 10                      ("")
+        54    store_var 13                       (_19)
+        55    load_var 13                        (_19)
+        56    store_var_load_var 12              (t)
 
-  356   60    load_var 12                        (t)
-        61    load_const 11                      ("content_block_delta")
-        62    cmp_op ==                          
-        63    pop_jump_if_false +2               (to 65)
-        64    jump +143                          (to 207)
+  356   57    load_const 11                      ("content_block_delta")
+        58    cmp_op ==                          
+        59    pop_jump_if_false +2               (to 61)
+        60    jump +143                          (to 203)
 
-  372   65    load_var 12                        (t)
-        66    load_const 12                      ("message_start")
-        67    cmp_op ==                          
-        68    pop_jump_if_false +2               (to 70)
-        69    jump +76                           (to 145)
+  372   61    load_var 12                        (t)
+        62    load_const 12                      ("message_start")
+        63    cmp_op ==                          
+        64    pop_jump_if_false +2               (to 66)
+        65    jump +76                           (to 141)
 
-  381   70    load_var 12                        (t)
-        71    load_const 13                      ("message_delta")
-        72    cmp_op ==                          
-        73    pop_jump_if_false +2               (to 75)
-        74    jump +11                           (to 85)
+  381   66    load_var 12                        (t)
+        67    load_const 13                      ("message_delta")
+        68    cmp_op ==                          
+        69    pop_jump_if_false +2               (to 71)
+        70    jump +11                           (to 81)
 
-  394   75    load_var 12                        (t)
-        76    load_const 14                      ("message_stop")
-        77    cmp_op ==                          
-        78    pop_jump_if_false -69              (to 9)
+  394   71    load_var 12                        (t)
+        72    load_const 14                      ("message_stop")
+        73    cmp_op ==                          
+        74    pop_jump_if_false -65              (to 9)
 
-  395   79    load_type 0                        
-        80    load_var 3                         (out)
-        81    alloc_instance 358 ntypeargs=0     (ai.stream.TurnDone)
-        82    call 4 ntypeargs=1                 (baml.Array.push)
-        83    pop 1                              
-        84    jump -75                           (to 9)
+  395   75    load_type 0                        
+        76    load_var 3                         (out)
+        77    alloc_instance 358 ntypeargs=0     (ai.stream.TurnDone)
+        78    call 4 ntypeargs=1                 (baml.Array.push)
+        79    pop 1                              
+        80    jump -71                           (to 9)
 
-  382   85    load_var 11                        (event)
-        86    load_field 1                       (delta)
-        87    load_const 8                       (null)
-        88    cmp_op ==                          
-        89    pop_jump_if_false +2               (to 91)
-        90    jump +6                            (to 96)
-        91    load_var 11                        (event)
-        92    load_field 1                       (delta)
-        93    load_field 2                       (2)
-        94    store_var 24                       (_67)
-        95    jump +3                            (to 98)
-        96    load_const 8                       (null)
-        97    store_var 24                       (_67)
-        98    load_var 24                        (_67)
-        99    load_const 8                       (null)
-        100   cmp_op ==                          
-        101   pop_jump_if_false +2               (to 103)
-        102   jump +6                            (to 108)
-        103   load_var 24                        (_67)
-        104   store_var_load_var 25              (s)
+  382   81    load_var 11                        (event)
+        82    load_field 1                       (delta)
+        83    load_const 8                       (null)
+        84    cmp_op ==                          
+        85    pop_jump_if_false +2               (to 87)
+        86    jump +6                            (to 92)
+        87    load_var 11                        (event)
+        88    load_field 1                       (delta)
+        89    load_field 2                       (2)
+        90    store_var 23                       (_70)
+        91    jump +3                            (to 94)
+        92    load_const 8                       (null)
+        93    store_var 23                       (_70)
+        94    load_var 23                        (_70)
+        95    load_const 8                       (null)
+        96    cmp_op ==                          
+        97    pop_jump_if_false +2               (to 99)
+        98    jump +6                            (to 104)
+        99    load_var 23                        (_70)
+        100   store_var_load_var 24              (s)
 
-  384   105   call 892 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
-        106   store_var 23                       (stop)
-        107   jump +3                            (to 110)
+  384   101   call 892 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+        102   store_var 22                       (stop)
+        103   jump +3                            (to 106)
 
-  383   108   load_const 8                       (null)
-        109   store_var 23                       (stop)
+  383   104   load_const 8                       (null)
+        105   store_var 22                       (stop)
 
-  388   110   load_var 23                        (stop)
-        111   store_var 26                       (_76)
+  388   106   load_var 22                        (stop)
+        107   store_var 25                       (_79)
 
-  389   112   load_var 11                        (event)
-        113   load_field 3                       (usage)
-        114   load_const 8                       (null)
-        115   cmp_op ==                          
-        116   pop_jump_if_false +2               (to 118)
-        117   jump +6                            (to 123)
-        118   load_var 11                        (event)
-        119   load_field 3                       (usage)
-        120   load_field 0                       (0)
-        121   store_var 27                       (_77)
-        122   jump +3                            (to 125)
+  389   108   load_var 11                        (event)
+        109   load_field 3                       (usage)
+        110   load_const 8                       (null)
+        111   cmp_op ==                          
+        112   pop_jump_if_false +2               (to 114)
+        113   jump +6                            (to 119)
+        114   load_var 11                        (event)
+        115   load_field 3                       (usage)
+        116   load_field 0                       (0)
+        117   store_var 26                       (_80)
+        118   jump +3                            (to 121)
+        119   load_const 8                       (null)
+        120   store_var 26                       (_80)
+
+  390   121   load_var 11                        (event)
+        122   load_field 3                       (usage)
         123   load_const 8                       (null)
-        124   store_var 27                       (_77)
+        124   cmp_op ==                          
+        125   pop_jump_if_false +2               (to 127)
+        126   jump +6                            (to 132)
+        127   load_var 11                        (event)
+        128   load_field 3                       (usage)
+        129   load_field 1                       (1)
+        130   store_var 27                       (_84)
+        131   jump +3                            (to 134)
+        132   load_const 8                       (null)
+        133   store_var 27                       (_84)
 
-  390   125   load_var 11                        (event)
-        126   load_field 3                       (usage)
-        127   load_const 8                       (null)
-        128   cmp_op ==                          
-        129   pop_jump_if_false +2               (to 131)
-        130   jump +6                            (to 136)
-        131   load_var 11                        (event)
-        132   load_field 3                       (usage)
-        133   load_field 1                       (1)
-        134   store_var 28                       (_81)
-        135   jump +3                            (to 138)
-        136   load_const 8                       (null)
-        137   store_var 28                       (_81)
+  386   134   load_type 0                        
+        135   load_var2 3 25                     
 
-  386   138   load_type 0                        
-        139   load_var2 3 26                     
+  387   136   load_var2 26 27                    
+        137   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
+        138   call 4 ntypeargs=1                 (baml.Array.push)
+        139   pop 1                              
+        140   jump -131                          (to 9)
 
-  387   140   load_var2 27 28                    
-        141   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
-        142   call 4 ntypeargs=1                 (baml.Array.push)
-        143   pop 1                              
-        144   jump -135                          (to 9)
+  376   141   load_var 11                        (event)
+        142   load_field 2                       (message)
+        143   load_const 8                       (null)
+        144   cmp_op ==                          
+        145   pop_jump_if_false +2               (to 147)
+        146   jump +20                           (to 166)
+        147   load_var 11                        (event)
+        148   load_field 2                       (message)
+        149   load_field 0                       (0)
+        150   load_const 8                       (null)
+        151   cmp_op ==                          
+        152   pop_jump_if_false +2               (to 154)
+        153   jump +13                           (to 166)
+        154   load_var 11                        (event)
+        155   load_field 2                       (message)
+        156   load_const 8                       (null)
+        157   cmp_op ==                          
+        158   pop_jump_if_false +2               (to 160)
+        159   jump +7                            (to 166)
+        160   load_var 11                        (event)
+        161   load_field 2                       (message)
+        162   load_field 0                       (0)
+        163   load_field 0                       (0)
+        164   store_var 20                       (_46)
+        165   jump +3                            (to 168)
+        166   load_const 8                       (null)
+        167   store_var 20                       (_46)
 
-  376   145   load_var 11                        (event)
-        146   load_field 2                       (message)
-        147   load_const 8                       (null)
-        148   cmp_op ==                          
-        149   pop_jump_if_false +2               (to 151)
-        150   jump +20                           (to 170)
-        151   load_var 11                        (event)
-        152   load_field 2                       (message)
-        153   load_field 0                       (0)
-        154   load_const 8                       (null)
-        155   cmp_op ==                          
-        156   pop_jump_if_false +2               (to 158)
-        157   jump +13                           (to 170)
-        158   load_var 11                        (event)
-        159   load_field 2                       (message)
-        160   load_const 8                       (null)
-        161   cmp_op ==                          
-        162   pop_jump_if_false +2               (to 164)
-        163   jump +7                            (to 170)
-        164   load_var 11                        (event)
-        165   load_field 2                       (message)
-        166   load_field 0                       (0)
-        167   load_field 0                       (0)
-        168   store_var 21                       (_43)
-        169   jump +3                            (to 172)
+  377   168   load_var 11                        (event)
+        169   load_field 2                       (message)
         170   load_const 8                       (null)
-        171   store_var 21                       (_43)
+        171   cmp_op ==                          
+        172   pop_jump_if_false +2               (to 174)
+        173   jump +20                           (to 193)
+        174   load_var 11                        (event)
+        175   load_field 2                       (message)
+        176   load_field 0                       (0)
+        177   load_const 8                       (null)
+        178   cmp_op ==                          
+        179   pop_jump_if_false +2               (to 181)
+        180   jump +13                           (to 193)
+        181   load_var 11                        (event)
+        182   load_field 2                       (message)
+        183   load_const 8                       (null)
+        184   cmp_op ==                          
+        185   pop_jump_if_false +2               (to 187)
+        186   jump +7                            (to 193)
+        187   load_var 11                        (event)
+        188   load_field 2                       (message)
+        189   load_field 0                       (0)
+        190   load_field 1                       (1)
+        191   store_var 21                       (_56)
+        192   jump +3                            (to 195)
+        193   load_const 8                       (null)
+        194   store_var 21                       (_56)
 
-  377   172   load_var 11                        (event)
-        173   load_field 2                       (message)
-        174   load_const 8                       (null)
-        175   cmp_op ==                          
-        176   pop_jump_if_false +2               (to 178)
-        177   jump +20                           (to 197)
-        178   load_var 11                        (event)
-        179   load_field 2                       (message)
-        180   load_field 0                       (0)
-        181   load_const 8                       (null)
-        182   cmp_op ==                          
-        183   pop_jump_if_false +2               (to 185)
-        184   jump +13                           (to 197)
-        185   load_var 11                        (event)
-        186   load_field 2                       (message)
-        187   load_const 8                       (null)
-        188   cmp_op ==                          
-        189   pop_jump_if_false +2               (to 191)
-        190   jump +7                            (to 197)
-        191   load_var 11                        (event)
-        192   load_field 2                       (message)
-        193   load_field 0                       (0)
-        194   load_field 1                       (1)
-        195   store_var 22                       (_53)
-        196   jump +3                            (to 199)
-        197   load_const 8                       (null)
-        198   store_var 22                       (_53)
+  373   195   load_type 0                        
+        196   load_var 3                         (out)
 
-  373   199   load_type 0                        
-        200   load_var 3                         (out)
+  374   197   load_const 8                       (null)
+        198   load_var2 20 21                    
+        199   init_instance 1                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
+        200   call 4 ntypeargs=1                 (baml.Array.push)
+        201   pop 1                              
+        202   jump -193                          (to 9)
 
-  374   201   load_const 8                       (null)
-        202   load_var2 21 22                    
-        203   init_instance 1                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
-        204   call 4 ntypeargs=1                 (baml.Array.push)
-        205   pop 1                              
-        206   jump -197                          (to 9)
+  357   203   load_var 11                        (event)
+        204   load_field 1                       (delta)
+        205   store_var 15                       (_28)
+        206   load_var 15                        (_28)
+        207   narrow_bind 15 15                  
+        208   pop_jump_if_false -199             (to 9)
+        209   load_var 15                        (_28)
+        210   store_var_load_var 16              (d)
 
-  357   207   load_var 11                        (event)
-        208   load_field 1                       (delta)
-        209   store_var 15                       (_26)
-        210   load_var 15                        (_26)
-        211   narrow_bind 15 15                  
-        212   pop_jump_if_false -203             (to 9)
-        213   load_var 15                        (_26)
-        214   store_var 16                       (d)
+  358   211   load_field 0                       (type)
+        212   store_var_load_var 17              (_32)
+        213   load_const 8                       (null)
+        214   cmp_op ==                          
+        215   pop_jump_if_false +3               (to 218)
+        216   load_const 16                      ("")
+        217   store_var 17                       (_32)
+        218   load_var 17                        (_32)
+        219   load_const 17                      ("text_delta")
+        220   cmp_op ==                          
+        221   pop_jump_if_false -212             (to 9)
 
-  358   215   load_var 16                        (d)
-        216   load_field 0                       (type)
-        217   store_var 18                       (_30)
-        218   load_var 18                        (_30)
-        219   store_var 17                       (_29)
-        220   load_var 18                        (_30)
-        221   load_const 8                       (null)
-        222   cmp_op ==                          
-        223   pop_jump_if_false +3               (to 226)
-        224   load_const 16                      ("")
-        225   store_var 17                       (_29)
-        226   load_var 17                        (_29)
-        227   load_const 17                      ("text_delta")
-        228   cmp_op ==                          
-        229   pop_jump_if_false -220             (to 9)
+  359   222   load_var 16                        (d)
+        223   load_field 1                       (text)
+        224   store_var 18                       (_36)
+        225   load_var 18                        (_36)
+        226   narrow_bind 6 18                   
+        227   pop_jump_if_false -218             (to 9)
+        228   load_var 18                        (_36)
+        229   store_var 19                       (text)
 
-  359   230   load_var 16                        (d)
-        231   load_field 1                       (text)
-        232   store_var 19                       (_33)
-        233   load_var 19                        (_33)
-        234   narrow_bind 6 19                   
-        235   pop_jump_if_false -226             (to 9)
-        236   load_var 19                        (_33)
-        237   store_var 20                       (text)
+  360   230   load_type 0                        
+        231   load_var2 3 19                     
+        232   init_instance 2                    (ai.stream.TextDelta .text)
+        233   call 4 ntypeargs=1                 (baml.Array.push)
+        234   pop 1                              
+        235   jump -226                          (to 9)
 
-  360   238   load_type 0                        
-        239   load_var2 3 20                     
-        240   init_instance 2                    (ai.stream.TextDelta .text)
-        241   call 4 ntypeargs=1                 (baml.Array.push)
-        242   pop 1                              
-        243   jump -234                          (to 9)
-
-  409   244   load_var 3                         (out)
-        245   store_var 2                        (_0)
-        246   load_var 2                         (_0)
-        247   return                             
+  409   236   load_var 3                         (out)
+        237   store_var 2                        (_0)
+        238   load_var 2                         (_0)
+        239   return                             
 }
 
 function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic.internal.AnthropicMessage[] {
@@ -4391,249 +4365,245 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         63    load_const 11                      (null)
         64    cmp_op ==                          
         65    pop_jump_if_false +2               (to 67)
-        66    jump +8                            (to 74)
+        66    jump +7                            (to 73)
         67    load_type 5                        
         68    load_var 8                         (lowered)
         69    load_const 10                      (0)
         70    call 3 ntypeargs=1                 (baml.Array.at)
         71    load_field 0                       (0)
-        72    store_var 14                       (_32)
-        73    jump +3                            (to 76)
-        74    load_const 11                      (null)
-        75    store_var 14                       (_32)
-        76    load_var 14                        (_32)
-        77    store_var 13                       (first_role)
-        78    load_var 14                        (_32)
-        79    load_const 11                      (null)
-        80    cmp_op ==                          
-        81    pop_jump_if_false +3               (to 84)
-        82    load_const 12                      ("")
-        83    store_var 13                       (first_role)
+        72    jump +2                            (to 74)
+        73    load_const 11                      (null)
+        74    store_var_load_var 14              (_32)
+        75    load_const 11                      (null)
+        76    cmp_op ==                          
+        77    pop_jump_if_false +3               (to 80)
+        78    load_const 12                      ("")
+        79    store_var 14                       (_32)
+        80    load_var 14                        (_32)
+        81    store_var_load_var 13              (first_role)
 
-  199   84    load_var 13                        (first_role)
-        85    load_const 13                      ("user")
-        86    cmp_op !=                          
-        87    jump_if_false +8                   (to 95)
-        88    pop 1                              
-        89    load_var 7                         (system)
-        90    container_len                      
-        91    store_var 15                       (_42)
-        92    load_var 15                        (_42)
-        93    load_const 10                      (0)
-        94    cmp_int_op >                       
-        95    pop_jump_if_false +2               (to 97)
-        96    jump +26                           (to 122)
+  199   82    load_const 13                      ("user")
+        83    cmp_op !=                          
+        84    jump_if_false +8                   (to 92)
+        85    pop 1                              
+        86    load_var 7                         (system)
+        87    container_len                      
+        88    store_var 15                       (_43)
+        89    load_var 15                        (_43)
+        90    load_const 10                      (0)
+        91    cmp_int_op >                       
+        92    pop_jump_if_false +2               (to 94)
+        93    jump +26                           (to 119)
 
-  204   97    load_var 7                         (system)
-        98    container_len                      
-        99    store_var 18                       (_55)
-        100   load_var 18                        (_55)
-        101   load_const 10                      (0)
-        102   cmp_int_op >                       
-        103   pop_jump_if_false +8               (to 111)
+  204   94    load_var 7                         (system)
+        95    container_len                      
+        96    store_var 18                       (_56)
+        97    load_var 18                        (_56)
+        98    load_const 10                      (0)
+        99    cmp_int_op >                       
+        100   pop_jump_if_false +8               (to 108)
 
-  205   104   load_type 6                        
-        105   load_type 7                        
-        106   load_var 12                        (body)
-        107   load_const 14                      ("system")
-        108   load_var 7                         (system)
-        109   call 37 ntypeargs=2                (baml.Map.set)
-        110   pop 1                              
+  205   101   load_type 6                        
+        102   load_type 7                        
+        103   load_var 12                        (body)
+        104   load_const 14                      ("system")
+        105   load_var 7                         (system)
+        106   call 37 ntypeargs=2                (baml.Map.set)
+        107   pop 1                              
 
-  210   111   load_var 8                         (lowered)
-        112   call 890 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
-        113   store_var 19                       (_61)
-        114   load_type 6                        
-        115   load_type 7                        
-        116   load_var 12                        (body)
-        117   load_const 15                      ("messages")
-        118   load_var 19                        (_61)
-        119   call 37 ntypeargs=2                (baml.Map.set)
-        120   pop 1                              
-        121   jump +21                           (to 142)
+  210   108   load_var 8                         (lowered)
+        109   call 890 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        110   store_var 19                       (_62)
+        111   load_type 6                        
+        112   load_type 7                        
+        113   load_var 12                        (body)
+        114   load_const 15                      ("messages")
+        115   load_var 19                        (_62)
+        116   call 37 ntypeargs=2                (baml.Map.set)
+        117   pop 1                              
+        118   jump +21                           (to 139)
 
-  200   122   load_const 16                      ("user")
-        123   load_const 17                      (false)
-        124   load_var 7                         (system)
-        125   init_instance 0                    (anthropic.internal.AnthropicMessage .role, .tool_results, .blocks)
-        126   store_var 16                       (first)
+  200   119   load_const 16                      ("user")
+        120   load_const 17                      (false)
+        121   load_var 7                         (system)
+        122   init_instance 0                    (anthropic.internal.AnthropicMessage .role, .tool_results, .blocks)
+        123   store_var 16                       (first)
 
-  201   127   load_type 5                        
-        128   load_var 16                        (first)
-        129   load_type 5                        
-        130   alloc_array 1                      
-        131   load_var 8                         (lowered)
-        132   call 7 ntypeargs=1                 (baml.Array.concat)
-        133   call 890 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
-        134   store_var 17                       (_46)
-        135   load_type 6                        
-        136   load_type 7                        
-        137   load_var 12                        (body)
-        138   load_const 18                      ("messages")
-        139   load_var 17                        (_46)
-        140   call 37 ntypeargs=2                (baml.Map.set)
-        141   pop 1                              
+  201   124   load_type 5                        
+        125   load_var 16                        (first)
+        126   load_type 5                        
+        127   alloc_array 1                      
+        128   load_var 8                         (lowered)
+        129   call 7 ntypeargs=1                 (baml.Array.concat)
+        130   call 890 ntypeargs=0               (anthropic.internal._anthropic_render_messages)
+        131   store_var 17                       (_47)
+        132   load_type 6                        
+        133   load_type 7                        
+        134   load_var 12                        (body)
+        135   load_const 18                      ("messages")
+        136   load_var 17                        (_47)
+        137   call 37 ntypeargs=2                (baml.Map.set)
+        138   pop 1                              
 
-  213   142   load_var 2                         (input)
-        143   load_field 2                       (toolbox)
-        144   call 823 ntypeargs=0               (ai.tools.Toolbox.is_empty)
-        145   unary_op !                         
-        146   pop_jump_if_false +80              (to 226)
+  213   139   load_var 2                         (input)
+        140   load_field 2                       (toolbox)
+        141   call 823 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        142   unary_op !                         
+        143   pop_jump_if_false +80              (to 223)
 
-  214   147   load_type 19                       
-        148   alloc_array 0                      
-        149   store_var 20                       (tools)
+  214   144   load_type 19                       
+        145   alloc_array 0                      
+        146   store_var 20                       (tools)
 
-  215   150   load_var 2                         (input)
-        151   load_field 2                       (toolbox)
-        152   call 821 ntypeargs=0               (ai.tools.Toolbox.list)
-        153   load_type 20                       
-        154   load_const 21                      ("iter")
-        155   virtual_call nargs=1 ntypeargs=0   
-        156   store_var 21                       (_71)
-        157   load_var 21                        (_71)
-        158   load_type 22                       
-        159   load_const 23                      ("next")
-        160   virtual_call nargs=1 ntypeargs=0   
-        161   store_var 22                       (_72)
-        162   load_var 22                        (_72)
-        163   is_type 4                          
-        164   pop_jump_if_false +2               (to 166)
-        165   jump +36                           (to 201)
-        166   load_var 22                        (_72)
-        167   store_var 23                       (t)
+  215   147   load_var 2                         (input)
+        148   load_field 2                       (toolbox)
+        149   call 821 ntypeargs=0               (ai.tools.Toolbox.list)
+        150   load_type 20                       
+        151   load_const 21                      ("iter")
+        152   virtual_call nargs=1 ntypeargs=0   
+        153   store_var 21                       (_72)
+        154   load_var 21                        (_72)
+        155   load_type 22                       
+        156   load_const 23                      ("next")
+        157   virtual_call nargs=1 ntypeargs=0   
+        158   store_var 22                       (_73)
+        159   load_var 22                        (_73)
+        160   is_type 4                          
+        161   pop_jump_if_false +2               (to 163)
+        162   jump +36                           (to 198)
+        163   load_var 22                        (_73)
+        164   store_var 23                       (t)
 
-  216   168   load_type 6                        
-        169   load_type 7                        
-        170   alloc_map 0                        
-        171   store_var 24                       (tw)
+  216   165   load_type 6                        
+        166   load_type 7                        
+        167   alloc_map 0                        
+        168   store_var 24                       (tw)
 
-  217   172   load_type 6                        
-        173   load_type 7                        
-        174   load_var 24                        (tw)
-        175   load_const 24                      ("name")
-        176   load_var 23                        (t)
-        177   load_field 0                       (name)
-        178   call 37 ntypeargs=2                (baml.Map.set)
-        179   pop 1                              
+  217   169   load_type 6                        
+        170   load_type 7                        
+        171   load_var 24                        (tw)
+        172   load_const 24                      ("name")
+        173   load_var 23                        (t)
+        174   load_field 0                       (name)
+        175   call 37 ntypeargs=2                (baml.Map.set)
+        176   pop 1                              
 
-  218   180   load_type 6                        
-        181   load_type 7                        
-        182   load_var 24                        (tw)
-        183   load_const 25                      ("description")
-        184   load_var 23                        (t)
-        185   load_field 1                       (description)
-        186   call 37 ntypeargs=2                (baml.Map.set)
-        187   pop 1                              
+  218   177   load_type 6                        
+        178   load_type 7                        
+        179   load_var 24                        (tw)
+        180   load_const 25                      ("description")
+        181   load_var 23                        (t)
+        182   load_field 1                       (description)
+        183   call 37 ntypeargs=2                (baml.Map.set)
+        184   pop 1                              
 
-  219   188   load_type 6                        
-        189   load_type 7                        
-        190   load_var 24                        (tw)
-        191   load_const 26                      ("input_schema")
-        192   load_var 23                        (t)
-        193   load_field 2                       (input_schema)
-        194   call 37 ntypeargs=2                (baml.Map.set)
-        195   pop 1                              
+  219   185   load_type 6                        
+        186   load_type 7                        
+        187   load_var 24                        (tw)
+        188   load_const 26                      ("input_schema")
+        189   load_var 23                        (t)
+        190   load_field 2                       (input_schema)
+        191   call 37 ntypeargs=2                (baml.Map.set)
+        192   pop 1                              
 
-  220   196   load_type 19                       
-        197   load_var2 20 24                    
-        198   call 4 ntypeargs=1                 (baml.Array.push)
-        199   pop 1                              
-        200   jump -43                           (to 157)
+  220   193   load_type 19                       
+        194   load_var2 20 24                    
+        195   call 4 ntypeargs=1                 (baml.Array.push)
+        196   pop 1                              
+        197   jump -43                           (to 154)
 
-  222   201   load_type 6                        
-        202   load_type 7                        
-        203   alloc_map 0                        
-        204   store_var 25                       (tc)
+  222   198   load_type 6                        
+        199   load_type 7                        
+        200   alloc_map 0                        
+        201   store_var 25                       (tc)
 
-  223   205   load_type 6                        
-        206   load_type 7                        
-        207   load_var 25                        (tc)
-        208   load_const 27                      ("type")
-        209   load_const 28                      ("auto")
-        210   call 37 ntypeargs=2                (baml.Map.set)
-        211   pop 1                              
+  223   202   load_type 6                        
+        203   load_type 7                        
+        204   load_var 25                        (tc)
+        205   load_const 27                      ("type")
+        206   load_const 28                      ("auto")
+        207   call 37 ntypeargs=2                (baml.Map.set)
+        208   pop 1                              
 
-  224   212   load_type 6                        
-        213   load_type 7                        
-        214   load_var 12                        (body)
-        215   load_const 29                      ("tools")
-        216   load_var 20                        (tools)
-        217   call 37 ntypeargs=2                (baml.Map.set)
-        218   pop 1                              
+  224   209   load_type 6                        
+        210   load_type 7                        
+        211   load_var 12                        (body)
+        212   load_const 29                      ("tools")
+        213   load_var 20                        (tools)
+        214   call 37 ntypeargs=2                (baml.Map.set)
+        215   pop 1                              
 
-  225   219   load_type 6                        
-        220   load_type 7                        
-        221   load_var 12                        (body)
-        222   load_const 30                      ("tool_choice")
-        223   load_var 25                        (tc)
-        224   call 37 ntypeargs=2                (baml.Map.set)
-        225   pop 1                              
+  225   216   load_type 6                        
+        217   load_type 7                        
+        218   load_var 12                        (body)
+        219   load_const 30                      ("tool_choice")
+        220   load_var 25                        (tc)
+        221   call 37 ntypeargs=2                (baml.Map.set)
+        222   pop 1                              
 
-  231   226   load_var 3                         (stream)
-        227   pop_jump_if_false +8               (to 235)
+  231   223   load_var 3                         (stream)
+        224   pop_jump_if_false +8               (to 232)
 
-  232   228   load_type 6                        
-        229   load_type 7                        
-        230   load_var 12                        (body)
-        231   load_const 31                      ("stream")
-        232   load_const 32                      (true)
-        233   call 37 ntypeargs=2                (baml.Map.set)
-        234   pop 1                              
+  232   225   load_type 6                        
+        226   load_type 7                        
+        227   load_var 12                        (body)
+        228   load_const 31                      ("stream")
+        229   load_const 32                      (true)
+        230   call 37 ntypeargs=2                (baml.Map.set)
+        231   pop 1                              
 
-  238   235   load_var 1                         (c)
-        236   load_field 2                       (base_url)
-        237   store_var 27                       (_108)
-        238   load_var 27                        (_108)
-        239   store_var 26                       (base)
-        240   load_var 27                        (_108)
-        241   load_const 11                      (null)
-        242   cmp_op ==                          
-        243   pop_jump_if_false +3               (to 246)
-        244   load_const 33                      ("https://api.anthropic.com")
-        245   store_var 26                       (base)
+  238   232   load_var 1                         (c)
+        233   load_field 2                       (base_url)
+        234   store_var_load_var 27              (_109)
+        235   load_const 11                      (null)
+        236   cmp_op ==                          
+        237   pop_jump_if_false +3               (to 240)
+        238   load_const 33                      ("https://api.anthropic.com")
+        239   store_var 27                       (_109)
+        240   load_var 27                        (_109)
+        241   store_var 26                       (base)
 
-  241   246   load_type 6                        
-        247   load_var 26                        (base)
-        248   call 138 ntypeargs=1               (baml.String.from)
-        249   store_var 28                       (_111)
+  241   242   load_type 6                        
+        243   load_var 26                        (base)
+        244   call 138 ntypeargs=1               (baml.String.from)
+        245   store_var 28                       (_113)
 
-  243   250   load_var 1                         (c)
-        251   load_field 1                       (api_key)
-        252   store_var 30                       (_116)
-        253   load_var2 30 30                    
-        254   load_const 11                      (null)
-        255   cmp_op ==                          
-        256   pop_jump_if_false +3               (to 259)
-        257   load_const 34                      ("ANTHROPIC_API_KEY")
-        258   call 211 ntypeargs=0               (baml.env.get_or_panic)
+  243   246   load_var 1                         (c)
+        247   load_field 1                       (api_key)
+        248   store_var_load_var 30              (_118)
+        249   load_const 11                      (null)
+        250   cmp_op ==                          
+        251   pop_jump_if_false +4               (to 255)
+        252   load_const 34                      ("ANTHROPIC_API_KEY")
+        253   call 211 ntypeargs=0               (baml.env.get_or_panic)
+        254   store_var 30                       (_118)
+        255   load_var 30                        (_118)
+        256   load_const 35                      ("2023-06-01")
+        257   load_const 36                      ("application/json")
+        258   load_const 37                      ("x-api-key")
+        259   load_const 38                      ("anthropic-version")
+        260   load_const 39                      ("content-type")
+        261   load_type 6                        
+        262   load_type 6                        
+        263   alloc_map 3                        
+        264   store_var 29                       (_116)
 
-  242   259   load_const 35                      ("2023-06-01")
-        260   load_const 36                      ("application/json")
-        261   load_const 37                      ("x-api-key")
-        262   load_const 38                      ("anthropic-version")
-        263   load_const 39                      ("content-type")
-        264   load_type 6                        
-        265   load_type 6                        
-        266   alloc_map 3                        
-        267   store_var 29                       (_114)
+  247   265   load_type 19                       
+        266   load_var 12                        (body)
+        267   call 331 ntypeargs=1               (baml.json.to_json)
+        268   call 328 ntypeargs=0               (baml.json.stringify)
+        269   store_var 31                       (_121)
 
-  247   268   load_type 19                       
-        269   load_var 12                        (body)
-        270   call 331 ntypeargs=1               (baml.json.to_json)
-        271   call 328 ntypeargs=0               (baml.json.stringify)
-        272   store_var 31                       (_118)
+  239   270   load_const 40                      ("POST")
 
-  239   273   load_const 40                      ("POST")
-
-  241   274   load_var 28                        (_111)
-        275   load_const 41                      ("/v1/messages")
-        276   bin_op +                           
-        277   load_var2 29 31                    
-        278   init_instance 1                    (baml.http.Request .method, .url, .headers, .body)
-        279   store_var 4                        (_0)
-        280   load_var 4                         (_0)
-        281   return                             
+  241   271   load_var 28                        (_113)
+        272   load_const 41                      ("/v1/messages")
+        273   bin_op +                           
+        274   load_var2 29 31                    
+        275   init_instance 1                    (baml.http.Request .method, .url, .headers, .body)
+        276   store_var 4                        (_0)
+        277   load_var 4                         (_0)
+        278   return                             
 }
 
 function anthropic.internal._anthropic_stop_reason(s: string) -> ai.content.StopReason {
@@ -4705,7 +4675,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         23    load_var 7                         (_10)
         24    is_type 8                          
         25    pop_jump_if_false +2               (to 27)
-        26    jump +97                           (to 123)
+        26    jump +86                           (to 112)
         27    load_var 7                         (_10)
         28    store_var_load_var 8               (b)
 
@@ -4713,14 +4683,14 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
         30    load_const 9                       ("text")
         31    cmp_op ==                          
         32    pop_jump_if_false +2               (to 34)
-        33    jump +73                           (to 106)
+        33    jump +65                           (to 98)
 
   274   34    load_var 8                         (b)
         35    load_field 0                       (type)
         36    load_const 10                      ("thinking")
         37    cmp_op ==                          
         38    pop_jump_if_false +2               (to 40)
-        39    jump +50                           (to 89)
+        39    jump +45                           (to 84)
 
   277   40    load_var 8                         (b)
         41    load_field 0                       (type)
@@ -4731,135 +4701,125 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
   278   45    load_type 12                       
         46    load_type 13                       
         47    alloc_map 0                        
-        48    store_var 13                       (empty_args)
+        48    store_var 11                       (empty_args)
 
   281   49    load_var 8                         (b)
         50    load_field 3                       (id)
-        51    store_var 15                       (_36)
-        52    load_var 15                        (_36)
-        53    store_var 14                       (_35)
-        54    load_var 15                        (_36)
-        55    load_const 14                      (null)
-        56    cmp_op ==                          
-        57    pop_jump_if_false +3               (to 60)
-        58    load_const 15                      ("")
-        59    store_var 14                       (_35)
+        51    store_var_load_var 13              (_38)
+        52    load_const 14                      (null)
+        53    cmp_op ==                          
+        54    pop_jump_if_false +3               (to 57)
+        55    load_const 15                      ("")
+        56    store_var 13                       (_38)
+        57    load_var 13                        (_38)
+        58    store_var 12                       (_37)
 
-  282   60    load_var 8                         (b)
-        61    load_field 4                       (name)
-        62    store_var 17                       (_39)
-        63    load_var 17                        (_39)
-        64    store_var 16                       (_38)
-        65    load_var 17                        (_39)
-        66    load_const 14                      (null)
-        67    cmp_op ==                          
-        68    pop_jump_if_false +3               (to 71)
-        69    load_const 16                      ("")
-        70    store_var 16                       (_38)
+  282   59    load_var 8                         (b)
+        60    load_field 4                       (name)
+        61    store_var_load_var 15              (_42)
+        62    load_const 14                      (null)
+        63    cmp_op ==                          
+        64    pop_jump_if_false +3               (to 67)
+        65    load_const 16                      ("")
+        66    store_var 15                       (_42)
+        67    load_var 15                        (_42)
+        68    store_var 14                       (_41)
 
-  283   71    load_var 8                         (b)
-        72    load_field 5                       (input)
-        73    store_var 19                       (_42)
-        74    load_var 19                        (_42)
-        75    store_var 18                       (_41)
-        76    load_var 19                        (_42)
-        77    load_const 14                      (null)
-        78    cmp_op ==                          
-        79    pop_jump_if_false +3               (to 82)
-        80    load_var 13                        (empty_args)
-        81    store_var 18                       (_41)
+  283   69    load_var 8                         (b)
+        70    load_field 5                       (input)
+        71    store_var_load_var 16              (_46)
+        72    load_const 14                      (null)
+        73    cmp_op ==                          
+        74    pop_jump_if_false +3               (to 77)
+        75    load_var 11                        (empty_args)
+        76    store_var 16                       (_46)
 
-  279   82    load_type 3                        
-        83    load_var2 5 14                     
+  279   77    load_type 3                        
+        78    load_var2 5 12                     
 
-  280   84    load_var2 16 18                    
-        85    init_instance 0                    (ai.content.ToolUse .id, .name, .args)
-        86    call 4 ntypeargs=1                 (baml.Array.push)
-        87    pop 1                              
-        88    jump -70                           (to 18)
+  280   79    load_var2 14 16                    
 
-  275   89    load_var 8                         (b)
-        90    load_field 2                       (thinking)
-        91    store_var 12                       (_27)
-        92    load_var 12                        (_27)
-        93    store_var 11                       (_26)
-        94    load_var 12                        (_27)
-        95    load_const 14                      (null)
-        96    cmp_op ==                          
-        97    pop_jump_if_false +3               (to 100)
-        98    load_const 17                      ("")
-        99    store_var 11                       (_26)
-        100   load_type 3                        
-        101   load_var2 5 11                     
-        102   init_instance 1                    (ai.content.Reasoning .summary)
-        103   call 4 ntypeargs=1                 (baml.Array.push)
-        104   pop 1                              
-        105   jump -87                           (to 18)
+  283   80    init_instance 0                    (ai.content.ToolUse .id, .name, .args)
+        81    call 4 ntypeargs=1                 (baml.Array.push)
+        82    pop 1                              
+        83    jump -65                           (to 18)
 
-  272   106   load_var 8                         (b)
-        107   load_field 1                       (text)
-        108   store_var 10                       (_19)
-        109   load_var 10                        (_19)
-        110   store_var 9                        (_18)
-        111   load_var 10                        (_19)
-        112   load_const 14                      (null)
-        113   cmp_op ==                          
-        114   pop_jump_if_false +3               (to 117)
-        115   load_const 18                      ("")
-        116   store_var 9                        (_18)
-        117   load_type 3                        
-        118   load_var2 5 9                      
-        119   init_instance 2                    (ai.content.Text .text)
-        120   call 4 ntypeargs=1                 (baml.Array.push)
-        121   pop 1                              
-        122   jump -104                          (to 18)
+  275   84    load_var 8                         (b)
+        85    load_field 2                       (thinking)
+        86    store_var_load_var 10              (_28)
+        87    load_const 14                      (null)
+        88    cmp_op ==                          
+        89    pop_jump_if_false +3               (to 92)
+        90    load_const 17                      ("")
+        91    store_var 10                       (_28)
+        92    load_type 3                        
+        93    load_var2 5 10                     
+        94    init_instance 1                    (ai.content.Reasoning .summary)
+        95    call 4 ntypeargs=1                 (baml.Array.push)
+        96    pop 1                              
+        97    jump -79                           (to 18)
 
-  292   123   load_var 4                         (resp)
-        124   load_field 1                       (stop_reason)
-        125   store_var_load_var 21              (_46)
-        126   load_const 14                      (null)
-        127   cmp_op ==                          
-        128   pop_jump_if_false +2               (to 130)
-        129   jump +6                            (to 135)
-        130   load_var 21                        (_46)
-        131   store_var_load_var 22              (s)
+  272   98    load_var 8                         (b)
+        99    load_field 1                       (text)
+        100   store_var_load_var 9               (_19)
+        101   load_const 14                      (null)
+        102   cmp_op ==                          
+        103   pop_jump_if_false +3               (to 106)
+        104   load_const 18                      ("")
+        105   store_var 9                        (_19)
+        106   load_type 3                        
+        107   load_var2 5 9                      
+        108   init_instance 2                    (ai.content.Text .text)
+        109   call 4 ntypeargs=1                 (baml.Array.push)
+        110   pop 1                              
+        111   jump -93                           (to 18)
 
-  294   132   call 892 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
-        133   store_var 20                       (stop)
-        134   jump +4                            (to 138)
+  292   112   load_var 4                         (resp)
+        113   load_field 1                       (stop_reason)
+        114   store_var_load_var 18              (_51)
+        115   load_const 14                      (null)
+        116   cmp_op ==                          
+        117   pop_jump_if_false +2               (to 119)
+        118   jump +6                            (to 124)
+        119   load_var 18                        (_51)
+        120   store_var_load_var 19              (s)
 
-  293   135   load_const 19                      (ai.content.StopReason.Complete)
-        136   alloc_variant 436                  (ai.content.StopReason)
-        137   store_var 20                       (stop)
+  294   121   call 892 ntypeargs=0               (anthropic.internal._anthropic_stop_reason)
+        122   store_var 17                       (stop)
+        123   jump +4                            (to 127)
 
-  297   138   load_var 4                         (resp)
-        139   load_field 2                       (usage)
-        140   store_var 24                       (_52)
-        141   load_var 24                        (_52)
-        142   narrow_bind 20 24                  
-        143   pop_jump_if_false +2               (to 145)
-        144   jump +4                            (to 148)
+  293   124   load_const 19                      (ai.content.StopReason.Complete)
+        125   alloc_variant 436                  (ai.content.StopReason)
+        126   store_var 17                       (stop)
 
-  306   145   load_const 14                      (null)
-        146   store_var 23                       (usage)
+  297   127   load_var 4                         (resp)
+        128   load_field 2                       (usage)
+        129   store_var 21                       (_57)
+        130   load_var 21                        (_57)
+        131   narrow_bind 20 21                  
+        132   pop_jump_if_false +2               (to 134)
+        133   jump +4                            (to 137)
 
-  297   147   jump +10                           (to 157)
-        148   load_var 24                        (_52)
-        149   store_var_load_var 25              (u)
+  306   134   load_const 14                      (null)
+        135   store_var 20                       (usage)
 
-  300   150   load_field 0                       (input_tokens)
+  297   136   jump +10                           (to 146)
+        137   load_var 21                        (_57)
+        138   store_var_load_var 22              (u)
 
-  301   151   load_var 25                        (u)
-        152   load_field 1                       (output_tokens)
-        153   load_const 14                      (null)
-        154   load_const 14                      (null)
-        155   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
-        156   store_var 23                       (usage)
+  300   139   load_field 0                       (input_tokens)
 
-  309   157   load_var2 5 20                     
-        158   load_var 23                        (usage)
-        159   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
-        160   return                             
+  301   140   load_var 22                        (u)
+        141   load_field 1                       (output_tokens)
+        142   load_const 14                      (null)
+        143   load_const 14                      (null)
+        144   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
+        145   store_var 20                       (usage)
+
+  309   146   load_var2 5 17                     
+        147   load_var 20                        (usage)
+        148   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
+        149   return                             
 }
 
 function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
@@ -5205,20 +5165,20 @@ function claude_code.ClaudeCodeClient.new(model: string, executable: string, cwd
        46   store_var 8            (servers)
 
   34   47   load_var 7             (mcp_servers)
-       48   store_var 9            (_16)
-       49   load_var 7             (mcp_servers)
-       50   load_const 3           (null)
-       51   cmp_op ==              
-       52   pop_jump_if_false +3   (to 55)
-       53   load_var 8             (servers)
-       54   store_var 9            (_16)
+       48   store_var_load_var 9   (_17)
+       49   load_const 3           (null)
+       50   cmp_op ==              
+       51   pop_jump_if_false +3   (to 54)
+       52   load_var 8             (servers)
+       53   store_var 9            (_17)
 
-  27   55   load_var2 2 1          
-       56   load_var2 3 4          
-       57   load_var2 5 6          
-       58   load_var 9             (_16)
-       59   init_instance 0        (claude_code.ClaudeCodeClient .executable, .model, .cwd, .timeout_ms, .permission_mode, .harness_tools, .mcp_servers)
-       60   return                 
+  27   54   load_var2 2 1          
+       55   load_var2 3 4          
+       56   load_var2 5 6          
+
+  34   57   load_var 9             (_17)
+       58   init_instance 0        (claude_code.ClaudeCodeClient .executable, .model, .cwd, .timeout_ms, .permission_mode, .harness_tools, .mcp_servers)
+       59   return                 
 }
 
 function claude_code.internal._log_cc_event(raw: baml.json.json) -> null {
@@ -7179,7 +7139,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         14    load_var 5                         (_5)
         15    is_type 5                          
         16    pop_jump_if_false +2               (to 18)
-        17    jump +237                          (to 254)
+        17    jump +229                          (to 246)
         18    load_var 5                         (_5)
         19    store_var_load_var 6               (raw)
 
@@ -7226,236 +7186,228 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
         55    load_const 8                       (null)
         56    cmp_op ==                          
         57    pop_jump_if_false +2               (to 59)
-        58    jump +17                           (to 75)
+        58    jump +16                           (to 74)
         59    load_var 12                        (cand)
         60    load_field 0                       (0)
         61    load_const 8                       (null)
         62    cmp_op ==                          
         63    pop_jump_if_false +2               (to 65)
-        64    jump +11                           (to 75)
+        64    jump +10                           (to 74)
         65    load_var 12                        (cand)
         66    load_const 8                       (null)
         67    cmp_op ==                          
         68    pop_jump_if_false +2               (to 70)
-        69    jump +6                            (to 75)
+        69    jump +5                            (to 74)
         70    load_var 12                        (cand)
         71    load_field 0                       (0)
         72    load_field 0                       (0)
-        73    store_var 14                       (_24)
-        74    jump +3                            (to 77)
-        75    load_const 8                       (null)
-        76    store_var 14                       (_24)
-        77    load_var 14                        (_24)
-        78    store_var 13                       (parts)
-        79    load_var 14                        (_24)
-        80    load_const 8                       (null)
-        81    cmp_op ==                          
-        82    pop_jump_if_false +4               (to 86)
-        83    load_type 11                       
-        84    alloc_array 0                      
-        85    store_var 13                       (parts)
+        73    jump +2                            (to 75)
+        74    load_const 8                       (null)
+        75    store_var_load_var 14              (_24)
+        76    load_const 8                       (null)
+        77    cmp_op ==                          
+        78    pop_jump_if_false +4               (to 82)
+        79    load_type 11                       
+        80    alloc_array 0                      
+        81    store_var 14                       (_24)
+        82    load_var 14                        (_24)
+        83    store_var_load_var 13              (parts)
 
-  376   86    load_var 13                        (parts)
-        87    load_type 12                       
-        88    load_const 13                      ("iter")
-        89    virtual_call nargs=1 ntypeargs=0   
-        90    store_var 15                       (_36)
-        91    load_var 15                        (_36)
-        92    load_type 14                       
-        93    load_const 15                      ("next")
-        94    virtual_call nargs=1 ntypeargs=0   
-        95    store_var 16                       (_37)
-        96    load_var 16                        (_37)
-        97    is_type 5                          
-        98    pop_jump_if_false +2               (to 100)
-        99    jump +30                           (to 129)
-        100   load_var 16                        (_37)
-        101   store_var_load_var 17              (p)
+  376   84    load_type 12                       
+        85    load_const 13                      ("iter")
+        86    virtual_call nargs=1 ntypeargs=0   
+        87    store_var 15                       (_37)
+        88    load_var 15                        (_37)
+        89    load_type 14                       
+        90    load_const 15                      ("next")
+        91    virtual_call nargs=1 ntypeargs=0   
+        92    store_var 16                       (_38)
+        93    load_var 16                        (_38)
+        94    is_type 5                          
+        95    pop_jump_if_false +2               (to 97)
+        96    jump +27                           (to 123)
+        97    load_var 16                        (_38)
+        98    store_var_load_var 17              (p)
 
-  377   102   load_field 0                       (text)
-        103   store_var 18                       (_42)
-        104   load_var 18                        (_42)
-        105   narrow_bind 6 18                   
-        106   pop_jump_if_false -15              (to 91)
-        107   load_var 18                        (_42)
-        108   store_var 19                       (t)
+  377   99    load_field 0                       (text)
+        100   store_var 18                       (_43)
+        101   load_var 18                        (_43)
+        102   narrow_bind 6 18                   
+        103   pop_jump_if_false -15              (to 88)
+        104   load_var 18                        (_43)
+        105   store_var 19                       (t)
 
-  378   109   load_var 17                        (p)
-        110   load_field 1                       (thought)
-        111   store_var 21                       (_45)
-        112   load_var 21                        (_45)
-        113   store_var 20                       (_44)
-        114   load_var 21                        (_45)
-        115   load_const 8                       (null)
-        116   cmp_op ==                          
-        117   pop_jump_if_false +3               (to 120)
-        118   load_const 16                      (false)
-        119   store_var 20                       (_44)
-        120   load_var 20                        (_44)
-        121   pop_jump_if_false +2               (to 123)
-        122   jump -31                           (to 91)
+  378   106   load_var 17                        (p)
+        107   load_field 1                       (thought)
+        108   store_var_load_var 20              (_46)
+        109   load_const 8                       (null)
+        110   cmp_op ==                          
+        111   pop_jump_if_false +3               (to 114)
+        112   load_const 16                      (false)
+        113   store_var 20                       (_46)
+        114   load_var 20                        (_46)
+        115   pop_jump_if_false +2               (to 117)
+        116   jump -28                           (to 88)
 
-  381   123   load_type 0                        
-        124   load_var2 3 19                     
-        125   init_instance 0                    (ai.stream.TextDelta .text)
-        126   call 4 ntypeargs=1                 (baml.Array.push)
-        127   pop 1                              
-        128   jump -37                           (to 91)
+  381   117   load_type 0                        
+        118   load_var2 3 19                     
+        119   init_instance 0                    (ai.stream.TextDelta .text)
+        120   call 4 ntypeargs=1                 (baml.Array.push)
+        121   pop 1                              
+        122   jump -34                           (to 88)
 
-  388   129   load_var 12                        (cand)
-        130   load_const 8                       (null)
-        131   cmp_op ==                          
-        132   pop_jump_if_false +2               (to 134)
-        133   jump +5                            (to 138)
-        134   load_var 12                        (cand)
-        135   load_field 1                       (1)
-        136   store_var 23                       (_52)
-        137   jump +3                            (to 140)
-        138   load_const 8                       (null)
-        139   store_var 23                       (_52)
-        140   load_var 23                        (_52)
-        141   store_var 22                       (finish)
-        142   load_var 23                        (_52)
-        143   load_const 8                       (null)
-        144   cmp_op ==                          
-        145   pop_jump_if_false +3               (to 148)
-        146   load_const 17                      ("")
-        147   store_var 22                       (finish)
+  388   123   load_var 12                        (cand)
+        124   load_const 8                       (null)
+        125   cmp_op ==                          
+        126   pop_jump_if_false +2               (to 128)
+        127   jump +4                            (to 131)
+        128   load_var 12                        (cand)
+        129   load_field 1                       (1)
+        130   jump +2                            (to 132)
+        131   load_const 8                       (null)
+        132   store_var_load_var 22              (_54)
+        133   load_const 8                       (null)
+        134   cmp_op ==                          
+        135   pop_jump_if_false +3               (to 138)
+        136   load_const 17                      ("")
+        137   store_var 22                       (_54)
+        138   load_var 22                        (_54)
+        139   store_var 21                       (finish)
 
-  389   148   load_var 11                        (resp)
-        149   load_field 2                       (promptFeedback)
+  389   140   load_var 11                        (resp)
+        141   load_field 2                       (promptFeedback)
+        142   load_const 8                       (null)
+        143   cmp_op ==                          
+        144   pop_jump_if_false +2               (to 146)
+        145   jump +5                            (to 150)
+        146   load_var 11                        (resp)
+        147   load_field 2                       (promptFeedback)
+        148   load_field 0                       (0)
+        149   jump +2                            (to 151)
         150   load_const 8                       (null)
-        151   cmp_op ==                          
-        152   pop_jump_if_false +2               (to 154)
-        153   jump +5                            (to 158)
-        154   load_var 11                        (resp)
-        155   load_field 2                       (promptFeedback)
-        156   load_field 0                       (0)
-        157   jump +2                            (to 159)
-        158   load_const 8                       (null)
-        159   load_const 8                       (null)
-        160   call 653 ntypeargs=0               (baml.ops.equals_equals)
-        161   unary_op !                         
-        162   store_var 24                       (blocked)
+        151   load_const 8                       (null)
+        152   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        153   unary_op !                         
+        154   store_var 23                       (blocked)
 
-  390   163   load_var 22                        (finish)
-        164   load_const 18                      ("MAX_TOKENS")
-        165   cmp_op ==                          
-        166   pop_jump_if_false +2               (to 168)
-        167   jump +38                           (to 205)
+  390   155   load_var 21                        (finish)
+        156   load_const 18                      ("MAX_TOKENS")
+        157   cmp_op ==                          
+        158   pop_jump_if_false +2               (to 160)
+        159   jump +38                           (to 197)
 
-  393   168   load_var 24                        (blocked)
-        169   jump_if_false +2                   (to 171)
-        170   jump +5                            (to 175)
-        171   pop 1                              
+  393   160   load_var 23                        (blocked)
+        161   jump_if_false +2                   (to 163)
+        162   jump +5                            (to 167)
+        163   pop 1                              
 
-  394   172   load_var 22                        (finish)
-        173   load_const 19                      ("SAFETY")
-        174   cmp_op ==                          
+  394   164   load_var 21                        (finish)
+        165   load_const 19                      ("SAFETY")
+        166   cmp_op ==                          
 
-  393   175   jump_if_false +2                   (to 177)
-        176   jump +5                            (to 181)
-        177   pop 1                              
+  393   167   jump_if_false +2                   (to 169)
+        168   jump +5                            (to 173)
+        169   pop 1                              
 
-  395   178   load_var 22                        (finish)
-        179   load_const 20                      ("RECITATION")
-        180   cmp_op ==                          
+  395   170   load_var 21                        (finish)
+        171   load_const 20                      ("RECITATION")
+        172   cmp_op ==                          
 
-  393   181   jump_if_false +2                   (to 183)
-        182   jump +5                            (to 187)
-        183   pop 1                              
+  393   173   jump_if_false +2                   (to 175)
+        174   jump +5                            (to 179)
+        175   pop 1                              
 
-  396   184   load_var 22                        (finish)
-        185   load_const 21                      ("PROHIBITED_CONTENT")
-        186   cmp_op ==                          
+  396   176   load_var 21                        (finish)
+        177   load_const 21                      ("PROHIBITED_CONTENT")
+        178   cmp_op ==                          
 
-  392   187   pop_jump_if_false +2               (to 189)
-        188   jump +13                           (to 201)
+  392   179   pop_jump_if_false +2               (to 181)
+        180   jump +13                           (to 193)
 
-  399   189   load_var 22                        (finish)
-        190   load_const 22                      ("")
-        191   cmp_op !=                          
-        192   pop_jump_if_false +2               (to 194)
-        193   jump +4                            (to 197)
+  399   181   load_var 21                        (finish)
+        182   load_const 22                      ("")
+        183   cmp_op !=                          
+        184   pop_jump_if_false +2               (to 186)
+        185   jump +4                            (to 189)
 
-  402   194   load_const 8                       (null)
-        195   store_var 25                       (stop)
+  402   186   load_const 8                       (null)
+        187   store_var 24                       (stop)
 
-  399   196   jump +12                           (to 208)
+  399   188   jump +12                           (to 200)
 
-  400   197   load_const 10                      (ai.content.StopReason.Complete)
+  400   189   load_const 10                      (ai.content.StopReason.Complete)
+        190   alloc_variant 436                  (ai.content.StopReason)
+        191   store_var 24                       (stop)
+
+  399   192   jump +8                            (to 200)
+
+  398   193   load_const 23                      (ai.content.StopReason.Refused)
+        194   alloc_variant 436                  (ai.content.StopReason)
+        195   store_var 24                       (stop)
+
+  392   196   jump +4                            (to 200)
+
+  391   197   load_const 24                      (ai.content.StopReason.MaxTokens)
         198   alloc_variant 436                  (ai.content.StopReason)
-        199   store_var 25                       (stop)
+        199   store_var 24                       (stop)
 
-  399   200   jump +8                            (to 208)
+  404   200   load_var 11                        (resp)
+        201   load_field 1                       (usageMetadata)
+        202   store_var 25                       (usage)
 
-  398   201   load_const 23                      (ai.content.StopReason.Refused)
-        202   alloc_variant 436                  (ai.content.StopReason)
-        203   store_var 25                       (stop)
+  405   203   load_var 24                        (stop)
+        204   load_const 8                       (null)
+        205   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        206   unary_op !                         
+        207   jump_if_false +2                   (to 209)
+        208   jump +6                            (to 214)
+        209   pop 1                              
+        210   load_var 25                        (usage)
+        211   load_const 8                       (null)
+        212   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        213   unary_op !                         
+        214   pop_jump_if_false -205             (to 9)
 
-  392   204   jump +4                            (to 208)
+  408   215   load_var 24                        (stop)
+        216   store_var 26                       (_87)
 
-  391   205   load_const 24                      (ai.content.StopReason.MaxTokens)
-        206   alloc_variant 436                  (ai.content.StopReason)
-        207   store_var 25                       (stop)
-
-  404   208   load_var 11                        (resp)
-        209   load_field 1                       (usageMetadata)
-        210   store_var 26                       (usage)
-
-  405   211   load_var 25                        (stop)
-        212   load_const 8                       (null)
-        213   call 653 ntypeargs=0               (baml.ops.equals_equals)
-        214   unary_op !                         
-        215   jump_if_false +2                   (to 217)
-        216   jump +6                            (to 222)
-        217   pop 1                              
-        218   load_var 26                        (usage)
-        219   load_const 8                       (null)
-        220   call 653 ntypeargs=0               (baml.ops.equals_equals)
-        221   unary_op !                         
-        222   pop_jump_if_false -213             (to 9)
-
-  408   223   load_var 25                        (stop)
-        224   store_var 27                       (_84)
-
-  409   225   load_var 26                        (usage)
+  409   217   load_var 25                        (usage)
+        218   load_const 8                       (null)
+        219   cmp_op ==                          
+        220   pop_jump_if_false +2               (to 222)
+        221   jump +5                            (to 226)
+        222   load_var 25                        (usage)
+        223   load_field 0                       (0)
+        224   store_var 27                       (_88)
+        225   jump +3                            (to 228)
         226   load_const 8                       (null)
-        227   cmp_op ==                          
-        228   pop_jump_if_false +2               (to 230)
-        229   jump +5                            (to 234)
-        230   load_var 26                        (usage)
-        231   load_field 0                       (0)
-        232   store_var 28                       (_85)
-        233   jump +3                            (to 236)
-        234   load_const 8                       (null)
-        235   store_var 28                       (_85)
+        227   store_var 27                       (_88)
 
-  410   236   load_var 26                        (usage)
+  410   228   load_var 25                        (usage)
+        229   load_const 8                       (null)
+        230   cmp_op ==                          
+        231   pop_jump_if_false +2               (to 233)
+        232   jump +5                            (to 237)
+        233   load_var 25                        (usage)
+        234   load_field 1                       (1)
+        235   store_var 28                       (_92)
+        236   jump +3                            (to 239)
         237   load_const 8                       (null)
-        238   cmp_op ==                          
-        239   pop_jump_if_false +2               (to 241)
-        240   jump +5                            (to 245)
-        241   load_var 26                        (usage)
-        242   load_field 1                       (1)
-        243   store_var 29                       (_89)
-        244   jump +3                            (to 247)
-        245   load_const 8                       (null)
-        246   store_var 29                       (_89)
+        238   store_var 28                       (_92)
 
-  406   247   load_type 0                        
-        248   load_var2 3 27                     
+  406   239   load_type 0                        
+        240   load_var2 3 26                     
 
-  407   249   load_var2 28 29                    
-        250   init_instance 1                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
-        251   call 4 ntypeargs=1                 (baml.Array.push)
-        252   pop 1                              
-        253   jump -244                          (to 9)
+  407   241   load_var2 27 28                    
+        242   init_instance 1                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
+        243   call 4 ntypeargs=1                 (baml.Array.push)
+        244   pop 1                              
+        245   jump -236                          (to 9)
 
-  426   254   load_var 3                         (out)
-        255   store_var 2                        (_0)
-        256   load_var 2                         (_0)
-        257   return                             
+  426   246   load_var 3                         (out)
+        247   store_var 2                        (_0)
+        248   load_var 2                         (_0)
+        249   return                             
 }
 
 function google.internal._google_request(c: google.GoogleClient, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
@@ -7714,67 +7666,64 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   278   219   load_var 1                         (c)
         220   load_field 2                       (base_url)
-        221   store_var 28                       (_105)
-        222   load_var 28                        (_105)
-        223   store_var 27                       (_104)
-        224   load_var 28                        (_105)
-        225   load_const 29                      (null)
-        226   cmp_op ==                          
-        227   pop_jump_if_false +3               (to 230)
-        228   load_const 30                      ("https://generativelanguage.googleapis.com/v1beta")
-        229   store_var 27                       (_104)
-        230   load_type 6                        
-        231   load_var 27                        (_104)
-        232   call 138 ntypeargs=1               (baml.String.from)
-        233   store_var 26                       (_103)
-        234   load_type 6                        
-        235   load_var 1                         (c)
-        236   load_field 0                       (model)
-        237   call 138 ntypeargs=1               (baml.String.from)
-        238   store_var 29                       (_108)
-        239   load_type 6                        
-        240   load_var 25                        (method)
-        241   call 138 ntypeargs=1               (baml.String.from)
-        242   store_var 30                       (_111)
+        221   store_var_load_var 27              (_105)
+        222   load_const 29                      (null)
+        223   cmp_op ==                          
+        224   pop_jump_if_false +3               (to 227)
+        225   load_const 30                      ("https://generativelanguage.googleapis.com/v1beta")
+        226   store_var 27                       (_105)
+        227   load_type 6                        
+        228   load_var 27                        (_105)
+        229   call 138 ntypeargs=1               (baml.String.from)
+        230   store_var 26                       (_103)
+        231   load_type 6                        
+        232   load_var 1                         (c)
+        233   load_field 0                       (model)
+        234   call 138 ntypeargs=1               (baml.String.from)
+        235   store_var 28                       (_109)
+        236   load_type 6                        
+        237   load_var 25                        (method)
+        238   call 138 ntypeargs=1               (baml.String.from)
+        239   store_var 29                       (_112)
 
-  280   243   load_var 1                         (c)
-        244   load_field 1                       (api_key)
-        245   store_var 32                       (_116)
-        246   load_var2 32 32                    
-        247   load_const 29                      (null)
-        248   cmp_op ==                          
-        249   pop_jump_if_false +3               (to 252)
-        250   load_const 31                      ("GOOGLE_API_KEY")
-        251   call 211 ntypeargs=0               (baml.env.get_or_panic)
+  280   240   load_var 1                         (c)
+        241   load_field 1                       (api_key)
+        242   store_var_load_var 31              (_117)
+        243   load_const 29                      (null)
+        244   cmp_op ==                          
+        245   pop_jump_if_false +4               (to 249)
+        246   load_const 31                      ("GOOGLE_API_KEY")
+        247   call 211 ntypeargs=0               (baml.env.get_or_panic)
+        248   store_var 31                       (_117)
+        249   load_var 31                        (_117)
+        250   load_const 32                      ("application/json")
+        251   load_const 33                      ("x-goog-api-key")
+        252   load_const 34                      ("content-type")
+        253   load_type 6                        
+        254   load_type 6                        
+        255   alloc_map 2                        
+        256   store_var 30                       (_115)
 
-  279   252   load_const 32                      ("application/json")
-        253   load_const 33                      ("x-goog-api-key")
-        254   load_const 34                      ("content-type")
-        255   load_type 6                        
-        256   load_type 6                        
-        257   alloc_map 2                        
-        258   store_var 31                       (_114)
+  283   257   load_type 5                        
+        258   load_var 11                        (body)
+        259   call 331 ntypeargs=1               (baml.json.to_json)
+        260   call 328 ntypeargs=0               (baml.json.stringify)
+        261   store_var 32                       (_120)
 
-  283   259   load_type 5                        
-        260   load_var 11                        (body)
-        261   call 331 ntypeargs=1               (baml.json.to_json)
-        262   call 328 ntypeargs=0               (baml.json.stringify)
-        263   store_var 33                       (_118)
+  276   262   load_const 35                      ("POST")
 
-  276   264   load_const 35                      ("POST")
-
-  278   265   load_var 26                        (_103)
-        266   load_const 36                      ("/models/")
+  278   263   load_var 26                        (_103)
+        264   load_const 36                      ("/models/")
+        265   bin_op +                           
+        266   load_var 28                        (_109)
         267   bin_op +                           
-        268   load_var 29                        (_108)
+        268   load_var 29                        (_112)
         269   bin_op +                           
-        270   load_var 30                        (_111)
-        271   bin_op +                           
-        272   load_var2 31 33                    
-        273   init_instance 0                    (baml.http.Request .method, .url, .headers, .body)
-        274   store_var 4                        (_0)
-        275   load_var 4                         (_0)
-        276   return                             
+        270   load_var2 30 32                    
+        271   init_instance 0                    (baml.http.Request .method, .url, .headers, .body)
+        272   store_var 4                        (_0)
+        273   load_var 4                         (_0)
+        274   return                             
 }
 
 function google.internal.google_lower_journal(j: ai.Journal) -> map<string, unknown>[] {
@@ -8198,292 +8147,280 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         23    load_const 3                       (null)
         24    cmp_op ==                          
         25    pop_jump_if_false +2               (to 27)
-        26    jump +5                            (to 31)
+        26    jump +4                            (to 30)
         27    load_var 6                         (cand)
         28    load_field 1                       (1)
-        29    store_var 8                        (_12)
-        30    jump +3                            (to 33)
-        31    load_const 3                       (null)
-        32    store_var 8                        (_12)
-        33    load_var 8                         (_12)
-        34    store_var 7                        (finish)
-        35    load_var 8                         (_12)
-        36    load_const 3                       (null)
-        37    cmp_op ==                          
-        38    pop_jump_if_false +3               (to 41)
-        39    load_const 4                       ("")
-        40    store_var 7                        (finish)
+        29    jump +2                            (to 31)
+        30    load_const 3                       (null)
+        31    store_var_load_var 8               (_12)
+        32    load_const 3                       (null)
+        33    cmp_op ==                          
+        34    pop_jump_if_false +3               (to 37)
+        35    load_const 4                       ("")
+        36    store_var 8                        (_12)
+        37    load_var 8                         (_12)
+        38    store_var 7                        (finish)
 
-  296   41    load_var 6                         (cand)
-        42    load_const 3                       (null)
-        43    cmp_op ==                          
-        44    pop_jump_if_false +2               (to 46)
-        45    jump +17                           (to 62)
-        46    load_var 6                         (cand)
-        47    load_field 0                       (0)
-        48    load_const 3                       (null)
-        49    cmp_op ==                          
-        50    pop_jump_if_false +2               (to 52)
-        51    jump +11                           (to 62)
-        52    load_var 6                         (cand)
-        53    load_const 3                       (null)
-        54    cmp_op ==                          
-        55    pop_jump_if_false +2               (to 57)
-        56    jump +6                            (to 62)
-        57    load_var 6                         (cand)
-        58    load_field 0                       (0)
-        59    load_field 0                       (0)
-        60    store_var 10                       (_18)
-        61    jump +3                            (to 64)
-        62    load_const 3                       (null)
-        63    store_var 10                       (_18)
-        64    load_var 10                        (_18)
-        65    store_var 9                        (parts)
-        66    load_var 10                        (_18)
-        67    load_const 3                       (null)
-        68    cmp_op ==                          
-        69    pop_jump_if_false +4               (to 73)
-        70    load_type 5                        
-        71    alloc_array 0                      
-        72    store_var 9                        (parts)
+  296   39    load_var 6                         (cand)
+        40    load_const 3                       (null)
+        41    cmp_op ==                          
+        42    pop_jump_if_false +2               (to 44)
+        43    jump +16                           (to 59)
+        44    load_var 6                         (cand)
+        45    load_field 0                       (0)
+        46    load_const 3                       (null)
+        47    cmp_op ==                          
+        48    pop_jump_if_false +2               (to 50)
+        49    jump +10                           (to 59)
+        50    load_var 6                         (cand)
+        51    load_const 3                       (null)
+        52    cmp_op ==                          
+        53    pop_jump_if_false +2               (to 55)
+        54    jump +5                            (to 59)
+        55    load_var 6                         (cand)
+        56    load_field 0                       (0)
+        57    load_field 0                       (0)
+        58    jump +2                            (to 60)
+        59    load_const 3                       (null)
+        60    store_var_load_var 10              (_19)
+        61    load_const 3                       (null)
+        62    cmp_op ==                          
+        63    pop_jump_if_false +4               (to 67)
+        64    load_type 5                        
+        65    alloc_array 0                      
+        66    store_var 10                       (_19)
+        67    load_var 10                        (_19)
+        68    store_var_load_var 9               (parts)
 
-  297   73    load_var 9                         (parts)
-        74    load_type 6                        
-        75    load_const 7                       ("iter")
+  297   69    load_type 6                        
+        70    load_const 7                       ("iter")
+        71    virtual_call nargs=1 ntypeargs=0   
+        72    store_var 11                       (_32)
+        73    load_var 11                        (_32)
+        74    load_type 8                        
+        75    load_const 9                       ("next")
         76    virtual_call nargs=1 ntypeargs=0   
-        77    store_var 11                       (_30)
-        78    load_var 11                        (_30)
-        79    load_type 8                        
-        80    load_const 9                       ("next")
-        81    virtual_call nargs=1 ntypeargs=0   
-        82    store_var 12                       (_31)
-        83    load_var 12                        (_31)
-        84    is_type 10                         
-        85    pop_jump_if_false +2               (to 87)
-        86    jump +89                           (to 175)
-        87    load_var 12                        (_31)
-        88    store_var_load_var 13              (p)
+        77    store_var 12                       (_33)
+        78    load_var 12                        (_33)
+        79    is_type 10                         
+        80    pop_jump_if_false +2               (to 82)
+        81    jump +86                           (to 167)
+        82    load_var 12                        (_33)
+        83    store_var_load_var 13              (p)
 
-  298   89    load_field 2                       (functionCall)
-        90    store_var 14                       (_36)
-        91    load_var 14                        (_36)
-        92    narrow_bind 11 14                  
-        93    pop_jump_if_false +2               (to 95)
-        94    jump +35                           (to 129)
+  298   84    load_field 2                       (functionCall)
+        85    store_var 14                       (_38)
+        86    load_var 14                        (_38)
+        87    narrow_bind 11 14                  
+        88    pop_jump_if_false +2               (to 90)
+        89    jump +32                           (to 121)
 
-  310   95    load_var 13                        (p)
-        96    load_field 0                       (text)
-        97    store_var 21                       (_56)
-        98    load_var 21                        (_56)
-        99    narrow_bind 12 21                  
-        100   pop_jump_if_false -22              (to 78)
-        101   load_var 21                        (_56)
-        102   store_var 22                       (t)
+  310   90    load_var 13                        (p)
+        91    load_field 0                       (text)
+        92    store_var 21                       (_58)
+        93    load_var 21                        (_58)
+        94    narrow_bind 12 21                  
+        95    pop_jump_if_false -22              (to 73)
+        96    load_var 21                        (_58)
+        97    store_var 22                       (t)
 
-  311   103   load_var 13                        (p)
-        104   load_field 1                       (thought)
-        105   store_var 24                       (_59)
-        106   load_var 24                        (_59)
-        107   store_var 23                       (_58)
-        108   load_var 24                        (_59)
-        109   load_const 3                       (null)
-        110   cmp_op ==                          
-        111   pop_jump_if_false +3               (to 114)
-        112   load_const 1                       (false)
-        113   store_var 23                       (_58)
-        114   load_var 23                        (_58)
-        115   pop_jump_if_false +2               (to 117)
-        116   jump +7                            (to 123)
+  311   98    load_var 13                        (p)
+        99    load_field 1                       (thought)
+        100   store_var_load_var 23              (_61)
+        101   load_const 3                       (null)
+        102   cmp_op ==                          
+        103   pop_jump_if_false +3               (to 106)
+        104   load_const 1                       (false)
+        105   store_var 23                       (_61)
+        106   load_var 23                        (_61)
+        107   pop_jump_if_false +2               (to 109)
+        108   jump +7                            (to 115)
 
-  315   117   load_type 0                        
-        118   load_var2 3 22                     
-        119   init_instance 0                    (ai.content.Text .text)
-        120   call 4 ntypeargs=1                 (baml.Array.push)
-        121   pop 1                              
-        122   jump -44                           (to 78)
+  315   109   load_type 0                        
+        110   load_var2 3 22                     
+        111   init_instance 0                    (ai.content.Text .text)
+        112   call 4 ntypeargs=1                 (baml.Array.push)
+        113   pop 1                              
+        114   jump -41                           (to 73)
 
-  312   123   load_type 0                        
-        124   load_var2 3 22                     
-        125   init_instance 1                    (ai.content.Reasoning .summary)
-        126   call 4 ntypeargs=1                 (baml.Array.push)
-        127   pop 1                              
-        128   jump -50                           (to 78)
+  312   115   load_type 0                        
+        116   load_var2 3 22                     
+        117   init_instance 1                    (ai.content.Reasoning .summary)
+        118   call 4 ntypeargs=1                 (baml.Array.push)
+        119   pop 1                              
+        120   jump -47                           (to 73)
 
-  298   129   load_var 14                        (_36)
-        130   store_var 15                       (fc)
+  298   121   load_var 14                        (_38)
+        122   store_var 15                       (fc)
 
-  299   131   load_type 13                       
-        132   load_type 14                       
-        133   alloc_map 0                        
-        134   store_var 16                       (args)
+  299   123   load_type 13                       
+        124   load_type 14                       
+        125   alloc_map 0                        
+        126   store_var 16                       (args)
 
-  300   135   load_var 15                        (fc)
-        136   load_field 1                       (args)
-        137   store_var 17                       (_40)
-        138   load_var 17                        (_40)
-        139   narrow_bind 15 17                  
-        140   pop_jump_if_false +5               (to 145)
-        141   load_var 17                        (_40)
-        142   store_var 18                       (a)
+  300   127   load_var 15                        (fc)
+        128   load_field 1                       (args)
+        129   store_var 17                       (_42)
+        130   load_var 17                        (_42)
+        131   narrow_bind 15 17                  
+        132   pop_jump_if_false +5               (to 137)
+        133   load_var 17                        (_42)
+        134   store_var 18                       (a)
 
-  301   143   load_var 18                        (a)
-        144   store_var 16                       (args)
+  301   135   load_var 18                        (a)
+        136   store_var 16                       (args)
 
-  304   145   load_type 16                       
-        146   load_var 2                         (seq)
-        147   call 138 ntypeargs=1               (baml.String.from)
-        148   store_var 19                       (_47)
-        149   load_type 16                       
-        150   load_var 5                         (call_index)
-        151   call 138 ntypeargs=1               (baml.String.from)
-        152   store_var 20                       (_49)
+  304   137   load_type 16                       
+        138   load_var 2                         (seq)
+        139   call 138 ntypeargs=1               (baml.String.from)
+        140   store_var 19                       (_49)
+        141   load_type 16                       
+        142   load_var 5                         (call_index)
+        143   call 138 ntypeargs=1               (baml.String.from)
+        144   store_var 20                       (_51)
 
-  303   153   load_type 0                        
-        154   load_var 3                         (content)
+  303   145   load_type 0                        
+        146   load_var 3                         (content)
 
-  304   155   load_const 17                      ("call_")
-        156   load_var 19                        (_47)
-        157   bin_op +                           
-        158   load_const 18                      ("_")
-        159   bin_op +                           
-        160   load_var 20                        (_49)
-        161   bin_op +                           
-        162   load_var 15                        (fc)
-        163   load_field 0                       (name)
-        164   load_var 16                        (args)
-        165   init_instance 2                    (ai.content.ToolUse .id, .name, .args)
-        166   call 4 ntypeargs=1                 (baml.Array.push)
-        167   pop 1                              
+  304   147   load_const 17                      ("call_")
+        148   load_var 19                        (_49)
+        149   bin_op +                           
+        150   load_const 18                      ("_")
+        151   bin_op +                           
+        152   load_var 20                        (_51)
+        153   bin_op +                           
+        154   load_var 15                        (fc)
+        155   load_field 0                       (name)
+        156   load_var 16                        (args)
+        157   init_instance 2                    (ai.content.ToolUse .id, .name, .args)
+        158   call 4 ntypeargs=1                 (baml.Array.push)
+        159   pop 1                              
 
-  306   168   load_var 5                         (call_index)
-        169   load_const 12                      (1)
-        170   add_int                            
-        171   store_var 5                        (call_index)
+  306   160   load_var 5                         (call_index)
+        161   load_const 12                      (1)
+        162   add_int                            
+        163   store_var 5                        (call_index)
 
-  307   172   load_const 19                      (true)
-        173   store_var 4                        (has_call)
+  307   164   load_const 19                      (true)
+        165   store_var 4                        (has_call)
 
-  298   174   jump -96                           (to 78)
+  298   166   jump -93                           (to 73)
 
-  323   175   load_var 1                         (resp)
-        176   load_field 2                       (promptFeedback)
+  323   167   load_var 1                         (resp)
+        168   load_field 2                       (promptFeedback)
+        169   load_const 3                       (null)
+        170   cmp_op ==                          
+        171   pop_jump_if_false +2               (to 173)
+        172   jump +5                            (to 177)
+        173   load_var 1                         (resp)
+        174   load_field 2                       (promptFeedback)
+        175   load_field 0                       (0)
+        176   jump +2                            (to 178)
         177   load_const 3                       (null)
-        178   cmp_op ==                          
-        179   pop_jump_if_false +2               (to 181)
-        180   jump +5                            (to 185)
-        181   load_var 1                         (resp)
-        182   load_field 2                       (promptFeedback)
-        183   load_field 0                       (0)
-        184   jump +2                            (to 186)
-        185   load_const 3                       (null)
-        186   load_const 3                       (null)
-        187   call 653 ntypeargs=0               (baml.ops.equals_equals)
-        188   unary_op !                         
-        189   store_var 25                       (blocked)
+        178   load_const 3                       (null)
+        179   call 653 ntypeargs=0               (baml.ops.equals_equals)
+        180   unary_op !                         
+        181   store_var 24                       (blocked)
 
-  324   190   load_var 4                         (has_call)
-        191   pop_jump_if_false +2               (to 193)
-        192   jump +39                           (to 231)
+  324   182   load_var 4                         (has_call)
+        183   pop_jump_if_false +2               (to 185)
+        184   jump +39                           (to 223)
 
-  326   193   load_var 7                         (finish)
-        194   load_const 20                      ("MAX_TOKENS")
-        195   cmp_op ==                          
-        196   pop_jump_if_false +2               (to 198)
-        197   jump +30                           (to 227)
+  326   185   load_var 7                         (finish)
+        186   load_const 20                      ("MAX_TOKENS")
+        187   cmp_op ==                          
+        188   pop_jump_if_false +2               (to 190)
+        189   jump +30                           (to 219)
 
-  328   198   load_var 25                        (blocked)
-        199   jump_if_false +2                   (to 201)
-        200   jump +5                            (to 205)
-        201   pop 1                              
-        202   load_var 7                         (finish)
-        203   load_const 21                      ("SAFETY")
-        204   cmp_op ==                          
-        205   jump_if_false +2                   (to 207)
-        206   jump +5                            (to 211)
-        207   pop 1                              
-        208   load_var 7                         (finish)
-        209   load_const 22                      ("RECITATION")
-        210   cmp_op ==                          
-        211   jump_if_false +2                   (to 213)
-        212   jump +5                            (to 217)
-        213   pop 1                              
-        214   load_var 7                         (finish)
-        215   load_const 23                      ("PROHIBITED_CONTENT")
-        216   cmp_op ==                          
-        217   pop_jump_if_false +2               (to 219)
-        218   jump +5                            (to 223)
+  328   190   load_var 24                        (blocked)
+        191   jump_if_false +2                   (to 193)
+        192   jump +5                            (to 197)
+        193   pop 1                              
+        194   load_var 7                         (finish)
+        195   load_const 21                      ("SAFETY")
+        196   cmp_op ==                          
+        197   jump_if_false +2                   (to 199)
+        198   jump +5                            (to 203)
+        199   pop 1                              
+        200   load_var 7                         (finish)
+        201   load_const 22                      ("RECITATION")
+        202   cmp_op ==                          
+        203   jump_if_false +2                   (to 205)
+        204   jump +5                            (to 209)
+        205   pop 1                              
+        206   load_var 7                         (finish)
+        207   load_const 23                      ("PROHIBITED_CONTENT")
+        208   cmp_op ==                          
+        209   pop_jump_if_false +2               (to 211)
+        210   jump +5                            (to 215)
 
-  331   219   load_const 2                       (ai.content.StopReason.Complete)
+  331   211   load_const 2                       (ai.content.StopReason.Complete)
+        212   alloc_variant 436                  (ai.content.StopReason)
+        213   store_var 25                       (stop)
+
+  328   214   jump +12                           (to 226)
+
+  329   215   load_const 24                      (ai.content.StopReason.Refused)
+        216   alloc_variant 436                  (ai.content.StopReason)
+        217   store_var 25                       (stop)
+
+  328   218   jump +8                            (to 226)
+
+  327   219   load_const 25                      (ai.content.StopReason.MaxTokens)
         220   alloc_variant 436                  (ai.content.StopReason)
-        221   store_var 26                       (stop)
+        221   store_var 25                       (stop)
 
-  328   222   jump +12                           (to 234)
+  326   222   jump +4                            (to 226)
 
-  329   223   load_const 24                      (ai.content.StopReason.Refused)
+  325   223   load_const 12                      (ai.content.StopReason.ToolUse)
         224   alloc_variant 436                  (ai.content.StopReason)
-        225   store_var 26                       (stop)
+        225   store_var 25                       (stop)
 
-  328   226   jump +8                            (to 234)
+  333   226   load_var 1                         (resp)
+        227   load_field 1                       (usageMetadata)
+        228   store_var 27                       (_91)
+        229   load_var 27                        (_91)
+        230   narrow_bind 26 27                  
+        231   pop_jump_if_false +2               (to 233)
+        232   jump +4                            (to 236)
 
-  327   227   load_const 25                      (ai.content.StopReason.MaxTokens)
-        228   alloc_variant 436                  (ai.content.StopReason)
-        229   store_var 26                       (stop)
+  341   233   load_const 3                       (null)
+        234   store_var 26                       (usage)
 
-  326   230   jump +4                            (to 234)
+  333   235   jump +25                           (to 260)
+        236   load_var 27                        (_91)
+        237   store_var_load_var 28              (um)
 
-  325   231   load_const 12                      (ai.content.StopReason.ToolUse)
-        232   alloc_variant 436                  (ai.content.StopReason)
-        233   store_var 26                       (stop)
+  335   238   load_field 0                       (promptTokenCount)
+        239   store_var_load_var 30              (_94)
+        240   load_const 3                       (null)
+        241   cmp_op ==                          
+        242   pop_jump_if_false +3               (to 245)
+        243   load_const 2                       (0)
+        244   store_var 30                       (_94)
+        245   load_var 30                        (_94)
+        246   store_var 29                       (_93)
 
-  333   234   load_var 1                         (resp)
-        235   load_field 1                       (usageMetadata)
-        236   store_var 28                       (_88)
-        237   load_var 28                        (_88)
-        238   narrow_bind 26 28                  
-        239   pop_jump_if_false +2               (to 241)
-        240   jump +4                            (to 244)
+  336   247   load_var 28                        (um)
+        248   load_field 1                       (candidatesTokenCount)
+        249   store_var_load_var 31              (_98)
+        250   load_const 3                       (null)
+        251   cmp_op ==                          
+        252   pop_jump_if_false +3               (to 255)
+        253   load_const 2                       (0)
+        254   store_var 31                       (_98)
 
-  341   241   load_const 3                       (null)
-        242   store_var 27                       (usage)
+  334   255   load_var2 29 31                    
 
-  333   243   jump +30                           (to 273)
-        244   load_var 28                        (_88)
-        245   store_var 29                       (um)
+  336   256   load_const 3                       (null)
+        257   load_const 3                       (null)
+        258   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
+        259   store_var 26                       (usage)
 
-  335   246   load_var 29                        (um)
-        247   load_field 0                       (promptTokenCount)
-        248   store_var 31                       (_91)
-        249   load_var 31                        (_91)
-        250   store_var 30                       (_90)
-        251   load_var 31                        (_91)
-        252   load_const 3                       (null)
-        253   cmp_op ==                          
-        254   pop_jump_if_false +3               (to 257)
-        255   load_const 2                       (0)
-        256   store_var 30                       (_90)
-
-  336   257   load_var 29                        (um)
-        258   load_field 1                       (candidatesTokenCount)
-        259   store_var 33                       (_94)
-        260   load_var 33                        (_94)
-        261   store_var 32                       (_93)
-        262   load_var 33                        (_94)
-        263   load_const 3                       (null)
-        264   cmp_op ==                          
-        265   pop_jump_if_false +3               (to 268)
-        266   load_const 2                       (0)
-        267   store_var 32                       (_93)
-
-  334   268   load_var2 30 32                    
-        269   load_const 3                       (null)
-        270   load_const 3                       (null)
-        271   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
-        272   store_var 27                       (usage)
-
-  343   273   load_var2 3 26                     
-        274   load_var 27                        (usage)
-        275   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
-        276   return                             
+  343   260   load_var2 3 25                     
+        261   load_var 26                        (usage)
+        262   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
+        263   return                             
 }
 
 function google.internal.google_render(c: google.GoogleClient, input: ai.ModelTurnInput) -> baml.http.Request {
@@ -8718,7 +8655,7 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         14    load_var 5                         (_5)
         15    is_type 5                          
         16    pop_jump_if_false +2               (to 18)
-        17    jump +129                          (to 146)
+        17    jump +125                          (to 142)
         18    load_var 5                         (_5)
         19    store_var_load_var 6               (raw)
 
@@ -8744,131 +8681,127 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
         36    narrow_bind 9 10                   
         37    pop_jump_if_false -28              (to 9)
         38    load_var 10                        (_16)
-        39    store_var 11                       (event)
+        39    store_var_load_var 11              (event)
 
-  261   40    load_var 11                        (event)
-        41    load_field 0                       (type)
-        42    store_var 14                       (_20)
-        43    load_var 14                        (_20)
-        44    store_var 13                       (_19)
-        45    load_var 14                        (_20)
-        46    load_const 8                       (null)
-        47    cmp_op ==                          
-        48    pop_jump_if_false +4               (to 52)
-        49    load_var 6                         (raw)
-        50    load_field 0                       (event)
-        51    store_var 13                       (_19)
-        52    load_var 13                        (_19)
-        53    store_var 12                       (t)
-        54    load_var 13                        (_19)
-        55    load_const 8                       (null)
-        56    cmp_op ==                          
-        57    pop_jump_if_false +3               (to 60)
-        58    load_const 10                      ("")
-        59    store_var 12                       (t)
+  261   40    load_field 0                       (type)
+        41    store_var_load_var 14              (_21)
+        42    load_const 8                       (null)
+        43    cmp_op ==                          
+        44    pop_jump_if_false +4               (to 48)
+        45    load_var 6                         (raw)
+        46    load_field 0                       (event)
+        47    store_var 14                       (_21)
+        48    load_var 14                        (_21)
+        49    store_var_load_var 13              (_19)
+        50    load_const 8                       (null)
+        51    cmp_op ==                          
+        52    pop_jump_if_false +3               (to 55)
+        53    load_const 10                      ("")
+        54    store_var 13                       (_19)
+        55    load_var 13                        (_19)
+        56    store_var_load_var 12              (t)
 
-  262   60    load_var 12                        (t)
-        61    load_const 11                      ("response.output_text.delta")
-        62    cmp_op ==                          
-        63    pop_jump_if_false +2               (to 65)
-        64    jump +68                           (to 132)
+  262   57    load_const 11                      ("response.output_text.delta")
+        58    cmp_op ==                          
+        59    pop_jump_if_false +2               (to 61)
+        60    jump +68                           (to 128)
 
-  270   65    load_var 12                        (t)
-        66    load_const 12                      ("response.completed")
-        67    cmp_op ==                          
-        68    jump_if_false +2                   (to 70)
-        69    jump +5                            (to 74)
-        70    pop 1                              
-        71    load_var 12                        (t)
-        72    load_const 13                      ("response.incomplete")
-        73    cmp_op ==                          
-        74    jump_if_false +2                   (to 76)
-        75    jump +5                            (to 80)
-        76    pop 1                              
-        77    load_var 12                        (t)
-        78    load_const 14                      ("response.failed")
-        79    cmp_op ==                          
-        80    pop_jump_if_false -71              (to 9)
+  270   61    load_var 12                        (t)
+        62    load_const 12                      ("response.completed")
+        63    cmp_op ==                          
+        64    jump_if_false +2                   (to 66)
+        65    jump +5                            (to 70)
+        66    pop 1                              
+        67    load_var 12                        (t)
+        68    load_const 13                      ("response.incomplete")
+        69    cmp_op ==                          
+        70    jump_if_false +2                   (to 72)
+        71    jump +5                            (to 76)
+        72    pop 1                              
+        73    load_var 12                        (t)
+        74    load_const 14                      ("response.failed")
+        75    cmp_op ==                          
+        76    pop_jump_if_false -67              (to 9)
 
-  271   81    load_var 11                        (event)
-        82    load_field 2                       (response)
-        83    store_var 17                       (_39)
-        84    load_var 17                        (_39)
-        85    narrow_bind 15 17                  
-        86    pop_jump_if_false +40              (to 126)
-        87    load_var 17                        (_39)
-        88    store_var_load_var 18              (r)
+  271   77    load_var 11                        (event)
+        78    load_field 2                       (response)
+        79    store_var 17                       (_41)
+        80    load_var 17                        (_41)
+        81    narrow_bind 15 17                  
+        82    pop_jump_if_false +40              (to 122)
+        83    load_var 17                        (_41)
+        84    store_var_load_var 18              (r)
 
-  272   89    call 878 ntypeargs=0               (openai.internal.openai_parse)
-        90    store_var 19                       (turn)
+  272   85    call 878 ntypeargs=0               (openai.internal.openai_parse)
+        86    store_var 19                       (turn)
 
-  275   91    load_var 19                        (turn)
-        92    load_field 1                       (stop_reason)
-        93    store_var 20                       (_45)
+  275   87    load_var 19                        (turn)
+        88    load_field 1                       (stop_reason)
+        89    store_var 20                       (_47)
 
-  276   94    load_var 19                        (turn)
-        95    load_field 2                       (usage)
-        96    load_const 8                       (null)
-        97    cmp_op ==                          
-        98    pop_jump_if_false +2               (to 100)
-        99    jump +6                            (to 105)
-        100   load_var 19                        (turn)
-        101   load_field 2                       (usage)
-        102   load_field 0                       (0)
-        103   store_var 21                       (_46)
-        104   jump +3                            (to 107)
+  276   90    load_var 19                        (turn)
+        91    load_field 2                       (usage)
+        92    load_const 8                       (null)
+        93    cmp_op ==                          
+        94    pop_jump_if_false +2               (to 96)
+        95    jump +6                            (to 101)
+        96    load_var 19                        (turn)
+        97    load_field 2                       (usage)
+        98    load_field 0                       (0)
+        99    store_var 21                       (_48)
+        100   jump +3                            (to 103)
+        101   load_const 8                       (null)
+        102   store_var 21                       (_48)
+
+  277   103   load_var 19                        (turn)
+        104   load_field 2                       (usage)
         105   load_const 8                       (null)
-        106   store_var 21                       (_46)
+        106   cmp_op ==                          
+        107   pop_jump_if_false +2               (to 109)
+        108   jump +6                            (to 114)
+        109   load_var 19                        (turn)
+        110   load_field 2                       (usage)
+        111   load_field 1                       (1)
+        112   store_var 22                       (_52)
+        113   jump +3                            (to 116)
+        114   load_const 8                       (null)
+        115   store_var 22                       (_52)
 
-  277   107   load_var 19                        (turn)
-        108   load_field 2                       (usage)
-        109   load_const 8                       (null)
-        110   cmp_op ==                          
-        111   pop_jump_if_false +2               (to 113)
-        112   jump +6                            (to 118)
-        113   load_var 19                        (turn)
-        114   load_field 2                       (usage)
-        115   load_field 1                       (1)
-        116   store_var 22                       (_50)
-        117   jump +3                            (to 120)
-        118   load_const 8                       (null)
-        119   store_var 22                       (_50)
+  273   116   load_type 0                        
+        117   load_var2 3 20                     
 
-  273   120   load_type 0                        
-        121   load_var2 3 20                     
+  274   118   load_var2 21 22                    
+        119   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
+        120   call 4 ntypeargs=1                 (baml.Array.push)
+        121   pop 1                              
 
-  274   122   load_var2 21 22                    
-        123   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
-        124   call 4 ntypeargs=1                 (baml.Array.push)
-        125   pop 1                              
+  284   122   load_type 0                        
+        123   load_var 3                         (out)
+        124   alloc_instance 358 ntypeargs=0     (ai.stream.TurnDone)
+        125   call 4 ntypeargs=1                 (baml.Array.push)
+        126   pop 1                              
+        127   jump -118                          (to 9)
 
-  284   126   load_type 0                        
-        127   load_var 3                         (out)
-        128   alloc_instance 358 ntypeargs=0     (ai.stream.TurnDone)
-        129   call 4 ntypeargs=1                 (baml.Array.push)
-        130   pop 1                              
-        131   jump -122                          (to 9)
+  263   128   load_var 11                        (event)
+        129   load_field 1                       (delta)
+        130   store_var 15                       (_28)
+        131   load_var 15                        (_28)
+        132   narrow_bind 6 15                   
+        133   pop_jump_if_false -124             (to 9)
+        134   load_var 15                        (_28)
+        135   store_var 16                       (d)
 
-  263   132   load_var 11                        (event)
-        133   load_field 1                       (delta)
-        134   store_var 15                       (_26)
-        135   load_var 15                        (_26)
-        136   narrow_bind 6 15                   
-        137   pop_jump_if_false -128             (to 9)
-        138   load_var 15                        (_26)
-        139   store_var 16                       (d)
+  264   136   load_type 0                        
+        137   load_var2 3 16                     
+        138   init_instance 1                    (ai.stream.TextDelta .text)
+        139   call 4 ntypeargs=1                 (baml.Array.push)
+        140   pop 1                              
+        141   jump -132                          (to 9)
 
-  264   140   load_type 0                        
-        141   load_var2 3 16                     
-        142   init_instance 1                    (ai.stream.TextDelta .text)
-        143   call 4 ntypeargs=1                 (baml.Array.push)
-        144   pop 1                              
-        145   jump -136                          (to 9)
-
-  298   146   load_var 3                         (out)
-        147   store_var 2                        (_0)
-        148   load_var 2                         (_0)
-        149   return                             
+  298   142   load_var 3                         (out)
+        143   store_var 2                        (_0)
+        144   load_var 2                         (_0)
+        145   return                             
 }
 
 function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
@@ -9051,54 +8984,51 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
 
   162   155   load_var 1                         (c)
         156   call 870 ntypeargs=0               (openai.OpenAiClient.resolved_base_url)
-        157   store_var 18                       (_78)
-        158   load_var 18                        (_78)
-        159   store_var 17                       (_77)
-        160   load_var 18                        (_78)
-        161   load_const 27                      (null)
-        162   cmp_op ==                          
-        163   pop_jump_if_false +3               (to 166)
-        164   load_const 28                      ("https://api.openai.com/v1")
-        165   store_var 17                       (_77)
-        166   load_type 6                        
-        167   load_var 17                        (_77)
-        168   call 138 ntypeargs=1               (baml.String.from)
-        169   store_var 16                       (_76)
+        157   store_var_load_var 17              (_78)
+        158   load_const 27                      (null)
+        159   cmp_op ==                          
+        160   pop_jump_if_false +3               (to 163)
+        161   load_const 28                      ("https://api.openai.com/v1")
+        162   store_var 17                       (_78)
+        163   load_type 6                        
+        164   load_var 17                        (_78)
+        165   call 138 ntypeargs=1               (baml.String.from)
+        166   store_var 16                       (_76)
 
-  163   170   load_var 1                         (c)
-        171   call 869 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
-        172   store_var 20                       (_84)
-        173   load_type 6                        
-        174   load_var 20                        (_84)
-        175   call 138 ntypeargs=1               (baml.String.from)
-        176   store_var 19                       (_83)
+  163   167   load_var 1                         (c)
+        168   call 869 ntypeargs=0               (openai.OpenAiClient.resolved_api_key)
+        169   store_var 19                       (_85)
+        170   load_type 6                        
+        171   load_var 19                        (_85)
+        172   call 138 ntypeargs=1               (baml.String.from)
+        173   store_var 18                       (_84)
 
-  164   177   load_type 5                        
-        178   load_var 10                        (body)
-        179   call 331 ntypeargs=1               (baml.json.to_json)
-        180   call 328 ntypeargs=0               (baml.json.stringify)
-        181   store_var 21                       (_86)
+  164   174   load_type 5                        
+        175   load_var 10                        (body)
+        176   call 331 ntypeargs=1               (baml.json.to_json)
+        177   call 328 ntypeargs=0               (baml.json.stringify)
+        178   store_var 20                       (_87)
 
-  160   182   load_const 29                      ("POST")
+  160   179   load_const 29                      ("POST")
 
-  162   183   load_var 16                        (_76)
-        184   load_const 30                      ("/responses")
+  162   180   load_var 16                        (_76)
+        181   load_const 30                      ("/responses")
+        182   bin_op +                           
+
+  163   183   load_const 31                      ("Bearer ")
+        184   load_var 18                        (_84)
         185   bin_op +                           
-
-  163   186   load_const 31                      ("Bearer ")
-        187   load_var 19                        (_83)
-        188   bin_op +                           
-        189   load_const 32                      ("application/json")
-        190   load_const 33                      ("authorization")
-        191   load_const 34                      ("content-type")
-        192   load_type 6                        
-        193   load_type 6                        
-        194   alloc_map 2                        
-        195   load_var 21                        (_86)
-        196   init_instance 0                    (baml.http.Request .method, .url, .headers, .body)
-        197   store_var 4                        (_0)
-        198   load_var 4                         (_0)
-        199   return                             
+        186   load_const 32                      ("application/json")
+        187   load_const 33                      ("authorization")
+        188   load_const 34                      ("content-type")
+        189   load_type 6                        
+        190   load_type 6                        
+        191   alloc_map 2                        
+        192   load_var 20                        (_87)
+        193   init_instance 0                    (baml.http.Request .method, .url, .headers, .body)
+        194   store_var 4                        (_0)
+        195   load_var 4                         (_0)
+        196   return                             
 }
 
 function openai.internal.invoke(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
@@ -9551,7 +9481,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         16    load_var 5                         (_6)
         17    is_type 6                          
         18    pop_jump_if_false +2               (to 20)
-        19    jump +167                          (to 186)
+        19    jump +152                          (to 171)
         20    load_var 5                         (_6)
         21    store_var_load_var 6               (item)
 
@@ -9559,14 +9489,14 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         23    load_const 7                       ("function_call")
         24    cmp_op ==                          
         25    pop_jump_if_false +2               (to 27)
-        26    jump +113                          (to 139)
+        26    jump +102                          (to 128)
 
   183   27    load_var 6                         (item)
         28    load_field 0                       (type)
         29    load_const 8                       ("message")
         30    cmp_op ==                          
         31    pop_jump_if_false +2               (to 33)
-        32    jump +47                           (to 79)
+        32    jump +45                           (to 77)
 
   194   33    load_var 6                         (item)
         34    load_field 0                       (type)
@@ -9576,232 +9506,214 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
 
   195   38    load_var 6                         (item)
         39    load_field 5                       (summary)
-        40    store_var 24                       (_52)
-        41    load_var 24                        (_52)
-        42    store_var 23                       (parts)
-        43    load_var 24                        (_52)
-        44    load_const 10                      (null)
-        45    cmp_op ==                          
-        46    pop_jump_if_false +4               (to 50)
-        47    load_type 11                       
-        48    alloc_array 0                      
-        49    store_var 23                       (parts)
+        40    store_var_load_var 21              (_57)
+        41    load_const 10                      (null)
+        42    cmp_op ==                          
+        43    pop_jump_if_false +4               (to 47)
+        44    load_type 11                       
+        45    alloc_array 0                      
+        46    store_var 21                       (_57)
+        47    load_var 21                        (_57)
+        48    store_var_load_var 20              (parts)
 
-  196   50    load_var 23                        (parts)
-        51    load_type 12                       
-        52    load_const 13                      ("iter")
-        53    virtual_call nargs=1 ntypeargs=0   
-        54    store_var 25                       (_55)
-        55    load_var 25                        (_55)
-        56    load_type 14                       
-        57    load_const 15                      ("next")
-        58    virtual_call nargs=1 ntypeargs=0   
-        59    store_var 26                       (_56)
-        60    load_var 26                        (_56)
-        61    is_type 6                          
-        62    pop_jump_if_false +2               (to 64)
-        63    jump -52                           (to 11)
-        64    load_var 26                        (_56)
-        65    store_var_load_var 27              (part)
+  196   49    load_type 12                       
+        50    load_const 13                      ("iter")
+        51    virtual_call nargs=1 ntypeargs=0   
+        52    store_var 22                       (_61)
+        53    load_var 22                        (_61)
+        54    load_type 14                       
+        55    load_const 15                      ("next")
+        56    virtual_call nargs=1 ntypeargs=0   
+        57    store_var 23                       (_62)
+        58    load_var 23                        (_62)
+        59    is_type 6                          
+        60    pop_jump_if_false +2               (to 62)
+        61    jump -50                           (to 11)
+        62    load_var 23                        (_62)
+        63    store_var_load_var 24              (part)
 
-  197   66    load_field 1                       (text)
-        67    store_var 28                       (_61)
-        68    load_var 28                        (_61)
-        69    narrow_bind 16 28                  
-        70    pop_jump_if_false -15              (to 55)
-        71    load_var 28                        (_61)
-        72    store_var 29                       (txt)
+  197   64    load_field 1                       (text)
+        65    store_var 25                       (_67)
+        66    load_var 25                        (_67)
+        67    narrow_bind 16 25                  
+        68    pop_jump_if_false -15              (to 53)
+        69    load_var 25                        (_67)
+        70    store_var 26                       (txt)
 
-  198   73    load_type 0                        
-        74    load_var2 2 29                     
-        75    init_instance 0                    (ai.content.Reasoning .summary)
-        76    call 4 ntypeargs=1                 (baml.Array.push)
-        77    pop 1                              
-        78    jump -23                           (to 55)
+  198   71    load_type 0                        
+        72    load_var2 2 26                     
+        73    init_instance 0                    (ai.content.Reasoning .summary)
+        74    call 4 ntypeargs=1                 (baml.Array.push)
+        75    pop 1                              
+        76    jump -23                           (to 53)
 
-  184   79    load_var 6                         (item)
-        80    load_field 4                       (content)
-        81    store_var 15                       (_31)
-        82    load_var 15                        (_31)
-        83    store_var 14                       (parts)
-        84    load_var 15                        (_31)
-        85    load_const 10                      (null)
-        86    cmp_op ==                          
-        87    pop_jump_if_false +4               (to 91)
-        88    load_type 11                       
-        89    alloc_array 0                      
-        90    store_var 14                       (parts)
+  184   77    load_var 6                         (item)
+        78    load_field 4                       (content)
+        79    store_var_load_var 14              (_33)
+        80    load_const 10                      (null)
+        81    cmp_op ==                          
+        82    pop_jump_if_false +4               (to 86)
+        83    load_type 11                       
+        84    alloc_array 0                      
+        85    store_var 14                       (_33)
+        86    load_var 14                        (_33)
+        87    store_var_load_var 13              (parts)
 
-  185   91    load_var 14                        (parts)
-        92    load_type 12                       
-        93    load_const 17                      ("iter")
-        94    virtual_call nargs=1 ntypeargs=0   
-        95    store_var 16                       (_34)
-        96    load_var 16                        (_34)
-        97    load_type 14                       
-        98    load_const 18                      ("next")
-        99    virtual_call nargs=1 ntypeargs=0   
-        100   store_var 17                       (_35)
-        101   load_var 17                        (_35)
-        102   is_type 6                          
-        103   pop_jump_if_false +2               (to 105)
-        104   jump -93                           (to 11)
-        105   load_var 17                        (_35)
-        106   store_var 18                       (part)
+  185   88    load_type 12                       
+        89    load_const 17                      ("iter")
+        90    virtual_call nargs=1 ntypeargs=0   
+        91    store_var 15                       (_37)
+        92    load_var 15                        (_37)
+        93    load_type 14                       
+        94    load_const 18                      ("next")
+        95    virtual_call nargs=1 ntypeargs=0   
+        96    store_var 16                       (_38)
+        97    load_var 16                        (_38)
+        98    is_type 6                          
+        99    pop_jump_if_false +2               (to 101)
+        100   jump -89                           (to 11)
+        101   load_var 16                        (_38)
+        102   store_var_load_var 17              (part)
 
-  186   107   load_var 18                        (part)
-        108   load_field 0                       (type)
-        109   store_var 20                       (_41)
-        110   load_var 20                        (_41)
-        111   store_var 19                       (_40)
-        112   load_var 20                        (_41)
-        113   load_const 10                      (null)
-        114   cmp_op ==                          
-        115   pop_jump_if_false +3               (to 118)
-        116   load_const 19                      ("")
-        117   store_var 19                       (_40)
-        118   load_var 19                        (_40)
-        119   load_const 20                      ("output_text")
-        120   cmp_op ==                          
-        121   pop_jump_if_false -25              (to 96)
+  186   103   load_field 0                       (type)
+        104   store_var_load_var 18              (_44)
+        105   load_const 10                      (null)
+        106   cmp_op ==                          
+        107   pop_jump_if_false +3               (to 110)
+        108   load_const 19                      ("")
+        109   store_var 18                       (_44)
+        110   load_var 18                        (_44)
+        111   load_const 20                      ("output_text")
+        112   cmp_op ==                          
+        113   pop_jump_if_false -21              (to 92)
 
-  187   122   load_var 18                        (part)
-        123   load_field 1                       (text)
-        124   store_var 22                       (_46)
-        125   load_var 22                        (_46)
-        126   store_var 21                       (_45)
-        127   load_var 22                        (_46)
-        128   load_const 10                      (null)
-        129   cmp_op ==                          
-        130   pop_jump_if_false +3               (to 133)
-        131   load_const 21                      ("")
-        132   store_var 21                       (_45)
-        133   load_type 0                        
-        134   load_var2 2 21                     
-        135   init_instance 1                    (ai.content.Text .text)
-        136   call 4 ntypeargs=1                 (baml.Array.push)
-        137   pop 1                              
-        138   jump -42                           (to 96)
+  187   114   load_var 17                        (part)
+        115   load_field 1                       (text)
+        116   store_var_load_var 19              (_50)
+        117   load_const 10                      (null)
+        118   cmp_op ==                          
+        119   pop_jump_if_false +3               (to 122)
+        120   load_const 21                      ("")
+        121   store_var 19                       (_50)
+        122   load_type 0                        
+        123   load_var2 2 19                     
+        124   init_instance 1                    (ai.content.Text .text)
+        125   call 4 ntypeargs=1                 (baml.Array.push)
+        126   pop 1                              
+        127   jump -35                           (to 92)
 
-  174   139   load_const 22                      (true)
-        140   store_var 3                        (has_call)
+  174   128   load_const 22                      (true)
+        129   store_var 3                        (has_call)
 
-  175   141   load_type 23                       
-        142   load_type 24                       
-        143   alloc_map 0                        
-        144   store_var 7                        (args)
+  175   130   load_type 23                       
+        131   load_type 24                       
+        132   alloc_map 0                        
+        133   store_var 7                        (args)
 
-  176   145   load_var 6                         (item)
-        146   load_field 3                       (arguments)
-        147   store_var 8                        (_14)
-        148   load_var 8                         (_14)
-        149   narrow_bind 16 8                   
-        150   pop_jump_if_false +7               (to 157)
-        151   load_var 8                         (_14)
-        152   store_var 9                        (s)
+  176   134   load_var 6                         (item)
+        135   load_field 3                       (arguments)
+        136   store_var 8                        (_14)
+        137   load_var 8                         (_14)
+        138   narrow_bind 16 8                   
+        139   pop_jump_if_false +7               (to 146)
+        140   load_var 8                         (_14)
+        141   store_var 9                        (s)
 
-  177   153   load_type 25                       
-        154   load_var 9                         (s)
-        155   call 333 ntypeargs=1               (baml.json.from_string)
-        156   store_var 7                        (args)
+  177   142   load_type 25                       
+        143   load_var 9                         (s)
+        144   call 333 ntypeargs=1               (baml.json.from_string)
+        145   store_var 7                        (args)
 
-  180   157   load_var 6                         (item)
-        158   load_field 1                       (call_id)
-        159   store_var 11                       (_21)
-        160   load_var 11                        (_21)
-        161   store_var 10                       (_20)
-        162   load_var 11                        (_21)
-        163   load_const 10                      (null)
-        164   cmp_op ==                          
-        165   pop_jump_if_false +3               (to 168)
-        166   load_const 26                      ("")
-        167   store_var 10                       (_20)
-        168   load_var 6                         (item)
-        169   load_field 2                       (name)
-        170   store_var 13                       (_24)
-        171   load_var 13                        (_24)
-        172   store_var 12                       (_23)
-        173   load_var 13                        (_24)
-        174   load_const 10                      (null)
-        175   cmp_op ==                          
-        176   pop_jump_if_false +3               (to 179)
-        177   load_const 27                      ("")
-        178   store_var 12                       (_23)
+  180   146   load_var 6                         (item)
+        147   load_field 1                       (call_id)
+        148   store_var_load_var 11              (_21)
+        149   load_const 10                      (null)
+        150   cmp_op ==                          
+        151   pop_jump_if_false +3               (to 154)
+        152   load_const 26                      ("")
+        153   store_var 11                       (_21)
+        154   load_var 11                        (_21)
+        155   store_var 10                       (_20)
+        156   load_var 6                         (item)
+        157   load_field 2                       (name)
+        158   store_var_load_var 12              (_25)
+        159   load_const 10                      (null)
+        160   cmp_op ==                          
+        161   pop_jump_if_false +3               (to 164)
+        162   load_const 27                      ("")
+        163   store_var 12                       (_25)
 
-  179   179   load_type 0                        
-        180   load_var2 2 10                     
+  179   164   load_type 0                        
+        165   load_var2 2 10                     
 
-  180   181   load_var2 12 7                     
-        182   init_instance 2                    (ai.content.ToolUse .id, .name, .args)
-        183   call 4 ntypeargs=1                 (baml.Array.push)
-        184   pop 1                              
-        185   jump -174                          (to 11)
+  180   166   load_var2 12 7                     
+        167   init_instance 2                    (ai.content.ToolUse .id, .name, .args)
+        168   call 4 ntypeargs=1                 (baml.Array.push)
+        169   pop 1                              
+        170   jump -159                          (to 11)
 
-  209   186   load_var 3                         (has_call)
-        187   pop_jump_if_false +2               (to 189)
-        188   jump +25                           (to 213)
+  209   171   load_var 3                         (has_call)
+        172   pop_jump_if_false +2               (to 174)
+        173   jump +22                           (to 195)
 
-  211   189   load_var 1                         (resp)
-        190   load_field 0                       (status)
-        191   store_var 32                       (_71)
-        192   load_var 32                        (_71)
-        193   store_var 31                       (_70)
-        194   load_var 32                        (_71)
-        195   load_const 10                      (null)
-        196   cmp_op ==                          
-        197   pop_jump_if_false +3               (to 200)
-        198   load_const 28                      ("")
-        199   store_var 31                       (_70)
-        200   load_var 31                        (_70)
-        201   load_const 29                      ("incomplete")
-        202   cmp_op ==                          
+  211   174   load_var 1                         (resp)
+        175   load_field 0                       (status)
+        176   store_var_load_var 28              (_77)
+        177   load_const 10                      (null)
+        178   cmp_op ==                          
+        179   pop_jump_if_false +3               (to 182)
+        180   load_const 28                      ("")
+        181   store_var 28                       (_77)
+        182   load_var 28                        (_77)
+        183   load_const 29                      ("incomplete")
+        184   cmp_op ==                          
+        185   pop_jump_if_false +2               (to 187)
+        186   jump +5                            (to 191)
+
+  214   187   load_const 30                      (ai.content.StopReason.Complete)
+        188   alloc_variant 436                  (ai.content.StopReason)
+        189   store_var 27                       (stop)
+
+  211   190   jump +8                            (to 198)
+
+  212   191   load_const 31                      (ai.content.StopReason.MaxTokens)
+        192   alloc_variant 436                  (ai.content.StopReason)
+        193   store_var 27                       (stop)
+
+  211   194   jump +4                            (to 198)
+
+  210   195   load_const 16                      (ai.content.StopReason.ToolUse)
+        196   alloc_variant 436                  (ai.content.StopReason)
+        197   store_var 27                       (stop)
+
+  216   198   load_var 1                         (resp)
+        199   load_field 2                       (usage)
+        200   store_var 30                       (_82)
+        201   load_var 30                        (_82)
+        202   narrow_bind 32 30                  
         203   pop_jump_if_false +2               (to 205)
-        204   jump +5                            (to 209)
+        204   jump +4                            (to 208)
 
-  214   205   load_const 30                      (ai.content.StopReason.Complete)
-        206   alloc_variant 436                  (ai.content.StopReason)
-        207   store_var 30                       (stop)
+  224   205   load_const 10                      (null)
+        206   store_var 29                       (usage)
 
-  211   208   jump +8                            (to 216)
+  216   207   jump +10                           (to 217)
+        208   load_var 30                        (_82)
+        209   store_var_load_var 31              (u)
 
-  212   209   load_const 31                      (ai.content.StopReason.MaxTokens)
-        210   alloc_variant 436                  (ai.content.StopReason)
-        211   store_var 30                       (stop)
+  218   210   load_field 0                       (input_tokens)
 
-  211   212   jump +4                            (to 216)
+  219   211   load_var 31                        (u)
+        212   load_field 1                       (output_tokens)
+        213   load_const 10                      (null)
+        214   load_const 10                      (null)
+        215   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
+        216   store_var 29                       (usage)
 
-  210   213   load_const 16                      (ai.content.StopReason.ToolUse)
-        214   alloc_variant 436                  (ai.content.StopReason)
-        215   store_var 30                       (stop)
-
-  216   216   load_var 1                         (resp)
-        217   load_field 2                       (usage)
-        218   store_var 34                       (_75)
-        219   load_var 34                        (_75)
-        220   narrow_bind 32 34                  
-        221   pop_jump_if_false +2               (to 223)
-        222   jump +4                            (to 226)
-
-  224   223   load_const 10                      (null)
-        224   store_var 33                       (usage)
-
-  216   225   jump +10                           (to 235)
-        226   load_var 34                        (_75)
-        227   store_var_load_var 35              (u)
-
-  218   228   load_field 0                       (input_tokens)
-
-  219   229   load_var 35                        (u)
-        230   load_field 1                       (output_tokens)
-        231   load_const 10                      (null)
-        232   load_const 10                      (null)
-        233   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
-        234   store_var 33                       (usage)
-
-  226   235   load_var2 2 30                     
-        236   load_var 33                        (usage)
-        237   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
-        238   return                             
+  226   217   load_var2 2 27                     
+        218   load_var 29                        (usage)
+        219   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
+        220   return                             
 }
 
 function openai.internal.openai_render(c: openai.OpenAiClient, input: ai.ModelTurnInput) -> baml.http.Request {

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -16,18 +16,17 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
     store_var ?20
     load_deref ?1
     load_field .client
-    store_var _4
-    load_var _4
-    store_var selected
-    load_var _4
+    store_var_load_var _4
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_deref ?2
     load_field .default_client
-    store_var selected
+    store_var _4
 
   L0:
+    load_var _4
+    store_var selected
     load_type #0
     load_deref ?2
     call ai.Journal.new
@@ -89,8 +88,8 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
     store_var calls
     load_var calls
     container_len
-    store_var _28
-    load_var _28
+    store_var _29
+    load_var _29
     load_const 0
     cmp_int_op >
     pop_jump_if_false L4
@@ -99,17 +98,16 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
   L4:
     load_var turn
     call ai.ModelTurn.terminal_text
-    store_var _96
-    load_var _96
-    store_var candidate
-    load_var _96
+    store_var_load_var _98
     load_const null
     cmp_op ==
     pop_jump_if_false L5
     load_const ""
-    store_var candidate
+    store_var _98
 
   L5:
+    load_var _98
+    store_var candidate
     load_type #0
     load_var candidate
     call baml.sap.parse
@@ -121,8 +119,8 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _103
-    load_var2 37 33
+    store_var _106
+    load_var2 36 32
     init_instance ai.errors.ParseFailed .provider, .raw_output
     throw
 
@@ -136,8 +134,8 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
     load_type baml.json.JsonSerializationError
     load_var e
     call baml.String.from
-    store_var _112
-    load_var2 38 39
+    store_var _115
+    load_var2 37 38
     load_type string
     alloc_array 1
     init_instance baml.errors.UnknownError .data, .message
@@ -145,9 +143,9 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   L7:
     call baml.json.stringify
-    store_var _117
+    store_var _120
     load_deref ?5
-    load_var _117
+    load_var _120
     init_instance ai.events.FinalProduced .value_json
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced
     alloc_array 1
@@ -201,21 +199,21 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   L9:
     load_var i
-    store_var _47
+    store_var _48
     load_var entries
     container_len
-    store_var _48
+    store_var _49
     load_var2 17 18
     cmp_int_op <
     pop_jump_if_false L1
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced
     load_var2 15 16
     call baml.Array.at
-    store_var _52
-    load_var _52
+    store_var _53
+    load_var _53
     narrow_bind ai.events.ToolFailed, slot=19
     pop_jump_if_false L11
-    load_var _52
+    load_var _53
     store_deref ?20
     load_type ai.content.ToolUse
     load_type never
@@ -224,44 +222,41 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
     load_var f
     make_closure .<lambda(Agent.run, 2)>, captures=1, ntypeargs=1
     call baml.Array.find
-    store_var _58
-    load_var _58
+    store_var _59
+    load_var _59
     narrow_bind ai.content.ToolUse, slot=21
     pop_jump_if_false L11
-    load_var _58
+    load_var _59
     store_var known
     load_type string
     load_var known
     load_field .name
     call baml.String.from
-    store_var _62
+    store_var _63
     load_type string
     load_deref ?20
     load_field .message
     call baml.String.from
-    store_var _65
-    load_var _62
+    store_var _66
+    load_var _63
     load_const "|"
     bin_op +
-    load_var _65
+    load_var _66
     bin_op +
     store_var key
     load_type string
     load_type int
     load_var2 9 23
     call baml.Map.get
-    store_var _70
-    load_var _70
-    store_var _69
-    load_var _70
+    store_var_load_var _71
     load_const null
     cmp_op ==
     pop_jump_if_false L10
     load_const 0
-    store_var _69
+    store_var _71
 
   L10:
-    load_var _69
+    load_var _71
     load_const 1
     add_int
     store_var n
@@ -287,26 +282,26 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
   L12:
     load_var known
     load_field .id
-    store_var _83
+    store_var _85
     load_var known
     load_field .name
-    store_var _84
+    store_var _86
     load_type int
     load_var n
     call baml.String.from
-    store_var _88
+    store_var _90
     load_type string
     load_deref ?20
     load_field .message
     call baml.String.from
-    store_var _91
-    load_var2 29 30
+    store_var _93
+    load_var2 28 29
     load_const "the same tool call failed "
-    load_var _88
+    load_var _90
     bin_op +
     load_const " times; stopping the run: "
     bin_op +
-    load_var _91
+    load_var _93
     bin_op +
     load_const null
     init_instance ai.errors.ToolFailedError .id, .name, .message, .cause
@@ -365,15 +360,12 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
     store_var ci
     load_var total
     load_field .cached_input_tokens
-    store_var _23
-    load_var _23
-    store_var _22
-    load_var _23
+    store_var_load_var _23
     load_const null
     cmp_op ==
     pop_jump_if_false L0
     load_const 0
-    store_var _22
+    store_var _23
 
   L0:
     load_var2 5 15
@@ -384,26 +376,23 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
   L1:
     load_var u
     load_field .reasoning_tokens
-    store_var _27
-    load_var _27
-    narrow_bind int, slot=17
+    store_var _28
+    load_var _28
+    narrow_bind int, slot=16
     pop_jump_if_false L3
-    load_var _27
+    load_var _28
     store_var rt
     load_var total
     load_field .reasoning_tokens
-    store_var _30
-    load_var _30
-    store_var _29
-    load_var _30
+    store_var_load_var _31
     load_const null
     cmp_op ==
     pop_jump_if_false L2
     load_const 0
-    store_var _29
+    store_var _31
 
   L2:
-    load_var2 5 19
+    load_var2 5 18
     load_var rt
     bin_op +
     store_field .reasoning_tokens
@@ -411,13 +400,13 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
   L3:
     load_var turn
     load_field .content
-    store_var _35
+    store_var _37
     load_var c
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _36
-    load_var2 22 23
+    store_var _38
+    load_var2 20 21
     init_instance ai.events.AssistantMessage .content, .client_id
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced
     alloc_array 1
@@ -427,24 +416,24 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
     load_type baml.iter.Iterable<Error = never, Item = ai.content.ToolUse>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _38
+    store_var _40
 
   L4:
-    load_var _38
+    load_var _40
     load_type baml.iter.Iterator<Error = never, Item = ai.content.ToolUse>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _39
-    load_var _39
+    store_var _41
+    load_var _41
     is_type baml.iter.Done
     pop_jump_if_false L5
     jump L6
 
   L5:
-    load_var _39
+    load_var _41
     store_var u
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced
-    load_var2 21 26
+    load_var2 19 24
     load_field .id
     load_var u
     load_field .name
@@ -458,34 +447,33 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
   L6:
     load_var turn
     load_field .usage
-    store_var _50
-    load_var _50
-    narrow_bind ai.events.Usage, slot=27
+    store_var _52
+    load_var _52
+    narrow_bind ai.events.Usage, slot=25
     pop_jump_if_false L7
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced
-    load_var2 21 27
+    load_var2 19 25
     call baml.Array.push
     pop 1
 
   L7:
     load_var turn
     call ai.ModelTurn.terminal_text
-    store_var _56
-    load_var _56
-    store_var candidate
-    load_var _56
+    store_var_load_var _58
     load_const null
     cmp_op ==
     pop_jump_if_false L8
     load_const ""
-    store_var candidate
+    store_var _58
 
   L8:
+    load_var _58
+    store_var candidate
     load_var turn
     call ai.ModelTurn.tool_uses
     container_len
-    store_var _62
-    load_var _62
+    store_var _65
+    load_var _65
     load_const 0
     cmp_int_op >
     jump_if_false L9
@@ -518,7 +506,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
   L13:
     pop 1
     load_type #0
-    load_var2 1 28
+    load_var2 1 26
     call ai.Agent._parses
 
   L14:
@@ -533,15 +521,15 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
     jump L17
 
   L16:
-    load_var2 4 21
+    load_var2 4 19
     call ai.Journal.append_all
     pop 1
     load_var c
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _89
-    load_var2 33 28
+    store_var _92
+    load_var2 31 26
     init_instance ai.errors.ParseFailed .provider, .raw_output
     throw
 
@@ -552,7 +540,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
     init_instance ai.events.UserMessage .content
     call baml.Array.push
     pop 1
-    load_var2 4 21
+    load_var2 4 19
     call ai.Journal.append_all
     pop 1
     load_type #0
@@ -565,7 +553,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
     jump L21
 
   L18:
-    load_var2 4 21
+    load_var2 4 19
     call ai.Journal.append_all
     pop 1
     load_var turn
@@ -596,8 +584,8 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _77
-    load_var _77
+    store_var _80
+    load_var _80
     load_const "the model declined to answer"
     load_const null
     init_instance ai.errors.Refused .provider, .reason, .raw_body
@@ -608,8 +596,8 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _74
-    load_var2 31 28
+    store_var _77
+    load_var2 29 26
     init_instance ai.errors.ParseFailed .provider, .raw_output
     throw
 }
@@ -733,15 +721,15 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
   L0:
     load_var call
     load_field .id
-    store_var _41
+    store_var _42
     load_type string
     load_var call
     load_field .name
     call baml.String.from
-    store_var _43
-    load_var2 4 19
+    store_var _44
+    load_var2 4 18
     load_const "tool is not in the active toolbox: "
-    load_var _43
+    load_var _44
     bin_op +
     init_instance ai.events.ToolFailed .id, .message
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced
@@ -777,19 +765,16 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
     pop 1
     load_var t
     load_field .on_error
-    store_var _20
-    load_var _20
-    store_var _19
-    load_var _20
+    store_var_load_var _20
     load_const null
     cmp_op ==
     pop_jump_if_false L2
     load_var self
     load_field .tool_errors
-    store_var _19
+    store_var _20
 
   L2:
-    load_var _19
+    load_var _20
     load_const ai.tools.ErrorMode.Raise
     alloc_variant ai.tools.ErrorMode
     call baml.ops.equals_equals
@@ -803,9 +788,9 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
 
   L4:
     load_var e
-    store_var _23
-    load_var _23
-    narrow_bind ai.errors.Failure, slot=14
+    store_var _24
+    load_var _24
+    narrow_bind ai.errors.Failure, slot=13
     pop_jump_if_false L5
     jump L6
 
@@ -815,34 +800,34 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
     jump L7
 
   L6:
-    load_var _23
+    load_var _24
     store_var classified
 
   L7:
     load_var call
     load_field .id
-    store_var _26
+    store_var _27
     load_var call
     load_field .name
-    store_var _27
+    store_var _28
     load_type unknown
     load_var e
     call baml.String.from
-    store_var _28
-    load_var2 15 16
-    load_var2 17 13
+    store_var _29
+    load_var2 14 15
+    load_var2 16 12
     init_instance ai.errors.ToolFailedError .id, .name, .message, .cause
     throw
 
   L8:
     load_var outcome
-    store_var _31
-    load_var _31
-    narrow_bind string, slot=18
+    store_var _32
+    load_var _32
+    narrow_bind string, slot=17
     pop_jump_if_false L9
     load_var2 4 3
     load_field .id
-    load_var _31
+    load_var _32
     init_instance ai.events.ToolCompleted .id, .output
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced
     alloc_array 1
@@ -891,14 +876,13 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
 
   L3:
     load_var on_event
-    store_var _9
-    load_var on_event
+    store_var_load_var _10
     load_const null
     cmp_op ==
     pop_jump_if_false L4
     load_type #0
     make_closure .<lambda(Agent.new, 0)>, captures=0, ntypeargs=1
-    store_var _9
+    store_var _10
 
   L4:
     load_var2 1 2
@@ -1423,18 +1407,18 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
 
   L2:
     load_var retry_if
-    store_var _8
-    load_var retry_if
+    store_var_load_var _9
     load_const null
     cmp_op ==
     pop_jump_if_false L3
     load_const ai.clients.default_retry_judgment
-    store_var _8
+    store_var _9
 
   L3:
+    load_var _9
+    store_var _8
     load_var backoff
-    store_var _10
-    load_var backoff
+    store_var_load_var _12
     load_const null
     cmp_op ==
     pop_jump_if_false L4
@@ -1442,11 +1426,11 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
     load_const <omitted>
     load_const <omitted>
     call ai.clients.Backoff.new
-    store_var _10
+    store_var _12
 
   L4:
     load_var2 1 2
-    load_var2 5 6
+    load_var2 5 7
     init_instance ai.clients.Retry .inner, .max_attempts, .retry_if, .backoff
     return
 }
@@ -2577,28 +2561,24 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
   L5:
     load_var self
     load_field ._input_tokens
-    store_var _12
-    load_var _12
-    store_var _11
-    load_var _12
+    store_var_load_var _12
     load_const null
     cmp_op ==
     pop_jump_if_false L6
     load_const 0
-    store_var _11
+    store_var _12
 
   L6:
+    load_var _12
+    store_var _11
     load_var self
     load_field ._output_tokens
-    store_var _15
-    load_var _15
-    store_var _14
-    load_var _15
+    store_var_load_var _16
     load_const null
     cmp_op ==
     pop_jump_if_false L7
     load_const 0
-    store_var _14
+    store_var _16
 
   L7:
     load_var2 4 6
@@ -2610,16 +2590,13 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
   L8:
     load_var self
     load_field ._stop_reason
-    store_var _21
-    load_var _21
-    store_var _20
-    load_var _21
+    store_var_load_var _23
     load_const null
     cmp_op ==
     pop_jump_if_false L9
     load_const ai.content.StopReason.Complete
     alloc_variant ai.content.StopReason
-    store_var _20
+    store_var _23
 
   L9:
     load_var self
@@ -2627,7 +2604,7 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
     init_instance ai.content.Text .text
     load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse
     alloc_array 1
-    load_var2 8 3
+    load_var2 7 3
     init_instance ai.ModelTurn .content, .stop_reason, .usage
     return
 }
@@ -3266,19 +3243,18 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
     call reflect.signature
     store_var sig
     load_var name
-    store_var resolved_name
-    load_var name
+    store_var_load_var _10
     load_const null
     cmp_op ==
     pop_jump_if_false L3
     load_var sig
     load_field .name
-    store_var resolved_name
+    store_var _10
 
   L3:
-    load_var resolved_name
-    store_var _11
-    load_var _11
+    load_var _10
+    store_var _12
+    load_var _12
     narrow_bind string, slot=7
     pop_jump_if_false L4
     jump L5
@@ -3289,7 +3265,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
     throw
 
   L5:
-    load_var _11
+    load_var _12
     store_var_load_var n
     load_const "__baml_return_output"
     cmp_op ==
@@ -3298,31 +3274,31 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
 
   L6:
     load_var description
-    store_var _18
-    load_var description
+    store_var_load_var _21
     load_const null
     cmp_op ==
     pop_jump_if_false L7
     load_var sig
     load_field .docstring
-    store_var _18
+    store_var _21
 
   L7:
-    load_var _18
-    store_var _17
-    load_var _18
+    load_var _21
+    store_var_load_var _19
     load_const null
     cmp_op ==
     pop_jump_if_false L8
     load_const ""
-    store_var _17
+    store_var _19
 
   L8:
+    load_var _19
+    store_var _18
     load_var handler
     call ai.internal._schema_for_signature
-    store_var _21
+    store_var _24
     load_var2 8 9
-    load_var2 11 1
+    load_var2 12 1
     load_const null
     load_var on_error
     init_instance ai.tools.Tool .name, .description, .input_schema, .handler, .raw_handler, .on_error
@@ -3637,32 +3613,28 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
     narrow_bind anthropic.internal.AnthStreamEvent, slot=8
     pop_jump_if_false L0
     load_var _16
-    store_var event
-    load_var event
+    store_var_load_var event
     load_field .type
-    store_var _20
-    load_var _20
-    store_var _19
-    load_var _20
+    store_var_load_var _21
     load_const null
     cmp_op ==
     pop_jump_if_false L3
     load_var raw
     load_field .event
-    store_var _19
+    store_var _21
 
   L3:
-    load_var _19
-    store_var t
-    load_var _19
+    load_var _21
+    store_var_load_var _19
     load_const null
     cmp_op ==
     pop_jump_if_false L4
     load_const ""
-    store_var t
+    store_var _19
 
   L4:
-    load_var t
+    load_var _19
+    store_var_load_var t
     load_const "content_block_delta"
     cmp_op ==
     pop_jump_if_false L5
@@ -3706,22 +3678,22 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
     load_var event
     load_field .delta
     load_field .2
-    store_var _67
+    store_var _70
     jump L11
 
   L10:
     load_const null
-    store_var _67
+    store_var _70
 
   L11:
-    load_var _67
+    load_var _70
     load_const null
     cmp_op ==
     pop_jump_if_false L12
     jump L13
 
   L12:
-    load_var _67
+    load_var _70
     call anthropic.internal._anthropic_stop_reason
     store_var stop
     jump L14
@@ -3732,7 +3704,7 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
 
   L14:
     load_var stop
-    store_var _76
+    store_var _79
     load_var event
     load_field .usage
     load_const null
@@ -3744,12 +3716,12 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
     load_var event
     load_field .usage
     load_field .0
-    store_var _77
+    store_var _80
     jump L17
 
   L16:
     load_const null
-    store_var _77
+    store_var _80
 
   L17:
     load_var event
@@ -3763,17 +3735,17 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
     load_var event
     load_field .usage
     load_field .1
-    store_var _81
+    store_var _84
     jump L20
 
   L19:
     load_const null
-    store_var _81
+    store_var _84
 
   L20:
     load_type ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone
-    load_var2 2 22
-    load_var2 23 24
+    load_var2 2 21
+    load_var2 22 23
     init_instance ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens
     call baml.Array.push
     pop 1
@@ -3809,12 +3781,12 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
     load_field .message
     load_field .0
     load_field .0
-    store_var _43
+    store_var _46
     jump L26
 
   L25:
     load_const null
-    store_var _43
+    store_var _46
 
   L26:
     load_var event
@@ -3846,18 +3818,18 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
     load_field .message
     load_field .0
     load_field .1
-    store_var _53
+    store_var _56
     jump L31
 
   L30:
     load_const null
-    store_var _53
+    store_var _56
 
   L31:
     load_type ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone
     load_var out
     load_const null
-    load_var2 18 19
+    load_var2 17 18
     init_instance ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens
     call baml.Array.push
     pop 1
@@ -3866,37 +3838,33 @@ function anthropic.internal._anthropic_decode_batch(batch: string) -> (ai.stream
   L32:
     load_var event
     load_field .delta
-    store_var _26
-    load_var _26
+    store_var _28
+    load_var _28
     narrow_bind anthropic.internal.AnthStreamDelta, slot=13
     pop_jump_if_false L0
-    load_var _26
-    store_var d
-    load_var d
+    load_var _28
+    store_var_load_var d
     load_field .type
-    store_var _30
-    load_var _30
-    store_var _29
-    load_var _30
+    store_var_load_var _32
     load_const null
     cmp_op ==
     pop_jump_if_false L33
     load_const ""
-    store_var _29
+    store_var _32
 
   L33:
-    load_var _29
+    load_var _32
     load_const "text_delta"
     cmp_op ==
     pop_jump_if_false L0
     load_var d
     load_field .text
-    store_var _33
-    load_var _33
-    narrow_bind string, slot=17
+    store_var _36
+    load_var _36
+    narrow_bind string, slot=16
     pop_jump_if_false L0
     load_type ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone
-    load_var2 2 17
+    load_var2 2 16
     init_instance ai.stream.TextDelta .text
     call baml.Array.push
     pop 1
@@ -4363,33 +4331,29 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
     load_const 0
     call baml.Array.at
     load_field .0
-    store_var _32
     jump L5
 
   L4:
     load_const null
-    store_var _32
 
   L5:
-    load_var _32
-    store_var first_role
-    load_var _32
+    store_var_load_var _32
     load_const null
     cmp_op ==
     pop_jump_if_false L6
     load_const ""
-    store_var first_role
+    store_var _32
 
   L6:
-    load_var first_role
+    load_var _32
     load_const "user"
     cmp_op !=
     jump_if_false L7
     pop 1
     load_var system
     container_len
-    store_var _42
-    load_var _42
+    store_var _43
+    load_var _43
     load_const 0
     cmp_int_op >
 
@@ -4400,8 +4364,8 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
   L8:
     load_var system
     container_len
-    store_var _55
-    load_var _55
+    store_var _56
+    load_var _56
     load_const 0
     cmp_int_op >
     pop_jump_if_false L9
@@ -4416,12 +4380,12 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
   L9:
     load_var lowered
     call anthropic.internal._anthropic_render_messages
-    store_var _61
+    store_var _62
     load_type string
     load_type unknown
     load_var body
     load_const "messages"
-    load_var _61
+    load_var _62
     call baml.Map.set
     pop 1
     jump L11
@@ -4437,12 +4401,12 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
     load_var lowered
     call baml.Array.concat
     call anthropic.internal._anthropic_render_messages
-    store_var _46
+    store_var _47
     load_type string
     load_type unknown
     load_var body
     load_const "messages"
-    load_var _46
+    load_var _47
     call baml.Map.set
     pop 1
 
@@ -4461,21 +4425,21 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
     load_type baml.iter.Iterable<Error = never, Item = ai.tools.Tool>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _71
+    store_var _72
 
   L12:
-    load_var _71
+    load_var _72
     load_type baml.iter.Iterator<Error = never, Item = ai.tools.Tool>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _72
-    load_var _72
+    store_var _73
+    load_var _73
     is_type baml.iter.Done
     pop_jump_if_false L13
     jump L14
 
   L13:
-    load_var _72
+    load_var _73
     store_var t
     load_type string
     load_type unknown
@@ -4506,7 +4470,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
     call baml.Map.set
     pop 1
     load_type map<string, unknown>
-    load_var2 17 21
+    load_var2 16 20
     call baml.Array.push
     pop 1
     jump L12
@@ -4552,32 +4516,30 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
   L16:
     load_var c
     load_field .base_url
-    store_var _108
-    load_var _108
-    store_var base
-    load_var _108
+    store_var_load_var _109
     load_const null
     cmp_op ==
     pop_jump_if_false L17
     load_const "https://api.anthropic.com"
-    store_var base
+    store_var _109
 
   L17:
     load_type string
-    load_var base
+    load_var _109
     call baml.String.from
-    store_var _111
+    store_var _113
     load_var c
     load_field .api_key
-    store_var _116
-    load_var2 27 27
+    store_var_load_var _118
     load_const null
     cmp_op ==
     pop_jump_if_false L18
     load_const "ANTHROPIC_API_KEY"
     call baml.env.get_or_panic
+    store_var _118
 
   L18:
+    load_var _118
     load_const "2023-06-01"
     load_const "application/json"
     load_const "x-api-key"
@@ -4586,17 +4548,17 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
     load_type string
     load_type string
     alloc_map 3
-    store_var _114
+    store_var _116
     load_type map<string, unknown>
     load_var body
     call baml.json.to_json
     call baml.json.stringify
-    store_var _118
+    store_var _121
     load_const "POST"
-    load_var _111
+    load_var _113
     load_const "/v1/messages"
     bin_op +
-    load_var2 26 28
+    load_var2 24 26
     init_instance baml.http.Request .method, .url, .headers, .body
     return
 }
@@ -4701,48 +4663,43 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
     pop_jump_if_false L0
     load_var b
     load_field .id
-    store_var _36
-    load_var _36
-    store_var _35
-    load_var _36
+    store_var_load_var _38
     load_const null
     cmp_op ==
     pop_jump_if_false L4
     load_const ""
-    store_var _35
+    store_var _38
 
   L4:
+    load_var _38
+    store_var _37
     load_var b
     load_field .name
-    store_var _39
-    load_var _39
-    store_var _38
-    load_var _39
+    store_var_load_var _42
     load_const null
     cmp_op ==
     pop_jump_if_false L5
     load_const ""
-    store_var _38
+    store_var _42
 
   L5:
-    load_var b
-    load_field .input
-    store_var _42
     load_var _42
     store_var _41
-    load_var _42
+    load_var b
+    load_field .input
+    store_var_load_var _46
     load_const null
     cmp_op ==
     pop_jump_if_false L6
     load_type string
     load_type unknown
     alloc_map 0
-    store_var _41
+    store_var _46
 
   L6:
     load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse
-    load_var2 5 13
-    load_var2 15 17
+    load_var2 5 11
+    load_var2 13 15
     init_instance ai.content.ToolUse .id, .name, .args
     call baml.Array.push
     pop 1
@@ -4751,19 +4708,16 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
   L7:
     load_var b
     load_field .thinking
-    store_var _27
-    load_var _27
-    store_var _26
-    load_var _27
+    store_var_load_var _28
     load_const null
     cmp_op ==
     pop_jump_if_false L8
     load_const ""
-    store_var _26
+    store_var _28
 
   L8:
     load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse
-    load_var2 5 11
+    load_var2 5 10
     init_instance ai.content.Reasoning .summary
     call baml.Array.push
     pop 1
@@ -4772,15 +4726,12 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
   L9:
     load_var b
     load_field .text
-    store_var _19
-    load_var _19
-    store_var _18
-    load_var _19
+    store_var_load_var _19
     load_const null
     cmp_op ==
     pop_jump_if_false L10
     load_const ""
-    store_var _18
+    store_var _19
 
   L10:
     load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse
@@ -4793,14 +4744,14 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
   L11:
     load_var resp
     load_field .stop_reason
-    store_var_load_var _46
+    store_var_load_var _51
     load_const null
     cmp_op ==
     pop_jump_if_false L12
     jump L13
 
   L12:
-    load_var _46
+    load_var _51
     call anthropic.internal._anthropic_stop_reason
     store_var stop
     jump L14
@@ -4813,9 +4764,9 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
   L14:
     load_var resp
     load_field .usage
-    store_var _52
-    load_var _52
-    narrow_bind anthropic.internal.AnthropicUsage, slot=22
+    store_var _57
+    load_var _57
+    narrow_bind anthropic.internal.AnthropicUsage, slot=19
     pop_jump_if_false L15
     jump L16
 
@@ -4825,7 +4776,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
     jump L17
 
   L16:
-    load_var _52
+    load_var _57
     store_var_load_var u
     load_field .input_tokens
     load_var u
@@ -4836,7 +4787,7 @@ function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.Model
     store_var usage
 
   L17:
-    load_var2 5 19
+    load_var2 5 16
     load_var usage
     init_instance ai.ModelTurn .content, .stop_reason, .usage
     return
@@ -5208,21 +5159,20 @@ function claude_code.ClaudeCodeClient.new(model: string, executable: string, cwd
 
   L6:
     load_var mcp_servers
-    store_var _16
-    load_var mcp_servers
+    store_var_load_var _17
     load_const null
     cmp_op ==
     pop_jump_if_false L7
     load_type string
     load_type baml.json.json
     alloc_map 0
-    store_var _16
+    store_var _17
 
   L7:
     load_var2 2 1
     load_var2 3 4
     load_var2 5 6
-    load_var _16
+    load_var _17
     init_instance claude_code.ClaudeCodeClient .executable, .model, .cwd, .timeout_ms, .permission_mode, .harness_tools, .mcp_servers
     return
 }
@@ -7171,72 +7121,65 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
     load_var cand
     load_field .0
     load_field .0
-    store_var _24
     jump L10
 
   L9:
     load_const null
-    store_var _24
 
   L10:
-    load_var _24
-    store_var parts
-    load_var _24
+    store_var_load_var _24
     load_const null
     cmp_op ==
     pop_jump_if_false L11
     load_type google.internal.GmPart
     alloc_array 0
-    store_var parts
+    store_var _24
 
   L11:
-    load_var parts
+    load_var _24
     load_type baml.iter.Iterable<Error = never, Item = google.internal.GmPart>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _36
+    store_var _37
 
   L12:
-    load_var _36
+    load_var _37
     load_type baml.iter.Iterator<Error = never, Item = google.internal.GmPart>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _37
-    load_var _37
+    store_var _38
+    load_var _38
     is_type baml.iter.Done
     pop_jump_if_false L13
     jump L16
 
   L13:
-    load_var _37
+    load_var _38
     store_var_load_var p
     load_field .text
-    store_var _42
-    load_var _42
-    narrow_bind string, slot=15
+    store_var _43
+    load_var _43
+    narrow_bind string, slot=14
     pop_jump_if_false L12
-    load_var _42
+    load_var _43
     store_var t
     load_var p
     load_field .thought
-    store_var _45
-    load_var _45
-    store_var _44
-    load_var _45
+    store_var_load_var _46
     load_const null
     cmp_op ==
     pop_jump_if_false L14
     load_const false
-    store_var _44
+    store_var _46
 
   L14:
-    load_var _44
+    load_var _46
     pop_jump_if_false L15
     jump L12
 
   L15:
     load_type ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone
-    load_var2 2 16
+    load_var2 2 15
     init_instance ai.stream.TextDelta .text
     call baml.Array.push
     pop 1
@@ -7252,24 +7195,22 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
   L17:
     load_var cand
     load_field .1
-    store_var _52
     jump L19
 
   L18:
     load_const null
-    store_var _52
 
   L19:
-    load_var _52
-    store_var finish
-    load_var _52
+    store_var_load_var _54
     load_const null
     cmp_op ==
     pop_jump_if_false L20
     load_const ""
-    store_var finish
+    store_var _54
 
   L20:
+    load_var _54
+    store_var finish
     load_var resp
     load_field .promptFeedback
     load_const null
@@ -7289,7 +7230,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
   L23:
     load_const null
     call baml.ops.equals_equals
-    store_var _62
+    store_var _65
     load_var finish
     load_const "MAX_TOKENS"
     cmp_op ==
@@ -7297,7 +7238,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
     jump L35
 
   L24:
-    load_var _62
+    load_var _65
     unary_op !
     jump_if_false L25
     jump L26
@@ -7382,7 +7323,7 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
   L38:
     pop_jump_if_false L0
     load_var stop
-    store_var _84
+    store_var _87
     load_var usage
     load_const null
     cmp_op ==
@@ -7392,12 +7333,12 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
   L39:
     load_var usage
     load_field .0
-    store_var _85
+    store_var _88
     jump L41
 
   L40:
     load_const null
-    store_var _85
+    store_var _88
 
   L41:
     load_var usage
@@ -7409,17 +7350,17 @@ function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextD
   L42:
     load_var usage
     load_field .1
-    store_var _89
+    store_var _92
     jump L44
 
   L43:
     load_const null
-    store_var _89
+    store_var _92
 
   L44:
     load_type ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone
-    load_var2 2 24
-    load_var2 25 26
+    load_var2 2 22
+    load_var2 23 24
     init_instance ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens
     call baml.Array.push
     pop 1
@@ -7677,62 +7618,60 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
   L13:
     load_var c
     load_field .base_url
-    store_var _105
-    load_var _105
-    store_var _104
-    load_var _105
+    store_var_load_var _105
     load_const null
     cmp_op ==
     pop_jump_if_false L14
     load_const "https://generativelanguage.googleapis.com/v1beta"
-    store_var _104
+    store_var _105
 
   L14:
     load_type string
-    load_var _104
+    load_var _105
     call baml.String.from
     store_var _103
     load_type string
     load_var c
     load_field .model
     call baml.String.from
-    store_var _108
+    store_var _109
     load_type string
     load_var method
     call baml.String.from
-    store_var _111
+    store_var _112
     load_var c
     load_field .api_key
-    store_var _116
-    load_var2 29 29
+    store_var_load_var _117
     load_const null
     cmp_op ==
     pop_jump_if_false L15
     load_const "GOOGLE_API_KEY"
     call baml.env.get_or_panic
+    store_var _117
 
   L15:
+    load_var _117
     load_const "application/json"
     load_const "x-goog-api-key"
     load_const "content-type"
     load_type string
     load_type string
     alloc_map 2
-    store_var _114
+    store_var _115
     load_type map<string, unknown>
     load_var body
     call baml.json.to_json
     call baml.json.stringify
-    store_var _118
+    store_var _120
     load_const "POST"
     load_var _103
     load_const "/models/"
     bin_op +
-    load_var _108
+    load_var _109
     bin_op +
-    load_var _111
+    load_var _112
     bin_op +
-    load_var2 28 30
+    load_var2 27 29
     init_instance baml.http.Request .method, .url, .headers, .body
     return
 }
@@ -8165,24 +8104,22 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
   L3:
     load_var cand
     load_field .1
-    store_var _12
     jump L5
 
   L4:
     load_const null
-    store_var _12
 
   L5:
-    load_var _12
-    store_var finish
-    load_var _12
+    store_var_load_var _12
     load_const null
     cmp_op ==
     pop_jump_if_false L6
     load_const ""
-    store_var finish
+    store_var _12
 
   L6:
+    load_var _12
+    store_var finish
     load_var cand
     load_const null
     cmp_op ==
@@ -8208,81 +8145,74 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
     load_var cand
     load_field .0
     load_field .0
-    store_var _18
     jump L11
 
   L10:
     load_const null
-    store_var _18
 
   L11:
-    load_var _18
-    store_var parts
-    load_var _18
+    store_var_load_var _19
     load_const null
     cmp_op ==
     pop_jump_if_false L12
     load_type google.internal.GmPart
     alloc_array 0
-    store_var parts
+    store_var _19
 
   L12:
-    load_var parts
+    load_var _19
     load_type baml.iter.Iterable<Error = never, Item = google.internal.GmPart>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _30
+    store_var _32
 
   L13:
-    load_var _30
+    load_var _32
     load_type baml.iter.Iterator<Error = never, Item = google.internal.GmPart>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _31
-    load_var _31
+    store_var _33
+    load_var _33
     is_type baml.iter.Done
     pop_jump_if_false L14
     jump L21
 
   L14:
-    load_var _31
+    load_var _33
     store_var_load_var p
     load_field .functionCall
-    store_var _36
-    load_var _36
-    narrow_bind google.internal.GmFunctionCall, slot=14
+    store_var _38
+    load_var _38
+    narrow_bind google.internal.GmFunctionCall, slot=13
     pop_jump_if_false L15
     jump L19
 
   L15:
     load_var p
     load_field .text
-    store_var _56
-    load_var _56
-    narrow_bind string, slot=20
+    store_var _58
+    load_var _58
+    narrow_bind string, slot=19
     pop_jump_if_false L13
-    load_var _56
+    load_var _58
     store_var t
     load_var p
     load_field .thought
-    store_var _59
-    load_var _59
-    store_var _58
-    load_var _59
+    store_var_load_var _61
     load_const null
     cmp_op ==
     pop_jump_if_false L16
     load_const false
-    store_var _58
+    store_var _61
 
   L16:
-    load_var _58
+    load_var _61
     pop_jump_if_false L17
     jump L18
 
   L17:
     load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse
-    load_var2 3 21
+    load_var2 3 20
     init_instance ai.content.Text .text
     call baml.Array.push
     pop 1
@@ -8290,14 +8220,14 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
 
   L18:
     load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse
-    load_var2 3 21
+    load_var2 3 20
     init_instance ai.content.Reasoning .summary
     call baml.Array.push
     pop 1
     jump L13
 
   L19:
-    load_var _36
+    load_var _38
     store_var fc
     load_type string
     load_type unknown
@@ -8305,30 +8235,30 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
     store_var args
     load_var fc
     load_field .args
-    store_var _40
-    load_var _40
-    narrow_bind map<string, unknown>, slot=17
+    store_var _42
+    load_var _42
+    narrow_bind map<string, unknown>, slot=16
     pop_jump_if_false L20
-    load_var _40
+    load_var _42
     store_var args
 
   L20:
     load_type int
     load_var seq
     call baml.String.from
-    store_var _47
+    store_var _49
     load_type int
     load_var call_index
     call baml.String.from
-    store_var _49
+    store_var _51
     load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse
     load_var content
     load_const "call_"
-    load_var _47
+    load_var _49
     bin_op +
     load_const "_"
     bin_op +
-    load_var _49
+    load_var _51
     bin_op +
     load_var fc
     load_field .name
@@ -8364,7 +8294,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
   L24:
     load_const null
     call baml.ops.equals_equals
-    store_var _74
+    store_var _77
     load_var has_call
     pop_jump_if_false L25
     jump L36
@@ -8377,7 +8307,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
     jump L35
 
   L26:
-    load_var _74
+    load_var _77
     unary_op !
     jump_if_false L27
     jump L28
@@ -8438,9 +8368,9 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
   L37:
     load_var resp
     load_field .usageMetadata
-    store_var _88
-    load_var _88
-    narrow_bind google.internal.GmUsageMetadata, slot=27
+    store_var _91
+    load_var _91
+    narrow_bind google.internal.GmUsageMetadata, slot=25
     pop_jump_if_false L38
     jump L39
 
@@ -8450,42 +8380,37 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
     jump L42
 
   L39:
-    load_var _88
-    store_var um
-    load_var um
+    load_var _91
+    store_var_load_var um
     load_field .promptTokenCount
-    store_var _91
-    load_var _91
-    store_var _90
-    load_var _91
+    store_var_load_var _94
     load_const null
     cmp_op ==
     pop_jump_if_false L40
     load_const 0
-    store_var _90
+    store_var _94
 
   L40:
-    load_var um
-    load_field .candidatesTokenCount
-    store_var _94
     load_var _94
     store_var _93
-    load_var _94
+    load_var um
+    load_field .candidatesTokenCount
+    store_var_load_var _98
     load_const null
     cmp_op ==
     pop_jump_if_false L41
     load_const 0
-    store_var _93
+    store_var _98
 
   L41:
-    load_var2 29 31
+    load_var2 27 29
     load_const null
     load_const null
     init_instance ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens
     store_var usage
 
   L42:
-    load_var2 3 25
+    load_var2 3 23
     load_var usage
     init_instance ai.ModelTurn .content, .stop_reason, .usage
     return
@@ -8744,32 +8669,28 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
     narrow_bind openai.internal.OaStreamEvent, slot=8
     pop_jump_if_false L0
     load_var _16
-    store_var event
-    load_var event
+    store_var_load_var event
     load_field .type
-    store_var _20
-    load_var _20
-    store_var _19
-    load_var _20
+    store_var_load_var _21
     load_const null
     cmp_op ==
     pop_jump_if_false L3
     load_var raw
     load_field .event
-    store_var _19
+    store_var _21
 
   L3:
-    load_var _19
-    store_var t
-    load_var _19
+    load_var _21
+    store_var_load_var _19
     load_const null
     cmp_op ==
     pop_jump_if_false L4
     load_const ""
-    store_var t
+    store_var _19
 
   L4:
-    load_var t
+    load_var _19
+    store_var_load_var t
     load_const "response.output_text.delta"
     cmp_op ==
     pop_jump_if_false L5
@@ -8802,16 +8723,16 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
     pop_jump_if_false L0
     load_var event
     load_field .response
-    store_var _39
-    load_var _39
+    store_var _41
+    load_var _41
     narrow_bind openai.internal.OaResponse, slot=14
     pop_jump_if_false L16
-    load_var _39
+    load_var _41
     call openai.internal.openai_parse
     store_var turn
     load_var turn
     load_field .stop_reason
-    store_var _45
+    store_var _47
     load_var turn
     load_field .usage
     load_const null
@@ -8823,12 +8744,12 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
     load_var turn
     load_field .usage
     load_field .0
-    store_var _46
+    store_var _48
     jump L12
 
   L11:
     load_const null
-    store_var _46
+    store_var _48
 
   L12:
     load_var turn
@@ -8842,12 +8763,12 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
     load_var turn
     load_field .usage
     load_field .1
-    store_var _50
+    store_var _52
     jump L15
 
   L14:
     load_const null
-    store_var _50
+    store_var _52
 
   L15:
     load_type ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone
@@ -8868,8 +8789,8 @@ function openai.internal._openai_decode_batch(batch: string) -> (ai.stream.TextD
   L17:
     load_var event
     load_field .delta
-    store_var _26
-    load_var _26
+    store_var _28
+    load_var _28
     narrow_bind string, slot=13
     pop_jump_if_false L0
     load_type ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone
@@ -9056,39 +8977,36 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
   L7:
     load_var c
     call openai.OpenAiClient.resolved_base_url
-    store_var _78
-    load_var _78
-    store_var _77
-    load_var _78
+    store_var_load_var _78
     load_const null
     cmp_op ==
     pop_jump_if_false L8
     load_const "https://api.openai.com/v1"
-    store_var _77
+    store_var _78
 
   L8:
     load_type string
-    load_var _77
+    load_var _78
     call baml.String.from
     store_var _76
     load_var c
     call openai.OpenAiClient.resolved_api_key
-    store_var _84
+    store_var _85
     load_type string
-    load_var _84
+    load_var _85
     call baml.String.from
-    store_var _83
+    store_var _84
     load_type map<string, unknown>
     load_var body
     call baml.json.to_json
     call baml.json.stringify
-    store_var _86
+    store_var _87
     load_const "POST"
     load_var _76
     load_const "/responses"
     bin_op +
     load_const "Bearer "
-    load_var _83
+    load_var _84
     bin_op +
     load_const "application/json"
     load_const "authorization"
@@ -9096,7 +9014,7 @@ function openai.internal._openai_request(c: openai.OpenAiClient, input: ai.Model
     load_type string
     load_type string
     alloc_map 2
-    load_var _86
+    load_var _87
     init_instance baml.http.Request .method, .url, .headers, .body
     return
 }
@@ -9562,44 +9480,41 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
     pop_jump_if_false L0
     load_var item
     load_field .summary
-    store_var _52
-    load_var _52
-    store_var parts
-    load_var _52
+    store_var_load_var _57
     load_const null
     cmp_op ==
     pop_jump_if_false L4
     load_type openai.internal.OaContentPart
     alloc_array 0
-    store_var parts
+    store_var _57
 
   L4:
-    load_var parts
+    load_var _57
     load_type baml.iter.Iterable<Error = never, Item = openai.internal.OaContentPart>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _55
+    store_var _61
 
   L5:
-    load_var _55
+    load_var _61
     load_type baml.iter.Iterator<Error = never, Item = openai.internal.OaContentPart>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _56
-    load_var _56
+    store_var _62
+    load_var _62
     is_type baml.iter.Done
     pop_jump_if_false L6
     jump L0
 
   L6:
-    load_var _56
+    load_var _62
     load_field .text
-    store_var _61
-    load_var _61
-    narrow_bind string, slot=26
+    store_var _67
+    load_var _67
+    narrow_bind string, slot=21
     pop_jump_if_false L5
     load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse
-    load_var2 2 26
+    load_var2 2 21
     init_instance ai.content.Reasoning .summary
     call baml.Array.push
     pop 1
@@ -9608,70 +9523,60 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
   L7:
     load_var item
     load_field .content
-    store_var _31
-    load_var _31
-    store_var parts
-    load_var _31
+    store_var_load_var _33
     load_const null
     cmp_op ==
     pop_jump_if_false L8
     load_type openai.internal.OaContentPart
     alloc_array 0
-    store_var parts
+    store_var _33
 
   L8:
-    load_var parts
+    load_var _33
     load_type baml.iter.Iterable<Error = never, Item = openai.internal.OaContentPart>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
-    store_var _34
+    store_var _37
 
   L9:
-    load_var _34
+    load_var _37
     load_type baml.iter.Iterator<Error = never, Item = openai.internal.OaContentPart>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _35
-    load_var _35
+    store_var _38
+    load_var _38
     is_type baml.iter.Done
     pop_jump_if_false L10
     jump L0
 
   L10:
-    load_var _35
-    store_var part
-    load_var part
+    load_var _38
+    store_var_load_var part
     load_field .type
-    store_var _41
-    load_var _41
-    store_var _40
-    load_var _41
+    store_var_load_var _44
     load_const null
     cmp_op ==
     pop_jump_if_false L11
     load_const ""
-    store_var _40
+    store_var _44
 
   L11:
-    load_var _40
+    load_var _44
     load_const "output_text"
     cmp_op ==
     pop_jump_if_false L9
     load_var part
     load_field .text
-    store_var _46
-    load_var _46
-    store_var _45
-    load_var _46
+    store_var_load_var _50
     load_const null
     cmp_op ==
     pop_jump_if_false L12
     load_const ""
-    store_var _45
+    store_var _50
 
   L12:
     load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse
-    load_var2 2 20
+    load_var2 2 17
     init_instance ai.content.Text .text
     call baml.Array.push
     pop 1
@@ -9698,28 +9603,24 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
   L14:
     load_var item
     load_field .call_id
-    store_var _21
-    load_var _21
-    store_var _20
-    load_var _21
+    store_var_load_var _21
     load_const null
     cmp_op ==
     pop_jump_if_false L15
     load_const ""
-    store_var _20
+    store_var _21
 
   L15:
+    load_var _21
+    store_var _20
     load_var item
     load_field .name
-    store_var _24
-    load_var _24
-    store_var _23
-    load_var _24
+    store_var_load_var _25
     load_const null
     cmp_op ==
     pop_jump_if_false L16
     load_const ""
-    store_var _23
+    store_var _25
 
   L16:
     load_type ai.content.Text | ai.content.Reasoning | ai.content.ToolUse
@@ -9738,18 +9639,15 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
   L18:
     load_var resp
     load_field .status
-    store_var _71
-    load_var _71
-    store_var _70
-    load_var _71
+    store_var_load_var _77
     load_const null
     cmp_op ==
     pop_jump_if_false L19
     load_const ""
-    store_var _70
+    store_var _77
 
   L19:
-    load_var _70
+    load_var _77
     load_const "incomplete"
     cmp_op ==
     pop_jump_if_false L20
@@ -9775,9 +9673,9 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
   L23:
     load_var resp
     load_field .usage
-    store_var _75
-    load_var _75
-    narrow_bind openai.internal.OaUsage, slot=31
+    store_var _82
+    load_var _82
+    narrow_bind openai.internal.OaUsage, slot=25
     pop_jump_if_false L24
     jump L25
 
@@ -9787,7 +9685,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
     jump L26
 
   L25:
-    load_var _75
+    load_var _82
     store_var_load_var u
     load_field .input_tokens
     load_var u
@@ -9798,7 +9696,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
     store_var usage
 
   L26:
-    load_var2 2 27
+    load_var2 2 22
     load_var usage
     init_instance ai.ModelTurn .content, .stop_reason, .usage
     return

--- a/baml_language/crates/baml_tests/tests/incremental_typing_repro.rs
+++ b/baml_language/crates/baml_tests/tests/incremental_typing_repro.rs
@@ -140,3 +140,57 @@ fn incremental_incomplete_log_repro_stays_alive() {
 fn incremental_incomplete_log_repro_child() {
     run_incomplete_log_repro_sequence();
 }
+
+#[test]
+fn incremental_property_syntax_change_invalidates_inference() {
+    let mut db = ProjectDatabase::new();
+    let root = Path::new("/property-syntax");
+    let file = Path::new("/property-syntax/main.baml");
+    db.set_project_root(root);
+
+    db.add_or_update_file(
+        file,
+        r#"
+function build() -> map<string, string> {
+  { key }
+}
+"#,
+    );
+    let shorthand_messages: Vec<_> = collect_compiler2_diagnostics(&db)
+        .into_iter()
+        .map(|diagnostic| diagnostic.message)
+        .collect();
+    assert!(
+        shorthand_messages
+            .iter()
+            .any(|message| message.contains("property shorthand `key`")),
+        "expected shorthand diagnostic, got: {shorthand_messages:#?}"
+    );
+
+    // These forms have identical key/value expressions after desugaring, so
+    // property syntax must participate in the structural body equality.
+    db.add_or_update_file(
+        file,
+        r#"
+function build() -> map<string, string> {
+  { "key": key }
+}
+"#,
+    );
+    let explicit_messages: Vec<_> = collect_compiler2_diagnostics(&db)
+        .into_iter()
+        .map(|diagnostic| diagnostic.message)
+        .collect();
+    assert!(
+        explicit_messages
+            .iter()
+            .any(|message| message.contains("unresolved name: `key`")),
+        "expected ordinary unresolved-name diagnostic, got: {explicit_messages:#?}"
+    );
+    assert!(
+        explicit_messages
+            .iter()
+            .all(|message| !message.contains("property shorthand")),
+        "explicit syntax reused stale shorthand inference: {explicit_messages:#?}"
+    );
+}

--- a/baml_language/crates/bex_vm/src/package_baml/json.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/json.rs
@@ -1013,13 +1013,7 @@ fn serialize_class_instance(
 /// runtime media value is an `Object::Instance` of one of these std classes
 /// (carrying a `$rust_type` `_data` field); there is no `Generic` media *value*.
 pub(crate) fn media_kind_from_fqn(fqn: &str) -> Option<MediaKind> {
-    match fqn {
-        "baml.media.Image" => Some(MediaKind::Image),
-        "baml.media.Audio" => Some(MediaKind::Audio),
-        "baml.media.Video" => Some(MediaKind::Video),
-        "baml.media.Pdf" => Some(MediaKind::Pdf),
-        _ => None,
-    }
+    MediaKind::from_wrapper_class_name(fqn)
 }
 
 /// Emit a tagged JSON object for a media value.
@@ -1400,21 +1394,14 @@ fn deserialize_media_by_kind(
     kind: MediaKind,
     path: &mut String,
 ) -> Result<Value, VmRustFnError> {
-    let class_short = match kind {
-        MediaKind::Image => "Image",
-        MediaKind::Audio => "Audio",
-        MediaKind::Video => "Video",
-        MediaKind::Pdf => "Pdf",
-        MediaKind::Generic => {
-            return Err(raise_decode(
-                vm,
-                "cannot deserialize generic media — type must be concrete (image|audio|video|pdf)",
-                path,
-            ));
-        }
+    let Some(fqn) = kind.wrapper_class_name() else {
+        return Err(raise_decode(
+            vm,
+            "cannot deserialize generic media - type must be concrete (image|audio|video|pdf)",
+            path,
+        ));
     };
-    let fqn_string = format!("baml.media.{class_short}");
-    let qtn = TypeName::from_dotted_path(&fqn_string);
+    let qtn = TypeName::from_dotted_path(fqn);
     deserialize_media(vm, json, kind, &qtn, path)
 }
 
@@ -1435,6 +1422,20 @@ fn deserialize_media(
             ));
         }
     };
+    let tagged_kind = map
+        .get("kind")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| raise_decode(vm, "media object missing `kind`", path))?;
+    if tagged_kind != kind.tag_str() {
+        return Err(raise_decode(
+            vm,
+            format!(
+                "media kind mismatch: expected `{}`, got `{tagged_kind}`",
+                kind.tag_str()
+            ),
+            path,
+        ));
+    }
     let source = map
         .get("source")
         .and_then(serde_json::Value::as_str)


### PR DESCRIPTION
## Summary

- preserve assignment destinations while lowering null-coalescing expressions
- represent property shorthand structurally and resolve shorthand values in their lexical expression scope
- make runtime type-test classification exhaustive, including type values and structural media matching
- validate media JSON kind tags so union decoding selects the correct member

## Testing

- repository pre-commit hooks, including cargo fmt and workspace cargo clippy
- cargo test -p bex_vm
- cargo test -p baml_compiler2_emit
- focused compiler AST, diagnostic, and incremental tests
- cargo check -p baml_tests --tests
- native BAML runtime regressions for null coalescing, shorthand binders, runtime leaf narrowing, and media JSON unions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Property shorthand syntax is preserved for object and map expressions, improving diagnostics and scope handling.
  * Runtime type checks and narrowing now support `type` values and media types more accurately.
  * Media JSON deserialization validates declared media kinds and rejects mismatches.

* **Bug Fixes**
  * Fixed null-coalescing assignments involving existing locals or fields.
  * Improved matching and serialization for image, audio, video, and PDF values.

* **Tests**
  * Added coverage for shorthand syntax, media unions, runtime narrowing, diagnostics, and incremental typing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->