### PR TITLE
fix(windows): harden path and URI handling (batch 2)

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -705,6 +705,7 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "toml_edit 0.22.27",
+ "url",
  "uuid",
  "webbrowser",
 ]

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -281,6 +281,7 @@ tracing-subscriber = { version = "0.3.18", default-features = false, features = 
 ] }
 unicode-normalization = "0.1.25"
 ureq = { version = "3", default-features = false, features = [ "rustls", "gzip" ] }
+url = "2.5.2"
 uuid = { version = "1", features = [ "serde", "v4" ] }
 walkdir = { version = "2.4" }
 tsify = { version = "0.5", features = [ "js" ] }

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_glob/glob.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_glob/glob.baml
@@ -15,6 +15,9 @@ class ScanOptions {
 }
 
 /// A compiled glob pattern. Create one with `baml.glob.new(pattern)`.
+/// Patterns and paths use `/` separators on every platform, including
+/// Windows drive paths (`C:/work/**`) and UNC paths (`//server/share/**`).
+/// Backslash is the glob escape character, not a native path separator.
 class Glob {
     _handle: $rust_type,
 
@@ -25,12 +28,14 @@ class Glob {
     }
 
     /// Returns `true` if `path` matches this glob pattern.
+    /// `path` must use the portable `/`-separated form described above.
     function matches(self, path: string) -> bool throws root.errors.Io {
         $rust_io_function
     }
 }
 
-/// Compiles a glob `pattern` and returns a `Glob` object for scanning or matching.
+/// Compiles a portable, `/`-separated glob `pattern` and returns a `Glob` object.
+/// `Glob.scan` accepts a native `cwd` but matches walker entries in portable form.
 function new(pattern: string) -> Glob throws root.errors.Io {
     $rust_io_function
 }

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -69,6 +69,7 @@ text-size = { workspace = true }
 tokio = { workspace = true }
 toml = { workspace = true }
 toml_edit = { workspace = true }
+url = { workspace = true }
 uuid = { workspace = true }
 webbrowser = { workspace = true }
 

--- a/baml_language/crates/baml_cli/src/paint.rs
+++ b/baml_language/crates/baml_cli/src/paint.rs
@@ -27,6 +27,7 @@ use baml_ide::{
 };
 use console::Style;
 use text_size::{TextRange, TextSize};
