### PR TITLE
B-1545: temporarily disable macOS SDK tests

### DIFF
--- a/.github/workflows/cargo-tests.reusable.yaml
+++ b/.github/workflows/cargo-tests.reusable.yaml
@@ -495,6 +495,7 @@ jobs:
     outputs:
       matrix: ${{ steps.matrix.outputs.matrix }}
       sdk-dirs: ${{ steps.matrix.outputs.sdk-dirs }}
+      temporarily-disabled-sdk-dirs: ${{ steps.matrix.outputs.temporarily-disabled-sdk-dirs }}
     steps:
       - name: "Build matrix"
         id: matrix
@@ -780,15 +781,21 @@ jobs:
               },
             ];
 
+            // TODO(B-1545): Re-enable macOS SDK tests after the SIGABRT flakiness is fixed: https://linear.app/boundaryml2/issue/B-1545/investigate-flakiness-in-cargo-test-aarch64-apple-darwin-ci-job
+            const enabledMatrix = baseMatrix.filter((entry) => entry["os-label"] !== "macos");
             const matrix = context.eventName === "merge_group"
-              ? baseMatrix.filter((entry) => entry["os-label"] === "linux")
-              : baseMatrix;
+              ? enabledMatrix.filter((entry) => entry["os-label"] === "linux")
+              : enabledMatrix;
+            const enabledSdkDirs = new Set(enabledMatrix.map((entry) => entry["sdk-dir"]));
+            const temporarilyDisabledSdkDirs = [...new Set(
+              baseMatrix
+                .map((entry) => entry["sdk-dir"])
+                .filter((sdkDir) => !enabledSdkDirs.has(sdkDir)),
+            )].sort();
 
             core.setOutput("matrix", JSON.stringify(matrix, null, 2));
-            core.setOutput(
-              "sdk-dirs",
-              JSON.stringify([...new Set(baseMatrix.map((entry) => entry["sdk-dir"]))].sort()),
-            );
+            core.setOutput("sdk-dirs", JSON.stringify([...enabledSdkDirs].sort()));
+            core.setOutput("temporarily-disabled-sdk-dirs", JSON.stringify(temporarilyDisabledSdkDirs));
 
   sdk-test-coverage:
     name: "sdk test coverage"
@@ -803,6 +810,7 @@ jobs:
         uses: actions/github-script@v8
         env:
           MATRIX_SDK_DIRS: ${{ needs.sdk-test-matrix.outputs.sdk-dirs }}
+          TEMPORARILY_DISABLED_SDK_DIRS: ${{ needs.sdk-test-matrix.outputs.temporarily-disabled-sdk-dirs }}
         with:
           script: |
             const fs = require("fs");
@@ -815,13 +823,23 @@ jobs:
               .filter((sdkDir) => sdkDir !== "agent-docs")
               .sort();
             const coveredSdkDirs = new Set(JSON.parse(process.env.MATRIX_SDK_DIRS));
-            const missingSdkDirs = sdkDirs.filter((sdkDir) => !coveredSdkDirs.has(sdkDir));
+            const temporarilyDisabledSdkDirs = new Set(JSON.parse(process.env.TEMPORARILY_DISABLED_SDK_DIRS));
+            const missingSdkDirs = sdkDirs.filter(
+              (sdkDir) => !coveredSdkDirs.has(sdkDir) && !temporarilyDisabledSdkDirs.has(sdkDir),
+            );
 
             await core.summary
               .addHeading("SDK test matrix coverage")
               .addTable([
                 [{ data: "SDK directory", header: true }, { data: "Matrix entry", header: true }],
-                ...sdkDirs.map((sdkDir) => [sdkDir, coveredSdkDirs.has(sdkDir) ? "yes" : "no"]),
+                ...sdkDirs.map((sdkDir) => [
+                  sdkDir,
+                  coveredSdkDirs.has(sdkDir)
+                    ? "yes"
+                    : temporarilyDisabledSdkDirs.has(sdkDir)
+                      ? "temporarily disabled (B-1545)"
+                      : "no",
+                ]),
               ])
               .write();
 


### PR DESCRIPTION
## Summary

- Temporarily filter every macOS SDK-test matrix lane while preserving the full matrix configuration for a one-line restore.
- Keep Linux and Windows SDK-test lanes unchanged.
- Make the SDK coverage guard report Swift as temporarily disabled instead of claiming active coverage or failing.
- Leave the separate `cargo-test-macos` mitigation and all non-SDK macOS jobs unchanged.

## Why

The macOS SDK tests are currently affected by the same SIGABRT flakiness tracked in [B-1545](https://linear.app/boundaryml2/issue/B-1545/investigate-flakiness-in-cargo-test-aarch64-apple-darwin-ci-job). This is a temporary mitigation to unblock CI until the underlying macOS failure is resolved.

## Validation

- `actionlint .github/workflows/cargo-tests.reusable.yaml`
- Embedded JavaScript syntax and execution for pull-request and merge-group contexts
- Coverage guard execution against the repository's SDK directories
- Baseline/current matrix comparison: exactly nine macOS SDK-test jobs removed; no retained entries added or changed
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated SDK test matrix reporting to identify temporarily disabled SDK directories.
  * Excluded macOS entries and temporarily disabled SDKs from enabled test and coverage checks.
  * Limited merge-queue test runs to enabled Linux entries.
  * Added clearer reporting for SDKs temporarily disabled under B-1545.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->