### PR TITLE
ci: serialize TypeScript web worker fixtures

### DIFF
--- a/baml_language/.config/nextest.toml
+++ b/baml_language/.config/nextest.toml
@@ -21,6 +21,7 @@ rust-sdk-fixture = { max-threads = 2 }
 java-gradle-serial = { max-threads = 1 }
 # C# fixtures share the bridge project's MSBuild obj directory.
 csharp-sdk-fixture = { max-threads = 1 }
+typescript-web-workers = { max-threads = 1 }
 
 [[profile.default.overrides]]
 filter = 'package(=sdk_test_rust)'
@@ -29,6 +30,10 @@ test-group = 'rust-sdk-fixture'
 [[profile.default.overrides]]
 filter = 'package(=sdk_test_csharp)'
 test-group = 'csharp-sdk-fixture'
+
+[[profile.default.overrides]]
+filter = 'package(=sdk_test_typescript_web) & test(/::vitest_workers$/)'
+test-group = 'typescript-web-workers'
 
 # Node TypeScript tests build only the native bridge and Node fixture packages.
 [scripts.setup.typescript_pnpm_unix]


### PR DESCRIPTION
## Summary

- add a max-threads=1 nextest group for the TypeScript web worker fixture gates
- scope the override to sdk_test_typescript_web tests ending in ::vitest_workers
- keep all other TypeScript web tests on the existing scheduler

## Why

Each workerd import can peak at roughly 7-8 GiB. The four outer vitest_workers fixture gates could overlap, multiplying that peak and causing host OOMs. Serializing only those four outer gates preserves inner fixture behavior while bounding aggregate memory.

## Verification

- cargo nextest list found 30 tests in sdk_test_typescript_web, with exactly four matching ::vitest_workers: docstrings_etc, function_calls, llm_functions, and type_shapes
- cargo nextest show-config test-groups assigned exactly those four tests to typescript-web-workers with max-threads=1
- full pinned gate: 3,748 passed, 24 skipped; doctests clean; no unreferenced or pending snapshots

Base: fdd05ac9acbc1dd3ff5ee229411234ed695f2f13
Head: 2b22fbd65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Configured TypeScript web-worker tests to run in a single-threaded test group.
  * Added a profile-specific override for the matching Vitest worker tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->