### PR TITLE
fix(csharp): align release verifier with generated surface

### DIFF
--- a/baml_language/sdk_tests/crates/csharp/phase12_resources/Program.cs
+++ b/baml_language/sdk_tests/crates/csharp/phase12_resources/Program.cs
@@ -400,55 +400,21 @@ finally
 
 using Baml.Csv.CsvReader csvReader = Baml.Csv.Functions.Reader(
     "name,count\nalpha,7\n");
-Require(ReferenceEquals(csvReader, csvReader.Iter()), "CsvReader.Iter did not preserve iterator identity");
 IReadOnlyList<string>? headers = await csvReader.HeadersAsync();
 Require(
     headers is not null && headers.SequenceEqual(new[] { "name", "count" }),
     "native CsvReader.headers changed");
 
 using Baml.Csv.CsvRows<CsvRow> csvRows = csvReader.Rows<CsvRow>();
+// Interface-implementation methods such as iter and next are not emitted on generated C# resource classes.
 Require(
     csvRows.Reader.Headers()!.SequenceEqual(new[] { "name", "count" }),
     "CsvRows<CsvRow>.Reader did not preserve the public resource field");
-Baml.BamlUnion<Baml.Iter.Done, CsvRow> typedNext = await csvRows.NextAsync();
-Require(
-    typedNext.IsT1
-        && typedNext.AsT1.Name == "alpha"
-        && typedNext.AsT1.Count == 7,
-    "CsvRows<CsvRow>.Next did not decode the generic row");
-Require(csvRows.Next().IsT0, "CsvRows<CsvRow> did not reach Done");
-Require(
-    ReferenceEquals(csvRows, csvRows.Iter())
-        && csvRows.Iter().Reader.Headers()!.SequenceEqual(new[] { "name", "count" }),
-    "CsvRows<CsvRow>.Iter lost the closed generic resource carrier");
 Require(
     csvReader.Skipped().Count == 0
         && await csvReader.SkippedCountAsync() == 0
-        && csvReader.Position().Record == 1,
+        && csvReader.Position().Record == 0,
     "CsvReader skipped/position state methods changed");
-
-using Baml.Csv.CsvReader recordReader = Baml.Csv.Functions.Reader(
-    "name,count\nalpha,7\n");
-_ = recordReader.Headers();
-Baml.BamlUnion<Baml.Csv.CsvRecord, Baml.Iter.Done> rawNext = recordReader.Next();
-Require(rawNext.IsT0, "CsvReader.Next did not return a CsvRecord");
-using Baml.Csv.CsvRecord record = rawNext.AsT0;
-Require(
-    record.Length() == 2
-        && record.Fields().SequenceEqual(new[] { "alpha", "7" })
-        && record.Position().Record == 0,
-    "CsvRecord snapshot methods changed");
-Require(
-    !record.Get<string>("name").IsNull
-        && record.Get<string>("name").Value == "alpha"
-        && record.GetAt<long>(1).Value == 7,
-    "CsvRecord generic cell access changed");
-CsvRow decodedRecord = record.Decode<CsvRow>();
-Require(
-    decodedRecord.Name == "alpha"
-        && decodedRecord.Count == 7
-        && record.ToMap()["count"] == "7",
-    "CsvRecord generic decode or map projection changed");
 
 using Baml.Csv.CsvWriter writer = Baml.Csv.Functions.Buffer();
 _ = writer.WriteRow(new CsvRow { Name = "alpha", Count = 7 });
@@ -488,7 +454,6 @@ using Boundary.LocalId capturedId = localId.Capture(inputs: true, output: false,
 Require(!capturedId.IsClosed, "boundary.LocalId.capture returned a closed resource");
 
 _ = csvReader.Close();
-_ = recordReader.Close();
 
 clonedGlob.Dispose();
 ObjectDisposedException disposedClone = Expect<ObjectDisposedException>(() => clonedGlob.Clone());


### PR DESCRIPTION
## Summary

- Fixes the deterministic C# verification failure in the baml_language 0.17.0 production release run: https://github.com/BoundaryML/baml/actions/runs/31857280879
- Aligns the phase-12 package consumer with the generated C# surface established by #4366, which intentionally omits methods inherited through BAML interface implementations.
- Keeps runtime coverage for the C# CSV methods and resource fields that are generated.

## Root cause

The phase-12 fixture is normally ignored because of B-1059, but the production full-surface package verifier compiles and runs it. Its stale calls to CsvReader.Iter/Next and CsvRows.Iter/Next no longer compile after #4366 removed interface-implementation methods from generated class method collections.

## Validation

- cargo nextest run -p sdk_test_csharp --all-features --run-ignored only -E test(test_phase12_executes_native_typed_resource_apis_lifetimes_and_state)
- dotnet build sdk_tests/crates/csharp/phase12_resources/Phase12Resources.csproj --configuration Release --no-restore
- git diff --check

## Release follow-up

After this merges and post-merge canary CI succeeds, 0.17.0 must be dispatched from the new immutable baml-language source tag. This PR does not publish or dispatch the release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated C# CSV resource validation to verify headers, reader availability, and the initial reading position.
  * Simplified resource cleanup validation to ensure the active CSV reader is properly closed.
  * Removed checks for iterator identity, typed row decoding, and raw record access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->