### PR TITLE
chore: auto-enqueue size-gate baseline refresh PRs

### DIFF
--- a/.github/workflows/size-gate-baseline-refresh.yml
+++ b/.github/workflows/size-gate-baseline-refresh.yml
@@ -130,15 +130,165 @@ jobs:
             baml_language/.ci/size-gate/*.toml
             baml_language/.cargo/size-gate.toml
 
-      - name: "Enable auto-merge"
-        # Only when a PR actually exists (no diff → no PR → nothing to do).
-        # With canary's required checks, auto-merge waits for this PR's own
-        # size-gate CI to pass before merging, so a refresh that would
-        # regress never lands. Uses the PAT (the GITHUB_TOKEN can't enable
-        # auto-merge on a PR it didn't author).
+      - name: "Validate and enqueue baseline-refresh PR"
+        # Only when create-pull-request returned the exact PR it created or
+        # updated (no diff/no PR -> nothing to do). Repository auto-merge is
+        # disabled, so enroll directly in canary's merge queue. The queue
+        # preserves branch protection and waits for all required checks.
+        #
+        # Reuse the PAT required above so creating the PR still triggers CI;
+        # the workflow's GITHUB_TOKEN remains read-only. Validate the full PR
+        # identity and changed-file scope before making any merge mutation.
         if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE }}
+          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
+          EXPECTED_REPOSITORY: BoundaryML/baml
+          EXPECTED_HEAD: chore/size-gate-baseline-refresh
+          EXPECTED_BASE: canary
+          EXPECTED_TITLE: "chore: refresh size-gate baselines"
         run: |
-          gh pr merge "${{ steps.cpr.outputs.pull-request-number }}" \
-            --squash --auto
+          set -euo pipefail
+
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::create-pull-request returned an invalid PR number: $PR_NUMBER"
+            exit 1
+          fi
+
+          read_pr() {
+            gh api graphql \
+              -f owner='BoundaryML' \
+              -f name='baml' \
+              -F number="$PR_NUMBER" \
+              -f query='query($owner: String!, $name: String!, $number: Int!) {
+                repository(owner: $owner, name: $name) {
+                  nameWithOwner
+                  pullRequest(number: $number) {
+                    id
+                    number
+                    state
+                    merged
+                    title
+                    headRefName
+                    headRefOid
+                    baseRefName
+                    headRepository { nameWithOwner }
+                    baseRepository { nameWithOwner }
+                    mergeQueueEntry { id position }
+                  }
+                }
+              }'
+          }
+
+          echo "Inspecting $EXPECTED_REPOSITORY PR #$PR_NUMBER returned by create-pull-request"
+          pr_json=$(read_pr)
+          if ! jq -e '.data.repository.pullRequest != null' <<< "$pr_json" >/dev/null; then
+            echo "::error::PR #$PR_NUMBER was not found in $EXPECTED_REPOSITORY"
+            exit 1
+          fi
+
+          actual_repository=$(jq -r '.data.repository.nameWithOwner' <<< "$pr_json")
+          actual_number=$(jq -r '.data.repository.pullRequest.number' <<< "$pr_json")
+          state=$(jq -r '.data.repository.pullRequest.state' <<< "$pr_json")
+          merged=$(jq -r '.data.repository.pullRequest.merged' <<< "$pr_json")
+
+          if [[ "$actual_repository" != "$EXPECTED_REPOSITORY" || "$actual_number" != "$PR_NUMBER" ]]; then
+            echo "::error::Resolved PR identity does not match $EXPECTED_REPOSITORY#$PR_NUMBER"
+            exit 1
+          fi
+          if [[ "$merged" == 'true' || "$state" == 'MERGED' ]]; then
+            echo "PR #$PR_NUMBER is already merged; nothing to enqueue"
+            exit 0
+          fi
+          if [[ "$state" != 'OPEN' ]]; then
+            echo "::error::Expected PR #$PR_NUMBER to be open, found state $state"
+            exit 1
+          fi
+
+          head_repository=$(jq -r '.data.repository.pullRequest.headRepository.nameWithOwner // ""' <<< "$pr_json")
+          base_repository=$(jq -r '.data.repository.pullRequest.baseRepository.nameWithOwner // ""' <<< "$pr_json")
+          head_ref=$(jq -r '.data.repository.pullRequest.headRefName' <<< "$pr_json")
+          base_ref=$(jq -r '.data.repository.pullRequest.baseRefName' <<< "$pr_json")
+          title=$(jq -r '.data.repository.pullRequest.title' <<< "$pr_json")
+          pr_id=$(jq -r '.data.repository.pullRequest.id' <<< "$pr_json")
+          head_oid=$(jq -r '.data.repository.pullRequest.headRefOid' <<< "$pr_json")
+          queue_position=$(jq -r '.data.repository.pullRequest.mergeQueueEntry.position // ""' <<< "$pr_json")
+
+          if [[ "$head_repository" != "$EXPECTED_REPOSITORY" || "$base_repository" != "$EXPECTED_REPOSITORY" ]]; then
+            echo "::error::Expected head and base repositories to be $EXPECTED_REPOSITORY; found head=$head_repository base=$base_repository"
+            exit 1
+          fi
+          if [[ "$head_ref" != "$EXPECTED_HEAD" ]]; then
+            echo "::error::Expected head branch $EXPECTED_HEAD; found $head_ref"
+            exit 1
+          fi
+          if [[ "$base_ref" != "$EXPECTED_BASE" ]]; then
+            echo "::error::Expected base branch $EXPECTED_BASE; found $base_ref"
+            exit 1
+          fi
+          if [[ "$title" != "$EXPECTED_TITLE" ]]; then
+            echo "::error::Expected title '$EXPECTED_TITLE'; found '$title'"
+            exit 1
+          fi
+
+          # These are exactly the two add-paths scopes configured on the
+          # create-pull-request step above. Fetch every page before deciding.
+          files_json=$(gh api --paginate --slurp \
+            -H 'Accept: application/vnd.github+json' \
+            "repos/BoundaryML/baml/pulls/$PR_NUMBER/files?per_page=100")
+          file_count=$(jq '[.[][]] | length' <<< "$files_json")
+          if [[ "$file_count" -eq 0 ]]; then
+            echo "PR #$PR_NUMBER has no changed files; nothing to enqueue"
+            exit 0
+          fi
+
+          echo "Validating $file_count changed file(s):"
+          jq -r '.[][] | "  - \(.filename)"' <<< "$files_json"
+          invalid_files=$(jq -r '.[][] | .filename | select((
+            test("^baml_language/\\.ci/size-gate/[^/]+\\.toml$") or
+            . == "baml_language/.cargo/size-gate.toml"
+          ) | not)' <<< "$files_json")
+          if [[ -n "$invalid_files" ]]; then
+            echo "::error::PR #$PR_NUMBER changes files outside the configured size-gate baseline paths"
+            while IFS= read -r file; do
+              echo "::error file=$file::Unexpected changed file"
+            done <<< "$invalid_files"
+            exit 1
+          fi
+
+          if [[ -n "$queue_position" ]]; then
+            echo "PR #$PR_NUMBER is already in the merge queue at position $queue_position"
+            exit 0
+          fi
+
+          echo "All safety checks passed; enqueueing PR #$PR_NUMBER at head $head_oid"
+          if enqueue_json=$(gh api graphql \
+            -f query='mutation($prId: ID!, $headOid: GitObjectID!) {
+              enqueuePullRequest(input: {pullRequestId: $prId, expectedHeadOid: $headOid}) {
+                mergeQueueEntry { position }
+              }
+            }' \
+            -F prId="$pr_id" \
+            -F headOid="$head_oid" 2>&1); then
+            queue_position=$(jq -r '.data.enqueuePullRequest.mergeQueueEntry.position // "unknown"' <<< "$enqueue_json")
+            echo "Enqueued PR #$PR_NUMBER in the canary merge queue at position $queue_position"
+            exit 0
+          fi
+
+          # A concurrent run may have queued or merged the PR after the first
+          # read. Treat only those confirmed outcomes as idempotent success.
+          latest_pr_json=$(read_pr)
+          latest_state=$(jq -r '.data.repository.pullRequest.state // ""' <<< "$latest_pr_json")
+          latest_merged=$(jq -r '.data.repository.pullRequest.merged // false' <<< "$latest_pr_json")
+          latest_queue_position=$(jq -r '.data.repository.pullRequest.mergeQueueEntry.position // ""' <<< "$latest_pr_json")
+          if [[ "$latest_merged" == 'true' || "$latest_state" == 'MERGED' ]]; then
+            echo "PR #$PR_NUMBER was merged concurrently; nothing left to enqueue"
+            exit 0
+          fi
+          if [[ -n "$latest_queue_position" ]]; then
+            echo "PR #$PR_NUMBER was queued concurrently at position $latest_queue_position"
+            exit 0
+          fi
+
+          echo "::error::Failed to enqueue PR #$PR_NUMBER: $enqueue_json"
+          exit 1

--- a/.github/workflows/size-gate-baseline-refresh.yml
+++ b/.github/workflows/size-gate-baseline-refresh.yml
@@ -130,103 +130,19 @@ jobs:
             baml_language/.ci/size-gate/*.toml
             baml_language/.cargo/size-gate.toml
 
-      - name: "Validate and enqueue baseline-refresh PR"
-        # Only when create-pull-request returned the exact PR it created or
-        # updated (no diff/no PR -> nothing to do). Repository auto-merge is
-        # disabled, so enroll directly in canary's merge queue. The queue
-        # preserves branch protection and waits for all required checks.
-        #
-        # Reuse the PAT required above so creating the PR still triggers CI;
-        # the workflow's GITHUB_TOKEN remains read-only. Validate the full PR
-        # identity and changed-file scope before making any merge mutation.
+      - name: "Enqueue to merge queue"
+        # No diff means no PR number and nothing to enqueue.
         if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE }}
-          PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
-          set -euo pipefail
-
-          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::create-pull-request returned an invalid PR number: $PR_NUMBER"
-            exit 1
-          fi
-
-          echo "Inspecting BoundaryML/baml PR #$PR_NUMBER returned by create-pull-request"
-          pr_json=$(gh api graphql \
-            -F number="$PR_NUMBER" \
-            -f query='query($number: Int!) {
-              repository(owner: "BoundaryML", name: "baml") {
-                nameWithOwner
-                pullRequest(number: $number) {
-                  id number state title headRefName headRefOid baseRefName
-                  headRepository { nameWithOwner }
-                  baseRepository { nameWithOwner }
-                  mergeQueueEntry { position }
-                  files(first: 100) { totalCount nodes { path } }
-                }
-              }
-            }')
-
-          state=$(jq -r '.data.repository.pullRequest.state // ""' <<< "$pr_json")
-          if [[ "$state" == 'MERGED' ]]; then
-            echo "PR #$PR_NUMBER is already merged; nothing to enqueue"
-            exit 0
-          fi
-
-          file_count=$(jq '.data.repository.pullRequest.files.totalCount // 0' <<< "$pr_json")
-          # Fail closed unless the exact automation PR and every changed path
-          # match the create-pull-request configuration above. More than 100
-          # files also fails because the query intentionally reads at most 100.
-          if ! jq -e --argjson number "$PR_NUMBER" '
-            .data.repository as $repo
-            | ($repo.nameWithOwner == "BoundaryML/baml") and
-              ($repo.pullRequest |
-                .number == $number and
-                .state == "OPEN" and
-                .title == "chore: refresh size-gate baselines" and
-                .headRefName == "chore/size-gate-baseline-refresh" and
-                .baseRefName == "canary" and
-                .headRepository.nameWithOwner == "BoundaryML/baml" and
-                .baseRepository.nameWithOwner == "BoundaryML/baml" and
-                .files.totalCount == (.files.nodes | length) and
-                all(.files.nodes[].path;
-                  test("^baml_language/\\.ci/size-gate/[^/]+\\.toml$") or
-                  . == "baml_language/.cargo/size-gate.toml"))
-          ' <<< "$pr_json" >/dev/null; then
-            jq '.data.repository | {
-              repository: .nameWithOwner,
-              pullRequest: (.pullRequest | {
-                number, state, title, headRefName, baseRefName,
-                headRepository: .headRepository.nameWithOwner,
-                baseRepository: .baseRepository.nameWithOwner,
-                changedFiles: [.files.nodes[].path],
-                changedFileCount: .files.totalCount
-              })
-            }' <<< "$pr_json"
-            echo "::error::PR identity or changed-file scope did not match the baseline-refresh automation"
-            exit 1
-          fi
-
-          if [[ "$file_count" -eq 0 ]]; then
-            echo "PR #$PR_NUMBER has no changed files; nothing to enqueue"
-            exit 0
-          fi
-
-          queue_position=$(jq -r '.data.repository.pullRequest.mergeQueueEntry.position // ""' <<< "$pr_json")
-          if [[ -n "$queue_position" ]]; then
-            echo "PR #$PR_NUMBER is already in the merge queue at position $queue_position"
-            exit 0
-          fi
-
-          pr_id=$(jq -r '.data.repository.pullRequest.id' <<< "$pr_json")
-          head_oid=$(jq -r '.data.repository.pullRequest.headRefOid' <<< "$pr_json")
-          echo "Validated $file_count baseline file(s); enqueueing PR #$PR_NUMBER at head $head_oid"
+          pr_id=$(gh api \
+            "repos/${{ github.repository }}/pulls/${{ steps.cpr.outputs.pull-request-number }}" \
+            --jq .node_id)
           gh api graphql \
-            -f query='mutation($prId: ID!, $headOid: GitObjectID!) {
-              enqueuePullRequest(input: {pullRequestId: $prId, expectedHeadOid: $headOid}) {
+            -f query='mutation($prId: ID!) {
+              enqueuePullRequest(input: {pullRequestId: $prId}) {
                 mergeQueueEntry { position }
               }
             }' \
-            -F prId="$pr_id" \
-            -F headOid="$head_oid" \
-            --jq '"Enqueued in the canary merge queue at position \(.data.enqueuePullRequest.mergeQueueEntry.position)"'
+            -F prId="$pr_id"

--- a/.github/workflows/size-gate-baseline-refresh.yml
+++ b/.github/workflows/size-gate-baseline-refresh.yml
@@ -132,6 +132,9 @@ jobs:
 
       - name: "Enqueue to merge queue"
         # No diff means no PR number and nothing to enqueue.
+        # We want "merge when ready" immediately after filing the PR. While
+        # checks are pending, `gh pr merge` tries repository auto-merge instead;
+        # `enqueuePullRequest` directly enrolls the PR in canary's merge queue.
         if: steps.cpr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE }}

--- a/.github/workflows/size-gate-baseline-refresh.yml
+++ b/.github/workflows/size-gate-baseline-refresh.yml
@@ -143,10 +143,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.SAM_GITHUB_BOUNDARYML_READWRITE }}
           PR_NUMBER: ${{ steps.cpr.outputs.pull-request-number }}
-          EXPECTED_REPOSITORY: BoundaryML/baml
-          EXPECTED_HEAD: chore/size-gate-baseline-refresh
-          EXPECTED_BASE: canary
-          EXPECTED_TITLE: "chore: refresh size-gate baselines"
         run: |
           set -euo pipefail
 
@@ -155,147 +151,82 @@ jobs:
             exit 1
           fi
 
-          read_pr() {
-            gh api graphql \
-              -f owner='BoundaryML' \
-              -f name='baml' \
-              -F number="$PR_NUMBER" \
-              -f query='query($owner: String!, $name: String!, $number: Int!) {
-                repository(owner: $owner, name: $name) {
-                  nameWithOwner
-                  pullRequest(number: $number) {
-                    id
-                    number
-                    state
-                    merged
-                    title
-                    headRefName
-                    headRefOid
-                    baseRefName
-                    headRepository { nameWithOwner }
-                    baseRepository { nameWithOwner }
-                    mergeQueueEntry { id position }
-                  }
+          echo "Inspecting BoundaryML/baml PR #$PR_NUMBER returned by create-pull-request"
+          pr_json=$(gh api graphql \
+            -F number="$PR_NUMBER" \
+            -f query='query($number: Int!) {
+              repository(owner: "BoundaryML", name: "baml") {
+                nameWithOwner
+                pullRequest(number: $number) {
+                  id number state title headRefName headRefOid baseRefName
+                  headRepository { nameWithOwner }
+                  baseRepository { nameWithOwner }
+                  mergeQueueEntry { position }
+                  files(first: 100) { totalCount nodes { path } }
                 }
-              }'
-          }
+              }
+            }')
 
-          echo "Inspecting $EXPECTED_REPOSITORY PR #$PR_NUMBER returned by create-pull-request"
-          if ! pr_json=$(read_pr); then
-            echo "::error::Failed to inspect PR #$PR_NUMBER in $EXPECTED_REPOSITORY"
-            exit 1
-          fi
-          if ! jq -e '.data.repository.pullRequest != null' <<< "$pr_json" >/dev/null; then
-            echo "::error::PR #$PR_NUMBER was not found in $EXPECTED_REPOSITORY"
-            exit 1
-          fi
-
-          actual_repository=$(jq -r '.data.repository.nameWithOwner' <<< "$pr_json")
-          actual_number=$(jq -r '.data.repository.pullRequest.number' <<< "$pr_json")
-          state=$(jq -r '.data.repository.pullRequest.state' <<< "$pr_json")
-          merged=$(jq -r '.data.repository.pullRequest.merged' <<< "$pr_json")
-
-          if [[ "$actual_repository" != "$EXPECTED_REPOSITORY" || "$actual_number" != "$PR_NUMBER" ]]; then
-            echo "::error::Resolved PR identity does not match $EXPECTED_REPOSITORY#$PR_NUMBER"
-            exit 1
-          fi
-          if [[ "$merged" == 'true' || "$state" == 'MERGED' ]]; then
+          state=$(jq -r '.data.repository.pullRequest.state // ""' <<< "$pr_json")
+          if [[ "$state" == 'MERGED' ]]; then
             echo "PR #$PR_NUMBER is already merged; nothing to enqueue"
             exit 0
           fi
-          if [[ "$state" != 'OPEN' ]]; then
-            echo "::error::Expected PR #$PR_NUMBER to be open, found state $state"
+
+          file_count=$(jq '.data.repository.pullRequest.files.totalCount // 0' <<< "$pr_json")
+          # Fail closed unless the exact automation PR and every changed path
+          # match the create-pull-request configuration above. More than 100
+          # files also fails because the query intentionally reads at most 100.
+          if ! jq -e --argjson number "$PR_NUMBER" '
+            .data.repository as $repo
+            | ($repo.nameWithOwner == "BoundaryML/baml") and
+              ($repo.pullRequest |
+                .number == $number and
+                .state == "OPEN" and
+                .title == "chore: refresh size-gate baselines" and
+                .headRefName == "chore/size-gate-baseline-refresh" and
+                .baseRefName == "canary" and
+                .headRepository.nameWithOwner == "BoundaryML/baml" and
+                .baseRepository.nameWithOwner == "BoundaryML/baml" and
+                .files.totalCount == (.files.nodes | length) and
+                all(.files.nodes[].path;
+                  test("^baml_language/\\.ci/size-gate/[^/]+\\.toml$") or
+                  . == "baml_language/.cargo/size-gate.toml"))
+          ' <<< "$pr_json" >/dev/null; then
+            jq '.data.repository | {
+              repository: .nameWithOwner,
+              pullRequest: (.pullRequest | {
+                number, state, title, headRefName, baseRefName,
+                headRepository: .headRepository.nameWithOwner,
+                baseRepository: .baseRepository.nameWithOwner,
+                changedFiles: [.files.nodes[].path],
+                changedFileCount: .files.totalCount
+              })
+            }' <<< "$pr_json"
+            echo "::error::PR identity or changed-file scope did not match the baseline-refresh automation"
             exit 1
           fi
 
-          head_repository=$(jq -r '.data.repository.pullRequest.headRepository.nameWithOwner // ""' <<< "$pr_json")
-          base_repository=$(jq -r '.data.repository.pullRequest.baseRepository.nameWithOwner // ""' <<< "$pr_json")
-          head_ref=$(jq -r '.data.repository.pullRequest.headRefName' <<< "$pr_json")
-          base_ref=$(jq -r '.data.repository.pullRequest.baseRefName' <<< "$pr_json")
-          title=$(jq -r '.data.repository.pullRequest.title' <<< "$pr_json")
-          pr_id=$(jq -r '.data.repository.pullRequest.id' <<< "$pr_json")
-          head_oid=$(jq -r '.data.repository.pullRequest.headRefOid' <<< "$pr_json")
-          queue_position=$(jq -r '.data.repository.pullRequest.mergeQueueEntry.position // ""' <<< "$pr_json")
-
-          if [[ "$head_repository" != "$EXPECTED_REPOSITORY" || "$base_repository" != "$EXPECTED_REPOSITORY" ]]; then
-            echo "::error::Expected head and base repositories to be $EXPECTED_REPOSITORY; found head=$head_repository base=$base_repository"
-            exit 1
-          fi
-          if [[ "$head_ref" != "$EXPECTED_HEAD" ]]; then
-            echo "::error::Expected head branch $EXPECTED_HEAD; found $head_ref"
-            exit 1
-          fi
-          if [[ "$base_ref" != "$EXPECTED_BASE" ]]; then
-            echo "::error::Expected base branch $EXPECTED_BASE; found $base_ref"
-            exit 1
-          fi
-          if [[ "$title" != "$EXPECTED_TITLE" ]]; then
-            echo "::error::Expected title '$EXPECTED_TITLE'; found '$title'"
-            exit 1
-          fi
-
-          # These are exactly the two add-paths scopes configured on the
-          # create-pull-request step above. Fetch every page before deciding.
-          files_json=$(gh api --paginate --slurp \
-            -H 'Accept: application/vnd.github+json' \
-            "repos/BoundaryML/baml/pulls/$PR_NUMBER/files?per_page=100")
-          file_count=$(jq '[.[][]] | length' <<< "$files_json")
           if [[ "$file_count" -eq 0 ]]; then
             echo "PR #$PR_NUMBER has no changed files; nothing to enqueue"
             exit 0
           fi
 
-          echo "Validating $file_count changed file(s):"
-          jq -r '.[][] | "  - \(.filename)"' <<< "$files_json"
-          invalid_files=$(jq -r '.[][] | .filename | select((
-            test("^baml_language/\\.ci/size-gate/[^/]+\\.toml$") or
-            . == "baml_language/.cargo/size-gate.toml"
-          ) | not)' <<< "$files_json")
-          if [[ -n "$invalid_files" ]]; then
-            echo "::error::PR #$PR_NUMBER changes files outside the configured size-gate baseline paths"
-            while IFS= read -r file; do
-              echo "::error file=$file::Unexpected changed file"
-            done <<< "$invalid_files"
-            exit 1
-          fi
-
+          queue_position=$(jq -r '.data.repository.pullRequest.mergeQueueEntry.position // ""' <<< "$pr_json")
           if [[ -n "$queue_position" ]]; then
             echo "PR #$PR_NUMBER is already in the merge queue at position $queue_position"
             exit 0
           fi
 
-          echo "All safety checks passed; enqueueing PR #$PR_NUMBER at head $head_oid"
-          enqueue_error_file=$(mktemp)
-          trap 'rm -f "$enqueue_error_file"' EXIT
-          if enqueue_json=$(gh api graphql \
+          pr_id=$(jq -r '.data.repository.pullRequest.id' <<< "$pr_json")
+          head_oid=$(jq -r '.data.repository.pullRequest.headRefOid' <<< "$pr_json")
+          echo "Validated $file_count baseline file(s); enqueueing PR #$PR_NUMBER at head $head_oid"
+          gh api graphql \
             -f query='mutation($prId: ID!, $headOid: GitObjectID!) {
               enqueuePullRequest(input: {pullRequestId: $prId, expectedHeadOid: $headOid}) {
                 mergeQueueEntry { position }
               }
             }' \
             -F prId="$pr_id" \
-            -F headOid="$head_oid" 2>"$enqueue_error_file"); then
-            queue_position=$(jq -r '.data.enqueuePullRequest.mergeQueueEntry.position // "unknown"' <<< "$enqueue_json")
-            echo "Enqueued PR #$PR_NUMBER in the canary merge queue at position $queue_position"
-            exit 0
-          fi
-          enqueue_error=$(<"$enqueue_error_file")
-
-          # A concurrent run may have queued or merged the PR after the first
-          # read. Treat only those confirmed outcomes as idempotent success.
-          if latest_pr_json=$(read_pr); then
-            latest_state=$(jq -r '.data.repository.pullRequest.state // ""' <<< "$latest_pr_json")
-            latest_merged=$(jq -r '.data.repository.pullRequest.merged // false' <<< "$latest_pr_json")
-            latest_queue_position=$(jq -r '.data.repository.pullRequest.mergeQueueEntry.position // ""' <<< "$latest_pr_json")
-            if [[ "$latest_merged" == 'true' || "$latest_state" == 'MERGED' ]]; then
-              echo "PR #$PR_NUMBER was merged concurrently; nothing left to enqueue"
-              exit 0
-            fi
-            if [[ -n "$latest_queue_position" ]]; then
-              echo "PR #$PR_NUMBER was queued concurrently at position $latest_queue_position"
-              exit 0
-            fi
-          fi
-
-          echo "::error::Failed to enqueue PR #$PR_NUMBER: $enqueue_error"
-          exit 1
+            -F headOid="$head_oid" \
+            --jq '"Enqueued in the canary merge queue at position \(.data.enqueuePullRequest.mergeQueueEntry.position)"'

--- a/.github/workflows/size-gate-baseline-refresh.yml
+++ b/.github/workflows/size-gate-baseline-refresh.yml
@@ -181,7 +181,10 @@ jobs:
           }
 
           echo "Inspecting $EXPECTED_REPOSITORY PR #$PR_NUMBER returned by create-pull-request"
-          pr_json=$(read_pr)
+          if ! pr_json=$(read_pr); then
+            echo "::error::Failed to inspect PR #$PR_NUMBER in $EXPECTED_REPOSITORY"
+            exit 1
+          fi
           if ! jq -e '.data.repository.pullRequest != null' <<< "$pr_json" >/dev/null; then
             echo "::error::PR #$PR_NUMBER was not found in $EXPECTED_REPOSITORY"
             exit 1
@@ -262,6 +265,8 @@ jobs:
           fi
 
           echo "All safety checks passed; enqueueing PR #$PR_NUMBER at head $head_oid"
+          enqueue_error_file=$(mktemp)
+          trap 'rm -f "$enqueue_error_file"' EXIT
           if enqueue_json=$(gh api graphql \
             -f query='mutation($prId: ID!, $headOid: GitObjectID!) {
               enqueuePullRequest(input: {pullRequestId: $prId, expectedHeadOid: $headOid}) {
@@ -269,26 +274,28 @@ jobs:
               }
             }' \
             -F prId="$pr_id" \
-            -F headOid="$head_oid" 2>&1); then
+            -F headOid="$head_oid" 2>"$enqueue_error_file"); then
             queue_position=$(jq -r '.data.enqueuePullRequest.mergeQueueEntry.position // "unknown"' <<< "$enqueue_json")
             echo "Enqueued PR #$PR_NUMBER in the canary merge queue at position $queue_position"
             exit 0
           fi
+          enqueue_error=$(<"$enqueue_error_file")
 
           # A concurrent run may have queued or merged the PR after the first
           # read. Treat only those confirmed outcomes as idempotent success.
-          latest_pr_json=$(read_pr)
-          latest_state=$(jq -r '.data.repository.pullRequest.state // ""' <<< "$latest_pr_json")
-          latest_merged=$(jq -r '.data.repository.pullRequest.merged // false' <<< "$latest_pr_json")
-          latest_queue_position=$(jq -r '.data.repository.pullRequest.mergeQueueEntry.position // ""' <<< "$latest_pr_json")
-          if [[ "$latest_merged" == 'true' || "$latest_state" == 'MERGED' ]]; then
-            echo "PR #$PR_NUMBER was merged concurrently; nothing left to enqueue"
-            exit 0
-          fi
-          if [[ -n "$latest_queue_position" ]]; then
-            echo "PR #$PR_NUMBER was queued concurrently at position $latest_queue_position"
-            exit 0
+          if latest_pr_json=$(read_pr); then
+            latest_state=$(jq -r '.data.repository.pullRequest.state // ""' <<< "$latest_pr_json")
+            latest_merged=$(jq -r '.data.repository.pullRequest.merged // false' <<< "$latest_pr_json")
+            latest_queue_position=$(jq -r '.data.repository.pullRequest.mergeQueueEntry.position // ""' <<< "$latest_pr_json")
+            if [[ "$latest_merged" == 'true' || "$latest_state" == 'MERGED' ]]; then
+              echo "PR #$PR_NUMBER was merged concurrently; nothing left to enqueue"
+              exit 0
+            fi
+            if [[ -n "$latest_queue_position" ]]; then
+              echo "PR #$PR_NUMBER was queued concurrently at position $latest_queue_position"
+              exit 0
+            fi
           fi
 
-          echo "::error::Failed to enqueue PR #$PR_NUMBER: $enqueue_json"
+          echo "::error::Failed to enqueue PR #$PR_NUMBER: $enqueue_error"
           exit 1


### PR DESCRIPTION
## Summary

- replace `gh pr merge --squash --auto` with the merge queue's `enqueuePullRequest` GraphQL mutation
- use only the PR number returned by `peter-evans/create-pull-request`; no PR number means no enqueue step
- keep the existing PAT used to create the CI-triggering PR

## Why

`canary` uses a merge queue and repository auto-merge is disabled. `gh pr merge --auto` therefore calls `enablePullRequestAutoMerge` and fails, while `enqueuePullRequest` directly enrolls the PR and lets the queue enforce its configured merge method and required checks.

## Validation

- `actionlint .github/workflows/size-gate-baseline-refresh.yml`
- `git diff --check`
- read-only PR-number-to-node-ID lookup against BoundaryML/baml PR #4465; no enqueue or merge mutation performed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pull requests are automatically enrolled in the merge queue when created.
  * The workflow reports each pull request’s position in the queue.
* **Bug Fixes**
  * Pull requests with no changes continue to be skipped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->