### PR TITLE
fix: restore E0007 for member access on unknown receivers

### DIFF
--- a/baml_language/CHANGELOG.md
+++ b/baml_language/CHANGELOG.md
@@ -26,6 +26,7 @@ This changelog covers the independent `baml_language` release line. It does not 
 
 ### Fixes
 
+- Restored E0007 diagnostics for method calls on `unknown` receivers, preventing unresolved calls from reaching an internal VM error. ([#4466](https://github.com/BoundaryML/baml/pull/4466)) - Antonio Sarosi
 - Rejected runtime-checked arguments on indirect calls with E0010; release builds had previously compiled them while silently omitting the check. ([#4460](https://github.com/BoundaryML/baml/pull/4460)) - Antonio Sarosi
 - Enabled runtime package compilation from `baml run` scripts and expressions. ([#4451](https://github.com/BoundaryML/baml/pull/4451)) - Antonio Sarosi
 - Supported double-quoted LLM prompts as literal, non-interpolating prompts and fixed the segfault they could cause. ([#4432](https://github.com/BoundaryML/baml/pull/4432)) - 2kai2kai2

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -5486,7 +5486,6 @@ impl<'db> InferenceContext<'db> {
                 && self.member_probe_depth == 0
                 && !resolved.has_error()
                 && !resolved.has_infer()
-                && !matches!(resolved.kind(), TyKind::Unknown { .. })
             {
                 if matches!(resolved.kind(), TyKind::Union(..)) {
                     self.pending_diags

--- a/baml_language/crates/baml_compiler_diagnostics/src/runtime_type.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/runtime_type.rs
@@ -81,6 +81,14 @@ pub fn mismatched_types() -> Diagnostic {
     Diagnostic::error(DiagnosticId::TypeMismatch, "mismatched types")
 }
 
+/// E0001 — a reflection class operation received a non-instance value.
+pub fn expected_class_instance(callee: &str, got: &str) -> Diagnostic {
+    Diagnostic::error(
+        DiagnosticId::TypeMismatch,
+        format!("{callee} expected a class instance, got {got}"),
+    )
+}
+
 /// E0002 — a value-shaped generic argument omitted the required marker.
 pub fn computed_generic_argument_requires_unreflect(name: &str) -> Diagnostic {
     Diagnostic::error(
@@ -159,6 +167,11 @@ mod tests {
     fn constructors_own_code_and_complete_message() {
         let cases = [
             (mismatched_types(), "E0001", "mismatched types"),
+            (
+                expected_class_instance("reflect.class.get_field", "int"),
+                "E0001",
+                "reflect.class.get_field expected a class instance, got int",
+            ),
             (
                 computed_generic_argument_requires_unreflect("runtime_t"),
                 "E0002",

--- a/baml_language/crates/baml_tests/tests/runtime_classes_and_composites.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_classes_and_composites.rs
@@ -2,8 +2,36 @@
 //! through offline LLM companions, retain mint identity, and remain usable
 //! through the dynamic access/JSON surfaces.
 
+use baml_compiler_diagnostics::Severity;
+use baml_project::{collect_diagnostics, testing::setup_test_db};
 use baml_tests::baml_test;
 use bex_engine::BexExternalValue;
+
+fn compile_errors(source: &str) -> Vec<(String, String)> {
+    collect_diagnostics(&setup_test_db(source))
+        .into_iter()
+        .filter(|diagnostic| diagnostic.severity == Severity::Error)
+        .map(|diagnostic| (diagnostic.code().to_string(), diagnostic.message))
+        .collect()
+}
+
+#[test]
+fn unknown_get_field_method_is_rejected_at_compile_time() {
+    let errors = compile_errors(
+        r#"
+        function inspect(value: unknown) -> string {
+            value.get_field<string>("name")
+        }
+        "#,
+    );
+
+    assert!(
+        errors.iter().any(|(code, message)| {
+            code == "E0007" && message.contains("get_field") && message.contains("unknown")
+        }),
+        "missing unresolved-member diagnostic: {errors:#?}"
+    );
+}
 
 #[tokio::test]
 async fn scenario_2_saved_form_class_renders_parses_and_assert_reads() {

--- a/baml_language/crates/bex_vm/src/package_baml/type_kinds.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/type_kinds.rs
@@ -641,24 +641,20 @@ impl BamlNamespaceReflectClass for PackageBamlImpl {
                 &[compiler_diagnostic(DiagnosticId::TypeMismatch, message)],
             ))
         };
+        let fail_non_instance = |vm: &mut BexVm| {
+            let diagnostic = runtime_type::expected_class_instance(
+                "reflect.class.get_field",
+                &vm.type_of(value).to_string(),
+            )
+            .with_phase(DiagnosticPhase::Hir);
+            crate::errors::VmRustFnError::Thrown(alloc_compilation_error(vm, &[diagnostic]))
+        };
         let Some(instance_ptr) = value.as_object_ptr() else {
-            return Err(fail(
-                vm,
-                format!(
-                    "reflect.class.get_field expected a class instance, got {}",
-                    vm.type_of(value)
-                ),
-            ));
+            return Err(fail_non_instance(vm));
         };
         let (field_value, class_name) = {
             let Object::Instance(instance) = vm.get_object(instance_ptr) else {
-                return Err(fail(
-                    vm,
-                    format!(
-                        "reflect.class.get_field expected a class instance, got {}",
-                        vm.type_of(value)
-                    ),
-                ));
+                return Err(fail_non_instance(vm));
             };
             let Object::Class(class) = vm.get_object(instance.class) else {
                 unreachable!("Instance.class must point to Object::Class")


### PR DESCRIPTION
## Summary

The `reflect.class.Instance` / `reflect.class.instance_from` design was superseded and has been completely removed from this branch. This PR now retains only two independent fixes discovered during that work:

- restore E0007 for unresolved method calls on `unknown` receivers, preventing invalid calls such as `unknown_value.get_field<T>("x")` from reaching emission and failing inside the VM
- route the pre-existing `reflect.class.get_field` non-instance E0001 through the shared runtime diagnostic factory without changing its text or behavior

There is no replacement reflection API in this PR. The separately ratified `reflect.AnyClass` direction is out of scope.

## Commits

1. `fix: restore unknown member diagnostics`
2. `refactor: share class reflection mismatch diagnostic`

## Validation

- `CARGO_BUILD_JOBS=8 CARGO_INCREMENTAL=0 rustup run 1.93.0 cargo insta test --test-runner nextest -p baml_tests -p baml_cli -p baml_lsp2_actions -p baml_lsp2_actions_tests -p baml_surface --all-features --unreferenced=reject` — 3,753 passed, 24 skipped; doctests clean; no unreferenced or pending snapshots
- focused E0007 compile regression passed
- shared diagnostic constructor oracle passed
- commit hooks passed, including workspace Clippy and formatting

## Superseded-design cleanup verification

All commands were run after the final commits. Empty results are shown explicitly.

```text
$ rg -n --hidden -g '!target/**' -g '!.git/**' 'instance_from|reflect\.class\.Instance|baml\.reflect\.class\.Instance|copy::reflect::class::Instance' baml_language CHANGELOG.md
<empty>

$ rg -n --hidden -g '!target/**' -g '!.git/**' 'class[[:space:]]+Instance' baml_language
<empty>

$ git diff --unified=0 origin/canary...HEAD | rg '^\+.*(instance_from|reflect\.class\.Instance|class[[:space:]]+Instance|cannot_construct_reflection_instance|is_reflect_class_instance)'
<empty>

$ rg --files -g '*.snap.new'
<empty>
```

The final diff is limited to five files: the inference guard, its regression and changelog entry, the shared diagnostic factory, and the existing `reflect.class.get_field` implementation. There are no stdlib declarations, generated files, docs, completions, snapshots, or codegen changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored compile-time diagnostics when accessing unresolved members on `unknown` values.
  * Improved error messages when class-only operations receive non-class values.
  * Prevented invalid unresolved calls from reaching an internal runtime error.

* **Documentation**
  * Added a changelog entry describing the restored diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->