### PR TITLE
release: changelog cleanup, notify slack on successful canary releases

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -2368,4 +2368,5 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOUNDARY_BOT_TOKEN }}
           VERSION: ${{ needs.plan.outputs.version }}
           CHANNEL: ${{ needs.plan.outputs.channel }}
+          RELEASE_SUCCEEDED: ${{ needs.publish-pkg-channel.result == 'success' }}
         run: uv run --script tools/notify-release-failure.py

--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -2297,7 +2297,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
   notify-slack:
-    name: Notify Slack on failure
+    name: Notify Slack
     needs:
       - plan
       - build-matrix
@@ -2341,7 +2341,7 @@ jobs:
       - publish-pkg-channel
       - smoke-swift-release
     # Use the dispatch input so a failure in plan itself is still reportable.
-    # This job must run after failed dependencies; the script posts only when the run contains failures.
+    # This job must run after failed dependencies. Failures and successful canary releases notify Slack; successful nightlies stay silent.
     if: ${{ always() && inputs.dry_run == false && needs.plan.outputs.source_branch == 'canary' }}
     runs-on: ubuntu-latest
     environment: boundary-tools-dev
@@ -2361,7 +2361,7 @@ jobs:
       - uses: ./.github/actions/setup-mise
         with:
           install_args: uv
-      - name: Find failures and notify Slack
+      - name: Notify Slack of the release result
         env:
           GH_TOKEN: ${{ github.token }}
           SLACK_CHANNEL: "#general"

--- a/baml_language/CHANGELOG.md
+++ b/baml_language/CHANGELOG.md
@@ -6,8 +6,8 @@ This changelog covers the independent `baml_language` release line. It does not 
 
 ### Features
 
