### PR TITLE
perf(compiler): reuse inference caches

### DIFF
--- a/baml_language/crates/baml_compiler2_hir_ty/src/facts.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/facts.rs
@@ -59,9 +59,55 @@ impl<'db> Facts<'db> {
     /// Resolves a qualified name back to its definition through the owning
     /// package's canonical (ppir) items.
     pub fn definition_of(&self, name: &QualifiedTypeName) -> Option<Definition<'db>> {
-        let package = PackageId::new(self.db, name.package().clone());
-        baml_compiler2_ppir::package_items(self.db, package)
-            .lookup_type(name.namespace(), name.name())
+        definition_of(self.db, name)
+    }
+}
+
+fn definition_of<'db>(
+    db: &'db dyn baml_compiler2_ppir::Db,
+    name: &QualifiedTypeName,
+) -> Option<Definition<'db>> {
+    let package = PackageId::new(db, name.package().clone());
+    baml_compiler2_ppir::package_items(db, package).lookup_type(name.namespace(), name.name())
+}
+
+/// Resolves an alias without allocating a memo table. Short-lived fact-poor
+/// contexts use this directly; body-lifetime [`Facts`] caches its result.
+pub(crate) fn uncached_alias_def(
+    db: &dyn baml_compiler2_ppir::Db,
+    name: &QualifiedTypeName,
+) -> Option<Ty> {
+    if let Some(Definition::TypeAlias(alias)) = definition_of(db, name) {
+        return Some(crate::lower::type_alias_value(db, alias).to_plain());
+    }
+    match crate::package_interface::mounted_type_row(db, name) {
+        Some(crate::package_interface::ExportedType::TypeAlias { resolved, .. }) => {
+            Some(resolved.clone())
+        }
+        _ => None,
+    }
+}
+
+/// Resolves enum variants without allocating a memo table. Short-lived
+/// fact-poor contexts use this directly; body-lifetime [`Facts`] caches it.
+pub(crate) fn uncached_enum_variants(
+    db: &dyn baml_compiler2_ppir::Db,
+    name: &QualifiedTypeName,
+) -> Option<Vec<Name>> {
+    if let Some(Definition::Enum(enum_loc)) = definition_of(db, name) {
+        return Some(
+            baml_compiler2_ppir::item_data::enum_data(db, enum_loc)
+                .variants
+                .iter()
+                .map(|variant| variant.name.clone())
+                .collect(),
+        );
+    }
+    match crate::package_interface::mounted_type_row(db, name) {
+        Some(crate::package_interface::ExportedType::Enum { variants, .. }) => {
+            Some(variants.clone())
+        }
+        _ => None,
     }
 }
 
@@ -70,16 +116,7 @@ impl TypeContext for Facts<'_> {
         if let Some(cached) = self.alias_defs.borrow().get(name) {
             return cached.clone();
         }
-        let resolved = if let Some(Definition::TypeAlias(alias)) = self.definition_of(name) {
-            Some(crate::lower::type_alias_value(self.db, alias).to_plain())
-        } else {
-            match crate::package_interface::mounted_type_row(self.db, name) {
-                Some(crate::package_interface::ExportedType::TypeAlias { resolved, .. }) => {
-                    Some(resolved.clone())
-                }
-                _ => None,
-            }
-        };
+        let resolved = uncached_alias_def(self.db, name);
         self.alias_defs
             .borrow_mut()
             .insert(name.clone(), resolved.clone());
@@ -90,22 +127,7 @@ impl TypeContext for Facts<'_> {
         if let Some(cached) = self.enum_variants.borrow().get(name) {
             return cached.clone();
         }
-        let resolved = if let Some(Definition::Enum(enum_loc)) = self.definition_of(name) {
-            Some(
-                baml_compiler2_ppir::item_data::enum_data(self.db, enum_loc)
-                    .variants
-                    .iter()
-                    .map(|variant| variant.name.clone())
-                    .collect(),
-            )
-        } else {
-            match crate::package_interface::mounted_type_row(self.db, name) {
-                Some(crate::package_interface::ExportedType::Enum { variants, .. }) => {
-                    Some(variants.clone())
-                }
-                _ => None,
-            }
-        };
+        let resolved = uncached_enum_variants(self.db, name);
         self.enum_variants
             .borrow_mut()
             .insert(name.clone(), resolved.clone());

