### PR TITLE
fix: preserve mutable identities across loop calls

### DIFF
--- a/baml_language/CHANGELOG.md
+++ b/baml_language/CHANGELOG.md
@@ -26,6 +26,7 @@ This changelog covers the independent `baml_language` release line. It does not 
 
 ### Fixes
 
+- Fixed a silent miscompile where a map, list, or class instance allocated before a loop and mutated by a callee called inside that loop was re-allocated on every iteration. ([#4467](https://github.com/BoundaryML/baml/pull/4467)) - Antonio Sarosi
 - Restored E0007 diagnostics for method calls on `unknown` receivers, preventing unresolved calls from reaching an internal VM error. ([#4466](https://github.com/BoundaryML/baml/pull/4466)) - Antonio Sarosi
 - Rejected runtime-checked arguments on indirect calls with E0010; release builds had previously compiled them while silently omitting the check. ([#4460](https://github.com/BoundaryML/baml/pull/4460)) - Antonio Sarosi
 - Enabled runtime package compilation from `baml run` scripts and expressions. ([#4451](https://github.com/BoundaryML/baml/pull/4451)) - Antonio Sarosi

--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -1487,17 +1487,25 @@ fn can_be_virtual(
             }
         }
 
-        // Check if the use block is a loop header (has back-edge predecessors)
-        // If so, be conservative and don't inline
+        // Preserve the existing protection for values used directly in a loop
+        // header.
         let use_preds = predecessors
             .get(&use_loc.block)
-            .map_or(&[] as &[_], |v| v.as_slice());
-
-        let has_back_edge = use_preds
+            .map_or(&[] as &[_], Vec::as_slice);
+        let use_is_loop_header = use_preds
             .iter()
             .any(|&pred| dominators.dominates(use_loc.block, pred));
 
-        if has_back_edge {
+        // A map allocation also has observable mutable identity. Merely checking
+        // whether the use block is a loop header misses the common shape
+        // `header -> body(use) -> header`: sinking a map allocated before that
+        // loop into its body creates a fresh map on every iteration. Look for a
+        // path from the use back to itself which does not cross the definition
+        // block, and keep the allocation materialized when such a path exists.
+        let repeats_map_allocation = matches!(&def.rvalue, Rvalue::Map(..))
+            && use_repeats_without_definition(body, def.block, use_loc.block);
+
+        if use_is_loop_header || repeats_map_allocation {
             return false;
         }
 
@@ -1524,6 +1532,43 @@ fn can_be_virtual(
     }
 
     true
+}
+
+/// Whether `use_block` can execute again without first executing `def_block`.
+///
+/// `can_be_virtual` sinks an rvalue from its definition to its use. If a CFG
+/// cycle can revisit the use while bypassing the definition, sinking changes a
+/// once-evaluated binding into a per-iteration evaluation. That is observably
+/// wrong for a mutable map allocation, so its cross-block virtualization must
+/// reject the shape.
+fn use_repeats_without_definition(
+    body: &MirFunctionBody,
+    def_block: BlockId,
+    use_block: BlockId,
+) -> bool {
+    let Some(terminator) = body.block(use_block).terminator.as_ref() else {
+        return false;
+    };
+
+    let mut worklist = terminator.successors();
+    let mut visited = HashSet::new();
+
+    while let Some(block) = worklist.pop() {
+        if block == def_block {
+            continue;
+        }
+        if block == use_block {
+            return true;
+        }
+        if !visited.insert(block) {
+            continue;
+        }
+        if let Some(terminator) = body.block(block).terminator.as_ref() {
+            worklist.extend(terminator.successors());
+        }
+    }
+
+    false
 }
 
 /// Whether evaluating this rvalue reads through any field/index projection.

--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -1496,16 +1496,17 @@ fn can_be_virtual(
             .iter()
             .any(|&pred| dominators.dominates(use_loc.block, pred));
 
-        // A map allocation also has observable mutable identity. Merely checking
-        // whether the use block is a loop header misses the common shape
-        // `header -> body(use) -> header`: sinking a map allocated before that
-        // loop into its body creates a fresh map on every iteration. Look for a
-        // path from the use back to itself which does not cross the definition
-        // block, and keep the allocation materialized when such a path exists.
-        let repeats_map_allocation = matches!(&def.rvalue, Rvalue::Map(..))
+        // An allocation with observable identity cannot be repeated implicitly.
+        // Merely checking whether the use block is a loop header misses the
+        // common shape `header -> body(use) -> header`: sinking an allocation
+        // made before that loop into its body creates a fresh object on every
+        // iteration. Look for a path from the use back to itself which does not
+        // cross the definition block, and keep the allocation materialized when
+        // such a path exists.
+        let repeats_allocation = rvalue_allocates_with_identity(&def.rvalue)
             && use_repeats_without_definition(body, def.block, use_loc.block);
 
-        if use_is_loop_header || repeats_map_allocation {
+        if use_is_loop_header || repeats_allocation {
             return false;
         }
 
@@ -1534,13 +1535,43 @@ fn can_be_virtual(
     true
 }
 
+/// Whether evaluating this rvalue allocates a fresh object whose identity is
+/// observable (mutable containers, class instances, and callable objects).
+///
+/// Matched exhaustively on purpose: a wrong `false` silently miscompiles.
+fn rvalue_allocates_with_identity(rvalue: &Rvalue) -> bool {
+    match rvalue {
+        Rvalue::Map(..)
+        | Rvalue::Array(..)
+        | Rvalue::Uint8Array(_)
+        | Rvalue::Aggregate { .. }
+        | Rvalue::MakeClosure { .. }
+        | Rvalue::MakeBoundMethod { .. }
+        | Rvalue::MakeVirtualBoundMethod { .. } => true,
+        Rvalue::Use(_)
+        | Rvalue::BinaryOp { .. }
+        | Rvalue::UnaryOp { .. }
+        | Rvalue::Discriminant(_)
+        | Rvalue::TypeTag(_)
+        | Rvalue::Len(_)
+        | Rvalue::IsType { .. }
+        | Rvalue::IsTypeTag { .. }
+        | Rvalue::RuntimeIsType { .. }
+        | Rvalue::VirtualFieldAccess { .. }
+        | Rvalue::MakeGenericFunction { .. }
+        | Rvalue::MakeGenericFunctionFromValue { .. }
+        | Rvalue::LoadType(_)
+        | Rvalue::CurrentPackage(_) => false,
+    }
+}
+
 /// Whether `use_block` can execute again without first executing `def_block`.
 ///
 /// `can_be_virtual` sinks an rvalue from its definition to its use. If a CFG
 /// cycle can revisit the use while bypassing the definition, sinking changes a
 /// once-evaluated binding into a per-iteration evaluation. That is observably
-/// wrong for a mutable map allocation, so its cross-block virtualization must
-/// reject the shape.
+/// wrong for an allocation with observable identity, so its cross-block
+/// virtualization must reject the shape.
 fn use_repeats_without_definition(
     body: &MirFunctionBody,
     def_block: BlockId,
@@ -2308,6 +2339,135 @@ mod tests {
             scope_span: None,
             is_captured: false,
         }
+    }
+
+    fn int_list_local_decl(name: Option<&str>) -> LocalDecl {
+        LocalDecl {
+            name: name.map(baml_base::Name::new),
+            ty: RuntimeTy::list(RuntimeTy::int()),
+            span: None,
+            scope_span: None,
+            is_captured: false,
+        }
+    }
+
+    /// A single static use in a CFG cycle represents repeated dynamic uses.
+    /// Sinking the array allocation from block 0 into the call in block 1 would
+    /// allocate a fresh array on every trip around the cycle.
+    #[test]
+    fn repeated_identity_allocation_is_not_virtualized() {
+        let array = Local(1);
+        let call_result = Local(2);
+        let body = MirFunctionBody {
+            blocks: vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    statements: vec![Statement {
+                        kind: StatementKind::Assign {
+                            destination: Place::Local(array),
+                            value: Rvalue::Array(
+                                baml_type::TyTemplate::from(baml_type::RealizedTy::int()),
+                                vec![],
+                            ),
+                        },
+                        span: None,
+                    }],
+                    terminator: Some(Terminator::Goto { target: BlockId(1) }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    statements: vec![],
+                    terminator: Some(Terminator::Call {
+                        callee: Operand::Constant(Constant::Null),
+                        args: vec![Operand::copy_local(array)],
+                        ntypeargs: 0,
+                        runtime_type_check: false,
+                        runtime_id: None,
+                        destination: Place::Local(call_result),
+                        target: BlockId(2),
+                        unwind: None,
+                    }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(2),
+                    statements: vec![],
+                    terminator: Some(Terminator::Goto { target: BlockId(1) }),
+                    span: None,
+                    terminator_span: None,
+                },
+            ],
+            entry: BlockId(0),
+            locals: vec![
+                int_local_decl(None),
+                int_list_local_decl(Some("items")),
+                int_local_decl(Some("result")),
+            ],
+            catch_regions: vec![],
+            viz_nodes: vec![],
+        };
+
+        let analysis = AnalysisResult::analyze(&body, 0, OptLevel::One);
+        assert_eq!(
+            analysis.classifications.get(&array),
+            Some(&LocalClassification::Real)
+        );
+    }
+
+    /// The identity guard is cycle-specific: a single cross-block use that
+    /// cannot repeat without re-running the definition remains virtualizable.
+    #[test]
+    fn non_repeating_identity_allocation_stays_virtualized() {
+        let array = Local(1);
+        let body = MirFunctionBody {
+            blocks: vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    statements: vec![Statement {
+                        kind: StatementKind::Assign {
+                            destination: Place::Local(array),
+                            value: Rvalue::Array(
+                                baml_type::TyTemplate::from(baml_type::RealizedTy::int()),
+                                vec![],
+                            ),
+                        },
+                        span: None,
+                    }],
+                    terminator: Some(Terminator::Goto { target: BlockId(1) }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    statements: vec![Statement {
+                        kind: StatementKind::Assign {
+                            destination: Place::Local(Local(0)),
+                            value: Rvalue::Use(Operand::copy_local(array)),
+                        },
+                        span: None,
+                    }],
+                    terminator: Some(Terminator::Return),
+                    span: None,
+                    terminator_span: None,
+                },
+            ],
+            entry: BlockId(0),
+            locals: vec![
+                int_list_local_decl(None),
+                int_list_local_decl(Some("items")),
+            ],
+            catch_regions: vec![],
+            viz_nodes: vec![],
+        };
+
+        let analysis = AnalysisResult::analyze(&body, 0, OptLevel::One);
+        assert_eq!(
+            analysis.classifications.get(&array),
+            Some(&LocalClassification::Virtual)
+        );
     }
 
     /// Verifies `Rvalue::Len` bindings are always classified as materialized locals.

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
+assertion_line: 169
 ---
 function lambdas.$init_test_ns_lambdas_lambdas(registry: testing.TestCollector) -> null {
     load_var registry
@@ -336,6 +337,9 @@ function lambdas.lambdas_captures_loop_variable_accumulation() -> int {
     store_var ?1
     load_const 0
     store_deref ?1
+    load_var sum
+    make_closure .<lambda(lambdas_captures_loop_variable_accumulation, 0)>, 1
+    store_var add_to_sum
     load_const 1
     load_const 2
     load_const 3
@@ -358,8 +362,7 @@ function lambdas.lambdas_captures_loop_variable_accumulation() -> int {
     jump L2
 
   L1:
-    load_var2 3 1
-    make_closure .<lambda(lambdas_captures_loop_variable_accumulation, 0)>, 1
+    load_var2 4 2
     call_indirect
     pop 1
     jump L0

--- a/baml_language/crates/baml_tests/tests/map_aliasing.rs
+++ b/baml_language/crates/baml_tests/tests/map_aliasing.rs
@@ -1,0 +1,70 @@
+//! Regression tests for preserving mutable map identity across calls and loops.
+
+use baml_tests::baml_test;
+use bex_engine::BexExternalValue;
+
+fn ok_string(value: &str) -> Result<BexExternalValue, String> {
+    Ok(BexExternalValue::String(value.to_string().into()))
+}
+
+/// A single static use in a loop is many dynamic uses. The map binding must be
+/// materialized once before the loop so callee mutations accumulate.
+#[tokio::test]
+async fn callee_map_mutations_persist_when_caller_does_not_read_map() {
+    let output = baml_test!(
+        r#"
+        function put(m: map<string, int>, k: string) -> int throws unknown {
+            m.set(k, 1)
+            return m.length()
+        }
+
+        function main() -> string {
+            let m: map<string, int> = {}
+            let out = ""
+            let i = 0
+            while (i < 3) {
+                let n = put(m, "k" + i.to_string()) catch (e) { _ => -1 }
+                out = out + n.to_string() + ","
+                i += 1
+            }
+            out
+        }
+        "#
+    );
+
+    assert_eq!(
+        output.result.map_err(|error| format!("{error:?}")),
+        ok_string("1,2,3,")
+    );
+}
+
+/// Pin the formerly masking caller read as a positive control: observing the
+/// map after the loop must retain the same alias and accumulated mutations.
+#[tokio::test]
+async fn callee_map_mutations_persist_when_caller_reads_map() {
+    let output = baml_test!(
+        r#"
+        function put(m: map<string, int>, k: string) -> int throws unknown {
+            m.set(k, 1)
+            return m.length()
+        }
+
+        function main() -> string {
+            let m: map<string, int> = {}
+            let out = ""
+            let i = 0
+            while (i < 3) {
+                let n = put(m, "k" + i.to_string()) catch (e) { _ => -1 }
+                out = out + n.to_string() + ","
+                i += 1
+            }
+            out + " caller=" + m.length().to_string()
+        }
+        "#
+    );
+
+    assert_eq!(
+        output.result.map_err(|error| format!("{error:?}")),
+        ok_string("1,2,3, caller=3")
+    );
+}

--- a/baml_language/crates/baml_tests/tests/map_aliasing.rs
+++ b/baml_language/crates/baml_tests/tests/map_aliasing.rs
@@ -1,11 +1,56 @@
 //! Regression tests for preserving mutable map identity across calls and loops.
 
-use baml_tests::baml_test;
+use baml_tests::{baml_test, baml_test_optimized};
 use bex_engine::BexExternalValue;
 
 fn ok_string(value: &str) -> Result<BexExternalValue, String> {
     Ok(BexExternalValue::String(value.to_string().into()))
 }
+
+macro_rules! check_output {
+    ($name:ident, $source:expr, $expected:expr) => {
+        #[tokio::test]
+        async fn $name() {
+            let output = baml_test!($source);
+            assert_eq!(
+                output.result.map_err(|error| format!("{error:?}")),
+                ok_string($expected)
+            );
+        }
+    };
+}
+
+macro_rules! check_optimized_output {
+    ($name:ident, $source:expr, $expected:expr) => {
+        #[tokio::test]
+        async fn $name() {
+            let output = baml_test_optimized!($source);
+            assert_eq!(
+                output.result.map_err(|error| format!("{error:?}")),
+                ok_string($expected)
+            );
+        }
+    };
+}
+
+const INT_LIST_SOURCE: &str = r#"
+    function put(xs: int[]) -> int {
+        xs.push(1)
+        xs.length()
+    }
+
+    function main() -> string {
+        let xs: int[] = []
+        let out = ""
+        let i = 0
+        while (i < 3) {
+            let n = put(xs)
+            out = out + n.to_string() + ","
+            i += 1
+        }
+        out
+    }
+"#;
 
 /// A single static use in a loop is many dynamic uses. The map binding must be
 /// materialized once before the loop so callee mutations accumulate.
@@ -68,3 +113,191 @@ async fn callee_map_mutations_persist_when_caller_reads_map() {
         ok_string("1,2,3, caller=3")
     );
 }
+
+// Pin the no-`return`, no-`catch` repro, whose tail `ReturnPhi` produces a
+// different CFG from the original regression.
+check_output!(
+    map_identity_survives_return_phi_loop_cfg,
+    r#"
+    function put(m: map<string, int>, k: string) -> int {
+        m.set(k, 1)
+        m.length()
+    }
+
+    function main() -> string {
+        let m: map<string, int> = {}
+        let out = ""
+        let i = 0
+        while (i < 3) {
+            let n = put(m, "k" + i.to_string())
+            out = out + n.to_string() + ","
+            i += 1
+        }
+        out
+    }
+    "#,
+    "1,2,3,"
+);
+
+// Allocations authored inside the loop must remain fresh on every iteration.
+check_output!(
+    map_allocated_inside_loop_stays_fresh,
+    r#"
+    function put(m: map<string, int>) -> int {
+        m.set("k", 1)
+        m.length()
+    }
+
+    function main() -> string {
+        let out = ""
+        let i = 0
+        while (i < 3) {
+            let m: map<string, int> = {}
+            let n = put(m)
+            out = out + n.to_string() + ","
+            i += 1
+        }
+        out
+    }
+    "#,
+    "1,1,1,"
+);
+
+check_output!(
+    int_list_identity_survives_callee_mutation_in_loop,
+    INT_LIST_SOURCE,
+    "1,2,3,"
+);
+
+check_optimized_output!(
+    int_list_identity_survives_callee_mutation_in_loop_at_o2,
+    INT_LIST_SOURCE,
+    "1,2,3,"
+);
+
+check_output!(
+    string_list_identity_survives_callee_mutation_in_loop,
+    r#"
+    function put(xs: string[], value: string) -> int {
+        xs.push(value)
+        xs.length()
+    }
+
+    function main() -> string {
+        let xs: string[] = []
+        let out = ""
+        let i = 0
+        while (i < 3) {
+            let n = put(xs, "v" + i.to_string())
+            out = out + n.to_string() + ","
+            i += 1
+        }
+        out
+    }
+    "#,
+    "1,2,3,"
+);
+
+check_output!(
+    nested_list_identity_survives_callee_mutation_in_loop,
+    r#"
+    function put(xs: int[][], value: int) -> int {
+        xs.push([value])
+        xs.length()
+    }
+
+    function main() -> string {
+        let xs: int[][] = []
+        let out = ""
+        let i = 0
+        while (i < 3) {
+            let n = put(xs, i)
+            out = out + n.to_string() + ","
+            i += 1
+        }
+        out
+    }
+    "#,
+    "1,2,3,"
+);
+
+check_output!(
+    class_identity_survives_callee_field_mutation_in_loop,
+    r#"
+    class Counter {
+        n int
+    }
+
+    function bump(counter: Counter) -> int {
+        counter.n = counter.n + 1
+        counter.n
+    }
+
+    function main() -> string {
+        let counter = Counter { n: 0 }
+        let out = ""
+        let i = 0
+        while (i < 3) {
+            let n = bump(counter)
+            out = out + n.to_string() + ","
+            i += 1
+        }
+        out
+    }
+    "#,
+    "1,2,3,"
+);
+
+check_output!(
+    class_with_map_identity_survives_callee_mutation_in_loop,
+    r#"
+    class Box {
+        items map<string, int>
+    }
+
+    function put(box: Box, key: string) -> int {
+        box.items.set(key, 1)
+        box.items.length()
+    }
+
+    function main() -> string {
+        let box = Box { items: {} }
+        let out = ""
+        let i = 0
+        while (i < 3) {
+            let n = put(box, "k" + i.to_string())
+            out = out + n.to_string() + ","
+            i += 1
+        }
+        out
+    }
+    "#,
+    "1,2,3,"
+);
+
+check_output!(
+    class_with_list_identity_survives_callee_mutation_in_loop,
+    r#"
+    class Acc {
+        items string[]
+    }
+
+    function put(acc: Acc, value: string) -> int {
+        acc.items.push(value)
+        acc.items.length()
+    }
+
+    function main() -> string {
+        let acc = Acc { items: [] }
+        let out = ""
+        let i = 0
+        while (i < 3) {
+            let n = put(acc, "v" + i.to_string())
+            out = out + n.to_string() + ","
+            i += 1
+        }
+        out
+    }
+    "#,
+    "1,2,3,"
+);


### PR DESCRIPTION
## Summary

- preserve mutable map identity when a map allocated before a loop is used by a callee inside the loop
- detect CFG paths that revisit the map-allocation use without re-executing its definition, while retaining the existing loop-header guard
- add regressions for both the formerly failing no-caller-read shape and the formerly masking caller-read control
- add a changelog entry

## Root cause

Cross-block virtualization only rejected uses that were themselves loop headers. In the common `header -> body(use) -> header` shape, an empty map allocated before the loop was sunk into the body, so each iteration passed a fresh map and callee mutations did not accumulate.

The new check is intentionally limited to map allocations. An earlier broad CFG guard passed all runtime tests but changed seven unrelated string/copy/closure bytecode snapshots; those pending snapshots were rejected and are not part of this PR. The final implementation keeps all existing snapshots byte-identical.

## Verification

- focused regressions: 2/2 passed
  - no caller read: `"1,2,3,"`
  - caller read control: `"1,2,3, caller=3"`
- all eight standalone repros under `thoughts/antonio/repros/map-aliasing/` produced their expected output; m1-m4 and the sequential-call negative control remained unchanged
- exact pinned gate:
  - `CARGO_BUILD_JOBS=8 CARGO_INCREMENTAL=0 rustup run 1.93.0 cargo insta test --test-runner nextest -p baml_tests -p baml_cli -p baml_lsp2_actions -p baml_lsp2_actions_tests -p baml_surface --all-features --unreferenced=reject`
  - 3,753/3,753 passed, 24 skipped
  - no unreferenced snapshots; no snapshots to review
- pre-commit workspace clippy/format checks passed

## Release A/B benchmark audit

Patched / canary baseline medians:

- class method call 100k: 29.46 ms / 31.30 ms
- array build + sum 100k: 79.46 ms / 80.66 ms
- call chain 100 x 10k: 112.7 ms / 104.8 ms
- pure call 1m: 151.0 ms / 149.5 ms
- shared array, 1 writer + 4 readers: 23.23 ms / 23.16 ms
- shared array push, 4 x 25k: 22.46 ms / 12.06 ms (highly noisy)

There was no systematic regression: the isolated call-chain delta and concurrent-push result were noisy, while the other workloads were flat or faster.

## Scope audit

The PR contains exactly three files: emitter analysis, two regression tests, and the changelog. It contains no TypeScript bridge rebuild output.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where mutable maps, lists, and class instances could be recreated during loop iterations, causing unexpected state changes when modified by called functions.
  - Preserved object identity across loops and nested data structures, including class fields and returned values.
  - Ensured fresh allocations created inside loops continue to behave correctly.

- **Tests**
  - Added comprehensive coverage for mutation, aliasing, control flow, and optimized execution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->