### PR TITLE
feat(cli): install the runtime compiler in `baml run`

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -783,6 +783,7 @@ dependencies = [
  "base64",
  "bex_cache",
  "bex_engine",
+ "bex_project",
  "bex_vm_types",
  "borsh",
  "clap",

--- a/baml_language/crates/baml_cli/Cargo.toml
+++ b/baml_language/crates/baml_cli/Cargo.toml
@@ -32,6 +32,7 @@ baml_version = { workspace = true }
 baml_workspace = { workspace = true }
 bex_cache = { workspace = true }
 bex_engine = { workspace = true }
+bex_project = { workspace = true }
 bex_vm_types = { workspace = true }
 sdkgen_cpp = { workspace = true }
 sdkgen_csharp = { workspace = true }

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -305,8 +305,13 @@ impl RunArgs {
             },
         )
         .map_err(|e| anyhow!("compilation failed: {e:?}"))?;
-        BexEngine::new(bytecode, Arc::new(sys_native::SysOps::native()), argv)
-            .map_err(|e| anyhow!("failed to create engine: {e:?}"))
+        BexEngine::new_with_runtime_compiler(
+            bytecode,
+            Arc::new(sys_native::SysOps::native()),
+            argv,
+            bex_project::runtime_compiler(),
+        )
+        .map_err(|e| anyhow!("failed to create engine: {e:?}"))
     }
 
     pub fn run(&self) -> Result<crate::ExitCode> {

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -750,10 +750,11 @@ impl RunArgs {
 
         if let Some(program) = session.try_cached_program() {
             self.vlog(format_args!("Bytecode cache hit — skipping compile"));
-            match BexEngine::new(
+            match BexEngine::new_with_runtime_compiler(
                 program,
                 Arc::new(sys_native::SysOps::native()),
                 argv.clone(),
+                bex_project::runtime_compiler(),
             ) {
                 Ok(engine) => return Ok((session.db, engine, needs_format_hint)),
                 Err(error) => crate::bytecode_cache::cache_debug(format_args!(
@@ -835,8 +836,13 @@ impl RunArgs {
             baml_db::baml_compiler2_hir_ty::package_interface::stdlib_honest_derivations()
         ));
         let program = compiled.program;
-        let engine = BexEngine::new(program, Arc::new(sys_native::SysOps::native()), argv)
-            .map_err(|e| anyhow!("failed to create engine: {e:?}"))?;
+        let engine = BexEngine::new_with_runtime_compiler(
+            program,
+            Arc::new(sys_native::SysOps::native()),
+            argv,
+            bex_project::runtime_compiler(),
+        )
+        .map_err(|e| anyhow!("failed to create engine: {e:?}"))?;
         self.vlog(format_args!(
             "Compiled {} user function(s)",
             engine.user_functions().len()

--- a/baml_language/crates/sys_auth/src/io_bridge.rs
+++ b/baml_language/crates/sys_auth/src/io_bridge.rs
@@ -102,13 +102,11 @@ pub(crate) fn split_command(command: &str) -> Option<Vec<String>> {
                     quote = Some(c);
                     has_current = true;
                 }
-                '\\' => match chars.next() {
-                    Some(next) => {
-                        current.push(next);
-                        has_current = true;
-                    }
-                    None => return None,
-                },
+                '\\' => {
+                    let next = chars.next()?;
+                    current.push(next);
+                    has_current = true;
+                }
                 c if c.is_whitespace() => {
                     if has_current {
                         parts.push(std::mem::take(&mut current));


### PR DESCRIPTION
## What

`baml run` (script/expression runner) constructed its engine without the host runtime compiler, so any program calling `reflect.Package.compile` threw `baml.errors.Unsupported: runtime compiler was not installed by the host` — while the test harness and packed binaries were properly wired. Found live while demoing the seven BEP-066 scenarios end to end through `baml run --file`; scenario 5 was the only one that couldn't run.

The fix wires `bex_project::runtime_compiler()` into the run command's engine construction, mirroring `baml_tests/src/engine.rs` and the packed-binary path.

Rider: fixes the pre-existing `clippy::question_mark` lint in `sys_auth/io_bridge.rs` that currently fails every local pre-commit run on canary (mechanical clippy-suggested rewrite, no behavior change).

## Evidence

With this change, a standalone demo file exercising all seven BEP-066 scenarios — including `Package.compile` with real caught diagnostics and Sessions with mounted packages — runs to completion via `baml run --file`. Demo source preserved at `thoughts/antonio/bep066_demo.baml` (author's notes, not in-tree).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of escaped characters in command-line input.
  * Unterminated escape sequences are now handled safely without causing unexpected parsing behavior.

* **Improvements**
  * Runtime compilation is now integrated into project execution.
  * Project code can be compiled and run more reliably across standalone, cached, and newly compiled workflows.
  * Improved support for dynamic project execution without changing existing command-line behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->