--- a/baml_language/crates/baml_compiler2_hir_ty/src/impls.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/impls.rs
@@ -255,23 +255,21 @@ pub fn package_impl_locs<'db>(
 /// termination argument (a fact-rich context would let the matcher
 /// re-enter the resolver that called it).
 pub(crate) struct AliasOnlyFacts<'db> {
-    facts: crate::facts::Facts<'db>,
+    db: &'db dyn baml_compiler2_ppir::Db,
 }
 
 impl<'db> AliasOnlyFacts<'db> {
     pub(crate) fn new(db: &'db dyn baml_compiler2_ppir::Db) -> AliasOnlyFacts<'db> {
-        AliasOnlyFacts {
-            facts: crate::facts::Facts::new(db),
-        }
+        AliasOnlyFacts { db }
     }
 }
 
 impl TypeContext for AliasOnlyFacts<'_> {
     fn alias_def(&self, name: &TypeName) -> Option<baml_type::Ty> {
-        self.facts.alias_def(name)
+        crate::facts::uncached_alias_def(self.db, name)
     }
     fn enum_variants(&self, name: &TypeName) -> Option<Vec<Name>> {
-        self.facts.enum_variants(name)
+        crate::facts::uncached_enum_variants(self.db, name)
     }
     fn implements_interface(&self, _: &baml_type::Ty, _: &baml_type::Interface) -> bool {
         false

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -2944,9 +2944,12 @@ impl<'db> InferenceContext<'db> {
             // wherever it later reaches a real binding or join.
             let narrowed = self.table.resolve_completely(&assigned);
             let fits = match &declared {
-                Some(declared) if !declared.has_error() => {
-                    crate::infer::pat::provable_subtype(&narrowed, declared, &self.facts)
-                }
+                Some(declared) if !declared.has_error() => crate::infer::pat::provable_subtype(
+                    &narrowed,
+                    declared,
+                    &self.facts,
+                    &self.canonical_cache,
+                ),
                 _ => false,
             };
             if fits {
@@ -8438,10 +8441,15 @@ impl<'db> InferenceContext<'db> {
                 let mut may: Vec<Ty> = Vec::new();
                 let mut definite: Vec<Ty> = Vec::new();
                 for fact in &facts {
-                    if pat::provable_subtype(fact, &claim, &self.facts) {
+                    if pat::provable_subtype(fact, &claim, &self.facts, &self.canonical_cache) {
                         may.push(fact.clone());
                         definite.push(fact.clone());
-                    } else if pat::provable_subtype(&claim, fact, &self.facts) {
+                    } else if pat::provable_subtype(
+                        &claim,
+                        fact,
+                        &self.facts,
+                        &self.canonical_cache,
+                    ) {
                         may.push(fact.clone());
                     }
                 }

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer/flow.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer/flow.rs
@@ -165,7 +165,7 @@ impl InferenceContext<'_> {
     /// The tighter of two refinements of the same binding (approximate
     /// meet, same policy as pattern narrowing).
     fn narrow_meet(&self, a: &Ty, b: &Ty) -> Ty {
-        if crate::infer::pat::provable_subtype(a, b, &self.facts) {
+        if crate::infer::pat::provable_subtype(a, b, &self.facts, &self.canonical_cache) {
             a.clone()
         } else {
             b.clone()
@@ -216,7 +216,14 @@ impl InferenceContext<'_> {
         };
         let kept: Vec<Ty> = members
             .iter()
-            .filter(|member| !crate::infer::pat::provable_subtype(member, matched, &self.facts))
+            .filter(|member| {
+                !crate::infer::pat::provable_subtype(
+                    member,
+                    matched,
+                    &self.facts,
+                    &self.canonical_cache,
+                )
+            })
             .cloned()
             .collect();
         if kept.len() == members.len() {

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
@@ -25,7 +25,7 @@ use baml_compiler2_ast::{ExprBody, ExprId, MatchArmId, PatId, Pattern};
 use baml_type::{
     Freshness, TyAttr,
     interned::{InterfaceRef, Ty, TyKind},
-    normalize::{TypeContext as _, is_subtype_interned, normalize_interned},
+    normalize::{TypeContext as _, normalize_interned},
 };
 
 use super::{Expectation, InferenceContext};
@@ -696,7 +696,7 @@ impl<'db> InferenceContext<'db> {
                 })
             })
             .collect();
-        let head_covers = provable_subtype(scrut, &head, &self.facts);
+        let head_covers = provable_subtype(scrut, &head, &self.facts, &self.canonical_cache);
 
         // The matrix's single-ctor STRUCT VIEW of an existential
         // (`Ctor::Interface`, rustc's non-enum struct treatment): field
@@ -891,7 +891,7 @@ impl<'db> InferenceContext<'db> {
                 consumes_matched: false,
             };
         }
-        let covers = provable_subtype(scrut, pat_ty, &self.facts);
+        let covers = provable_subtype(scrut, pat_ty, &self.facts, &self.canonical_cache);
         if let TyKind::Union(members, _) = scrut.kind()
             && !covers
         {
@@ -899,8 +899,8 @@ impl<'db> InferenceContext<'db> {
             let claimed: Vec<&Ty> = members
                 .iter()
                 .filter(|member| {
-                    provable_subtype(member, pat_ty, &self.facts)
-                        || provable_subtype(pat_ty, member, &self.facts)
+                    provable_subtype(member, pat_ty, &self.facts, &self.canonical_cache)
+                        || provable_subtype(pat_ty, member, &self.facts, &self.canonical_cache)
                 })
                 .collect();
             if !claimed.is_empty() {
@@ -908,11 +908,13 @@ impl<'db> InferenceContext<'db> {
                 let alts: Vec<DPat> = claimed
                     .iter()
                     .map(|member| {
-                        let inner = if provable_subtype(member, pat_ty, &self.facts) {
-                            DPat::wildcard(member.to_plain())
-                        } else {
-                            self.dpat_for_type(pat_ty, member)
-                        };
+                        let inner =
+                            if provable_subtype(member, pat_ty, &self.facts, &self.canonical_cache)
+                            {
+                                DPat::wildcard(member.to_plain())
+                            } else {
+                                self.dpat_for_type(pat_ty, member)
+                            };
                         DPat::union_member(member.to_plain(), inner, scrut_plain.clone())
                     })
                     .collect();
@@ -959,7 +961,7 @@ impl<'db> InferenceContext<'db> {
     /// pattern type stands (rigid pairs keep the written type - TIR's
     /// `intersect_pattern_flow_types` policy).
     fn narrow_to(&self, scrut: &Ty, pat_ty: &Ty) -> Ty {
-        if provable_subtype(scrut, pat_ty, &self.facts) {
+        if provable_subtype(scrut, pat_ty, &self.facts, &self.canonical_cache) {
             scrut.clone()
         } else {
             pat_ty.clone()
@@ -976,7 +978,7 @@ impl<'db> InferenceContext<'db> {
         // provably fits is a wildcard at this column, whatever its shape
         // (a same-union pattern must not decompose into per-member
         // singles that no longer align with UnionMember ctors).
-        if provable_subtype(col, pat_ty, &self.facts) {
+        if provable_subtype(col, pat_ty, &self.facts, &self.canonical_cache) {
             return DPat::wildcard(col_plain);
         }
         match pat_ty.kind() {
@@ -1044,7 +1046,7 @@ impl<'db> InferenceContext<'db> {
                 }
             }
             _ => {
-                if provable_subtype(col, pat_ty, &self.facts) {
+                if provable_subtype(col, pat_ty, &self.facts, &self.canonical_cache) {
                     DPat::wildcard(col_plain)
                 } else {
                     DPat::single(pat_plain, col_plain)
@@ -1194,7 +1196,7 @@ impl<'db> InferenceContext<'db> {
                 })
             })
             .collect();
-        let head_covers = provable_subtype(scrut, &head, &self.facts);
+        let head_covers = provable_subtype(scrut, &head, &self.facts, &self.canonical_cache);
 
         // Union scrutinee: claim the same-class member.
         let dpat = {
@@ -1415,8 +1417,17 @@ impl<'db> InferenceContext<'db> {
                     return true;
                 };
                 if let Some(ascribed) = self.pattern_ascription_ty(body, sub) {
-                    return provable_subtype(&ascribed, &expanded, &self.facts)
-                        || provable_subtype(&expanded, &ascribed, &self.facts);
+                    return provable_subtype(
+                        &ascribed,
+                        &expanded,
+                        &self.facts,
+                        &self.canonical_cache,
+                    ) || provable_subtype(
+                        &expanded,
+                        &ascribed,
+                        &self.facts,
+                        &self.canonical_cache,
+                    );
                 }
                 self.pattern_fits(body, sub, &expanded)
             }
@@ -1473,7 +1484,12 @@ impl<'db> InferenceContext<'db> {
 /// A PROVABLE subtype verdict: ground on both sides and confirmed by the
 /// oracle. Rigid or unresolved pairs are not provable - the conservative
 /// direction for both coverage and claiming.
-pub(super) fn provable_subtype(sub: &Ty, sup: &Ty, facts: &crate::facts::Facts<'_>) -> bool {
+pub(super) fn provable_subtype(
+    sub: &Ty,
+    sup: &Ty,
+    facts: &crate::facts::Facts<'_>,
+    canonical_cache: &baml_type::normalize::InternedCanonicalCache,
+) -> bool {
     if sub == sup {
         return true;
     }
@@ -1485,7 +1501,7 @@ pub(super) fn provable_subtype(sub: &Ty, sup: &Ty, facts: &crate::facts::Facts<'
     // against an unrelated concrete does not - which is exactly the B-633
     // rule). The corpus pinned the case this matters for: a synthetic
     // effect var IS covered by `throws unknown`.
-    is_subtype_interned(sub, sup, facts)
+    canonical_cache.is_subtype(sub, sup, facts)
 }
 
 /// The legal shapes of a rest sub-pattern: the wildcard, a bare


### PR DESCRIPTION
## Summary

- Thread the existing canonical subtype cache through provable_subtype call sites while retaining equality and infer/error filtering before cache entry.
- Extract uncached definition and enum lookup helpers so short-lived AliasOnlyFacts avoids allocating memo maps.
- Keep memoization on long-lived Facts, with the existing debug assertions preserving cache consistency checks.

This is a pure performance refactor with no intended semantic delta.

## Benchmarks

| benchmark | canary baseline | candidate repeats | repeat-median delta |
| --- | ---: | ---: | ---: |
| compile_baml_tests_project | 2.114 s | 2.193 s / 2.194 s | +3.8% |
| compile_empty_project | 490.7 ms | 505.5 ms / 504.4 ms | +2.9% |

Both deltas are within the established +/-5% run-to-run band. The aggregate result is neutral/noisy, so this PR does not claim an end-to-end speedup; the win is the removal of redundant cache construction and canonical subtype work.

## Scope note

The optional #4453 M4 item was skipped because it belongs to separate VM/GC benchmark and retention work rather than this contained compiler follow-up.

## Validation

- Focused nextest: 384/384 passed for baml_type, baml_compiler2_hir, and baml_compiler2_hir_ty with all features.
- Strict Clippy passed for those packages across all targets and features.
- Cargo format and diff checks passed.
- Exact pinned full gate passed: 3748/3748 tests, 24 skipped, 51 slow, 1409.829 s; doctests clean; no unreferenced snapshots and no snapshots to review.

Full gate command: CARGO_BUILD_JOBS=8 rustup run 1.93.0 cargo insta test --test-runner nextest -p baml_tests -p baml_cli -p baml_lsp2_actions -p baml_lsp2_actions_tests -p baml_surface --all-features --unreferenced=reject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved type resolution for aliases and enum variants.
  - Improved type checking for pattern matching, assignment narrowing, and catch-arm handling.
  - Made subtype checks more consistent across interfaces, classes, arrays, unions, and pattern-based matching.
  - Improved handling of type narrowing and subtraction in flow analysis.

- **Performance**
  - Reduced repeated subtype calculations during compilation, which may improve compiler responsiveness for complex type definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->