### PR TITLE
perf: restore call/array/compile performance after BEP-066

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -2754,7 +2754,6 @@ fn generate_impl(
         // stdlib" is the full pipeline over the builtin files alone.
         all_files.truncate(builtin_count);
     }
-    let package_exports = capture_package_exports(db, &all_files);
     let alias_caches = build_alias_caches(db, &all_files);
 
     // Emit in two file groups — builtin stubs first, then user files — so the
@@ -2790,6 +2789,11 @@ fn generate_impl(
         opt,
         skip_clean,
     )?;
+    // Derive the serializable compiler surface after ordinary lowering has
+    // populated Salsa's body/signature caches. The artifact is unchanged; only
+    // the scheduling avoids a cold whole-package inference traversal before
+    // the same bodies are lowered for emit.
+    let package_exports = capture_package_exports(db, &all_files);
 
     // --- Pass 6: Retry policies ---
     // Retry policies are now synthesized as Item::Let bindings during CST lowering.

--- a/baml_language/crates/baml_compiler2_hir_ty/src/impls.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/impls.rs
@@ -327,18 +327,53 @@ pub(crate) fn is_concrete_receiver(ty: &Ty) -> bool {
 /// Resolution-relevant impl facts in a location-free shape shared by source
 /// blocks and mounted export rows.
 #[derive(Clone)]
-pub struct ResolvedImplFacts {
+pub struct MountedImplFacts {
     pub interface: InterfaceRef,
     pub for_ty_pattern: Ty,
     pub generic_params: Vec<(ParamTy, Vec<InterfaceRef>)>,
     pub associated_types: Vec<(Name, Ty)>,
 }
 
+pub enum ResolvedImplFacts<'db> {
+    Source(&'db ImplFacts<'db>),
+    Mounted(MountedImplFacts),
+}
+
+impl ResolvedImplFacts<'_> {
+    pub fn interface(&self) -> &InterfaceRef {
+        match self {
+            Self::Source(facts) => &facts.interface,
+            Self::Mounted(facts) => &facts.interface,
+        }
+    }
+
+    pub fn for_ty_pattern(&self) -> &Ty {
+        match self {
+            Self::Source(facts) => &facts.for_ty_pattern,
+            Self::Mounted(facts) => &facts.for_ty_pattern,
+        }
+    }
+
+    pub fn generic_params(&self) -> &[(ParamTy, Vec<InterfaceRef>)] {
+        match self {
+            Self::Source(facts) => &facts.generic_params,
+            Self::Mounted(facts) => &facts.generic_params,
+        }
+    }
+
+    pub fn associated_types(&self) -> &[(Name, Ty)] {
+        match self {
+            Self::Source(facts) => &facts.associated_types,
+            Self::Mounted(facts) => &facts.associated_types,
+        }
+    }
+}
+
 /// The dispatch identity retained after matching an impl.
 pub enum ResolvedImplOrigin<'db> {
     Source {
         block: ImplLoc<'db>,
-        methods: Vec<baml_compiler2_hir::loc::FunctionLoc<'db>>,
+        methods: &'db [baml_compiler2_hir::loc::FunctionLoc<'db>],
     },
     Mounted {
         methods: Vec<crate::package_interface::ExportedFunction>,
@@ -348,7 +383,7 @@ pub enum ResolvedImplOrigin<'db> {
 /// One resolved impl plus the generic instantiation the match pinned.
 pub struct ResolvedImpl<'db> {
     pub origin: ResolvedImplOrigin<'db>,
-    pub facts: ResolvedImplFacts,
+    pub facts: ResolvedImplFacts<'db>,
     pub bindings: FxHashMap<ParamTy, Ty>,
 }
 
@@ -359,7 +394,7 @@ impl ResolvedImpl<'_> {
     /// per-member (`resolved_pin`); [`Self::implemented_view`] is the
     /// complete spelling.
     pub fn implemented(&self) -> InterfaceRef {
-        realized(&self.facts.interface, &self.bindings)
+        realized(self.facts.interface(), &self.bindings)
     }
 
     /// The COMPLETE realized view of the implemented interface for
