### PR TITLE
perf(compiler): memoize canonical body inference facts

### DIFF
--- a/baml_language/crates/baml_compiler2_hir/src/package.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/package.rs
@@ -258,10 +258,13 @@ mod tests {
     };
 
     use baml_base::{FileId, SourceFile};
-    use baml_workspace::{Compiler2ExtraFiles, Project};
+    use baml_workspace::{Compiler2ExtraFiles, MountedPackages, Project};
     use salsa::Setter;
 
-    use super::{PackageId, is_allowed_builtin_namespace_shadow, package_items};
+    use super::{
+        PackageId, is_allowed_builtin_namespace_shadow, is_external_package, is_mounted_package,
+        is_precompiled_package, package_items,
+    };
     use crate::Db;
 
     #[salsa::db]
@@ -270,6 +273,7 @@ mod tests {
         next_file_id: AtomicU32,
         project: Option<Project>,
         extra: Option<Compiler2ExtraFiles>,
+        mounted: Option<MountedPackages>,
     }
 
     impl Default for TestDb {
@@ -279,6 +283,7 @@ mod tests {
                 next_file_id: AtomicU32::new(0),
                 project: None,
                 extra: None,
+                mounted: None,
             }
         }
     }
@@ -301,6 +306,15 @@ mod tests {
             db.extra = Some(Compiler2ExtraFiles::new(&db, builtin_files));
             db
         }
+
+        fn with_mounts(
+            by_package: std::collections::BTreeMap<String, Vec<u8>>,
+            immutable_precompiled: std::collections::BTreeSet<String>,
+        ) -> Self {
+            let mut db = Self::default();
+            db.mounted = Some(MountedPackages::new(&db, by_package, immutable_precompiled));
+            db
+        }
     }
 
     #[salsa::db]
@@ -310,6 +324,10 @@ mod tests {
     impl baml_workspace::Db for TestDb {
         fn project(&self) -> Project {
             self.project.expect("test db initialized")
+        }
+
+        fn mounted_packages(&self) -> Option<MountedPackages> {
+            self.mounted
         }
     }
 
@@ -365,6 +383,31 @@ mod tests {
             &[baml_base::Name::new("other")],
             id_def
         ));
+    }
+
+    #[test]
+    fn external_package_fast_path_matches_composed_classification() {
+        let absent = TestDb::default();
+        assert!(!is_external_package(&absent, &baml_base::Name::new("app")));
+
+        let by_package = ["app", "baml", "log", "user"]
+            .into_iter()
+            .map(|name| (name.to_owned(), Vec::new()))
+            .collect();
+        let immutable_precompiled = ["baml", "user", "missing"]
+            .into_iter()
+            .map(str::to_owned)
+            .collect();
+        let db = TestDb::with_mounts(by_package, immutable_precompiled);
+
+        for raw_name in ["app", "baml", "log", "user", "missing", "env"] {
+            let name = baml_base::Name::new(raw_name);
+            assert_eq!(
+                is_external_package(&db, &name),
+                is_mounted_package(&db, &name) || is_precompiled_package(&db, &name),
+                "fused classification diverged for {raw_name}"
+            );
+        }
     }
 }
 
