### PR TITLE
fix: reject non-data LLM output schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@ All notable changes to this project will be documented in this file. See [conven
 
 ## [0.226.0](https://github.com/boundaryml/baml/compare/0.225.0..0.226.0) - 2026-08-17
 
-### Bug Fixes
-
-- return a catchable diagnostic when non-data LLM output types reach schema rendering
-
 ### Features
 
 - **(runtime)** make connection pooling configurable ([#3975](https://github.com/BoundaryML/baml/pull/3975)) - ([521919c](https://github.com/BoundaryML/baml/commit/521919c7f58b0b930ae1709df1882651db8ca865)) - Dex Hunter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. See [conven
 
 ## [0.226.0](https://github.com/boundaryml/baml/compare/0.225.0..0.226.0) - 2026-08-17
 
+### Bug Fixes
+
+- return a catchable diagnostic when non-data LLM output types reach schema rendering
+
 ### Features
 
 - **(runtime)** make connection pooling configurable ([#3975](https://github.com/BoundaryML/baml/pull/3975)) - ([521919c](https://github.com/BoundaryML/baml/commit/521919c7f58b0b930ae1709df1882651db8ca865)) - Dex Hunter

--- a/baml_language/CHANGELOG.md
+++ b/baml_language/CHANGELOG.md
@@ -26,6 +26,7 @@ This changelog covers the independent `baml_language` release line. It does not 
 
 ### Fixes
 
+- Rejected non-data LLM output schemas with catchable E0164 diagnostics instead of aborting or silently omitting the schema; this intentionally makes previously degraded renders for fields such as `uint8array`, `type`, and mixed non-data unions fail loudly. ([#4470](https://github.com/BoundaryML/baml/pull/4470)) - Antonio Sarosi
 - Fixed a silent miscompile where a map, list, or class instance allocated before a loop and mutated by a callee called inside that loop was re-allocated on every iteration. ([#4467](https://github.com/BoundaryML/baml/pull/4467)) - Antonio Sarosi
 - Restored E0007 diagnostics for method calls on `unknown` receivers, preventing unresolved calls from reaching an internal VM error. ([#4466](https://github.com/BoundaryML/baml/pull/4466)) - Antonio Sarosi
 - Rejected runtime-checked arguments on indirect calls with E0010; release builds had previously compiled them while silently omitting the check. ([#4460](https://github.com/BoundaryML/baml/pull/4460)) - Antonio Sarosi

--- a/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
@@ -368,6 +368,10 @@ pub enum DiagnosticId {
     ConflictingTypeDefinitionAtRender,
     /// A top-level declaration ($init) can reach a yielding io sysop.
     InitIoNotAllowed,
+
+    /// A non-data type reached an LLM output schema renderer. These types are
+    /// valid in BAML's type system but have no output-format representation.
+    NonDataTypeAtRender,
 }
 
 impl DiagnosticId {
@@ -546,6 +550,7 @@ impl DiagnosticId {
             DiagnosticId::OpenInterfaceAtRender => "E0161",
             DiagnosticId::ConflictingTypeDefinitionAtRender => "E0162",
             DiagnosticId::InitIoNotAllowed => "E0163",
+            DiagnosticId::NonDataTypeAtRender => "E0164",
             DiagnosticId::GenericBoundNotInterface => "E0145",
             DiagnosticId::GenericSysOpMethodInInterfaceImpl => "E0153",
 

--- a/baml_language/crates/baml_compiler_diagnostics/src/runtime_type.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/runtime_type.rs
@@ -167,6 +167,16 @@ pub fn non_data_type_at_render(ty: &str) -> Diagnostic {
     )
 }
 
+/// E0164 — a class field contains a non-data type at the LLM schema boundary.
+pub fn non_data_field_at_render(field: &str, ty: &str) -> Diagnostic {
+    Diagnostic::error(
+        DiagnosticId::NonDataTypeAtRender,
+        format!(
+            "field `{field}` has non-data type `{ty}`, which cannot be rendered as an LLM output schema"
+        ),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -234,6 +244,11 @@ mod tests {
                 non_data_type_at_render("never"),
                 "E0164",
                 "non-data type `never` cannot be rendered as an LLM output schema",
+            ),
+            (
+                non_data_field_at_render("Envelope.payload", "unknown"),
+                "E0164",
+                "field `Envelope.payload` has non-data type `unknown`, which cannot be rendered as an LLM output schema",
             ),
         ];
 

--- a/baml_language/crates/baml_compiler_diagnostics/src/runtime_type.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/runtime_type.rs
@@ -159,6 +159,14 @@ pub fn open_interface_at_render(field: &str, open_type: &str) -> Diagnostic {
     )
 }
 
+/// E0164 — a non-data type reached an LLM schema render.
+pub fn non_data_type_at_render(ty: &str) -> Diagnostic {
+    Diagnostic::error(
+        DiagnosticId::NonDataTypeAtRender,
+        format!("non-data type `{ty}` cannot be rendered as an LLM output schema"),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -221,6 +229,11 @@ mod tests {
                 open_interface_at_render("payload", "user.Open"),
                 "E0161",
                 "field `payload` has open interface type `user.Open`, which cannot be rendered as an LLM output schema",
+            ),
+            (
+                non_data_type_at_render("never"),
+                "E0164",
+                "non-data type `never` cannot be rendered as an LLM output schema",
             ),
         ];
 

--- a/baml_language/crates/baml_tests/tests/output_format_non_data.rs
+++ b/baml_language/crates/baml_tests/tests/output_format_non_data.rs
@@ -1,0 +1,133 @@
+//! Regression coverage for non-data types at the LLM output-schema boundary.
+
+use baml_tests::baml_test;
+use bex_engine::BexExternalValue;
+
+fn result_string(output: baml_tests::engine::TestOutput) -> String {
+    let BexExternalValue::String(value) = output.result.expect("program should return a string")
+    else {
+        panic!("expected string result")
+    };
+    value.to_string()
+}
+
+const GENERIC_LIST: &str = r#"
+client TestClient = openai.ResponsesClient.new(
+    model = "gpt-4o-mini",
+    api_key = "test-key",
+    base_url = "http://localhost:1234",
+);
+
+function GenericList<T>(topic: string) -> T[] {
+    client: TestClient
+    prompt: `List ${topic}.\n${ctx.output_format}`
+}
+"#;
+
+#[tokio::test]
+async fn static_never_specialization_throws_compilation_error() {
+    let source = format!(
+        r#"
+            {GENERIC_LIST}
+
+            function main() -> string throws never {{
+                let rendered = GenericList$render_prompt<never>("items") catch (e) {{
+                    baml.reflect.errors.CompilationError => e.diagnostics[0].code + "|" + e.diagnostics[0].message,
+                    _ => "wrong error",
+                }}
+                if rendered is string {{
+                    return rendered
+                }}
+                "render did not throw"
+            }}
+            "#
+    );
+    let output = baml_test!(&source);
+
+    assert_eq!(
+        result_string(output),
+        "E0164|non-data type `never` cannot be rendered as an LLM output schema"
+    );
+}
+
+#[tokio::test]
+async fn runtime_never_specialization_uses_the_same_diagnostic() {
+    let source = format!(
+        r#"
+            {GENERIC_LIST}
+
+            function main() -> string throws never {{
+                let runtime_t = type.of<never>()
+                let rendered = GenericList$render_prompt<unreflect(runtime_t)>("items") catch (e) {{
+                    baml.reflect.errors.CompilationError => e.diagnostics[0].code + "|" + e.diagnostics[0].message,
+                    _ => "wrong error",
+                }}
+                if rendered is string {{
+                    return rendered
+                }}
+                "render did not throw"
+            }}
+            "#
+    );
+    let output = baml_test!(&source);
+
+    assert_eq!(
+        result_string(output),
+        "E0164|non-data type `never` cannot be rendered as an LLM output schema"
+    );
+}
+
+#[tokio::test]
+async fn direct_llm_execution_fails_before_network_io() {
+    let source = format!(
+        r#"
+            {GENERIC_LIST}
+
+            function main() -> string throws never {{
+                let result = GenericList<never>("items") catch (e) {{
+                    baml.reflect.errors.CompilationError => e.diagnostics[0].code + "|" + e.diagnostics[0].message,
+                    _ => "wrong error",
+                }}
+                if result is string {{
+                    return result
+                }}
+                "call did not throw"
+            }}
+            "#
+    );
+    let output = baml_test!(&source);
+
+    assert_eq!(
+        result_string(output),
+        "E0164|non-data type `never` cannot be rendered as an LLM output schema"
+    );
+}
+
+#[tokio::test]
+async fn ordinary_data_specialization_still_renders() {
+    let source = format!(
+        r#"
+            {GENERIC_LIST}
+
+            class Item {{
+                name string?
+                description string?
+            }}
+
+            function main() -> string throws unknown {{
+                GenericList$render_prompt<Item>("items").text()
+            }}
+            "#
+    );
+    let output = baml_test!(&source);
+
+    let rendered = result_string(output);
+    assert!(
+        rendered.contains("name"),
+        "missing class schema: {rendered}"
+    );
+    assert!(
+        rendered.contains("description"),
+        "missing class schema: {rendered}"
+    );
+}

--- a/baml_language/crates/baml_tests/tests/output_format_non_data.rs
+++ b/baml_language/crates/baml_tests/tests/output_format_non_data.rs
@@ -24,6 +24,19 @@ function GenericList<T>(topic: string) -> T[] {
 }
 "#;
 
+const GENERIC_VALUE: &str = r#"
+client TestClient = openai.ResponsesClient.new(
+    model = "gpt-4o-mini",
+    api_key = "test-key",
+    base_url = "http://localhost:1234",
+);
+
+function GenericValue<T>(topic: string) -> T {
+    client: TestClient
+    prompt: `Describe ${topic}.\n${ctx.output_format}`
+}
+"#;
+
 #[tokio::test]
 async fn static_never_specialization_throws_compilation_error() {
     let source = format!(
@@ -129,5 +142,170 @@ async fn ordinary_data_specialization_still_renders() {
     assert!(
         rendered.contains("description"),
         "missing class schema: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn unknown_class_field_reports_its_path() {
+    let source = format!(
+        r#"
+            {GENERIC_VALUE}
+
+            class Payload {{
+                value unknown
+            }}
+
+            function main() -> string throws never {{
+                let rendered = GenericValue$render_prompt<Payload>("payload") catch (e) {{
+                    baml.reflect.errors.CompilationError => e.diagnostics[0].code + "|" + e.diagnostics[0].message,
+                    _ => "wrong error",
+                }}
+                if rendered is string {{
+                    return rendered
+                }}
+                "render did not throw"
+            }}
+            "#
+    );
+    let output = baml_test!(&source);
+
+    assert_eq!(
+        result_string(output),
+        "E0164|field `Payload.value` has non-data type `unknown`, which cannot be rendered as an LLM output schema"
+    );
+}
+
+#[tokio::test]
+async fn nested_non_data_class_field_reports_the_full_path() {
+    let source = format!(
+        r#"
+            {GENERIC_VALUE}
+
+            class Inner {{
+                payload type
+            }}
+
+            class Envelope {{
+                inner Inner
+            }}
+
+            function main() -> string throws never {{
+                let rendered = GenericValue$render_prompt<Envelope>("envelope") catch (e) {{
+                    baml.reflect.errors.CompilationError => e.diagnostics[0].code + "|" + e.diagnostics[0].message,
+                    _ => "wrong error",
+                }}
+                if rendered is string {{
+                    return rendered
+                }}
+                "render did not throw"
+            }}
+            "#
+    );
+    let output = baml_test!(&source);
+
+    assert_eq!(
+        result_string(output),
+        "E0164|field `Envelope.inner.payload` has non-data type `type`, which cannot be rendered as an LLM output schema"
+    );
+}
+
+#[tokio::test]
+async fn runtime_minted_nested_non_data_field_is_rejected() {
+    let source = format!(
+        r#"
+            {GENERIC_VALUE}
+
+            function main() -> string throws unknown {{
+                let inner = reflect.class.new("RuntimeInner", {{
+                    "payload": type.of<unknown>(),
+                }})
+                let outer = reflect.class.new("RuntimeOuter", {{
+                    "inner": inner.as_type(),
+                }})
+                let rendered = GenericValue$render_prompt<unreflect(outer.as_type())>("runtime") catch (e) {{
+                    baml.reflect.errors.CompilationError => e.diagnostics[0].code + "|" + e.diagnostics[0].message,
+                    _ => "wrong error",
+                }}
+                if rendered is string {{
+                    return rendered
+                }}
+                "render did not throw"
+            }}
+            "#
+    );
+    let output = baml_test!(&source);
+
+    assert_eq!(
+        result_string(output),
+        "E0164|field `RuntimeOuter.inner.payload` has non-data type `unknown`, which cannot be rendered as an LLM output schema"
+    );
+}
+
+#[tokio::test]
+async fn skipped_non_data_and_open_interface_fields_do_not_block_rendering() {
+    let source = format!(
+        r#"
+            {GENERIC_VALUE}
+
+            interface HiddenOpen {{}}
+
+            class SkipControl {{
+                visible string
+                raw_blob uint8array? @skip
+                dynamic unknown @skip
+                open HiddenOpen? @skip
+            }}
+
+            function main() -> string throws unknown {{
+                GenericValue$render_prompt<SkipControl>("visible data").text()
+            }}
+            "#
+    );
+    let output = baml_test!(&source);
+    let rendered = result_string(output);
+
+    assert!(
+        rendered.contains("visible"),
+        "missing data field: {rendered}"
+    );
+    for skipped in ["raw_blob", "dynamic", "open"] {
+        assert!(
+            !rendered.contains(skipped),
+            "skipped field `{skipped}` leaked into schema: {rendered}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn generic_class_output_fails_before_provider_io() {
+    let source = format!(
+        r#"
+            {GENERIC_VALUE}
+
+            class Item {{
+                name string
+            }}
+
+            class Wrapper<T> {{
+                value T
+            }}
+
+            function main() -> string throws never {{
+                let result = GenericValue<Wrapper<Item>>("wrapped item") catch (e) {{
+                    baml.reflect.errors.CompilationError => e.diagnostics[0].code + "|" + e.diagnostics[0].message,
+                    _ => "wrong error",
+                }}
+                if result is string {{
+                    return result
+                }}
+                "call did not throw"
+            }}
+            "#
+    );
+    let output = baml_test!(&source);
+
+    assert_eq!(
+        result_string(output),
+        "E0164|non-data type `Wrapper<Item>` cannot be rendered as an LLM output schema"
     );
 }

--- a/baml_language/crates/bex_vm/src/package_baml/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/type_class.rs
@@ -191,28 +191,40 @@ impl BamlClassTypeValue for PackageBamlImpl {
             _ => "output".to_string(),
         };
         let mut visited = std::collections::HashSet::new();
-        let Some((field, open_ty)) =
+        if let Some((field, open_ty)) =
             first_open_interface(vm, &type_value.ty, type_value.defs(), &root, &mut visited)
-        else {
-            if let Some(name) = first_conflicting_render_name(vm, &type_value.ty, type_value.defs())
-            {
-                let diagnostic = super::type_kinds::compiler_diagnostic(
-                    baml_compiler_diagnostics::DiagnosticId::ConflictingTypeDefinitionAtRender,
-                    format!(
-                        "type `{name}` has non-equivalent definitions in the same LLM render context"
-                    ),
-                );
-                return Err(VmRustFnError::Thrown(
-                    super::type_kinds::alloc_compilation_error(vm, &[diagnostic]),
-                ));
-            }
-            return Ok(());
-        };
-        let diagnostic =
-            baml_compiler_diagnostics::runtime_type::open_interface_at_render(&field, &open_ty);
-        Err(VmRustFnError::Thrown(
-            super::type_kinds::alloc_compilation_error(vm, &[diagnostic]),
-        ))
+        {
+            let diagnostic =
+                baml_compiler_diagnostics::runtime_type::open_interface_at_render(&field, &open_ty);
+            return Err(VmRustFnError::Thrown(
+                super::type_kinds::alloc_compilation_error(vm, &[diagnostic]),
+            ));
+        }
+
+        if let Some(name) = first_conflicting_render_name(vm, &type_value.ty, type_value.defs()) {
+            let diagnostic = super::type_kinds::compiler_diagnostic(
+                baml_compiler_diagnostics::DiagnosticId::ConflictingTypeDefinitionAtRender,
+                format!(
+                    "type `{name}` has non-equivalent definitions in the same LLM render context"
+                ),
+            );
+            return Err(VmRustFnError::Thrown(
+                super::type_kinds::alloc_compilation_error(vm, &[diagnostic]),
+            ));
+        }
+
+        let mut visited = std::collections::HashSet::new();
+        if let Some(non_data_ty) =
+            first_non_data_type(vm, &type_value.ty, type_value.defs(), &mut visited)
+        {
+            let diagnostic =
+                baml_compiler_diagnostics::runtime_type::non_data_type_at_render(&non_data_ty);
+            return Err(VmRustFnError::Thrown(
+                super::type_kinds::alloc_compilation_error(vm, &[diagnostic]),
+            ));
+        }
+
+        Ok(())
     }
 
     /// Returns the `RealizedTy`'s display name.  Includes namespaces and (for
@@ -790,6 +802,126 @@ fn first_open_interface(
     }
 }
 
+/// Find the first type that has no output-format representation.
+///
+/// This match is exhaustive over `RealizedTy` so a newly added runtime type
+/// must make an explicit renderability decision at the shared LLM boundary.
+fn is_non_data_render_type(ty: &baml_type::RealizedTy) -> bool {
+    match ty {
+        baml_type::RealizedTy::Uint8Array { .. }
+        | baml_type::RealizedTy::EnumVariant(..)
+        | baml_type::RealizedTy::Function { .. }
+        | baml_type::RealizedTy::Future(..)
+        | baml_type::RealizedTy::RustType { .. }
+        | baml_type::RealizedTy::Type { .. }
+        | baml_type::RealizedTy::Resource { .. }
+        | baml_type::RealizedTy::PromptAst { .. }
+        | baml_type::RealizedTy::Void { .. }
+        | baml_type::RealizedTy::BuiltinUnknown { .. }
+        | baml_type::RealizedTy::Never { .. } => true,
+        baml_type::RealizedTy::Int { .. }
+        | baml_type::RealizedTy::Bigint { .. }
+        | baml_type::RealizedTy::Float { .. }
+        | baml_type::RealizedTy::String { .. }
+        | baml_type::RealizedTy::Bool { .. }
+        | baml_type::RealizedTy::Null { .. }
+        | baml_type::RealizedTy::Media(..)
+        | baml_type::RealizedTy::Literal(..)
+        | baml_type::RealizedTy::Class(..)
+        | baml_type::RealizedTy::Interface(..)
+        | baml_type::RealizedTy::Enum(..)
+        | baml_type::RealizedTy::List(..)
+        | baml_type::RealizedTy::Map { .. }
+        | baml_type::RealizedTy::Union(..)
+        | baml_type::RealizedTy::TypeAlias(..) => false,
+    }
+}
+
+fn first_non_data_type(
+    vm: &BexVm,
+    ty: &baml_type::RealizedTy,
+    defs: &DynTypeDefs,
+    visited: &mut std::collections::HashSet<baml_type::RealizedTy>,
+) -> Option<String> {
+    if is_non_data_render_type(ty) {
+        return Some(ty.to_string());
+    }
+
+    match ty {
+        baml_type::RealizedTy::Class(name, args, _) => {
+            if !visited.insert(ty.clone()) {
+                return None;
+            }
+            let class_ptr = defs
+                .classes
+                .get(name)
+                .copied()
+                .or_else(|| vm.lookup_type(name))?;
+            let Object::Class(class) = vm.get_object(class_ptr) else {
+                return None;
+            };
+            for field in &class.fields {
+                if let Some(runtime) = &field.runtime_type {
+                    if let Some(found) =
+                        first_non_data_type(vm, &runtime.ty, runtime.defs(), visited)
+                    {
+                        return Some(found);
+                    }
+                    continue;
+                }
+                let field_ty = field
+                    .field_template
+                    .substitute(args, vm)
+                    .ok()
+                    .or_else(|| baml_type::RealizedTy::try_from(field.field_type.clone()).ok());
+                if let Some(field_ty) = field_ty
+                    && let Some(found) = first_non_data_type(vm, &field_ty, defs, visited)
+                {
+                    return Some(found);
+                }
+            }
+            None
+        }
+        baml_type::RealizedTy::List(element, _) => first_non_data_type(vm, element, defs, visited),
+        baml_type::RealizedTy::Map { key, value, .. } => {
+            first_non_data_type(vm, key, defs, visited)
+                .or_else(|| first_non_data_type(vm, value, defs, visited))
+        }
+        baml_type::RealizedTy::Union(members, _) => members
+            .iter()
+            .find_map(|member| first_non_data_type(vm, member, defs, visited)),
+        baml_type::RealizedTy::TypeAlias(name, _) => {
+            if !visited.insert(ty.clone()) {
+                return None;
+            }
+            vm.recursive_type_alias(name)
+                .and_then(|alias| baml_type::RealizedTy::try_from(alias.clone()).ok())
+                .and_then(|alias| first_non_data_type(vm, &alias, defs, visited))
+        }
+        baml_type::RealizedTy::Int { .. }
+        | baml_type::RealizedTy::Bigint { .. }
+        | baml_type::RealizedTy::Float { .. }
+        | baml_type::RealizedTy::String { .. }
+        | baml_type::RealizedTy::Bool { .. }
+        | baml_type::RealizedTy::Null { .. }
+        | baml_type::RealizedTy::Uint8Array { .. }
+        | baml_type::RealizedTy::Media(..)
+        | baml_type::RealizedTy::Literal(..)
+        | baml_type::RealizedTy::Interface(..)
+        | baml_type::RealizedTy::Enum(..)
+        | baml_type::RealizedTy::EnumVariant(..)
+        | baml_type::RealizedTy::Function { .. }
+        | baml_type::RealizedTy::Future(..)
+        | baml_type::RealizedTy::RustType { .. }
+        | baml_type::RealizedTy::Type { .. }
+        | baml_type::RealizedTy::Resource { .. }
+        | baml_type::RealizedTy::PromptAst { .. }
+        | baml_type::RealizedTy::Void { .. }
+        | baml_type::RealizedTy::BuiltinUnknown { .. }
+        | baml_type::RealizedTy::Never { .. } => None,
+    }
+}
+
 fn cloned_type_value(vm: &BexVm, value: Value) -> TypeValue {
     let ptr = value
         .as_object_ptr()
@@ -1091,4 +1223,84 @@ fn primitive_type_name(ty: &baml_type::RealizedTy) -> Option<baml_type::TypeName
     Some(baml_type::QualifiedTypeName::local(baml_type::Name::new(
         name,
     )))
+}
+
+#[cfg(test)]
+mod renderability_tests {
+    use super::*;
+
+    fn attr() -> baml_type::TyAttr {
+        baml_type::TyAttr::default()
+    }
+
+    #[test]
+    fn full_realized_type_family_has_an_explicit_renderability_classification() {
+        let name = baml_type::TypeName::local(baml_type::Name::new("Example"));
+        let non_data = vec![
+            baml_type::RealizedTy::Uint8Array { attr: attr() },
+            baml_type::RealizedTy::EnumVariant(name.clone(), baml_type::Name::new("VALUE"), attr()),
+            baml_type::RealizedTy::Function {
+                params: vec![],
+                ret: Box::new(baml_type::RealizedTy::int()),
+                throws: Box::new(baml_type::RealizedTy::never()),
+                attr: attr(),
+            },
+            baml_type::RealizedTy::Future(
+                Box::new(baml_type::RealizedTy::int()),
+                Box::new(baml_type::RealizedTy::never()),
+                attr(),
+            ),
+            baml_type::RealizedTy::RustType { attr: attr() },
+            baml_type::RealizedTy::Type { attr: attr() },
+            baml_type::RealizedTy::Resource { attr: attr() },
+            baml_type::RealizedTy::PromptAst { attr: attr() },
+            baml_type::RealizedTy::Void { attr: attr() },
+            baml_type::RealizedTy::unknown(),
+            baml_type::RealizedTy::never(),
+        ];
+        for ty in non_data {
+            assert!(
+                is_non_data_render_type(&ty),
+                "expected `{ty}` to be rejected before output-format rendering"
+            );
+        }
+
+        let data = vec![
+            baml_type::RealizedTy::int(),
+            baml_type::RealizedTy::Bigint { attr: attr() },
+            baml_type::RealizedTy::Float { attr: attr() },
+            baml_type::RealizedTy::string(),
+            baml_type::RealizedTy::Bool { attr: attr() },
+            baml_type::RealizedTy::null(),
+            baml_type::RealizedTy::Media(baml_type::MediaKind::Image, attr()),
+            baml_type::RealizedTy::Literal(
+                baml_type::Literal::String("value".to_string()),
+                baml_type::Freshness::Regular,
+                attr(),
+            ),
+            baml_type::RealizedTy::Class(name.clone(), vec![], attr()),
+            baml_type::RealizedTy::Interface(name.clone(), vec![], vec![], attr()),
+            baml_type::RealizedTy::Enum(name.clone(), attr()),
+            baml_type::RealizedTy::list(baml_type::RealizedTy::string()),
+            baml_type::RealizedTy::Map {
+                key: Box::new(baml_type::RealizedTy::string()),
+                value: Box::new(baml_type::RealizedTy::int()),
+                attr: attr(),
+            },
+            baml_type::RealizedTy::Union(
+                vec![
+                    baml_type::RealizedTy::string(),
+                    baml_type::RealizedTy::null(),
+                ],
+                attr(),
+            ),
+            baml_type::RealizedTy::TypeAlias(name, attr()),
+        ];
+        for ty in data {
+            assert!(
+                !is_non_data_render_type(&ty),
+                "expected `{ty}` to remain eligible for output-format rendering"
+            );
+        }
+    }
 }

--- a/baml_language/crates/bex_vm/src/package_baml/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/type_class.rs
@@ -214,11 +214,17 @@ impl BamlClassTypeValue for PackageBamlImpl {
         }
 
         let mut visited = std::collections::HashSet::new();
-        if let Some(non_data_ty) =
-            first_non_data_type(vm, &type_value.ty, type_value.defs(), &mut visited)
+        if let Some((path, non_data_ty)) =
+            first_non_data_type(vm, &type_value.ty, type_value.defs(), &root, &mut visited)
         {
-            let diagnostic =
-                baml_compiler_diagnostics::runtime_type::non_data_type_at_render(&non_data_ty);
+            let diagnostic = if path == root {
+                baml_compiler_diagnostics::runtime_type::non_data_type_at_render(&non_data_ty)
+            } else {
+                baml_compiler_diagnostics::runtime_type::non_data_field_at_render(
+                    &path,
+                    &non_data_ty,
+                )
+            };
             return Err(VmRustFnError::Thrown(
                 super::type_kinds::alloc_compilation_error(vm, &[diagnostic]),
             ));
@@ -742,7 +748,7 @@ fn first_open_interface(
             let Object::Class(class) = vm.get_object(class_ptr) else {
                 return None;
             };
-            for field in &class.fields {
+            for field in class.fields.iter().filter(|field| !field.skip) {
                 let child_path = format!("{path}.{}", field.name);
                 if let Some(runtime) = &field.runtime_type {
                     if let Some(found) =
@@ -841,10 +847,11 @@ fn first_non_data_type(
     vm: &BexVm,
     ty: &baml_type::RealizedTy,
     defs: &DynTypeDefs,
+    path: &str,
     visited: &mut std::collections::HashSet<baml_type::RealizedTy>,
-) -> Option<String> {
+) -> Option<(String, String)> {
     if is_non_data_render_type(ty) {
-        return Some(ty.to_string());
+        return Some((path.to_string(), ty.to_string()));
     }
 
     match ty {
@@ -860,10 +867,18 @@ fn first_non_data_type(
             let Object::Class(class) = vm.get_object(class_ptr) else {
                 return None;
             };
-            for field in &class.fields {
+            // The output formatter currently walks `ClassField::field_type`,
+            // whose class-generic leaves are intentionally unsubstituted.
+            // Reject this path before rendering can silently erase the schema;
+            // substituting class arguments in `sys_ops` is a separate fix.
+            if class.generic_param_count > 0 {
+                return Some((path.to_string(), ty.to_string()));
+            }
+            for field in class.fields.iter().filter(|field| !field.skip) {
+                let child_path = format!("{path}.{}", field.name);
                 if let Some(runtime) = &field.runtime_type {
                     if let Some(found) =
-                        first_non_data_type(vm, &runtime.ty, runtime.defs(), visited)
+                        first_non_data_type(vm, &runtime.ty, runtime.defs(), &child_path, visited)
                     {
                         return Some(found);
                     }
@@ -875,28 +890,31 @@ fn first_non_data_type(
                     .ok()
                     .or_else(|| baml_type::RealizedTy::try_from(field.field_type.clone()).ok());
                 if let Some(field_ty) = field_ty
-                    && let Some(found) = first_non_data_type(vm, &field_ty, defs, visited)
+                    && let Some(found) =
+                        first_non_data_type(vm, &field_ty, defs, &child_path, visited)
                 {
                     return Some(found);
                 }
             }
             None
         }
-        baml_type::RealizedTy::List(element, _) => first_non_data_type(vm, element, defs, visited),
+        baml_type::RealizedTy::List(element, _) => {
+            first_non_data_type(vm, element, defs, path, visited)
+        }
         baml_type::RealizedTy::Map { key, value, .. } => {
-            first_non_data_type(vm, key, defs, visited)
-                .or_else(|| first_non_data_type(vm, value, defs, visited))
+            first_non_data_type(vm, key, defs, path, visited)
+                .or_else(|| first_non_data_type(vm, value, defs, path, visited))
         }
         baml_type::RealizedTy::Union(members, _) => members
             .iter()
-            .find_map(|member| first_non_data_type(vm, member, defs, visited)),
+            .find_map(|member| first_non_data_type(vm, member, defs, path, visited)),
         baml_type::RealizedTy::TypeAlias(name, _) => {
             if !visited.insert(ty.clone()) {
                 return None;
             }
             vm.recursive_type_alias(name)
                 .and_then(|alias| baml_type::RealizedTy::try_from(alias.clone()).ok())
-                .and_then(|alias| first_non_data_type(vm, &alias, defs, visited))
+                .and_then(|alias| first_non_data_type(vm, &alias, defs, path, visited))
         }
         baml_type::RealizedTy::Int { .. }
         | baml_type::RealizedTy::Bigint { .. }

--- a/baml_language/crates/sys_ops/src/output_format.rs
+++ b/baml_language/crates/sys_ops/src/output_format.rs
@@ -590,9 +590,10 @@ impl OutputFormatContent {
             | RuntimeTy::TypeVar(..)
             | RuntimeTy::AssociatedTypeProjection { .. }
             | RuntimeTy::Never { .. }
-            | RuntimeTy::RustType { .. } => {
-                unreachable!("non-data type {:?} should not reach output_format", ty)
-            }
+            // Public LLM render paths reject these at `validate_output_type`.
+            // Keep the formatter fallible too so an internal caller cannot
+            // turn a missing boundary check into a process abort.
+            | RuntimeTy::RustType { .. } => Err(RenderError::UnsupportedType(ty.to_string())),
         }
     }
 
@@ -1674,6 +1675,15 @@ mod tests {
         let content = OutputFormatContent::new(RuntimeTy::type_type());
         let err = content.render(&RenderOptions::default()).unwrap_err();
         assert!(matches!(err, RenderError::UnsupportedType(s) if s == "type"));
+    }
+
+    #[test]
+    fn test_render_non_data_type_returns_error_instead_of_panicking() {
+        let content = OutputFormatContent::new(RuntimeTy::Never {
+            attr: TyAttr::default(),
+        });
+        let err = content.render(&RenderOptions::default()).unwrap_err();
+        assert!(matches!(err, RenderError::UnsupportedType(s) if s == "never"));
     }
 
     // ========================================================================

--- a/baml_language/crates/sys_ops/src/output_format.rs
+++ b/baml_language/crates/sys_ops/src/output_format.rs
@@ -590,9 +590,10 @@ impl OutputFormatContent {
             | RuntimeTy::TypeVar(..)
             | RuntimeTy::AssociatedTypeProjection { .. }
             | RuntimeTy::Never { .. }
-            // Public LLM render paths reject these at `validate_output_type`.
-            // Keep the formatter fallible too so an internal caller cannot
-            // turn a missing boundary check into a process abort.
+            // Checked LLM execution and render-companion paths reject these at
+            // `validate_output_type`. Throws-never low-level output-format
+            // helpers may still degrade this error to an empty string, so keep
+            // the formatter fallible rather than aborting the process.
             | RuntimeTy::RustType { .. } => Err(RenderError::UnsupportedType(ty.to_string())),
         }
     }


### PR DESCRIPTION
## Summary

- reject non-data realized types at the shared LLM render boundary with catchable E0164 diagnostics
- report nested failures with their full class-field path and ignore fields marked `@skip`
- reject realized generic classes before the current unsubstituted renderer can silently erase their schema and proceed to provider I/O
- replace the low-level `unreachable!` fallback with a fallible formatter error

## Root cause

`type._validate_renderable` guarded open interfaces, conflicting runtime definitions, and empty enums, but did not recursively reject non-data leaves. Those leaves reached `sys_ops::output_format`; `never` and its family aborted the process, while the first fix made unsubstituted generic-class fields return an error that throws-never helper callers swallowed into an empty schema.

## Compatibility / strictness

This intentionally makes previously degraded renders fail loudly with E0164: examples include a `uint8array` field that rendered as `RESULT=[]`, a `type` field, and a `string | uint8array` field that rendered only the string branch. Skipped fields remain ignored, matching the renderer. Generic functions whose realized outputs are non-generic remain supported.

## Deliberate deferrals

- Real substitution of realized generic class arguments into `ClassDefinition.field_type` in `sys_ops::output_format` is a separate migration follow-up. Until then, generic classes fail safely instead of aborting or rendering without a schema.
- Static rejection is intentionally not implemented: this is the runtime-only shared seam, matching E0159/E0161/E0162 precedent.
- The throws-never low-level output-format helpers are not routed through `_validate_renderable`; their comment is narrowed because they may still degrade an unsupported formatter error to an empty string.

## Tests

- root and nested non-data diagnostics, including `unknown` and `type`
- runtime-minted nested class definitions
- skipped non-data and open-interface fields
- generic-class rejection before provider I/O
- generic-function concrete-output positive control
- existing E0159/E0161/E0162 precedence coverage
- full pinned gate: 3,761/3,761 passed, 24 skipped; doctests clean; zero unreferenced or pending snapshots

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * LLM output schemas with unsupported non-data types now return catchable `E0164` diagnostics instead of crashing or being silently ignored.
  * Improved validation across nested types, unions, aliases, generic classes, and skipped fields.
  * Rendering now reports clear errors for unsupported types, including `never`, `uint8array`, and `type`.
  * Valid data-class fields continue to render successfully.

* **Documentation**
  * Added changelog coverage for the updated diagnostic behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->