-- [review] Added runtime reflection and type construction, including compiling and mounting packages, invoking reflected callables, and isolating dynamic work in sessions. ([#4325](https://github.com/BoundaryML/baml/pull/4325)) - Antonio Sarosi
-- [review] Added native BAML clients for OpenAI, Anthropic, Google, Vertex AI, AWS Bedrock, Azure, Ollama, OpenRouter, and Vercel AI Gateway, including typed streaming, media outputs, AWS SigV4, and Google Cloud authentication. ([#4430](https://github.com/BoundaryML/baml/pull/4430)) - aaronvg
+- Added runtime reflection and type construction, including compiling and mounting packages, invoking reflected callables, and isolating dynamic work in sessions. ([#4325](https://github.com/BoundaryML/baml/pull/4325)) - Antonio Sarosi
+- Added native BAML clients for OpenAI, Anthropic, Google, Vertex AI, AWS Bedrock, Azure, Ollama, OpenRouter, and Vercel AI Gateway, including typed streaming, media outputs, AWS SigV4, and Google Cloud authentication. ([#4430](https://github.com/BoundaryML/baml/pull/4430)) - aaronvg
 - Added `baml.sys.pid()`, `baml.fs.chmod()`, and `baml.fs.symlink()`. ([#4427](https://github.com/BoundaryML/baml/pull/4427)) - 2kai2kai2
 - Added `baml.crypto.*` APIs for SHA-256 hashing, authenticated encryption, and key generation. ([#4431](https://github.com/BoundaryML/baml/pull/4431)) - 2kai2kai2
 - Added `baml toolchain pin <canary|nightly|version|path>` to select a project-local toolchain in the nearest `baml.toml` ([#4386](https://github.com/BoundaryML/baml/pull/4386)) - Sam Lijin
@@ -18,7 +18,7 @@ This changelog covers the independent `baml_language` release line. It does not 
 
 ### Breaking and compatibility changes
 
-- [review] Renamed `openai.OpenAiClient` to `openai.ResponsesClient`. ([#4430](https://github.com/BoundaryML/baml/pull/4430)) - aaronvg
+- Renamed `openai.OpenAiClient` to `openai.ResponsesClient`. ([#4430](https://github.com/BoundaryML/baml/pull/4430)) - aaronvg
 - Improved the string stdlib APIs: renamed `String.char_at` to `String.at`, kept negative indexing, and made out-of-range access return `null`; made `String.code_point_at` return `null` out of range; removed `String.matches` in favor of `String.includes`; renamed `String.substring` to `String.slice`; and added `String.last_index_of`. ([#4433](https://github.com/BoundaryML/baml/pull/4433)) - 2kai2kai2
 - Drop support for Jinja templates: BAML now has TS-style template literals that are much easier to use. ([#4367](https://github.com/BoundaryML/baml/pull/4367)) - Avery Townsend
 - LLM function fields now require colon-delimited `client:`, `prompt:`, and `tools:` syntax. ([#4317](https://github.com/BoundaryML/baml/pull/4317)) - Vaibhav Mittal
@@ -26,8 +26,8 @@ This changelog covers the independent `baml_language` release line. It does not 
 
 ### Fixes
 
-- [review] Rejected runtime-checked arguments on indirect calls with E0010; release builds had previously compiled them while silently omitting the check. ([#4460](https://github.com/BoundaryML/baml/pull/4460)) - Antonio Sarosi
-- [review] Enabled runtime package compilation from `baml run` scripts and expressions. ([#4451](https://github.com/BoundaryML/baml/pull/4451)) - Antonio Sarosi
+- Rejected runtime-checked arguments on indirect calls with E0010; release builds had previously compiled them while silently omitting the check. ([#4460](https://github.com/BoundaryML/baml/pull/4460)) - Antonio Sarosi
+- Enabled runtime package compilation from `baml run` scripts and expressions. ([#4451](https://github.com/BoundaryML/baml/pull/4451)) - Antonio Sarosi
 - Supported double-quoted LLM prompts as literal, non-interpolating prompts and fixed the segfault they could cause. ([#4432](https://github.com/BoundaryML/baml/pull/4432)) - 2kai2kai2
 - Made `Array.join` stringify non-string elements instead of silently replacing them with empty strings. ([#4433](https://github.com/BoundaryML/baml/pull/4433)) - 2kai2kai2
 - Fixed null-coalescing assignments, property shorthand scope, runtime type tests, and media kind validation. ([#4434](https://github.com/BoundaryML/baml/pull/4434)) - Avery Townsend
@@ -41,8 +41,5 @@ This changelog covers the independent `baml_language` release line. It does not 
 - Made `//#` header comments parse consistently: they are preserved in expression functions, executable blocks, match arms, and catch arms, and rejected elsewhere with a targeted diagnostic instead of causing cascading parser failures. ([#4406](https://github.com/BoundaryML/baml/pull/4406)) - Sam Lijin
 - Corrected the no-project CLI diagnostic to recommend the supported `baml test --project <DIR>` option instead of the nonexistent `--file` option. ([#4410](https://github.com/BoundaryML/baml/pull/4410)) - Sam Lijin
 - Prevented required interface methods from being treated as callable default bodies. ([#4301](https://github.com/BoundaryML/baml/pull/4301)) - Avery Townsend
--  Make `Array.sort_by` and `Array.sort_by_key` a stable O(n log n) merge sort. ([#4382](https://github.com/BoundaryML/baml/pull/4382)) - Sam Lijin
-
-### Performance
-
-- [review] Restored and improved compiler and VM performance after BEP-066, reducing overhead in package inference, calls, arrays, interface dispatch, and string operations. ([#4448](https://github.com/BoundaryML/baml/pull/4448); [#4450](https://github.com/BoundaryML/baml/pull/4450)) - Antonio Sarosi
+- Make `Array.sort_by` and `Array.sort_by_key` a stable O(n log n) merge sort. ([#4382](https://github.com/BoundaryML/baml/pull/4382)) - Sam Lijin
+- Restored and improved compiler and VM performance after BEP-066, reducing overhead in package inference, calls, arrays, interface dispatch, and string operations. ([#4448](https://github.com/BoundaryML/baml/pull/4448); [#4450](https://github.com/BoundaryML/baml/pull/4450)) - Antonio Sarosi

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -665,9 +665,31 @@ class WorkflowGraphTests(unittest.TestCase):
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         notifier = RELEASE_NOTIFIER.read_text(encoding="utf-8")
         notify_slack = job_block(workflow, "notify-slack")
+        notify_step = step_block(notify_slack, "Notify Slack of the release result")
 
         self.assertIn("always()", notify_slack)
+        self.assertIn(
+            "run: uv run --script tools/notify-release-failure.py",
+            notify_step,
+        )
+        self.assertIn(
+            "CHANNEL: ${{ needs.plan.outputs.channel }}",
+            notify_step,
+        )
+        self.assertIn(
+            "VERSION: ${{ needs.plan.outputs.version }}",
+            notify_step,
+        )
+        self.assertIn(
+            "RELEASE_SUCCEEDED: ${{ needs.publish-pkg-channel.result == 'success' }}",
+            notify_step,
+        )
         self.assertIn('if not failures and channel != "canary"', notifier)
+        self.assertIn(
+            'SUCCESSFUL_JOB_CONCLUSIONS = {"success", "skipped"}',
+            notifier,
+        )
+        self.assertIn("conclusion not in SUCCESSFUL_JOB_CONCLUSIONS", notifier)
         self.assertIn("❌ BAML {channel} release failed", notifier)
         self.assertIn("✅ BAML {channel} release succeeded", notifier)
 

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -684,7 +684,10 @@ class WorkflowGraphTests(unittest.TestCase):
             "RELEASE_SUCCEEDED: ${{ needs.publish-pkg-channel.result == 'success' }}",
             notify_step,
         )
-        self.assertIn('if not failures and channel != "canary"', notifier)
+        self.assertIn(
+            'if release_succeeded and not failures and channel != "canary"',
+            notifier,
+        )
         self.assertIn(
             'SUCCESSFUL_JOB_CONCLUSIONS = {"success", "skipped"}',
             notifier,

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -18,6 +18,7 @@ GO_RELEASE_SMOKE = ROOT / "scripts" / "smoke-go-release.py"
 GO_SDK_ASSEMBLER = ROOT / "scripts" / "assemble-go-sdk-mirror"
 PLATFORMS = ROOT / "release" / "platforms.json"
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release-baml-language.yml"
+RELEASE_NOTIFIER = ROOT / "tools" / "notify-release-failure.py"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yaml"
 NIGHTLY_WORKFLOW = ROOT / ".github" / "workflows" / "nightly-release.yml"
 SIZE_POLICY = ROOT / "release" / "csharp-package-size-policy.json"
@@ -660,6 +661,16 @@ def step_inputs(step: str) -> dict[str, str]:
 
 
 class WorkflowGraphTests(unittest.TestCase):
+    def test_release_slack_notifications_cover_failures_and_canary_success(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        notifier = RELEASE_NOTIFIER.read_text(encoding="utf-8")
+        notify_slack = job_block(workflow, "notify-slack")
+
+        self.assertIn("always()", notify_slack)
+        self.assertIn('if not failures and channel != "canary"', notifier)
+        self.assertIn("❌ BAML {channel} release failed", notifier)
+        self.assertIn("✅ BAML {channel} release succeeded", notifier)
+
     def test_cpp_verifier_stamps_the_frozen_release_plan(self) -> None:
         workflow = CPP_VERIFIER.read_text(encoding="utf-8")
         verify = job_block(workflow, "verify")

--- a/tools/notify-release-failure.py
+++ b/tools/notify-release-failure.py
@@ -146,7 +146,7 @@ def main() -> int:
         release_succeeded = os.environ.get("RELEASE_SUCCEEDED") == "true"
         started_at = get_run_started_at(repository, run_id, run_attempt, github_token)
         failures = find_failures(repository, run_id, run_attempt, github_token)
-        if not failures and channel != "canary":
+        if release_succeeded and not failures and channel != "canary":
             print(f"Successful {channel} release; skipping Slack notification.")
             return 0
 

--- a/tools/notify-release-failure.py
+++ b/tools/notify-release-failure.py
@@ -53,7 +53,7 @@ def get_json(url: str, token: str) -> tuple[dict[str, Any], str | None]:
         headers={
             "Accept": "application/vnd.github+json",
             "Authorization": f"Bearer {token}",
-            "User-Agent": "baml-release-failure-notifier",
+            "User-Agent": "baml-release-notifier",
             "X-GitHub-Api-Version": "2022-11-28",
         },
     )
@@ -132,25 +132,32 @@ def main() -> int:
         slack_channel = required_env("SLACK_CHANNEL")
         slack_token = required_env("SLACK_BOT_TOKEN")
 
-        started_at = get_run_started_at(repository, run_id, run_attempt, github_token)
-        failures = find_failures(repository, run_id, run_attempt, github_token)
-        if not failures:
-            print("No failed jobs or steps found; skipping Slack notification.")
-            return 0
-
         version = os.environ.get("VERSION") or "unknown version"
         channel = os.environ.get("CHANNEL") or "unknown channel"
+        started_at = get_run_started_at(repository, run_id, run_attempt, github_token)
+        failures = find_failures(repository, run_id, run_attempt, github_token)
+        if not failures and channel != "canary":
+            print(f"Successful {channel} release; skipping Slack notification.")
+            return 0
+
         run_url = (
             f"https://github.com/{repository}/actions/runs/{run_id}"
             f"/attempts/{run_attempt}"
         )
-        failure_text = "\n".join(format_failure(failure) for failure in failures)
-        message = (
-            f"BAML {channel} release failed: {version}, "
-            f"started at {format_pacific_time(started_at)}\n\n"
-            f"*Failures:*\n{failure_text}\n\n"
-            f"*Run:* <{run_url}|View workflow run>"
-        )
+        if failures:
+            failure_text = "\n".join(format_failure(failure) for failure in failures)
+            message = (
+                f"❌ BAML {channel} release failed: {version}, "
+                f"started at {format_pacific_time(started_at)}\n\n"
+                f"*Failures:*\n{failure_text}\n\n"
+                f"*Run:* <{run_url}|View workflow run>"
+            )
+        else:
+            message = (
+                f"✅ BAML {channel} release succeeded: {version}, "
+                f"started at {format_pacific_time(started_at)}\n\n"
+                f"*Run:* <{run_url}|View workflow run>"
+            )
 
         WebClient(token=slack_token).chat_postMessage(
             channel=slack_channel,
@@ -166,7 +173,7 @@ def main() -> int:
     except SlackClientError as error:
         print(f"Slack request failed: {error}", file=sys.stderr)
     except (KeyError, RuntimeError, urllib.error.URLError) as error:
-        print(f"Release failure notification failed: {error}", file=sys.stderr)
+        print(f"Release notification failed: {error}", file=sys.stderr)
     return 1
 
 

--- a/tools/notify-release-failure.py
+++ b/tools/notify-release-failure.py
@@ -21,12 +21,14 @@ from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError, SlackClientError
 
 GITHUB_API_TIMEOUT_SECONDS = 30
+SUCCESSFUL_JOB_CONCLUSIONS = {"success", "skipped"}
 
 
 @dataclass(frozen=True)
 class Failure:
     job_name: str
     job_url: str
+    conclusion: str
     step_names: list[str]
 
 
@@ -80,16 +82,20 @@ def find_failures(
     while url:
         payload, link_header = get_json(url, token)
         for job in payload["jobs"]:
+            conclusion = job.get("conclusion")
             failed_steps = [
                 step["name"]
                 for step in job.get("steps", [])
                 if step.get("conclusion") == "failure"
             ]
-            if job.get("conclusion") == "failure" or failed_steps:
+            if (
+                conclusion not in SUCCESSFUL_JOB_CONCLUSIONS and conclusion is not None
+            ) or failed_steps:
                 failures.append(
                     Failure(
                         job_name=job["name"],
                         job_url=job["html_url"],
+                        conclusion=conclusion or "failure",
                         step_names=failed_steps,
                     )
                 )
@@ -117,10 +123,13 @@ def format_pacific_time(timestamp: datetime) -> str:
 
 def format_failure(failure: Failure) -> str:
     job = f"<{failure.job_url}|{failure.job_name}>"
-    if not failure.step_names:
+    if failure.step_names:
+        suffix = "" if len(failure.step_names) == 1 else "s"
+        return f"• {job} — failed step{suffix}: {', '.join(failure.step_names)}"
+    if failure.conclusion == "failure":
         return f"• {job} — job failed before a failed step was reported"
-    suffix = "" if len(failure.step_names) == 1 else "s"
-    return f"• {job} — failed step{suffix}: {', '.join(failure.step_names)}"
+    conclusion = failure.conclusion.replace("_", " ")
+    return f"• {job} — job concluded {conclusion}"
 
 
 def main() -> int:
@@ -134,6 +143,7 @@ def main() -> int:
 
         version = os.environ.get("VERSION") or "unknown version"
         channel = os.environ.get("CHANNEL") or "unknown channel"
+        release_succeeded = os.environ.get("RELEASE_SUCCEEDED") == "true"
         started_at = get_run_started_at(repository, run_id, run_attempt, github_token)
         failures = find_failures(repository, run_id, run_attempt, github_token)
         if not failures and channel != "canary":
@@ -144,8 +154,13 @@ def main() -> int:
             f"https://github.com/{repository}/actions/runs/{run_id}"
             f"/attempts/{run_attempt}"
         )
-        if failures:
-            failure_text = "\n".join(format_failure(failure) for failure in failures)
+        if failures or not release_succeeded:
+            if failures:
+                failure_text = "\n".join(
+                    format_failure(failure) for failure in failures
+                )
+            else:
+                failure_text = "• Required release completion gate did not succeed"
             message = (
                 f"❌ BAML {channel} release failed: {version}, "
                 f"started at {format_pacific_time(started_at)}\n\n"


### PR DESCRIPTION
## Summary

- remove the remaining `[review]` markers from the baml_language 0.17.0 changelog while preserving the reviewed wording and section edits
- send a ✅ Slack notification when a canary release succeeds
- prefix release failure notifications with ❌ and keep successful nightly releases silent
- add a release-pipeline contract assertion for the notification behavior

## Validation

- `python3 -m unittest scripts.tests.test_release_pipeline_contract`
- `actionlint .github/workflows/release-baml-language.yml`
- `git diff --check`
- verified `baml_language/CHANGELOG.md` contains no `[review]` markers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release notifications now include the release version and channel.
  * Successful canary releases send a success notification.
  * Failed releases provide clearer failure details.
  * Successful nightly releases remain silent to reduce unnecessary notifications.

* **Documentation**
  * Updated changelog formatting and removed review labels.

* **Tests**
  * Added coverage for release notifications across success, failure, and skipped-job scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->