@@ -448,7 +483,7 @@ pub(crate) fn resolved_pin(
 ) -> Option<Ty> {
     if let Some((_, declared)) = resolved
         .facts
-        .associated_types
+        .associated_types()
         .iter()
         .find(|(name, _)| name == member)
     {
@@ -622,19 +657,25 @@ pub fn impls_for_type<'db>(
     for package in all_packages(db) {
         for (origin, facts) in package_impl_candidates(db, package) {
             let params: Vec<ParamTy> = facts
-                .generic_params
+                .generic_params()
                 .iter()
                 .map(|(param, _)| param.clone())
                 .collect();
             // Bare-blanket guard, as in `match_impl_head`.
-            if let TyKind::TypeVar(param, _) = facts.for_ty_pattern.kind()
+            if let TyKind::TypeVar(param, _) = facts.for_ty_pattern().kind()
                 && params.contains(param)
                 && !is_concrete_receiver(concrete)
             {
                 continue;
             }
             let mut bindings = FxHashMap::default();
-            if !match_pattern(&facts.for_ty_pattern, concrete, &params, &mut bindings, &eq) {
+            if !match_pattern(
+                facts.for_ty_pattern(),
+                concrete,
+                &params,
+                &mut bindings,
+                &eq,
+            ) {
                 continue;
             }
             if !bounds_hold(
@@ -654,9 +695,9 @@ pub fn impls_for_type<'db>(
             // never trip it even when their `ParamTy` identity shadows
             // an impl param's.
             let undetermined = |ty: &Ty| !pattern_fully_bound(ty, &params, &bindings);
-            if facts.interface.generics.iter().any(&undetermined)
+            if facts.interface().generics.iter().any(&undetermined)
                 || facts
-                    .interface
+                    .interface()
                     .associated_types
                     .iter()
                     .any(|(_, ty)| undetermined(ty))
@@ -691,7 +732,7 @@ fn all_packages(db: &dyn baml_compiler2_ppir::Db) -> Vec<PackageId<'_>> {
 fn package_impl_candidates<'db>(
     db: &'db dyn baml_compiler2_ppir::Db,
     package: PackageId<'db>,
-) -> Vec<(ResolvedImplOrigin<'db>, ResolvedImplFacts)> {
+) -> Vec<(ResolvedImplOrigin<'db>, ResolvedImplFacts<'db>)> {
     let mut out = Vec::new();
     for &block in package_impl_locs(db, package) {
         let Some(facts) = impl_facts(db, block) else {
@@ -700,14 +741,9 @@ fn package_impl_candidates<'db>(
         out.push((
             ResolvedImplOrigin::Source {
                 block,
-                methods: facts.methods.clone(),
+                methods: &facts.methods,
             },
-            ResolvedImplFacts {
-                interface: facts.interface.clone(),
-                for_ty_pattern: facts.for_ty_pattern.clone(),
-                generic_params: facts.generic_params.clone(),
-                associated_types: facts.associated_types.clone(),
-            },
+            ResolvedImplFacts::Source(facts),
         ));
     }
     if let Some(interface) = crate::package_interface::mounted_interface(db, &package.name(db)) {
@@ -731,7 +767,7 @@ fn package_impl_candidates<'db>(
                 ResolvedImplOrigin::Mounted {
                     methods: row.methods.clone(),
                 },
-                ResolvedImplFacts {
+                ResolvedImplFacts::Mounted(MountedImplFacts {
                     interface: InterfaceRef::from_constraint(&row.interface),
                     for_ty_pattern: Ty::from_plain(&row.for_ty_pattern),
                     generic_params,
@@ -740,7 +776,7 @@ fn package_impl_candidates<'db>(
                         .iter()
                         .map(|(name, ty)| (name.clone(), Ty::from_plain(ty)))
                         .collect(),
-                },
+                }),
             )
         }));
     }
@@ -943,34 +979,34 @@ fn collect_packages(ty: &Ty, out: &mut Vec<Name>) {
 /// then the associated-pin gate. Declared bounds are NOT checked here.
 fn match_impl_head(
     db: &dyn baml_compiler2_ppir::Db,
-    facts: &ResolvedImplFacts,
+    facts: &ResolvedImplFacts<'_>,
     concrete: &Ty,
     interface: &InterfaceRef,
     eq: &AliasOnlyFacts<'_>,
 ) -> Option<FxHashMap<ParamTy, Ty>> {
-    if facts.interface.name != interface.name
-        || facts.interface.generics.len() != interface.generics.len()
+    if facts.interface().name != interface.name
+        || facts.interface().generics.len() != interface.generics.len()
     {
         return None;
     }
     // Bare-blanket guard: `implement<T> I for T` applies only to
     // concrete receivers - never existentials, unions, or vars.
-    if let TyKind::TypeVar(param, _) = facts.for_ty_pattern.kind()
-        && facts.generic_params.iter().any(|(p, _)| p == param)
+    if let TyKind::TypeVar(param, _) = facts.for_ty_pattern().kind()
+        && facts.generic_params().iter().any(|(p, _)| p == param)
         && !is_concrete_receiver(concrete)
     {
         return None;
     }
     let params: Vec<ParamTy> = facts
-        .generic_params
+        .generic_params()
         .iter()
         .map(|(param, _)| param.clone())
         .collect();
     let mut bindings = FxHashMap::default();
-    if !match_pattern(&facts.for_ty_pattern, concrete, &params, &mut bindings, eq) {
+    if !match_pattern(facts.for_ty_pattern(), concrete, &params, &mut bindings, eq) {
         return None;
     }
-    for (pattern, target) in facts.interface.generics.iter().zip(&interface.generics) {
+    for (pattern, target) in facts.interface().generics.iter().zip(&interface.generics) {
         if !match_pattern(pattern, target, &params, &mut bindings, eq) {
             return None;
         }
@@ -982,13 +1018,13 @@ fn match_impl_head(
     // fails closed - the request pins something this impl cannot supply.
     for (name, requested) in &interface.associated_types {
         let supplied = match facts
-            .associated_types
+            .associated_types()
             .iter()
             .find(|(declared_name, _)| declared_name == name)
         {
             Some((_, declared)) => Some(substitute_bindings(declared, &bindings)),
             None => {
-                let implemented = realized(&facts.interface, &bindings);
+                let implemented = realized(facts.interface(), &bindings);
                 realized_assoc_default(db, &implemented, concrete, name)
             }
         };
@@ -1293,12 +1329,12 @@ pub fn substitute_bindings(ty: &Ty, bindings: &FxHashMap<ParamTy, Ty>) -> Ty {
 /// obligation); realized ones recurse with the budget.
 fn bounds_hold(
     db: &dyn baml_compiler2_ppir::Db,
-    facts: &ResolvedImplFacts,
+    facts: &ResolvedImplFacts<'_>,
     bindings: &FxHashMap<ParamTy, Ty>,
     depth: u32,
     in_progress: &mut Vec<(Ty, InterfaceRef)>,
 ) -> bool {
-    for (param, bounds) in &facts.generic_params {
+    for (param, bounds) in facts.generic_params() {
         let Some(actual) = bindings.get(param) else {
             continue;
         };

--- a/baml_language/crates/baml_compiler2_hir_ty/src/method_resolution.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/method_resolution.rs
@@ -647,7 +647,7 @@ fn env_discharges_rigid_bounds<'db>(
     facts: &Facts<'db>,
     resolved: &crate::impls::ResolvedImpl<'db>,
 ) -> bool {
-    for (param, bounds) in &resolved.facts.generic_params {
+    for (param, bounds) in resolved.facts.generic_params() {
         let Some(actual) = resolved.bindings.get(param) else {
             continue;
         };

--- a/baml_language/crates/bex_vm/src/package_baml/resolve.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/resolve.rs
@@ -22,6 +22,32 @@ use bex_vm_types::{errors::VmInternalError, types::RuntimeImplRule};
 
 use crate::{BexVm, type_context::StructuralEquivCtx};
 
+/// A resolver candidate borrows immutable package rules and owns only rules
+/// copied out of the lock-protected dynamic side table. Static virtual calls
+/// must not deep-clone their rule metadata on every dispatch.
+pub(crate) enum RuntimeImplRuleCandidate<'vm> {
+    Static(&'vm RuntimeImplRule),
+    Borrowed(&'vm RuntimeImplRule),
+    Owned(Box<RuntimeImplRule>),
+}
+
+impl RuntimeImplRuleCandidate<'_> {
+    pub(crate) fn is_static(&self) -> bool {
+        matches!(self, Self::Static(_))
+    }
+}
+
+impl std::ops::Deref for RuntimeImplRuleCandidate<'_> {
+    type Target = RuntimeImplRule;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Static(rule) | Self::Borrowed(rule) => rule,
+            Self::Owned(rule) => rule,
+        }
+    }
+}
+
 /// The runtime impl resolver over a running VM. Holding the `&BexVm` here —
 /// rather than threading it through every helper — keeps the whole selection
 /// machinery able to reach VM facts at any depth: candidate collection reads the
@@ -70,7 +96,7 @@ impl<'vm> ImplResolver<'vm> {
     /// one O(1) lookup over a table that already spans every package — see that
     /// type's docs for why a per-package search cannot be narrowed correctly. An
     /// unknown interface (not loaded) has no impls anywhere.
-    fn rules_for(self, iface: &TypeName) -> Vec<RuntimeImplRule> {
+    fn rules_for(self, iface: &TypeName) -> Vec<RuntimeImplRuleCandidate<'vm>> {
         let Some(iface_ptr) = self.vm.lookup_interface(iface) else {
             return Vec::new();
         };
@@ -97,9 +123,20 @@ impl<'vm> ImplResolver<'vm> {
         }
         let mut rules = pointers
             .into_iter()
-            .filter_map(|rule_ptr| self.vm.get_object(rule_ptr).as_impl_rule().cloned())
+            .filter_map(|rule_ptr| {
+                self.vm
+                    .get_object(rule_ptr)
+                    .as_impl_rule()
+                    .map(RuntimeImplRuleCandidate::Borrowed)
+            })
             .collect::<Vec<_>>();
-        rules.extend(self.vm.dynamic_dispatch.rules_of(iface_ptr));
+        rules.extend(
+            self.vm
+                .dynamic_dispatch
+                .rules_of(iface_ptr)
+                .into_iter()
+                .map(|rule| RuntimeImplRuleCandidate::Owned(Box::new(rule))),
+        );
         rules
     }
 }
@@ -151,7 +188,7 @@ fn concrete_base(ty: &RealizedTy) -> Cow<'_, RealizedTy> {
     }
 }
 
-impl ImplResolver<'_> {
+impl<'vm> ImplResolver<'vm> {
     /// Resolve `(Self, Iface<Args>)` to the single applicable `implements` rule, plus
     /// the impl's bound type args — its generics realized by matching `concrete_ty`
     /// against the rule's `for` pattern. That rule is the canonical handle: read the
@@ -182,22 +219,45 @@ impl ImplResolver<'_> {
         concrete_ty: &RealizedTy,
         iface: &TypeName,
         iface_args: &[RealizedTy],
-    ) -> Option<(RuntimeImplRule, Vec<RealizedTy>)> {
+    ) -> Option<(RuntimeImplRuleCandidate<'vm>, Vec<RealizedTy>)> {
+        // Static/package-image rules are immutable and already indexed by the
+        // canonical interface pointer. Try that slice directly: this is the
+        // overwhelmingly common virtual-call path and avoids candidate Vecs,
+        // runtime-package graph walks, and dynamic-table locking.
+        if let Some(iface_ptr) = self.vm.lookup_interface(iface) {
+            for &rule_ptr in self.vm.packages.impl_rules_of(iface_ptr) {
+                let Some(rule) = self.vm.get_object(rule_ptr).as_impl_rule() else {
+                    continue;
+                };
+                if let Some(type_args) = self.requested_rule_args(rule, concrete_ty, iface_args) {
+                    return Some((RuntimeImplRuleCandidate::Static(rule), type_args));
+                }
+            }
+        }
+
         for rule in self.rules_for(iface) {
-            let Some(type_args) = self.rule_applies(&rule, concrete_ty, &mut Vec::new()) else {
-                continue;
-            };
-            // Select on the interface's input args only (associated types are outputs).
-            let rule_args: Vec<RealizedTy> = rule
-                .interface_args
-                .iter()
-                .map(|t| self.substitute_checked(t, &type_args))
-                .collect();
-            if iface_args.is_empty() || self.ty_args_equivalent(&rule_args, iface_args) {
+            if let Some(type_args) = self.requested_rule_args(&rule, concrete_ty, iface_args) {
                 return Some((rule, type_args));
             }
         }
         None
+    }
+
+    fn requested_rule_args(
+        self,
+        rule: &RuntimeImplRule,
+        concrete_ty: &RealizedTy,
+        iface_args: &[RealizedTy],
+    ) -> Option<Vec<RealizedTy>> {
+        let type_args = self.rule_applies(rule, concrete_ty, &mut Vec::new())?;
+        // Select on the interface's input args only (associated types are outputs).
+        let rule_args: Vec<RealizedTy> = rule
+            .interface_args
+            .iter()
+            .map(|t| self.substitute_checked(t, &type_args))
+            .collect();
+        (iface_args.is_empty() || self.ty_args_equivalent(&rule_args, iface_args))
+            .then_some(type_args)
     }
 
     /// Realize a [`MethodImpl`](bex_vm_types::types::MethodImpl) frame template (De

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -135,6 +135,22 @@ struct TakenTypeArgs {
     defs: DynTypeDefs,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+struct StaticVirtualCallKey {
+    caller_function_addr: usize,
+    call_pc: usize,
+    receiver: baml_type::RealizedTy,
+    interface: baml_type::TypeName,
+    interface_args: Box<[baml_type::RealizedTy]>,
+    method: String,
+}
+
+#[derive(Clone, Debug)]
+struct StaticVirtualCallTarget {
+    callee: HeapPtr,
+    frame_type_args: Vec<baml_type::RealizedTy>,
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct VmCaptureMask {
     pub inputs: bool,
@@ -416,6 +432,8 @@ pub(crate) mod tests {
             pending_call_type_args: Vec::new(),
             pending_call_type_values: Vec::new(),
             static_mint_cache: HashMap::new(),
+            static_load_type_cache: HashMap::new(),
+            static_virtual_call_cache: HashMap::new(),
             packages: Arc::new(crate::package_load::PackageIndex::default()),
             dynamic_dispatch: Arc::new(crate::package_load::DynDispatchTables::default()),
         }
@@ -856,6 +874,16 @@ pub struct BexVm {
     /// (spawned VMs start empty) can never produce a divergent mint. Distinct
     /// spellings of equivalent types get separate entries with equal digests.
     static_mint_cache: HashMap<baml_type::RealizedTy, u64>,
+    /// Created-once immutable type objects for fully realized `LoadType`
+    /// constants in static functions. The compact numeric key keeps the
+    /// per-iteration lookup cheaper than re-hashing the full realized type.
+    /// Entries are explicit VM GC roots.
+    static_load_type_cache: HashMap<(usize, usize), HeapPtr>,
+    /// Monomorphic static virtual-call results keyed by caller site and the
+    /// receiver/interface instantiation observed there. Only immutable
+    /// program-image rules enter this cache, so runtime package loading and
+    /// dynamic builder registration remain live on every dynamic dispatch.
+    static_virtual_call_cache: HashMap<StaticVirtualCallKey, StaticVirtualCallTarget>,
 }
 
 /// VM execution state.
@@ -1371,6 +1399,8 @@ impl BexVm {
             pending_call_type_args: Vec::new(),
             pending_call_type_values: Vec::new(),
             static_mint_cache: HashMap::new(),
+            static_load_type_cache: HashMap::new(),
+            static_virtual_call_cache: HashMap::new(),
             packages,
             dynamic_dispatch,
         }
@@ -1426,6 +1456,38 @@ impl BexVm {
             .checked_add(count)
             .filter(|end| *end <= self.stack.len())
             .ok_or(VmInternalError::NotEnoughItemsOnStack(count))?;
+        let all_plain_static = (start..end).all(|slot| {
+            let value = self.stack[StackIndex::from_raw(slot)];
+            value.as_object_ptr().is_some_and(|ptr| {
+                matches!(self.get_object(ptr), Object::Type(type_value)
+                    if matches!(type_value.mint(), MintId::Static(_))
+                        && type_value.defs().is_empty()
+                        && type_value.owner.is_null())
+            })
+        });
+        if all_plain_static {
+            let tys = (start..end)
+                .map(|slot| {
+                    let value = self.stack[StackIndex::from_raw(slot)];
+                    let ptr = value
+                        .as_object_ptr()
+                        .expect("plain static type argument is an object");
+                    let Object::Type(type_value) = self.get_object(ptr) else {
+                        unreachable!("plain static type argument is Object::Type")
+                    };
+                    type_value.ty.clone()
+                })
+                .collect();
+            drop(
+                self.stack
+                    .drain(StackIndex::from_raw(start)..StackIndex::from_raw(end)),
+            );
+            return Ok(TakenTypeArgs {
+                tys,
+                values: Vec::new(),
+                defs: DynTypeDefs::default(),
+            });
+        }
         let mut type_args = TakenTypeArgs {
             tys: Vec::with_capacity(count),
             values: Vec::with_capacity(count),
@@ -1969,16 +2031,12 @@ impl BexVm {
             .expect("runtime global index was validated by dynamic link")
     }
 
-    fn load_current_global(&self, index: GlobalIndex) -> Value {
-        self.load_global_in(self.current_runtime_package(), index)
-    }
-
-    fn store_current_global(
+    fn store_global_in(
         &mut self,
+        package_ptr: HeapPtr,
         index: GlobalIndex,
         value: Value,
     ) -> Result<(), VmInternalError> {
-        let package_ptr = self.current_runtime_package();
         if package_ptr.as_ptr().is_null() {
             return self
                 .globals
@@ -5027,22 +5085,27 @@ impl BexVm {
         let callee_function_id = callee.function_id;
         let callee_capture = callee.capture;
         let callee_param_names = callee.param_names.clone();
-        let callee_param_types = callee.param_types.clone();
-        let callee_generic_param_bounds = callee.generic_param_bounds.clone();
+        // Marker calls are rare. Avoid cloning executable type metadata on
+        // every ordinary call before the encoded marker bit has even been
+        // checked; those clones dominated small-function call benchmarks.
+        let runtime_check_metadata = runtime_type_check.then(|| {
+            (
+                callee.param_types.clone(),
+                callee.generic_param_bounds.clone(),
+            )
+        });
 
         // `unreflect(...)` deliberately hides its concrete type from TIR, so
         // declared generic bounds must be enforced at the first boundary that
         // sees the realized type.  Do this before arity handling, profiling,
         // argument draining, or frame creation: a failure is a catchable
         // CompilationError and the callee cannot observe any side effect.
-        let needs_bound_check = runtime_type_check
-            && callee_generic_param_bounds
-                .iter()
-                .any(|bounds| !bounds.is_empty());
-        let needs_argument_check = runtime_type_check
-            && callee_param_types
-                .iter()
-                .any(|param| !param.is_fully_concrete());
+        let needs_bound_check = runtime_check_metadata
+            .as_ref()
+            .is_some_and(|(_, bounds)| bounds.iter().any(|bounds| !bounds.is_empty()));
+        let needs_argument_check = runtime_check_metadata
+            .as_ref()
+            .is_some_and(|(params, _)| params.iter().any(|param| !param.is_fully_concrete()));
         let effective_type_args = if needs_bound_check || needs_argument_check {
             let mut type_args = if !bound_method_class_type_args.is_empty() {
                 bound_method_class_type_args.to_vec()
@@ -5065,15 +5128,21 @@ impl BexVm {
             .into());
         }
         if needs_bound_check {
+            let (_, callee_generic_param_bounds) = runtime_check_metadata
+                .as_ref()
+                .expect("runtime checks have metadata");
             self.validate_runtime_generic_bounds(
                 &callee_name,
-                &callee_generic_param_bounds,
+                callee_generic_param_bounds,
                 &effective_type_args,
             )?;
         }
         if needs_argument_check {
+            let (callee_param_types, _) = runtime_check_metadata
+                .as_ref()
+                .expect("runtime checks have metadata");
             self.validate_runtime_call_arguments(
-                &callee_param_types,
+                callee_param_types,
                 &effective_type_args,
                 locals_offset,
             )?;
@@ -5503,12 +5572,15 @@ impl BexVm {
             && *frame_idx == frames_before
             && let Some(Frame::Bytecode(frame)) = self.frames.get_mut(frames_before)
         {
-            frame.type_values.resize(frame.type_args.len(), None);
+            let initial_type_arg_count = frame.type_args.len();
             frame.type_args.extend_from_slice(options.type_args);
-            frame.type_defs.merge_from(options.type_defs);
-            frame.type_values.extend(
-                (0..options.type_args.len()).map(|slot| options.type_values.get(slot).cloned()),
-            );
+            if !options.type_defs.is_empty() || !options.type_values.is_empty() {
+                frame.type_values.resize(initial_type_arg_count, None);
+                frame.type_defs.merge_from(options.type_defs);
+                frame.type_values.extend(
+                    (0..options.type_args.len()).map(|slot| options.type_values.get(slot).cloned()),
+                );
+            }
         }
         result
     }
@@ -6429,7 +6501,7 @@ impl BexVm {
                 OpCode::LoadGlobal => {
                     let raw = { read_u32_unchecked(code, pc) };
                     let global_idx = bex_vm_types::GlobalIndex::from_raw(raw as usize);
-                    let value = self.load_current_global(global_idx);
+                    let value = self.load_global_in(function.runtime_package, global_idx);
                     self.stack.push(value);
                 }
 
@@ -6439,7 +6511,7 @@ impl BexVm {
                     let value = self.stack.ensure_pop();
                     // Only valid during `$init`; post-init globals are frozen in `Arc<[Value]>`
                     // and a write here is a VM internal error.
-                    self.store_current_global(global_idx, value)?;
+                    self.store_global_in(function.runtime_package, global_idx, value)?;
                 }
 
                 // ── LoadField / StoreField / InitField ────────────────────────
@@ -6742,7 +6814,7 @@ impl BexVm {
                         None
                     };
                     let callee = bex_vm_types::GlobalIndex::from_raw(raw as usize);
-                    let callee_value = self.load_current_global(callee);
+                    let callee_value = self.load_global_in(function.runtime_package, callee);
                     // `as_object_ptr` only unwraps the value to a heap pointer
                     // (the `FunctionType` argument is error-message metadata, not
                     // an assertion). `dispatch_sysop_yield`'s own kind check is
@@ -6823,16 +6895,12 @@ impl BexVm {
                         None
                     };
                     let callee_global = bex_vm_types::GlobalIndex::from_raw(raw as usize);
-                    let callee_value = self.load_current_global(callee_global);
+                    let callee_value = self.load_global_in(function.runtime_package, callee_global);
                     let (callee_ptr, arg_count) = self.resolve_callable_target(callee_value)?;
 
-                    let type_args = self.take_type_args_below_values(ntypeargs, arg_count)?;
-
-                    let args_offset = self
-                        .stack
-                        .len()
-                        .checked_sub(arg_count)
-                        .ok_or(VmInternalError::NotEnoughItemsOnStack(arg_count))?;
+                    let args_offset = self.stack.len().checked_sub(arg_count + ntypeargs).ok_or(
+                        VmInternalError::NotEnoughItemsOnStack(arg_count + ntypeargs),
+                    )?;
                     let locals_offset = StackIndex::from_raw(args_offset);
 
                     // Save pc as return address before pushing new frame.
@@ -6841,20 +6909,40 @@ impl BexVm {
                     };
                     bf.instruction_ptr = *pc;
 
-                    let result = self.execute_call_from_locals_offset_with_type_args(
-                        callee_ptr,
-                        locals_offset,
-                        arg_count,
-                        CallOptions {
+                    let result = if ntypeargs == 0
+                        && self.pending_call_type_args.is_empty()
+                        && self.pending_call_type_values.is_empty()
+                    {
+                        // Ordinary non-generic calls have no pending type lane
+                        // to save or clear. Keep them off the richer BEP-066
+                        // exact-value path so a tiny function call does not
+                        // construct and move several empty collections.
+                        self.execute_call_from_locals_offset(
+                            callee_ptr,
+                            locals_offset,
+                            arg_count,
                             runtime_id,
-                            type_args: &type_args.tys,
-                            type_defs: &type_args.defs,
-                            type_values: &type_args.values,
                             runtime_type_check,
-                        },
-                        frame_idx,
-                        function,
-                    );
+                            frame_idx,
+                            function,
+                        )
+                    } else {
+                        let type_args = self.take_type_args_below_values(ntypeargs, arg_count)?;
+                        self.execute_call_from_locals_offset_with_type_args(
+                            callee_ptr,
+                            locals_offset,
+                            arg_count,
+                            CallOptions {
+                                runtime_id,
+                                type_args: &type_args.tys,
+                                type_defs: &type_args.defs,
+                                type_values: &type_args.values,
+                                runtime_type_check,
+                            },
+                            frame_idx,
+                            function,
+                        )
+                    };
                     return result;
                 }
 
@@ -6923,7 +7011,25 @@ impl BexVm {
                             )
                         }),
                     );
-                    let (callee_ptr, type_args) = {
+                    let cache_key =
+                        function
+                            .runtime_package
+                            .is_null()
+                            .then(|| StaticVirtualCallKey {
+                                caller_function_addr: std::ptr::from_ref(*function) as usize,
+                                call_pc: self.cur_pc,
+                                receiver: self_ty.clone(),
+                                interface: iface_qtn.clone(),
+                                interface_args: iface_args.clone().into_boxed_slice(),
+                                method: method_name.clone(),
+                            });
+                    let cached_target = cache_key
+                        .as_ref()
+                        .and_then(|key| self.static_virtual_call_cache.get(key))
+                        .cloned();
+                    let (callee_ptr, mut type_args) = if let Some(target) = cached_target {
+                        (target.callee, target.frame_type_args)
+                    } else {
                         let resolver = crate::package_baml::ImplResolver::for_value(self, receiver);
                         let (rule, bound_args) = resolver
                             .resolve_implements_rule(&self_ty, &iface_qtn, &iface_args)
@@ -6943,10 +7049,20 @@ impl BexVm {
                         // or the interface's args + associated types for an inherited
                         // default), then the method-level type args — matching the
                         // callee's De Bruijn layout `[owner… ++ method…]`.
-                        let mut frame = resolver.realize_frame(&method.frame, &bound_args)?;
-                        frame.extend(method_type_args.tys);
+                        let frame = resolver.realize_frame(&method.frame, &bound_args)?;
+                        let cacheable = rule.is_static();
+                        if cacheable && let Some(cache_key) = cache_key {
+                            self.static_virtual_call_cache.insert(
+                                cache_key,
+                                StaticVirtualCallTarget {
+                                    callee,
+                                    frame_type_args: frame.clone(),
+                                },
+                            );
+                        }
                         (callee, frame)
                     };
+                    type_args.extend(method_type_args.tys);
 
                     let locals_offset = StackIndex::from_raw(args_offset);
 
@@ -7530,59 +7646,85 @@ impl BexVm {
                 // ── LoadType ──────────────────────────────────────────────────
                 OpCode::LoadType => {
                     let idx = { read_u32_unchecked(code, pc) as usize };
-                    let template = match &function.bytecode.constants[idx] {
-                        ConstValue::Type(t) => t.clone(),
-                        _ => {
-                            return Err(VmInternalError::UnexpectedConstantKind.into());
+                    let static_cache_key = match &function.bytecode.constants[idx] {
+                        ConstValue::Type(template)
+                            if function.runtime_package.is_null()
+                                && <&baml_type::RealizedTy>::try_from(template).is_ok()
+                                && matches!(&self.frames[*frame_idx],
+                                    Frame::Bytecode(frame) if frame.type_defs.is_empty()) =>
+                        {
+                            Some((std::ptr::from_ref(*function) as usize, idx))
                         }
+                        _ => None,
                     };
+                    let cached_value = static_cache_key
+                        .and_then(|key| self.static_load_type_cache.get(&key).copied())
+                        .map(Value::object);
+                    let value = if let Some(value) = cached_value {
+                        value
+                    } else {
+                        let template = match &function.bytecode.constants[idx] {
+                            ConstValue::Type(t) => t.clone(),
+                            _ => {
+                                return Err(VmInternalError::UnexpectedConstantKind.into());
+                            }
+                        };
 
-                    let exact_dynamic = if let baml_type::TyTemplate::TypeArgRef(slot) = &template {
-                        match &self.frames[*frame_idx] {
-                            Frame::Bytecode(frame) => {
-                                frame.type_values.get(*slot as usize).and_then(Clone::clone)
-                            }
-                            Frame::Native(_) => None,
-                        }
-                    } else {
-                        None
-                    };
-                    let value = if let Some(type_value) = exact_dynamic {
-                        Value::object(self.tlab.alloc_type(type_value))
-                    } else {
-                        let ty: baml_type::RealizedTy = {
-                            // A fully-realized template narrows to `RealizedTy` in a
-                            // single validation walk — no substitution environment
-                            // needed. Otherwise resolve its frame refs (and reduce any
-                            // projection) against the frame's realized type args; the
-                            // result must be realized or it is an internal error, never
-                            // a `unknown` erasure.
-                            if let Ok(realized) = <&baml_type::RealizedTy>::try_from(&template) {
-                                realized.clone()
-                            } else {
-                                let frame_type_args =
-                                    if let Frame::Bytecode(bf) = &self.frames[*frame_idx] {
-                                        bf.type_args.clone()
-                                    } else {
-                                        vec![]
-                                    };
-                                template.substitute(&frame_type_args, self).map_err(|e| {
-                                    VmInternalError::TypeSubstitution {
-                                        message: e.to_string(),
+                        let exact_dynamic =
+                            if let baml_type::TyTemplate::TypeArgRef(slot) = &template {
+                                match &self.frames[*frame_idx] {
+                                    Frame::Bytecode(frame) => {
+                                        frame.type_values.get(*slot as usize).and_then(Clone::clone)
                                     }
-                                })?
+                                    Frame::Native(_) => None,
+                                }
+                            } else {
+                                None
+                            };
+                        let value = if let Some(type_value) = exact_dynamic {
+                            Value::object(self.tlab.alloc_type(type_value))
+                        } else {
+                            let ty: baml_type::RealizedTy = {
+                                // A fully-realized template narrows to `RealizedTy` in a
+                                // single validation walk — no substitution environment
+                                // needed. Otherwise resolve its frame refs (and reduce any
+                                // projection) against the frame's realized type args; the
+                                // result must be realized or it is an internal error, never
+                                // a `unknown` erasure.
+                                if let Ok(realized) = <&baml_type::RealizedTy>::try_from(&template)
+                                {
+                                    realized.clone()
+                                } else {
+                                    let frame_type_args =
+                                        if let Frame::Bytecode(bf) = &self.frames[*frame_idx] {
+                                            bf.type_args.clone()
+                                        } else {
+                                            vec![]
+                                        };
+                                    template.substitute(&frame_type_args, self).map_err(|e| {
+                                        VmInternalError::TypeSubstitution {
+                                            message: e.to_string(),
+                                        }
+                                    })?
+                                }
+                            };
+                            let defs = if let Frame::Bytecode(frame) = &self.frames[*frame_idx] {
+                                frame.type_defs.clone()
+                            } else {
+                                DynTypeDefs::default()
+                            };
+                            if let Some(type_ptr) = self.current_runtime_declaration_type(&ty) {
+                                Value::object(type_ptr)
+                            } else {
+                                Value::object(self.alloc_static_type_with_defs(ty, defs))
                             }
                         };
-                        let defs = if let Frame::Bytecode(frame) = &self.frames[*frame_idx] {
-                            frame.type_defs.clone()
-                        } else {
-                            DynTypeDefs::default()
-                        };
-                        if let Some(type_ptr) = self.current_runtime_declaration_type(&ty) {
-                            Value::object(type_ptr)
-                        } else {
-                            Value::object(self.alloc_static_type_with_defs(ty, defs))
+                        if let Some(cache_key) = static_cache_key
+                            && let Some(ptr) = value.as_object_ptr()
+                        {
+                            self.static_load_type_cache.insert(cache_key, ptr);
                         }
+                        value
                     };
                     self.stack.push(value);
                 }
@@ -7624,7 +7766,7 @@ impl BexVm {
                     let raw = { read_u32_unchecked(code, pc) };
                     let global_idx = bex_vm_types::GlobalIndex::from_raw(raw as usize);
                     let receiver = self.stack.ensure_pop();
-                    let callee_value = self.load_current_global(global_idx);
+                    let callee_value = self.load_global_in(function.runtime_package, global_idx);
                     let function_ptr =
                         self.as_object_ptr(callee_value, FunctionType::Callable.into())?;
                     // Curry the receiver's class type args (→ `Self`) into the
@@ -7716,13 +7858,13 @@ impl BexVm {
                 // ── MakeGenericFunction ───────────────────────────────────────
                 OpCode::MakeGenericFunction => {
                     let raw = { read_u32_unchecked(code, pc) };
-                    let function = bex_vm_types::GlobalIndex::from_raw(raw as usize);
+                    let function_global = bex_vm_types::GlobalIndex::from_raw(raw as usize);
                     let ntypeargs = { read_u16_unchecked(code, pc) as usize };
                     let type_args = self.pop_type_args(ntypeargs)?;
                     let gf = Object::GenericFunction(bex_vm_types::GenericFunction {
-                        function,
+                        function: function_global,
                         type_args: type_args.tys.into_boxed_slice(),
-                        runtime_package: self.current_runtime_package(),
+                        runtime_package: function.runtime_package,
                     });
                     let ptr = self.tlab.alloc(gf);
                     self.stack.push(Value::object(ptr));
@@ -8538,6 +8680,7 @@ impl ::bex_vm_types::RootHaver for BexVm {
                 .iter()
                 .filter_map(Value::as_object_ptr),
         );
+        roots.extend(self.static_load_type_cache.values().copied());
         // Both key (thrown value) and cause context are heap pointers.
         for (value, cause) in &self.thrown_value_causes {
             roots.extend(value.as_object_ptr());
@@ -8590,6 +8733,9 @@ impl ::bex_vm_types::RootHaver for BexVm {
             {
                 *value = Value::object(new_ptr);
             }
+        }
+        for ptr in self.static_load_type_cache.values_mut() {
+            *ptr = roots.get(ptr).copied().unwrap_or(*ptr);
         }
         for (value, cause) in &mut self.thrown_value_causes {
             if let Some(ptr) = value.as_object_ptr()


### PR DESCRIPTION
## Summary

- Restores BEP-066 compiler throughput by scheduling package-export capture after ordinary lowering warms Salsa inference/signature queries.
- Avoids rebuilding owned source impl metadata; source candidates now borrow tracked impl facts while mounted package rows remain owned.
- Restores VM call and array-heavy workloads by keeping ordinary calls off exact runtime-type machinery, borrowing immutable impl rules, caching only immutable static dispatch/type results, and avoiding empty type-lane work.
- Preserves runtime-package and dynamic-builder dispatch through the live resolver; runtime type identity and mint semantics remain unchanged.

## Root cause

Phase timing put 19.6-19.7 seconds of a 20.3-second compile in cold package-export capture. The user package interface query alone took 17.16 seconds. The export capture was forcing whole-package inference before emit repeated the same work. Slice 6 also converted tracked source impl facts into owned method/type vectors for every candidate.

Runtime bytecode for array build and grid allocation was identical to pre-merge canary; pure-call differed only by its absolute global index. The slowdown was in VM execution:

- ordinary non-generic calls cloned runtime-check metadata and moved empty type collections;
- every static LoadType execution rematerialized a type object;
- Iterator.next dispatch rebuilt candidate vectors and deep-cloned RuntimeImplRule metadata on every iteration;
- static calls repeatedly walked runtime package graphs and dynamic tables.

Static caches are identity-complete (referenced function plus call site, receiver, interface, interface arguments, and method) and accept results only from immutable program-image rules. Runtime package and dynamic side-table rules are never cached.

## Benchmarks

Five samples, BAML_PROFILE=0, same machine. Baseline is pre-merge canary d8ad5e58c; PR is d149f6da6.

### Compiler

| Benchmark | d8ad5e58c median | PR median | Delta |
|---|---:|---:|---:|
| compile_baml_tests_project | 2.194 s | 2.402 s | +9.5% |
| compile_empty_project | 328.1 ms | 365.1 ms | +11.3% |

The full-project result is below the 3.5-second acceptance bar and the 2.5-second recovery target.

### Runtime

| Workload | d8ad5e58c median (ms) | PR median (ms) | Delta |
|---|---:|---:|---:|
| classes/method_call_100k | 35.88 | 37.37 | +4.2% |
| classes/method_chain_100k | 36.65 | 43.14 | +17.7% |
| compute/array_build_sum_100k | 190.5 | 136.7 | -28.2% |
| compute/binary_tree_depth_20 | 338.5 | 342.5 | +1.2% |
| compute/bubble_sort_5k | 1976 | 1805 | -8.7% |
| compute/call_chain_100x10k | 117.6 | 132.2 | +12.4% |
| compute/class_instances_100k | 14.61 | 18.24 | +24.8% |
| compute/closure_apply_1m | 530.8 | 556.9 | +4.9% |
| compute/collatz_100k | 729.1 | 654.3 | -10.3% |
| compute/divide_guard_1m | 199.7 | 196.2 | -1.8% |
| compute/fib32_recursive | 1107 | 1140 | +3.0% |
| compute/fib_iterative_100k | 259.1 | 246.9 | -4.7% |
| compute/generic_apply_with_inferred_type_args_1m | 677.6 | 601.6 | -11.2% |
| compute/grid_alloc_1000x100 | 167.6 | 148.7 | -11.3% |
| compute/guard_clauses_1m | 227.4 | 230 | +1.1% |
| compute/if_else_dispatch_1m | 218.5 | 230.4 | +5.4% |
| compute/mixed_ops_5k | 3.479 | 2.915 | -16.2% |
| compute/nested_field_access_500k | 155.4 | 210.7 | +35.6% |
| compute/nested_loops_500x500 | 11.17 | 9.973 | -10.7% |
| compute/pure_call_1m | 150.5 | 162.5 | +8.0% |
| compute/wide_nested_class_create_50k | 64.83 | 75.96 | +17.2% |
| concurrency/parallel_sum_4x250k | 15.26 | 13.34 | -12.6% |
| concurrency/parallel_sum_sequential_1m | 42.35 | 33.75 | -20.3% |
| concurrency/shared_array_1w_4r | 19.85 | 22.16 | +11.6% |
| concurrency/shared_array_push_4x25k | 24.02 | 9.127 | -62.0% |
| concurrency/spawn_await_x10k | 119.5 | 111.5 | -6.7% |
| concurrency/spawn_fan_out_100 | 0.5291 | 0.5771 | +9.1% |
| interfaces/default_method_100k | 278.3 | 269.8 | -3.1% |
| interfaces/match_dispatch_100k | 104.2 | 110.7 | +6.2% |
| interfaces/polymorphic_dispatch_100k | 102.1 | 136 | +33.2% |
| string/concat_loop_10k | 1.032 | 1.053 | +2.0% |
| string/contains_medium_literal_100k | 17.63 | 14.93 | -15.3% |
| string/split_long_literal_1k | 2.768 | 2.361 | -14.7% |
| string/split_medium_literal_10k | 13.96 | 13.67 | -2.1% |
| string/split_short_literal_100k | 85.61 | 83.35 | -2.6% |
| string/string_split_100k | 85.51 | 47.02 | -45.0% |
| string/substring_slice_long_100k | 40.76 | 34.82 | -14.6% |
| string/trim_padded_literal_100k | 34.58 | 29.41 | -15.0% |

Acceptance workloads:

| Workload | Ratified limit | PR median | Result |
|---|---:|---:|---|
| array_build_sum_100k | 182.85 ms | 136.7 ms | pass |
| grid_alloc_1000x100 | 188.6 ms | 148.7 ms | pass |
| pure_call_1m | 181.2 ms | 162.5 ms | pass |

## Validation

- Comparison driver: 17/17 passed.
- Focused bex_vm + baml_compiler2_hir_ty nextest: 226/226 passed.
- Pinned gate: 3,724/3,724 passed, 24 skipped; doctests passed; no changed or unreferenced snapshots.
- Pinned gate package set includes baml_tests, baml_cli, baml_lsp2_actions, baml_lsp2_actions_tests, and baml_surface with all features.
- cargo fmt --all -- --check passed.
- Workspace clippy with all targets/features and warnings denied passed in pre-commit hooks.
- Temporary phase timing and bytecode-dump instrumentation was removed before commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved runtime performance by caching static type information and virtual-call targets.
  * Reduced unnecessary copying during implementation and rule resolution.
  * Streamlined generic type handling and runtime call validation.

* **Reliability**
  * Improved implementation resolution across source and packaged implementations.
  * Ensured runtime global lookups use the correct executing package.
  * Preserved dynamic type information while reusing cached static objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->