### PR TITLE
perf(compiler): restore alias memos for impl scans

### DIFF
--- a/baml_language/crates/baml_compiler2_hir_ty/src/facts.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/facts.rs
@@ -71,8 +71,8 @@ fn definition_of<'db>(
     baml_compiler2_ppir::package_items(db, package).lookup_type(name.namespace(), name.name())
 }
 
-/// Resolves an alias without allocating a memo table. Short-lived fact-poor
-/// contexts use this directly; body-lifetime [`Facts`] caches its result.
+/// Resolves an alias without retaining the result in a memo. One-shot
+/// fact-poor contexts use this directly; repeated scans use a cached context.
 pub(crate) fn uncached_alias_def(
     db: &dyn baml_compiler2_ppir::Db,
     name: &QualifiedTypeName,
@@ -88,8 +88,8 @@ pub(crate) fn uncached_alias_def(
     }
 }
 
-/// Resolves enum variants without allocating a memo table. Short-lived
-/// fact-poor contexts use this directly; body-lifetime [`Facts`] caches it.
+/// Resolves enum variants without retaining the result in a memo. One-shot
+/// fact-poor contexts use this directly; repeated scans use a cached context.
 pub(crate) fn uncached_enum_variants(
     db: &dyn baml_compiler2_ppir::Db,
     name: &QualifiedTypeName,

--- a/baml_language/crates/baml_compiler2_hir_ty/src/impls.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/impls.rs
@@ -256,20 +256,39 @@ pub fn package_impl_locs<'db>(
 /// re-enter the resolver that called it).
 pub(crate) struct AliasOnlyFacts<'db> {
     db: &'db dyn baml_compiler2_ppir::Db,
+    memoized: Option<crate::facts::Facts<'db>>,
 }
 
 impl<'db> AliasOnlyFacts<'db> {
+    /// A one-shot alias/enum context. Use [`Self::memoized`] when the same
+    /// context spans a candidate scan and will see repeated type heads.
     pub(crate) fn new(db: &'db dyn baml_compiler2_ppir::Db) -> AliasOnlyFacts<'db> {
-        AliasOnlyFacts { db }
+        AliasOnlyFacts { db, memoized: None }
+    }
+
+    /// A scan-local alias/enum context. Cached Salsa-derived rows widen the
+    /// re-entrancy window versus direct lookup, so this must not outlive the
+    /// surrounding candidate scan.
+    fn memoized(db: &'db dyn baml_compiler2_ppir::Db) -> AliasOnlyFacts<'db> {
+        AliasOnlyFacts {
+            db,
+            memoized: Some(crate::facts::Facts::new(db)),
+        }
     }
 }
 
 impl TypeContext for AliasOnlyFacts<'_> {
     fn alias_def(&self, name: &TypeName) -> Option<baml_type::Ty> {
-        crate::facts::uncached_alias_def(self.db, name)
+        self.memoized.as_ref().map_or_else(
+            || crate::facts::uncached_alias_def(self.db, name),
+            |facts| facts.alias_def(name),
+        )
     }
     fn enum_variants(&self, name: &TypeName) -> Option<Vec<Name>> {
-        crate::facts::uncached_enum_variants(self.db, name)
+        self.memoized.as_ref().map_or_else(
+            || crate::facts::uncached_enum_variants(self.db, name),
+            |facts| facts.enum_variants(name),
+        )
     }
     fn implements_interface(&self, _: &baml_type::Ty, _: &baml_type::Interface) -> bool {
         false
@@ -805,7 +824,7 @@ fn impls_for_type_cached<'db>(
     type_key: ImplTypeKey<'db>,
 ) -> Vec<CachedResolvedImpl<'db>> {
     let concrete = type_key.concrete(db);
-    let eq = AliasOnlyFacts::new(db);
+    let eq = AliasOnlyFacts::memoized(db);
     let mut out = Vec::new();
     for &package in all_packages(db) {
         // Do not short-circuit this iterator: `impl_facts` dependencies are
@@ -1111,7 +1130,7 @@ fn resolve_within_depth<'db>(
         return None;
     }
     in_progress.push((concrete.clone(), interface.clone()));
-    let eq = AliasOnlyFacts::new(db);
+    let eq = AliasOnlyFacts::memoized(db);
     let mut resolved = None;
     'search: for package in search_roots(db, concrete, interface) {
         for (origin, facts) in package_impl_candidates(db, package) {

--- a/baml_language/crates/baml_compiler2_hir_ty/src/impls.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/impls.rs
@@ -266,9 +266,9 @@ impl<'db> AliasOnlyFacts<'db> {
         AliasOnlyFacts { db, memoized: None }
     }
 
-    /// A scan-local alias/enum context. Cached Salsa-derived rows widen the
-    /// re-entrancy window versus direct lookup, so this must not outlive the
-    /// surrounding candidate scan.
+    /// A scan-local alias/enum context. A memo must not outlive one query
+    /// execution - it would serve rows from a stale revision and suppress the
+    /// dependency reads a later execution needs.
     fn memoized(db: &'db dyn baml_compiler2_ppir::Db) -> AliasOnlyFacts<'db> {
         AliasOnlyFacts {
             db,

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -2944,12 +2944,9 @@ impl<'db> InferenceContext<'db> {
             // wherever it later reaches a real binding or join.
             let narrowed = self.table.resolve_completely(&assigned);
             let fits = match &declared {
-                Some(declared) if !declared.has_error() => crate::infer::pat::provable_subtype(
-                    &narrowed,
-                    declared,
-                    &self.facts,
-                    &self.canonical_cache,
-                ),
+                Some(declared) if !declared.has_error() => {
+                    self.provable_subtype(&narrowed, declared)
+                }
                 _ => false,
             };
             if fits {
@@ -3381,6 +3378,25 @@ impl<'db> InferenceContext<'db> {
         if sub.has_infer() || sup.has_infer() {
             return is_subtype_interned(sub, sup, &self.facts);
         }
+        self.canonical_cache.is_subtype(sub, sup, &self.facts)
+    }
+
+    /// A PROVABLE subtype verdict: ground on both sides and confirmed by this
+    /// inference body's paired facts and canonical cache. Rigid or unresolved
+    /// pairs are not provable, the conservative direction for coverage and
+    /// claiming.
+    fn provable_subtype(&self, sub: &Ty, sup: &Ty) -> bool {
+        if sub == sup {
+            return true;
+        }
+        if sub.has_infer() || sup.has_infer() || sub.has_error() || sup.has_error() {
+            return false;
+        }
+        // Rigid variables go to the oracle too: its typevar arms are already
+        // conservative (`T <: T`, `T <: unknown`, `never <: T` prove; a rigid
+        // against an unrelated concrete does not - which is exactly the B-633
+        // rule). The corpus pins the case this matters for: a synthetic effect
+        // var IS covered by `throws unknown`.
         self.canonical_cache.is_subtype(sub, sup, &self.facts)
     }
 
@@ -8441,15 +8457,10 @@ impl<'db> InferenceContext<'db> {
                 let mut may: Vec<Ty> = Vec::new();
                 let mut definite: Vec<Ty> = Vec::new();
                 for fact in &facts {
-                    if pat::provable_subtype(fact, &claim, &self.facts, &self.canonical_cache) {
+                    if self.provable_subtype(fact, &claim) {
                         may.push(fact.clone());
                         definite.push(fact.clone());
-                    } else if pat::provable_subtype(
-                        &claim,
-                        fact,
-                        &self.facts,
-                        &self.canonical_cache,
-                    ) {
+                    } else if self.provable_subtype(&claim, fact) {
                         may.push(fact.clone());
                     }
                 }

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer/flow.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer/flow.rs
@@ -165,7 +165,7 @@ impl InferenceContext<'_> {
     /// The tighter of two refinements of the same binding (approximate
     /// meet, same policy as pattern narrowing).
     fn narrow_meet(&self, a: &Ty, b: &Ty) -> Ty {
-        if crate::infer::pat::provable_subtype(a, b, &self.facts, &self.canonical_cache) {
+        if self.provable_subtype(a, b) {
             a.clone()
         } else {
             b.clone()
@@ -216,14 +216,7 @@ impl InferenceContext<'_> {
         };
         let kept: Vec<Ty> = members
             .iter()
-            .filter(|member| {
-                !crate::infer::pat::provable_subtype(
-                    member,
-                    matched,
-                    &self.facts,
-                    &self.canonical_cache,
-                )
-            })
+            .filter(|member| !self.provable_subtype(member, matched))
             .cloned()
             .collect();
         if kept.len() == members.len() {

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
@@ -696,7 +696,7 @@ impl<'db> InferenceContext<'db> {
                 })
             })
             .collect();
-        let head_covers = provable_subtype(scrut, &head, &self.facts, &self.canonical_cache);
+        let head_covers = self.provable_subtype(scrut, &head);
 
         // The matrix's single-ctor STRUCT VIEW of an existential
         // (`Ctor::Interface`, rustc's non-enum struct treatment): field
@@ -891,7 +891,7 @@ impl<'db> InferenceContext<'db> {
                 consumes_matched: false,
             };
         }
-        let covers = provable_subtype(scrut, pat_ty, &self.facts, &self.canonical_cache);
+        let covers = self.provable_subtype(scrut, pat_ty);
         if let TyKind::Union(members, _) = scrut.kind()
             && !covers
         {
@@ -899,8 +899,7 @@ impl<'db> InferenceContext<'db> {
             let claimed: Vec<&Ty> = members
                 .iter()
                 .filter(|member| {
-                    provable_subtype(member, pat_ty, &self.facts, &self.canonical_cache)
-                        || provable_subtype(pat_ty, member, &self.facts, &self.canonical_cache)
+                    self.provable_subtype(member, pat_ty) || self.provable_subtype(pat_ty, member)
                 })
                 .collect();
             if !claimed.is_empty() {
@@ -908,13 +907,11 @@ impl<'db> InferenceContext<'db> {
                 let alts: Vec<DPat> = claimed
                     .iter()
                     .map(|member| {
-                        let inner =
-                            if provable_subtype(member, pat_ty, &self.facts, &self.canonical_cache)
-                            {
-                                DPat::wildcard(member.to_plain())
-                            } else {
-                                self.dpat_for_type(pat_ty, member)
-                            };
+                        let inner = if self.provable_subtype(member, pat_ty) {
+                            DPat::wildcard(member.to_plain())
+                        } else {
+                            self.dpat_for_type(pat_ty, member)
+                        };
                         DPat::union_member(member.to_plain(), inner, scrut_plain.clone())
                     })
                     .collect();
@@ -961,7 +958,7 @@ impl<'db> InferenceContext<'db> {
     /// pattern type stands (rigid pairs keep the written type - TIR's
     /// `intersect_pattern_flow_types` policy).
     fn narrow_to(&self, scrut: &Ty, pat_ty: &Ty) -> Ty {
-        if provable_subtype(scrut, pat_ty, &self.facts, &self.canonical_cache) {
+        if self.provable_subtype(scrut, pat_ty) {
             scrut.clone()
         } else {
             pat_ty.clone()
@@ -978,7 +975,7 @@ impl<'db> InferenceContext<'db> {
         // provably fits is a wildcard at this column, whatever its shape
         // (a same-union pattern must not decompose into per-member
         // singles that no longer align with UnionMember ctors).
-        if provable_subtype(col, pat_ty, &self.facts, &self.canonical_cache) {
+        if self.provable_subtype(col, pat_ty) {
             return DPat::wildcard(col_plain);
         }
         match pat_ty.kind() {
@@ -1046,7 +1043,7 @@ impl<'db> InferenceContext<'db> {
                 }
             }
             _ => {
-                if provable_subtype(col, pat_ty, &self.facts, &self.canonical_cache) {
+                if self.provable_subtype(col, pat_ty) {
                     DPat::wildcard(col_plain)
                 } else {
                     DPat::single(pat_plain, col_plain)
@@ -1196,7 +1193,7 @@ impl<'db> InferenceContext<'db> {
                 })
             })
             .collect();
-        let head_covers = provable_subtype(scrut, &head, &self.facts, &self.canonical_cache);
+        let head_covers = self.provable_subtype(scrut, &head);
 
         // Union scrutinee: claim the same-class member.
         let dpat = {
@@ -1417,17 +1414,8 @@ impl<'db> InferenceContext<'db> {
                     return true;
                 };
                 if let Some(ascribed) = self.pattern_ascription_ty(body, sub) {
-                    return provable_subtype(
-                        &ascribed,
-                        &expanded,
-                        &self.facts,
-                        &self.canonical_cache,
-                    ) || provable_subtype(
-                        &expanded,
-                        &ascribed,
-                        &self.facts,
-                        &self.canonical_cache,
-                    );
+                    return self.provable_subtype(&ascribed, &expanded)
+                        || self.provable_subtype(&expanded, &ascribed);
                 }
                 self.pattern_fits(body, sub, &expanded)
             }
@@ -1479,29 +1467,6 @@ impl<'db> InferenceContext<'db> {
             _ => Vec::new(),
         }
     }
-}
-
-/// A PROVABLE subtype verdict: ground on both sides and confirmed by the
-/// oracle. Rigid or unresolved pairs are not provable - the conservative
-/// direction for both coverage and claiming.
-pub(super) fn provable_subtype(
-    sub: &Ty,
-    sup: &Ty,
-    facts: &crate::facts::Facts<'_>,
-    canonical_cache: &baml_type::normalize::InternedCanonicalCache,
-) -> bool {
-    if sub == sup {
-        return true;
-    }
-    if sub.has_infer() || sup.has_infer() || sub.has_error() || sup.has_error() {
-        return false;
-    }
-    // Rigid variables go to the oracle too: its typevar arms are already
-    // conservative (`T <: T`, `T <: unknown`, `never <: T` prove; a rigid
-    // against an unrelated concrete does not - which is exactly the B-633
-    // rule). The corpus pinned the case this matters for: a synthetic
-    // effect var IS covered by `throws unknown`.
-    canonical_cache.is_subtype(sub, sup, facts)
 }
 
 /// The legal shapes of a rest sub-pattern: the wildcard, a bare


### PR DESCRIPTION
## Summary

- restore alias and enum memoization only in the project-scale candidate scans in impls_for_type_cached and resolve_within_depth
- keep the memo-free AliasOnlyFacts constructor at Facts::project, infer/obligations.rs, method_resolution.rs, and interface_requires_inner
- make provable_subtype an InferenceContext method so the body facts and canonical cache are structurally paired at every call
- correct the one-shot context documentation and document the Salsa re-entrancy-window caveat for scan-local memos

This is the focused correction for the #4461 post-merge audit. It restores repeated alias-head lookup reuse without widening memoization to the four one-shot sites.

## Fresh back-to-back A/B

Both refs were measured consecutively in the same shell and target cache with profiling disabled. Both workloads used exactly five one-compile samples:

cargo bench -p baml_tests --bench compiler_benchmark -- compile_ --sample-count 5 --sample-size 1

Environment: Rust 1.93.0, CARGO_BUILD_JOBS=8, BAML_PROFILE=0.

| benchmark | canary 07c118b68, 5 samples | candidate 0eb5f0915, 5 samples | median delta |
| --- | ---: | ---: | ---: |
| compile_baml_tests_project | 2.180 s (2.144-2.351 s) | 2.133 s (2.122-2.295 s) | -47 ms (-2.2%) |
| compile_empty_project | 497.5 ms (485.8-499.9 ms) | 485.6 ms (478.2-488.5 ms) | -11.9 ms (-2.4%) |

No earlier baseline values are reused. Canary 07c118b68 was the exact #4461 tip when this branch and A/B began; #4462 landed afterward and changes only nextest scheduling configuration.

## Validation

- cargo check -p baml_compiler2_hir_ty
- focused nextest: 384/384 passed for baml_type, baml_compiler2_hir, and baml_compiler2_hir_ty with all features
- strict all-target/all-feature Clippy passed for those packages; workspace commit-hook Clippy also passed
- cargo fmt --all -- --check and git diff --check
- exact pinned full gate: 3,748/3,748 passed, 24 skipped, 50 slow in 1,375.321 s
- doctests clean; no unreferenced snapshots and no snapshots to review

Full gate command: CARGO_BUILD_JOBS=8 rustup run 1.93.0 cargo insta test --test-runner nextest -p baml_tests -p baml_cli -p baml_lsp2_actions -p baml_lsp2_actions_tests -p baml_surface --all-features --unreferenced=reject

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved type inference consistency across assignments, pattern matching, flow narrowing, and catch-arm analysis.
  * Enhanced handling of aliases and enum variants during type resolution.
  * Repeated type checks are now more efficient, helping reduce unnecessary compiler work.
  * Existing subtype, union, coverage, and narrowing behavior remains consistent while benefiting from more centralized analysis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->