+use url::Url;
 
 fn style_for(token_type: SemanticTokenType, modifiers: ModifierSet) -> Style {
     let spec = semantic_highlight_style(token_type, modifiers);
@@ -310,20 +311,12 @@ fn osc8(uri: &str, text: &str) -> String {
     format!("\x1b]8;;{uri}\x1b\\{text}\x1b]8;;\x1b\\")
 }
 
-/// Minimal `file://` URI builder. Percent-encodes the few characters most likely
-/// to break a URI in a source path; not a full RFC 3986 encoder.
-fn file_uri(path: &Path) -> String {
-    let mut s = String::from("file://");
-    for ch in path.to_string_lossy().chars() {
-        match ch {
-            ' ' => s.push_str("%20"),
-            '%' => s.push_str("%25"),
-            '#' => s.push_str("%23"),
-            '?' => s.push_str("%3F"),
-            _ => s.push(ch),
-        }
-    }
-    s
+/// Convert an absolute native path into a standards-compliant file URI.
+///
+/// Conversion can fail for paths the URL model cannot represent (for example,
+/// non-UTF-8 paths on Unix), in which case callers should render plain text.
+fn file_uri(path: &Path) -> Option<String> {
+    Url::from_file_path(path).ok().map(Url::into)
 }
 
 // ── Painter ─────────────────────────────────────────────────────────────────────
@@ -427,7 +420,7 @@ impl Painter {
     pub fn location(&self, abs_path: &Path, display: &str, line_label: &str) -> String {
         let text = format!("{display}:{line_label}");
         if self.hyperlinks && abs_path.is_absolute() {
-            osc8(&file_uri(abs_path), &text)
+            file_uri(abs_path).map_or_else(|| text.clone(), |uri| osc8(&uri, &text))
         } else {
             text
         }
@@ -531,6 +524,7 @@ mod tests {
         },
     };
     use baml_ide::{ModifierSet, SemanticTokenType};
+    use url::Url;
 
     use super::{Highlighter, MessageHighlighter, highlight_str, style_for};
 
@@ -778,5 +772,30 @@ function make(v: int) -> Point {
             spans.is_err(),
             "a malformed prose fragment must request no-color diagnostic fallback"
         );
+    }
+
+    #[test]
+    fn file_uri_round_trips_native_paths_and_reserved_characters() {
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("space #% ü.baml");
+        let uri = super::file_uri(&path).unwrap();
+        let parsed = Url::parse(&uri).unwrap();
+
+        assert_eq!(parsed.to_file_path().unwrap(), path);
+        assert!(uri.contains("space%20%23%25%20%C3%BC.baml"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn file_uri_handles_drive_and_unc_paths() {
+        let drive = Path::new(r"C:\repo folder\main#.baml");
+        let drive_uri = Url::parse(&super::file_uri(drive).unwrap()).unwrap();
+        assert_eq!(drive_uri.scheme(), "file");
+        assert_eq!(drive_uri.to_file_path().unwrap(), drive);
+
+        let unc = Path::new(r"\\server\share\repo folder\main%.baml");
+        let unc_uri = Url::parse(&super::file_uri(unc).unwrap()).unwrap();
+        assert_eq!(unc_uri.host_str(), Some("server"));
+        assert_eq!(unc_uri.to_file_path().unwrap(), unc);
     }
 }

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -134,8 +134,8 @@ function         baml.future.__await_any          <builtin>/baml/ns_future/futur
 function         baml.future.race                 <builtin>/baml/ns_future/future.baml:153
 function         baml.future.any                  <builtin>/baml/ns_future/future.baml:169
 class            baml.glob.ScanOptions            <builtin>/baml/ns_glob/glob.baml:2
-class            baml.glob.Glob                   <builtin>/baml/ns_glob/glob.baml:18
-function         baml.glob.new                    <builtin>/baml/ns_glob/glob.baml:34
+class            baml.glob.Glob                   <builtin>/baml/ns_glob/glob.baml:21
+function         baml.glob.new                    <builtin>/baml/ns_glob/glob.baml:39
 function         baml.host.call_host_value        <builtin>/baml/ns_host/host.baml:20
 class            baml.host.HostValue              <builtin>/baml/ns_host/host.baml:26
 class            baml.http.Request                <builtin>/baml/ns_http/http.baml:8

--- a/baml_language/crates/sys_glob/src/lib.rs
+++ b/baml_language/crates/sys_glob/src/lib.rs
@@ -1,5 +1,11 @@
 //! Bun-compatible glob pattern matcher shared by `sys_native` and `bridge_wasm`.
 //!
+//! Patterns and paths use a portable, slash-separated grammar on every platform.
+//! Windows paths must therefore be written as `C:/...` or `//server/share/...`;
+//! backslash remains the glob escape character rather than a path separator. `Glob.scan`
+//! converts native walker entries at its boundary, while `Glob.matches` expects callers
+//! to supply this portable form directly.
+//!
 //! Supports: `*` (any non-separator chars), `**` (any chars including separators),
 //! `?` (single non-separator char), `[...]` (character classes), `{a,b}` (alternations),
 //! `!` prefix (negation), `\` (escape).
@@ -54,8 +60,9 @@ impl GlobPattern {
         self.target
     }
 
-    /// Test a single arbitrary path string against the compiled pattern.
-    /// Used by `Glob.matches(path)` where the caller decides what to pass.
+    /// Test one portable, slash-separated path against the compiled pattern.
+    /// Used by `Glob.matches(path)`; callers must convert native separators at
+    /// their filesystem boundary before calling this method.
     pub fn is_match(&self, path: &str) -> bool {
         let matched = self.re.is_match(path);
         if self.negated { !matched } else { matched }
@@ -344,6 +351,21 @@ mod tests {
         assert!(!g.is_match_entry("file.rs", "C:/scan/file.rs"));
     }
 
+    #[test]
+    fn absolute_unc_patterns_use_portable_slash_form() {
+        let g = GlobPattern::new("//server/share/**/*.baml").unwrap();
+        assert_eq!(g.target(), super::MatchTarget::Absolute);
+        assert!(g.is_match_entry("project/main.baml", "//server/share/project/main.baml"));
+        assert!(!g.is_match_entry("project/main.baml", "//other/share/project/main.baml"));
+    }
+
+    #[test]
+    fn backslash_is_an_escape_not_a_native_separator() {
+        let g = GlobPattern::new(r"dir\*.baml").unwrap();
+        assert!(g.is_match("dir*.baml"));
+        assert!(!g.is_match("dir/file.baml"));
+        assert!(!g.is_match(r"dir\file.baml"));
+    }
     #[test]
     fn match_entry_picks_relative_form_for_plain_pattern() {
         // Pattern `.*` (literal dot, then `*`) under the OR-against-three-forms


### PR DESCRIPTION
## Author Comment

This fixes 3 issues found in non legacy code. As mentioned in discord some findings were ignored because they were in legacy code.

## Codex Summary

This PR addresses the next batch of findings from the Windows path and URI audit across the glob API, native LSP/VFS path identity, and CLI file hyperlinks.

The public glob API already uses a portable, slash-separated grammar on every platform, but that boundary was not clearly documented or fully covered by tests. The contract now explicitly requires `/` separators for patterns and supplied paths, including Windows drive paths such as `C:/work/**` and UNC paths such as `//server/share/**`. Backslash remains the glob escape character rather than being treated as a native Windows separator. This documents and tests the existing matching behavior rather than changing it.

Native paths entering the LSP/VFS boundary previously retained their lexical spelling. Existing files reached through dotted components, filesystem aliases, or ordinary Windows case variants could therefore produce different VFS identities. Existing native paths are now canonicalized once at the platform boundary before conversion into VFS form. Nonexistent paths, including unsaved documents, retain absolute lexical normalization. Internal VFS paths continue to bypass native filesystem canonicalization.

The CLI previously constructed OSC-8 file hyperlinks by prefixing `file://` and manually encoding only a few characters. This was not a complete file URI conversion and produced malformed links for Windows drive paths, UNC paths, and other URI-sensitive characters. File URIs are now constructed with `url::Url::from_file_path`. Paths that cannot be represented faithfully as file URIs fall back to their original visible location text instead of emitting a malformed hyperlink.

Regression coverage verifies:

- Portable slash-form Windows drive and UNC glob patterns.
- Backslash remaining the glob escape character.
- Existing native path aliases resolving to one VFS identity.
- Dotted paths resolving to the same identity as their direct spelling.
- Windows case variants sharing identity when supported by the filesystem.
- Absolute lexical identity for nonexistent paths.
- File URI round-tripping for Windows drive and UNC paths.
- Correct encoding of spaces, `%`, `#`, and Unicode.

Tested on Windows with the relevant Rust formatting, unit, integration, all-features build, and targeted Clippy checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified portable slash-separated glob syntax across Windows and Unix-like platforms.
  - Documented backslashes as escape characters and clarified matching and scanning path behavior.

- **Bug Fixes**
  - Improved file links for native, drive-letter, UNC, and reserved-character paths.
  - Improved resolution of existing and missing paths, including equivalent spellings.
  - Workspace paths are now consistently canonicalized.
  - Added safer fallback behavior when a file path cannot be converted into a link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->