### PR TITLE
chore: refresh C# package size policy

### DIFF
--- a/release/csharp-package-size-policy.json
+++ b/release/csharp-package-size-policy.json
@@ -2,10 +2,10 @@
   "schema": 1,
   "description": "Reviewed C# NuGet size baseline. The package threshold is a regression budget, while the 200 MB limit remains a separate registry-safety ceiling.",
   "evidence": {
-    "workflow_run_id": "29989654236",
-    "source_sha": "ceae8ea6cf9a8af561b4f1aa81ae428ce504d6d4",
-    "measured_at": "2026-07-23",
-    "compressed_native_payload_bytes": 69559373
+    "workflow_run_id": "31925845745",
+    "source_sha": "4b08255ca0142419bf500d3007c1b84b86242cdc",
+    "measured_at": "2026-08-15",
+    "compressed_native_payload_bytes": 75118828
   },
   "compressed_package": {
     "baseline_bytes": 70000000,
@@ -15,14 +15,14 @@
   "native_assets": {
     "max_regression_percent": 10,
     "baseline_bytes_by_target": {
-      "aarch64-apple-darwin": 21359712,
-      "aarch64-pc-windows-msvc": 22662656,
-      "aarch64-unknown-linux-gnu": 21692688,
-      "aarch64-unknown-linux-musl": 21606408,
-      "x86_64-apple-darwin": 21773828,
-      "x86_64-pc-windows-msvc": 24630272,
-      "x86_64-unknown-linux-gnu": 24584488,
-      "x86_64-unknown-linux-musl": 24432880
+      "aarch64-apple-darwin": 23777024,
+      "aarch64-pc-windows-msvc": 25154560,
+      "aarch64-unknown-linux-gnu": 24024168,
+      "aarch64-unknown-linux-musl": 23941984,
+      "x86_64-apple-darwin": 24180680,
+      "x86_64-pc-windows-msvc": 27282944,
+      "x86_64-unknown-linux-gnu": 27116664,
+      "x86_64-unknown-linux-musl": 26973248
     }
   }
 }


### PR DESCRIPTION
## What changed

- Refresh all eight C# native asset baselines from the exact artifacts produced by release run 31925845745 at source `4b08255ca0142419bf500d3007c1b84b86242cdc`.
- Update the reviewed evidence to the reproduced 75,118,828-byte deterministic NuGet package.
- Keep the compressed-package regression baseline and 200 MB registry safety ceiling unchanged.

## Why

The 0.17.0 release verification failed because every native target had grown slightly beyond the stale July baseline plus its 10% budget. The first reported failure was Apple ARM64: 23,777,024 bytes against a 23,495,683-byte ceiling. Publishing remained blocked behind the all-builds gate.

Failed run: https://github.com/BoundaryML/baml/actions/runs/31925845745

## Validation

- Reproduced package assembly locally from all eight provenance-bound artifacts from run 31925845745.
- Both normalized NuGet builds produced SHA-256 `c37be3d9257070bb19034c5262f9a9ec30d9c5e05dbbb0a1ec1145e366e8d3ee`.
- Package size is 75,118,828 bytes, below the unchanged 80,500,000-byte regression ceiling.
- `python3 scripts/tests/test_release_pipeline_contract.py` (26 passed)
- `jq empty release/csharp-package-size-policy.json`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package size evidence with the latest workflow run, source commit, and measurement date.
  * Refreshed compressed native payload size measurements and platform-specific baselines across all supported targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->