### PR TITLE
chore: consolidate python/go release metadata under "sdks" key

### DIFF
--- a/.github/workflows/release-baml-language.yml
+++ b/.github/workflows/release-baml-language.yml
@@ -1423,8 +1423,9 @@ jobs:
             --arg module "github.com/boundaryml/baml-go" \
             '
               .version == $version
-              and .baml_bridge_go == {
-                "module": $module,
+              and .sdks.go == {
+                "registry": "go",
+                "package": $module,
                 "version": $go_version
               }
               and (.cffi | type == "object" and length > 0)

--- a/baml_language/crates/baml_release/src/manifest.rs
+++ b/baml_language/crates/baml_release/src/manifest.rs
@@ -24,11 +24,6 @@ pub struct VsixArtifact {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BamlBridgePypi {
-    pub version: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SdkPackage {
     /// Registry the package was published to, e.g. `crates_io`.
     pub registry: String,
@@ -53,8 +48,6 @@ pub struct ToolchainManifest {
     pub artifacts: BTreeMap<String, Artifact>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vsix: Option<VsixArtifact>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub baml_bridge_pypi: Option<BamlBridgePypi>,
     /// Engine cdylib assets (`target -> {url, sha256}`), recorded for
     /// completeness. The dylib-loader SDKs construct these GitHub-release URLs
     /// directly, so the loader never consults the manifest for them; `default`
@@ -218,7 +211,6 @@ mod tests {
             released_at: "2026-07-14T00:00:00Z".to_string(),
             artifacts: full_target_artifacts(),
             vsix: None,
-            baml_bridge_pypi: None,
             cffi,
             sdks: None,
         }
@@ -250,6 +242,24 @@ mod tests {
             r#"{"schema":1,"version":"0.1.0","channel":"canary","released_at":"t","artifacts":{}}"#;
         let manifest: ToolchainManifest = serde_json::from_str(json).unwrap();
         assert!(manifest.cffi.is_none());
+    }
+
+    #[test]
+    fn legacy_bridge_metadata_deserializes() {
+        let json = r#"{
+            "schema": 1,
+            "version": "0.1.0",
+            "channel": "canary",
+            "released_at": "t",
+            "artifacts": {},
+            "baml_bridge_pypi": {"version": "0.1.0"},
+            "baml_bridge_go": {
+                "module": "github.com/boundaryml/baml-go",
+                "version": "v0.1.0"
+            }
+        }"#;
+        let manifest: ToolchainManifest = serde_json::from_str(json).unwrap();
+        assert!(manifest.sdks.is_none());
     }
 
     #[test]

--- a/scripts/baml-release-manifests
+++ b/scripts/baml-release-manifests
@@ -117,8 +117,8 @@ def main() -> None:
     parser.add_argument("--version", required=True)
     parser.add_argument("--released-at", required=True)
     parser.add_argument("--pypi-version", required=True)
-    # Registry coordinates are optional to keep this utility useful for partial
-    # fixture generation; the release workflow supplies every enabled SDK only
+    # Native SDK registry coordinates are optional to keep this utility useful
+    # for partial fixture generation; the release workflow supplies each one
     # after its publisher succeeds.
     parser.add_argument("--crates-io-version", default=None)
     parser.add_argument("--nuget-version", default=None)
@@ -185,19 +185,24 @@ def main() -> None:
             "url": artifact_url(f"baml-language-{args.version}", vsix),
             "sha256": sha256(vsix),
         },
-        "baml_bridge_pypi": {
-            "version": args.pypi_version,
-        },
-        "baml_bridge_go": {
-            "module": "github.com/boundaryml/baml-go",
-            "version": f"v{args.version}",
-        },
         "cffi": collect_cffi_artifacts(args.cffi_dir, args.version),
     }
-    # Generated-SDK registry coordinates are supplied only after the matching
-    # publisher succeeds. Native packages also bind the manifest to the digest
-    # of the exact pre-publication package exercised by their consumer gates.
-    sdks = {}
+    # Python and Go replace their legacy top-level manifest fields. Additional
+    # SDK coordinates are supplied after the matching publisher succeeds.
+    # Native packages also bind the manifest to the digest of the exact
+    # pre-publication package exercised by their consumer gates.
+    sdks = {
+        "go": {
+            "registry": "go",
+            "package": "github.com/boundaryml/baml-go",
+            "version": f"v{args.version}",
+        },
+        "python": {
+            "registry": "pypi",
+            "package": "baml-bridge",
+            "version": args.pypi_version,
+        },
+    }
     if args.crates_io_version:
         sdks["rust"] = {
             "registry": "crates_io",

--- a/scripts/smoke-go-release.py
+++ b/scripts/smoke-go-release.py
@@ -237,8 +237,12 @@ def main() -> None:
     if manifest.get("version") != version:
         fail(f"manifest version is {manifest.get('version')!r}, expected {version!r}")
 
-    go_release = manifest.get("baml_bridge_go")
-    expected_go_release = {"module": GO_MODULE, "version": f"v{version}"}
+    go_release = manifest.get("sdks", {}).get("go")
+    expected_go_release = {
+        "registry": "go",
+        "package": GO_MODULE,
+        "version": f"v{version}",
+    }
     if go_release != expected_go_release:
         fail(f"manifest Go release is {go_release!r}, expected {expected_go_release!r}")
 

--- a/scripts/tests/test_baml_release_manifests.py
+++ b/scripts/tests/test_baml_release_manifests.py
@@ -102,6 +102,24 @@ class ReleaseManifestTests(unittest.TestCase):
         self.assertEqual(first_manifest.read_bytes(), second_manifest.read_bytes())
         manifest = json.loads(first_manifest.read_text(encoding="utf-8"))
         self.assertEqual(manifest["released_at"], "2026-07-23T12:34:56Z")
+        self.assertNotIn("baml_bridge_go", manifest)
+        self.assertNotIn("baml_bridge_pypi", manifest)
+        self.assertEqual(
+            manifest["sdks"]["go"],
+            {
+                "registry": "go",
+                "package": "github.com/boundaryml/baml-go",
+                "version": "v1.2.3",
+            },
+        )
+        self.assertEqual(
+            manifest["sdks"]["python"],
+            {
+                "registry": "pypi",
+                "package": "baml-bridge",
+                "version": "1.2.3",
+            },
+        )
         self.assertEqual(
             manifest["sdks"]["csharp"],
             {


### PR DESCRIPTION
## What changed

- publish Go release coordinates as `sdks.go` using the standard `registry`, `package`, and `version` shape
- publish Python release coordinates as `sdks.python` using the same shape
- stop emitting the legacy top-level `baml_bridge_go` and `baml_bridge_pypi` fields
- update the Go publication gate and release smoke test to consume `sdks.go`
- remove the obsolete typed PyPI field while preserving deserialization of historical manifests

## Why

Go and Python package coordinates belong with the other generated SDK registry metadata under `sdks`. A single shape makes manifest production and downstream registry validation consistent across languages.

## Compatibility

Existing wrappers continue to deserialize historical manifests containing the legacy fields because unknown JSON fields are ignored. Existing wrappers also accept the new Go and Python SDK entries through the generic `SdkPackage` map.

## Validation

- `python3 -m unittest scripts.tests.test_baml_release_manifests`
- `python3 -m unittest scripts.tests.test_release_pipeline_contract`
- `cargo test --manifest-path baml_language/Cargo.toml -p baml_release`
- `cargo fmt --manifest-path baml_language/Cargo.toml --all -- --check`
- `actionlint .github/workflows/release-baml-language.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Standardized release manifests to describe Go and Python SDK packages consistently.
  - Added package registry, package name, and version details for clearer SDK release metadata.
  - Preserved compatibility with manifests using legacy bridge metadata.
  - Improved validation and smoke testing for Go and Python release information.
  - Continued support for CFFI artifacts and conditionally included native SDK registry coordinates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->