### PR TITLE
chore: refresh size-gate baselines for 0.17.0

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -43,13 +43,13 @@ policy.max_delta_pct = 3.0
 # Reclaiming the `syn` cost would mean dropping prettyplease (raw,
 # unformatted generated SDK output).
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = "21.2 MiB"
+max_file_bytes = "21.9 MiB"
 
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = "27.2 MiB"
+max_file_bytes = "28.0 MiB"
 
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = "23.5 MiB"
+max_file_bytes = "23.6 MiB"
 
 [artifacts.packed-program]
 kind = "pack"
@@ -64,10 +64,10 @@ policy.max_delta_pct = 3.0
 # bytecode ships in every packed program. Each ceiling is ~3% above the
 # re-recorded baseline in `.ci/size-gate`.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = "17.0 MiB"
+max_file_bytes = "17.1 MiB"
 
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = "21.2 MiB"
+max_file_bytes = "21.3 MiB"
 
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
 max_file_bytes = "18.2 MiB"

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -1,15 +1,12 @@
 version = 1
-recorded_at = "2026-08-12T05:04:16Z"
-git_sha = "a51ffdf12b5caf288cc7028fa5fbd86449c0d518"
+recorded_at = "2026-08-16T03:28:16Z"
+git_sha = "e8c6ef36ac"
 
 [artifacts.baml-cli]
-file_bytes = "20.6 MiB"
-stripped_bytes = "20.6 MiB"
-gzip_bytes = "9.8 MiB"
+file_bytes = "21.2 MiB"
+stripped_bytes = "21.2 MiB"
+gzip_bytes = "10.0 MiB"
 
-# Re-recorded from CI run 31906918242: BEP-066 (evaluation/type-construction/
-# reflection) VM+bytecode surface plus the native provider stdlib additions
-# since the 2026-08-12 record (EnvRef, ai.internal prompt plumbing).
 [artifacts.packed-program]
 file_bytes = "16.6 MiB"
 gzip_bytes = "7.2 MiB"

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -1,9 +1,7 @@
 version = 1
-recorded_at = "2026-08-12T05:04:16Z"
-git_sha = "a51ffdf12b5caf288cc7028fa5fbd86449c0d518"
+recorded_at = "2026-08-16T03:28:16Z"
+git_sha = "e8c6ef36ac"
 
-# Re-recorded from CI run 31906918242: BEP-066 VM+bytecode surface plus the
-# native provider stdlib additions since the 2026-08-12 record.
 [artifacts.bridge_wasm]
-file_bytes = "17.0 MiB"
+file_bytes = "17.1 MiB"
 gzip_bytes = "4.6 MiB"

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -1,15 +1,12 @@
 version = 1
-recorded_at = "2026-08-12T05:04:16Z"
-git_sha = "a51ffdf12b5caf288cc7028fa5fbd86449c0d518"
+recorded_at = "2026-08-16T03:28:16Z"
+git_sha = "e8c6ef36ac"
 
-# Re-recorded from CI run 31906918242: BEP-066 (evaluation/type-construction/
-# reflection) VM+bytecode surface plus the native provider stdlib additions
-# since the 2026-08-12 record (EnvRef, ai.internal prompt plumbing).
 [artifacts.baml-cli]
-file_bytes = "22.8 MiB"
-stripped_bytes = "22.8 MiB"
+file_bytes = "22.9 MiB"
+stripped_bytes = "22.9 MiB"
 gzip_bytes = "10.2 MiB"
 
 [artifacts.packed-program]
-file_bytes = "17.6 MiB"
+file_bytes = "17.7 MiB"
 gzip_bytes = "7.3 MiB"

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -1,14 +1,12 @@
 version = 1
-recorded_at = "2026-08-12T05:04:16Z"
-git_sha = "a51ffdf12b5caf288cc7028fa5fbd86449c0d518"
+recorded_at = "2026-08-16T03:28:16Z"
+git_sha = "e8c6ef36ac"
 
 [artifacts.baml-cli]
-file_bytes = "26.4 MiB"
-stripped_bytes = "26.4 MiB"
-gzip_bytes = "11.2 MiB"
+file_bytes = "27.2 MiB"
+stripped_bytes = "27.2 MiB"
+gzip_bytes = "11.5 MiB"
 
-# Re-recorded from CI run 31906918242: BEP-066 VM+bytecode surface plus the
-# native provider stdlib additions since the 2026-08-12 record.
 [artifacts.packed-program]
-file_bytes = "20.6 MiB"
+file_bytes = "20.7 MiB"
 gzip_bytes = "8.1 MiB"

--- a/baml_language/crates/tools_size_gate/src/config.rs
+++ b/baml_language/crates/tools_size_gate/src/config.rs
@@ -342,6 +342,6 @@ mod tests {
         config.validate().unwrap();
 
         let macos = &config.artifacts["baml-cli"].platform["aarch64-apple-darwin"];
-        assert_eq!(macos.max_file_bytes, Some(22_229_811));
+        assert_eq!(macos.max_file_bytes, Some(22_963_814));
     }
 }


### PR DESCRIPTION
Refreshes the checked-in size baselines and 3% ceilings from all four platform reports produced by canary CI run 31919654825 at source SHA `e8c6ef36ac644dfebd6301227c9258bd7d646532`.

The macOS `baml-cli` grew to 22,259,408 bytes after #4451, exceeding the old hard ceiling by 29.6 KB and the relative 3% gate by a rounding margin. The repository-owned `cargo size-gate bake` command regenerated all platform baselines and ceilings from that single provenance-bound run. The matching checked-in ceiling assertion is updated from 21.2 MiB to 21.9 MiB.

Validation: `cargo test -p cargo-size-gate`; `cargo fmt --check -p cargo-size-gate`; `git diff --check`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated platform-specific size limits and recorded artifact measurements for CLI, packed program, and WebAssembly builds.
  * Refreshed build metadata and timestamps across supported platforms.
  * Updated macOS validation thresholds to reflect current artifact sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->