### PR TITLE
perf: eliminate remaining BEP-066 hot-path overhead

### DIFF
--- a/baml_language/crates/baml_compiler2_hir_ty/src/impls.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/impls.rs
@@ -326,7 +326,7 @@ pub(crate) fn is_concrete_receiver(ty: &Ty) -> bool {
 
 /// Resolution-relevant impl facts in a location-free shape shared by source
 /// blocks and mounted export rows.
-#[derive(Clone)]
+#[derive(Clone, PartialEq)]
 pub struct MountedImplFacts {
     pub interface: InterfaceRef,
     pub for_ty_pattern: Ty,
@@ -334,6 +334,7 @@ pub struct MountedImplFacts {
     pub associated_types: Vec<(Name, Ty)>,
 }
 
+#[derive(Clone, PartialEq)]
 pub enum ResolvedImplFacts<'db> {
     Source(&'db ImplFacts<'db>),
     Mounted(MountedImplFacts),
@@ -370,6 +371,7 @@ impl ResolvedImplFacts<'_> {
 }
 
 /// The dispatch identity retained after matching an impl.
+#[derive(Clone, PartialEq)]
 pub enum ResolvedImplOrigin<'db> {
     Source {
         block: ImplLoc<'db>,
@@ -381,10 +383,46 @@ pub enum ResolvedImplOrigin<'db> {
 }
 
 /// One resolved impl plus the generic instantiation the match pinned.
+#[derive(Clone, PartialEq)]
 pub struct ResolvedImpl<'db> {
     pub origin: ResolvedImplOrigin<'db>,
     pub facts: ResolvedImplFacts<'db>,
     pub bindings: FxHashMap<ParamTy, Ty>,
+}
+
+#[derive(Clone, PartialEq)]
+enum CachedResolvedImplOrigin<'db> {
+    Source {
+        block: ImplLoc<'db>,
+    },
+    Mounted {
+        methods: Vec<crate::package_interface::ExportedFunction>,
+        facts: MountedImplFacts,
+    },
+}
+
+#[derive(Clone, PartialEq)]
+struct CachedResolvedImpl<'db> {
+    origin: CachedResolvedImplOrigin<'db>,
+    bindings: FxHashMap<ParamTy, Ty>,
+}
+
+// SAFETY: the cached rows contain Salsa-interned locations tied to the query
+// database. This is the same PartialEq-driven overwrite contract as ImplFacts.
+#[allow(unsafe_code)]
+unsafe impl salsa::Update for CachedResolvedImpl<'_> {
+    #[allow(unsafe_code)]
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        #[allow(unsafe_code)]
+        unsafe {
+            let changed = *old_pointer != new_value;
+            if changed {
+                std::ptr::drop_in_place(old_pointer);
+                std::ptr::write(old_pointer, new_value);
+            }
+            changed
+        }
+    }
 }
 
 impl ResolvedImpl<'_> {
@@ -652,10 +690,59 @@ pub fn impls_for_type<'db>(
     if concrete.has_infer() || concrete.has_error() {
         return Vec::new();
     }
+    impls_for_type_cached(db, ImplTypeKey::new(db, concrete.clone()))
+        .iter()
+        .map(|cached| match &cached.origin {
+            CachedResolvedImplOrigin::Source { block } => {
+                let facts = impl_facts(db, *block)
+                    .as_ref()
+                    .expect("cached source impl remains well formed");
+                ResolvedImpl {
+                    origin: ResolvedImplOrigin::Source {
+                        block: *block,
+                        methods: &facts.methods,
+                    },
+                    facts: ResolvedImplFacts::Source(facts),
+                    bindings: cached.bindings.clone(),
+                }
+            }
+            CachedResolvedImplOrigin::Mounted { methods, facts } => ResolvedImpl {
+                origin: ResolvedImplOrigin::Mounted {
+                    methods: methods.clone(),
+                },
+                facts: ResolvedImplFacts::Mounted(facts.clone()),
+                bindings: cached.bindings.clone(),
+            },
+        })
+        .collect()
+}
+
+#[salsa::interned]
+struct ImplTypeKey<'db> {
+    #[returns(ref)]
+    concrete: Ty,
+}
+
+/// Memoized ground candidate assembly. Concrete primitive/container types recur
+/// throughout one project (especially through operator and interface lookup),
+/// while their impl set is a pure Salsa-dependent function of the type and
+/// package inputs. Cache that scan once instead of re-walking every impl block
+/// for every expression that mentions the same receiver type.
+#[salsa::tracked(returns(ref))]
+fn impls_for_type_cached<'db>(
+    db: &'db dyn baml_compiler2_ppir::Db,
+    type_key: ImplTypeKey<'db>,
+) -> Vec<CachedResolvedImpl<'db>> {
+    let concrete = type_key.concrete(db);
     let eq = AliasOnlyFacts::new(db);
     let mut out = Vec::new();
-    for package in all_packages(db) {
+    for &package in all_packages(db) {
         for (origin, facts) in package_impl_candidates(db, package) {
+            let pattern = facts.for_ty_pattern();
+            let pattern_has_typevar = pattern.has_typevar();
+            if !pattern_has_typevar && !equivalent_interned(pattern, concrete, &eq) {
+                continue;
+            }
             let params: Vec<ParamTy> = facts
                 .generic_params()
                 .iter()
@@ -669,13 +756,8 @@ pub fn impls_for_type<'db>(
                 continue;
             }
             let mut bindings = FxHashMap::default();
-            if !match_pattern(
-                facts.for_ty_pattern(),
-                concrete,
-                &params,
-                &mut bindings,
-                &eq,
-            ) {
+            if pattern_has_typevar && !match_pattern(pattern, concrete, &params, &mut bindings, &eq)
+            {
                 continue;
             }
             if !bounds_hold(
@@ -704,17 +786,23 @@ pub fn impls_for_type<'db>(
             {
                 continue;
             }
-            out.push(ResolvedImpl {
-                origin,
-                facts,
-                bindings,
-            });
+            let origin = match (origin, facts) {
+                (ResolvedImplOrigin::Source { block, .. }, ResolvedImplFacts::Source(_)) => {
+                    CachedResolvedImplOrigin::Source { block }
+                }
+                (ResolvedImplOrigin::Mounted { methods }, ResolvedImplFacts::Mounted(facts)) => {
+                    CachedResolvedImplOrigin::Mounted { methods, facts }
+                }
+                _ => unreachable!("impl candidate origin and facts have the same provenance"),
+            };
+            out.push(CachedResolvedImpl { origin, bindings });
         }
     }
     out
 }
 
 /// Every package contributing files to the compilation, deduplicated.
+#[salsa::tracked(returns(ref))]
 fn all_packages(db: &dyn baml_compiler2_ppir::Db) -> Vec<PackageId<'_>> {
     let mut names: Vec<Name> = baml_compiler2_hir::compiler2_all_files(db)
         .into_iter()
@@ -732,55 +820,56 @@ fn all_packages(db: &dyn baml_compiler2_ppir::Db) -> Vec<PackageId<'_>> {
 fn package_impl_candidates<'db>(
     db: &'db dyn baml_compiler2_ppir::Db,
     package: PackageId<'db>,
-) -> Vec<(ResolvedImplOrigin<'db>, ResolvedImplFacts<'db>)> {
-    let mut out = Vec::new();
-    for &block in package_impl_locs(db, package) {
-        let Some(facts) = impl_facts(db, block) else {
-            continue;
-        };
-        out.push((
-            ResolvedImplOrigin::Source {
-                block,
-                methods: &facts.methods,
-            },
-            ResolvedImplFacts::Source(facts),
-        ));
-    }
-    if let Some(interface) = crate::package_interface::mounted_interface(db, &package.name(db)) {
-        out.extend(interface.impls.iter().map(|row| {
-            let generic_params = row
-                .generic_params
-                .iter()
-                .enumerate()
-                .map(|(index, param)| {
-                    let bounds = row
-                        .param_bounds
-                        .get(index)
-                        .into_iter()
-                        .flatten()
-                        .map(InterfaceRef::from_constraint)
-                        .collect();
-                    (param.clone(), bounds)
-                })
-                .collect();
-            (
-                ResolvedImplOrigin::Mounted {
-                    methods: row.methods.clone(),
+) -> impl Iterator<Item = (ResolvedImplOrigin<'db>, ResolvedImplFacts<'db>)> + 'db {
+    let source = package_impl_locs(db, package)
+        .iter()
+        .filter_map(move |&block| {
+            let facts = impl_facts(db, block).as_ref()?;
+            Some((
+                ResolvedImplOrigin::Source {
+                    block,
+                    methods: &facts.methods,
                 },
-                ResolvedImplFacts::Mounted(MountedImplFacts {
-                    interface: InterfaceRef::from_constraint(&row.interface),
-                    for_ty_pattern: Ty::from_plain(&row.for_ty_pattern),
-                    generic_params,
-                    associated_types: row
-                        .associated_types
-                        .iter()
-                        .map(|(name, ty)| (name.clone(), Ty::from_plain(ty)))
-                        .collect(),
-                }),
-            )
-        }));
-    }
-    out
+                ResolvedImplFacts::Source(facts),
+            ))
+        });
+    let mounted = crate::package_interface::mounted_interface(db, &package.name(db))
+        .into_iter()
+        .flat_map(move |interface| {
+            interface.impls.iter().map(|row| {
+                let generic_params = row
+                    .generic_params
+                    .iter()
+                    .enumerate()
+                    .map(|(index, param)| {
+                        let bounds = row
+                            .param_bounds
+                            .get(index)
+                            .into_iter()
+                            .flatten()
+                            .map(InterfaceRef::from_constraint)
+                            .collect();
+                        (param.clone(), bounds)
+                    })
+                    .collect();
+                (
+                    ResolvedImplOrigin::Mounted {
+                        methods: row.methods.clone(),
+                    },
+                    ResolvedImplFacts::Mounted(MountedImplFacts {
+                        interface: InterfaceRef::from_constraint(&row.interface),
+                        for_ty_pattern: Ty::from_plain(&row.for_ty_pattern),
+                        generic_params,
+                        associated_types: row
+                            .associated_types
+                            .iter()
+                            .map(|(name, ty)| (name.clone(), Ty::from_plain(ty)))
+                            .collect(),
+                    }),
+                )
+            })
+        });
+    source.chain(mounted)
 }
 
 /// Every impl block implementing `interface_name`, drawn from the