@@ -449,7 +492,17 @@ pub fn is_precompiled_package(db: &dyn crate::Db, name: &Name) -> bool {
 /// Whether `name` is any source-less dependency served from a serialized
 /// `PackageInterface`.
 pub fn is_external_package(db: &dyn crate::Db, name: &Name) -> bool {
-    is_mounted_package(db, name) || is_precompiled_package(db, name)
+    let Some(mounted) = db.mounted_packages() else {
+        return false;
+    };
+    if !mounted.by_package(db).contains_key(name.as_str()) {
+        return false;
+    }
+    if !is_reserved_package_name(name.as_str()) {
+        return true;
+    }
+    baml_builtins2::stdlib_package_names().contains(&name.as_str())
+        && mounted.immutable_precompiled(db).contains(name.as_str())
 }
 
 /// The *direct* dependencies of `package_id` (hardcoded for now).

--- a/baml_language/crates/baml_compiler2_hir_ty/src/facts.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/facts.rs
@@ -21,6 +21,11 @@ pub struct Facts<'db> {
     /// The current scope's param env (I2): each rigid variable's declared
     /// bound conjunction, as plain constraints (the trait's vocabulary).
     bounds: rustc_hash::FxHashMap<ParamTy, Vec<Interface>>,
+    /// Canonicalization asks for the same recursive alias and enum facts many
+    /// times inside one body. Cache the owned plain rows at the oracle boundary
+    /// instead of repeatedly materializing them from interned compiler data.
+    alias_defs: std::cell::RefCell<rustc_hash::FxHashMap<QualifiedTypeName, Option<Ty>>>,
+    enum_variants: std::cell::RefCell<rustc_hash::FxHashMap<QualifiedTypeName, Option<Vec<Name>>>>,
 }
 
 impl<'db> Facts<'db> {
@@ -28,6 +33,8 @@ impl<'db> Facts<'db> {
         Facts {
             db,
             bounds: rustc_hash::FxHashMap::default(),
+            alias_defs: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
+            enum_variants: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
         }
     }
 
@@ -35,7 +42,12 @@ impl<'db> Facts<'db> {
         db: &'db dyn baml_compiler2_ppir::Db,
         bounds: rustc_hash::FxHashMap<ParamTy, Vec<Interface>>,
     ) -> Facts<'db> {
-        Facts { db, bounds }
+        Facts {
+            db,
+            bounds,
+            alias_defs: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
+            enum_variants: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
+        }
     }
 
     /// The scope's param env verbatim - the overlap oracle's `bounds` input
