### PR TITLE
fix(mir): dispatch optional interface method calls

### DIFF
--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -2810,6 +2810,38 @@ impl<'db> LoweringContext<'db> {
             .or_else(|| self.upcast_target_interface_view(expr_id, member))
     }
 
+    /// The interface view used to lower a member-access expression. Optional
+    /// member access has already guarded the null branch before the member is
+    /// evaluated, so dispatch must use the non-null receiver type.
+    fn dispatch_target_for_member_access(
+        &self,
+        access: AstExprId,
+        base: AstExprId,
+        member: &Name,
+    ) -> Option<InterfaceTypeView> {
+        let narrowed = if matches!(
+            &self.body.exprs[access],
+            AstExpr::OptionalMemberAccess { .. }
+        ) {
+            self.tir_expr_type(self.expr_metadata_key(base))
+                .map(Tir2Ty::strip_null)
+        } else {
+            None
+        };
+
+        narrowed
+            .as_ref()
+            .and_then(|ty| {
+                self.interface_dispatch_target_for_member(ty, member)
+                    .or_else(|| self.dispatch_target_for_concrete(ty, member))
+            })
+            .or_else(|| self.interface_dispatch_target_for_expr_member(base, member))
+            .or_else(|| {
+                self.tir_expr_type(self.expr_metadata_key(base))
+                    .and_then(|ty| self.dispatch_target_for_concrete(ty, member))
+            })
+    }
+
     fn source_param_interface_view_for_expr(
         &self,
         expr_id: AstExprId,
@@ -9525,12 +9557,7 @@ impl<'db> LoweringContext<'db> {
         // declaring interface is resolved *before* lowering the receiver so a
         // field access (no such method) falls through to the field path below
         // without evaluating the receiver expression twice.
-        if let Some(view) = self
-            .interface_dispatch_target_for_expr_member(base, field)
-            .or_else(|| {
-                self.tir_expr_type(self.expr_metadata_key(base))
-                    .and_then(|ty| self.dispatch_target_for_concrete(ty, field))
-            })
+        if let Some(view) = self.dispatch_target_for_member_access(expr_id, base, field)
             && self.mir_interface_declares_method(&view.0, field)
         {
             let recv_op = self.lower_to_operand(base);

--- a/baml_language/crates/baml_tests/baml_src/ns_interfaces/b_1180.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_interfaces/b_1180.baml
@@ -1,0 +1,45 @@
+interface B1180Named {
+  function name(self) -> string throws never
+}
+
+class B1180Person {
+    value: string,
+}
+
+implements B1180Named for B1180Person {
+  function name(self) -> string {
+    self.value
+  }
+}
+
+function b1180_optional_name(value: B1180Named?) -> string {
+    value?.name() ?? "nobody"
+}
+
+test "optional_interface_method_call_dispatches" {
+    assert.equal(b1180_optional_name(B1180Person { value: "Ada" }), "Ada");
+    assert.equal(b1180_optional_name(null), "nobody")
+}
+
+interface B1180Getter<T> {
+  function get(self) -> T throws never
+}
+
+class B1180IntValue {
+    value: int,
+}
+
+implements B1180Getter<int> for B1180IntValue {
+  function get(self) -> int {
+    self.value
+  }
+}
+
+function b1180_optional_get(value: B1180Getter<int>?) -> int {
+    value?.get() ?? -1
+}
+
+test "optional_generic_interface_method_call_preserves_type_args" {
+    assert.equal(b1180_optional_get(B1180IntValue { value: 42 }), 42);
+    assert.equal(b1180_optional_get(null), -1)
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
@@ -370,6 +370,9 @@ function $init_test(registry: unknown) -> null {
     load_var ?1
     call ?
     pop 1
+    load_var ?1
+    call ?
+    pop 1
     load_const ?
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/interfaces.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/interfaces.snap
@@ -1,6 +1,25 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
 ---
+function interfaces.$init_test_ns_interfaces_b_1180(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "root.interfaces"
+    load_const "optional_interface_method_call_dispatches"
+    make_closure .<lambda($init_test_ns_interfaces_b_1180, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.interfaces"
+    load_const "optional_generic_interface_method_call_preserves_type_args"
+    make_closure .<lambda($init_test_ns_interfaces_b_1180, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_const null
+    return
+}
+
 function interfaces.$init_test_ns_interfaces_interfaces(registry: testing.TestCollector) -> null {
     load_var registry
     load_const "root.interfaces"
@@ -1190,6 +1209,18 @@ function interfaces.ApssHybrid.ApssSerializer.encode(self: interfaces.ApssHybrid
 
 function interfaces.ApwuDog.ApwuAnimal.speak(self: interfaces.ApwuDog) -> string {
     load_const "Woof!"
+    return
+}
+
+function interfaces.B1180IntValue.B1180Getter<int>.get(self: interfaces.B1180IntValue) -> int {
+    load_var self
+    load_field .value
+    return
+}
+
+function interfaces.B1180Person.B1180Named.name(self: interfaces.B1180Person) -> string {
+    load_var self
+    load_field .value
     return
 }
 
@@ -2456,6 +2487,75 @@ function interfaces.ausi_main() -> bool {
     cmp_op ==
 
   L0:
+    return
+}
+
+function interfaces.b1180_optional_get(value: interfaces.B1180Getter<int> | null) -> int {
+    load_var value
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var value
+    load_type interfaces.B1180Getter<int>
+    load_const "get"
+    make_virtual_bound_method ntypeargs=0
+    call_indirect
+    store_var _3
+    jump L2
+
+  L1:
+    load_const null
+    store_var _3
+
+  L2:
+    load_var _3
+    store_var_load_var _2
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L3
+    load_const 1
+    unary_op -
+    store_var _2
+
+  L3:
+    load_var _2
+    return
+}
+
+function interfaces.b1180_optional_name(value: interfaces.B1180Named | null) -> string {
+    load_var value
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_var value
+    load_type interfaces.B1180Named
+    load_const "name"
+    make_virtual_bound_method ntypeargs=0
+    call_indirect
+    store_var _3
+    jump L2
+
+  L1:
+    load_const null
+    store_var _3
+
+  L2:
+    load_var _3
+    store_var_load_var _2
+    load_const null
+    cmp_op ==
+    pop_jump_if_false L3
+    load_const "nobody"
+    store_var _2
+
+  L3:
+    load_var _2
     return
 }
 


### PR DESCRIPTION
## Issue Reference

Fixes B-1180.

## Changes

- Narrow optional receivers to their non-null type before selecting interface dispatch.
- Preserve instantiated generic interface arguments during dispatch.
- Add native BAML regressions for null, non-null, and generic receivers.

## Testing

- `baml check --project crates/baml_tests/baml_src`
- BAML regressions: 2 passed
- `cargo test -p baml_compiler2_mir`: 3 passed
- `cargo test -p baml_tests --lib compiler2_mir`: 27 passed
- `cargo clippy -p baml_compiler2_mir --all-targets -- -D warnings`
- Repository pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed optional interface method calls so dispatch works correctly when values are present or null.
  * Preserved fallback behavior for optional method access.

* **Tests**
  * Added coverage for optional named-method and generic getter dispatch.
  * Verified correct results for both populated and null values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->