### PR TITLE
Add experimental GraphQL AST queries

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -331,6 +331,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +603,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto_enums"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3091d68264354f211516b91dce6f71046e444fab1867716035f736667243affb"
+dependencies = [
+ "derive_utils",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +810,7 @@ dependencies = [
  "indexmap",
  "indicatif",
  "insta",
+ "juniper",
  "libsui",
  "mimalloc",
  "mime_guess",
@@ -1004,6 +1023,7 @@ name = "baml_db"
 version = "0.0.0-beta"
 dependencies = [
  "baml_base",
+ "baml_compiler2_ast",
  "baml_compiler2_emit",
  "baml_compiler2_hir",
  "baml_compiler2_hir_ty",
@@ -2361,6 +2381,15 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
@@ -2669,10 +2698,23 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case 0.10.0",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.117",
+ "unicode-xid",
+]
+
+[[package]]
+name = "derive_utils"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc05a5d33db20c784f873e84934ad94bb209a090987ac5f62fede2c178234f23"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3595,6 +3637,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "graphql-parser"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a818c0d883d7c0801df27be910917750932be279c7bc82dc541b8769425f409"
+dependencies = [
+ "combine",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "graphviz-rust"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4349,6 +4401,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "juniper"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "118749c965e171dcccffb7ca0dff6ab00451b08ba2710914caaaebc3686a7c3f"
+dependencies = [
+ "arcstr",
+ "async-trait",
+ "auto_enums",
+ "compact_str",
+ "derive_more",
+ "fnv",
+ "futures",
+ "graphql-parser",
+ "indexmap",
+ "itertools 0.14.0",
+ "juniper_codegen",
+ "ref-cast",
+ "serde",
+ "static_assertions",
+ "void",
+]
+
+[[package]]
+name = "juniper_codegen"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8634f500d6d2ec5c91c115b83e15d998d9ea05645aaa43f7afec09e660c483ba"
+dependencies = [
+ "derive_more",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "url",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4839,7 +4927,7 @@ version = "3.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b3f766e04667e6da0e181e2da4f85475d5a6513b7cf6a80bea184e224a5b42"
 dependencies = [
- "convert_case",
+ "convert_case 0.11.0",
  "ctor",
  "napi-derive-backend",
  "proc-macro2",
@@ -4853,7 +4941,7 @@ version = "5.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d5af30503edf933ce7377cf6d4c877a62b0f1107ea05585f1b5e430e88d5baf"
 dependencies = [
- "convert_case",
+ "convert_case 0.11.0",
  "proc-macro2",
  "quote",
  "semver",
@@ -6333,6 +6421,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7456,6 +7564,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8529,6 +8648,12 @@ checksum = "9e723b9e1c02a3cf9f9d0de6a4ddb8cdc1df859078902fe0ae0589d615711ae6"
 dependencies = [
  "filetime",
 ]
+
+[[package]]
+name = "void"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "walkdir"

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -192,6 +192,7 @@ indexmap = { version = "2.13", features = [ "serde" ] }
 indicatif = "0.18"
 infer = "0.16.0"
 insta = { version = "1.34", features = [ "yaml", "redactions" ] }
+juniper = { version = "0.17.1", features = [ "schema-language" ] }
 similar = "2"
 jiff = { version = "0.2" }
 la-arena = { version = "0.3" }

--- a/baml_language/GRAPHQL.md
+++ b/baml_language/GRAPHQL.md
@@ -1,0 +1,44 @@
+# Experimental GraphQL AST queries
+
+`baml graphql` is an experimental, read-only, one-shot interface for querying a BAML project's source model. It performs no network or LLM calls and does not start a server.
+
+## Command contract
+
+The command discovers the nearest project using the same global `--project <PATH>` and `--directory <PATH>` behavior as the rest of the CLI. Supply a GraphQL document with exactly one of `--query <DOCUMENT>`, `--query-file <PATH>`, or stdin when neither flag is present. Use `--variables <JSON>` for a JSON object of GraphQL variables and `--operation <NAME>` when a document contains multiple operations.
+
+`--schema` prints deterministic GraphQL SDL without loading a project. `--introspect` prints the standard GraphQL introspection response as JSON and also does not require a project. These modes conflict with query input options.
+
+Successful queries and GraphQL request failures use the standard GraphQL JSON response shape on stdout. A project with BAML errors produces a GraphQL error with `extensions.code = "BAML_VALIDATION_FAILED"` and deterministic structured diagnostics in `extensions.diagnostics`. GraphQL parse, validation, variables, project loading, and BAML validation failures return a nonzero exit status. Human-oriented progress, colors, and network activity are disabled for this command so stdout remains machine-readable.
+
+## Schema contract
+
+The schema is a stable GraphQL-facing snapshot, not a serialization of Salsa, CST, AST, HIR, or manifest structs. Renaming or reorganizing compiler internals therefore does not imply a schema change.
+
+The query root exposes `project`, `packages`, `files`, `definitions`, `classes`, `enums`, `functions`, `clients`, `generators`, and `tests`. Collection fields accept practical exact-match filters such as `name`, `kind`, or `path`; they deliberately do not implement a general text index. Results use deterministic source order with path and name tie-breakers.
+
+Definitions expose names, qualified names, documentation where present, attributes where present, and source locations. Classes traverse to fields, enums to values, functions to parameters and return or throws types, tests to targeted functions, packages and files to their contained definitions, and every typed declaration traverses a recursive `TypeRef`. `TypeRef` includes a stable kind, source spelling, named path, nested element/key/value/member types as applicable, attributes, and location. Source locations use project-relative slash-separated paths plus 1-based start and end line and column values.
+
+The initial schema covers user-authored classes, fields, enums, enum values, type aliases, functions, parameters and return types, clients, manifest generators, legacy declarative tests where the compiler exposes them, documentation, raw attributes, packages, namespaces, files, and locations. Compiler-generated definitions and builtin package sources are excluded from project results.
+
+## Examples
+
+```sh
+baml graphql --query '{ classes(name: "Resume") { name fields { name type { display kind } } } }'
+```
+
+```sh
+baml graphql --query 'query Find($name: String!) { functions(name: $name) { qualifiedName parameters { name type { display } } returnType { display } location { path startLine startColumn } } }' --variables '{"name":"ExtractResume"}'
+```
+
+```sh
+baml graphql --query-file ./queries/project.graphql --operation ProjectSummary
+```
+
+```sh
+printf '%s\n' '{ definitions(kind: [CLASS, ENUM]) { kind name qualifiedName location { path startLine } } }' | baml graphql
+```
+
+```sh
+baml graphql --schema
+baml graphql --introspect
+```

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -52,6 +52,7 @@ flate2 = { workspace = true }
 hex = { workspace = true }
 indexmap = { workspace = true }
 indicatif = { workspace = true }
+juniper = { workspace = true }
 libsui = { workspace = true }
 mimalloc = { workspace = true }
 mime_guess = { workspace = true }

--- a/baml_language/crates/baml_cli/README.md
+++ b/baml_language/crates/baml_cli/README.md
@@ -14,7 +14,7 @@ Successful queries and GraphQL request failures use the standard GraphQL JSON re
 
 The schema is a stable GraphQL-facing snapshot, not a serialization of Salsa, CST, AST, HIR, or manifest structs. Renaming or reorganizing compiler internals therefore does not imply a schema change.
 
-The query root exposes `project`, `packages`, `files`, `definitions`, `classes`, `enums`, `functions`, `clients`, `generators`, and `tests`. Collection fields accept practical exact-match filters such as `name`, `kind`, or `path`; they deliberately do not implement a general text index. Results use deterministic source order with path and name tie-breakers.
+The query root exposes `project`, `packages`, `files`, `definitions`, `classes`, `enums`, `typeAliases`, `functions`, `clients`, `generators`, and `tests`. Collection fields accept practical exact-match filters such as `name`, `kind`, or `path`; they deliberately do not implement a general text index. Results use deterministic source order with path and name tie-breakers.
 
 Definitions expose names, qualified names, documentation where present, attributes where present, and source locations. Classes traverse to fields, enums to values, functions to parameters and return or throws types, tests to targeted functions, packages and files to their contained definitions, and every typed declaration traverses a recursive `TypeRef`. `TypeRef` includes a stable kind, source spelling, named path, nested element/key/value/member types as applicable, attributes, and location. Source locations use project-relative slash-separated paths plus 1-based start and end line and column values.
 

--- a/baml_language/crates/baml_cli/README.md
+++ b/baml_language/crates/baml_cli/README.md
@@ -1,4 +1,4 @@
-# Experimental GraphQL AST queries
+# `baml graphql`
 
 `baml graphql` is an experimental, read-only, one-shot interface for querying a BAML project's source model. It performs no network or LLM calls and does not start a server.
 

--- a/baml_language/crates/baml_cli/src/commands.rs
+++ b/baml_language/crates/baml_cli/src/commands.rs
@@ -170,6 +170,9 @@ pub(crate) enum Commands {
     #[command(about = "Generate client code from BAML definitions")]
     Generate(crate::generate::GenerateArgs),
 
+    #[command(about = "Query the BAML project AST with GraphQL")]
+    Graphql(crate::graphql_command::GraphqlArgs),
+
     #[command(about = "Run BAML tests")]
     Test(crate::test_command::TestArgs),
 
@@ -347,9 +350,13 @@ impl RuntimeCli {
         // of the guard (after the match below returns) the queue file is
         // sealed and a detached child process delivers it after this
         // process has already exited. It never fails or delays the command.
-        let _telemetry = crate::telemetry::record_invocation(
-            self.invoked_subcommand.as_deref().unwrap_or("unknown"),
-        );
+        let _telemetry = if matches!(&self.command, Commands::Graphql(_)) {
+            None
+        } else {
+            Some(crate::telemetry::record_invocation(
+                self.invoked_subcommand.as_deref().unwrap_or("unknown"),
+            ))
+        };
 
         // Resolve every output dial once, before any subcommand writes.
         crate::output::init(self.output);
@@ -377,6 +384,7 @@ impl RuntimeCli {
             Commands::Agent(args) => args.run(),
             Commands::Describe(args) => args.run(),
             Commands::Generate(args) => args.run(),
+            Commands::Graphql(args) => args.run(),
             Commands::Test(args) => args.run(),
             Commands::LanguageServer(args) => match args.run() {
                 Ok(()) => Ok(crate::ExitCode::Success),
@@ -403,6 +411,7 @@ impl Commands {
             Self::Check(args) => args.from.is_some(),
             Self::Format(args) => args.from.is_some(),
             Self::Describe(args) => args.from.is_some(),
+            Self::Graphql(args) => args.from.is_some(),
             Self::Generate(args) => args.has_legacy_project(),
             Self::Test(args) => args.from.is_some(),
             Self::Run(args) => args.from.is_some(),
@@ -424,6 +433,7 @@ impl Commands {
             Self::Check(args) => args.from = Some(project.clone()),
             Self::Format(args) => args.from = Some(project.clone()),
             Self::Describe(args) => args.from = Some(project.clone()),
+            Self::Graphql(args) => args.from = Some(project.clone()),
             Self::Generate(args) => args.apply_project(&project),
             Self::Test(args) => args.from = Some(project.clone()),
             Self::Run(args) => args.from = Some(project.clone()),
@@ -483,6 +493,7 @@ mod tests {
         &["fmt"],
         &["describe"],
         &["generate"],
+        &["graphql"],
         &["test"],
         &["init"],
         &["new"],
@@ -872,6 +883,13 @@ mod tests {
             &["baml", "generate"],
             &["baml", "generate", "--project", "./my-project"],
             &["baml", "generate", "--output-dir", "./generated"],
+            &[
+                "baml",
+                "graphql",
+                "--query",
+                "{ classes { name fields { name type { display } } } }",
+            ],
+            &["baml", "graphql", "--schema"],
             &["baml", "init"],
             &["baml", "init", "./my-project", "--name", "my_project"],
             &["baml", "new", "./my-project"],

--- a/baml_language/crates/baml_cli/src/graphql_command.rs
+++ b/baml_language/crates/baml_cli/src/graphql_command.rs
@@ -1,0 +1,1424 @@
+//! Experimental, one-shot GraphQL queries over a stable BAML source snapshot.
+
+use std::{
+    collections::BTreeMap,
+    io::{IsTerminal as _, Read as _, Write as _},
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context as _, Result};
+use baml_db::{
+    SourceFile,
+    baml_compiler2_ast::ast::{
+        DeclarativeMeta, FunctionDef, FunctionOrigin, Item, LetOrigin, RawAttribute, TestArgValue,
+        TypeExpr, TypeExprKind,
+    },
+    baml_compiler2_hir,
+};
+use baml_project::ProjectDatabase;
+use clap::Args;
+use juniper::{
+    DefaultScalarValue, EmptyMutation, EmptySubscription, GraphQLEnum, GraphQLObject, RootNode,
+    http::{GraphQLRequest, GraphQLResponse},
+};
+use serde_json::{Value as JsonValue, json};
+use text_size::TextRange;
+
+/// Query a BAML project's source model with GraphQL.
+#[derive(Args, Clone, Debug)]
+#[command(after_long_help = "\
+Examples:
+  Query classes and fields:
+    baml graphql --query '{ classes { name fields { name type { display } } } }'
+
+  Use variables:
+    baml graphql --query 'query Find($name: String!) { functions(name: $name) { qualifiedName } }' --variables '{\"name\":\"Extract\"}'
+
+  Read a document from a file:
+    baml graphql --query-file ./queries/project.graphql
+
+  Read a document from stdin:
+    printf '%s\\n' '{ files { path definitions { kind name } } }' | baml graphql
+
+  Print the schema:
+    baml graphql --schema
+
+  Print standard introspection JSON:
+    baml graphql --introspect")]
+pub struct GraphqlArgs {
+    /// GraphQL document to execute.
+    #[arg(long, value_name = "DOCUMENT", conflicts_with_all = ["query_file", "schema", "introspect"])]
+    pub query: Option<String>,
+
+    /// Read the GraphQL document from this file.
+    #[arg(long, value_name = "PATH", conflicts_with_all = ["query", "schema", "introspect"])]
+    pub query_file: Option<PathBuf>,
+
+    /// JSON object containing GraphQL variables.
+    #[arg(long, value_name = "JSON", conflicts_with_all = ["schema", "introspect"])]
+    pub variables: Option<String>,
+
+    /// Named operation to execute when the document contains more than one.
+    #[arg(long, value_name = "NAME", conflicts_with_all = ["schema", "introspect"])]
+    pub operation: Option<String>,
+
+    /// Print the deterministic GraphQL schema in SDL format.
+    #[arg(long, conflicts_with = "introspect")]
+    pub schema: bool,
+
+    /// Print the standard GraphQL introspection response as JSON.
+    #[arg(long, conflicts_with = "schema")]
+    pub introspect: bool,
+
+    /// Deprecated alias for `--project`.
+    #[arg(long, value_name = "PATH", hide = true)]
+    pub from: Option<PathBuf>,
+}
+
+impl GraphqlArgs {
+    pub fn run(&self) -> Result<crate::ExitCode> {
+        match self.run_inner() {
+            Ok(code) => Ok(code),
+            Err(error) => {
+                write_error_response("GRAPHQL_COMMAND_FAILED", &format!("{error:#}"), None)?;
+                Ok(crate::ExitCode::Other)
+            }
+        }
+    }
+
+    fn run_inner(&self) -> Result<crate::ExitCode> {
+        let schema = schema();
+        if self.schema {
+            print!("{}", schema.as_sdl());
+            return Ok(crate::ExitCode::Success);
+        }
+
+        if self.introspect {
+            let context = GraphqlContext::empty();
+            let response = GraphQLResponse::from_result(juniper::introspect(
+                &schema,
+                &context,
+                juniper::IntrospectionFormat::All,
+            ));
+            return write_graphql_response(&response);
+        }
+
+        let query = self.read_query()?;
+        let variables = match self.parse_variables() {
+            Ok(variables) => variables,
+            Err(error) => {
+                write_error_response("INVALID_VARIABLES", &error.to_string(), None)?;
+                return Ok(crate::ExitCode::InvalidArgs);
+            }
+        };
+
+        let mut session = match crate::project_session::ProjectSession::open(
+            self.from.as_deref(),
+            crate::project_session::CacheUse::Off,
+        ) {
+            Ok(session) => session,
+            Err(error) => {
+                write_error_response(
+                    "PROJECT_LOAD_FAILED",
+                    &format!("failed to load BAML project: {error:#}"),
+                    None,
+                )?;
+                return Ok(crate::ExitCode::Other);
+            }
+        };
+        session.warm_prep_seeds_only();
+        session.prime();
+
+        let diagnostics = baml_project::collect_diagnostics(&session.db);
+        let user_file_ids = session
+            .db
+            .get_source_files()
+            .into_iter()
+            .map(|file| file.file_id(&session.db))
+            .collect::<std::collections::HashSet<_>>();
+        let errors = diagnostics
+            .iter()
+            .filter(|diagnostic| {
+                diagnostic.severity == baml_db::baml_compiler_diagnostics::Severity::Error
+                    && diagnostic
+                        .file_id()
+                        .is_none_or(|file_id| user_file_ids.contains(&file_id))
+            })
+            .collect::<Vec<_>>();
+        if !errors.is_empty() {
+            let structured = errors
+                .into_iter()
+                .map(|diagnostic| diagnostic_json(&session.db, session.root(), diagnostic))
+                .collect::<Vec<_>>();
+            write_error_response(
+                "BAML_VALIDATION_FAILED",
+                &format!(
+                    "BAML project contains {} error{}",
+                    structured.len(),
+                    if structured.len() == 1 { "" } else { "s" }
+                ),
+                Some(json!({ "diagnostics": structured })),
+            )?;
+            return Ok(crate::ExitCode::Other);
+        }
+
+        let snapshot = build_snapshot(
+            &session.db,
+            session.root(),
+            session.resolved.manifest.as_deref(),
+        )?;
+        let context = GraphqlContext { snapshot };
+        let request =
+            GraphQLRequest::<DefaultScalarValue>::new(query, self.operation.clone(), variables);
+        let response = request.execute_sync(&schema, &context);
+        write_graphql_response(&response)
+    }
+
+    fn read_query(&self) -> Result<String> {
+        if let Some(query) = &self.query {
+            return Ok(query.clone());
+        }
+        if let Some(path) = &self.query_file {
+            return std::fs::read_to_string(path).with_context(|| {
+                format!("failed to read GraphQL document from {}", path.display())
+            });
+        }
+        if std::io::stdin().is_terminal() {
+            anyhow::bail!("provide a GraphQL document with `--query`, `--query-file`, or stdin");
+        }
+        let mut query = String::new();
+        std::io::stdin()
+            .read_to_string(&mut query)
+            .context("failed to read GraphQL document from stdin")?;
+        Ok(query)
+    }
+
+    fn parse_variables(&self) -> Result<Option<juniper::InputValue<DefaultScalarValue>>> {
+        let Some(raw) = &self.variables else {
+            return Ok(None);
+        };
+        let json: JsonValue = serde_json::from_str(raw).context("variables must be valid JSON")?;
+        if !json.is_object() {
+            anyhow::bail!("variables must be a JSON object");
+        }
+        serde_json::from_value(json)
+            .context("variables contain a value GraphQL cannot represent")
+            .map(Some)
+    }
+}
+
+type Schema = RootNode<QueryRoot, EmptyMutation<GraphqlContext>, EmptySubscription<GraphqlContext>>;
+
+fn schema() -> Schema {
+    Schema::new(
+        QueryRoot,
+        EmptyMutation::<GraphqlContext>::new(),
+        EmptySubscription::<GraphqlContext>::new(),
+    )
+}
+
+struct GraphqlContext {
+    snapshot: Snapshot,
+}
+
+impl juniper::Context for GraphqlContext {}
+
+impl GraphqlContext {
+    fn empty() -> Self {
+        Self {
+            snapshot: Snapshot::empty(),
+        }
+    }
+}
+
+struct QueryRoot;
+
+#[juniper::graphql_object(Context = GraphqlContext)]
+impl QueryRoot {
+    /// The loaded BAML project.
+    fn project(context: &GraphqlContext) -> &GraphProject {
+        &context.snapshot.project
+    }
+
+    /// Source packages, optionally filtered by exact package name.
+    fn packages<'a>(context: &'a GraphqlContext, name: Option<String>) -> Vec<&'a GraphPackage> {
+        filter_name(
+            &context.snapshot.project.packages,
+            name.as_deref(),
+            |item| &item.name,
+        )
+    }
+
+    /// Source files, optionally filtered by exact project-relative path.
+    fn files<'a>(context: &'a GraphqlContext, path: Option<String>) -> Vec<&'a GraphSourceFile> {
+        context
+            .snapshot
+            .project
+            .files
+            .iter()
+            .filter(|file| path.as_deref().is_none_or(|path| file.path == path))
+            .collect()
+    }
+
+    /// All top-level definitions with exact name and kind filters.
+    fn definitions<'a>(
+        context: &'a GraphqlContext,
+        name: Option<String>,
+        kind: Option<Vec<DefinitionKind>>,
+    ) -> Vec<&'a GraphDefinition> {
+        context
+            .snapshot
+            .project
+            .definitions
+            .iter()
+            .filter(|item| name.as_deref().is_none_or(|name| item.name == name))
+            .filter(|item| kind.as_ref().is_none_or(|kinds| kinds.contains(&item.kind)))
+            .collect()
+    }
+
+    fn classes<'a>(context: &'a GraphqlContext, name: Option<String>) -> Vec<&'a GraphClass> {
+        filter_name(&context.snapshot.project.classes, name.as_deref(), |item| {
+            &item.name
+        })
+    }
+
+    fn enums<'a>(context: &'a GraphqlContext, name: Option<String>) -> Vec<&'a GraphEnum> {
+        filter_name(&context.snapshot.project.enums, name.as_deref(), |item| {
+            &item.name
+        })
+    }
+
+    fn type_aliases<'a>(
+        context: &'a GraphqlContext,
+        name: Option<String>,
+    ) -> Vec<&'a GraphTypeAlias> {
+        filter_name(
+            &context.snapshot.project.type_aliases,
+            name.as_deref(),
+            |item| &item.name,
+        )
+    }
+
+    fn functions<'a>(context: &'a GraphqlContext, name: Option<String>) -> Vec<&'a GraphFunction> {
+        filter_name(
+            &context.snapshot.project.functions,
+            name.as_deref(),
+            |item| &item.name,
+        )
+    }
+
+    fn clients<'a>(context: &'a GraphqlContext, name: Option<String>) -> Vec<&'a GraphClient> {
+        filter_name(&context.snapshot.project.clients, name.as_deref(), |item| {
+            &item.name
+        })
+    }
+
+    fn generators<'a>(
+        context: &'a GraphqlContext,
+        name: Option<String>,
+    ) -> Vec<&'a GraphGenerator> {
+        filter_name(
+            &context.snapshot.project.generators,
+            name.as_deref(),
+            |item| &item.name,
+        )
+    }
+
+    fn tests<'a>(context: &'a GraphqlContext, name: Option<String>) -> Vec<&'a GraphTest> {
+        filter_name(&context.snapshot.project.tests, name.as_deref(), |item| {
+            &item.name
+        })
+    }
+}
+
+fn filter_name<'a, T>(
+    items: &'a [T],
+    name: Option<&str>,
+    item_name: impl Fn(&T) -> &String,
+) -> Vec<&'a T> {
+    items
+        .iter()
+        .filter(|item| name.is_none_or(|name| item_name(item) == name))
+        .collect()
+}
+
+#[derive(Clone, Copy, Debug, Eq, GraphQLEnum, PartialEq)]
+enum DefinitionKind {
+    Class,
+    Field,
+    Enum,
+    EnumValue,
+    TypeAlias,
+    Function,
+    Parameter,
+    Client,
+    Generator,
+    Test,
+    Interface,
+    TemplateString,
+}
+
+#[derive(Clone, Copy, Debug, Eq, GraphQLEnum, PartialEq)]
+enum TypeRefKind {
+    Named,
+    AssociatedType,
+    Int,
+    Bigint,
+    Float,
+    String,
+    Bool,
+    Null,
+    Never,
+    Void,
+    Bytes,
+    Media,
+    Optional,
+    List,
+    Map,
+    Union,
+    Literal,
+    Function,
+    Unknown,
+    Type,
+    Rust,
+    #[graphql(name = "ERROR")]
+    Invalid,
+    Infer,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct SourceLocation {
+    /// Project-relative, slash-separated path.
+    path: String,
+    /// Inclusive, 1-based start line.
+    start_line: i32,
+    /// Inclusive, 1-based start column.
+    start_column: i32,
+    /// Exclusive, 1-based end line.
+    end_line: i32,
+    /// Exclusive, 1-based end column.
+    end_column: i32,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphAttributeArgument {
+    key: Option<String>,
+    value: String,
+    location: SourceLocation,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphAttribute {
+    name: String,
+    arguments: Vec<GraphAttributeArgument>,
+    location: SourceLocation,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphTypeRef {
+    kind: TypeRefKind,
+    /// Canonical source-like spelling.
+    display: String,
+    /// Unqualified named type, associated member, literal, or media kind.
+    name: Option<String>,
+    /// Dotted named-type path as individual segments.
+    path: Vec<String>,
+    /// Nested type for optional/list/associated-type references.
+    element_type: Option<Box<GraphTypeRef>>,
+    key_type: Option<Box<GraphTypeRef>>,
+    value_type: Option<Box<GraphTypeRef>>,
+    /// Union members, generic arguments, or associated interface constraints.
+    member_types: Vec<GraphTypeRef>,
+    /// Function-type parameter types.
+    parameter_types: Vec<GraphTypeRef>,
+    return_type: Option<Box<GraphTypeRef>>,
+    throws_type: Option<Box<GraphTypeRef>>,
+    attributes: Vec<GraphAttribute>,
+    location: SourceLocation,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphDefinition {
+    kind: DefinitionKind,
+    name: String,
+    qualified_name: String,
+    documentation: Option<String>,
+    attributes: Vec<GraphAttribute>,
+    location: SourceLocation,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphField {
+    name: String,
+    documentation: Option<String>,
+    attributes: Vec<GraphAttribute>,
+    #[graphql(name = "type")]
+    type_ref: GraphTypeRef,
+    location: SourceLocation,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphEnumValue {
+    name: String,
+    documentation: Option<String>,
+    attributes: Vec<GraphAttribute>,
+    location: SourceLocation,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphParameter {
+    name: String,
+    #[graphql(name = "type")]
+    type_ref: Option<GraphTypeRef>,
+    has_default: bool,
+    location: SourceLocation,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphFunction {
+    name: String,
+    qualified_name: String,
+    documentation: Option<String>,
+    attributes: Vec<GraphAttribute>,
+    generic_parameters: Vec<String>,
+    parameters: Vec<GraphParameter>,
+    return_type: Option<GraphTypeRef>,
+    throws_type: Option<GraphTypeRef>,
+    is_llm: bool,
+    client_name: Option<String>,
+    location: SourceLocation,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphClass {
+    name: String,
+    qualified_name: String,
+    documentation: Option<String>,
+    attributes: Vec<GraphAttribute>,
+    generic_parameters: Vec<String>,
+    fields: Vec<GraphField>,
+    methods: Vec<GraphFunction>,
+    location: SourceLocation,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphEnum {
+    name: String,
+    qualified_name: String,
+    documentation: Option<String>,
+    attributes: Vec<GraphAttribute>,
+    values: Vec<GraphEnumValue>,
+    location: SourceLocation,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphTypeAlias {
+    name: String,
+    qualified_name: String,
+    documentation: Option<String>,
+    #[graphql(name = "type")]
+    type_ref: Option<GraphTypeRef>,
+    location: SourceLocation,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphConfigEntry {
+    key: String,
+    value: String,
+    location: SourceLocation,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphClient {
+    name: String,
+    qualified_name: String,
+    properties: Vec<GraphConfigEntry>,
+    location: SourceLocation,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphGenerator {
+    name: String,
+    output_type: Option<String>,
+    output_dir: Option<String>,
+    naming_convention: Option<String>,
+    sdk_import_path: Option<String>,
+    location: SourceLocation,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphTestArgument {
+    name: String,
+    value_json: String,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphTest {
+    name: String,
+    qualified_name: String,
+    functions: Vec<String>,
+    arguments: Vec<GraphTestArgument>,
+    location: SourceLocation,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphSourceFile {
+    path: String,
+    package: String,
+    namespace: Vec<String>,
+    definitions: Vec<GraphDefinition>,
+    classes: Vec<GraphClass>,
+    enums: Vec<GraphEnum>,
+    type_aliases: Vec<GraphTypeAlias>,
+    functions: Vec<GraphFunction>,
+    clients: Vec<GraphClient>,
+    tests: Vec<GraphTest>,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphPackage {
+    name: String,
+    files: Vec<GraphSourceFile>,
+    definitions: Vec<GraphDefinition>,
+    classes: Vec<GraphClass>,
+    enums: Vec<GraphEnum>,
+    type_aliases: Vec<GraphTypeAlias>,
+    functions: Vec<GraphFunction>,
+    clients: Vec<GraphClient>,
+    generators: Vec<GraphGenerator>,
+    tests: Vec<GraphTest>,
+}
+
+#[derive(Clone, GraphQLObject)]
+struct GraphProject {
+    /// Package name from baml.toml, when present.
+    name: Option<String>,
+    /// Canonical project root.
+    root: String,
+    packages: Vec<GraphPackage>,
+    files: Vec<GraphSourceFile>,
+    definitions: Vec<GraphDefinition>,
+    classes: Vec<GraphClass>,
+    enums: Vec<GraphEnum>,
+    type_aliases: Vec<GraphTypeAlias>,
+    functions: Vec<GraphFunction>,
+    clients: Vec<GraphClient>,
+    generators: Vec<GraphGenerator>,
+    tests: Vec<GraphTest>,
+}
+
+struct Snapshot {
+    project: GraphProject,
+}
+
+impl Snapshot {
+    fn empty() -> Self {
+        Self {
+            project: GraphProject {
+                name: None,
+                root: String::new(),
+                packages: Vec::new(),
+                files: Vec::new(),
+                definitions: Vec::new(),
+                classes: Vec::new(),
+                enums: Vec::new(),
+                type_aliases: Vec::new(),
+                functions: Vec::new(),
+                clients: Vec::new(),
+                generators: Vec::new(),
+                tests: Vec::new(),
+            },
+        }
+    }
+}
+
+fn build_snapshot(
+    db: &ProjectDatabase,
+    root: &Path,
+    manifest_source: Option<&str>,
+) -> Result<Snapshot> {
+    let mut files = db.get_source_files();
+    files.sort_by_key(|file| normalized_relative_path(&file.path(db), root));
+
+    let mut graph_files = Vec::with_capacity(files.len());
+    for file in files {
+        graph_files.push(build_file(db, root, file));
+    }
+
+    let (project_name, generators) = build_generators(manifest_source)?;
+    let mut packages = BTreeMap::<String, GraphPackage>::new();
+    for file in &graph_files {
+        let package = packages
+            .entry(file.package.clone())
+            .or_insert_with(|| GraphPackage {
+                name: file.package.clone(),
+                files: Vec::new(),
+                definitions: Vec::new(),
+                classes: Vec::new(),
+                enums: Vec::new(),
+                type_aliases: Vec::new(),
+                functions: Vec::new(),
+                clients: Vec::new(),
+                generators: Vec::new(),
+                tests: Vec::new(),
+            });
+        package.files.push(file.clone());
+        package.definitions.extend(file.definitions.clone());
+        package.classes.extend(file.classes.clone());
+        package.enums.extend(file.enums.clone());
+        package.type_aliases.extend(file.type_aliases.clone());
+        package.functions.extend(file.functions.clone());
+        package.clients.extend(file.clients.clone());
+        package.tests.extend(file.tests.clone());
+    }
+    let user_package = packages
+        .entry("user".to_string())
+        .or_insert_with(|| GraphPackage {
+            name: "user".to_string(),
+            files: Vec::new(),
+            definitions: Vec::new(),
+            classes: Vec::new(),
+            enums: Vec::new(),
+            type_aliases: Vec::new(),
+            functions: Vec::new(),
+            clients: Vec::new(),
+            generators: Vec::new(),
+            tests: Vec::new(),
+        });
+    user_package.generators = generators.clone();
+    user_package
+        .definitions
+        .extend(generators.iter().map(GraphGenerator::summary));
+
+    let mut project = GraphProject {
+        name: project_name,
+        root: normalize_path(root),
+        packages: packages.into_values().collect(),
+        files: graph_files,
+        definitions: Vec::new(),
+        classes: Vec::new(),
+        enums: Vec::new(),
+        type_aliases: Vec::new(),
+        functions: Vec::new(),
+        clients: Vec::new(),
+        generators,
+        tests: Vec::new(),
+    };
+    for file in &project.files {
+        project.definitions.extend(file.definitions.clone());
+        project.classes.extend(file.classes.clone());
+        project.enums.extend(file.enums.clone());
+        project.type_aliases.extend(file.type_aliases.clone());
+        project.functions.extend(file.functions.clone());
+        project.clients.extend(file.clients.clone());
+        project.tests.extend(file.tests.clone());
+    }
+    project
+        .definitions
+        .extend(project.generators.iter().map(GraphGenerator::summary));
+    Ok(Snapshot { project })
+}
+
+fn build_file(db: &ProjectDatabase, root: &Path, file: SourceFile) -> GraphSourceFile {
+    let source_path = file.path(db);
+    let path = normalized_relative_path(&source_path, root);
+    let source = file.text(db);
+    let package_info = baml_compiler2_hir::file_package::file_package(db, file);
+    let namespace = package_info
+        .namespace_path
+        .iter()
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    let mut output = GraphSourceFile {
+        path: path.clone(),
+        package: package_info.package.to_string(),
+        namespace: namespace.clone(),
+        definitions: Vec::new(),
+        classes: Vec::new(),
+        enums: Vec::new(),
+        type_aliases: Vec::new(),
+        functions: Vec::new(),
+        clients: Vec::new(),
+        tests: Vec::new(),
+    };
+    let ast = baml_compiler2_hir::file_ast(db, file);
+    for item in &ast.items {
+        match item {
+            Item::Class(item) => {
+                let class = GraphClass {
+                    name: item.name.to_string(),
+                    qualified_name: qualified_name(&namespace, item.name.as_str()),
+                    documentation: item.docstring.clone(),
+                    attributes: graph_attributes(&path, source, &item.attributes),
+                    generic_parameters: item
+                        .generic_params
+                        .iter()
+                        .map(|param| param.name.to_string())
+                        .collect(),
+                    fields: item
+                        .fields
+                        .iter()
+                        .map(|field| GraphField {
+                            name: field.name.to_string(),
+                            documentation: field.docstring.clone(),
+                            attributes: graph_attributes(&path, source, &field.attributes),
+                            type_ref: graph_type_ref(&path, source, &field.type_expr),
+                            location: source_location(&path, source, field.span),
+                        })
+                        .collect(),
+                    methods: item
+                        .methods
+                        .iter()
+                        .filter(|method| method.metadata.origin == FunctionOrigin::UserDefined)
+                        .map(|method| graph_function(&path, source, &namespace, method))
+                        .collect(),
+                    location: source_location(&path, source, item.span),
+                };
+                output.definitions.push(class.summary());
+                output
+                    .definitions
+                    .extend(class.fields.iter().map(|field| GraphDefinition {
+                        kind: DefinitionKind::Field,
+                        name: field.name.clone(),
+                        qualified_name: format!("{}.{}", class.qualified_name, field.name),
+                        documentation: field.documentation.clone(),
+                        attributes: field.attributes.clone(),
+                        location: field.location.clone(),
+                    }));
+                output
+                    .definitions
+                    .extend(class.methods.iter().map(|method| method.summary()));
+                for method in &class.methods {
+                    output
+                        .definitions
+                        .extend(method.parameters.iter().map(|parameter| GraphDefinition {
+                            kind: DefinitionKind::Parameter,
+                            name: parameter.name.clone(),
+                            qualified_name: format!("{}.{}", method.qualified_name, parameter.name),
+                            documentation: None,
+                            attributes: Vec::new(),
+                            location: parameter.location.clone(),
+                        }));
+                }
+                output.classes.push(class);
+            }
+            Item::Enum(item) => {
+                let graph_enum = GraphEnum {
+                    name: item.name.to_string(),
+                    qualified_name: qualified_name(&namespace, item.name.as_str()),
+                    documentation: item.docstring.clone(),
+                    attributes: graph_attributes(&path, source, &item.attributes),
+                    values: item
+                        .variants
+                        .iter()
+                        .map(|value| GraphEnumValue {
+                            name: value.name.to_string(),
+                            documentation: value.docstring.clone(),
+                            attributes: graph_attributes(&path, source, &value.attributes),
+                            location: source_location(&path, source, value.span),
+                        })
+                        .collect(),
+                    location: source_location(&path, source, item.span),
+                };
+                output.definitions.push(graph_enum.summary());
+                output
+                    .definitions
+                    .extend(graph_enum.values.iter().map(|value| GraphDefinition {
+                        kind: DefinitionKind::EnumValue,
+                        name: value.name.clone(),
+                        qualified_name: format!("{}.{}", graph_enum.qualified_name, value.name),
+                        documentation: value.documentation.clone(),
+                        attributes: value.attributes.clone(),
+                        location: value.location.clone(),
+                    }));
+                output.enums.push(graph_enum);
+            }
+            Item::TypeAlias(item) => {
+                let alias = GraphTypeAlias {
+                    name: item.name.to_string(),
+                    qualified_name: qualified_name(&namespace, item.name.as_str()),
+                    documentation: item.docstring.clone(),
+                    type_ref: item
+                        .type_expr
+                        .as_ref()
+                        .map(|ty| graph_type_ref(&path, source, ty)),
+                    location: source_location(&path, source, item.span),
+                };
+                output.definitions.push(alias.summary());
+                output.type_aliases.push(alias);
+            }
+            Item::Function(item) if item.metadata.origin == FunctionOrigin::UserDefined => {
+                let function = graph_function(&path, source, &namespace, item);
+                output.definitions.push(function.summary());
+                output
+                    .definitions
+                    .extend(function.parameters.iter().map(|parameter| GraphDefinition {
+                        kind: DefinitionKind::Parameter,
+                        name: parameter.name.clone(),
+                        qualified_name: format!("{}.{}", function.qualified_name, parameter.name),
+                        documentation: None,
+                        attributes: Vec::new(),
+                        location: parameter.location.clone(),
+                    }));
+                output.functions.push(function);
+            }
+            Item::Client(item) => {
+                let client = GraphClient {
+                    name: item.name.to_string(),
+                    qualified_name: qualified_name(&namespace, item.name.as_str()),
+                    properties: item
+                        .config_items
+                        .iter()
+                        .map(|property| GraphConfigEntry {
+                            key: property.key.to_string(),
+                            value: property.value.clone(),
+                            location: source_location(&path, source, property.span),
+                        })
+                        .collect(),
+                    location: source_location(&path, source, item.span),
+                };
+                output.definitions.push(client.summary());
+                output.clients.push(client);
+            }
+            Item::Let(item) if item.origin == LetOrigin::Client => {
+                let client = GraphClient {
+                    name: item.name.to_string(),
+                    qualified_name: qualified_name(&namespace, item.name.as_str()),
+                    properties: Vec::new(),
+                    location: source_location(&path, source, item.span),
+                };
+                output.definitions.push(client.summary());
+                output.clients.push(client);
+            }
+            Item::Test(item) => {
+                let test = GraphTest {
+                    name: item.name.to_string(),
+                    qualified_name: qualified_name(&namespace, item.name.as_str()),
+                    functions: item.function_refs.iter().map(ToString::to_string).collect(),
+                    arguments: item
+                        .args
+                        .iter()
+                        .map(|(name, value)| GraphTestArgument {
+                            name: name.to_string(),
+                            value_json: test_arg_json(value).to_string(),
+                        })
+                        .collect(),
+                    location: source_location(&path, source, item.span),
+                };
+                output.definitions.push(test.summary());
+                output.tests.push(test);
+            }
+            Item::Interface(item) => output.definitions.push(GraphDefinition {
+                kind: DefinitionKind::Interface,
+                name: item.name.to_string(),
+                qualified_name: qualified_name(&namespace, item.name.as_str()),
+                documentation: item.docstring.clone(),
+                attributes: graph_attributes(&path, source, &item.attributes),
+                location: source_location(&path, source, item.span),
+            }),
+            Item::TemplateString(item) => output.definitions.push(GraphDefinition {
+                kind: DefinitionKind::TemplateString,
+                name: item.name.to_string(),
+                qualified_name: qualified_name(&namespace, item.name.as_str()),
+                documentation: None,
+                attributes: Vec::new(),
+                location: source_location(&path, source, item.span),
+            }),
+            Item::Function(_) | Item::Let(_) | Item::RetryPolicy(_) | Item::ImplementsFor(_) => {}
+        }
+    }
+    output
+}
+
+fn graph_function(
+    path: &str,
+    source: &str,
+    namespace: &[String],
+    item: &FunctionDef,
+) -> GraphFunction {
+    let (is_llm, client_name) = match &item.declarative_meta {
+        Some(DeclarativeMeta::Llm(meta)) => (true, meta.client.as_ref().map(ToString::to_string)),
+        None => (false, None),
+    };
+    GraphFunction {
+        name: item.name.to_string(),
+        qualified_name: qualified_name(namespace, item.name.as_str()),
+        documentation: item.docstring.clone(),
+        attributes: graph_attributes(path, source, &item.attributes),
+        generic_parameters: item
+            .generic_params
+            .iter()
+            .map(|param| param.name.to_string())
+            .collect(),
+        parameters: item
+            .params
+            .iter()
+            .map(|param| GraphParameter {
+                name: param.name.to_string(),
+                type_ref: param
+                    .type_expr
+                    .as_ref()
+                    .map(|ty| graph_type_ref(path, source, ty)),
+                has_default: param.default.is_some(),
+                location: source_location(path, source, param.span),
+            })
+            .collect(),
+        return_type: item
+            .return_type
+            .as_ref()
+            .map(|ty| graph_type_ref(path, source, ty)),
+        throws_type: item
+            .throws
+            .as_ref()
+            .map(|ty| graph_type_ref(path, source, ty)),
+        is_llm,
+        client_name,
+        location: source_location(path, source, item.span),
+    }
+}
+
+fn graph_type_ref(path: &str, source: &str, ty: &TypeExpr) -> GraphTypeRef {
+    let mut output = GraphTypeRef {
+        kind: TypeRefKind::Unknown,
+        display: ty.to_string(),
+        name: None,
+        path: Vec::new(),
+        element_type: None,
+        key_type: None,
+        value_type: None,
+        member_types: Vec::new(),
+        parameter_types: Vec::new(),
+        return_type: None,
+        throws_type: None,
+        attributes: graph_attributes(path, source, ty.kind.attrs()),
+        location: source_location(path, source, ty.span),
+    };
+    match &ty.kind {
+        TypeExprKind::Path {
+            segments,
+            generic_args,
+            associated_type_bindings,
+            ..
+        } => {
+            output.kind = TypeRefKind::Named;
+            output.name = segments.last().map(ToString::to_string);
+            output.path = segments.iter().map(ToString::to_string).collect();
+            output.member_types = generic_args
+                .iter()
+                .chain(
+                    associated_type_bindings
+                        .iter()
+                        .map(|binding| binding.ty.as_ref()),
+                )
+                .map(|ty| graph_type_ref(path, source, ty))
+                .collect();
+        }
+        TypeExprKind::AssociatedTypeProjection {
+            base,
+            interface,
+            member,
+            ..
+        } => {
+            output.kind = TypeRefKind::AssociatedType;
+            output.name = Some(member.to_string());
+            output.element_type = Some(Box::new(graph_type_ref(path, source, base)));
+            output.member_types = interface
+                .iter()
+                .map(|ty| graph_type_ref(path, source, ty))
+                .collect();
+        }
+        TypeExprKind::Int { .. } => output.kind = TypeRefKind::Int,
+        TypeExprKind::Bigint { .. } => output.kind = TypeRefKind::Bigint,
+        TypeExprKind::Float { .. } => output.kind = TypeRefKind::Float,
+        TypeExprKind::String { .. } => output.kind = TypeRefKind::String,
+        TypeExprKind::Bool { .. } => output.kind = TypeRefKind::Bool,
+        TypeExprKind::Null { .. } => output.kind = TypeRefKind::Null,
+        TypeExprKind::Never { .. } => output.kind = TypeRefKind::Never,
+        TypeExprKind::Void { .. } => output.kind = TypeRefKind::Void,
+        TypeExprKind::Uint8Array { .. } => output.kind = TypeRefKind::Bytes,
+        TypeExprKind::Media { kind, .. } => {
+            output.kind = TypeRefKind::Media;
+            output.name = Some(format!("{kind:?}").to_ascii_lowercase());
+        }
+        TypeExprKind::Optional { inner, .. } => {
+            output.kind = TypeRefKind::Optional;
+            output.element_type = Some(Box::new(graph_type_ref(path, source, inner)));
+        }
+        TypeExprKind::List { inner, .. } => {
+            output.kind = TypeRefKind::List;
+            output.element_type = Some(Box::new(graph_type_ref(path, source, inner)));
+        }
+        TypeExprKind::Map { key, value, .. } => {
+            output.kind = TypeRefKind::Map;
+            output.key_type = Some(Box::new(graph_type_ref(path, source, key)));
+            output.value_type = Some(Box::new(graph_type_ref(path, source, value)));
+        }
+        TypeExprKind::Union { variants, .. } => {
+            output.kind = TypeRefKind::Union;
+            output.member_types = variants
+                .iter()
+                .map(|ty| graph_type_ref(path, source, ty))
+                .collect();
+        }
+        TypeExprKind::Literal { value, .. } => {
+            output.kind = TypeRefKind::Literal;
+            output.name = Some(value.to_string());
+        }
+        TypeExprKind::Function {
+            params,
+            ret,
+            throws,
+            ..
+        } => {
+            output.kind = TypeRefKind::Function;
+            output.parameter_types = params
+                .iter()
+                .map(|param| graph_type_ref(path, source, &param.ty))
+                .collect();
+            output.return_type = Some(Box::new(graph_type_ref(path, source, ret)));
+            output.throws_type = throws
+                .as_ref()
+                .map(|ty| Box::new(graph_type_ref(path, source, ty)));
+        }
+        TypeExprKind::BuiltinUnknown { .. } | TypeExprKind::Unknown { .. } => {
+            output.kind = TypeRefKind::Unknown;
+        }
+        TypeExprKind::Type { .. } => output.kind = TypeRefKind::Type,
+        TypeExprKind::Rust { .. } => output.kind = TypeRefKind::Rust,
+        TypeExprKind::Error { .. } => output.kind = TypeRefKind::Invalid,
+        TypeExprKind::Infer { .. } => output.kind = TypeRefKind::Infer,
+    }
+    output
+}
+
+fn graph_attributes(path: &str, source: &str, attributes: &[RawAttribute]) -> Vec<GraphAttribute> {
+    attributes
+        .iter()
+        .map(|attribute| GraphAttribute {
+            name: attribute.name.to_string(),
+            arguments: attribute
+                .args
+                .iter()
+                .map(|argument| GraphAttributeArgument {
+                    key: argument.key.as_ref().map(ToString::to_string),
+                    value: argument.value.clone(),
+                    location: source_location(path, source, argument.span),
+                })
+                .collect(),
+            location: source_location(path, source, attribute.span),
+        })
+        .collect()
+}
+
+fn build_generators(source: Option<&str>) -> Result<(Option<String>, Vec<GraphGenerator>)> {
+    let Some(source) = source else {
+        return Ok((None, Vec::new()));
+    };
+    let manifest =
+        crate::manifest::parse(source).context("failed to parse baml.toml for GraphQL")?;
+    let project_name = manifest.package.and_then(|package| package.name);
+    let generators = manifest
+        .generator
+        .into_iter()
+        .map(|(name, generator)| {
+            let range = text_range(generator.span());
+            let generator = generator.into_inner();
+            GraphGenerator {
+                name,
+                output_type: generator.output_type.map(|value| value.into_inner()),
+                output_dir: generator.output_dir,
+                naming_convention: generator.naming_convention.map(|value| value.into_inner()),
+                sdk_import_path: generator.sdk_import_path.map(|value| value.into_inner()),
+                location: source_location("baml.toml", source, range),
+            }
+        })
+        .collect();
+    Ok((project_name, generators))
+}
+
+fn text_range(range: std::ops::Range<usize>) -> TextRange {
+    TextRange::new(
+        u32::try_from(range.start).unwrap_or(u32::MAX).into(),
+        u32::try_from(range.end).unwrap_or(u32::MAX).into(),
+    )
+}
+
+fn test_arg_json(value: &TestArgValue) -> JsonValue {
+    match value {
+        TestArgValue::Null => JsonValue::Null,
+        TestArgValue::Int(value) => json!(value),
+        TestArgValue::FloatBits(bits) => json!(f64::from_bits(*bits)),
+        TestArgValue::Bool(value) => json!(value),
+        TestArgValue::String(value) => json!(value),
+        TestArgValue::Array(values) => JsonValue::Array(values.iter().map(test_arg_json).collect()),
+        TestArgValue::Map(entries) => JsonValue::Object(
+            entries
+                .iter()
+                .map(|(key, value)| (key.clone(), test_arg_json(value)))
+                .collect(),
+        ),
+    }
+}
+
+impl GraphClass {
+    fn summary(&self) -> GraphDefinition {
+        definition_summary(
+            DefinitionKind::Class,
+            &self.name,
+            &self.qualified_name,
+            self.documentation.clone(),
+            self.attributes.clone(),
+            self.location.clone(),
+        )
+    }
+}
+
+impl GraphEnum {
+    fn summary(&self) -> GraphDefinition {
+        definition_summary(
+            DefinitionKind::Enum,
+            &self.name,
+            &self.qualified_name,
+            self.documentation.clone(),
+            self.attributes.clone(),
+            self.location.clone(),
+        )
+    }
+}
+
+impl GraphTypeAlias {
+    fn summary(&self) -> GraphDefinition {
+        definition_summary(
+            DefinitionKind::TypeAlias,
+            &self.name,
+            &self.qualified_name,
+            self.documentation.clone(),
+            Vec::new(),
+            self.location.clone(),
+        )
+    }
+}
+
+impl GraphFunction {
+    fn summary(&self) -> GraphDefinition {
+        definition_summary(
+            DefinitionKind::Function,
+            &self.name,
+            &self.qualified_name,
+            self.documentation.clone(),
+            self.attributes.clone(),
+            self.location.clone(),
+        )
+    }
+}
+
+impl GraphClient {
+    fn summary(&self) -> GraphDefinition {
+        definition_summary(
+            DefinitionKind::Client,
+            &self.name,
+            &self.qualified_name,
+            None,
+            Vec::new(),
+            self.location.clone(),
+        )
+    }
+}
+
+impl GraphGenerator {
+    fn summary(&self) -> GraphDefinition {
+        definition_summary(
+            DefinitionKind::Generator,
+            &self.name,
+            &self.name,
+            None,
+            Vec::new(),
+            self.location.clone(),
+        )
+    }
+}
+
+impl GraphTest {
+    fn summary(&self) -> GraphDefinition {
+        definition_summary(
+            DefinitionKind::Test,
+            &self.name,
+            &self.qualified_name,
+            None,
+            Vec::new(),
+            self.location.clone(),
+        )
+    }
+}
+
+fn definition_summary(
+    kind: DefinitionKind,
+    name: &str,
+    qualified_name: &str,
+    documentation: Option<String>,
+    attributes: Vec<GraphAttribute>,
+    location: SourceLocation,
+) -> GraphDefinition {
+    GraphDefinition {
+        kind,
+        name: name.to_string(),
+        qualified_name: qualified_name.to_string(),
+        documentation,
+        attributes,
+        location,
+    }
+}
+
+fn qualified_name(namespace: &[String], name: &str) -> String {
+    if namespace.is_empty() {
+        name.to_string()
+    } else {
+        format!("{}.{name}", namespace.join("."))
+    }
+}
+
+fn source_location(path: &str, source: &str, range: TextRange) -> SourceLocation {
+    let start = usize::from(range.start()).min(source.len());
+    let end = usize::from(range.end()).min(source.len());
+    let (start_line, start_column) = line_column(source, start);
+    let (end_line, end_column) = line_column(source, end);
+    SourceLocation {
+        path: path.to_string(),
+        start_line,
+        start_column,
+        end_line,
+        end_column,
+    }
+}
+
+fn line_column(source: &str, offset: usize) -> (i32, i32) {
+    let offset = floor_char_boundary(source, offset.min(source.len()));
+    let before = &source[..offset];
+    let line = before.bytes().filter(|byte| *byte == b'\n').count() + 1;
+    let column = before
+        .rsplit_once('\n')
+        .map_or(before, |(_, line)| line)
+        .chars()
+        .count()
+        + 1;
+    (
+        i32::try_from(line).unwrap_or(i32::MAX),
+        i32::try_from(column).unwrap_or(i32::MAX),
+    )
+}
+
+fn floor_char_boundary(source: &str, mut offset: usize) -> usize {
+    while !source.is_char_boundary(offset) {
+        offset = offset.saturating_sub(1);
+    }
+    offset
+}
+
+fn normalized_relative_path(path: &Path, root: &Path) -> String {
+    normalize_path(path.strip_prefix(root).unwrap_or(path))
+}
+
+fn normalize_path(path: &Path) -> String {
+    path.to_string_lossy().replace('\\', "/")
+}
+
+fn diagnostic_json(
+    db: &ProjectDatabase,
+    root: &Path,
+    diagnostic: &baml_db::baml_compiler_diagnostics::Diagnostic,
+) -> JsonValue {
+    let location = diagnostic.primary_span().and_then(|span| {
+        let path = db.file_id_to_path(span.file_id)?;
+        let file = db
+            .get_source_files()
+            .into_iter()
+            .find(|file| file.file_id(db) == span.file_id)?;
+        Some(source_location(
+            &normalized_relative_path(path, root),
+            file.text(db),
+            span.range,
+        ))
+    });
+    json!({
+        "code": diagnostic.code(),
+        "severity": format!("{:?}", diagnostic.severity).to_ascii_lowercase(),
+        "message": diagnostic.message_with_primary_label(),
+        "location": location.map(location_json),
+    })
+}
+
+fn location_json(location: SourceLocation) -> JsonValue {
+    json!({
+        "path": location.path,
+        "startLine": location.start_line,
+        "startColumn": location.start_column,
+        "endLine": location.end_line,
+        "endColumn": location.end_column,
+    })
+}
+
+fn write_graphql_response(
+    response: &GraphQLResponse<DefaultScalarValue>,
+) -> Result<crate::ExitCode> {
+    let is_ok = response.is_ok();
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    serde_json::to_writer(&mut stdout, response).context("failed to write GraphQL response")?;
+    writeln!(stdout).context("failed to finish GraphQL response")?;
+    Ok(if is_ok {
+        crate::ExitCode::Success
+    } else {
+        crate::ExitCode::InvalidArgs
+    })
+}
+
+fn write_error_response(
+    code: &str,
+    message: &str,
+    extra_extensions: Option<JsonValue>,
+) -> Result<()> {
+    let mut extensions = serde_json::Map::new();
+    extensions.insert("code".to_string(), json!(code));
+    if let Some(JsonValue::Object(extra)) = extra_extensions {
+        extensions.extend(extra);
+    }
+    let response = json!({
+        "errors": [{
+            "message": message,
+            "extensions": extensions,
+        }],
+    });
+    let stdout = std::io::stdout();
+    let mut stdout = stdout.lock();
+    serde_json::to_writer(&mut stdout, &response)
+        .context("failed to write GraphQL error response")?;
+    writeln!(stdout).context("failed to finish GraphQL error response")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn line_columns_are_one_based_and_unicode_aware() {
+        assert_eq!(line_column("αβ\nvalue", 0), (1, 1));
+        assert_eq!(line_column("αβ\nvalue", "α".len()), (1, 2));
+        assert_eq!(line_column("αβ\nvalue", "αβ\n".len()), (2, 1));
+    }
+
+    #[test]
+    fn schema_sdl_is_stable_and_has_search_roots() {
+        let sdl = schema().as_sdl();
+        assert!(
+            sdl.contains("classes(name: String): [GraphClass!]!"),
+            "{sdl}"
+        );
+        assert!(
+            sdl.contains("definitions(name: String, kind: [DefinitionKind!])"),
+            "{sdl}"
+        );
+        assert!(sdl.contains("type GraphTypeRef"), "{sdl}");
+        assert_eq!(sdl, schema().as_sdl());
+    }
+}

--- a/baml_language/crates/baml_cli/src/graphql_command.rs
+++ b/baml_language/crates/baml_cli/src/graphql_command.rs
@@ -89,7 +89,9 @@ impl GraphqlArgs {
     fn run_inner(&self) -> Result<crate::ExitCode> {
         let schema = schema();
         if self.schema {
-            print!("{}", schema.as_sdl());
+            let stdout = std::io::stdout();
+            let mut stdout = stdout.lock();
+            write!(stdout, "{}", schema.as_sdl()).context("failed to write GraphQL schema")?;
             return Ok(crate::ExitCode::Success);
         }
 
@@ -241,7 +243,7 @@ impl QueryRoot {
     }
 
     /// Source packages, optionally filtered by exact package name.
-    fn packages<'a>(context: &'a GraphqlContext, name: Option<String>) -> Vec<&'a GraphPackage> {
+    fn packages(context: &GraphqlContext, name: Option<String>) -> Vec<&GraphPackage> {
         filter_name(
             &context.snapshot.project.packages,
             name.as_deref(),
@@ -250,7 +252,7 @@ impl QueryRoot {
     }
 
     /// Source files, optionally filtered by exact project-relative path.
-    fn files<'a>(context: &'a GraphqlContext, path: Option<String>) -> Vec<&'a GraphSourceFile> {
+    fn files(context: &GraphqlContext, path: Option<String>) -> Vec<&GraphSourceFile> {
         context
             .snapshot
             .project
@@ -261,11 +263,11 @@ impl QueryRoot {
     }
 
     /// All top-level definitions with exact name and kind filters.
-    fn definitions<'a>(
-        context: &'a GraphqlContext,
+    fn definitions(
+        context: &GraphqlContext,
         name: Option<String>,
         kind: Option<Vec<DefinitionKind>>,
-    ) -> Vec<&'a GraphDefinition> {
+    ) -> Vec<&GraphDefinition> {
         context
             .snapshot
             .project
@@ -276,22 +278,19 @@ impl QueryRoot {
             .collect()
     }
 
-    fn classes<'a>(context: &'a GraphqlContext, name: Option<String>) -> Vec<&'a GraphClass> {
+    fn classes(context: &GraphqlContext, name: Option<String>) -> Vec<&GraphClass> {
         filter_name(&context.snapshot.project.classes, name.as_deref(), |item| {
             &item.name
         })
     }
 
-    fn enums<'a>(context: &'a GraphqlContext, name: Option<String>) -> Vec<&'a GraphEnum> {
+    fn enums(context: &GraphqlContext, name: Option<String>) -> Vec<&GraphEnum> {
         filter_name(&context.snapshot.project.enums, name.as_deref(), |item| {
             &item.name
         })
     }
 
-    fn type_aliases<'a>(
-        context: &'a GraphqlContext,
-        name: Option<String>,
-    ) -> Vec<&'a GraphTypeAlias> {
+    fn type_aliases(context: &GraphqlContext, name: Option<String>) -> Vec<&GraphTypeAlias> {
         filter_name(
             &context.snapshot.project.type_aliases,
             name.as_deref(),
@@ -299,7 +298,7 @@ impl QueryRoot {
         )
     }
 
-    fn functions<'a>(context: &'a GraphqlContext, name: Option<String>) -> Vec<&'a GraphFunction> {
+    fn functions(context: &GraphqlContext, name: Option<String>) -> Vec<&GraphFunction> {
         filter_name(
             &context.snapshot.project.functions,
             name.as_deref(),
@@ -307,16 +306,13 @@ impl QueryRoot {
         )
     }
 
-    fn clients<'a>(context: &'a GraphqlContext, name: Option<String>) -> Vec<&'a GraphClient> {
+    fn clients(context: &GraphqlContext, name: Option<String>) -> Vec<&GraphClient> {
         filter_name(&context.snapshot.project.clients, name.as_deref(), |item| {
             &item.name
         })
     }
 
-    fn generators<'a>(
-        context: &'a GraphqlContext,
-        name: Option<String>,
-    ) -> Vec<&'a GraphGenerator> {
+    fn generators(context: &GraphqlContext, name: Option<String>) -> Vec<&GraphGenerator> {
         filter_name(
             &context.snapshot.project.generators,
             name.as_deref(),
@@ -324,7 +320,7 @@ impl QueryRoot {
         )
     }
 
-    fn tests<'a>(context: &'a GraphqlContext, name: Option<String>) -> Vec<&'a GraphTest> {
+    fn tests(context: &GraphqlContext, name: Option<String>) -> Vec<&GraphTest> {
         filter_name(&context.snapshot.project.tests, name.as_deref(), |item| {
             &item.name
         })
@@ -401,6 +397,7 @@ struct SourceLocation {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "AttributeArgument")]
 struct GraphAttributeArgument {
     key: Option<String>,
     value: String,
@@ -408,6 +405,7 @@ struct GraphAttributeArgument {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "Attribute")]
 struct GraphAttribute {
     name: String,
     arguments: Vec<GraphAttributeArgument>,
@@ -415,6 +413,7 @@ struct GraphAttribute {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "TypeRef")]
 struct GraphTypeRef {
     kind: TypeRefKind,
     /// Canonical source-like spelling.
@@ -438,6 +437,7 @@ struct GraphTypeRef {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "Definition")]
 struct GraphDefinition {
     kind: DefinitionKind,
     name: String,
@@ -448,6 +448,7 @@ struct GraphDefinition {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "Field")]
 struct GraphField {
     name: String,
     documentation: Option<String>,
@@ -458,6 +459,7 @@ struct GraphField {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "EnumValue")]
 struct GraphEnumValue {
     name: String,
     documentation: Option<String>,
@@ -466,6 +468,7 @@ struct GraphEnumValue {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "Parameter")]
 struct GraphParameter {
     name: String,
     #[graphql(name = "type")]
@@ -475,6 +478,7 @@ struct GraphParameter {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "Function")]
 struct GraphFunction {
     name: String,
     qualified_name: String,
@@ -490,6 +494,7 @@ struct GraphFunction {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "Class")]
 struct GraphClass {
     name: String,
     qualified_name: String,
@@ -502,6 +507,7 @@ struct GraphClass {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "Enum")]
 struct GraphEnum {
     name: String,
     qualified_name: String,
@@ -512,6 +518,7 @@ struct GraphEnum {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "TypeAlias")]
 struct GraphTypeAlias {
     name: String,
     qualified_name: String,
@@ -522,6 +529,7 @@ struct GraphTypeAlias {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "ConfigEntry")]
 struct GraphConfigEntry {
     key: String,
     value: String,
@@ -529,6 +537,7 @@ struct GraphConfigEntry {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "Client")]
 struct GraphClient {
     name: String,
     qualified_name: String,
@@ -537,6 +546,7 @@ struct GraphClient {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "Generator")]
 struct GraphGenerator {
     name: String,
     output_type: Option<String>,
@@ -547,12 +557,14 @@ struct GraphGenerator {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "TestArgument")]
 struct GraphTestArgument {
     name: String,
     value_json: String,
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "Test")]
 struct GraphTest {
     name: String,
     qualified_name: String,
@@ -562,6 +574,7 @@ struct GraphTest {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "SourceFile")]
 struct GraphSourceFile {
     path: String,
     package: String,
@@ -576,6 +589,7 @@ struct GraphSourceFile {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "Package")]
 struct GraphPackage {
     name: String,
     files: Vec<GraphSourceFile>,
@@ -590,6 +604,7 @@ struct GraphPackage {
 }
 
 #[derive(Clone, GraphQLObject)]
+#[graphql(name = "Project")]
 struct GraphProject {
     /// Package name from baml.toml, when present.
     name: Option<String>,
@@ -1410,15 +1425,12 @@ mod tests {
     #[test]
     fn schema_sdl_is_stable_and_has_search_roots() {
         let sdl = schema().as_sdl();
-        assert!(
-            sdl.contains("classes(name: String): [GraphClass!]!"),
-            "{sdl}"
-        );
+        assert!(sdl.contains("classes(name: String): [Class!]!"), "{sdl}");
         assert!(
             sdl.contains("definitions(name: String, kind: [DefinitionKind!])"),
             "{sdl}"
         );
-        assert!(sdl.contains("type GraphTypeRef"), "{sdl}");
+        assert!(sdl.contains("type TypeRef"), "{sdl}");
         assert_eq!(sdl, schema().as_sdl());
     }
 }

--- a/baml_language/crates/baml_cli/src/graphql_command.rs
+++ b/baml_language/crates/baml_cli/src/graphql_command.rs
@@ -25,7 +25,7 @@ use serde_json::{Value as JsonValue, json};
 use text_size::TextRange;
 
 /// Query a BAML project's source model with GraphQL.
-#[derive(Args, Clone, Debug)]
+#[derive(Args, Clone, Debug, Default)]
 #[command(after_long_help = "\
 Examples:
   Query classes and fields:
@@ -86,6 +86,7 @@ impl GraphqlArgs {
         }
     }
 
+    /// Execute the selected query, schema, or introspection mode.
     fn run_inner(&self) -> Result<crate::ExitCode> {
         let schema = schema();
         if self.schema {
@@ -182,6 +183,7 @@ impl GraphqlArgs {
         write_graphql_response(&response)
     }
 
+    /// Read the query document from its selected input source.
     fn read_query(&self) -> Result<String> {
         if let Some(query) = &self.query {
             return Ok(query.clone());
@@ -201,6 +203,7 @@ impl GraphqlArgs {
         Ok(query)
     }
 
+    /// Parse and validate the optional JSON variables object.
     fn parse_variables(&self) -> Result<Option<juniper::InputValue<DefaultScalarValue>>> {
         let Some(raw) = &self.variables else {
             return Ok(None);
@@ -217,6 +220,7 @@ impl GraphqlArgs {
 
 type Schema = RootNode<QueryRoot, EmptyMutation<GraphqlContext>, EmptySubscription<GraphqlContext>>;
 
+/// Construct the stateless GraphQL schema.
 fn schema() -> Schema {
     Schema::new(
         QueryRoot,
@@ -232,6 +236,7 @@ struct GraphqlContext {
 impl juniper::Context for GraphqlContext {}
 
 impl GraphqlContext {
+    /// Construct the projectless context used by introspection.
     fn empty() -> Self {
         Self {
             snapshot: Snapshot::empty(),
@@ -284,18 +289,21 @@ impl QueryRoot {
             .collect()
     }
 
+    /// Classes, optionally filtered by exact unqualified name.
     fn classes(context: &GraphqlContext, name: Option<String>) -> Vec<&GraphClass> {
         filter_name(&context.snapshot.project.classes, name.as_deref(), |item| {
             &item.name
         })
     }
 
+    /// Enums, optionally filtered by exact unqualified name.
     fn enums(context: &GraphqlContext, name: Option<String>) -> Vec<&GraphEnum> {
         filter_name(&context.snapshot.project.enums, name.as_deref(), |item| {
             &item.name
         })
     }
 
+    /// Type aliases, optionally filtered by exact unqualified name.
     fn type_aliases(context: &GraphqlContext, name: Option<String>) -> Vec<&GraphTypeAlias> {
         filter_name(
             &context.snapshot.project.type_aliases,
@@ -304,6 +312,7 @@ impl QueryRoot {
         )
     }
 
+    /// User-defined functions, optionally filtered by exact unqualified name.
     fn functions(context: &GraphqlContext, name: Option<String>) -> Vec<&GraphFunction> {
         filter_name(
             &context.snapshot.project.functions,
@@ -312,12 +321,14 @@ impl QueryRoot {
         )
     }
 
+    /// Clients, optionally filtered by exact unqualified name.
     fn clients(context: &GraphqlContext, name: Option<String>) -> Vec<&GraphClient> {
         filter_name(&context.snapshot.project.clients, name.as_deref(), |item| {
             &item.name
         })
     }
 
+    /// Manifest generators, optionally filtered by exact name.
     fn generators(context: &GraphqlContext, name: Option<String>) -> Vec<&GraphGenerator> {
         filter_name(
             &context.snapshot.project.generators,
@@ -326,6 +337,7 @@ impl QueryRoot {
         )
     }
 
+    /// Legacy declarative tests, optionally filtered by exact name.
     fn tests(context: &GraphqlContext, name: Option<String>) -> Vec<&GraphTest> {
         filter_name(&context.snapshot.project.tests, name.as_deref(), |item| {
             &item.name
@@ -333,6 +345,7 @@ impl QueryRoot {
     }
 }
 
+/// Apply a shared optional exact-name filter while preserving source order.
 fn filter_name<'a, T>(
     items: &'a [T],
     name: Option<&str>,
@@ -633,6 +646,7 @@ struct Snapshot {
 }
 
 impl Snapshot {
+    /// Construct the projectless snapshot used only for schema introspection.
     fn empty() -> Self {
         Self {
             project: GraphProject {
@@ -653,6 +667,7 @@ impl Snapshot {
     }
 }
 
+/// Build the stable owned GraphQL model from compiler and manifest data.
 fn build_snapshot(
     db: &ProjectDatabase,
     root: &Path,
@@ -740,10 +755,12 @@ fn build_snapshot(
     Ok(Snapshot { project })
 }
 
+/// Convert one user source file and its AST into the public GraphQL model.
 fn build_file(db: &ProjectDatabase, root: &Path, file: SourceFile) -> GraphSourceFile {
     let source_path = file.path(db);
     let path = normalized_relative_path(&source_path, root);
     let source = file.text(db);
+    let line_index = LineIndex::new(source);
     let package_info = baml_compiler2_hir::file_package::file_package(db, file);
     let namespace = package_info
         .namespace_path
@@ -770,7 +787,7 @@ fn build_file(db: &ProjectDatabase, root: &Path, file: SourceFile) -> GraphSourc
                     name: item.name.to_string(),
                     qualified_name: qualified_name(&namespace, item.name.as_str()),
                     documentation: item.docstring.clone(),
-                    attributes: graph_attributes(&path, source, &item.attributes),
+                    attributes: graph_attributes(&path, source, &line_index, &item.attributes),
                     generic_parameters: item
                         .generic_params
                         .iter()
@@ -782,18 +799,25 @@ fn build_file(db: &ProjectDatabase, root: &Path, file: SourceFile) -> GraphSourc
                         .map(|field| GraphField {
                             name: field.name.to_string(),
                             documentation: field.docstring.clone(),
-                            attributes: graph_attributes(&path, source, &field.attributes),
-                            type_ref: graph_type_ref(&path, source, &field.type_expr),
-                            location: source_location(&path, source, field.span),
+                            attributes: graph_attributes(
+                                &path,
+                                source,
+                                &line_index,
+                                &field.attributes,
+                            ),
+                            type_ref: graph_type_ref(&path, source, &line_index, &field.type_expr),
+                            location: source_location(&path, source, &line_index, field.span),
                         })
                         .collect(),
                     methods: item
                         .methods
                         .iter()
                         .filter(|method| method.metadata.origin == FunctionOrigin::UserDefined)
-                        .map(|method| graph_function(&path, source, &namespace, method))
+                        .map(|method| {
+                            graph_function(&path, source, &line_index, &namespace, method)
+                        })
                         .collect(),
-                    location: source_location(&path, source, item.span),
+                    location: source_location(&path, source, &line_index, item.span),
                 };
                 output.definitions.push(class.summary());
                 output
@@ -828,18 +852,23 @@ fn build_file(db: &ProjectDatabase, root: &Path, file: SourceFile) -> GraphSourc
                     name: item.name.to_string(),
                     qualified_name: qualified_name(&namespace, item.name.as_str()),
                     documentation: item.docstring.clone(),
-                    attributes: graph_attributes(&path, source, &item.attributes),
+                    attributes: graph_attributes(&path, source, &line_index, &item.attributes),
                     values: item
                         .variants
                         .iter()
                         .map(|value| GraphEnumValue {
                             name: value.name.to_string(),
                             documentation: value.docstring.clone(),
-                            attributes: graph_attributes(&path, source, &value.attributes),
-                            location: source_location(&path, source, value.span),
+                            attributes: graph_attributes(
+                                &path,
+                                source,
+                                &line_index,
+                                &value.attributes,
+                            ),
+                            location: source_location(&path, source, &line_index, value.span),
                         })
                         .collect(),
-                    location: source_location(&path, source, item.span),
+                    location: source_location(&path, source, &line_index, item.span),
                 };
                 output.definitions.push(graph_enum.summary());
                 output
@@ -862,14 +891,14 @@ fn build_file(db: &ProjectDatabase, root: &Path, file: SourceFile) -> GraphSourc
                     type_ref: item
                         .type_expr
                         .as_ref()
-                        .map(|ty| graph_type_ref(&path, source, ty)),
-                    location: source_location(&path, source, item.span),
+                        .map(|ty| graph_type_ref(&path, source, &line_index, ty)),
+                    location: source_location(&path, source, &line_index, item.span),
                 };
                 output.definitions.push(alias.summary());
                 output.type_aliases.push(alias);
             }
             Item::Function(item) if item.metadata.origin == FunctionOrigin::UserDefined => {
-                let function = graph_function(&path, source, &namespace, item);
+                let function = graph_function(&path, source, &line_index, &namespace, item);
                 output.definitions.push(function.summary());
                 output
                     .definitions
@@ -893,10 +922,10 @@ fn build_file(db: &ProjectDatabase, root: &Path, file: SourceFile) -> GraphSourc
                         .map(|property| GraphConfigEntry {
                             key: property.key.to_string(),
                             value: property.value.clone(),
-                            location: source_location(&path, source, property.span),
+                            location: source_location(&path, source, &line_index, property.span),
                         })
                         .collect(),
-                    location: source_location(&path, source, item.span),
+                    location: source_location(&path, source, &line_index, item.span),
                 };
                 output.definitions.push(client.summary());
                 output.clients.push(client);
@@ -906,7 +935,7 @@ fn build_file(db: &ProjectDatabase, root: &Path, file: SourceFile) -> GraphSourc
                     name: item.name.to_string(),
                     qualified_name: qualified_name(&namespace, item.name.as_str()),
                     properties: Vec::new(),
-                    location: source_location(&path, source, item.span),
+                    location: source_location(&path, source, &line_index, item.span),
                 };
                 output.definitions.push(client.summary());
                 output.clients.push(client);
@@ -924,7 +953,7 @@ fn build_file(db: &ProjectDatabase, root: &Path, file: SourceFile) -> GraphSourc
                             value_json: test_arg_json(value).to_string(),
                         })
                         .collect(),
-                    location: source_location(&path, source, item.span),
+                    location: source_location(&path, source, &line_index, item.span),
                 };
                 output.definitions.push(test.summary());
                 output.tests.push(test);
@@ -934,8 +963,8 @@ fn build_file(db: &ProjectDatabase, root: &Path, file: SourceFile) -> GraphSourc
                 name: item.name.to_string(),
                 qualified_name: qualified_name(&namespace, item.name.as_str()),
                 documentation: item.docstring.clone(),
-                attributes: graph_attributes(&path, source, &item.attributes),
-                location: source_location(&path, source, item.span),
+                attributes: graph_attributes(&path, source, &line_index, &item.attributes),
+                location: source_location(&path, source, &line_index, item.span),
             }),
             Item::TemplateString(item) => output.definitions.push(GraphDefinition {
                 kind: DefinitionKind::TemplateString,
@@ -943,7 +972,7 @@ fn build_file(db: &ProjectDatabase, root: &Path, file: SourceFile) -> GraphSourc
                 qualified_name: qualified_name(&namespace, item.name.as_str()),
                 documentation: None,
                 attributes: Vec::new(),
-                location: source_location(&path, source, item.span),
+                location: source_location(&path, source, &line_index, item.span),
             }),
             Item::Function(_) | Item::Let(_) | Item::RetryPolicy(_) | Item::ImplementsFor(_) => {}
         }
@@ -951,9 +980,11 @@ fn build_file(db: &ProjectDatabase, root: &Path, file: SourceFile) -> GraphSourc
     output
 }
 
+/// Convert a user-defined function or method.
 fn graph_function(
     path: &str,
     source: &str,
+    line_index: &LineIndex,
     namespace: &[String],
     item: &FunctionDef,
 ) -> GraphFunction {
@@ -965,7 +996,7 @@ fn graph_function(
         name: item.name.to_string(),
         qualified_name: qualified_name(namespace, item.name.as_str()),
         documentation: item.docstring.clone(),
-        attributes: graph_attributes(path, source, &item.attributes),
+        attributes: graph_attributes(path, source, line_index, &item.attributes),
         generic_parameters: item
             .generic_params
             .iter()
@@ -979,26 +1010,27 @@ fn graph_function(
                 type_ref: param
                     .type_expr
                     .as_ref()
-                    .map(|ty| graph_type_ref(path, source, ty)),
+                    .map(|ty| graph_type_ref(path, source, line_index, ty)),
                 has_default: param.default.is_some(),
-                location: source_location(path, source, param.span),
+                location: source_location(path, source, line_index, param.span),
             })
             .collect(),
         return_type: item
             .return_type
             .as_ref()
-            .map(|ty| graph_type_ref(path, source, ty)),
+            .map(|ty| graph_type_ref(path, source, line_index, ty)),
         throws_type: item
             .throws
             .as_ref()
-            .map(|ty| graph_type_ref(path, source, ty)),
+            .map(|ty| graph_type_ref(path, source, line_index, ty)),
         is_llm,
         client_name,
-        location: source_location(path, source, item.span),
+        location: source_location(path, source, line_index, item.span),
     }
 }
 
-fn graph_type_ref(path: &str, source: &str, ty: &TypeExpr) -> GraphTypeRef {
+/// Convert a recursive compiler type expression into a stable type reference.
+fn graph_type_ref(path: &str, source: &str, line_index: &LineIndex, ty: &TypeExpr) -> GraphTypeRef {
     let mut output = GraphTypeRef {
         kind: TypeRefKind::Unknown,
         display: ty.to_string(),
@@ -1011,8 +1043,8 @@ fn graph_type_ref(path: &str, source: &str, ty: &TypeExpr) -> GraphTypeRef {
         parameter_types: Vec::new(),
         return_type: None,
         throws_type: None,
-        attributes: graph_attributes(path, source, ty.kind.attrs()),
-        location: source_location(path, source, ty.span),
+        attributes: graph_attributes(path, source, line_index, ty.kind.attrs()),
+        location: source_location(path, source, line_index, ty.span),
     };
     match &ty.kind {
         TypeExprKind::Path {
@@ -1031,7 +1063,7 @@ fn graph_type_ref(path: &str, source: &str, ty: &TypeExpr) -> GraphTypeRef {
                         .iter()
                         .map(|binding| binding.ty.as_ref()),
                 )
-                .map(|ty| graph_type_ref(path, source, ty))
+                .map(|ty| graph_type_ref(path, source, line_index, ty))
                 .collect();
         }
         TypeExprKind::AssociatedTypeProjection {
@@ -1042,10 +1074,10 @@ fn graph_type_ref(path: &str, source: &str, ty: &TypeExpr) -> GraphTypeRef {
         } => {
             output.kind = TypeRefKind::AssociatedType;
             output.name = Some(member.to_string());
-            output.element_type = Some(Box::new(graph_type_ref(path, source, base)));
+            output.element_type = Some(Box::new(graph_type_ref(path, source, line_index, base)));
             output.member_types = interface
                 .iter()
-                .map(|ty| graph_type_ref(path, source, ty))
+                .map(|ty| graph_type_ref(path, source, line_index, ty))
                 .collect();
         }
         TypeExprKind::Int { .. } => output.kind = TypeRefKind::Int,
@@ -1063,22 +1095,22 @@ fn graph_type_ref(path: &str, source: &str, ty: &TypeExpr) -> GraphTypeRef {
         }
         TypeExprKind::Optional { inner, .. } => {
             output.kind = TypeRefKind::Optional;
-            output.element_type = Some(Box::new(graph_type_ref(path, source, inner)));
+            output.element_type = Some(Box::new(graph_type_ref(path, source, line_index, inner)));
         }
         TypeExprKind::List { inner, .. } => {
             output.kind = TypeRefKind::List;
-            output.element_type = Some(Box::new(graph_type_ref(path, source, inner)));
+            output.element_type = Some(Box::new(graph_type_ref(path, source, line_index, inner)));
         }
         TypeExprKind::Map { key, value, .. } => {
             output.kind = TypeRefKind::Map;
-            output.key_type = Some(Box::new(graph_type_ref(path, source, key)));
-            output.value_type = Some(Box::new(graph_type_ref(path, source, value)));
+            output.key_type = Some(Box::new(graph_type_ref(path, source, line_index, key)));
+            output.value_type = Some(Box::new(graph_type_ref(path, source, line_index, value)));
         }
         TypeExprKind::Union { variants, .. } => {
             output.kind = TypeRefKind::Union;
             output.member_types = variants
                 .iter()
-                .map(|ty| graph_type_ref(path, source, ty))
+                .map(|ty| graph_type_ref(path, source, line_index, ty))
                 .collect();
         }
         TypeExprKind::Literal { value, .. } => {
@@ -1094,12 +1126,12 @@ fn graph_type_ref(path: &str, source: &str, ty: &TypeExpr) -> GraphTypeRef {
             output.kind = TypeRefKind::Function;
             output.parameter_types = params
                 .iter()
-                .map(|param| graph_type_ref(path, source, &param.ty))
+                .map(|param| graph_type_ref(path, source, line_index, &param.ty))
                 .collect();
-            output.return_type = Some(Box::new(graph_type_ref(path, source, ret)));
+            output.return_type = Some(Box::new(graph_type_ref(path, source, line_index, ret)));
             output.throws_type = throws
                 .as_ref()
-                .map(|ty| Box::new(graph_type_ref(path, source, ty)));
+                .map(|ty| Box::new(graph_type_ref(path, source, line_index, ty)));
         }
         TypeExprKind::BuiltinUnknown { .. } | TypeExprKind::Unknown { .. } => {
             output.kind = TypeRefKind::Unknown;
@@ -1112,7 +1144,13 @@ fn graph_type_ref(path: &str, source: &str, ty: &TypeExpr) -> GraphTypeRef {
     output
 }
 
-fn graph_attributes(path: &str, source: &str, attributes: &[RawAttribute]) -> Vec<GraphAttribute> {
+/// Convert raw source attributes without exposing compiler AST structs.
+fn graph_attributes(
+    path: &str,
+    source: &str,
+    line_index: &LineIndex,
+    attributes: &[RawAttribute],
+) -> Vec<GraphAttribute> {
     attributes
         .iter()
         .map(|attribute| GraphAttribute {
@@ -1123,20 +1161,22 @@ fn graph_attributes(path: &str, source: &str, attributes: &[RawAttribute]) -> Ve
                 .map(|argument| GraphAttributeArgument {
                     key: argument.key.as_ref().map(ToString::to_string),
                     value: argument.value.clone(),
-                    location: source_location(path, source, argument.span),
+                    location: source_location(path, source, line_index, argument.span),
                 })
                 .collect(),
-            location: source_location(path, source, attribute.span),
+            location: source_location(path, source, line_index, attribute.span),
         })
         .collect()
 }
 
+/// Read the project name and generator declarations from the manifest.
 fn build_generators(source: Option<&str>) -> Result<(Option<String>, Vec<GraphGenerator>)> {
     let Some(source) = source else {
         return Ok((None, Vec::new()));
     };
     let manifest =
         crate::manifest::parse(source).context("failed to parse baml.toml for GraphQL")?;
+    let line_index = LineIndex::new(source);
     let project_name = manifest.package.and_then(|package| package.name);
     let generators = manifest
         .generator
@@ -1150,13 +1190,14 @@ fn build_generators(source: Option<&str>) -> Result<(Option<String>, Vec<GraphGe
                 output_dir: generator.output_dir,
                 naming_convention: generator.naming_convention.map(|value| value.into_inner()),
                 sdk_import_path: generator.sdk_import_path.map(|value| value.into_inner()),
-                location: source_location("baml.toml", source, range),
+                location: source_location("baml.toml", source, &line_index, range),
             }
         })
         .collect();
     Ok((project_name, generators))
 }
 
+/// Convert manifest byte ranges to compiler-compatible text ranges.
 fn text_range(range: std::ops::Range<usize>) -> TextRange {
     TextRange::new(
         u32::try_from(range.start).unwrap_or(u32::MAX).into(),
@@ -1164,6 +1205,7 @@ fn text_range(range: std::ops::Range<usize>) -> TextRange {
     )
 }
 
+/// Convert legacy declarative test values to deterministic JSON.
 fn test_arg_json(value: &TestArgValue) -> JsonValue {
     match value {
         TestArgValue::Null => JsonValue::Null,
@@ -1272,6 +1314,7 @@ impl GraphTest {
     }
 }
 
+/// Construct a searchable definition projection for a richer entity.
 fn definition_summary(
     kind: DefinitionKind,
     name: &str,
@@ -1290,6 +1333,7 @@ fn definition_summary(
     }
 }
 
+/// Join a namespace and local name using the public dotted convention.
 fn qualified_name(namespace: &[String], name: &str) -> String {
     if namespace.is_empty() {
         name.to_string()
@@ -1298,11 +1342,43 @@ fn qualified_name(namespace: &[String], name: &str) -> String {
     }
 }
 
-fn source_location(path: &str, source: &str, range: TextRange) -> SourceLocation {
+/// Reusable line starts for location lookups within one source file.
+struct LineIndex {
+    line_starts: Vec<usize>,
+}
+
+impl LineIndex {
+    /// Index the byte offset at which each source line begins.
+    fn new(source: &str) -> Self {
+        let mut line_starts = vec![0];
+        line_starts.extend(source.match_indices('\n').map(|(index, _)| index + 1));
+        Self { line_starts }
+    }
+
+    /// Resolve a byte offset to a 1-based Unicode-aware line and column.
+    fn line_column(&self, source: &str, offset: usize) -> (i32, i32) {
+        let offset = floor_char_boundary(source, offset.min(source.len()));
+        let line = self.line_starts.partition_point(|start| *start <= offset);
+        let line_start = self.line_starts[line.saturating_sub(1)];
+        let column = source[line_start..offset].chars().count() + 1;
+        (
+            i32::try_from(line).unwrap_or(i32::MAX),
+            i32::try_from(column).unwrap_or(i32::MAX),
+        )
+    }
+}
+
+/// Convert a byte range into a public source location.
+fn source_location(
+    path: &str,
+    source: &str,
+    line_index: &LineIndex,
+    range: TextRange,
+) -> SourceLocation {
     let start = usize::from(range.start()).min(source.len());
     let end = usize::from(range.end()).min(source.len());
-    let (start_line, start_column) = line_column(source, start);
-    let (end_line, end_column) = line_column(source, end);
+    let (start_line, start_column) = line_index.line_column(source, start);
+    let (end_line, end_column) = line_index.line_column(source, end);
     SourceLocation {
         path: path.to_string(),
         start_line,
@@ -1312,22 +1388,7 @@ fn source_location(path: &str, source: &str, range: TextRange) -> SourceLocation
     }
 }
 
-fn line_column(source: &str, offset: usize) -> (i32, i32) {
-    let offset = floor_char_boundary(source, offset.min(source.len()));
-    let before = &source[..offset];
-    let line = before.bytes().filter(|byte| *byte == b'\n').count() + 1;
-    let column = before
-        .rsplit_once('\n')
-        .map_or(before, |(_, line)| line)
-        .chars()
-        .count()
-        + 1;
-    (
-        i32::try_from(line).unwrap_or(i32::MAX),
-        i32::try_from(column).unwrap_or(i32::MAX),
-    )
-}
-
+/// Move an arbitrary byte offset back to a safe UTF-8 boundary.
 fn floor_char_boundary(source: &str, mut offset: usize) -> usize {
     while !source.is_char_boundary(offset) {
         offset = offset.saturating_sub(1);
@@ -1335,6 +1396,7 @@ fn floor_char_boundary(source: &str, mut offset: usize) -> usize {
     offset
 }
 
+/// Produce a slash-separated project-relative path across OS path forms.
 fn normalized_relative_path(path: &Path, root: &Path) -> String {
     if let Ok(relative) = path.strip_prefix(root) {
         return normalize_path(relative);
@@ -1355,6 +1417,7 @@ fn normalized_relative_path(path: &Path, root: &Path) -> String {
     }
 }
 
+/// Normalize separators and Windows verbatim prefixes for GraphQL output.
 fn normalize_path(path: &Path) -> String {
     let path = path.to_string_lossy().replace('\\', "/");
     if let Some(path) = path.strip_prefix("//?/UNC/") {
@@ -1364,6 +1427,7 @@ fn normalize_path(path: &Path) -> String {
     }
 }
 
+/// Convert a compiler diagnostic into the deterministic error extension shape.
 fn diagnostic_json(
     db: &ProjectDatabase,
     root: &Path,
@@ -1375,9 +1439,11 @@ fn diagnostic_json(
             .get_source_files()
             .into_iter()
             .find(|file| file.file_id(db) == span.file_id)?;
+        let line_index = LineIndex::new(file.text(db));
         Some(source_location(
             &normalized_relative_path(path, root),
             file.text(db),
+            &line_index,
             span.range,
         ))
     });
@@ -1389,6 +1455,7 @@ fn diagnostic_json(
     })
 }
 
+/// Serialize a source location using GraphQL-style camelCase field names.
 fn location_json(location: SourceLocation) -> JsonValue {
     json!({
         "path": location.path,
@@ -1399,6 +1466,7 @@ fn location_json(location: SourceLocation) -> JsonValue {
     })
 }
 
+/// Write one compact standard GraphQL response and choose its exit code.
 fn write_graphql_response(
     response: &GraphQLResponse<DefaultScalarValue>,
 ) -> Result<crate::ExitCode> {
@@ -1414,6 +1482,7 @@ fn write_graphql_response(
     })
 }
 
+/// Write a deterministic command or BAML validation error on stdout.
 fn write_error_response(
     code: &str,
     message: &str,
@@ -1444,9 +1513,11 @@ mod tests {
 
     #[test]
     fn line_columns_are_one_based_and_unicode_aware() {
-        assert_eq!(line_column("αβ\nvalue", 0), (1, 1));
-        assert_eq!(line_column("αβ\nvalue", "α".len()), (1, 2));
-        assert_eq!(line_column("αβ\nvalue", "αβ\n".len()), (2, 1));
+        let source = "αβ\nvalue";
+        let line_index = LineIndex::new(source);
+        assert_eq!(line_index.line_column(source, 0), (1, 1));
+        assert_eq!(line_index.line_column(source, "α".len()), (1, 2));
+        assert_eq!(line_index.line_column(source, "αβ\n".len()), (2, 1));
     }
 
     #[test]
@@ -1458,6 +1529,35 @@ mod tests {
         let unc_path = Path::new(r"\\?\UNC\server\share\project\main.baml");
         let unc_root = Path::new(r"\\server\share\project");
         assert_eq!(normalized_relative_path(unc_path, unc_root), "main.baml");
+    }
+
+    #[test]
+    fn variables_must_be_a_json_object() {
+        let args = GraphqlArgs {
+            variables: Some("[1]".to_string()),
+            ..GraphqlArgs::default()
+        };
+        let error = args
+            .parse_variables()
+            .expect_err("array variables must be rejected");
+        assert!(error.to_string().contains("JSON object"), "{error:#}");
+    }
+
+    #[test]
+    fn missing_query_file_reports_its_path() {
+        let temp = tempfile::tempdir().expect("create temp directory");
+        let path = temp.path().join("missing.graphql");
+        let args = GraphqlArgs {
+            query_file: Some(path.clone()),
+            ..GraphqlArgs::default()
+        };
+        let error = args
+            .read_query()
+            .expect_err("missing query file must be rejected");
+        assert!(
+            format!("{error:#}").contains(&path.display().to_string()),
+            "{error:#}"
+        );
     }
 
     #[test]

--- a/baml_language/crates/baml_cli/src/graphql_command.rs
+++ b/baml_language/crates/baml_cli/src/graphql_command.rs
@@ -130,6 +130,12 @@ impl GraphqlArgs {
         };
         session.warm_prep_seeds_only();
         session.prime();
+        let project_root = session
+            .db
+            .get_project()
+            .context("loaded BAML project has no database root")?
+            .root(&session.db)
+            .clone();
 
         let diagnostics = baml_project::collect_diagnostics(&session.db);
         let user_file_ids = session
@@ -150,7 +156,7 @@ impl GraphqlArgs {
         if !errors.is_empty() {
             let structured = errors
                 .into_iter()
-                .map(|diagnostic| diagnostic_json(&session.db, session.root(), diagnostic))
+                .map(|diagnostic| diagnostic_json(&session.db, &project_root, diagnostic))
                 .collect::<Vec<_>>();
             write_error_response(
                 "BAML_VALIDATION_FAILED",
@@ -166,7 +172,7 @@ impl GraphqlArgs {
 
         let snapshot = build_snapshot(
             &session.db,
-            session.root(),
+            &project_root,
             session.resolved.manifest.as_deref(),
         )?;
         let context = GraphqlContext { snapshot };
@@ -1330,11 +1336,32 @@ fn floor_char_boundary(source: &str, mut offset: usize) -> usize {
 }
 
 fn normalized_relative_path(path: &Path, root: &Path) -> String {
-    normalize_path(path.strip_prefix(root).unwrap_or(path))
+    if let Ok(relative) = path.strip_prefix(root) {
+        return normalize_path(relative);
+    }
+
+    let path = normalize_path(path);
+    let root = normalize_path(root);
+    let root = root.trim_end_matches('/');
+    let Some(prefix) = path.get(..root.len()) else {
+        return path;
+    };
+    let windows_path = root.as_bytes().get(1) == Some(&b':') || root.starts_with("//");
+    let same_root = prefix == root || (windows_path && prefix.eq_ignore_ascii_case(root));
+    if same_root && path.as_bytes().get(root.len()) == Some(&b'/') {
+        path[root.len() + 1..].to_string()
+    } else {
+        path
+    }
 }
 
 fn normalize_path(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
+    let path = path.to_string_lossy().replace('\\', "/");
+    if let Some(path) = path.strip_prefix("//?/UNC/") {
+        format!("//{path}")
+    } else {
+        path.strip_prefix("//?/").unwrap_or(&path).to_string()
+    }
 }
 
 fn diagnostic_json(
@@ -1420,6 +1447,17 @@ mod tests {
         assert_eq!(line_column("αβ\nvalue", 0), (1, 1));
         assert_eq!(line_column("αβ\nvalue", "α".len()), (1, 2));
         assert_eq!(line_column("αβ\nvalue", "αβ\n".len()), (2, 1));
+    }
+
+    #[test]
+    fn windows_verbatim_paths_are_project_relative() {
+        let path = Path::new(r"\\?\C:\work\project\baml_src\main.baml");
+        let root = Path::new(r"C:\work\project");
+        assert_eq!(normalized_relative_path(path, root), "baml_src/main.baml");
+
+        let unc_path = Path::new(r"\\?\UNC\server\share\project\main.baml");
+        let unc_root = Path::new(r"\\server\share\project");
+        assert_eq!(normalized_relative_path(unc_path, unc_root), "main.baml");
     }
 
     #[test]

--- a/baml_language/crates/baml_cli/src/lib.rs
+++ b/baml_language/crates/baml_cli/src/lib.rs
@@ -28,6 +28,7 @@ pub(crate) mod feedback_command;
 pub(crate) mod file_signature;
 pub(crate) mod format;
 pub(crate) mod generate;
+pub(crate) mod graphql_command;
 pub(crate) mod help_command;
 pub(crate) mod ide_command;
 pub(crate) mod init_command;

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__root_concise_help.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__root_concise_help.snap
@@ -14,6 +14,7 @@ Commands:
   fmt         Format BAML source files
   describe    Describe a BAML symbol
   generate    Generate client code from BAML definitions
+  graphql     Query the BAML project AST with GraphQL
   test        Run BAML tests
   init        Initialize a new BAML project (creates baml.toml)
   new         Create a new BAML project directory

--- a/baml_language/crates/baml_cli/tests/graphql_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/graphql_e2e.rs
@@ -105,7 +105,7 @@ fn realistic_query_supports_fragments_variables_traversal_and_locations() {
   generators { name outputType outputDir }
   tests { name qualifiedName functions arguments { name valueJson } }
 }
-fragment ClassDetails on GraphClass {
+fragment ClassDetails on Class {
   name
   qualifiedName
   documentation
@@ -238,7 +238,7 @@ fn stdin_queries_and_introspection_work_without_a_server() {
     assert!(schema.status.success());
     let schema = String::from_utf8(schema.stdout).unwrap();
     assert!(schema.contains("type QueryRoot"), "{schema}");
-    assert!(schema.contains("type GraphTypeRef"), "{schema}");
+    assert!(schema.contains("type TypeRef"), "{schema}");
 }
 
 #[test]

--- a/baml_language/crates/baml_cli/tests/graphql_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/graphql_e2e.rs
@@ -1,0 +1,287 @@
+use std::{
+    io::Write as _,
+    path::Path,
+    process::{Command, Output, Stdio},
+};
+
+fn create_project(root: &Path, source: &str) {
+    std::fs::create_dir_all(root.join("baml_src/ns_api")).unwrap();
+    std::fs::write(
+        root.join("baml.toml"),
+        "[package]\nname = \"graphql-fixture\"\n\n[generator.typescript]\noutput_type = \"typescript\"\nnaming_convention = \"preserve-case\"\noutput_dir = \"../generated\"\n",
+    )
+    .unwrap();
+    std::fs::write(root.join("baml_src/main.baml"), source).unwrap();
+    std::fs::write(
+        root.join("baml_src/ns_api/main.baml"),
+        r#"/// Looks up one person.
+function Lookup(id: string, tags: string[]) -> string {
+  id
+}
+
+client Demo = openai.OpenAiClient.new(model = "gpt-4o-mini");
+
+test LookupCase {
+  functions [Lookup]
+  args {
+    id "person-1"
+    tags ["one", "two"]
+  }
+}
+"#,
+    )
+    .unwrap();
+}
+
+fn valid_source() -> &'static str {
+    r#"/// A person record.
+class Person {
+  /// Name shown to users.
+  name string @alias("full_name")
+  tags string[]
+}
+
+enum Status {
+  Active
+  Done
+}
+
+type PersonId = string
+"#
+}
+
+fn run(root: &Path, args: &[&str], stdin: Option<&str>) -> Output {
+    let home = root.join(".baml-home");
+    std::fs::create_dir_all(&home).unwrap();
+    std::fs::write(home.join("config.toml"), "[update]\nauto_check = false\n").unwrap();
+    let mut command = Command::new(env!("CARGO_BIN_EXE_baml-cli"));
+    command
+        .args(args)
+        .current_dir(root)
+        .env("BAML_CLI_ALLOW_DIRECT", "1")
+        .env("BAML_HOME", home)
+        .env("BAML_OUTPUT_PRESET", "human")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if stdin.is_some() {
+        command.stdin(Stdio::piped());
+    }
+    let mut child = command.spawn().unwrap();
+    if let Some(stdin) = stdin {
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(stdin.as_bytes())
+            .unwrap();
+    }
+    child.wait_with_output().unwrap()
+}
+
+fn json_stdout(output: &Output) -> serde_json::Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "stdout is not JSON: {error}\nstdout: {}\nstderr: {}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        )
+    })
+}
+
+#[test]
+fn realistic_query_supports_fragments_variables_traversal_and_locations() {
+    let project = tempfile::tempdir().unwrap();
+    create_project(project.path(), valid_source());
+    let query = r#"query Find($name: String!) {
+  classes(name: $name) {
+    ...ClassDetails
+  }
+  functions(name: "Lookup") {
+    qualifiedName
+    parameters { name type { kind display elementType { kind display } } }
+    returnType { kind display }
+  }
+  clients { name qualifiedName }
+  generators { name outputType outputDir }
+  tests { name qualifiedName functions arguments { name valueJson } }
+}
+fragment ClassDetails on GraphClass {
+  name
+  qualifiedName
+  documentation
+  fields {
+    name
+    documentation
+    attributes { name arguments { value } }
+    type { kind display elementType { kind display } }
+    location { path startLine startColumn endLine endColumn }
+  }
+  location { path startLine startColumn endLine endColumn }
+}"#;
+    let args = [
+        "graphql",
+        "--query",
+        query,
+        "--variables",
+        r#"{"name":"Person"}"#,
+    ];
+    let first = run(project.path(), &args, None);
+    let second = run(project.path(), &args, None);
+    assert!(
+        first.status.success(),
+        "{}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    assert_eq!(
+        first.stdout, second.stdout,
+        "GraphQL JSON must be byte-stable"
+    );
+    assert!(
+        first.stderr.is_empty(),
+        "{}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+
+    let response = json_stdout(&first);
+    assert_eq!(response["data"]["classes"][0]["name"], "Person");
+    assert_eq!(
+        response["data"]["classes"][0]["documentation"],
+        "A person record."
+    );
+    assert_eq!(
+        response["data"]["classes"][0]["fields"][0]["attributes"][0]["name"],
+        "alias"
+    );
+    assert_eq!(
+        response["data"]["classes"][0]["fields"][0]["location"]["path"],
+        "baml_src/main.baml"
+    );
+    assert_eq!(
+        response["data"]["classes"][0]["fields"][0]["location"]["startLine"],
+        4
+    );
+    assert_eq!(
+        response["data"]["functions"][0]["qualifiedName"],
+        "api.Lookup"
+    );
+    assert_eq!(
+        response["data"]["functions"][0]["parameters"][1]["type"]["kind"],
+        "LIST"
+    );
+    assert_eq!(
+        response["data"]["functions"][0]["parameters"][1]["type"]["elementType"]["kind"],
+        "STRING"
+    );
+    assert_eq!(response["data"]["clients"][0]["qualifiedName"], "api.Demo");
+    assert_eq!(response["data"]["generators"][0]["name"], "typescript");
+    assert_eq!(
+        response["data"]["tests"][0]["qualifiedName"],
+        "api.LookupCase"
+    );
+}
+
+#[test]
+fn query_file_operation_selection_and_empty_results_are_standard_json() {
+    let project = tempfile::tempdir().unwrap();
+    create_project(project.path(), valid_source());
+    let document = project.path().join("query.graphql");
+    std::fs::write(
+        &document,
+        "query Ignored { classes(name: \"Missing\") { name } }\nquery Selected($name: String!) { classes(name: $name) { name } }\n",
+    )
+    .unwrap();
+    let output = run(
+        project.path(),
+        &[
+            "graphql",
+            "--query-file",
+            document.to_str().unwrap(),
+            "--operation",
+            "Selected",
+            "--variables",
+            r#"{"name":"Missing"}"#,
+        ],
+        None,
+    );
+    assert!(output.status.success());
+    assert_eq!(
+        String::from_utf8(output.stdout).unwrap(),
+        "{\"data\":{\"classes\":[]}}\n"
+    );
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
+fn stdin_queries_and_introspection_work_without_a_server() {
+    let project = tempfile::tempdir().unwrap();
+    create_project(project.path(), valid_source());
+    let stdin_output = run(
+        project.path(),
+        &["graphql"],
+        Some("{ definitions(kind: [CLASS, ENUM]) { kind name } }"),
+    );
+    assert!(stdin_output.status.success());
+    let stdin_json = json_stdout(&stdin_output);
+    assert_eq!(
+        stdin_json["data"]["definitions"].as_array().unwrap().len(),
+        2
+    );
+
+    let introspection = run(project.path(), &["graphql", "--introspect"], None);
+    assert!(introspection.status.success());
+    assert_eq!(
+        json_stdout(&introspection)["data"]["__schema"]["queryType"]["name"],
+        "QueryRoot"
+    );
+
+    let schema = run(project.path(), &["graphql", "--schema"], None);
+    assert!(schema.status.success());
+    let schema = String::from_utf8(schema.stdout).unwrap();
+    assert!(schema.contains("type QueryRoot"), "{schema}");
+    assert!(schema.contains("type GraphTypeRef"), "{schema}");
+}
+
+#[test]
+fn invalid_graphql_is_deterministic_standard_error_json() {
+    let project = tempfile::tempdir().unwrap();
+    create_project(project.path(), valid_source());
+    let args = ["graphql", "--query", "{ classes { notAField } }"];
+    let first = run(project.path(), &args, None);
+    let second = run(project.path(), &args, None);
+    assert!(!first.status.success());
+    assert_eq!(first.stdout, second.stdout);
+    assert!(first.stderr.is_empty());
+    let response = json_stdout(&first);
+    assert!(response.get("data").is_none());
+    assert!(
+        response["errors"][0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("notAField")
+    );
+}
+
+#[test]
+fn invalid_baml_is_structured_and_deterministic() {
+    let project = tempfile::tempdir().unwrap();
+    create_project(project.path(), "class Broken {\n  value MissingType\n}\n");
+    let args = ["graphql", "--query", "{ classes { name } }"];
+    let first = run(project.path(), &args, None);
+    let second = run(project.path(), &args, None);
+    assert!(!first.status.success());
+    assert_eq!(first.stdout, second.stdout);
+    assert!(first.stderr.is_empty());
+    let response = json_stdout(&first);
+    assert_eq!(
+        response["errors"][0]["extensions"]["code"],
+        "BAML_VALIDATION_FAILED"
+    );
+    assert_eq!(
+        response["errors"][0]["extensions"]["diagnostics"][0]["location"]["path"],
+        "baml_src/main.baml"
+    );
+    assert_eq!(
+        response["errors"][0]["extensions"]["diagnostics"][0]["location"]["startLine"],
+        1
+    );
+}

--- a/baml_language/crates/baml_db/Cargo.toml
+++ b/baml_language/crates/baml_db/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 
 [dependencies]
 baml_base = { workspace = true }
+baml_compiler2_ast = { workspace = true }
 baml_compiler2_emit = { workspace = true }
 baml_compiler2_hir = { workspace = true }
 baml_compiler2_hir_ty = { workspace = true }
@@ -29,4 +30,3 @@ baml_compiler_parser = { workspace = true }
 baml_compiler_syntax = { workspace = true }
 baml_workspace = { workspace = true }
 salsa = { workspace = true }
-

--- a/baml_language/crates/baml_db/src/lib.rs
+++ b/baml_language/crates/baml_db/src/lib.rs
@@ -15,6 +15,7 @@ pub use baml_compiler_diagnostics;
 pub use baml_compiler_lexer;
 pub use baml_compiler_parser;
 pub use baml_compiler_syntax;
+pub use baml_compiler2_ast;
 pub use baml_compiler2_emit;
 pub use baml_compiler2_hir;
 pub use baml_compiler2_hir_ty;


### PR DESCRIPTION
## What changed

- adds an experimental `baml graphql` one-shot command with query flag, query file, stdin, variables, named operations, SDL output, and introspection
- builds a stable GraphQL-facing source snapshot for packages, files, classes, fields, enums, values, aliases, functions, parameters, clients, manifest generators, tests, type references, documentation, attributes, and locations
- emits standard GraphQL JSON on stdout, including deterministic structured BAML validation errors, and performs no network, telemetry, LLM, or server work
- documents the public command and schema contract with copy-paste examples
- adds focused unit and CLI end-to-end coverage for realistic traversal, fragments, variables, query files, operation selection, stdin, empty results, source locations, stable JSON, invalid GraphQL, invalid BAML, SDL, and introspection

## Interface and schema tradeoffs

This is deliberately a one-shot read-only command instead of a server. It reuses the CLI global `--project` and `--directory` discovery contract, accepts exactly one document source, and keeps stdout machine-readable. Exact name, kind, and path filters cover practical lookup without introducing a text index.

The GraphQL schema owns an immutable snapshot rather than deriving serialization from Salsa/compiler structs. Public types use contract names such as `Project`, `Class`, and `TypeRef`, so compiler and Rust implementation names are not exposed. Compiler-generated and builtin source items are excluded. Legacy declarative tests are exposed where the current compiler AST preserves them; expression-style test bodies remain outside the MVP. Manifest generators are included because generator declarations moved from BAML source into `baml.toml`.

Juniper 0.17.1 is added with only the `schema-language` feature. It provides synchronous execution, fragments, variables, standard response serialization, introspection, and deterministically sorted SDL without adding an async server stack. The repository size gate passes on all seven artifacts; `baml-cli` is 21.1 MB on macOS and 201.4 KB smaller than the local comparison baseline (-0.9%), while CI reports -0.8% to -0.9% across Linux, macOS, and Windows.

## Checks

- `cargo fmt --all -- --check`
- `scripts/validate_markdown.py`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo run -p cargo-stow -- stow --check`
- `cargo test -p baml_cli --all-features`
- `cargo run -p cargo-size-gate -- size-gate check --only baml-cli`

All CI and CodeRabbit checks pass; this remains a draft for Sam's review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the experimental `baml graphql` command for running one-shot GraphQL queries against validated BAML projects.
  * Supports inline, file, and standard-input queries, variables, named operations, schema output, and introspection JSON.
  * Provides structured, deterministic results and validation errors.

* **Documentation**
  * Added CLI usage guidance, supported schema entities, output behavior, and examples.

* **Tests**
  * Added end-to-end coverage for queries, fragments, variables, introspection, schemas, stdin input, and stable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
