### PR TITLE
docs: add stacked PR landing and rollout guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,3 +35,5 @@ there before submitting, and format with:
 ```bash
 cargo fmt -- --config imports_granularity="Crate" --config group_imports="StdExternalCrate"
 ```
+
+Maintainers preparing dependent changes can use the experimental [stacked pull request workflow](./docs/stacked-prs.md).

--- a/docs/stacked-prs.md
+++ b/docs/stacked-prs.md
@@ -119,3 +119,51 @@ mise run pr-unresolved
 ```
 
 GitHub Actions exposes stack metadata as `github.event.pull_request.stack`. If duplicated heavyweight CI becomes expensive, use that metadata for a deliberate optimization rather than excluding child bases from validation.
+
+## Land a stack safely
+
+Before merging, confirm the stack is linear and every pull request through the intended stopping point is approved, open rather than draft, and passing its required checks.
+
+Use the interactive merge command and select the highest layer you want to land:
+
+```bash
+gh stack merge --squash
+```
+
+GitHub merges the selected pull request and every unmerged layer below it as one all-or-nothing operation ordered from bottom to top. Because `canary` uses a merge queue, the complete contiguous group is enqueued in order. A failure prevents the group from partially merging, and an ejected pull request also removes every layer above it from the queue.
+
+After the merge completes, synchronize and prune merged local branches:
+
+```bash
+gh stack sync --prune
+```
+
+`gh stack sync --prune` fetches and fast-forwards `canary`, rebases any remaining layers, pushes their updated branches, synchronizes pull request state, and removes local branches for merged layers.
+
+If a layer is closed without merging, stop and use `gh stack modify` or the GitHub Unstack action to make the intended dependency change explicit. Do not leave a silently retargeted chain in review.
+
+## Using `jj` or existing branches
+
+This checkout is a regular Git worktree. In a colocated `jj` repository, keep branch and commit management in `jj` and use the stateless link command to create or adopt the GitHub stack:
+
+```bash
+gh stack link --base canary sam/parser-cleanup-01 sam/parser-cleanup-02 sam/parser-cleanup-03
+```
+
+Arguments are ordered bottom to top. Branch arguments are pushed automatically and pull requests are created when missing, so inspect the bookmarks and commits before running the command. Existing pull requests can be linked without recreating them by passing their numbers or URLs.
+
+## Options considered
+
+| Option | Fit for BAML | Decision |
+| --- | --- | --- |
+| GitHub `gh stack` | First-party stack objects and review UI; no enablement; existing protections and Actions apply to every layer; native merge-queue and atomic stack merge support; external-tool link mode supports `jj`. Public preview and same-repository linear stacks only. | Use for the pilot. |
+| `git-spice` | Mature local branch manipulation and multi-forge support, but needs separate stack metadata and a manual or custom integration with BAML's squash-only GitHub merge queue. | Remove from the repo-local experiment now that GitHub provides the required native path. |
+| Graphite | Mature author and reviewer experience, but requires accounts, a GitHub App, and external configuration. | Unnecessary for the smallest first-party pilot. |
+| Aviator Stacked PRs | Stack-aware CLI and hosted merge queue, but introduces another service and queue. | Unnecessary while GitHub's native queue supports stacks. |
+| Plain Git plus `gh pr` | No added extension, but lacks native local topology operations and makes safe cascade rebases manual. | Keep only as a fallback. |
+
+## Pilot success criteria and next steps
+
+Try one non-urgent two- or three-layer maintainer stack. Record whether the public-preview CLI remains predictable, reviews stay focused after cascade rebases, every expected CI workflow runs per layer, and the existing merge queue lands the selected contiguous group atomically.
+
+If CI duplication is material, inspect the new stack event metadata and add a narrowly scoped optimization with contract tests. If the CLI or API changes during public preview, update this guide and the pilot before broad rollout.


### PR DESCRIPTION
## Summary

- document atomic stack landing through BAML's existing GitHub merge queue
- add post-merge synchronization and pruning guidance
- cover stateless `gh stack link` usage for `jj` and existing branches
- record evaluated alternatives, pilot success criteria, and next steps
- link the experimental guide from `CONTRIBUTING.md`

## Stack position

This is layer 3 of 3 and depends on #4438 and #4437.

## Validation

- rebased the complete local stack against `origin/canary`
- verified all three isolated commit diffs with `git diff --check`
- confirmed GitHub stack #4440 reports the intended bases and three open draft PRs

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>