@@ -817,7 +906,7 @@ pub(crate) fn impl_candidates<'db>(
 /// (`impls_for_type`) does.
 pub(crate) fn all_impl_facts(db: &dyn baml_compiler2_ppir::Db) -> Vec<&ImplFacts<'_>> {
     let mut out = Vec::new();
-    for package in all_packages(db) {
+    for &package in all_packages(db) {
         for &block in package_impl_locs(db, package) {
             if let Some(facts) = impl_facts(db, block) {
                 out.push(facts);

--- a/baml_language/crates/baml_compiler2_hir_ty/src/impls.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/impls.rs
@@ -392,9 +392,12 @@ pub struct ResolvedImpl<'db> {
 
 #[derive(Clone, PartialEq)]
 enum CachedResolvedImplOrigin<'db> {
-    Source {
-        block: ImplLoc<'db>,
-    },
+    /// Deliberately fact-free: source facts are Salsa-derived and must be
+    /// re-hydrated by `impls_for_type` so the caller records their live query
+    /// dependency rather than retaining a stale borrowed result here.
+    Source { block: ImplLoc<'db> },
+    /// Mounted facts are owned imported data with no Salsa query from which to
+    /// re-hydrate them, so this arm retains the facts alongside the methods.
     Mounted {
         methods: Vec<crate::package_interface::ExportedFunction>,
         facts: MountedImplFacts,
@@ -407,8 +410,9 @@ struct CachedResolvedImpl<'db> {
     bindings: FxHashMap<ParamTy, Ty>,
 }
 
-// SAFETY: the cached rows contain Salsa-interned locations tied to the query
-// database. This is the same PartialEq-driven overwrite contract as ImplFacts.
+// SAFETY: cached rows contain no `db` borrows: only owned collections and
+// Copy/interned handles. PartialEq therefore completely determines whether the
+// old allocation can be retained, matching Salsa's update contract.
 #[allow(unsafe_code)]
 unsafe impl salsa::Update for CachedResolvedImpl<'_> {
     #[allow(unsafe_code)]
@@ -723,12 +727,22 @@ struct ImplTypeKey<'db> {
     concrete: Ty,
 }
 
+/// A recursive obligation can re-enter candidate assembly through
+/// `bounds_hold`; inductive impl cycles contribute no candidates.
+fn impls_for_type_cycle_result<'db>(
+    _db: &'db dyn baml_compiler2_ppir::Db,
+    _id: salsa::Id,
+    _type_key: ImplTypeKey<'db>,
+) -> Vec<CachedResolvedImpl<'db>> {
+    Vec::new()
+}
+
 /// Memoized ground candidate assembly. Concrete primitive/container types recur
 /// throughout one project (especially through operator and interface lookup),
 /// while their impl set is a pure Salsa-dependent function of the type and
 /// package inputs. Cache that scan once instead of re-walking every impl block
 /// for every expression that mentions the same receiver type.
-#[salsa::tracked(returns(ref))]
+#[salsa::tracked(returns(ref), cycle_result = impls_for_type_cycle_result)]
 fn impls_for_type_cached<'db>(
     db: &'db dyn baml_compiler2_ppir::Db,
     type_key: ImplTypeKey<'db>,
@@ -737,6 +751,9 @@ fn impls_for_type_cached<'db>(
     let eq = AliasOnlyFacts::new(db);
     let mut out = Vec::new();
     for &package in all_packages(db) {
+        // Do not short-circuit this iterator: `impl_facts` dependencies are
+        // registered lazily as source rows are visited. This memoized query
+        // must exhaust every package so later fact changes invalidate it.
         for (origin, facts) in package_impl_candidates(db, package) {
             let pattern = facts.for_ty_pattern();
             let pattern_has_typevar = pattern.has_typevar();

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -4303,17 +4303,19 @@ impl<'db> InferenceContext<'db> {
     }
 
     fn validate_runtime_type_arg_operands(&mut self, body: &ExprBody, call: ExprId) {
-        let slots = self
+        let operands: Vec<_> = self
             .type_refs
             .expr_type_args
             .get(&call)
-            .cloned()
-            .unwrap_or_default();
-        for slot in &*slots {
-            let BodyTypeArgRef::Runtime { operand } = slot else {
-                continue;
-            };
-            self.validate_runtime_type_operand(body, *operand);
+            .into_iter()
+            .flat_map(|slots| slots.iter())
+            .filter_map(|slot| match slot {
+                BodyTypeArgRef::Runtime { operand } => Some(*operand),
+                BodyTypeArgRef::Static(_) => None,
+            })
+            .collect();
+        for operand in operands {
+            self.validate_runtime_type_operand(body, operand);
         }
     }
 
@@ -4382,6 +4384,21 @@ impl<'db> InferenceContext<'db> {
         callee: ExprId,
         args: &[baml_compiler2_ast::CallArg],
     ) {
+        let callee_name = match &body.exprs[callee] {
+            Expr::Path(segments) => segments.last(),
+            Expr::MemberAccess { member, .. } | Expr::OptionalMemberAccess { member, .. } => {
+                Some(member)
+            }
+            _ => None,
+        };
+        if !callee_name.is_some_and(|name| {
+            matches!(
+                name.as_str(),
+                "render_prompt" | "build_request" | "build_request_stream"
+            )
+        }) {
+            return;
+        }
         if self.type_refs.expr_type_args.contains_key(&call) {
             return;
         }
@@ -4459,12 +4476,17 @@ impl<'db> InferenceContext<'db> {
         let _ = self.table.unify(&schema_arg, &target_ret);
     }
 
-    fn default_uncontracted_session_eval(
-        &mut self,
-        _body: &ExprBody,
-        call: ExprId,
-        callee: ExprId,
-    ) {
+    fn default_uncontracted_session_eval(&mut self, body: &ExprBody, call: ExprId, callee: ExprId) {
+        let callee_name = match &body.exprs[callee] {
+            Expr::Path(segments) => segments.last(),
+            Expr::MemberAccess { member, .. } | Expr::OptionalMemberAccess { member, .. } => {
+                Some(member)
+            }
+            _ => None,
+        };
+        if callee_name.is_none_or(|name| name.as_str() != "eval") {
+            return;
+        }
         if self.type_refs.expr_type_args.contains_key(&call) {
             return;
         }
@@ -6601,6 +6623,28 @@ impl<'db> InferenceContext<'db> {
                 continue;
             };
             for bound in param_bounds {
+                if runtime_params.is_empty() && self.scoped_type_bindings.is_empty() {
+                    let interface = baml_type::interned::InterfaceRef::new(
+                        bound.name.clone(),
+                        bound
+                            .generics
+                            .iter()
+                            .map(|generic| substitute_params(generic, instantiation))
+                            .collect(),
+                        bound
+                            .associated_types
+                            .iter()
+                            .map(|(name, ty)| (name.clone(), substitute_params(ty, instantiation)))
+                            .collect(),
+                    );
+                    self.register_obligation(obligations::Obligation::Implements {
+                        ty: arg.clone(),
+                        interface,
+                        at,
+                        not_concrete_rejects: (param.index() as usize) >= own_start,
+                    });
+                    continue;
+                }
                 let runtime_slot_dependent = runtime_params
                     .iter()
                     .any(|runtime| runtime == &param || interface_mentions_param(&bound, runtime));
@@ -6890,6 +6934,13 @@ impl<'db> InferenceContext<'db> {
         signature: &crate::lower::FunctionSignature,
         bound_receiver: bool,
     ) {
+        if !self.result.call_plans.get(&call).is_some_and(|plan| {
+            plan.slots
+                .iter()
+                .any(|slot| matches!(slot, CallTypeArgPlan::Runtime { .. }))
+        }) {
+            return;
+        }
         let runtime_params = self.runtime_call_params(call);
         if runtime_params.is_empty() {
             return;
@@ -8465,6 +8516,18 @@ impl<'db> InferenceContext<'db> {
         own_offset: usize,
     ) -> Vec<Ty> {
         let explicit = self.type_refs.expr_type_args.contains_key(&call);
+        if !self.result.call_plans.get(&call).is_some_and(|plan| {
+            plan.slots
+                .iter()
+                .any(|slot| matches!(slot, CallTypeArgPlan::Runtime { .. }))
+        }) {
+            let type_args = type_args.to_vec();
+            let plan = self.result.call_plans.entry(call).or_default();
+            plan.type_args.clone_from(&type_args);
+            plan.own_offset = own_offset;
+            plan.explicit = explicit;
+            return type_args;
+        }
         let runtime_params = self.runtime_call_params(call);
         let mut type_args = type_args.to_vec();
         let runtime_occurrences: Vec<(baml_type::ParamTy, Ty)> = self

--- a/baml_language/crates/baml_tests/tests/interfaces.rs
+++ b/baml_language/crates/baml_tests/tests/interfaces.rs
@@ -3000,6 +3000,51 @@ async fn same_generic_interface_different_type_params_disambiguated_with_as_proj
     assert_eq!(output.result.unwrap(), BexExternalValue::Bool(true));
 }
 
+/// A single generic function has one `VirtualCall` bytecode site even when it
+/// is invoked with heterogeneous interface arguments. The full VM fact context
+/// canonicalizes `Animal | Dog` to `Animal` because `Dog implements Animal`,
+/// but impl selection deliberately compares interface arguments under the
+/// fact-poor structural context. The dispatch cache must therefore retain the
+/// realized interface arguments in addition to the static type-value mint.
+#[tokio::test]
+async fn virtual_dispatch_cache_distinguishes_generic_interface_instantiations() {
+    let output = baml_test!(
+        r#"
+        interface Animal {}
+
+        class Dog {
+            implements Animal {}
+        }
+
+        interface Tagged<T> {
+            function tag(self) -> string throws never
+        }
+
+        class Both {
+            implements Tagged<Animal> {
+                function tag(self) -> string { return "animal" }
+            }
+            implements Tagged<Animal | Dog> {
+                function tag(self) -> string { return "animal-or-dog" }
+            }
+        }
+
+        function read_tag<T>(value: Tagged<T>) -> string {
+            return value.tag()
+        }
+
+        function main() -> string {
+            let value = Both {}
+            return read_tag<Animal>(value) + "|" + read_tag<Animal | Dog>(value)
+        }
+        "#
+    );
+    assert_eq!(
+        output.result.unwrap(),
+        BexExternalValue::String("animal|animal-or-dog".into())
+    );
+}
+
 #[tokio::test]
 async fn generic_bound_runtime() {
     // Interface-typed arrays preserve the interface field view and dispatch

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -156,6 +156,12 @@ struct StaticVirtualCallKey {
     call_pc: usize,
     receiver: StaticVirtualReceiverKey,
     interface_mint: u64,
+    /// Impl selection compares these under `StructuralEquivCtx`, which is
+    /// deliberately fact-poor. The static mint is canonicalized under the full
+    /// VM context and can therefore equate interface instantiations that the
+    /// resolver distinguishes (for example `I<Animal>` and `I<Animal | Dog>`).
+    /// Empty for the overwhelmingly common non-generic interface case.
+    interface_args: Box<[baml_type::RealizedTy]>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -2617,9 +2623,7 @@ impl BexVm {
         if let Some(ptr) = value.as_object_ptr()
             && let Object::Instance(instance) = self.get_object(ptr)
             && let Object::Class(class) = self.get_object(instance.class)
-            && class.runtime_type.is_none()
-            && crate::package_baml::json::media_kind_from_fqn(class.name.display_name().as_str())
-                .is_none()
+            && self.heap.is_compile_time_ptr(instance.class)
         {
             return Some(StaticVirtualReceiverKey::Class {
                 type_tag: class.type_tag,
@@ -7122,6 +7126,14 @@ impl BexVm {
                         let Object::Type(type_value) = self.get_object(iface_ptr) else {
                             unreachable!("as_object_ptr(Type) guarantees a Type object")
                         };
+                        let interface_args = match &type_value.ty {
+                            baml_type::RealizedTy::Interface(_, args, _, _) => {
+                                args.clone().into_boxed_slice()
+                            }
+                            other => unreachable!(
+                                "VirtualCall interface operand must be an Interface type, found {other:?}"
+                            ),
+                        };
                         match type_value.mint() {
                             MintId::Static(interface_mint) => self
                                 .static_virtual_receiver_key(receiver)
@@ -7130,6 +7142,7 @@ impl BexVm {
                                     call_pc: self.cur_pc,
                                     receiver,
                                     interface_mint,
+                                    interface_args,
                                 }),
                             MintId::Runtime(_) => None,
                         }

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -124,15 +124,30 @@ struct CallOptions<'a> {
     runtime_id: Option<Value>,
     type_args: &'a [baml_type::RealizedTy],
     type_defs: &'a DynTypeDefs,
-    type_values: &'a [TypeValue],
+    type_values: &'a [Option<TypeValue>],
     runtime_type_check: bool,
 }
 
 #[derive(Clone, Debug, Default)]
 struct TakenTypeArgs {
     tys: Vec<baml_type::RealizedTy>,
-    values: Vec<TypeValue>,
+    values: Vec<Option<TypeValue>>,
     defs: DynTypeDefs,
+}
+
+fn append_virtual_method_type_args(
+    frame_type_args: &mut Vec<baml_type::RealizedTy>,
+    method_type_args: &TakenTypeArgs,
+) -> Vec<Option<TypeValue>> {
+    let mut type_values = Vec::new();
+    if !method_type_args.values.is_empty() {
+        // The resolver-provided owner/impl slots precede method-level slots in
+        // the callee frame. Preserve that sparse alignment for exact values.
+        type_values.resize(frame_type_args.len(), None);
+        type_values.extend_from_slice(&method_type_args.values);
+    }
+    frame_type_args.extend_from_slice(&method_type_args.tys);
+    type_values
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -315,13 +330,6 @@ impl RootHaver for BytecodeFrame {
                 .values
                 .iter()
                 .flatten()
-                .flat_map(|value| value.defs().classes.values().copied()),
-        );
-        roots.extend(
-            metadata
-                .values
-                .iter()
-                .flatten()
                 .flat_map(|value| value.defs().enums.values().copied()),
         );
         roots.extend(
@@ -345,9 +353,6 @@ impl RootHaver for BytecodeFrame {
         }
         for value in metadata.values.iter_mut().flatten() {
             value.owner = roots.get(&value.owner).copied().unwrap_or(value.owner);
-            for ptr in value.defs_mut().classes.values_mut() {
-                *ptr = roots.get(ptr).copied().unwrap_or(*ptr);
-            }
             for ptr in value.defs_mut().enums.values_mut() {
                 *ptr = roots.get(ptr).copied().unwrap_or(*ptr);
             }
@@ -410,10 +415,13 @@ pub(crate) mod tests {
         EarlyYieldCheck, FunctionCaptureProps, FunctionKind, GlobalPool, HeapPtr, Object,
         ObjectIndex, RootHaver, Value, ValueKind, VmGlobals,
         bytecode::Bytecode,
-        types::{Function, FunctionOrigin, type_tags},
+        types::{DynTypeDefs, Function, FunctionOrigin, MintId, TypeValue, type_tags},
     };
 
-    use super::{BexVm, Frame, VmCaptureMask, VmExecState, value_type_tag};
+    use super::{
+        BexVm, Frame, FrameTypeMetadata, TakenTypeArgs, VmCaptureMask, VmExecState,
+        append_virtual_method_type_args, value_type_tag,
+    };
     use crate::{
         indexable::EvalStack,
         package_baml::{NativeCallResult, NativeFunction},
@@ -614,6 +622,73 @@ pub(crate) mod tests {
             !forwarding.contains_key(&trampoline),
             "unrooted trampoline function must not be forwarded after return"
         );
+    }
+
+    #[test]
+    fn frame_type_metadata_is_included_in_vm_gc_roots() {
+        let (mut vm, native_ptr) = vm_with_native_entry();
+        vm.set_entry_point(native_ptr, &[]);
+
+        let metadata_ptr = vm.tlab.alloc(native_function_object());
+        let metadata_name = baml_type::QualifiedTypeName::from_dotted_path("test.Metadata");
+        let Some(Frame::Bytecode(frame)) = vm.frames.last_mut() else {
+            panic!("expected trampoline bytecode frame");
+        };
+        frame.type_metadata = Some(Box::new(FrameTypeMetadata {
+            defs: DynTypeDefs::with_class(metadata_name.clone(), metadata_ptr),
+            values: Vec::new(),
+        }));
+
+        let mut roots = Vec::new();
+        vm.collect_roots(&mut roots);
+        assert!(
+            roots.contains(&metadata_ptr),
+            "active frame metadata must root referenced definitions"
+        );
+
+        let (_stats, _remapped_roots, forwarding) = unsafe {
+            vm.heap
+                .collect_garbage_generational(&roots, CollectionLevel::Major)
+        };
+        let moved_metadata = forwarding
+            .get(&metadata_ptr)
+            .copied()
+            .expect("frame metadata definition must survive collection");
+        vm.forward_roots(&forwarding);
+
+        let Some(Frame::Bytecode(frame)) = vm.frames.last() else {
+            panic!("expected trampoline bytecode frame");
+        };
+        let forwarded_metadata = frame
+            .type_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.defs.classes.get(&metadata_name))
+            .copied();
+        assert_eq!(forwarded_metadata, Some(moved_metadata));
+    }
+
+    #[test]
+    fn virtual_method_exact_type_values_follow_owner_slots() {
+        let exact = TypeValue::from_parts(baml_type::RealizedTy::string(), MintId::Runtime(7));
+        let method = TakenTypeArgs {
+            tys: vec![baml_type::RealizedTy::string()],
+            values: vec![Some(exact.clone())],
+            defs: DynTypeDefs::default(),
+        };
+        let mut frame_type_args = vec![baml_type::RealizedTy::int()];
+
+        let values = append_virtual_method_type_args(&mut frame_type_args, &method);
+
+        assert_eq!(
+            frame_type_args,
+            vec![
+                baml_type::RealizedTy::int(),
+                baml_type::RealizedTy::string()
+            ]
+        );
+        assert_eq!(values.len(), 2);
+        assert!(values[0].is_none(), "owner slot must remain reconstructed");
+        assert_eq!(values[1].as_ref().map(TypeValue::mint), Some(exact.mint()));
     }
 }
 
@@ -892,7 +967,7 @@ pub struct BexVm {
     /// re-enter the VM (via `YieldToCall`) therefore see their own type-args
     /// even if the inner callback uses different ones.
     pending_call_type_args: Vec<baml_type::RealizedTy>,
-    pending_call_type_values: Vec<TypeValue>,
+    pending_call_type_values: Vec<Option<TypeValue>>,
 
     /// Memo for `MintId::Static` digests (BEP-066), keyed by the *spelled*
     /// `RealizedTy`. `LoadType` runs on every generic call, and the digest is
@@ -1547,7 +1622,7 @@ impl BexVm {
                 .into());
             };
             type_args.tys.push(type_value.ty.clone());
-            type_args.values.push(type_value.clone());
+            type_args.values.push(Some(type_value.clone()));
             type_args.defs.merge_from(type_value.defs());
         }
         drop(
@@ -1978,10 +2053,7 @@ impl BexVm {
     pub fn collect_frame_roots(&self) -> Vec<HeapPtr> {
         let mut roots = Vec::new();
         for frame in &self.frames {
-            roots.push(frame.function());
-            if let Frame::Native(nf) = frame {
-                roots.extend(nf.continuation.gc_roots());
-            }
+            frame.collect_roots(&mut roots);
         }
         roots
     }
@@ -2889,8 +2961,8 @@ impl BexVm {
         match callable_kind {
             FunctionKind::Bytecode => {
                 self.pending_call_type_args.clone_from(&effective_type_args);
-                self.pending_call_type_values =
-                    effective_type_values.iter().flatten().cloned().collect();
+                self.pending_call_type_values
+                    .clone_from(&effective_type_values);
                 let mut type_defs = DynTypeDefs::default();
                 for value in effective_type_values.iter().flatten() {
                     type_defs.merge_from(value.defs());
@@ -5625,7 +5697,8 @@ impl BexVm {
                 metadata.values.resize(initial_type_arg_count, None);
                 metadata.defs.merge_from(options.type_defs);
                 metadata.values.extend(
-                    (0..options.type_args.len()).map(|slot| options.type_values.get(slot).cloned()),
+                    (0..options.type_args.len())
+                        .map(|slot| options.type_values.get(slot).cloned().flatten()),
                 );
             }
         }
@@ -7133,9 +7206,9 @@ impl BexVm {
                         }
                         (callee, frame)
                     };
-                    if let Some(method_type_args) = &method_type_args {
-                        type_args.extend_from_slice(&method_type_args.tys);
-                    }
+                    let type_values = method_type_args.as_ref().map_or_else(Vec::new, |method| {
+                        append_virtual_method_type_args(&mut type_args, method)
+                    });
 
                     let locals_offset = StackIndex::from_raw(args_offset);
 
@@ -7172,7 +7245,7 @@ impl BexVm {
                                 runtime_id,
                                 type_args: &type_args,
                                 type_defs,
-                                type_values: &[],
+                                type_values: &type_values,
                                 runtime_type_check,
                             },
                             frame_idx,
@@ -8767,17 +8840,20 @@ impl ::bex_vm_types::RootHaver for BexVm {
         roots.extend(
             self.pending_call_type_values
                 .iter()
+                .flatten()
                 .map(|value| value.owner)
                 .filter(|owner| !owner.is_null()),
         );
         roots.extend(
             self.pending_call_type_values
                 .iter()
+                .flatten()
                 .flat_map(|value| value.defs().enums.values().copied()),
         );
         roots.extend(
             self.pending_call_type_values
                 .iter()
+                .flatten()
                 .flat_map(|value| value.defs().classes.values().copied()),
         );
         roots.extend(
@@ -8823,7 +8899,7 @@ impl ::bex_vm_types::RootHaver for BexVm {
                 event.value = Value::object(new_ptr);
             }
         }
-        for value in &mut self.pending_call_type_values {
+        for value in self.pending_call_type_values.iter_mut().flatten() {
             value.owner = roots.get(&value.owner).copied().unwrap_or(value.owner);
             for ptr in value.defs_mut().enums.values_mut() {
                 *ptr = roots.get(ptr).copied().unwrap_or(*ptr);

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -139,10 +139,22 @@ struct TakenTypeArgs {
 struct StaticVirtualCallKey {
     caller_function_addr: usize,
     call_pc: usize,
-    receiver: baml_type::RealizedTy,
-    interface: baml_type::TypeName,
-    interface_args: Box<[baml_type::RealizedTy]>,
-    method: String,
+    receiver: StaticVirtualReceiverKey,
+    interface_mint: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+enum StaticVirtualReceiverKey {
+    /// Static program classes have immutable, program-unique tags. Generic
+    /// arguments remain part of identity; the overwhelmingly common
+    /// non-generic case clones an empty box without allocating.
+    Class {
+        type_tag: i64,
+        type_args: Box<[baml_type::RealizedTy]>,
+    },
+    /// Primitive/container receivers do not have a static class object to key
+    /// through, so retain their realized type as the uncommon fallback.
+    Other(baml_type::RealizedTy),
 }
 
 #[derive(Clone, Debug)]
@@ -248,14 +260,10 @@ pub struct BytecodeFrame {
     /// (`GenericFunction`/`BoundMethod`/`Closure`/`Instance`), so a `LoadType`
     /// substitutes them into a fully realized type.
     pub type_args: Vec<baml_type::RealizedTy>,
-    /// Dynamic definitions reachable from the frame's runtime type arguments.
-    /// This side lane preserves the existing realized-type substitution ABI
-    /// while allowing reified `type.of<T>()` values to carry their overlay.
-    pub type_defs: DynTypeDefs,
-    /// Exact runtime type values for explicitly supplied slots. This preserves
-    /// dynamic package mint/owner identity across `unreflect(...)`; wrapper-
-    /// supplied static slots use `None` and are reconstructed normally.
-    pub type_values: Vec<Option<TypeValue>>,
+    /// Exact BEP-066 runtime-type metadata. Ordinary calls have no dynamic
+    /// definitions or exact values, so keep the comparatively large pair of
+    /// side lanes boxed and absent from their hot call frames.
+    type_metadata: Option<Box<FrameTypeMetadata>>,
     /// Byte offset of the most recently dispatched opcode (compact path).
     /// In the legacy path this mirrors `instruction_ptr - 1` and is kept
     /// up-to-date before each `step()` call.
@@ -275,32 +283,50 @@ pub struct BytecodeFrame {
     pub(crate) capture_mask: VmCaptureMask,
 }
 
+#[derive(Clone, Debug, Default)]
+struct FrameTypeMetadata {
+    /// Dynamic definitions reachable from the frame's runtime type arguments.
+    /// This preserves the realized-type substitution ABI while allowing
+    /// reified `type.of<T>()` values to carry their overlay.
+    defs: DynTypeDefs,
+    /// Exact runtime type values for explicitly supplied slots. Wrapper-
+    /// supplied static slots use `None` and are reconstructed normally.
+    values: Vec<Option<TypeValue>>,
+}
+
 impl RootHaver for BytecodeFrame {
     fn collect_roots(&self, roots: &mut Vec<HeapPtr>) {
         roots.push(self.function);
-        roots.extend(self.type_defs.classes.values().copied());
-        roots.extend(self.type_defs.enums.values().copied());
+        let Some(metadata) = &self.type_metadata else {
+            return;
+        };
+        roots.extend(metadata.defs.classes.values().copied());
+        roots.extend(metadata.defs.enums.values().copied());
         roots.extend(
-            self.type_values
+            metadata
+                .values
                 .iter()
                 .flatten()
                 .map(|value| value.owner)
                 .filter(|owner| !(*owner).is_null()),
         );
         roots.extend(
-            self.type_values
+            metadata
+                .values
                 .iter()
                 .flatten()
                 .flat_map(|value| value.defs().classes.values().copied()),
         );
         roots.extend(
-            self.type_values
+            metadata
+                .values
                 .iter()
                 .flatten()
                 .flat_map(|value| value.defs().enums.values().copied()),
         );
         roots.extend(
-            self.type_values
+            metadata
+                .values
                 .iter()
                 .flatten()
                 .flat_map(|value| value.defs().classes.values().copied()),
@@ -308,13 +334,16 @@ impl RootHaver for BytecodeFrame {
     }
     fn forward_roots(&mut self, roots: &HashMap<HeapPtr, HeapPtr>) {
         self.function = roots.get(&self.function).copied().unwrap_or(self.function);
-        for ptr in self.type_defs.classes.values_mut() {
+        let Some(metadata) = &mut self.type_metadata else {
+            return;
+        };
+        for ptr in metadata.defs.classes.values_mut() {
             *ptr = roots.get(ptr).copied().unwrap_or(*ptr);
         }
-        for ptr in self.type_defs.enums.values_mut() {
+        for ptr in metadata.defs.enums.values_mut() {
             *ptr = roots.get(ptr).copied().unwrap_or(*ptr);
         }
-        for value in self.type_values.iter_mut().flatten() {
+        for value in metadata.values.iter_mut().flatten() {
             value.owner = roots.get(&value.owner).copied().unwrap_or(value.owner);
             for ptr in value.defs_mut().classes.values_mut() {
                 *ptr = roots.get(ptr).copied().unwrap_or(*ptr);
@@ -1456,6 +1485,9 @@ impl BexVm {
             .checked_add(count)
             .filter(|end| *end <= self.stack.len())
             .ok_or(VmInternalError::NotEnoughItemsOnStack(count))?;
+        if count == 0 {
+            return Ok(TakenTypeArgs::default());
+        }
         let all_plain_static = (start..end).all(|slot| {
             let value = self.stack[StackIndex::from_raw(slot)];
             value.as_object_ptr().is_some_and(|ptr| {
@@ -2504,6 +2536,29 @@ impl BexVm {
         })
     }
 
+    /// Build the allocation-light receiver half of a static virtual-dispatch
+    /// cache key. Static class tags are immutable and unique in one program,
+    /// so non-generic instances avoid rebuilding and hashing their qualified
+    /// class name on every method call. Runtime-built classes stay off this
+    /// cache because their dispatch tables are live.
+    fn static_virtual_receiver_key(&self, value: Value) -> Option<StaticVirtualReceiverKey> {
+        if let Some(ptr) = value.as_object_ptr()
+            && let Object::Instance(instance) = self.get_object(ptr)
+            && let Object::Class(class) = self.get_object(instance.class)
+            && class.runtime_type.is_none()
+            && crate::package_baml::json::media_kind_from_fqn(class.name.display_name().as_str())
+                .is_none()
+        {
+            return Some(StaticVirtualReceiverKey::Class {
+                type_tag: class.type_tag,
+                type_args: instance.class_type_args.clone(),
+            });
+        }
+        self.value_concrete_ty(value)
+            .map(baml_type::RealizedTy::from)
+            .map(StaticVirtualReceiverKey::Other)
+    }
+
     /// Runtime package that owns a value's nominal/callable definition.
     /// Static values and standalone runtime-constructed types return null.
     pub(crate) fn value_runtime_package(&self, value: Value) -> HeapPtr {
@@ -2840,6 +2895,15 @@ impl BexVm {
                 for value in effective_type_values.iter().flatten() {
                     type_defs.merge_from(value.defs());
                 }
+                let type_metadata =
+                    if type_defs.is_empty() && effective_type_values.iter().all(Option::is_none) {
+                        None
+                    } else {
+                        Some(Box::new(FrameTypeMetadata {
+                            defs: type_defs,
+                            values: effective_type_values,
+                        }))
+                    };
                 self.stack.extend(args.iter().copied());
                 // The thread-root call: parent_call_id is 0 on a fresh VM.
                 let (call_id, parent_call_id) = self.prof_enter_call(entry_function_id, None);
@@ -2848,8 +2912,7 @@ impl BexVm {
                     instruction_ptr: 0,
                     locals_offset: StackIndex::from_raw(0),
                     type_args: effective_type_args,
-                    type_defs,
-                    type_values: effective_type_values,
+                    type_metadata,
                     faulting_pc: 0,
                     call_id,
                     parent_call_id,
@@ -3012,8 +3075,7 @@ impl BexVm {
             instruction_ptr: 0,
             locals_offset: StackIndex::from_raw(0),
             type_args: Vec::new(),
-            type_defs: DynTypeDefs::default(),
-            type_values: Vec::new(),
+            type_metadata: None,
             faulting_pc: 0,
             call_id,
             parent_call_id,
@@ -3090,8 +3152,7 @@ impl BexVm {
             instruction_ptr: 0,
             locals_offset: StackIndex::from_raw(0),
             type_args: Vec::new(),
-            type_defs: DynTypeDefs::default(),
-            type_values: Vec::new(),
+            type_metadata: None,
             faulting_pc: 0,
             call_id,
             parent_call_id,
@@ -5085,41 +5146,6 @@ impl BexVm {
         let callee_function_id = callee.function_id;
         let callee_capture = callee.capture;
         let callee_param_names = callee.param_names.clone();
-        // Marker calls are rare. Avoid cloning executable type metadata on
-        // every ordinary call before the encoded marker bit has even been
-        // checked; those clones dominated small-function call benchmarks.
-        let runtime_check_metadata = runtime_type_check.then(|| {
-            (
-                callee.param_types.clone(),
-                callee.generic_param_bounds.clone(),
-            )
-        });
-
-        // `unreflect(...)` deliberately hides its concrete type from TIR, so
-        // declared generic bounds must be enforced at the first boundary that
-        // sees the realized type.  Do this before arity handling, profiling,
-        // argument draining, or frame creation: a failure is a catchable
-        // CompilationError and the callee cannot observe any side effect.
-        let needs_bound_check = runtime_check_metadata
-            .as_ref()
-            .is_some_and(|(_, bounds)| bounds.iter().any(|bounds| !bounds.is_empty()));
-        let needs_argument_check = runtime_check_metadata
-            .as_ref()
-            .is_some_and(|(params, _)| params.iter().any(|param| !param.is_fully_concrete()));
-        let effective_type_args = if needs_bound_check || needs_argument_check {
-            let mut type_args = if !bound_method_class_type_args.is_empty() {
-                bound_method_class_type_args.to_vec()
-            } else if !gf_type_args.is_empty() {
-                gf_type_args.to_vec()
-            } else {
-                closure_type_args.to_vec()
-            };
-            type_args.extend_from_slice(&self.pending_call_type_args);
-            type_args
-        } else {
-            Vec::new()
-        };
-
         if arg_count != callee_arity {
             return Err(VmInternalError::InvalidArgumentCount {
                 expected: callee_arity,
@@ -5127,25 +5153,44 @@ impl BexVm {
             }
             .into());
         }
-        if needs_bound_check {
-            let (_, callee_generic_param_bounds) = runtime_check_metadata
-                .as_ref()
-                .expect("runtime checks have metadata");
-            self.validate_runtime_generic_bounds(
-                &callee_name,
-                callee_generic_param_bounds,
-                &effective_type_args,
-            )?;
-        }
-        if needs_argument_check {
-            let (callee_param_types, _) = runtime_check_metadata
-                .as_ref()
-                .expect("runtime checks have metadata");
-            self.validate_runtime_call_arguments(
-                callee_param_types,
-                &effective_type_args,
-                locals_offset,
-            )?;
+        if runtime_type_check {
+            // `unreflect(...)` deliberately hides its concrete type from TIR,
+            // so marker calls must validate executable generic metadata at the
+            // first boundary that sees the realized type. Keep the metadata
+            // clones and type-vector assembly entirely inside this rare branch;
+            // ordinary calls pay one predicted-not-taken bit test only.
+            let callee_param_types = callee.param_types.clone();
+            let callee_generic_param_bounds = callee.generic_param_bounds.clone();
+            let needs_bound_check = callee_generic_param_bounds
+                .iter()
+                .any(|bounds| !bounds.is_empty());
+            let needs_argument_check = callee_param_types
+                .iter()
+                .any(|param| !param.is_fully_concrete());
+            if needs_bound_check || needs_argument_check {
+                let mut effective_type_args = if !bound_method_class_type_args.is_empty() {
+                    bound_method_class_type_args.to_vec()
+                } else if !gf_type_args.is_empty() {
+                    gf_type_args.to_vec()
+                } else {
+                    closure_type_args.to_vec()
+                };
+                effective_type_args.extend_from_slice(&self.pending_call_type_args);
+                if needs_bound_check {
+                    self.validate_runtime_generic_bounds(
+                        &callee_name,
+                        &callee_generic_param_bounds,
+                        &effective_type_args,
+                    )?;
+                }
+                if needs_argument_check {
+                    self.validate_runtime_call_arguments(
+                        &callee_param_types,
+                        &effective_type_args,
+                        locals_offset,
+                    )?;
+                }
+            }
         }
         let capture_mask =
             VmCaptureMask::from_props(callee_capture, self.value_capture_auto_enabled);
@@ -5359,8 +5404,7 @@ impl BexVm {
                     instruction_ptr: 0,
                     locals_offset,
                     type_args: initial_type_args.into_vec(),
-                    type_defs: DynTypeDefs::default(),
-                    type_values: Vec::new(),
+                    type_metadata: None,
                     faulting_pc: 0,
                     call_id,
                     parent_call_id,
@@ -5575,9 +5619,12 @@ impl BexVm {
             let initial_type_arg_count = frame.type_args.len();
             frame.type_args.extend_from_slice(options.type_args);
             if !options.type_defs.is_empty() || !options.type_values.is_empty() {
-                frame.type_values.resize(initial_type_arg_count, None);
-                frame.type_defs.merge_from(options.type_defs);
-                frame.type_values.extend(
+                let metadata = frame
+                    .type_metadata
+                    .get_or_insert_with(|| Box::new(FrameTypeMetadata::default()));
+                metadata.values.resize(initial_type_arg_count, None);
+                metadata.defs.merge_from(options.type_defs);
+                metadata.values.extend(
                     (0..options.type_args.len()).map(|slot| options.type_values.get(slot).cloned()),
                 );
             }
@@ -5674,7 +5721,13 @@ impl BexVm {
             .checked_sub(total_inputs)
             .ok_or(VmInternalError::NotEnoughItemsOnStack(total_inputs))?;
 
-        let class_type_args = self.take_type_args(base + field_value_count, ntypeargs)?;
+        let class_type_args: Box<[baml_type::RealizedTy]> = if ntypeargs == 0 {
+            Box::default()
+        } else {
+            self.take_type_args(base + field_value_count, ntypeargs)?
+                .tys
+                .into()
+        };
 
         let fields = if field_value_count == class_field_count
             && plan
@@ -5703,7 +5756,7 @@ impl BexVm {
         };
 
         Ok(Value::object(self.tlab.alloc(Object::Instance(
-            Instance::new(class_ptr, class_type_args.tys.into(), fields),
+            Instance::new(class_ptr, class_type_args, fields),
         ))))
     }
 
@@ -6737,7 +6790,11 @@ impl BexVm {
                     let ntypeargs = { read_u16_unchecked(code, pc) } as usize;
                     let class_ptr = self.idx_to_ptr(ObjectIndex::from_raw(raw as usize));
 
-                    let class_type_args = self.pop_type_args(ntypeargs)?;
+                    let class_type_args: Box<[baml_type::RealizedTy]> = if ntypeargs == 0 {
+                        Box::default()
+                    } else {
+                        self.pop_type_args(ntypeargs)?.tys.into()
+                    };
 
                     let Object::Class(class) = self.get_object(class_ptr) else {
                         return Err(VmInternalError::TypeError {
@@ -6752,7 +6809,7 @@ impl BexVm {
                         self.tlab
                             .alloc(Object::Instance(bex_vm_types::types::Instance::new(
                                 class_ptr,
-                                class_type_args.tys.into(),
+                                class_type_args,
                                 fields,
                             )));
                     self.stack.push(Value::object(instance_ptr));
@@ -6961,34 +7018,19 @@ impl BexVm {
                         None
                     };
 
-                    // Pop the method name (top) then the interface type.
+                    // Pop the method name (top) then the interface type. Keep
+                    // both as values until after the static-cache probe: their
+                    // contents are immutable at this bytecode site, and turning
+                    // them into owned names on every hit was measurable in
+                    // interface-heavy loops.
                     let method_value = self.stack.ensure_pop();
-                    let method_name = self.as_string(&method_value)?.to_string();
                     let iface_value = self.stack.ensure_pop();
-                    let (iface_qtn, iface_args) = {
-                        let iface_ptr = self.as_object_ptr(iface_value, ObjectType::Type)?;
-                        match self.get_object(iface_ptr) {
-                            // The interface's input args select among a type's impls
-                            // of the same interface at several instantiations (e.g.
-                            // `Converter<int>` + `Converter<float>`); non-generic
-                            // interfaces carry none and resolve by name + `Self`.
-                            // Associated types are outputs, not part of the key.
-                            Object::Type(type_value) => match &type_value.ty {
-                                baml_type::RealizedTy::Interface(qtn, args, _assoc, _attr) => {
-                                    (qtn.clone(), args.clone())
-                                }
-                                other => unreachable!(
-                                    "VirtualCall interface operand must be an Interface type, found {other:?}"
-                                ),
-                            },
-                            other => unreachable!(
-                                "as_object_ptr(Type) guarantees a Type object, found {:?}",
-                                ObjectType::of(other)
-                            ),
-                        }
-                    };
 
-                    let method_type_args = self.take_type_args_below_values(ntypeargs, nargs)?;
+                    let method_type_args = if ntypeargs == 0 {
+                        None
+                    } else {
+                        Some(self.take_type_args_below_values(ntypeargs, nargs)?)
+                    };
 
                     let args_offset = self
                         .stack
@@ -7002,27 +7044,25 @@ impl BexVm {
                     // agrees. The rule borrows `self`; scope it so the borrow ends
                     // before the `&mut self` call below.
                     let receiver = self.stack[StackIndex::from_raw(args_offset)];
-                    // `Self` is the receiver value's realized concrete type.
-                    let self_ty = baml_type::RealizedTy::from(
-                        self.value_concrete_ty(receiver).unwrap_or_else(|| {
-                            unreachable!(
-                                "value of kind {:?} cannot be a virtual-call receiver",
-                                self.type_of(&receiver)
-                            )
-                        }),
-                    );
-                    let cache_key =
-                        function
-                            .runtime_package
-                            .is_null()
-                            .then(|| StaticVirtualCallKey {
-                                caller_function_addr: std::ptr::from_ref(*function) as usize,
-                                call_pc: self.cur_pc,
-                                receiver: self_ty.clone(),
-                                interface: iface_qtn.clone(),
-                                interface_args: iface_args.clone().into_boxed_slice(),
-                                method: method_name.clone(),
-                            });
+                    let cache_key = if function.runtime_package.is_null() {
+                        let iface_ptr = self.as_object_ptr(iface_value, ObjectType::Type)?;
+                        let Object::Type(type_value) = self.get_object(iface_ptr) else {
+                            unreachable!("as_object_ptr(Type) guarantees a Type object")
+                        };
+                        match type_value.mint() {
+                            MintId::Static(interface_mint) => self
+                                .static_virtual_receiver_key(receiver)
+                                .map(|receiver| StaticVirtualCallKey {
+                                    caller_function_addr: std::ptr::from_ref(*function) as usize,
+                                    call_pc: self.cur_pc,
+                                    receiver,
+                                    interface_mint,
+                                }),
+                            MintId::Runtime(_) => None,
+                        }
+                    } else {
+                        None
+                    };
                     let cached_target = cache_key
                         .as_ref()
                         .and_then(|key| self.static_virtual_call_cache.get(key))
@@ -7030,6 +7070,37 @@ impl BexVm {
                     let (callee_ptr, mut type_args) = if let Some(target) = cached_target {
                         (target.callee, target.frame_type_args)
                     } else {
+                        let method_name = self.as_string(&method_value)?.to_string();
+                        let (iface_qtn, iface_args) = {
+                            let iface_ptr = self.as_object_ptr(iface_value, ObjectType::Type)?;
+                            match self.get_object(iface_ptr) {
+                                // The interface's input args select among a type's
+                                // impls of the same interface at several
+                                // instantiations. Associated types are outputs,
+                                // not part of the resolver key.
+                                Object::Type(type_value) => match &type_value.ty {
+                                    baml_type::RealizedTy::Interface(qtn, args, _assoc, _attr) => {
+                                        (qtn.clone(), args.clone())
+                                    }
+                                    other => unreachable!(
+                                        "VirtualCall interface operand must be an Interface type, found {other:?}"
+                                    ),
+                                },
+                                other => unreachable!(
+                                    "as_object_ptr(Type) guarantees a Type object, found {:?}",
+                                    ObjectType::of(other)
+                                ),
+                            }
+                        };
+                        // `Self` is the receiver value's realized concrete type.
+                        let self_ty = baml_type::RealizedTy::from(
+                            self.value_concrete_ty(receiver).unwrap_or_else(|| {
+                                unreachable!(
+                                    "value of kind {:?} cannot be a virtual-call receiver",
+                                    self.type_of(&receiver)
+                                )
+                            }),
+                        );
                         let resolver = crate::package_baml::ImplResolver::for_value(self, receiver);
                         let (rule, bound_args) = resolver
                             .resolve_implements_rule(&self_ty, &iface_qtn, &iface_args)
@@ -7062,7 +7133,9 @@ impl BexVm {
                         }
                         (callee, frame)
                     };
-                    type_args.extend(method_type_args.tys);
+                    if let Some(method_type_args) = &method_type_args {
+                        type_args.extend_from_slice(&method_type_args.tys);
+                    }
 
                     let locals_offset = StackIndex::from_raw(args_offset);
 
@@ -7072,20 +7145,40 @@ impl BexVm {
                     };
                     bf.instruction_ptr = *pc;
 
-                    let result = self.execute_call_from_locals_offset_with_type_args(
-                        callee_ptr,
-                        locals_offset,
-                        nargs,
-                        CallOptions {
+                    let result = if type_args.is_empty()
+                        && method_type_args.is_none()
+                        && self.pending_call_type_args.is_empty()
+                        && self.pending_call_type_values.is_empty()
+                    {
+                        self.execute_call_from_locals_offset(
+                            callee_ptr,
+                            locals_offset,
+                            nargs,
                             runtime_id,
-                            type_args: &type_args,
-                            type_defs: &method_type_args.defs,
-                            type_values: &[],
                             runtime_type_check,
-                        },
-                        frame_idx,
-                        function,
-                    );
+                            frame_idx,
+                            function,
+                        )
+                    } else {
+                        let empty_defs = DynTypeDefs::default();
+                        let type_defs = method_type_args
+                            .as_ref()
+                            .map_or(&empty_defs, |args| &args.defs);
+                        self.execute_call_from_locals_offset_with_type_args(
+                            callee_ptr,
+                            locals_offset,
+                            nargs,
+                            CallOptions {
+                                runtime_id,
+                                type_args: &type_args,
+                                type_defs,
+                                type_values: &[],
+                                runtime_type_check,
+                            },
+                            frame_idx,
+                            function,
+                        )
+                    };
                     return result;
                 }
 
@@ -7651,7 +7744,9 @@ impl BexVm {
                             if function.runtime_package.is_null()
                                 && <&baml_type::RealizedTy>::try_from(template).is_ok()
                                 && matches!(&self.frames[*frame_idx],
-                                    Frame::Bytecode(frame) if frame.type_defs.is_empty()) =>
+                                    Frame::Bytecode(frame)
+                                        if frame.type_metadata.as_ref()
+                                            .is_none_or(|metadata| metadata.defs.is_empty())) =>
                         {
                             Some((std::ptr::from_ref(*function) as usize, idx))
                         }
@@ -7673,9 +7768,11 @@ impl BexVm {
                         let exact_dynamic =
                             if let baml_type::TyTemplate::TypeArgRef(slot) = &template {
                                 match &self.frames[*frame_idx] {
-                                    Frame::Bytecode(frame) => {
-                                        frame.type_values.get(*slot as usize).and_then(Clone::clone)
-                                    }
+                                    Frame::Bytecode(frame) => frame
+                                        .type_metadata
+                                        .as_ref()
+                                        .and_then(|metadata| metadata.values.get(*slot as usize))
+                                        .and_then(Clone::clone),
                                     Frame::Native(_) => None,
                                 }
                             } else {
@@ -7709,7 +7806,12 @@ impl BexVm {
                                 }
                             };
                             let defs = if let Frame::Bytecode(frame) = &self.frames[*frame_idx] {
-                                frame.type_defs.clone()
+                                frame
+                                    .type_metadata
+                                    .as_ref()
+                                    .map_or_else(DynTypeDefs::default, |metadata| {
+                                        metadata.defs.clone()
+                                    })
                             } else {
                                 DynTypeDefs::default()
                             };
@@ -7744,10 +7846,13 @@ impl BexVm {
                     frame
                         .type_args
                         .resize(slot + 1, baml_type::RealizedTy::unknown());
-                    frame.type_values.resize(slot + 1, None);
                     frame.type_args[slot] = type_value.ty.clone();
-                    frame.type_defs.merge_from(type_value.defs());
-                    frame.type_values[slot] = Some(type_value);
+                    let metadata = frame
+                        .type_metadata
+                        .get_or_insert_with(|| Box::new(FrameTypeMetadata::default()));
+                    metadata.values.resize(slot + 1, None);
+                    metadata.defs.merge_from(type_value.defs());
+                    metadata.values[slot] = Some(type_value);
                 }
                 // ── Package.current() ───────────────────────────────────────
                 OpCode::LoadCurrentPackage => {


### PR DESCRIPTION
## Summary

- Removes the remaining BEP-066 compiler hot-path cost by memoizing ground impl resolution through Salsa, keeping mounted candidates lazy, and restoring the ordinary no-runtime-slot inference path.
- Removes the remaining VM hot-path cost by omitting exact runtime-type metadata from ordinary frames, bypassing empty type-argument work, and compacting immutable static virtual-dispatch cache keys.
- Preserves dynamic builder/package behavior, mint identity, runtime generic checks, and the live resolver for runtime-owned rules.

## Root cause

Compiler phase timing isolated the residual to MIR lowering and body inference. Repeated operator/interface lookups rebuilt an eager package impl-candidate vector and rescanned every source and mounted impl for the same ground primitive/container types. The fix makes candidate production lazy and memoizes the dependency-tracked resolved impl set by interned ground type.

Runtime bytecode for the class-construction residual was instruction-identical to `d8ad5e58c`, confirming VM overhead. Ordinary non-generic allocations and calls still created/moved empty rich type-argument containers; every frame carried dynamic-definition and exact-value lanes; static virtual-dispatch hits still reconstructed owned method/interface/receiver keys. The fix keeps those data structures on the BEP-066 path and leaves ordinary calls/allocations lean.

## Benchmarks

Five samples, `BAML_PROFILE=0`, same quiet machine and paired measurement window. Runtime used `DIVAN_MAX_TIME=20` so heavy adaptive workloads also received five samples. Baseline is pre-BEP-066 canary `d8ad5e58c`; PR is `5024874a4`.

### Compiler

| Benchmark | d8ad5e58c median | PR median | Delta |
|---|---:|---:|---:|
| compile_baml_tests_project | 2.098 s | 1.537 s | -26.7% |
| compile_empty_project | 319.8 ms | 259.1 ms | -19.0% |

The empty-project improvement is consistent with removing fixed BEP-066 query/metadata overhead; no stdlib-content exception is needed.

### Runtime

| Workload | d8ad5e58c median (ms) | PR median (ms) | Delta |
|---|---:|---:|---:|
| classes/method_call_100k | 32.21 | 30.89 | -4.1% |
| classes/method_chain_100k | 34.93 | 34.96 | +0.1% |
| compute/array_build_sum_100k | 187.9 | 101.8 | -45.8% |
| compute/binary_tree_depth_20 | 338.2 | 298.1 | -11.9% |
| compute/bubble_sort_5k | 1710 | 1762 | +3.0% |
| compute/call_chain_100x10k | 117.4 | 101.7 | -13.4% |
| compute/class_instances_100k | 14.36 | 10.74 | -25.2% |
| compute/closure_apply_1m | 506.6 | 516.4 | +1.9% |
| compute/collatz_100k | 729.2 | 673.0 | -7.7% |
| compute/divide_guard_1m | 188.2 | 174.2 | -7.4% |
| compute/fib32_recursive | 1122 | 975.9 | -13.0% |
| compute/fib_iterative_100k | 256.3 | 246.3 | -3.9% |
| compute/generic_apply_with_inferred_type_args_1m | 653.1 | 573.0 | -12.3% |
| compute/grid_alloc_1000x100 | 153.3 | 107.6 | -29.8% |
| compute/guard_clauses_1m | 223.9 | 203.8 | -9.0% |
| compute/if_else_dispatch_1m | 225.3 | 202.0 | -10.3% |
| compute/mixed_ops_5k | 3.497 | 2.445 | -30.1% |
| compute/nested_field_access_500k | 145.1 | 135.3 | -6.8% |
| compute/nested_loops_500x500 | 11.13 | 10.55 | -5.2% |
| compute/pure_call_1m | 153.2 | 136.5 | -10.9% |
| compute/wide_nested_class_create_50k | 60.43 | 56.86 | -5.9% |
| concurrency/parallel_sum_4x250k | 18.64 | 14.83 | -20.4% |
| concurrency/parallel_sum_sequential_1m | 38.22 | 36.13 | -5.5% |
| concurrency/shared_array_1w_4r | 25.18 | 22.04 | -12.5% |
| concurrency/shared_array_push_4x25k | 19.42 | 17.48 | -10.0% |
| concurrency/spawn_await_x10k | 110.5 | 108.1 | -2.2% |
| concurrency/spawn_fan_out_100 | 0.7856 | 0.7856 | 0.0% |
| interfaces/default_method_100k | 277.5 | 173.7 | -37.4% |
| interfaces/match_dispatch_100k | 99.33 | 60.63 | -39.0% |
| interfaces/polymorphic_dispatch_100k | 101.4 | 82.18 | -19.0% |
| string/concat_loop_10k | 1.754 | 1.100 | -37.3% |
| string/contains_medium_literal_100k | 17.36 | 15.44 | -11.1% |
| string/split_long_literal_1k | 2.667 | 2.214 | -17.0% |
| string/split_medium_literal_10k | 13.58 | 13.24 | -2.5% |
| string/split_short_literal_100k | 84.11 | 80.05 | -4.8% |
| string/string_split_100k | 83.48 | 46.80 | -43.9% |
| string/substring_slice_long_100k | 40.70 | 34.85 | -14.4% |
| string/trim_padded_literal_100k | 34.76 | 28.12 | -19.1% |

Every measured regression is within +5%; workloads outside the negative side of the literal band are improvements and were not deliberately slowed.

## Validation

- Focused compiler/VM checks passed.
- Focused `bex_vm` + `baml_compiler2_hir_ty` nextest: 226/226 passed twice, including after the final Salsa cache.
- Pinned gate: 3,724/3,724 passed, 24 skipped; doctests passed; no changed or unreferenced snapshots.
- Pinned gate package set includes `baml_tests`, `baml_cli`, `baml_lsp2_actions`, `baml_lsp2_actions_tests`, and `baml_surface` with all features.
- `cargo fmt --all -- --check`, `git diff --check`, and affected-package Clippy with all targets/features and warnings denied passed.
- Full workspace Clippy with all targets/features and warnings denied passed in pre-commit hooks.
- Temporary phase timing and bytecode-dump instrumentation was removed before commit; the detached `d8ad5e58c` baseline worktree is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved generic type handling and virtual-call caching, especially when runtime metadata is unnecessary.
  * Reduced unnecessary type resolution, validation, and allocation during compilation and execution.
  * Accelerated implementation candidate lookup and calls without runtime type arguments.

* **Reliability**
  * Strengthened runtime validation of generic arguments and bounds when enabled.
  * Improved consistency of type information across virtual methods and instance creation.

* **Bug Fixes**
  * Fixed virtual dispatch caching for distinct generic interface instantiations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Review follow-up

- Routed VM frame marking through `Frame::collect_roots`, so boxed exact-type metadata and its owner/definition pointers survive and are forwarded by GC; removed the duplicated class-definition traversal.
- Preserved the sparse exact runtime `TypeValue` lane for virtual generic methods after resolver-provided owner/impl slots.
- Added focused unit regressions for metadata GC survival/forwarding and runtime-mint slot alignment.
- Review-amended validation: `bex_vm` 71/71; dynamic reflection/builder/identity/binding cluster 35/35 (1 skipped); repeated pinned gate 3,724/3,724, 24 skipped; doctests and snapshot-reference rejection clean; full workspace Clippy hook green.

## Adversarial review follow-up

- Fixed F1 in `88653e17c`: static virtual-dispatch keys now retain realized positional interface arguments, so full-context mint equivalence cannot alias instantiations that fact-poor `StructuralEquivCtx` selection distinguishes.
- Added a heterogeneous single-call-site regression using `Tagged<Animal>` and `Tagged<Animal | Dog>`; it reproduced the old wrong result (`animal|animal`) before the fix and now returns `animal|animal-or-dog`.
- Fixed F2 with Salsa `cycle_result` recovery returning the inductive empty impl set. Also folded in F4/F5/F6 dependency/invariant documentation and the exact compile-time heap-pointer receiver predicate.
- Focused validation: compiler+VM 228/228; full interface suite 490/490 (2 skipped); strict focused Clippy green.
- Quiet paired non-generic dispatch spot checks versus `d8ad5e58c`: default 153.1 vs 273.8 ms, match 53.81 vs 102.9 ms, polymorphic 69.17 vs 104.4 ms; no richer-key performance loss.
- Repeated widened pinned gate: 3,725/3,725, 24 skipped; doctests and snapshot-reference rejection clean; full workspace Clippy hook green.