### PR TITLE
chore: refresh size-gate baselines

### DIFF
--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -1,15 +1,12 @@
 version = 1
-recorded_at = "2026-08-16T04:00:02Z"
-git_sha = "2273e45dbf4e23231743f428bd2e53d978b91e9a"
+recorded_at = "2026-08-17T09:30:29Z"
+git_sha = "1a997de0aaabac9d2b91828155e123af98bd8296"
 
 [artifacts.baml-cli]
-file_bytes = "24.2 MiB"
-stripped_bytes = "24.2 MiB"
+file_bytes = "24.3 MiB"
+stripped_bytes = "24.3 MiB"
 gzip_bytes = "10.6 MiB"
 
-# Re-recorded from CI run 31925567696: Package.compile's compiler-built stdlib
-# prefix is embedded in bex_project so first-call runtime compilation does not
-# rebuild the full stdlib.
 [artifacts.packed-program]
 file_bytes = "19.6 MiB"
 gzip_bytes = "7.8 MiB"


### PR DESCRIPTION
Adopted from CI run [`1a997de0aaabac9d2b91828155e123af98bd8296`](https://github.com/BoundaryML/baml/actions/runs/32013063923).

# Binary size checks passed

✅ **7** passed

| | Artifact | Platform | File | Gzip | Gated on | Baseline | Delta | Status |
|---|----------|----------|------|------|----------|----------|-------|--------|
| :white_check_mark: | `baml-cli` | Linux | 🔒 31.7 MB | 12.6 MB | **file** | 31.7 MB | +9.7 KB (+0.0%) | OK |
| :white_check_mark: | `packed-program` | Linux | 🔒 24.9 MB | 9.1 MB | **file** | 24.9 MB | +29.0 KB (+0.1%) | OK |
| :white_check_mark: | `baml-cli` | macOS | 🔒 25.4 MB | 11.1 MB | **file** | 25.4 MB | +54.4 KB (+0.2%) | OK |
| :white_check_mark: | `packed-program` | macOS | 🔒 20.6 MB | 8.2 MB | **file** | 20.6 MB | +41.7 KB (+0.2%) | OK |
| :white_check_mark: | `bridge_wasm` | WASM | 21.3 MB | 🔒 5.4 MB | **gzip** | 5.3 MB | +34.4 KB (+0.6%) | OK |
| :white_check_mark: | `baml-cli` | Windows | 🔒 27.2 MB | 11.3 MB | **file** | 27.2 MB | +16.8 KB (+0.1%) | OK |
| :white_check_mark: | `packed-program` | Windows | 🔒 21.7 MB | 8.2 MB | **file** | 21.7 MB | +10.9 KB (+0.1%) | OK |

> 🔒 = the size this artifact is GATED on (ceiling + delta). Binaries gate on **file** size (installed binary); WASM gates on **gzip** (download size). The other size is shown for information only.

---
*Generated by `cargo size-gate`*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated recorded build metadata for the Apple Silicon command-line artifact.
  * Refreshed artifact size measurements; compressed size remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->