@@ -55,33 +67,49 @@ impl<'db> Facts<'db> {
 
 impl TypeContext for Facts<'_> {
     fn alias_def(&self, name: &QualifiedTypeName) -> Option<Ty> {
-        if let Some(Definition::TypeAlias(alias)) = self.definition_of(name) {
-            return Some(crate::lower::type_alias_value(self.db, alias).to_plain());
+        if let Some(cached) = self.alias_defs.borrow().get(name) {
+            return cached.clone();
         }
-        match crate::package_interface::mounted_type_row(self.db, name) {
-            Some(crate::package_interface::ExportedType::TypeAlias { resolved, .. }) => {
-                Some(resolved.clone())
+        let resolved = if let Some(Definition::TypeAlias(alias)) = self.definition_of(name) {
+            Some(crate::lower::type_alias_value(self.db, alias).to_plain())
+        } else {
+            match crate::package_interface::mounted_type_row(self.db, name) {
+                Some(crate::package_interface::ExportedType::TypeAlias { resolved, .. }) => {
+                    Some(resolved.clone())
+                }
+                _ => None,
             }
-            _ => None,
-        }
+        };
+        self.alias_defs
+            .borrow_mut()
+            .insert(name.clone(), resolved.clone());
+        resolved
     }
 
     fn enum_variants(&self, name: &QualifiedTypeName) -> Option<Vec<Name>> {
-        if let Some(Definition::Enum(enum_loc)) = self.definition_of(name) {
-            return Some(
+        if let Some(cached) = self.enum_variants.borrow().get(name) {
+            return cached.clone();
+        }
+        let resolved = if let Some(Definition::Enum(enum_loc)) = self.definition_of(name) {
+            Some(
                 baml_compiler2_ppir::item_data::enum_data(self.db, enum_loc)
                     .variants
                     .iter()
                     .map(|variant| variant.name.clone())
                     .collect(),
-            );
-        }
-        match crate::package_interface::mounted_type_row(self.db, name) {
-            Some(crate::package_interface::ExportedType::Enum { variants, .. }) => {
-                Some(variants.clone())
+            )
+        } else {
+            match crate::package_interface::mounted_type_row(self.db, name) {
+                Some(crate::package_interface::ExportedType::Enum { variants, .. }) => {
+                    Some(variants.clone())
+                }
+                _ => None,
             }
-            _ => None,
-        }
+        };
+        self.enum_variants
+            .borrow_mut()
+            .insert(name.clone(), resolved.clone());
+        resolved
     }
 
     // -- Interface facts (I1: the impl registry answers; bounds and

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -1532,6 +1532,9 @@ struct InferenceContext<'db> {
     /// vars - for one `TypeRefId`. Without this, a `_` hole instantiates
     /// once per consumer and only the demand-connected copy solves.
     annotation_cache: FxHashMap<baml_compiler2_hir::type_ref::TypeRefId, Ty>,
+    /// Per-body memoization of ground canonical forms. Inference-bearing types
+    /// bypass it because their meaning changes as the table solves variables.
+    canonical_cache: baml_type::normalize::InternedCanonicalCache,
     /// Member-lookup PROBE depth (TIR's `suppress_member_lookup_errors`
     /// discipline): a failed lookup reports only when no fallback tier
     /// remains - probes increment, the committed frame reports.
@@ -1654,6 +1657,7 @@ impl<'db> InferenceContext<'db> {
             pending_diags: Vec::new(),
             hole_vars: Vec::new(),
             annotation_cache: FxHashMap::default(),
+            canonical_cache: baml_type::normalize::InternedCanonicalCache::default(),
             member_probe_depth: 0,
             or_probe_depth: 0,
             rest_reject_depth: 0,
@@ -3210,7 +3214,7 @@ impl<'db> InferenceContext<'db> {
                 let actual = self.table.resolve_completely(&actual);
                 let expected = self.table.resolve_completely(&expected);
                 if !actual.has_infer() && !expected.has_infer() {
-                    is_subtype_interned(&actual, &expected, &self.facts)
+                    self.cached_subtype(&actual, &expected)
                 } else {
                     // A SAME-INTERFACE pair with variables: identity is
                     // INVARIANT (args positional, pins by name) - rustc
@@ -3341,7 +3345,7 @@ impl<'db> InferenceContext<'db> {
             return true;
         }
         if !a.has_infer() && !b.has_infer() {
-            return equivalent_interned(&a, &b, &self.facts);
+            return self.cached_equivalent(&a, &b);
         }
         // A projection whose base still carries variables cannot relate
         // structurally - rustc keeps the pair as a lazy `Projection`
@@ -3355,6 +3359,20 @@ impl<'db> InferenceContext<'db> {
             return true;
         }
         self.table.unify(&a, &b).is_ok()
+    }
+
+    fn cached_equivalent(&self, a: &Ty, b: &Ty) -> bool {
+        if a.has_infer() || b.has_infer() {
+            return equivalent_interned(a, b, &self.facts);
+        }
+        self.canonical_cache.equivalent(a, b, &self.facts)
+    }
+
+    fn cached_subtype(&self, sub: &Ty, sup: &Ty) -> bool {
+        if sub.has_infer() || sup.has_infer() {
+            return is_subtype_interned(sub, sup, &self.facts);
+        }
+        self.canonical_cache.is_subtype(sub, sup, &self.facts)
     }
 
     /// A union of members that may still contain inference variables. The
@@ -4257,10 +4275,10 @@ impl<'db> InferenceContext<'db> {
             !ty.has_infer() && !ty.has_error() && !matches!(ty.kind(), TyKind::Never { .. })
         };
         if ground(&inner) && ground(&rhs) {
-            if is_subtype_interned(&rhs, &inner, &self.facts) {
+            if self.cached_subtype(&rhs, &inner) {
                 return inner;
             }
-            if is_subtype_interned(&inner, &rhs, &self.facts) {
+            if self.cached_subtype(&inner, &rhs) {
                 return rhs;
             }
         }
@@ -5169,7 +5187,7 @@ impl<'db> InferenceContext<'db> {
             let ty = bind_receiver(function_value_ty(signature, &candidate.class_args));
             if joined
                 .as_ref()
-                .is_some_and(|current| !equivalent_interned(current, &ty, &self.facts))
+                .is_some_and(|current| !self.cached_equivalent(current, &ty))
             {
                 return None;
             }
@@ -8786,7 +8804,7 @@ impl<'db> InferenceContext<'db> {
             }
             let judged_actual = skolemize_infer(&actual);
             let judged_expected = skolemize_infer(&expected);
-            if !is_subtype_interned(&judged_actual, &judged_expected, &self.facts) {
+            if !self.cached_subtype(&judged_actual, &judged_expected) {
                 self.result
                     .type_mismatches
                     .entry(anchor)
@@ -8884,9 +8902,7 @@ impl<'db> InferenceContext<'db> {
         for (expr, expected, actual) in std::mem::take(&mut self.provisional_checks) {
             let expected = self.finalize_ty(&expected);
             let actual = self.finalize_ty(&actual);
-            if expected.has_error()
-                || actual.has_error()
-                || is_subtype_interned(&actual, &expected, &self.facts)
+            if expected.has_error() || actual.has_error() || self.cached_subtype(&actual, &expected)
             {
                 continue;
             }
@@ -8925,7 +8941,7 @@ impl<'db> InferenceContext<'db> {
                 // A check can fail MID-INFERENCE on still-open variables
                 // that later resolution satisfies; only a mismatch that
                 // HOLDS in the finalized world reports.
-                if is_subtype_interned(actual, expected, &self.facts) {
+                if self.cached_subtype(actual, expected) {
                     continue;
                 }
                 // The for-desugar's iterability failure reads as its own
@@ -9558,7 +9574,7 @@ impl<'db> InferenceContext<'db> {
                         // later resolution satisfies; cascades suppress.
                         if declared.has_error()
                             || extra.has_error()
-                            || is_subtype_interned(&extra, &declared, &self.facts)
+                            || self.cached_subtype(&extra, &declared)
                         {
                             continue;
                         }
@@ -10120,7 +10136,7 @@ impl<'db> InferenceContext<'db> {
             let minimum = uppers.iter().find(|candidate| {
                 uppers
                     .iter()
-                    .all(|upper| is_subtype_interned(candidate, upper, &self.facts))
+                    .all(|upper| self.cached_subtype(candidate, upper))
             });
             match minimum {
                 Some(minimum) => minimum.clone(),
@@ -10143,12 +10159,11 @@ impl<'db> InferenceContext<'db> {
                 .zip(&widened)
                 .map(|(lower, wide)| lower != wide)
                 .collect();
-            let facts = &self.facts;
             let maximum_of = |candidates: &[Ty]| -> Option<Ty> {
                 let subsumes_all = |candidate: &&Ty| {
                     candidates
                         .iter()
-                        .all(|lower| is_subtype_interned(lower, candidate, facts))
+                        .all(|lower| self.cached_subtype(lower, candidate))
                 };
                 // Prefer a non-widening witness: the solution's
                 // freshness decides binding-site widening later, and a
@@ -10179,11 +10194,7 @@ impl<'db> InferenceContext<'db> {
             // (`-> 42 { id(42) }` is `42`, not Error).
             let maximum = if widening.iter().all(|&flag| flag) {
                 maximum_of(&widened)
-                    .filter(|max| {
-                        uppers
-                            .iter()
-                            .all(|upper| is_subtype_interned(max, upper, facts))
-                    })
+                    .filter(|max| uppers.iter().all(|upper| self.cached_subtype(max, upper)))
                     .or_else(|| maximum_of(&lowers))
             } else {
                 maximum_of(&lowers).or_else(|| maximum_of(&widened))
@@ -10192,7 +10203,7 @@ impl<'db> InferenceContext<'db> {
                 Some(maximum)
                     if uppers
                         .iter()
-                        .all(|upper| is_subtype_interned(&maximum, upper, &self.facts)) =>
+                        .all(|upper| self.cached_subtype(&maximum, upper)) =>
                 {
                     maximum
                 }
@@ -10504,7 +10515,7 @@ impl<'db> InferenceContext<'db> {
                 // provenance is VarBounds' business. The quiescence
                 // tiering makes a failure here reachable only for
                 // genuinely ill-typed programs.
-                if !is_subtype_interned(&actual, &expected, &self.facts)
+                if !self.cached_subtype(&actual, &expected)
                     && let Some(anchor) = anchor
                 {
                     self.result

--- a/baml_language/crates/baml_type/src/normalize.rs
+++ b/baml_language/crates/baml_type/src/normalize.rs
@@ -30,7 +30,10 @@
 //! absorb, or equate, so a missing fact can only yield "not *necessarily*
 //! equivalent / subtype", never a false claim of equivalence or membership.
 
-use std::collections::HashSet;
+use std::{
+    cell::RefCell,
+    collections::{HashMap, HashSet},
+};
 
 use crate::{
     FunctionParamMode, FunctionParamTy, Interface, Literal, MediaKind, Name, ParamTy,
@@ -2739,6 +2742,63 @@ mod tests;
 
 use crate::interned;
 
+/// Memoizes canonical forms for a sequence of interned relations evaluated
+/// under one immutable [`TypeContext`]. The cache deliberately takes the
+/// context at each call rather than owning it; callers are responsible for
+/// keeping one cache scoped to one fact set (compiler inference uses one per
+/// body). Inference-bearing types should be resolved before entering because
+/// their meaning is table-relative rather than a property of the handle alone.
+#[derive(Default)]
+pub struct InternedCanonicalCache {
+    canonical: RefCell<HashMap<interned::Ty, NormalTy>>,
+}
+
+impl InternedCanonicalCache {
+    fn canonical<C: TypeContext>(&self, ty: &interned::Ty, ctx: &C) -> NormalTy {
+        if let Some(canonical) = self.canonical.borrow().get(ty) {
+            return canonical.clone();
+        }
+        let canonical = NormalTy::canonical_interned(ty, ctx);
+        self.canonical
+            .borrow_mut()
+            .insert(ty.clone(), canonical.clone());
+        canonical
+    }
+
+    pub fn equivalent<C: TypeContext>(&self, a: &interned::Ty, b: &interned::Ty, ctx: &C) -> bool {
+        if a == b {
+            return true;
+        }
+        if interned_heads_definitely_differ(a, b) {
+            return false;
+        }
+        self.canonical(a, ctx) == self.canonical(b, ctx)
+    }
+
+    pub fn is_subtype<C: TypeContext>(
+        &self,
+        sub: &interned::Ty,
+        sup: &interned::Ty,
+        ctx: &C,
+    ) -> bool {
+        if sub == sup {
+            return true;
+        }
+        if !matches!(
+            (sub.kind(), sup.kind()),
+            (
+                interned::TyKind::Interface(..),
+                interned::TyKind::Interface(..)
+            )
+        ) && interned_heads_definitely_differ(sub, sup)
+        {
+            return false;
+        }
+        self.canonical(sub, ctx)
+            .is_subtype_of(&self.canonical(sup, ctx), ctx, &mut HashSet::new())
+    }
+}
+
 impl NormalTy {
     /// [`NormalTy::canonical_bottom_up`] for the interned representation: the
     /// same named-intermediate -> binder-resolution -> bottom-up-algebra
@@ -2948,6 +3008,16 @@ pub fn is_subtype_interned<C: TypeContext>(
     if sub == sup {
         return true;
     }
+    if !matches!(
+        (sub.kind(), sup.kind()),
+        (
+            interned::TyKind::Interface(..),
+            interned::TyKind::Interface(..)
+        )
+    ) && interned_heads_definitely_differ(sub, sup)
+    {
+        return false;
+    }
     let sub = NormalTy::canonical_interned(sub, ctx);
     let sup = NormalTy::canonical_interned(sup, ctx);
     sub.is_subtype_of(&sup, ctx, &mut HashSet::new())
@@ -2958,7 +3028,24 @@ pub fn equivalent_interned<C: TypeContext>(a: &interned::Ty, b: &interned::Ty, c
     if a == b {
         return true;
     }
+    if interned_heads_definitely_differ(a, b) {
+        return false;
+    }
     NormalTy::canonical_interned(a, ctx) == NormalTy::canonical_interned(b, ctx)
+}
+
+/// Interned counterpart of [`heads_definitely_differ`]. Hash-consing makes
+/// the identical-head fast path cheaper, but distinct nominal heads are still
+/// common during inference and cannot be changed by canonicalization.
+fn interned_heads_definitely_differ(a: &interned::Ty, b: &interned::Ty) -> bool {
+    use interned::TyKind as K;
+    match (a.kind(), b.kind()) {
+        (K::Class(q1, ..), K::Class(q2, ..))
+        | (K::Interface(q1, ..), K::Interface(q2, ..))
+        | (K::Enum(q1, ..), K::Enum(q2, ..)) => q1 != q2,
+        (K::EnumVariant(q1, v1, ..), K::EnumVariant(q2, v2, ..)) => q1 != q2 || v1 != v2,
+        _ => false,
+    }
 }
 
 /// [`TypeContext::normalize`] for interned types. Materializes once on the

--- a/baml_language/crates/baml_type/src/normalize.rs
+++ b/baml_language/crates/baml_type/src/normalize.rs
@@ -2755,6 +2755,7 @@ pub struct InternedCanonicalCache {
 
 impl InternedCanonicalCache {
     fn canonical<C: TypeContext>(&self, ty: &interned::Ty, ctx: &C) -> NormalTy {
+        debug_assert!(!ty.has_infer());
         if let Some(canonical) = self.canonical.borrow().get(ty) {
             return canonical.clone();
         }

--- a/baml_language/crates/baml_type/src/normalize/tests.rs
+++ b/baml_language/crates/baml_type/src/normalize/tests.rs
@@ -1622,10 +1622,11 @@ mod interned_entry {
     }
 
     #[test]
-    fn canonical_cache_matches_uncached_interned_relations() {
+    fn canonical_cache_matches_reject_free_canonical_relations() {
         let mut ctx = Ctx::default();
         ctx.enums
             .insert(qtn("Side"), vec![Name::new("L"), Name::new("R")]);
+        ctx.requires.push((qtn("Readable"), qtn("Displayable")));
         int_list_alias(&mut ctx, "JsonA");
         int_list_alias(&mut ctx, "JsonB");
 
@@ -1639,23 +1640,29 @@ mod interned_entry {
                 enum_ty("Side"),
             ),
             (class("Left"), class("Right")),
-            (iface("Readable"), iface("Writable")),
+            // Distinct interface heads cannot be rejected: the context makes
+            // this pair a valid subtype through `requires`.
+            (iface("Readable"), iface("Displayable")),
+            (iface("Displayable"), iface("Readable")),
         ];
         let pairs = pairs.map(|(a, b)| (it(&a), it(&b)));
         let cache = InternedCanonicalCache::default();
 
         // Run twice: the first pass populates canonical forms and the second
-        // proves that the warm path returns the same relation verdicts.
+        // proves that the warm path returns the same relation verdicts. The
+        // oracle deliberately bypasses the interned-entry fast rejection.
         for _ in 0..2 {
             for (a, b) in &pairs {
+                let canonical_a = NormalTy::canonical_interned(a, &ctx);
+                let canonical_b = NormalTy::canonical_interned(b, &ctx);
                 assert_eq!(
                     cache.equivalent(a, b, &ctx),
-                    equivalent_interned(a, b, &ctx),
+                    canonical_a == canonical_b,
                     "cached equivalence diverged for {a:?} == {b:?}"
                 );
                 assert_eq!(
                     cache.is_subtype(a, b, &ctx),
-                    is_subtype_interned(a, b, &ctx),
+                    canonical_a.is_subtype_of(&canonical_b, &ctx, &mut HashSet::new()),
                     "cached subtyping diverged for {a:?} <: {b:?}"
                 );
             }

--- a/baml_language/crates/baml_type/src/normalize/tests.rs
+++ b/baml_language/crates/baml_type/src/normalize/tests.rs
@@ -1621,6 +1621,47 @@ mod interned_entry {
         ));
     }
 
+    #[test]
+    fn canonical_cache_matches_uncached_interned_relations() {
+        let mut ctx = Ctx::default();
+        ctx.enums
+            .insert(qtn("Side"), vec![Name::new("L"), Name::new("R")]);
+        int_list_alias(&mut ctx, "JsonA");
+        int_list_alias(&mut ctx, "JsonB");
+
+        let pairs = [
+            (alias("JsonA"), alias("JsonB")),
+            (alias("JsonA"), Ty::int()),
+            (lit_int(1), Ty::int()),
+            (Ty::int(), union(vec![Ty::int(), Ty::string()])),
+            (
+                union(vec![variant("Side", "L"), variant("Side", "R")]),
+                enum_ty("Side"),
+            ),
+            (class("Left"), class("Right")),
+            (iface("Readable"), iface("Writable")),
+        ];
+        let pairs = pairs.map(|(a, b)| (it(&a), it(&b)));
+        let cache = InternedCanonicalCache::default();
+
+        // Run twice: the first pass populates canonical forms and the second
+        // proves that the warm path returns the same relation verdicts.
+        for _ in 0..2 {
+            for (a, b) in &pairs {
+                assert_eq!(
+                    cache.equivalent(a, b, &ctx),
+                    equivalent_interned(a, b, &ctx),
+                    "cached equivalence diverged for {a:?} == {b:?}"
+                );
+                assert_eq!(
+                    cache.is_subtype(a, b, &ctx),
+                    is_subtype_interned(a, b, &ctx),
+                    "cached subtyping diverged for {a:?} <: {b:?}"
+                );
+            }
+        }
+    }
+
     /// The plain entry gets the same spec rule (TYPE_SYSTEM.md:
     /// `(true | false) == bool`); the collapse lives in the shared algebra,
     /// not in an engine.


### PR DESCRIPTION
## Summary

- memoize recursive alias/enum facts and canonical interned forms within one body-inference context
- reject distinct stable nominal heads before canonicalization and fuse external-package classification into one mounted-package lookup
- add cold/warm cache coverage against a fast-reject-free canonical oracle, including a load-bearing interface `requires` relation
- assert the infer-free cache invariant at the private canonicalization boundary

## Diagnosis

The supplied #4430 profile showed body inference scaling super-linearly: the empty compile moved from about 368 ms to 989 ms, the realistic project from 2.39 s to 4.61 s, and the worst OpenAI bodies reached 500–660 ms.

Temporary phase/counter instrumentation on the current canary workload inferred 2,160 bodies. It ruled out two suspected causes: the entire compile registered/attempted only 42–51 obligations, and package-resolution misses were zero. A single-thread profile removed parallel lock-wait attribution and isolated recursive JSON/provider walkers instead. For example, `baml/ns_toml/toml.baml|item_to_json` performed 1,602 canonical roots / 5,542 canonical nodes; OpenAI metadata/directive walkers repeatedly traversed roughly 175–382 roots and 1,945–3,055 nodes per body.

The hot path rebuilt canonical forms for every subtype/equivalence query and repeatedly materialized the same recursive alias definitions and enum rows from interned compiler data. This change scopes both caches to one inference body and one immutable fact set; inference-bearing types bypass the canonical cache because their meaning is table-relative.

All diagnostic instrumentation and temporary proof drivers were removed before commit.

## Compiler A/B

Rust 1.93.0, `CARGO_BUILD_JOBS=8`, `BAML_PROFILE=0`, same machine and command on `a3bc09ba7` canary and this branch:

```sh
cargo bench -p baml_tests --bench compiler_benchmark -- compile_
```

| Benchmark | canary median | branch median | delta |
|---|---:|---:|---:|
| `compile_empty_project` | 530.2 ms | 489.1 ms | -41.1 ms (-7.75%) |
| `compile_baml_tests_project` | 2.333 s | 2.120 s | -0.213 s (-9.13%) |

Ranges: empty canary 511.6–553.8 ms vs branch 465.6–501.1 ms (100 samples); realistic canary 2.319–2.515 s vs branch 2.103–2.269 s (5 samples). This clears the brief's <500 ms empty median and <=2.8 s realistic ceilings.

Controlled per-body profile, 2,160 bodies on each side:

| Body | canary | branch | delta |
|---|---:|---:|---:|
| `openai/chat.baml|invoke_stream` | 196.4 ms | 131.6 ms | -33.0% |
| `openai/ns_internal/chat.baml|chat_invoke_stream` | 192.9 ms | 128.7 ms | -33.3% |
| `openai/generic.baml|invoke_stream` | 182.4 ms | 125.9 ms | -31.0% |
| `openai/ns_internal/chat.baml|chat_build_request` | 148.9 ms | 106.0 ms | -28.8% |

## Peak RSS A/B

Required review remeasurement of `compile_baml_tests_project`: release benchmark executable run directly under `/usr/bin/time`, three fresh processes per side, five Divan samples per process, `BAML_PROFILE=0`, and identical default/full-machine conditions on canary `a3bc09ba7` and the final candidate. Table values are medians across the three processes.

| Measurement | canary | branch | delta |
|---|---:|---:|---:|
| Peak RSS | 714,960 KiB (698.2 MiB) | 710,832 KiB (694.2 MiB) | -4,128 KiB / -4.0 MiB (-0.58%) |
| Compile median | 2.362 s | 2.193 s | -0.169 s (-7.16%) |

Peak-RSS ranges were 711,464–716,612 KiB on canary and 707,680–715,836 KiB on the branch.

The suggested `Rc<NormalTy>` memo was evaluated in the same three-process setup and dropped because it did not measure as a win: compile median 2.193→2.200 s (+0.3%) and peak RSS 710,832→712,864 KiB (+0.3%). The final patch retains the simpler owned cache. `provable_subtype` threading is intentionally deferred.

## Runtime safety

The full generated runtime speedtest suite ran in a same-machine A-B-A bracket with five samples per workload (`BAML_PROFILE=0`, `DIVAN_MAX_TIME=20`). All 38 non-sleep workloads completed; stable representative medians stayed flat (for example method call +1.8%, bubble sort +0.7%, call chain -0.8%, pure call +2.8%, interface default dispatch +2.4%, interface match dispatch +1.7%). Concurrency rows showed the expected broad scheduler variance across the bracket.

As a stronger zero-delta proof, a temporary harness compiled and Borsh-serialized every measured workload on canary and the branch. Both revisions produced exactly 38 programs, 94,239,414 aggregate bytes, and corpus digest `838ab2f95eb1bc62`: the VM received byte-identical programs. The harness was removed before commit.

## Validation

- reject-free canonical-cache oracle covers cold/warm recursive aliases, unions/literals, enum collapse, distinct nominal heads, and `Readable <: Displayable` through populated `requires`
- `cargo nextest run -p baml_type -p baml_compiler2_hir -p baml_compiler2_hir_ty --all-features`: 384/384 passed
- strict all-target/all-feature Clippy for the focused packages passed with warnings denied
- all three commit hooks passed full-workspace Clippy
- repeated pinned gate passed: 3,742/3,742 tests (59 slow), 24 skipped, in 1,505.171 s; doctests passed/ignored as expected
- Insta: no unreferenced snapshots and no snapshots to review

Pinned command, rerun with default cargo/nextest parallelism per the corrected coordinator instruction:

```sh
rustup run 1.93.0 cargo insta test --test-runner nextest \
  -p baml_tests -p baml_cli -p baml_lsp2_actions -p baml_lsp2_actions_tests \
  -p baml_surface --all-features --unreferenced=reject
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved type-checking responsiveness by caching repeated type comparisons and resolved type information.
  * Added faster handling for clearly unrelated type categories.

* **Bug Fixes**
  * Improved classification of mounted, precompiled, reserved, and standard-library packages.
  * Added coverage for recursive aliases, literals, unions, enums, classes, and interface requirements to ensure cached type results remain accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->