### PR TITLE
fix(compiler): literal patterns are membership tests, not `==` (B-1073)

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/emit.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/emit.rs
@@ -3507,6 +3507,20 @@ impl PullSink for StackifyCodegen<'_, '_> {
             // exhaustive final `let v: unknown` arm has its test elided.)
             TyTemplate::BuiltinUnknown { .. } => emit_true(self),
 
+            // ── Singleton (literal) ──────────────────────────────────────────
+            // A literal type is a set of one, so membership is decided against
+            // the value itself, not against a type tag: every tag a literal
+            // could name is its *base* type's, which answers `true` for every
+            // other inhabitant of that base (`x is One` matching every int when
+            // `type One = 1`). `ConstValue::Literal` is the exact test — the
+            // specialization of the `ConstValue::Type(Literal)` structural form
+            // the algebra would otherwise decide, minus the reconstruction.
+            TyTemplate::Literal(literal, _, _) => {
+                let c = self.add_constant(ConstValue::Literal(literal.clone()));
+                let inst = self.emit(Instruction::IsType(c));
+                self.set_operand(inst, OperandMeta::Const(literal.to_string()));
+            }
+
             // Fully realized leaves keep their exact identity/tag fast path,
             // then use structural matching when no exact fast path exists.
             // This list is exhaustive on purpose: a new template variant must
@@ -3518,7 +3532,6 @@ impl PullSink for StackifyCodegen<'_, '_> {
             | TyTemplate::Bool { .. }
             | TyTemplate::Null { .. }
             | TyTemplate::Uint8Array { .. }
-            | TyTemplate::Literal(..)
             | TyTemplate::Enum(..)
             | TyTemplate::EnumVariant(..)
             | TyTemplate::RustType { .. }
@@ -3717,13 +3730,13 @@ fn realized_type_tag(ty: &RealizedTy) -> Option<i64> {
         RealizedTy::Function { .. } => Some(baml_type::typetag::FUNCTION),
         RealizedTy::Type { .. } => Some(baml_type::typetag::TYPE),
         RealizedTy::Uint8Array { .. } => Some(baml_type::typetag::UINT8ARRAY),
-        RealizedTy::Literal(lit, _, _) => Some(match lit {
-            baml_base::Literal::Int(_) => baml_type::typetag::INT,
-            baml_base::Literal::Bigint(_) => baml_type::typetag::BIGINT,
-            baml_base::Literal::Float(_) => baml_type::typetag::FLOAT,
-            baml_base::Literal::String(_) => baml_type::typetag::STRING,
-            baml_base::Literal::Bool(_) => baml_type::typetag::BOOL,
-        }),
+        // A literal type has no type tag. Tags name base types, and a literal
+        // is a strict subset of its base, so its base's tag over-accepts every
+        // other inhabitant — `1` would admit any int. Literal membership is
+        // decided by `ConstValue::Literal` in `is_type` above, which never
+        // reaches here; returning `None` keeps that the only answer rather than
+        // leaving a wrong one for the next caller to find.
+        RealizedTy::Literal(..) => None,
         RealizedTy::Media(..)
         | RealizedTy::Class(..)
         | RealizedTy::Interface(..)

--- a/baml_language/crates/baml_compiler2_mir/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_mir/src/lower.rs
@@ -655,6 +655,22 @@ fn realized_leaf_template(ty: &RuntimeTy) -> TyTemplate {
     )
 }
 
+/// Whether every value of `ty` is a raw `int` — the precondition an integer
+/// `Switch` reads its discriminant under.
+///
+/// Int literals count: they are singleton subsets of `int`, so a switch over
+/// `1 | 2 | 3` needs no guard. A `bigint` or `float` does not, however close
+/// its values look in source — they are disjoint concrete types with their own
+/// runtime representations (`TYPE_SYSTEM.md` "Concrete Types").
+fn runtime_ty_is_int_only(ty: &RuntimeTy) -> bool {
+    match ty {
+        RuntimeTy::Int { .. } => true,
+        RuntimeTy::Literal(baml_type::Literal::Int(_), _, _) => true,
+        RuntimeTy::Union(members, _) => members.iter().all(runtime_ty_is_int_only),
+        _ => false,
+    }
+}
+
 /// Convert a TIR pattern type into a complete [`TyTemplate`], failing closed
 /// when a type variable has no runtime frame slot.
 fn tir2_to_pattern_template(
@@ -12804,6 +12820,25 @@ impl LoweringContext<'_> {
 
         // Emit the switch terminator in the entry block
         self.builder.set_current_block(bb_entry);
+        // An integer switch reads the scrutinee as a raw `int`. When the
+        // static type admits anything else — `int | float`, a union with a
+        // class — a non-int value reaching the switch is a *match failure*,
+        // not a broken invariant: it belongs to no arm, so it belongs to
+        // `otherwise`. Without the guard the VM raises a type error and the
+        // match aborts instead of falling through (B-1073). Provably int-only
+        // scrutinees, the overwhelmingly common case, keep the bare switch.
+        if matches!(switch_kind, Some(SwitchKind::Integer))
+            && !runtime_ty_is_int_only(&self.builder.local_ty(scrutinee))
+        {
+            let bb_switch = self.builder.create_block();
+            self.emit_is_type_tag_branch(
+                scrutinee,
+                baml_type::typetag::INT,
+                bb_switch,
+                bb_otherwise,
+            );
+            self.builder.set_current_block(bb_switch);
+        }
         self.builder.switch(
             switch_operand,
             switch_arms,
@@ -13689,18 +13724,27 @@ impl LoweringContext<'_> {
             // TypeExpr to recover OLD's per-kind codegen.
             AstPattern::Type(ty_expr) => match &ty_expr.kind {
                 AstTypeExprKind::Literal { value: lit, .. } => {
-                    let constant = Self::lower_literal(lit);
-                    let test = Rvalue::BinaryOp {
-                        op: BinOp::Eq,
-                        left: Operand::Copy(Place::Local(scrutinee)),
-                        right: Operand::Constant(constant),
-                    };
-                    let test_local = self.builder.temp(RuntimeTy::Bool {
-                        attr: TyAttr::default(),
-                    });
-                    self.builder.assign(Place::local(test_local), test);
-                    self.builder
-                        .branch(Operand::Copy(Place::Local(test_local)), success, failure);
+                    // A literal pattern is a membership test against a
+                    // singleton type, not an arithmetic equality: it asks
+                    // whether the value inhabits `{1}`, and `1`, `1.0` and `1n`
+                    // are disjoint types (TYPE_SYSTEM.md "Concrete Types").
+                    // Lowering it to
+                    // `BinOp::Eq` answered a different question — the `==`
+                    // operator widens across the numeric tower on purpose, so
+                    // the arm fired for `1.0` and every opcode downstream of the
+                    // narrowing then trusted an `int` it did not have (B-1073).
+                    // Routing through the same `IsType` relation every other
+                    // pattern kind uses keeps one definition of "matches".
+                    self.emit_is_type_branch(
+                        scrutinee,
+                        RuntimeTy::Literal(
+                            lit.clone(),
+                            baml_type::Freshness::Regular,
+                            TyAttr::default(),
+                        ),
+                        success,
+                        failure,
+                    );
                 }
                 AstTypeExprKind::Null { .. } => {
                     let test = Rvalue::BinaryOp {

--- a/baml_language/crates/baml_tests/baml_src/ns_literal_pattern_membership/literal_pattern_membership.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_literal_pattern_membership/literal_pattern_membership.baml
@@ -1,0 +1,112 @@
+// End-to-end tests for literal patterns as *membership* tests (B-1073).
+//
+// Matching `1` asks whether the value inhabits the singleton type `{1}`. The
+// type system holds `int`, `float` and `bigint` disjoint (TYPE_SYSTEM.md,
+// "Concrete Types":
+// no concrete type is a subtype of another), so no float and no bigint can
+// inhabit an int literal. The `==` operator deliberately widens across all
+// three -- that is what makes `1 + 1.0` work -- and literal patterns used to
+// lower onto it, so `x is 1` fired for `1.0`.
+//
+// The same construct has four lowerings, and the bug was that they disagreed:
+//
+//   * the `is` operator and any guarded match arm -- `BinOp::Eq`, which widened
+//   * a sparse int match -- the `SwitchKind::Integer` if-else chain, correct
+//   * a dense int match (>=4 arms) -- a `JumpTable`, which read the scrutinee
+//     as a raw int and raised a VM type error instead of falling through
+//   * `x is One` for `type One = 1` -- `IsType` against the literal's *base*
+//     type tag, which admitted every int
+//
+// All four now go through one relation, so each is exercised below against the
+// same value.
+
+// --- 1. the `is` operator ----------------------------------------------------
+
+function via_is(x: int | float) -> bool { x is 1 }
+
+test "is_matches_int_one" { assert.is_true(via_is(1)) }
+test "is_rejects_float_one" { assert.equal(via_is(1.0), false) }
+test "is_rejects_other_int" { assert.equal(via_is(2), false) }
+
+// --- 2. a guarded match arm (any guard disqualifies the jump table) ----------
+
+function via_guarded_match(x: int | float) -> bool {
+    match (x) {
+        1 if true => true
+        let _ => false
+    }
+}
+
+test "guarded_match_matches_int_one" { assert.is_true(via_guarded_match(1)) }
+test "guarded_match_rejects_float_one" { assert.equal(via_guarded_match(1.0), false) }
+
+// --- 3. a sparse int match (the if-else chain) -------------------------------
+
+function via_sparse_match(x: int | float) -> int {
+    match (x) {
+        1 => 1
+        2 => 2
+        let _ => 0
+    }
+}
+
+test "sparse_match_matches_int_one" { assert.equal(via_sparse_match(1), 1) }
+test "sparse_match_rejects_float_one" { assert.equal(via_sparse_match(1.0), 0) }
+
+// --- 4. a dense int match (the jump table) -----------------------------------
+//
+// A non-int scrutinee reaching an integer switch is a match *failure*, not a
+// broken invariant: it belongs to no arm, so it falls to `otherwise`. Before
+// the int-tag guard this aborted the whole match with a VM type error.
+
+function via_jump_table(x: int | float) -> int {
+    match (x) {
+        1 => 1
+        2 => 2
+        3 => 3
+        4 => 4
+        let _ => 0
+    }
+}
+
+test "jump_table_matches_int_one" { assert.equal(via_jump_table(1), 1) }
+test "jump_table_matches_int_four" { assert.equal(via_jump_table(4), 4) }
+test "jump_table_falls_through_on_float" { assert.equal(via_jump_table(1.0), 0) }
+test "jump_table_falls_through_on_unlisted_int" { assert.equal(via_jump_table(9), 0) }
+
+// --- 5. a literal reached through an alias (the `IsType` path) ---------------
+
+type One = 1
+
+function via_alias(x: int) -> bool { x is One }
+
+test "alias_matches_int_one" { assert.is_true(via_alias(1)) }
+test "alias_rejects_other_int" { assert.equal(via_alias(2), false) }
+
+// --- 6. the rest of the tower, and the non-numeric literals ------------------
+//
+// bigint and int are disjoint in both directions; bool is not an int however
+// it is represented; string literals compare by contents.
+
+function bigint_pattern(x: int | bigint) -> bool { x is 1n }
+function int_pattern_over_bigint(x: int | bigint) -> bool { x is 1 }
+function bool_pattern(x: int | bool) -> bool { x is true }
+function int_pattern_over_bool(x: int | bool) -> bool { x is 1 }
+
+function string_pattern(x: string) -> int {
+    match (x) {
+        "go" => 1
+        "stop" => 2
+        let _ => 0
+    }
+}
+
+test "bigint_literal_matches_bigint" { assert.is_true(bigint_pattern(1n)) }
+test "bigint_literal_rejects_int" { assert.equal(bigint_pattern(1), false) }
+test "int_literal_matches_int" { assert.is_true(int_pattern_over_bigint(1)) }
+test "int_literal_rejects_bigint" { assert.equal(int_pattern_over_bigint(1n), false) }
+test "bool_literal_matches_bool" { assert.is_true(bool_pattern(true)) }
+test "bool_literal_rejects_int" { assert.equal(bool_pattern(1), false) }
+test "int_literal_rejects_bool" { assert.equal(int_pattern_over_bool(true), false) }
+test "string_literal_matches_contents" { assert.equal(string_pattern("go"), 1) }
+test "string_literal_rejects_other" { assert.equal(string_pattern("nope"), 0) }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/_root.snap
@@ -431,6 +431,9 @@ function $init_test(registry: unknown) -> null {
     load_var ?1
     call ?
     pop 1
+    load_var ?1
+    call ?
+    pop 1
     load_const ?
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/closures.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/closures.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
-assertion_line: 149
 ---
 function closures.$init_test_ns_closures_closures(registry: testing.TestCollector) -> null {
     load_var registry
@@ -239,8 +238,7 @@ function closures.closures_bound_throwing_method_reference_catches_error() -> in
     call_indirect
     jump L2
     load_var e
-    load_const "negative"
-    cmp_op ==
+    is_type "negative"
     pop_jump_if_false L0
     jump L1
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/exceptions.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/exceptions.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
-assertion_line: 149
 ---
 function exceptions.$init_test_ns_exceptions_exceptions(registry: testing.TestCollector) -> null {
     load_var registry
@@ -827,29 +826,25 @@ function exceptions.catch_four_literal_arms_fn() -> int {
     call user.exceptions.s15_fails_lits
     jump L8
     load_var e
-    load_const "boom"
-    cmp_op ==
+    is_type "boom"
     pop_jump_if_false L0
     jump L7
 
   L0:
     load_var e
-    load_const "bang"
-    cmp_op ==
+    is_type "bang"
     pop_jump_if_false L1
     jump L6
 
   L1:
     load_var e
-    load_const "crash"
-    cmp_op ==
+    is_type "crash"
     pop_jump_if_false L2
     jump L5
 
   L2:
     load_var e
-    load_const "other"
-    cmp_op ==
+    is_type "other"
     pop_jump_if_false L3
     jump L4
 
@@ -1171,6 +1166,9 @@ function exceptions.catch_literal_int_match_fn() -> int {
     call user.exceptions.s1_fails_3
     jump L2
     load_var e
+    is_type type tag 0
+    pop_jump_if_false L0
+    load_var e
     load_const 42
     cmp_int_op ==
     pop_jump_if_false L0
@@ -1193,8 +1191,7 @@ function exceptions.catch_literal_string_match_fn() -> int {
     call user.exceptions.s1_fails_1
     jump L2
     load_var e
-    load_const "boom"
-    cmp_op ==
+    is_type "boom"
     pop_jump_if_false L0
     jump L1
 
@@ -1215,8 +1212,7 @@ function exceptions.catch_literal_string_no_match_falls_to_wildcard_fn() -> int 
     call user.exceptions.s1_fails_2
     jump L2
     load_var e
-    load_const "boom"
-    cmp_op ==
+    is_type "boom"
     pop_jump_if_false L0
     jump L1
 
@@ -1258,8 +1254,7 @@ function exceptions.catch_mixed_literal_and_typed_no_switch_fn() -> int {
     call user.exceptions.s16_fails_lit_typed
     jump L4
     load_var e
-    load_const "boom"
-    cmp_op ==
+    is_type "boom"
     pop_jump_if_false L0
     jump L3
 
@@ -1351,15 +1346,13 @@ function exceptions.catch_multiple_literals_dispatch_fn() -> int {
     call user.exceptions.s1_fails_4
     jump L4
     load_var e
-    load_const "alpha"
-    cmp_op ==
+    is_type "alpha"
     pop_jump_if_false L0
     jump L3
 
   L0:
     load_var e
-    load_const "beta"
-    cmp_op ==
+    is_type "beta"
     pop_jump_if_false L1
     jump L2
 
@@ -2320,8 +2313,7 @@ function exceptions.named_wrapper_value_catches_callback_throw_fn() -> string {
     call user.exceptions.s17_forward_cb
     jump L2
     load_var e
-    load_const "boom"
-    cmp_op ==
+    is_type "boom"
     pop_jump_if_false L0
     jump L1
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/generic_match_rigid.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/generic_match_rigid.snap
@@ -395,15 +395,13 @@ function generic_match_rigid.pick_mixed_union(x: #0 | bool) -> string {
 
   L1:
     load_var x
-    load_const true
-    cmp_op ==
+    is_type true
     pop_jump_if_false L2
     jump L3
 
   L2:
     load_var x
-    load_const false
-    cmp_op ==
+    is_type false
     pop_jump_if_false L6
     load_const "f"
     jump L5
@@ -557,8 +555,7 @@ function generic_match_rigid.rigid_cell_split(c: generic_match_rigid.RigidCell<i
     pop_jump_if_false L0
     load_var c
     load_field .v
-    load_const 1
-    cmp_op ==
+    is_type 1
     pop_jump_if_false L0
     jump L1
 
@@ -624,8 +621,7 @@ function generic_match_rigid.rigid_row_split(r: generic_match_rigid.RigidRow) ->
     pop_jump_if_false L0
     load_var r
     load_field .n
-    load_const 1
-    cmp_int_op ==
+    is_type 1
     pop_jump_if_false L0
     jump L1
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/interfaces.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/interfaces.snap
@@ -3611,8 +3611,7 @@ function interfaces.fz29_main() -> string {
 
 function interfaces.fz31_main() -> string {
     load_const true
-    load_const true
-    cmp_op ==
+    is_type true
     pop_jump_if_false L0
     jump L1
 
@@ -4446,8 +4445,7 @@ function interfaces.midr_describe(s: interfaces.MidrSwitch) -> string {
     load_var s
     load_type interfaces.MidrSwitch
     virtual_load_field .active
-    load_const true
-    cmp_op ==
+    is_type true
     pop_jump_if_false L0
     jump L1
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/is_operator.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/is_operator.snap
@@ -597,8 +597,7 @@ function is_operator.is_bare_binding_pattern_matches_fn() -> bool {
 
 function is_operator.is_bool_literal_pattern_false_fn() -> bool {
     load_const true
-    load_const false
-    cmp_op ==
+    is_type false
     pop_jump_if_false L0
     jump L1
 
@@ -615,8 +614,7 @@ function is_operator.is_bool_literal_pattern_false_fn() -> bool {
 
 function is_operator.is_bool_literal_pattern_true_fn() -> bool {
     load_const true
-    load_const true
-    cmp_op ==
+    is_type true
     pop_jump_if_false L0
     jump L1
 
@@ -1141,8 +1139,7 @@ function is_operator.is_inside_while_condition_fn() -> int {
 
 function is_operator.is_int_literal_pattern_mismatch_fn() -> bool {
     load_const 5
-    load_const 0
-    cmp_int_op ==
+    is_type 0
     pop_jump_if_false L0
     jump L1
 
@@ -1159,8 +1156,7 @@ function is_operator.is_int_literal_pattern_mismatch_fn() -> bool {
 
 function is_operator.is_int_literal_pattern_zero_fn() -> bool {
     load_const 0
-    load_const 0
-    cmp_int_op ==
+    is_type 0
     pop_jump_if_false L0
     jump L1
 
@@ -1322,22 +1318,19 @@ function is_operator.is_or_pattern_parenthesised_alternatives_fn() -> bool {
 
 function is_operator.is_or_pattern_with_literals_fn() -> bool {
     load_const 2
-    load_const 1
-    cmp_int_op ==
+    is_type 1
     pop_jump_if_false L0
     jump L3
 
   L0:
     load_const 2
-    load_const 2
-    cmp_int_op ==
+    is_type 2
     pop_jump_if_false L1
     jump L3
 
   L1:
     load_const 2
-    load_const 3
-    cmp_int_op ==
+    is_type 3
     pop_jump_if_false L2
     jump L3
 
@@ -1371,8 +1364,7 @@ function is_operator.is_pattern_disjoint_from_scrutinee_type_returns_false_fn() 
 
 function is_operator.is_string_literal_pattern_match_fn() -> bool {
     load_const "hello"
-    load_const "hello"
-    cmp_op ==
+    is_type "hello"
     pop_jump_if_false L0
     jump L1
 
@@ -1389,8 +1381,7 @@ function is_operator.is_string_literal_pattern_match_fn() -> bool {
 
 function is_operator.is_string_literal_pattern_mismatch_fn() -> bool {
     load_const "world"
-    load_const "hello"
-    cmp_op ==
+    is_type "hello"
     pop_jump_if_false L0
     jump L1
 
@@ -1693,8 +1684,7 @@ function is_operator.narrowing_else_branch_with_class_types_fn() -> string {
 
 function is_operator.narrowing_else_branch_with_literal_pattern_keeps_original_fn() -> int {
     load_const 5
-    load_const 0
-    cmp_int_op ==
+    is_type 0
     pop_jump_if_false L0
     jump L1
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lambdas.snap
@@ -426,8 +426,7 @@ function lambdas.lambdas_explicit_throwing_lambda_catches_error() -> int {
     call_indirect
     jump L2
     load_var e
-    load_const "negative"
-    cmp_op ==
+    is_type "negative"
     pop_jump_if_false L0
     jump L1
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/lexical_scoping.snap
@@ -253,8 +253,7 @@ function lexical_scoping.catch_base_uses_outer_lambda() -> int {
 
   L2:
     load_var caught
-    load_const "base"
-    cmp_op ==
+    is_type "base"
     pop_jump_if_false L3
     jump L4
 
@@ -420,8 +419,9 @@ function lexical_scoping.match_and_catch_main() -> int {
 
 function lexical_scoping.match_later_arm_uses_outer() -> int {
     load_const "value"
-    load_const "specific"
-    cmp_op ==
+    store_var _3
+    load_var _3
+    narrow_bind "specific", slot=1
     pop_jump_if_false L0
     jump L1
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/literal_pattern_membership.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/literal_pattern_membership.snap
@@ -1,0 +1,371 @@
+---
+source: crates/baml_tests/tests/baml_src.rs
+---
+function literal_pattern_membership.$init_test_ns_literal_pattern_membership_literal_pattern_membership(registry: testing.TestCollector) -> null {
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "is_matches_int_one"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 0)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "is_rejects_float_one"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 1)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "is_rejects_other_int"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 2)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "guarded_match_matches_int_one"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 3)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "guarded_match_rejects_float_one"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 4)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "sparse_match_matches_int_one"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 5)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "sparse_match_rejects_float_one"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 6)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "jump_table_matches_int_one"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 7)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "jump_table_matches_int_four"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 8)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "jump_table_falls_through_on_float"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 9)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "jump_table_falls_through_on_unlisted_int"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 10)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "alias_matches_int_one"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 11)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "alias_rejects_other_int"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 12)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "bigint_literal_matches_bigint"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 13)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "bigint_literal_rejects_int"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 14)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "int_literal_matches_int"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 15)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "int_literal_rejects_bigint"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 16)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "bool_literal_matches_bool"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 17)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "bool_literal_rejects_int"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 18)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "int_literal_rejects_bool"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 19)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "string_literal_matches_contents"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 20)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_var registry
+    load_const "root.literal_pattern_membership"
+    load_const "string_literal_rejects_other"
+    make_closure .<lambda($init_test_ns_literal_pattern_membership_literal_pattern_membership, 21)>, 0
+    load_const null
+    call testing.TestCollector.register_test_at
+    pop 1
+    load_const null
+    return
+}
+
+function literal_pattern_membership.bigint_pattern(x: int | bigint) -> bool {
+    load_var x
+    is_type 1n
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    jump L2
+
+  L1:
+    load_const true
+
+  L2:
+    return
+}
+
+function literal_pattern_membership.bool_pattern(x: int | bool) -> bool {
+    load_var x
+    is_type true
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    jump L2
+
+  L1:
+    load_const true
+
+  L2:
+    return
+}
+
+function literal_pattern_membership.int_pattern_over_bigint(x: int | bigint) -> bool {
+    load_var x
+    is_type 1
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    jump L2
+
+  L1:
+    load_const true
+
+  L2:
+    return
+}
+
+function literal_pattern_membership.int_pattern_over_bool(x: int | bool) -> bool {
+    load_var x
+    is_type 1
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    jump L2
+
+  L1:
+    load_const true
+
+  L2:
+    return
+}
+
+function literal_pattern_membership.string_pattern(x: string) -> int {
+    load_var x
+    is_type "go"
+    pop_jump_if_false L0
+    jump L3
+
+  L0:
+    load_var x
+    is_type "stop"
+    pop_jump_if_false L1
+    jump L2
+
+  L1:
+    load_const 0
+    jump L4
+
+  L2:
+    load_const 2
+    jump L4
+
+  L3:
+    load_const 1
+
+  L4:
+    return
+}
+
+function literal_pattern_membership.via_alias(x: int) -> bool {
+    load_var x
+    is_type 1
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    jump L2
+
+  L1:
+    load_const true
+
+  L2:
+    return
+}
+
+function literal_pattern_membership.via_guarded_match(x: int | float) -> bool {
+    load_var x
+    is_type 1
+    pop_jump_if_false L0
+    load_const true
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    jump L2
+
+  L1:
+    load_const true
+
+  L2:
+    return
+}
+
+function literal_pattern_membership.via_is(x: int | float) -> bool {
+    load_var x
+    is_type 1
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    jump L2
+
+  L1:
+    load_const true
+
+  L2:
+    return
+}
+
+function literal_pattern_membership.via_jump_table(x: int | float) -> int {
+    load_var x
+    is_type type tag 0
+    pop_jump_if_false L0
+    load_var x
+    jump_table [L4, L3, L2, L1], default L0
+
+  L0:
+    load_const 0
+    jump L5
+
+  L1: 4
+    load_const 4
+    jump L5
+
+  L2: 3
+    load_const 3
+    jump L5
+
+  L3: 2
+    load_const 2
+    jump L5
+
+  L4: 1
+    load_const 1
+
+  L5:
+    return
+}
+
+function literal_pattern_membership.via_sparse_match(x: int | float) -> int {
+    load_var x
+    is_type type tag 0
+    pop_jump_if_false L1
+    load_var x
+    load_const 1
+    cmp_int_op ==
+    pop_jump_if_false L0
+    jump L3
+
+  L0:
+    load_var x
+    load_const 2
+    cmp_int_op ==
+    pop_jump_if_false L1
+    jump L2
+
+  L1:
+    load_const 0
+    jump L4
+
+  L2:
+    load_const 2
+    jump L4
+
+  L3:
+    load_const 1
+
+  L4:
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/match_basics.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/match_basics.snap
@@ -355,8 +355,7 @@ function match_basics.catch_all_with_variable() -> int {
 
 function match_basics.check_bool(flag: bool) -> string {
     load_var flag
-    load_const true
-    cmp_op ==
+    is_type true
     pop_jump_if_false L0
     jump L1
 
@@ -424,15 +423,13 @@ function match_basics.classify_dense(n: int) -> int {
 
 function match_basics.classify_string(s: string) -> int {
     load_var s
-    load_const "hello"
-    cmp_op ==
+    is_type "hello"
     pop_jump_if_false L0
     jump L3
 
   L0:
     load_var s
-    load_const "world"
-    cmp_op ==
+    is_type "world"
     pop_jump_if_false L1
     jump L2
 
@@ -453,29 +450,25 @@ function match_basics.classify_string(s: string) -> int {
 
 function match_basics.classify_string_four_arms(s: string) -> int {
     load_var s
-    load_const "a"
-    cmp_op ==
+    is_type "a"
     pop_jump_if_false L0
     jump L7
 
   L0:
     load_var s
-    load_const "b"
-    cmp_op ==
+    is_type "b"
     pop_jump_if_false L1
     jump L6
 
   L1:
     load_var s
-    load_const "c"
-    cmp_op ==
+    is_type "c"
     pop_jump_if_false L2
     jump L5
 
   L2:
     load_var s
-    load_const "d"
-    cmp_op ==
+    is_type "d"
     pop_jump_if_false L3
     jump L4
 
@@ -504,29 +497,25 @@ function match_basics.classify_string_four_arms(s: string) -> int {
 
 function match_basics.classify_string_many(s: string) -> int {
     load_var s
-    load_const "alpha"
-    cmp_op ==
+    is_type "alpha"
     pop_jump_if_false L0
     jump L7
 
   L0:
     load_var s
-    load_const "beta"
-    cmp_op ==
+    is_type "beta"
     pop_jump_if_false L1
     jump L6
 
   L1:
     load_var s
-    load_const "gamma"
-    cmp_op ==
+    is_type "gamma"
     pop_jump_if_false L2
     jump L5
 
   L2:
     load_var s
-    load_const "delta"
-    cmp_op ==
+    is_type "delta"
     pop_jump_if_false L3
     jump L4
 
@@ -555,15 +544,13 @@ function match_basics.classify_string_many(s: string) -> int {
 
 function match_basics.classify_string_typed_fallback(s: string) -> int {
     load_var s
-    load_const "ok"
-    cmp_op ==
+    is_type "ok"
     pop_jump_if_false L0
     jump L3
 
   L0:
     load_var s
-    load_const "error"
-    cmp_op ==
+    is_type "error"
     pop_jump_if_false L1
     jump L2
 
@@ -665,8 +652,7 @@ function match_basics.helper_42() -> int {
 
 function match_basics.literal_bool_false() -> string {
     load_const false
-    load_const true
-    cmp_op ==
+    is_type true
     pop_jump_if_false L0
     jump L1
 
@@ -683,8 +669,7 @@ function match_basics.literal_bool_false() -> string {
 
 function match_basics.literal_bool_true() -> string {
     load_const true
-    load_const true
-    cmp_op ==
+    is_type true
     pop_jump_if_false L0
     jump L1
 
@@ -1008,8 +993,7 @@ function match_basics.process_optional_with_zero(x: int | null) -> string {
 
   L0:
     load_var x
-    load_const 0
-    cmp_op ==
+    is_type 0
     pop_jump_if_false L1
     jump L2
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/match_types.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/match_types.snap
@@ -232,8 +232,7 @@ function match_types.all_guarded_main() -> string {
 
 function match_types.classify_all_guarded(x: int, flag: bool) -> string {
     load_var x
-    load_const 0
-    cmp_int_op ==
+    is_type 0
     pop_jump_if_false L0
     load_var flag
     pop_jump_if_false L0
@@ -241,8 +240,7 @@ function match_types.classify_all_guarded(x: int, flag: bool) -> string {
 
   L0:
     load_var x
-    load_const 1
-    cmp_int_op ==
+    is_type 1
     pop_jump_if_false L1
     load_var flag
     pop_jump_if_false L1
@@ -250,8 +248,7 @@ function match_types.classify_all_guarded(x: int, flag: bool) -> string {
 
   L1:
     load_var x
-    load_const 2
-    cmp_int_op ==
+    is_type 2
     pop_jump_if_false L2
     load_var flag
     pop_jump_if_false L2
@@ -391,8 +388,7 @@ function match_types.classify_guard_on_typed_field(result: match_types.Success |
 
 function match_types.classify_guarded_int(x: int, flag: bool) -> string {
     load_var x
-    load_const 1
-    cmp_int_op ==
+    is_type 1
     pop_jump_if_false L0
     load_var flag
     pop_jump_if_false L0
@@ -400,15 +396,13 @@ function match_types.classify_guarded_int(x: int, flag: bool) -> string {
 
   L0:
     load_var x
-    load_const 1
-    cmp_int_op ==
+    is_type 1
     pop_jump_if_false L1
     jump L4
 
   L1:
     load_var x
-    load_const 2
-    cmp_int_op ==
+    is_type 2
     pop_jump_if_false L2
     jump L3
 
@@ -476,15 +470,13 @@ function match_types.classify_mixed_class_primitive(x: match_types.MyClass | int
 
 function match_types.classify_mixed_lit_typed_guard(x: int, flag: bool) -> string {
     load_var x
-    load_const 0
-    cmp_int_op ==
+    is_type 0
     pop_jump_if_false L0
     jump L3
 
   L0:
     load_var x
-    load_const 1
-    cmp_int_op ==
+    is_type 1
     pop_jump_if_false L1
     load_var flag
     pop_jump_if_false L1

--- a/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/patterns_new_runtime.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/tests/baml_src.rs
-assertion_line: 152
 ---
 function patterns_new_runtime.$init_test_ns_patterns_new_runtime_patterns_new_runtime(registry: testing.TestCollector) -> null {
     load_var registry
@@ -1085,8 +1084,7 @@ function patterns_new_runtime.match_coord_user() -> int {
     pop_jump_if_false L0
     load_var _10
     load_field .zip
-    load_const 11111
-    cmp_int_op ==
+    is_type 11111
     pop_jump_if_false L0
     jump L1
 
@@ -1111,8 +1109,7 @@ function patterns_new_runtime.match_person_as(p: patterns_new_runtime.PersonAS) 
     pop_jump_if_false L0
     load_var p
     load_field .age
-    load_const 7
-    cmp_int_op ==
+    is_type 7
     pop_jump_if_false L0
     jump L1
 
@@ -1155,8 +1152,7 @@ function patterns_new_runtime.or_deep_class() -> int {
     pop_jump_if_false L0
     load_var _7
     load_field .plus4
-    load_const 1
-    cmp_int_op ==
+    is_type 1
     pop_jump_if_false L0
     jump L3
 
@@ -1182,8 +1178,7 @@ function patterns_new_runtime.or_deep_class() -> int {
     pop_jump_if_false L1
     load_var _19
     load_field .plus4
-    load_const 2
-    cmp_int_op ==
+    is_type 2
     pop_jump_if_false L1
     jump L2
 
@@ -1867,8 +1862,7 @@ function patterns_new_runtime.score_bool_slice(xs: bool[]) -> int {
     load_var xs
     load_const 0
     load_array_element
-    load_const true
-    cmp_op ==
+    is_type true
     pop_jump_if_false L0
     jump L5
 
@@ -1889,8 +1883,7 @@ function patterns_new_runtime.score_bool_slice(xs: bool[]) -> int {
     load_const 1
     sub_int
     load_array_element
-    load_const false
-    cmp_op ==
+    is_type false
     pop_jump_if_false L1
     jump L4
 
@@ -2039,8 +2032,7 @@ function patterns_new_runtime.score_foo3(f: patterns_new_runtime.Foo3) -> int {
     pop_jump_if_false L0
     load_var f
     load_field .first
-    load_const true
-    cmp_op ==
+    is_type true
     pop_jump_if_false L0
     load_var f
     load_field .second
@@ -2055,8 +2047,7 @@ function patterns_new_runtime.score_foo3(f: patterns_new_runtime.Foo3) -> int {
     pop_jump_if_false L1
     load_var f
     load_field .first
-    load_const true
-    cmp_op ==
+    is_type true
     pop_jump_if_false L1
     load_var f
     load_field .second
@@ -2070,8 +2061,7 @@ function patterns_new_runtime.score_foo3(f: patterns_new_runtime.Foo3) -> int {
     pop_jump_if_false L2
     load_var f
     load_field .first
-    load_const false
-    cmp_op ==
+    is_type false
     pop_jump_if_false L2
     load_var f
     load_field .second
@@ -2143,15 +2133,13 @@ function patterns_new_runtime.score_int_optional(x: int | null) -> int {
 
   L0:
     load_var x
-    load_const 0
-    cmp_op ==
+    is_type 0
     pop_jump_if_false L1
     jump L4
 
   L1:
     load_var x
-    load_const 1
-    cmp_op ==
+    is_type 1
     pop_jump_if_false L2
     jump L3
 
@@ -2221,14 +2209,12 @@ function patterns_new_runtime.score_ints(xs: int[]) -> int {
     load_var xs
     load_const 0
     load_array_element
-    load_const 1
-    cmp_int_op ==
+    is_type 1
     pop_jump_if_false L0
     load_var xs
     load_const 1
     load_array_element
-    load_const 2
-    cmp_int_op ==
+    is_type 2
     pop_jump_if_false L0
     jump L3
 
@@ -2245,8 +2231,7 @@ function patterns_new_runtime.score_ints(xs: int[]) -> int {
     load_var xs
     load_const 0
     load_array_element
-    load_const 1
-    cmp_int_op ==
+    is_type 1
     pop_jump_if_false L1
     jump L2
 
@@ -2550,30 +2535,26 @@ function patterns_new_runtime.score_pair_or(p: patterns_new_runtime.PairAB) -> i
     load_var p
     load_field .a
     store_var_load_var _3
-    load_const 0
-    cmp_int_op ==
+    is_type 0
     pop_jump_if_false L0
     jump L1
 
   L0:
     load_var _3
-    load_const 1
-    cmp_int_op ==
+    is_type 1
     pop_jump_if_false L3
 
   L1:
     load_var p
     load_field .b
     store_var_load_var _6
-    load_const 2
-    cmp_int_op ==
+    is_type 2
     pop_jump_if_false L2
     jump L4
 
   L2:
     load_var _6
-    load_const 3
-    cmp_int_op ==
+    is_type 3
     pop_jump_if_false L3
     jump L4
 
@@ -4471,8 +4452,7 @@ function patterns_new_runtime.test_match_class_binds_inner_zip() -> int {
     pop_jump_if_false L0
     load_var _7
     load_field .zip
-    load_const 1
-    cmp_int_op ==
+    is_type 1
     pop_jump_if_false L0
     jump L1
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____04_5_mir.snap
@@ -1515,62 +1515,62 @@ fn ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     }
 
     bb9: {
-        _12 = copy _5 == const "openai";
+        _12 = is_type(copy _5, "openai");
         branch copy _12 -> [bb33, bb10];
     }
 
     bb10: {
-        _14 = copy _5 == const "openai-chat";
+        _14 = is_type(copy _5, "openai-chat");
         branch copy _14 -> [bb32, bb11];
     }
 
     bb11: {
-        _16 = copy _5 == const "openai-images";
+        _16 = is_type(copy _5, "openai-images");
         branch copy _16 -> [bb31, bb12];
     }
 
     bb12: {
-        _18 = copy _5 == const "azure";
+        _18 = is_type(copy _5, "azure");
         branch copy _18 -> [bb30, bb13];
     }
 
     bb13: {
-        _20 = copy _5 == const "ollama";
+        _20 = is_type(copy _5, "ollama");
         branch copy _20 -> [bb29, bb14];
     }
 
     bb14: {
-        _22 = copy _5 == const "openrouter";
+        _22 = is_type(copy _5, "openrouter");
         branch copy _22 -> [bb28, bb15];
     }
 
     bb15: {
-        _24 = copy _5 == const "anthropic";
+        _24 = is_type(copy _5, "anthropic");
         branch copy _24 -> [bb27, bb16];
     }
 
     bb16: {
-        _26 = copy _5 == const "google";
+        _26 = is_type(copy _5, "google");
         branch copy _26 -> [bb26, bb17];
     }
 
     bb17: {
-        _28 = copy _5 == const "vertex";
+        _28 = is_type(copy _5, "vertex");
         branch copy _28 -> [bb25, bb18];
     }
 
     bb18: {
-        _30 = copy _5 == const "bedrock";
+        _30 = is_type(copy _5, "bedrock");
         branch copy _30 -> [bb24, bb19];
     }
 
     bb19: {
-        _32 = copy _5 == const "ai-gateway-images";
+        _32 = is_type(copy _5, "ai-gateway-images");
         branch copy _32 -> [bb23, bb20];
     }
 
     bb20: {
-        _34 = copy _5 == const "claude-code";
+        _34 = is_type(copy _5, "claude-code");
         branch copy _34 -> [bb22, bb21];
     }
 
@@ -7977,17 +7977,17 @@ fn ai.Agent._media_value(self: ai.Agent, turn: ai.ModelTurn, provider: string) -
 
     bb10: {
         _13 = copy _14;
-        _20 = copy _7 == const "mixedlist";
+        _20 = is_type(copy _7, "mixedlist");
         branch copy _20 -> [bb55, bb11];
     }
 
     bb11: {
-        _22 = copy _7 == const "mixed";
+        _22 = is_type(copy _7, "mixed");
         branch copy _22 -> [bb39, bb12];
     }
 
     bb12: {
-        _47 = copy _7 == const "list";
+        _47 = is_type(copy _7, "list");
         branch copy _47 -> [bb36, bb13];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__ai_std__/baml_tests__compiles____ai_std____06_codegen.snap
@@ -841,22 +841,19 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
     load_var _14
     store_var kind
     load_var form
-    load_const "mixedlist"
-    cmp_op ==
+    is_type "mixedlist"
     pop_jump_if_false L2
     jump L22
 
   L2:
     load_var form
-    load_const "mixed"
-    cmp_op ==
+    is_type "mixed"
     pop_jump_if_false L3
     jump L14
 
   L3:
     load_var form
-    load_const "list"
-    cmp_op ==
+    is_type "list"
     pop_jump_if_false L4
     jump L13
 
@@ -2573,85 +2570,73 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     call baml.String.slice
     store_var model
     load_var prefix
-    load_const "openai"
-    cmp_op ==
+    is_type "openai"
     pop_jump_if_false L2
     jump L25
 
   L2:
     load_var prefix
-    load_const "openai-chat"
-    cmp_op ==
+    is_type "openai-chat"
     pop_jump_if_false L3
     jump L24
 
   L3:
     load_var prefix
-    load_const "openai-images"
-    cmp_op ==
+    is_type "openai-images"
     pop_jump_if_false L4
     jump L23
 
   L4:
     load_var prefix
-    load_const "azure"
-    cmp_op ==
+    is_type "azure"
     pop_jump_if_false L5
     jump L22
 
   L5:
     load_var prefix
-    load_const "ollama"
-    cmp_op ==
+    is_type "ollama"
     pop_jump_if_false L6
     jump L21
 
   L6:
     load_var prefix
-    load_const "openrouter"
-    cmp_op ==
+    is_type "openrouter"
     pop_jump_if_false L7
     jump L20
 
   L7:
     load_var prefix
-    load_const "anthropic"
-    cmp_op ==
+    is_type "anthropic"
     pop_jump_if_false L8
     jump L19
 
   L8:
     load_var prefix
-    load_const "google"
-    cmp_op ==
+    is_type "google"
     pop_jump_if_false L9
     jump L18
 
   L9:
     load_var prefix
-    load_const "vertex"
-    cmp_op ==
+    is_type "vertex"
     pop_jump_if_false L10
     jump L17
 
   L10:
     load_var prefix
-    load_const "bedrock"
-    cmp_op ==
+    is_type "bedrock"
     pop_jump_if_false L11
     jump L16
 
   L11:
     load_var prefix
-    load_const "ai-gateway-images"
-    cmp_op ==
+    is_type "ai-gateway-images"
     pop_jump_if_false L12
     jump L15
 
   L12:
     load_var prefix
-    load_const "claude-code"
-    cmp_op ==
+    is_type "claude-code"
     pop_jump_if_false L13
     jump L14
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__04_5_mir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 9761
 ---
 === MIR2 ===
 fn user.Sized.size(_1: void) -> void {
@@ -144,7 +143,7 @@ fn user.field_into_switch(item: T) -> int {
 
     bb0: {
         _2 = copy _1.name#0 as Named;
-        _3 = copy _2 == const "a";
+        _3 = is_type(copy _2, "a");
         branch copy _3 -> [bb2, bb1];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/generic_intersection_bounds/baml_tests__compiles__generic_intersection_bounds__06_codegen.snap
@@ -63,8 +63,7 @@ function user.field_into_switch(item: #0) -> int {
     load_var item
     load_type Named
     virtual_load_field .name
-    load_const "a"
-    cmp_op ==
+    is_type "a"
     pop_jump_if_false L0
     jump L1
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/is_operator/baml_tests__compiles__is_operator__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/is_operator/baml_tests__compiles__is_operator__04_5_mir.snap
@@ -188,7 +188,7 @@ fn user.is_zero(n: int) -> bool {
     let _2: bool
 
     bb0: {
-        _2 = copy _1 == const 0_i64;
+        _2 = is_type(copy _1, 0);
         branch copy _2 -> [bb2, bb1];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/is_operator/baml_tests__compiles__is_operator__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/is_operator/baml_tests__compiles__is_operator__06_codegen.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 10715
 ---
 function user.both_ints(a: int | string, b: int | string) -> bool {
     load_var a
@@ -122,8 +121,7 @@ function user.is_not_string(v: int | string) -> bool {
 
 function user.is_zero(n: int) -> bool {
     load_var n
-    load_const 0
-    cmp_int_op ==
+    is_type 0
     pop_jump_if_false L0
     jump L1
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__04_5_mir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 12948
 ---
 === MIR2 ===
 fn user.test_chained_map() -> int[] {
@@ -1222,12 +1221,12 @@ fn user.test_lambda_in_match_inferred() -> int {
 
     bb0: {
         _1 = const "double";
-        _3 = copy _1 == const "double";
+        _3 = is_type(copy _1, "double");
         branch copy _3 -> [bb4, bb1];
     }
 
     bb1: {
-        _4 = copy _1 == const "negate";
+        _4 = is_type(copy _1, "negate");
         branch copy _4 -> [bb3, bb2];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/lambda_advanced/baml_tests__compiles__lambda_advanced__06_codegen.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 13492
 ---
 function user.test_apply_twice_inferred() -> int {
     make_closure .<lambda(test_apply_twice_inferred, 0)>, 0
@@ -171,15 +170,13 @@ function user.test_lambda_calling_lambda() -> int {
 
 function user.test_lambda_in_match_inferred() -> int {
     load_const "double"
-    load_const "double"
-    cmp_op ==
+    is_type "double"
     pop_jump_if_false L0
     jump L3
 
   L0:
     load_const "double"
-    load_const "negate"
-    cmp_op ==
+    is_type "negate"
     pop_jump_if_false L1
     jump L2
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_class_destructure_namespaces/baml_tests__compiles__patterns_class_destructure_namespaces__04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_class_destructure_namespaces/baml_tests__compiles__patterns_class_destructure_namespaces__04_5_mir.snap
@@ -42,7 +42,7 @@ fn user.DestructureQualifiedMatch() -> int {
 
     bb1: {
         _3 = copy _1.1;
-        _4 = copy _3 == const 0_i64;
+        _4 = is_type(copy _3, 0);
         branch copy _4 -> [bb3, bb2];
     }
 
@@ -103,7 +103,7 @@ fn user.DestructureNamespaceQualifiedMatch() -> int {
 
     bb1: {
         _3 = copy _1.1;
-        _4 = copy _3 == const 0_i64;
+        _4 = is_type(copy _3, 0);
         branch copy _4 -> [bb3, bb2];
     }
 

--- a/baml_language/crates/baml_tests/snapshots/compiles/patterns_class_destructure_namespaces/baml_tests__compiles__patterns_class_destructure_namespaces__06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/patterns_class_destructure_namespaces/baml_tests__compiles__patterns_class_destructure_namespaces__06_codegen.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 21269
 ---
 function user.DeepGenericDestructureNamespaceQualifiedLet() -> int {
     load_const "done"
@@ -42,8 +41,7 @@ function user.DestructureNamespaceQualifiedMatch() -> int {
     pop_jump_if_false L0
     load_var response
     load_field .score
-    load_const 0
-    cmp_int_op ==
+    is_type 0
     pop_jump_if_false L0
     jump L1
 
@@ -76,8 +74,7 @@ function user.DestructureQualifiedMatch() -> int {
     pop_jump_if_false L0
     load_var response
     load_field .score
-    load_const 0
-    cmp_int_op ==
+    is_type 0
     pop_jump_if_false L0
     jump L1
 

--- a/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__sweep__s15_sweep_baml_src.snap
+++ b/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__sweep__s15_sweep_baml_src.snap
@@ -2,8 +2,8 @@
 source: crates/baml_tests/src/type_spec/sweep.rs
 expression: report
 ---
-files: 143
-typed nodes: 85350
+files: 144
+typed nodes: 85615
 hir_ty error-channel entries: 0
 panics: 0
 

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -202,7 +202,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         169   load_type 1                                
         170   load_var2 1 2                              
         171   load_var 5                                 (j)
-        172   make_closure 2266 captures=3 ntypeargs=1   
+        172   make_closure 2263 captures=3 ntypeargs=1   
         173   call 16 ntypeargs=3                        (baml.Array.map)
         174   store_var 14                               (futures)
 
@@ -251,7 +251,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         211   load_var 11                                (calls)
         212   load_type 1                                
         213   load_var 20                                (f)
-        214   make_closure 2267 captures=1 ntypeargs=1   
+        214   make_closure 2264 captures=1 ntypeargs=1   
         215   call 19 ntypeargs=2                        (baml.Array.find)
 
   327   216   store_var 21                               (_59)
@@ -818,286 +818,283 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
         36    store_var 9                        (kind)
 
   123   37    load_var 6                         (form)
-        38    load_const 9                       ("mixedlist")
-        39    cmp_op ==                          
-        40    pop_jump_if_false +2               (to 42)
-        41    jump +201                          (to 242)
-        42    load_var 6                         (form)
-        43    load_const 10                      ("mixed")
-        44    cmp_op ==                          
-        45    pop_jump_if_false +2               (to 47)
-        46    jump +129                          (to 175)
-        47    load_var 6                         (form)
-        48    load_const 11                      ("list")
-        49    cmp_op ==                          
-        50    pop_jump_if_false +2               (to 52)
-        51    jump +116                          (to 167)
+        38    is_type 9                          
+        39    pop_jump_if_false +2               (to 41)
+        40    jump +199                          (to 239)
+        41    load_var 6                         (form)
+        42    is_type 10                         
+        43    pop_jump_if_false +2               (to 45)
+        44    jump +128                          (to 172)
+        45    load_var 6                         (form)
+        46    is_type 11                         
+        47    pop_jump_if_false +2               (to 49)
+        48    jump +116                          (to 164)
 
-  152   52    load_var2 2 9                      
-        53    call 987 ntypeargs=0               (ai.internal._media_of_kind)
-        54    store_var 22                       (parts)
+  152   49    load_var2 2 9                      
+        50    call 987 ntypeargs=0               (ai.internal._media_of_kind)
+        51    store_var 22                       (parts)
 
-  153   55    load_var2 2 9                      
-        56    load_var 3                         (provider)
-        57    call 991 ntypeargs=0               (ai.internal._media_reject_mixed)
-        58    pop 1                              
+  153   52    load_var2 2 9                      
+        53    load_var 3                         (provider)
+        54    call 991 ntypeargs=0               (ai.internal._media_reject_mixed)
+        55    pop 1                              
 
-  154   59    load_var 22                        (parts)
-        60    container_len                      
-        61    store_var 23                       (_57)
-        62    load_var 23                        (_57)
-        63    load_const 7                       (1)
-        64    cmp_int_op !=                      
-        65    pop_jump_if_false +2               (to 67)
-        66    jump +23                           (to 89)
+  154   56    load_var 22                        (parts)
+        57    container_len                      
+        58    store_var 23                       (_57)
+        59    load_var 23                        (_57)
+        60    load_const 7                       (1)
+        61    cmp_int_op !=                      
+        62    pop_jump_if_false +2               (to 64)
+        63    jump +23                           (to 86)
 
-  164   67    load_const 4                       (null)
-        68    store_var 35                       (only)
+  164   64    load_const 4                       (null)
+        65    store_var 35                       (only)
 
-  165   69    load_var 22                        (parts)
-        70    load_type 12                       
-        71    load_const 13                      ("iter")
-        72    virtual_call nargs=1 ntypeargs=0   
-        73    store_var 36                       (_97)
-        74    load_var 36                        (_97)
-        75    load_type 14                       
-        76    load_const 15                      ("next")
-        77    virtual_call nargs=1 ntypeargs=0   
-        78    store_var 37                       (_98)
-        79    load_var 37                        (_98)
-        80    is_type 16                         
-        81    pop_jump_if_false +2               (to 83)
-        82    jump +4                            (to 86)
-        83    load_var 37                        (_98)
-        84    store_var 35                       (only)
-        85    jump -11                           (to 74)
+  165   66    load_var 22                        (parts)
+        67    load_type 12                       
+        68    load_const 13                      ("iter")
+        69    virtual_call nargs=1 ntypeargs=0   
+        70    store_var 36                       (_97)
+        71    load_var 36                        (_97)
+        72    load_type 14                       
+        73    load_const 15                      ("next")
+        74    virtual_call nargs=1 ntypeargs=0   
+        75    store_var 37                       (_98)
+        76    load_var 37                        (_98)
+        77    is_type 16                         
+        78    pop_jump_if_false +2               (to 80)
+        79    jump +4                            (to 83)
+        80    load_var 37                        (_98)
+        81    store_var 35                       (only)
+        82    jump -11                           (to 71)
 
-  168   86    load_var 35                        (only)
-        87    store_var 12                       (payload)
+  168   83    load_var 35                        (only)
+        84    store_var 12                       (payload)
 
-  123   88    jump +157                          (to 245)
+  123   85    jump +157                          (to 242)
 
-  157   89    load_var 6                         (form)
-        90    load_const 17                      ("one")
-        91    cmp_op ==                          
-        92    pop_jump_if_false +2               (to 94)
-        93    jump +42                           (to 135)
+  157   86    load_var 6                         (form)
+        87    load_const 17                      ("one")
+        88    cmp_op ==                          
+        89    pop_jump_if_false +2               (to 91)
+        90    jump +42                           (to 132)
 
-  160   94    load_type 2                        
-        95    load_var 9                         (kind)
-        96    call 138 ntypeargs=1               (baml.String.from)
-        97    store_var 29                       (_83)
-        98    load_var 4                         (t)
-        99    call 217 ntypeargs=0               (baml.TypeValue.baml.ToString.to_string)
-        100   store_var 31                       (_87)
-        101   load_type 2                        
-        102   load_var 31                        (_87)
-        103   call 138 ntypeargs=1               (baml.String.from)
-        104   store_var 30                       (_86)
-        105   load_var 22                        (parts)
-        106   container_len                      
-        107   store_var 33                       (_90)
-        108   load_type 18                       
-        109   load_var 33                        (_90)
-        110   call 138 ntypeargs=1               (baml.String.from)
-        111   store_var 32                       (_89)
-        112   load_type 2                        
-        113   load_var 9                         (kind)
-        114   call 138 ntypeargs=1               (baml.String.from)
-        115   store_var 34                       (_92)
-        116   load_const 19                      ("Expected zero or one ")
-        117   load_var 29                        (_83)
-        118   bin_op +                           
-        119   load_const 20                      (" output for ")
-        120   bin_op +                           
-        121   load_var 30                        (_86)
-        122   bin_op +                           
-        123   load_const 21                      (", got ")
-        124   bin_op +                           
-        125   load_var 32                        (_89)
-        126   bin_op +                           
-        127   load_const 22                      (". Use ")
-        128   bin_op +                           
-        129   load_var 34                        (_92)
-        130   bin_op +                           
-        131   load_const 23                      ("[] for multiple outputs.")
-        132   bin_op +                           
-        133   store_var 24                       (_59)
+  160   91    load_type 2                        
+        92    load_var 9                         (kind)
+        93    call 138 ntypeargs=1               (baml.String.from)
+        94    store_var 29                       (_83)
+        95    load_var 4                         (t)
+        96    call 217 ntypeargs=0               (baml.TypeValue.baml.ToString.to_string)
+        97    store_var 31                       (_87)
+        98    load_type 2                        
+        99    load_var 31                        (_87)
+        100   call 138 ntypeargs=1               (baml.String.from)
+        101   store_var 30                       (_86)
+        102   load_var 22                        (parts)
+        103   container_len                      
+        104   store_var 33                       (_90)
+        105   load_type 18                       
+        106   load_var 33                        (_90)
+        107   call 138 ntypeargs=1               (baml.String.from)
+        108   store_var 32                       (_89)
+        109   load_type 2                        
+        110   load_var 9                         (kind)
+        111   call 138 ntypeargs=1               (baml.String.from)
+        112   store_var 34                       (_92)
+        113   load_const 19                      ("Expected zero or one ")
+        114   load_var 29                        (_83)
+        115   bin_op +                           
+        116   load_const 20                      (" output for ")
+        117   bin_op +                           
+        118   load_var 30                        (_86)
+        119   bin_op +                           
+        120   load_const 21                      (", got ")
+        121   bin_op +                           
+        122   load_var 32                        (_89)
+        123   bin_op +                           
+        124   load_const 22                      (". Use ")
+        125   bin_op +                           
+        126   load_var 34                        (_92)
+        127   bin_op +                           
+        128   load_const 23                      ("[] for multiple outputs.")
+        129   bin_op +                           
+        130   store_var 24                       (_59)
 
-  157   134   jump +30                           (to 164)
+  157   131   jump +30                           (to 161)
 
-  158   135   load_type 2                        
-        136   load_var 9                         (kind)
-        137   call 138 ntypeargs=1               (baml.String.from)
-        138   store_var 25                       (_67)
-        139   load_var 22                        (parts)
-        140   container_len                      
-        141   store_var 27                       (_71)
-        142   load_type 18                       
-        143   load_var 27                        (_71)
-        144   call 138 ntypeargs=1               (baml.String.from)
-        145   store_var 26                       (_70)
-        146   load_type 2                        
-        147   load_var 9                         (kind)
-        148   call 138 ntypeargs=1               (baml.String.from)
-        149   store_var 28                       (_73)
-        150   load_const 24                      ("Expected exactly one ")
-        151   load_var 25                        (_67)
-        152   bin_op +                           
-        153   load_const 25                      (" output, got ")
-        154   bin_op +                           
-        155   load_var 26                        (_70)
-        156   bin_op +                           
-        157   load_const 26                      (". Use ")
-        158   bin_op +                           
-        159   load_var 28                        (_73)
-        160   bin_op +                           
-        161   load_const 27                      ("[] for multiple outputs.")
-        162   bin_op +                           
-        163   store_var 24                       (_59)
+  158   132   load_type 2                        
+        133   load_var 9                         (kind)
+        134   call 138 ntypeargs=1               (baml.String.from)
+        135   store_var 25                       (_67)
+        136   load_var 22                        (parts)
+        137   container_len                      
+        138   store_var 27                       (_71)
+        139   load_type 18                       
+        140   load_var 27                        (_71)
+        141   call 138 ntypeargs=1               (baml.String.from)
+        142   store_var 26                       (_70)
+        143   load_type 2                        
+        144   load_var 9                         (kind)
+        145   call 138 ntypeargs=1               (baml.String.from)
+        146   store_var 28                       (_73)
+        147   load_const 24                      ("Expected exactly one ")
+        148   load_var 25                        (_67)
+        149   bin_op +                           
+        150   load_const 25                      (" output, got ")
+        151   bin_op +                           
+        152   load_var 26                        (_70)
+        153   bin_op +                           
+        154   load_const 26                      (". Use ")
+        155   bin_op +                           
+        156   load_var 28                        (_73)
+        157   bin_op +                           
+        158   load_const 27                      ("[] for multiple outputs.")
+        159   bin_op +                           
+        160   store_var 24                       (_59)
 
-  155   164   load_var2 3 24                     
-        165   init_instance 0                    (ai.errors.ParseFailed .provider, .raw_output)
-        166   throw                              
+  155   161   load_var2 3 24                     
+        162   init_instance 0                    (ai.errors.ParseFailed .provider, .raw_output)
+        163   throw                              
 
-  147   167   load_var2 2 9                      
-        168   load_var 3                         (provider)
-        169   call 991 ntypeargs=0               (ai.internal._media_reject_mixed)
-        170   pop 1                              
+  147   164   load_var2 2 9                      
+        165   load_var 3                         (provider)
+        166   call 991 ntypeargs=0               (ai.internal._media_reject_mixed)
+        167   pop 1                              
 
-  148   171   load_var2 2 9                      
-        172   call 987 ntypeargs=0               (ai.internal._media_of_kind)
+  148   168   load_var2 2 9                      
+        169   call 987 ntypeargs=0               (ai.internal._media_of_kind)
 
-  149   173   store_var 12                       (payload)
+  149   170   store_var 12                       (payload)
 
-  123   174   jump +71                           (to 245)
+  123   171   jump +71                           (to 242)
 
-  129   175   load_var 2                         (turn)
-        176   call 988 ntypeargs=0               (ai.internal._media_mixed_parts)
-        177   store_var 13                       (items)
+  129   172   load_var 2                         (turn)
+        173   call 988 ntypeargs=0               (ai.internal._media_mixed_parts)
+        174   store_var 13                       (items)
 
-  130   178   load_var 13                        (items)
-        179   container_len                      
-        180   store_var 14                       (_25)
-        181   load_var 14                        (_25)
-        182   load_const 7                       (1)
-        183   cmp_int_op ==                      
-        184   pop_jump_if_false +2               (to 186)
-        185   jump +35                           (to 220)
+  130   175   load_var 13                        (items)
+        176   container_len                      
+        177   store_var 14                       (_25)
+        178   load_var 14                        (_25)
+        179   load_const 7                       (1)
+        180   cmp_int_op ==                      
+        181   pop_jump_if_false +2               (to 183)
+        182   jump +35                           (to 217)
 
-  136   186   load_var 13                        (items)
-        187   call 989 ntypeargs=0               (ai.internal._media_all_text)
-        188   pop_jump_if_false +2               (to 190)
-        189   jump +27                           (to 216)
+  136   183   load_var 13                        (items)
+        184   call 989 ntypeargs=0               (ai.internal._media_all_text)
+        185   pop_jump_if_false +2               (to 187)
+        186   jump +27                           (to 213)
 
-  142   190   load_var 4                         (t)
-        191   call 217 ntypeargs=0               (baml.TypeValue.baml.ToString.to_string)
-        192   store_var 19                       (_42)
-        193   load_type 2                        
-        194   load_var 19                        (_42)
-        195   call 138 ntypeargs=1               (baml.String.from)
-        196   store_var 18                       (_41)
-        197   load_var 13                        (items)
-        198   container_len                      
-        199   store_var 21                       (_45)
-        200   load_type 18                       
-        201   load_var 21                        (_45)
-        202   call 138 ntypeargs=1               (baml.String.from)
-        203   store_var 20                       (_44)
+  142   187   load_var 4                         (t)
+        188   call 217 ntypeargs=0               (baml.TypeValue.baml.ToString.to_string)
+        189   store_var 19                       (_42)
+        190   load_type 2                        
+        191   load_var 19                        (_42)
+        192   call 138 ntypeargs=1               (baml.String.from)
+        193   store_var 18                       (_41)
+        194   load_var 13                        (items)
+        195   container_len                      
+        196   store_var 21                       (_45)
+        197   load_type 18                       
+        198   load_var 21                        (_45)
+        199   call 138 ntypeargs=1               (baml.String.from)
+        200   store_var 20                       (_44)
 
-  140   204   load_var 3                         (provider)
+  140   201   load_var 3                         (provider)
 
-  142   205   load_const 28                      ("Expected one text or image output for ")
-        206   load_var 18                        (_41)
-        207   bin_op +                           
-        208   load_const 29                      (", got ")
-        209   bin_op +                           
-        210   load_var 20                        (_44)
-        211   bin_op +                           
-        212   load_const 30                      (" parts. Use (image | string)[] to preserve mixed outputs.")
-        213   bin_op +                           
-        214   init_instance 1                    (ai.errors.ParseFailed .provider, .raw_output)
-        215   throw                              
+  142   202   load_const 28                      ("Expected one text or image output for ")
+        203   load_var 18                        (_41)
+        204   bin_op +                           
+        205   load_const 29                      (", got ")
+        206   bin_op +                           
+        207   load_var 20                        (_44)
+        208   bin_op +                           
+        209   load_const 30                      (" parts. Use (image | string)[] to preserve mixed outputs.")
+        210   bin_op +                           
+        211   init_instance 1                    (ai.errors.ParseFailed .provider, .raw_output)
+        212   throw                              
 
-  138   216   load_var 13                        (items)
-        217   call 990 ntypeargs=0               (ai.internal._media_join_text)
-        218   store_var 12                       (payload)
-        219   jump +26                           (to 245)
+  138   213   load_var 13                        (items)
+        214   call 990 ntypeargs=0               (ai.internal._media_join_text)
+        215   store_var 12                       (payload)
+        216   jump +26                           (to 242)
 
-  131   220   load_const 4                       (null)
-        221   store_var 15                       (only)
+  131   217   load_const 4                       (null)
+        218   store_var 15                       (only)
 
-  132   222   load_var 13                        (items)
-        223   load_type 12                       
-        224   load_const 31                      ("iter")
-        225   virtual_call nargs=1 ntypeargs=0   
-        226   store_var 16                       (_28)
-        227   load_var 16                        (_28)
-        228   load_type 14                       
-        229   load_const 32                      ("next")
-        230   virtual_call nargs=1 ntypeargs=0   
-        231   store_var 17                       (_29)
-        232   load_var 17                        (_29)
-        233   is_type 16                         
-        234   pop_jump_if_false +2               (to 236)
-        235   jump +4                            (to 239)
-        236   load_var 17                        (_29)
-        237   store_var 15                       (only)
-        238   jump -11                           (to 227)
+  132   219   load_var 13                        (items)
+        220   load_type 12                       
+        221   load_const 31                      ("iter")
+        222   virtual_call nargs=1 ntypeargs=0   
+        223   store_var 16                       (_28)
+        224   load_var 16                        (_28)
+        225   load_type 14                       
+        226   load_const 32                      ("next")
+        227   virtual_call nargs=1 ntypeargs=0   
+        228   store_var 17                       (_29)
+        229   load_var 17                        (_29)
+        230   is_type 16                         
+        231   pop_jump_if_false +2               (to 233)
+        232   jump +4                            (to 236)
+        233   load_var 17                        (_29)
+        234   store_var 15                       (only)
+        235   jump -11                           (to 224)
 
-  135   239   load_var 15                        (only)
-        240   store_var 12                       (payload)
+  135   236   load_var 15                        (only)
+        237   store_var 12                       (payload)
 
-  130   241   jump +4                            (to 245)
+  130   238   jump +4                            (to 242)
 
-  125   242   load_var 2                         (turn)
-        243   call 988 ntypeargs=0               (ai.internal._media_mixed_parts)
+  125   239   load_var 2                         (turn)
+        240   call 988 ntypeargs=0               (ai.internal._media_mixed_parts)
 
-  126   244   store_var 12                       (payload)
+  126   241   store_var 12                       (payload)
 
-  171   245   load_type 0                        
-        246   load_var 12                        (payload)
-        247   call 358 ntypeargs=1               (baml.json.from_json)
-        248   jump +36                           (to 284)
-        249   load_var 38                        (e)
-        250   throw_if_panic                     
+  171   242   load_type 0                        
+        243   load_var 12                        (payload)
+        244   call 358 ntypeargs=1               (baml.json.from_json)
+        245   jump +36                           (to 281)
+        246   load_var 38                        (e)
+        247   throw_if_panic                     
 
-  175   251   load_type 2                        
-        252   load_var 9                         (kind)
-        253   call 138 ntypeargs=1               (baml.String.from)
-        254   store_var 39                       (_111)
-        255   load_var 4                         (t)
-        256   call 217 ntypeargs=0               (baml.TypeValue.baml.ToString.to_string)
-        257   store_var 41                       (_115)
-        258   load_type 2                        
-        259   load_var 41                        (_115)
-        260   call 138 ntypeargs=1               (baml.String.from)
-        261   store_var 40                       (_114)
-        262   load_type 33                       
-        263   load_var 38                        (e)
-        264   call 138 ntypeargs=1               (baml.String.from)
-        265   store_var 43                       (_118)
-        266   load_type 2                        
-        267   load_var 43                        (_118)
-        268   call 138 ntypeargs=1               (baml.String.from)
-        269   store_var 42                       (_117)
+  175   248   load_type 2                        
+        249   load_var 9                         (kind)
+        250   call 138 ntypeargs=1               (baml.String.from)
+        251   store_var 39                       (_111)
+        252   load_var 4                         (t)
+        253   call 217 ntypeargs=0               (baml.TypeValue.baml.ToString.to_string)
+        254   store_var 41                       (_115)
+        255   load_type 2                        
+        256   load_var 41                        (_115)
+        257   call 138 ntypeargs=1               (baml.String.from)
+        258   store_var 40                       (_114)
+        259   load_type 33                       
+        260   load_var 38                        (e)
+        261   call 138 ntypeargs=1               (baml.String.from)
+        262   store_var 43                       (_118)
+        263   load_type 2                        
+        264   load_var 43                        (_118)
+        265   call 138 ntypeargs=1               (baml.String.from)
+        266   store_var 42                       (_117)
 
-  173   270   load_var 3                         (provider)
+  173   267   load_var 3                         (provider)
 
-  175   271   load_const 34                      ("the ")
-        272   load_var 39                        (_111)
-        273   bin_op +                           
-        274   load_const 35                      (" output did not fit ")
-        275   bin_op +                           
-        276   load_var 40                        (_114)
-        277   bin_op +                           
-        278   load_const 36                      (": ")
-        279   bin_op +                           
-        280   load_var 42                        (_117)
-        281   bin_op +                           
-        282   init_instance 2                    (ai.errors.ParseFailed .provider, .raw_output)
-        283   throw                              
-        284   return                             
+  175   268   load_const 34                      ("the ")
+        269   load_var 39                        (_111)
+        270   bin_op +                           
+        271   load_const 35                      (" output did not fit ")
+        272   bin_op +                           
+        273   load_var 40                        (_114)
+        274   bin_op +                           
+        275   load_const 36                      (": ")
+        276   bin_op +                           
+        277   load_var 42                        (_117)
+        278   bin_op +                           
+        279   init_instance 2                    (ai.errors.ParseFailed .provider, .raw_output)
+        280   throw                              
+        281   return                             
 }
 
 function ai.Agent._parses(self: ai.Agent<#0>, turn: ai.ModelTurn, candidate: string) -> bool {
@@ -2467,81 +2464,82 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        47    store_var 5             (model)
 
   38   48    load_var 4              (prefix)
-       49    load_const 8            ("openai")
-       50    cmp_op ==               
-       51    pop_jump_if_false +2    (to 53)
-       52    jump +223               (to 275)
-       53    load_var 4              (prefix)
-       54    load_const 9            ("openai-chat")
-       55    cmp_op ==               
-       56    pop_jump_if_false +2    (to 58)
-       57    jump +204               (to 261)
-       58    load_var 4              (prefix)
-       59    load_const 10           ("openai-images")
-       60    cmp_op ==               
-       61    pop_jump_if_false +2    (to 63)
-       62    jump +181               (to 243)
-       63    load_var 4              (prefix)
-       64    load_const 11           ("azure")
-       65    cmp_op ==               
+       49    is_type 8               
+       50    pop_jump_if_false +2    (to 52)
+       51    jump +212               (to 263)
+       52    load_var 4              (prefix)
+       53    is_type 9               
+       54    pop_jump_if_false +2    (to 56)
+       55    jump +194               (to 249)
+       56    load_var 4              (prefix)
+       57    is_type 10              
+       58    pop_jump_if_false +2    (to 60)
+       59    jump +172               (to 231)
+       60    load_var 4              (prefix)
+       61    is_type 11              
+       62    pop_jump_if_false +2    (to 64)
+       63    jump +151               (to 214)
+       64    load_var 4              (prefix)
+       65    is_type 12              
        66    pop_jump_if_false +2    (to 68)
-       67    jump +159               (to 226)
+       67    jump +134               (to 201)
        68    load_var 4              (prefix)
-       69    load_const 12           ("ollama")
-       70    cmp_op ==               
-       71    pop_jump_if_false +2    (to 73)
-       72    jump +141               (to 213)
-       73    load_var 4              (prefix)
-       74    load_const 13           ("openrouter")
-       75    cmp_op ==               
-       76    pop_jump_if_false +2    (to 78)
-       77    jump +123               (to 200)
-       78    load_var 4              (prefix)
-       79    load_const 14           ("anthropic")
-       80    cmp_op ==               
-       81    pop_jump_if_false +2    (to 83)
-       82    jump +103               (to 185)
-       83    load_var 4              (prefix)
-       84    load_const 15           ("google")
-       85    cmp_op ==               
+       69    is_type 13              
+       70    pop_jump_if_false +2    (to 72)
+       71    jump +117               (to 188)
+       72    load_var 4              (prefix)
+       73    is_type 14              
+       74    pop_jump_if_false +2    (to 76)
+       75    jump +98                (to 173)
+       76    load_var 4              (prefix)
+       77    is_type 15              
+       78    pop_jump_if_false +2    (to 80)
+       79    jump +79                (to 158)
+       80    load_var 4              (prefix)
+       81    is_type 16              
+       82    pop_jump_if_false +2    (to 84)
+       83    jump +56                (to 139)
+       84    load_var 4              (prefix)
+       85    is_type 17              
        86    pop_jump_if_false +2    (to 88)
-       87    jump +83                (to 170)
+       87    jump +32                (to 119)
        88    load_var 4              (prefix)
-       89    load_const 16           ("vertex")
-       90    cmp_op ==               
-       91    pop_jump_if_false +2    (to 93)
-       92    jump +59                (to 151)
-       93    load_var 4              (prefix)
-       94    load_const 17           ("bedrock")
-       95    cmp_op ==               
-       96    pop_jump_if_false +2    (to 98)
-       97    jump +34                (to 131)
-       98    load_var 4              (prefix)
-       99    load_const 18           ("ai-gateway-images")
-       100   cmp_op ==               
-       101   pop_jump_if_false +2    (to 103)
-       102   jump +17                (to 119)
-       103   load_var 4              (prefix)
-       104   load_const 19           ("claude-code")
-       105   cmp_op ==               
-       106   pop_jump_if_false +2    (to 108)
-       107   jump +3                 (to 110)
+       89    is_type 18              
+       90    pop_jump_if_false +2    (to 92)
+       91    jump +16                (to 107)
+       92    load_var 4              (prefix)
+       93    is_type 19              
+       94    pop_jump_if_false +2    (to 96)
+       95    jump +3                 (to 98)
 
-  51   108   load_const 4            (null)
+  51   96    load_const 4            (null)
 
-  38   109   jump +181               (to 290)
+  38   97    jump +181               (to 278)
 
-  50   110   load_var 5              (model)
+  50   98    load_var 5              (model)
+       99    load_const 20           (<omitted>)
+       100   load_const 20           (<omitted>)
+       101   load_const 20           (<omitted>)
+       102   load_const 20           (<omitted>)
+       103   load_const 20           (<omitted>)
+       104   load_const 20           (<omitted>)
+       105   call 1351 ntypeargs=0   (claude_code.ClaudeCodeClient.new)
+       106   jump +172               (to 278)
+
+  49   107   load_var 5              (model)
+       108   load_const 20           (<omitted>)
+       109   load_const 20           (<omitted>)
+       110   load_const 20           (<omitted>)
        111   load_const 20           (<omitted>)
        112   load_const 20           (<omitted>)
        113   load_const 20           (<omitted>)
        114   load_const 20           (<omitted>)
        115   load_const 20           (<omitted>)
        116   load_const 20           (<omitted>)
-       117   call 1351 ntypeargs=0   (claude_code.ClaudeCodeClient.new)
-       118   jump +172               (to 290)
+       117   call 1330 ntypeargs=0   (vercel.AiGatewayImageClient.new)
+       118   jump +160               (to 278)
 
-  49   119   load_var 5              (model)
+  48   119   load_var 5              (model)
        120   load_const 20           (<omitted>)
        121   load_const 20           (<omitted>)
        122   load_const 20           (<omitted>)
@@ -2551,18 +2549,18 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        126   load_const 20           (<omitted>)
        127   load_const 20           (<omitted>)
        128   load_const 20           (<omitted>)
-       129   call 1330 ntypeargs=0   (vercel.AiGatewayImageClient.new)
-       130   jump +160               (to 290)
-
-  48   131   load_var 5              (model)
+       129   load_const 20           (<omitted>)
+       130   load_const 20           (<omitted>)
+       131   load_const 20           (<omitted>)
        132   load_const 20           (<omitted>)
        133   load_const 20           (<omitted>)
        134   load_const 20           (<omitted>)
        135   load_const 20           (<omitted>)
        136   load_const 20           (<omitted>)
-       137   load_const 20           (<omitted>)
-       138   load_const 20           (<omitted>)
-       139   load_const 20           (<omitted>)
+       137   call 1271 ntypeargs=0   (aws.BedrockClient.new)
+       138   jump +140               (to 278)
+
+  47   139   load_var 5              (model)
        140   load_const 20           (<omitted>)
        141   load_const 20           (<omitted>)
        142   load_const 20           (<omitted>)
@@ -2572,17 +2570,17 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        146   load_const 20           (<omitted>)
        147   load_const 20           (<omitted>)
        148   load_const 20           (<omitted>)
-       149   call 1271 ntypeargs=0   (aws.BedrockClient.new)
-       150   jump +140               (to 290)
-
-  47   151   load_var 5              (model)
+       149   load_const 20           (<omitted>)
+       150   load_const 20           (<omitted>)
+       151   load_const 20           (<omitted>)
        152   load_const 20           (<omitted>)
        153   load_const 20           (<omitted>)
        154   load_const 20           (<omitted>)
        155   load_const 20           (<omitted>)
-       156   load_const 20           (<omitted>)
-       157   load_const 20           (<omitted>)
-       158   load_const 20           (<omitted>)
+       156   call 1207 ntypeargs=0   (google.VertexClient.new)
+       157   jump +121               (to 278)
+
+  46   158   load_var 5              (model)
        159   load_const 20           (<omitted>)
        160   load_const 20           (<omitted>)
        161   load_const 20           (<omitted>)
@@ -2592,13 +2590,13 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        165   load_const 20           (<omitted>)
        166   load_const 20           (<omitted>)
        167   load_const 20           (<omitted>)
-       168   call 1207 ntypeargs=0   (google.VertexClient.new)
-       169   jump +121               (to 290)
+       168   load_const 20           (<omitted>)
+       169   load_const 20           (<omitted>)
+       170   load_const 20           (<omitted>)
+       171   call 1201 ntypeargs=0   (google.GoogleClient.new)
+       172   jump +106               (to 278)
 
-  46   170   load_var 5              (model)
-       171   load_const 20           (<omitted>)
-       172   load_const 20           (<omitted>)
-       173   load_const 20           (<omitted>)
+  45   173   load_var 5              (model)
        174   load_const 20           (<omitted>)
        175   load_const 20           (<omitted>)
        176   load_const 20           (<omitted>)
@@ -2608,13 +2606,13 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        180   load_const 20           (<omitted>)
        181   load_const 20           (<omitted>)
        182   load_const 20           (<omitted>)
-       183   call 1201 ntypeargs=0   (google.GoogleClient.new)
-       184   jump +106               (to 290)
+       183   load_const 20           (<omitted>)
+       184   load_const 20           (<omitted>)
+       185   load_const 20           (<omitted>)
+       186   call 1162 ntypeargs=0   (anthropic.AnthropicClient.new)
+       187   jump +91                (to 278)
 
-  45   185   load_var 5              (model)
-       186   load_const 20           (<omitted>)
-       187   load_const 20           (<omitted>)
-       188   load_const 20           (<omitted>)
+  44   188   load_var 5              (model)
        189   load_const 20           (<omitted>)
        190   load_const 20           (<omitted>)
        191   load_const 20           (<omitted>)
@@ -2624,11 +2622,11 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        195   load_const 20           (<omitted>)
        196   load_const 20           (<omitted>)
        197   load_const 20           (<omitted>)
-       198   call 1162 ntypeargs=0   (anthropic.AnthropicClient.new)
-       199   jump +91                (to 290)
+       198   load_const 20           (<omitted>)
+       199   call 1084 ntypeargs=0   (openai.OpenRouterClient.new)
+       200   jump +78                (to 278)
 
-  44   200   load_var 5              (model)
-       201   load_const 20           (<omitted>)
+  43   201   load_var 5              (model)
        202   load_const 20           (<omitted>)
        203   load_const 20           (<omitted>)
        204   load_const 20           (<omitted>)
@@ -2638,11 +2636,11 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        208   load_const 20           (<omitted>)
        209   load_const 20           (<omitted>)
        210   load_const 20           (<omitted>)
-       211   call 1084 ntypeargs=0   (openai.OpenRouterClient.new)
-       212   jump +78                (to 290)
+       211   load_const 20           (<omitted>)
+       212   call 1076 ntypeargs=0   (openai.OllamaClient.new)
+       213   jump +65                (to 278)
 
-  43   213   load_var 5              (model)
-       214   load_const 20           (<omitted>)
+  42   214   load_var 5              (model)
        215   load_const 20           (<omitted>)
        216   load_const 20           (<omitted>)
        217   load_const 20           (<omitted>)
@@ -2652,15 +2650,15 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        221   load_const 20           (<omitted>)
        222   load_const 20           (<omitted>)
        223   load_const 20           (<omitted>)
-       224   call 1076 ntypeargs=0   (openai.OllamaClient.new)
-       225   jump +65                (to 290)
-
-  42   226   load_var 5              (model)
+       224   load_const 20           (<omitted>)
+       225   load_const 20           (<omitted>)
+       226   load_const 20           (<omitted>)
        227   load_const 20           (<omitted>)
        228   load_const 20           (<omitted>)
-       229   load_const 20           (<omitted>)
-       230   load_const 20           (<omitted>)
-       231   load_const 20           (<omitted>)
+       229   call 1067 ntypeargs=0   (openai.AzureClient.new)
+       230   jump +48                (to 278)
+
+  41   231   load_var 5              (model)
        232   load_const 20           (<omitted>)
        233   load_const 20           (<omitted>)
        234   load_const 20           (<omitted>)
@@ -2670,16 +2668,16 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        238   load_const 20           (<omitted>)
        239   load_const 20           (<omitted>)
        240   load_const 20           (<omitted>)
-       241   call 1067 ntypeargs=0   (openai.AzureClient.new)
-       242   jump +48                (to 290)
-
-  41   243   load_var 5              (model)
+       241   load_const 20           (<omitted>)
+       242   load_const 20           (<omitted>)
+       243   load_const 20           (<omitted>)
        244   load_const 20           (<omitted>)
        245   load_const 20           (<omitted>)
        246   load_const 20           (<omitted>)
-       247   load_const 20           (<omitted>)
-       248   load_const 20           (<omitted>)
-       249   load_const 20           (<omitted>)
+       247   call 1092 ntypeargs=0   (openai.ImageClient.new)
+       248   jump +30                (to 278)
+
+  40   249   load_var 5              (model)
        250   load_const 20           (<omitted>)
        251   load_const 20           (<omitted>)
        252   load_const 20           (<omitted>)
@@ -2689,12 +2687,12 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        256   load_const 20           (<omitted>)
        257   load_const 20           (<omitted>)
        258   load_const 20           (<omitted>)
-       259   call 1092 ntypeargs=0   (openai.ImageClient.new)
-       260   jump +30                (to 290)
+       259   load_const 20           (<omitted>)
+       260   load_const 20           (<omitted>)
+       261   call 1051 ntypeargs=0   (openai.ChatClient.new)
+       262   jump +16                (to 278)
 
-  40   261   load_var 5              (model)
-       262   load_const 20           (<omitted>)
-       263   load_const 20           (<omitted>)
+  39   263   load_var 5              (model)
        264   load_const 20           (<omitted>)
        265   load_const 20           (<omitted>)
        266   load_const 20           (<omitted>)
@@ -2704,76 +2702,63 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        270   load_const 20           (<omitted>)
        271   load_const 20           (<omitted>)
        272   load_const 20           (<omitted>)
-       273   call 1051 ntypeargs=0   (openai.ChatClient.new)
-       274   jump +16                (to 290)
-
-  39   275   load_var 5              (model)
+       273   load_const 20           (<omitted>)
+       274   load_const 20           (<omitted>)
+       275   load_const 20           (<omitted>)
        276   load_const 20           (<omitted>)
-       277   load_const 20           (<omitted>)
-       278   load_const 20           (<omitted>)
-       279   load_const 20           (<omitted>)
-       280   load_const 20           (<omitted>)
-       281   load_const 20           (<omitted>)
-       282   load_const 20           (<omitted>)
-       283   load_const 20           (<omitted>)
-       284   load_const 20           (<omitted>)
-       285   load_const 20           (<omitted>)
-       286   load_const 20           (<omitted>)
-       287   load_const 20           (<omitted>)
-       288   load_const 20           (<omitted>)
-       289   call 1011 ntypeargs=0   (openai.ResponsesClient.new)
+       277   call 1011 ntypeargs=0   (openai.ResponsesClient.new)
 
-  53   290   store_var 8             (_36)
-       291   load_var 8              (_36)
-       292   narrow_bind 21 8        
-       293   pop_jump_if_false +2    (to 295)
-       294   jump +41                (to 335)
+  53   278   store_var 8             (_36)
+       279   load_var 8              (_36)
+       280   narrow_bind 21 8        
+       281   pop_jump_if_false +2    (to 283)
+       282   jump +41                (to 323)
 
-  59   295   load_type 2             
-       296   load_var 4              (prefix)
-       297   call 138 ntypeargs=1    (baml.String.from)
-       298   store_var 9             (_47)
-       299   load_type 2             
-       300   load_var 1              (shorthand)
-       301   call 138 ntypeargs=1    (baml.String.from)
-       302   store_var 10            (_50)
-       303   call 1001 ntypeargs=0   (ai.internal._shorthand_prefixes)
-       304   store_var 12            (_53)
-       305   load_type 2             
-       306   load_var 12             (_53)
-       307   call 138 ntypeargs=1    (baml.String.from)
-       308   store_var 11            (_52)
-       309   load_type 2             
-       310   load_var 5              (model)
-       311   call 138 ntypeargs=1    (baml.String.from)
-       312   store_var 13            (_55)
+  59   283   load_type 2             
+       284   load_var 4              (prefix)
+       285   call 138 ntypeargs=1    (baml.String.from)
+       286   store_var 9             (_47)
+       287   load_type 2             
+       288   load_var 1              (shorthand)
+       289   call 138 ntypeargs=1    (baml.String.from)
+       290   store_var 10            (_50)
+       291   call 1001 ntypeargs=0   (ai.internal._shorthand_prefixes)
+       292   store_var 12            (_53)
+       293   load_type 2             
+       294   load_var 12             (_53)
+       295   call 138 ntypeargs=1    (baml.String.from)
+       296   store_var 11            (_52)
+       297   load_type 2             
+       298   load_var 5              (model)
+       299   call 138 ntypeargs=1    (baml.String.from)
+       300   store_var 13            (_55)
 
-  56   313   load_const 22           ("ai.clients")
-       314   load_const 4            (null)
+  56   301   load_const 22           ("ai.clients")
+       302   load_const 4            (null)
 
-  59   315   load_const 23           ("no builtin provider for prefix \"")
-       316   load_var 9              (_47)
+  59   303   load_const 23           ("no builtin provider for prefix \"")
+       304   load_var 9              (_47)
+       305   bin_op +                
+       306   load_const 24           ("\" in client \"")
+       307   bin_op +                
+       308   load_var 10             (_50)
+       309   bin_op +                
+       310   load_const 25           ("\"; valid prefixes are ")
+       311   bin_op +                
+       312   load_var 11             (_52)
+       313   bin_op +                
+       314   load_const 26           (" (for any other OpenAI-compatible endpoint, build openai.GenericClient.new(base_url = ..., model = \"")
+       315   bin_op +                
+       316   load_var 13             (_55)
        317   bin_op +                
-       318   load_const 24           ("\" in client \"")
+       318   load_const 27           ("\"))")
        319   bin_op +                
-       320   load_var 10             (_50)
-       321   bin_op +                
-       322   load_const 25           ("\"; valid prefixes are ")
-       323   bin_op +                
-       324   load_var 11             (_52)
-       325   bin_op +                
-       326   load_const 26           (" (for any other OpenAI-compatible endpoint, build openai.GenericClient.new(base_url = ..., model = \"")
-       327   bin_op +                
-       328   load_var 13             (_55)
-       329   bin_op +                
-       330   load_const 27           ("\"))")
-       331   bin_op +                
-       332   load_const 4            (null)
-       333   init_instance 1         (ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body)
-       334   throw                   
+       320   load_const 4            (null)
+       321   init_instance 1         (ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body)
+       322   throw                   
 
-  53   335   load_var 8              (_36)
-       336   return                  
+  53   323   load_var 8              (_36)
+       324   return                  
 }
 
 function ai.internal._gcp_access_token(credentials_json: string | null, scope: string) -> string {
@@ -3643,7 +3628,7 @@ function ai.internal._proxy(conn: ai.mcp.McpConnection, name: string) -> (map<st
        5   store_var 2           
 
   12   6   load_var2 1 2         
-       7   make_closure 4349 2   
+       7   make_closure 4206 2   
        8   return                
 }
 
@@ -5662,7 +5647,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
   436   75    load_type 8                                
         76    load_type 2                                
         77    load_var 10                                (turns)
-        78    make_closure 2293 captures=1 ntypeargs=2   
+        78    make_closure 2290 captures=1 ntypeargs=2   
         79    load_var 15                                (_36)
         80    load_const 9                               ("")
         81    load_const 10                              (false)
@@ -7168,116 +7153,112 @@ function anthropic.internal._anth_stream_failure(error: anthropic.internal.AnthS
          33    store_var 5            (detail)
 
   1007   34    load_var 3             (kind)
-         35    load_const 2           ("rate_limit_error")
-         36    cmp_op ==              
-         37    pop_jump_if_false +2   (to 39)
-         38    jump +85               (to 123)
-         39    load_var 3             (kind)
-         40    load_const 3           ("overloaded_error")
-         41    cmp_op ==              
-         42    pop_jump_if_false +2   (to 44)
-         43    jump +63               (to 106)
-         44    load_var 3             (kind)
-         45    load_const 4           ("api_error")
-         46    cmp_op ==              
-         47    pop_jump_if_false +2   (to 49)
-         48    jump +41               (to 89)
-         49    load_var 3             (kind)
-         50    load_const 5           ("timeout_error")
-         51    cmp_op ==              
-         52    pop_jump_if_false +2   (to 54)
-         53    jump +19               (to 72)
+         35    is_type 2              
+         36    pop_jump_if_false +2   (to 38)
+         37    jump +82               (to 119)
+         38    load_var 3             (kind)
+         39    is_type 3              
+         40    pop_jump_if_false +2   (to 42)
+         41    jump +61               (to 102)
+         42    load_var 3             (kind)
+         43    is_type 4              
+         44    pop_jump_if_false +2   (to 46)
+         45    jump +40               (to 85)
+         46    load_var 3             (kind)
+         47    is_type 5              
+         48    pop_jump_if_false +2   (to 50)
+         49    jump +19               (to 68)
 
-  1023   54    load_type 6            
-         55    load_var 3             (kind)
+  1023   50    load_type 6            
+         51    load_var 3             (kind)
+         52    call 138 ntypeargs=1   (baml.String.from)
+         53    store_var 13           (_45)
+         54    load_type 6            
+         55    load_var 5             (detail)
          56    call 138 ntypeargs=1   (baml.String.from)
-         57    store_var 13           (_45)
-         58    load_type 6            
-         59    load_var 5             (detail)
-         60    call 138 ntypeargs=1   (baml.String.from)
-         61    store_var 14           (_48)
+         57    store_var 14           (_48)
 
-  1020   62    load_const 7           ("anthropic")
-         63    load_const 0           (null)
+  1020   58    load_const 7           ("anthropic")
+         59    load_const 0           (null)
 
-  1023   64    load_var 13            (_45)
-         65    load_const 8           (": ")
-         66    bin_op +               
-         67    load_var 14            (_48)
-         68    bin_op +               
-         69    load_var 2             (raw)
-         70    init_instance 0        (ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body)
+  1023   60    load_var 13            (_45)
+         61    load_const 8           (": ")
+         62    bin_op +               
+         63    load_var 14            (_48)
+         64    bin_op +               
+         65    load_var 2             (raw)
+         66    init_instance 0        (ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body)
 
-  1007   71    jump +56               (to 127)
+  1007   67    jump +56               (to 123)
 
-  1015   72    load_type 9            
-         73    load_var 3             (kind)
+  1015   68    load_type 9            
+         69    load_var 3             (kind)
+         70    call 138 ntypeargs=1   (baml.String.from)
+         71    store_var 11           (_37)
+         72    load_type 6            
+         73    load_var 5             (detail)
          74    call 138 ntypeargs=1   (baml.String.from)
-         75    store_var 11           (_37)
-         76    load_type 6            
-         77    load_var 5             (detail)
-         78    call 138 ntypeargs=1   (baml.String.from)
-         79    store_var 12           (_40)
+         75    store_var 12           (_40)
 
-  1013   80    load_const 10          ("anthropic")
+  1013   76    load_const 10          ("anthropic")
 
-  1015   81    load_var 11            (_37)
-         82    load_const 11          (": ")
-         83    bin_op +               
-         84    load_var 12            (_40)
-         85    bin_op +               
-         86    load_var 2             (raw)
-         87    init_instance 1        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
+  1015   77    load_var 11            (_37)
+         78    load_const 11          (": ")
+         79    bin_op +               
+         80    load_var 12            (_40)
+         81    bin_op +               
+         82    load_var 2             (raw)
+         83    init_instance 1        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
 
-  1007   88    jump +39               (to 127)
+  1007   84    jump +39               (to 123)
 
-  1015   89    load_type 9            
-         90    load_var 3             (kind)
+  1015   85    load_type 9            
+         86    load_var 3             (kind)
+         87    call 138 ntypeargs=1   (baml.String.from)
+         88    store_var 9            (_28)
+         89    load_type 6            
+         90    load_var 5             (detail)
          91    call 138 ntypeargs=1   (baml.String.from)
-         92    store_var 9            (_28)
-         93    load_type 6            
-         94    load_var 5             (detail)
-         95    call 138 ntypeargs=1   (baml.String.from)
-         96    store_var 10           (_31)
+         92    store_var 10           (_31)
 
-  1013   97    load_const 12          ("anthropic")
+  1013   93    load_const 12          ("anthropic")
 
-  1015   98    load_var 9             (_28)
-         99    load_const 13          (": ")
-         100   bin_op +               
-         101   load_var 10            (_31)
-         102   bin_op +               
-         103   load_var 2             (raw)
-         104   init_instance 2        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
+  1015   94    load_var 9             (_28)
+         95    load_const 13          (": ")
+         96    bin_op +               
+         97    load_var 10            (_31)
+         98    bin_op +               
+         99    load_var 2             (raw)
+         100   init_instance 2        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
 
-  1007   105   jump +22               (to 127)
+  1007   101   jump +22               (to 123)
 
-  1015   106   load_type 9            
-         107   load_var 3             (kind)
+  1015   102   load_type 9            
+         103   load_var 3             (kind)
+         104   call 138 ntypeargs=1   (baml.String.from)
+         105   store_var 7            (_19)
+         106   load_type 6            
+         107   load_var 5             (detail)
          108   call 138 ntypeargs=1   (baml.String.from)
-         109   store_var 7            (_19)
-         110   load_type 6            
-         111   load_var 5             (detail)
-         112   call 138 ntypeargs=1   (baml.String.from)
-         113   store_var 8            (_22)
+         109   store_var 8            (_22)
 
-  1013   114   load_const 14          ("anthropic")
+  1013   110   load_const 14          ("anthropic")
 
-  1015   115   load_var 7             (_19)
-         116   load_const 15          (": ")
-         117   bin_op +               
-         118   load_var 8             (_22)
-         119   bin_op +               
-         120   load_var 2             (raw)
-         121   init_instance 3        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
+  1015   111   load_var 7             (_19)
+         112   load_const 15          (": ")
+         113   bin_op +               
+         114   load_var 8             (_22)
+         115   bin_op +               
+         116   load_var 2             (raw)
+         117   init_instance 3        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
 
-  1007   122   jump +5                (to 127)
+  1007   118   jump +5                (to 123)
 
-  1008   123   load_const 16          ("anthropic")
-         124   load_const 0           (null)
-         125   load_var 2             (raw)
-         126   init_instance 4        (ai.errors.RateLimited .provider, .retry_after_ms, .raw_body)
-         127   return                 
+  1008   119   load_const 16          ("anthropic")
+         120   load_const 0           (null)
+         121   load_var 2             (raw)
+         122   init_instance 4        (ai.errors.RateLimited .provider, .retry_after_ms, .raw_body)
+         123   return                 
 }
 
 function anthropic.internal._anth_supported_image_mime(mime: string) -> bool {
@@ -8385,49 +8366,45 @@ function anthropic.internal._anthropic_sse_failure(message: string) -> ai.errors
 
 function anthropic.internal._anthropic_stop_reason(s: string) -> ai.content.StopReason {
   797   0    load_var 1             (s)
-        1    load_const 0           ("end_turn")
-        2    cmp_op ==              
-        3    pop_jump_if_false +2   (to 5)
-        4    jump +28               (to 32)
-        5    load_var 1             (s)
-        6    load_const 1           ("stop_sequence")
-        7    cmp_op ==              
-        8    pop_jump_if_false +2   (to 10)
-        9    jump +20               (to 29)
-        10   load_var 1             (s)
-        11   load_const 2           ("tool_use")
-        12   cmp_op ==              
-        13   pop_jump_if_false +2   (to 15)
-        14   jump +12               (to 26)
-        15   load_var 1             (s)
-        16   load_const 3           ("refusal")
-        17   cmp_op ==              
-        18   pop_jump_if_false +2   (to 20)
-        19   jump +4                (to 23)
+        1    is_type 0              
+        2    pop_jump_if_false +2   (to 4)
+        3    jump +25               (to 28)
+        4    load_var 1             (s)
+        5    is_type 1              
+        6    pop_jump_if_false +2   (to 8)
+        7    jump +18               (to 25)
+        8    load_var 1             (s)
+        9    is_type 2              
+        10   pop_jump_if_false +2   (to 12)
+        11   jump +11               (to 22)
+        12   load_var 1             (s)
+        13   is_type 3              
+        14   pop_jump_if_false +2   (to 16)
+        15   jump +4                (to 19)
 
-  802   20   load_const 4           (ai.content.StopReason.MaxTokens)
-        21   alloc_variant 774      (ai.content.StopReason)
+  802   16   load_const 4           (ai.content.StopReason.MaxTokens)
+        17   alloc_variant 774      (ai.content.StopReason)
 
-  797   22   jump +12               (to 34)
+  797   18   jump +12               (to 30)
 
-  800   23   load_const 5           (ai.content.StopReason.Refused)
-        24   alloc_variant 774      (ai.content.StopReason)
+  800   19   load_const 5           (ai.content.StopReason.Refused)
+        20   alloc_variant 774      (ai.content.StopReason)
 
-  797   25   jump +9                (to 34)
+  797   21   jump +9                (to 30)
 
-  799   26   load_const 6           (ai.content.StopReason.ToolUse)
-        27   alloc_variant 774      (ai.content.StopReason)
+  799   22   load_const 6           (ai.content.StopReason.ToolUse)
+        23   alloc_variant 774      (ai.content.StopReason)
 
-  797   28   jump +6                (to 34)
+  797   24   jump +6                (to 30)
 
-  798   29   load_const 7           (ai.content.StopReason.Complete)
-        30   alloc_variant 774      (ai.content.StopReason)
+  798   25   load_const 7           (ai.content.StopReason.Complete)
+        26   alloc_variant 774      (ai.content.StopReason)
 
-  797   31   jump +3                (to 34)
+  797   27   jump +3                (to 30)
 
-  798   32   load_const 7           (ai.content.StopReason.Complete)
-        33   alloc_variant 774      (ai.content.StopReason)
-        34   return                 
+  798   28   load_const 7           (ai.content.StopReason.Complete)
+        29   alloc_variant 774      (ai.content.StopReason)
+        30   return                 
 }
 
 function anthropic.internal._anthropic_thinking_param(thinking: anthropic.ThinkingConfig | null) -> anthropic.internal.AnthThinkingParam | null {
@@ -8555,7 +8532,7 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
          14    load_var 5                         (_6)
          15    is_type 5                          
          16    pop_jump_if_false +2               (to 18)
-         17    jump +541                          (to 558)
+         17    jump +529                          (to 546)
          18    load_var 5                         (_6)
          19    store_var_load_var 6               (raw)
 
@@ -8601,577 +8578,565 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
          55    load_var 13                        (_20)
          56    store_var_load_var 12              (t)
 
-  1040   57    load_const 11                      ("error")
-         58    cmp_op ==                          
-         59    pop_jump_if_false +2               (to 61)
-         60    jump +493                          (to 553)
-         61    load_var 12                        (t)
-         62    load_const 12                      ("message_start")
-         63    cmp_op ==                          
-         64    pop_jump_if_false +2               (to 66)
-         65    jump +366                          (to 431)
-         66    load_var 12                        (t)
-         67    load_const 13                      ("content_block_start")
-         68    cmp_op ==                          
-         69    pop_jump_if_false +2               (to 71)
-         70    jump +255                          (to 325)
-         71    load_var 12                        (t)
-         72    load_const 14                      ("content_block_delta")
-         73    cmp_op ==                          
+  1040   57    is_type 11                         
+         58    pop_jump_if_false +2               (to 60)
+         59    jump +482                          (to 541)
+         60    load_var 12                        (t)
+         61    is_type 12                         
+         62    pop_jump_if_false +2               (to 64)
+         63    jump +356                          (to 419)
+         64    load_var 12                        (t)
+         65    is_type 13                         
+         66    pop_jump_if_false +2               (to 68)
+         67    jump +248                          (to 315)
+         68    load_var 12                        (t)
+         69    is_type 14                         
+         70    pop_jump_if_false +2               (to 72)
+         71    jump +126                          (to 197)
+         72    load_var 12                        (t)
+         73    is_type 15                         
          74    pop_jump_if_false +2               (to 76)
-         75    jump +128                          (to 203)
+         75    jump +10                           (to 85)
          76    load_var 12                        (t)
-         77    load_const 15                      ("message_delta")
-         78    cmp_op ==                          
-         79    pop_jump_if_false +2               (to 81)
-         80    jump +11                           (to 91)
-         81    load_var 12                        (t)
-         82    load_const 16                      ("message_stop")
-         83    cmp_op ==                          
-         84    pop_jump_if_false -75              (to 9)
+         77    is_type 16                         
+         78    pop_jump_if_false -69              (to 9)
 
-  1170   85    load_type 0                        
-         86    load_var 3                         (out)
-         87    alloc_instance 410 ntypeargs=0     (ai.stream.TurnDone)
-         88    call 4 ntypeargs=1                 (baml.Array.push)
-         89    pop 1                              
-         90    jump -81                           (to 9)
+  1170   79    load_type 0                        
+         80    load_var 3                         (out)
+         81    alloc_instance 410 ntypeargs=0     (ai.stream.TurnDone)
+         82    call 4 ntypeargs=1                 (baml.Array.push)
+         83    pop 1                              
+         84    jump -75                           (to 9)
 
-  1143   91    load_var 11                        (event)
-         92    load_field 5                       (usage)
-         93    store_var 55                       (_169)
-         94    load_var 55                        (_169)
-         95    narrow_bind 17 55                  
-         96    pop_jump_if_false +44              (to 140)
-         97    load_var 55                        (_169)
-         98    store_var_load_var 56              (usage)
+  1143   85    load_var 11                        (event)
+         86    load_field 5                       (usage)
+         87    store_var 55                       (_169)
+         88    load_var 55                        (_169)
+         89    narrow_bind 17 55                  
+         90    pop_jump_if_false +44              (to 134)
+         91    load_var 55                        (_169)
+         92    store_var_load_var 56              (usage)
 
-  1145   99    load_field 2                       (cache_read_input_tokens)
-         100   store_var_load_var 57              (_171)
-         101   load_const 8                       (null)
-         102   cmp_op ==                          
-         103   pop_jump_if_false +4               (to 107)
-         104   load_var 2                         (state)
-         105   load_field 3                       (cache_read_input_tokens)
-         106   store_var 57                       (_171)
-         107   load_var2 2 57                     
-         108   store_field 3                      (cache_read_input_tokens)
+  1145   93    load_field 2                       (cache_read_input_tokens)
+         94    store_var_load_var 57              (_171)
+         95    load_const 8                       (null)
+         96    cmp_op ==                          
+         97    pop_jump_if_false +4               (to 101)
+         98    load_var 2                         (state)
+         99    load_field 3                       (cache_read_input_tokens)
+         100   store_var 57                       (_171)
+         101   load_var2 2 57                     
+         102   store_field 3                      (cache_read_input_tokens)
 
-  1147   109   load_var 56                        (usage)
-         110   load_field 3                       (cache_creation_input_tokens)
-         111   store_var_load_var 58              (_174)
+  1147   103   load_var 56                        (usage)
+         104   load_field 3                       (cache_creation_input_tokens)
+         105   store_var_load_var 58              (_174)
 
-  1148   112   load_const 8                       (null)
-         113   cmp_op ==                          
-         114   pop_jump_if_false +4               (to 118)
-         115   load_var 2                         (state)
-         116   load_field 4                       (cache_creation_input_tokens)
-         117   store_var 58                       (_174)
+  1148   106   load_const 8                       (null)
+         107   cmp_op ==                          
+         108   pop_jump_if_false +4               (to 112)
+         109   load_var 2                         (state)
+         110   load_field 4                       (cache_creation_input_tokens)
+         111   store_var 58                       (_174)
 
-  1147   118   load_var2 2 58                     
-         119   store_field 4                      (cache_creation_input_tokens)
+  1147   112   load_var2 2 58                     
+         113   store_field 4                      (cache_creation_input_tokens)
 
-  1150   120   load_var 56                        (usage)
+  1150   114   load_var 56                        (usage)
+         115   load_field 4                       (output_tokens_details)
+         116   load_const 8                       (null)
+         117   cmp_op ==                          
+         118   pop_jump_if_false +2               (to 120)
+         119   jump +5                            (to 124)
+         120   load_var 56                        (usage)
          121   load_field 4                       (output_tokens_details)
-         122   load_const 8                       (null)
-         123   cmp_op ==                          
-         124   pop_jump_if_false +2               (to 126)
-         125   jump +5                            (to 130)
-         126   load_var 56                        (usage)
-         127   load_field 4                       (output_tokens_details)
-         128   load_field 0                       (0)
-         129   jump +2                            (to 131)
-         130   load_const 8                       (null)
-         131   store_var_load_var 59              (_177)
-         132   load_const 8                       (null)
-         133   cmp_op ==                          
-         134   pop_jump_if_false +4               (to 138)
+         122   load_field 0                       (0)
+         123   jump +2                            (to 125)
+         124   load_const 8                       (null)
+         125   store_var_load_var 59              (_177)
+         126   load_const 8                       (null)
+         127   cmp_op ==                          
+         128   pop_jump_if_false +4               (to 132)
 
-  1151   135   load_var 2                         (state)
-         136   load_field 5                       (reasoning_tokens)
-         137   store_var 59                       (_177)
+  1151   129   load_var 2                         (state)
+         130   load_field 5                       (reasoning_tokens)
+         131   store_var 59                       (_177)
 
-  1150   138   load_var2 2 59                     
-         139   store_field 5                      (reasoning_tokens)
+  1150   132   load_var2 2 59                     
+         133   store_field 5                      (reasoning_tokens)
 
-  1153   140   load_var 11                        (event)
+  1153   134   load_var 11                        (event)
+         135   load_field 2                       (delta)
+         136   load_const 8                       (null)
+         137   cmp_op ==                          
+         138   pop_jump_if_false +2               (to 140)
+         139   jump +6                            (to 145)
+         140   load_var 11                        (event)
          141   load_field 2                       (delta)
-         142   load_const 8                       (null)
-         143   cmp_op ==                          
-         144   pop_jump_if_false +2               (to 146)
-         145   jump +6                            (to 151)
-         146   load_var 11                        (event)
-         147   load_field 2                       (delta)
-         148   load_field 5                       (5)
-         149   store_var 61                       (_184)
-         150   jump +3                            (to 153)
-         151   load_const 8                       (null)
-         152   store_var 61                       (_184)
-         153   load_var 61                        (_184)
-         154   load_const 8                       (null)
-         155   cmp_op ==                          
-         156   pop_jump_if_false +2               (to 158)
-         157   jump +9                            (to 166)
-         158   load_var 61                        (_184)
-         159   store_var 62                       (s)
+         142   load_field 5                       (5)
+         143   store_var 61                       (_184)
+         144   jump +3                            (to 147)
+         145   load_const 8                       (null)
+         146   store_var 61                       (_184)
+         147   load_var 61                        (_184)
+         148   load_const 8                       (null)
+         149   cmp_op ==                          
+         150   pop_jump_if_false +2               (to 152)
+         151   jump +9                            (to 160)
+         152   load_var 61                        (_184)
+         153   store_var 62                       (s)
 
-  1156   160   load_var2 2 62                     
-         161   store_field 6                      (stop_reason_raw)
+  1156   154   load_var2 2 62                     
+         155   store_field 6                      (stop_reason_raw)
 
-  1157   162   load_var 62                        (s)
-         163   call 1190 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
-         164   store_var 60                       (stop)
-         165   jump +3                            (to 168)
+  1157   156   load_var 62                        (s)
+         157   call 1190 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
+         158   store_var 60                       (stop)
+         159   jump +3                            (to 162)
 
-  1154   166   load_const 8                       (null)
-         167   store_var 60                       (stop)
+  1154   160   load_const 8                       (null)
+         161   store_var 60                       (stop)
 
-  1162   168   load_var 60                        (stop)
-         169   store_var 63                       (_193)
+  1162   162   load_var 60                        (stop)
+         163   store_var 63                       (_193)
 
-  1163   170   load_var 11                        (event)
+  1163   164   load_var 11                        (event)
+         165   load_field 5                       (usage)
+         166   load_const 8                       (null)
+         167   cmp_op ==                          
+         168   pop_jump_if_false +2               (to 170)
+         169   jump +6                            (to 175)
+         170   load_var 11                        (event)
          171   load_field 5                       (usage)
-         172   load_const 8                       (null)
-         173   cmp_op ==                          
-         174   pop_jump_if_false +2               (to 176)
-         175   jump +6                            (to 181)
-         176   load_var 11                        (event)
-         177   load_field 5                       (usage)
-         178   load_field 0                       (0)
-         179   store_var 64                       (_194)
-         180   jump +3                            (to 183)
-         181   load_const 8                       (null)
-         182   store_var 64                       (_194)
+         172   load_field 0                       (0)
+         173   store_var 64                       (_194)
+         174   jump +3                            (to 177)
+         175   load_const 8                       (null)
+         176   store_var 64                       (_194)
 
-  1164   183   load_var 11                        (event)
+  1164   177   load_var 11                        (event)
+         178   load_field 5                       (usage)
+         179   load_const 8                       (null)
+         180   cmp_op ==                          
+         181   pop_jump_if_false +2               (to 183)
+         182   jump +6                            (to 188)
+         183   load_var 11                        (event)
          184   load_field 5                       (usage)
-         185   load_const 8                       (null)
-         186   cmp_op ==                          
-         187   pop_jump_if_false +2               (to 189)
-         188   jump +6                            (to 194)
-         189   load_var 11                        (event)
-         190   load_field 5                       (usage)
-         191   load_field 1                       (1)
-         192   store_var 65                       (_198)
-         193   jump +3                            (to 196)
-         194   load_const 8                       (null)
-         195   store_var 65                       (_198)
+         185   load_field 1                       (1)
+         186   store_var 65                       (_198)
+         187   jump +3                            (to 190)
+         188   load_const 8                       (null)
+         189   store_var 65                       (_198)
 
-  1160   196   load_type 0                        
-         197   load_var2 3 63                     
+  1160   190   load_type 0                        
+         191   load_var2 3 63                     
 
-  1161   198   load_var2 64 65                    
-         199   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
+  1161   192   load_var2 64 65                    
+         193   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
 
-  1160   200   call 4 ntypeargs=1                 (baml.Array.push)
-         201   pop 1                              
-         202   jump -193                          (to 9)
+  1160   194   call 4 ntypeargs=1                 (baml.Array.push)
+         195   pop 1                              
+         196   jump -187                          (to 9)
 
-  1106   203   load_var 11                        (event)
-         204   load_field 2                       (delta)
-         205   store_var 39                       (_119)
-         206   load_var 39                        (_119)
-         207   narrow_bind 18 39                  
-         208   pop_jump_if_false -199             (to 9)
-         209   load_var 39                        (_119)
-         210   store_var_load_var 40              (d)
+  1106   197   load_var 11                        (event)
+         198   load_field 2                       (delta)
+         199   store_var 39                       (_119)
+         200   load_var 39                        (_119)
+         201   narrow_bind 18 39                  
+         202   pop_jump_if_false -193             (to 9)
+         203   load_var 39                        (_119)
+         204   store_var_load_var 40              (d)
 
-  1107   211   load_field 0                       (type)
-         212   store_var_load_var 42              (_122)
-         213   load_const 8                       (null)
-         214   cmp_op ==                          
-         215   pop_jump_if_false +3               (to 218)
-         216   load_const 19                      ("")
-         217   store_var 42                       (_122)
-         218   load_var 42                        (_122)
-         219   store_var_load_var 41              (kind)
+  1107   205   load_field 0                       (type)
+         206   store_var_load_var 42              (_122)
+         207   load_const 8                       (null)
+         208   cmp_op ==                          
+         209   pop_jump_if_false +3               (to 212)
+         210   load_const 19                      ("")
+         211   store_var 42                       (_122)
+         212   load_var 42                        (_122)
+         213   store_var_load_var 41              (kind)
 
-  1108   220   load_const 20                      ("text_delta")
-         221   cmp_op ==                          
-         222   pop_jump_if_false +2               (to 224)
-         223   jump +90                           (to 313)
-         224   load_var 41                        (kind)
-         225   load_const 21                      ("input_json_delta")
-         226   cmp_op ==                          
-         227   pop_jump_if_false +2               (to 229)
-         228   jump +54                           (to 282)
-         229   load_var 41                        (kind)
-         230   load_const 22                      ("thinking_delta")
-         231   cmp_op ==                          
-         232   pop_jump_if_false +2               (to 234)
-         233   jump +27                           (to 260)
-         234   load_var 41                        (kind)
-         235   load_const 23                      ("signature_delta")
-         236   cmp_op ==                          
-         237   pop_jump_if_false -228             (to 9)
+  1108   214   is_type 20                         
+         215   pop_jump_if_false +2               (to 217)
+         216   jump +87                           (to 303)
+         217   load_var 41                        (kind)
+         218   is_type 21                         
+         219   pop_jump_if_false +2               (to 221)
+         220   jump +52                           (to 272)
+         221   load_var 41                        (kind)
+         222   is_type 22                         
+         223   pop_jump_if_false +2               (to 225)
+         224   jump +26                           (to 250)
+         225   load_var 41                        (kind)
+         226   is_type 23                         
+         227   pop_jump_if_false -218             (to 9)
 
-  1131   238   load_type 24                       
-         239   load_var 2                         (state)
-         240   load_field 1                       (signature)
-         241   call 138 ntypeargs=1               (baml.String.from)
-         242   store_var 52                       (_158)
-         243   load_var 40                        (d)
-         244   load_field 4                       (signature)
-         245   store_var_load_var 54              (_163)
-         246   load_const 8                       (null)
-         247   cmp_op ==                          
-         248   pop_jump_if_false +3               (to 251)
-         249   load_const 25                      ("")
-         250   store_var 54                       (_163)
-         251   load_type 24                       
-         252   load_var 54                        (_163)
+  1131   228   load_type 24                       
+         229   load_var 2                         (state)
+         230   load_field 1                       (signature)
+         231   call 138 ntypeargs=1               (baml.String.from)
+         232   store_var 52                       (_158)
+         233   load_var 40                        (d)
+         234   load_field 4                       (signature)
+         235   store_var_load_var 54              (_163)
+         236   load_const 8                       (null)
+         237   cmp_op ==                          
+         238   pop_jump_if_false +3               (to 241)
+         239   load_const 25                      ("")
+         240   store_var 54                       (_163)
+         241   load_type 24                       
+         242   load_var 54                        (_163)
+         243   call 138 ntypeargs=1               (baml.String.from)
+         244   store_var 53                       (_161)
+         245   load_var2 2 52                     
+         246   load_var 53                        (_161)
+         247   bin_op +                           
+         248   store_field 1                      (signature)
+
+  1108   249   jump -240                          (to 9)
+
+  1127   250   load_type 24                       
+         251   load_var 2                         (state)
+         252   load_field 0                       (thinking)
          253   call 138 ntypeargs=1               (baml.String.from)
-         254   store_var 53                       (_161)
-         255   load_var2 2 52                     
-         256   load_var 53                        (_161)
-         257   bin_op +                           
-         258   store_field 1                      (signature)
+         254   store_var 49                       (_148)
+         255   load_var 40                        (d)
+         256   load_field 3                       (thinking)
+         257   store_var_load_var 51              (_153)
+         258   load_const 8                       (null)
+         259   cmp_op ==                          
+         260   pop_jump_if_false +3               (to 263)
+         261   load_const 26                      ("")
+         262   store_var 51                       (_153)
+         263   load_type 24                       
+         264   load_var 51                        (_153)
+         265   call 138 ntypeargs=1               (baml.String.from)
+         266   store_var 50                       (_151)
+         267   load_var2 2 49                     
+         268   load_var 50                        (_151)
+         269   bin_op +                           
+         270   store_field 0                      (thinking)
 
-  1108   259   jump -250                          (to 9)
+  1108   271   jump -262                          (to 9)
 
-  1127   260   load_type 24                       
-         261   load_var 2                         (state)
-         262   load_field 0                       (thinking)
-         263   call 138 ntypeargs=1               (baml.String.from)
-         264   store_var 49                       (_148)
-         265   load_var 40                        (d)
-         266   load_field 3                       (thinking)
-         267   store_var_load_var 51              (_153)
-         268   load_const 8                       (null)
-         269   cmp_op ==                          
-         270   pop_jump_if_false +3               (to 273)
-         271   load_const 26                      ("")
-         272   store_var 51                       (_153)
-         273   load_type 24                       
-         274   load_var 51                        (_153)
-         275   call 138 ntypeargs=1               (baml.String.from)
-         276   store_var 50                       (_151)
-         277   load_var2 2 49                     
-         278   load_var 50                        (_151)
-         279   bin_op +                           
-         280   store_field 0                      (thinking)
+  1116   272   load_var2 2 11                     
 
-  1108   281   jump -272                          (to 9)
+  1118   273   load_field 1                       (index)
 
-  1116   282   load_var2 2 11                     
+  1116   274   call 1195 ntypeargs=0              (anthropic.internal._anth_stream_call_at)
+         275   store_var 44                       (_136)
+         276   load_var 44                        (_136)
+         277   narrow_bind 27 44                  
+         278   pop_jump_if_false -269             (to 9)
+         279   load_var 44                        (_136)
+         280   store_var 45                       (call)
 
-  1118   283   load_field 1                       (index)
+  1120   281   load_type 24                       
+         282   load_var 45                        (call)
+         283   load_field 3                       (args_json)
+         284   call 138 ntypeargs=1               (baml.String.from)
+         285   store_var 46                       (_138)
+         286   load_var 40                        (d)
+         287   load_field 2                       (partial_json)
+         288   store_var_load_var 48              (_143)
+         289   load_const 8                       (null)
+         290   cmp_op ==                          
+         291   pop_jump_if_false +3               (to 294)
+         292   load_const 28                      ("")
+         293   store_var 48                       (_143)
+         294   load_type 24                       
+         295   load_var 48                        (_143)
+         296   call 138 ntypeargs=1               (baml.String.from)
+         297   store_var 47                       (_141)
+         298   load_var2 45 46                    
+         299   load_var 47                        (_141)
+         300   bin_op +                           
+         301   store_field 3                      (args_json)
 
-  1116   284   call 1195 ntypeargs=0              (anthropic.internal._anth_stream_call_at)
-         285   store_var 44                       (_136)
-         286   load_var 44                        (_136)
-         287   narrow_bind 27 44                  
-         288   pop_jump_if_false -279             (to 9)
-         289   load_var 44                        (_136)
-         290   store_var 45                       (call)
+  1116   302   jump -293                          (to 9)
 
-  1120   291   load_type 24                       
-         292   load_var 45                        (call)
-         293   load_field 3                       (args_json)
-         294   call 138 ntypeargs=1               (baml.String.from)
-         295   store_var 46                       (_138)
-         296   load_var 40                        (d)
-         297   load_field 2                       (partial_json)
-         298   store_var_load_var 48              (_143)
-         299   load_const 8                       (null)
-         300   cmp_op ==                          
-         301   pop_jump_if_false +3               (to 304)
-         302   load_const 28                      ("")
-         303   store_var 48                       (_143)
-         304   load_type 24                       
-         305   load_var 48                        (_143)
-         306   call 138 ntypeargs=1               (baml.String.from)
-         307   store_var 47                       (_141)
-         308   load_var2 45 46                    
-         309   load_var 47                        (_141)
-         310   bin_op +                           
-         311   store_field 3                      (args_json)
+  1110   303   load_var 40                        (d)
+         304   load_field 1                       (text)
+         305   store_var 43                       (_127)
+         306   load_var 43                        (_127)
+         307   narrow_bind 6 43                   
+         308   pop_jump_if_false -299             (to 9)
 
-  1116   312   jump -303                          (to 9)
+  1111   309   load_type 0                        
+         310   load_var2 3 43                     
 
-  1110   313   load_var 40                        (d)
-         314   load_field 1                       (text)
-         315   store_var 43                       (_127)
-         316   load_var 43                        (_127)
-         317   narrow_bind 6 43                   
-         318   pop_jump_if_false -309             (to 9)
+  1110   311   init_instance 1                    (ai.stream.TextDelta .text)
 
-  1111   319   load_type 0                        
-         320   load_var2 3 43                     
+  1111   312   call 4 ntypeargs=1                 (baml.Array.push)
+         313   pop 1                              
+         314   jump -305                          (to 9)
 
-  1110   321   init_instance 1                    (ai.stream.TextDelta .text)
+  1071   315   load_var 11                        (event)
+         316   load_field 3                       (content_block)
+         317   store_var 24                       (_74)
+         318   load_var 24                        (_74)
+         319   narrow_bind 29 24                  
+         320   pop_jump_if_false -311             (to 9)
+         321   load_var 24                        (_74)
+         322   store_var_load_var 25              (block)
 
-  1111   322   call 4 ntypeargs=1                 (baml.Array.push)
-         323   pop 1                              
-         324   jump -315                          (to 9)
+  1072   323   load_field 0                       (type)
+         324   store_var_load_var 27              (_77)
+         325   load_const 8                       (null)
+         326   cmp_op ==                          
+         327   pop_jump_if_false +3               (to 330)
+         328   load_const 30                      ("")
+         329   store_var 27                       (_77)
+         330   load_var 27                        (_77)
+         331   store_var_load_var 26              (kind)
 
-  1071   325   load_var 11                        (event)
-         326   load_field 3                       (content_block)
-         327   store_var 24                       (_74)
-         328   load_var 24                        (_74)
-         329   narrow_bind 29 24                  
-         330   pop_jump_if_false -321             (to 9)
-         331   load_var 24                        (_74)
-         332   store_var_load_var 25              (block)
+  1073   332   is_type 31                         
+         333   pop_jump_if_false +2               (to 335)
+         334   jump +44                           (to 378)
+         335   load_var 26                        (kind)
+         336   is_type 32                         
+         337   pop_jump_if_false +2               (to 339)
+         338   jump +18                           (to 356)
 
-  1072   333   load_field 0                       (type)
-         334   store_var_load_var 27              (_77)
-         335   load_const 8                       (null)
-         336   cmp_op ==                          
-         337   pop_jump_if_false +3               (to 340)
-         338   load_const 30                      ("")
-         339   store_var 27                       (_77)
-         340   load_var 27                        (_77)
-         341   store_var_load_var 26              (kind)
+  1091   339   load_var 25                        (block)
+         340   load_field 3                       (text)
+         341   store_var 37                       (_109)
+         342   load_var 37                        (_109)
+         343   narrow_bind 6 37                   
+         344   pop_jump_if_false -335             (to 9)
+         345   load_var 37                        (_109)
+         346   store_var_load_var 38              (text)
 
-  1073   342   load_const 31                      ("tool_use")
-         343   cmp_op ==                          
-         344   pop_jump_if_false +2               (to 346)
-         345   jump +45                           (to 390)
-         346   load_var 26                        (kind)
-         347   load_const 32                      ("thinking")
-         348   cmp_op ==                          
-         349   pop_jump_if_false +2               (to 351)
-         350   jump +18                           (to 368)
+  1092   347   load_const 33                      ("")
+         348   cmp_op !=                          
+         349   pop_jump_if_false -340             (to 9)
 
-  1091   351   load_var 25                        (block)
-         352   load_field 3                       (text)
-         353   store_var 37                       (_109)
-         354   load_var 37                        (_109)
-         355   narrow_bind 6 37                   
-         356   pop_jump_if_false -347             (to 9)
-         357   load_var 37                        (_109)
-         358   store_var_load_var 38              (text)
+  1093   350   load_type 0                        
+         351   load_var2 3 38                     
+         352   init_instance 2                    (ai.stream.TextDelta .text)
+         353   call 4 ntypeargs=1                 (baml.Array.push)
+         354   pop 1                              
+         355   jump -346                          (to 9)
 
-  1092   359   load_const 33                      ("")
-         360   cmp_op !=                          
-         361   pop_jump_if_false -352             (to 9)
-
-  1093   362   load_type 0                        
-         363   load_var2 3 38                     
-         364   init_instance 2                    (ai.stream.TextDelta .text)
-         365   call 4 ntypeargs=1                 (baml.Array.push)
-         366   pop 1                              
-         367   jump -358                          (to 9)
-
-  1086   368   load_type 24                       
-         369   load_var 2                         (state)
-         370   load_field 0                       (thinking)
+  1086   356   load_type 24                       
+         357   load_var 2                         (state)
+         358   load_field 0                       (thinking)
+         359   call 138 ntypeargs=1               (baml.String.from)
+         360   store_var 34                       (_99)
+         361   load_var 25                        (block)
+         362   load_field 4                       (thinking)
+         363   store_var_load_var 36              (_104)
+         364   load_const 8                       (null)
+         365   cmp_op ==                          
+         366   pop_jump_if_false +3               (to 369)
+         367   load_const 34                      ("")
+         368   store_var 36                       (_104)
+         369   load_type 24                       
+         370   load_var 36                        (_104)
          371   call 138 ntypeargs=1               (baml.String.from)
-         372   store_var 34                       (_99)
-         373   load_var 25                        (block)
-         374   load_field 4                       (thinking)
-         375   store_var_load_var 36              (_104)
-         376   load_const 8                       (null)
-         377   cmp_op ==                          
-         378   pop_jump_if_false +3               (to 381)
-         379   load_const 34                      ("")
-         380   store_var 36                       (_104)
-         381   load_type 24                       
-         382   load_var 36                        (_104)
-         383   call 138 ntypeargs=1               (baml.String.from)
-         384   store_var 35                       (_102)
-         385   load_var2 2 34                     
-         386   load_var 35                        (_102)
-         387   bin_op +                           
-         388   store_field 0                      (thinking)
+         372   store_var 35                       (_102)
+         373   load_var2 2 34                     
+         374   load_var 35                        (_102)
+         375   bin_op +                           
+         376   store_field 0                      (thinking)
 
-  1073   389   jump -380                          (to 9)
+  1073   377   jump -368                          (to 9)
 
-  1075   390   load_var 2                         (state)
-         391   load_field 2                       (tool_calls)
-         392   store_var 28                       (_82)
+  1075   378   load_var 2                         (state)
+         379   load_field 2                       (tool_calls)
+         380   store_var 28                       (_82)
 
-  1077   393   load_var 11                        (event)
-         394   load_field 1                       (index)
-         395   store_var_load_var 30              (_85)
+  1077   381   load_var 11                        (event)
+         382   load_field 1                       (index)
+         383   store_var_load_var 30              (_85)
+         384   load_const 8                       (null)
+         385   cmp_op ==                          
+         386   pop_jump_if_false +5               (to 391)
+         387   load_var 2                         (state)
+         388   load_field 2                       (tool_calls)
+         389   container_len                      
+         390   store_var 30                       (_85)
+         391   load_var 30                        (_85)
+         392   store_var 29                       (_84)
+
+  1078   393   load_var 25                        (block)
+         394   load_field 1                       (id)
+         395   store_var_load_var 32              (_90)
          396   load_const 8                       (null)
          397   cmp_op ==                          
-         398   pop_jump_if_false +5               (to 403)
-         399   load_var 2                         (state)
-         400   load_field 2                       (tool_calls)
-         401   container_len                      
-         402   store_var 30                       (_85)
-         403   load_var 30                        (_85)
-         404   store_var 29                       (_84)
+         398   pop_jump_if_false +3               (to 401)
+         399   load_const 35                      ("")
+         400   store_var 32                       (_90)
+         401   load_var 32                        (_90)
+         402   store_var 31                       (_89)
 
-  1078   405   load_var 25                        (block)
-         406   load_field 1                       (id)
-         407   store_var_load_var 32              (_90)
-         408   load_const 8                       (null)
-         409   cmp_op ==                          
-         410   pop_jump_if_false +3               (to 413)
-         411   load_const 35                      ("")
-         412   store_var 32                       (_90)
-         413   load_var 32                        (_90)
-         414   store_var 31                       (_89)
+  1079   403   load_var 25                        (block)
+         404   load_field 2                       (name)
+         405   store_var_load_var 33              (_94)
+         406   load_const 8                       (null)
+         407   cmp_op ==                          
+         408   pop_jump_if_false +3               (to 411)
+         409   load_const 36                      ("")
+         410   store_var 33                       (_94)
 
-  1079   415   load_var 25                        (block)
-         416   load_field 2                       (name)
-         417   store_var_load_var 33              (_94)
-         418   load_const 8                       (null)
-         419   cmp_op ==                          
-         420   pop_jump_if_false +3               (to 423)
-         421   load_const 36                      ("")
-         422   store_var 33                       (_94)
+  1075   411   load_type 37                       
+         412   load_var2 28 29                    
 
-  1075   423   load_type 37                       
-         424   load_var2 28 29                    
+  1076   413   load_var2 31 33                    
 
-  1076   425   load_var2 31 33                    
+  1079   414   load_const 38                      ("")
+         415   init_instance 3                    (anthropic.internal.AnthStreamToolCall .index, .id, .name, .args_json)
 
-  1079   426   load_const 38                      ("")
-         427   init_instance 3                    (anthropic.internal.AnthStreamToolCall .index, .id, .name, .args_json)
+  1075   416   call 4 ntypeargs=1                 (baml.Array.push)
+         417   pop 1                              
+         418   jump -409                          (to 9)
 
-  1075   428   call 4 ntypeargs=1                 (baml.Array.push)
-         429   pop 1                              
-         430   jump -421                          (to 9)
+  1045   419   load_var 11                        (event)
+         420   load_field 4                       (message)
+         421   store_var 15                       (_32)
+         422   load_var 15                        (_32)
+         423   narrow_bind 39 15                  
+         424   pop_jump_if_false +55              (to 479)
+         425   load_var 15                        (_32)
+         426   store_var 16                       (message)
 
-  1045   431   load_var 11                        (event)
-         432   load_field 4                       (message)
-         433   store_var 15                       (_32)
-         434   load_var 15                        (_32)
-         435   narrow_bind 39 15                  
-         436   pop_jump_if_false +55              (to 491)
-         437   load_var 15                        (_32)
-         438   store_var 16                       (message)
+  1046   427   load_var2 2 16                     
+         428   load_field 1                       (model)
+         429   store_field 7                      (model)
 
-  1046   439   load_var2 2 16                     
-         440   load_field 1                       (model)
-         441   store_field 7                      (model)
+  1047   430   load_var 16                        (message)
+         431   load_field 3                       (usage)
+         432   store_var 17                       (_35)
+         433   load_var 17                        (_35)
+         434   narrow_bind 17 17                  
+         435   pop_jump_if_false +44              (to 479)
+         436   load_var 17                        (_35)
+         437   store_var_load_var 18              (usage)
 
-  1047   442   load_var 16                        (message)
-         443   load_field 3                       (usage)
-         444   store_var 17                       (_35)
-         445   load_var 17                        (_35)
-         446   narrow_bind 17 17                  
-         447   pop_jump_if_false +44              (to 491)
-         448   load_var 17                        (_35)
-         449   store_var_load_var 18              (usage)
+  1049   438   load_field 2                       (cache_read_input_tokens)
+         439   store_var_load_var 19              (_37)
+         440   load_const 8                       (null)
+         441   cmp_op ==                          
+         442   pop_jump_if_false +4               (to 446)
+         443   load_var 2                         (state)
+         444   load_field 3                       (cache_read_input_tokens)
+         445   store_var 19                       (_37)
+         446   load_var2 2 19                     
+         447   store_field 3                      (cache_read_input_tokens)
 
-  1049   450   load_field 2                       (cache_read_input_tokens)
-         451   store_var_load_var 19              (_37)
-         452   load_const 8                       (null)
-         453   cmp_op ==                          
-         454   pop_jump_if_false +4               (to 458)
-         455   load_var 2                         (state)
-         456   load_field 3                       (cache_read_input_tokens)
-         457   store_var 19                       (_37)
-         458   load_var2 2 19                     
-         459   store_field 3                      (cache_read_input_tokens)
+  1051   448   load_var 18                        (usage)
+         449   load_field 3                       (cache_creation_input_tokens)
+         450   store_var_load_var 20              (_40)
 
-  1051   460   load_var 18                        (usage)
-         461   load_field 3                       (cache_creation_input_tokens)
-         462   store_var_load_var 20              (_40)
+  1052   451   load_const 8                       (null)
+         452   cmp_op ==                          
+         453   pop_jump_if_false +4               (to 457)
+         454   load_var 2                         (state)
+         455   load_field 4                       (cache_creation_input_tokens)
+         456   store_var 20                       (_40)
 
-  1052   463   load_const 8                       (null)
-         464   cmp_op ==                          
-         465   pop_jump_if_false +4               (to 469)
-         466   load_var 2                         (state)
-         467   load_field 4                       (cache_creation_input_tokens)
-         468   store_var 20                       (_40)
+  1051   457   load_var2 2 20                     
+         458   store_field 4                      (cache_creation_input_tokens)
 
-  1051   469   load_var2 2 20                     
-         470   store_field 4                      (cache_creation_input_tokens)
+  1054   459   load_var 18                        (usage)
+         460   load_field 4                       (output_tokens_details)
+         461   load_const 8                       (null)
+         462   cmp_op ==                          
+         463   pop_jump_if_false +2               (to 465)
+         464   jump +5                            (to 469)
+         465   load_var 18                        (usage)
+         466   load_field 4                       (output_tokens_details)
+         467   load_field 0                       (0)
+         468   jump +2                            (to 470)
+         469   load_const 8                       (null)
+         470   store_var_load_var 21              (_43)
+         471   load_const 8                       (null)
+         472   cmp_op ==                          
+         473   pop_jump_if_false +4               (to 477)
 
-  1054   471   load_var 18                        (usage)
-         472   load_field 4                       (output_tokens_details)
-         473   load_const 8                       (null)
-         474   cmp_op ==                          
-         475   pop_jump_if_false +2               (to 477)
-         476   jump +5                            (to 481)
-         477   load_var 18                        (usage)
-         478   load_field 4                       (output_tokens_details)
-         479   load_field 0                       (0)
-         480   jump +2                            (to 482)
+  1055   474   load_var 2                         (state)
+         475   load_field 5                       (reasoning_tokens)
+         476   store_var 21                       (_43)
+
+  1054   477   load_var2 2 21                     
+         478   store_field 5                      (reasoning_tokens)
+
+  1064   479   load_var 11                        (event)
+         480   load_field 4                       (message)
          481   load_const 8                       (null)
-         482   store_var_load_var 21              (_43)
-         483   load_const 8                       (null)
-         484   cmp_op ==                          
-         485   pop_jump_if_false +4               (to 489)
+         482   cmp_op ==                          
+         483   pop_jump_if_false +2               (to 485)
+         484   jump +20                           (to 504)
+         485   load_var 11                        (event)
+         486   load_field 4                       (message)
+         487   load_field 3                       (3)
+         488   load_const 8                       (null)
+         489   cmp_op ==                          
+         490   pop_jump_if_false +2               (to 492)
+         491   jump +13                           (to 504)
+         492   load_var 11                        (event)
+         493   load_field 4                       (message)
+         494   load_const 8                       (null)
+         495   cmp_op ==                          
+         496   pop_jump_if_false +2               (to 498)
+         497   jump +7                            (to 504)
+         498   load_var 11                        (event)
+         499   load_field 4                       (message)
+         500   load_field 3                       (3)
+         501   load_field 0                       (0)
+         502   store_var 22                       (_51)
+         503   jump +3                            (to 506)
+         504   load_const 8                       (null)
+         505   store_var 22                       (_51)
 
-  1055   486   load_var 2                         (state)
-         487   load_field 5                       (reasoning_tokens)
-         488   store_var 21                       (_43)
+  1065   506   load_var 11                        (event)
+         507   load_field 4                       (message)
+         508   load_const 8                       (null)
+         509   cmp_op ==                          
+         510   pop_jump_if_false +2               (to 512)
+         511   jump +20                           (to 531)
+         512   load_var 11                        (event)
+         513   load_field 4                       (message)
+         514   load_field 3                       (3)
+         515   load_const 8                       (null)
+         516   cmp_op ==                          
+         517   pop_jump_if_false +2               (to 519)
+         518   jump +13                           (to 531)
+         519   load_var 11                        (event)
+         520   load_field 4                       (message)
+         521   load_const 8                       (null)
+         522   cmp_op ==                          
+         523   pop_jump_if_false +2               (to 525)
+         524   jump +7                            (to 531)
+         525   load_var 11                        (event)
+         526   load_field 4                       (message)
+         527   load_field 3                       (3)
+         528   load_field 1                       (1)
+         529   store_var 23                       (_61)
+         530   jump +3                            (to 533)
+         531   load_const 8                       (null)
+         532   store_var 23                       (_61)
 
-  1054   489   load_var2 2 21                     
-         490   store_field 5                      (reasoning_tokens)
+  1061   533   load_type 0                        
+         534   load_var 3                         (out)
 
-  1064   491   load_var 11                        (event)
-         492   load_field 4                       (message)
-         493   load_const 8                       (null)
-         494   cmp_op ==                          
-         495   pop_jump_if_false +2               (to 497)
-         496   jump +20                           (to 516)
-         497   load_var 11                        (event)
-         498   load_field 4                       (message)
-         499   load_field 3                       (3)
-         500   load_const 8                       (null)
-         501   cmp_op ==                          
-         502   pop_jump_if_false +2               (to 504)
-         503   jump +13                           (to 516)
-         504   load_var 11                        (event)
-         505   load_field 4                       (message)
-         506   load_const 8                       (null)
-         507   cmp_op ==                          
-         508   pop_jump_if_false +2               (to 510)
-         509   jump +7                            (to 516)
-         510   load_var 11                        (event)
-         511   load_field 4                       (message)
-         512   load_field 3                       (3)
-         513   load_field 0                       (0)
-         514   store_var 22                       (_51)
-         515   jump +3                            (to 518)
-         516   load_const 8                       (null)
-         517   store_var 22                       (_51)
+  1062   535   load_const 8                       (null)
+         536   load_var2 22 23                    
+         537   init_instance 4                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
 
-  1065   518   load_var 11                        (event)
-         519   load_field 4                       (message)
-         520   load_const 8                       (null)
-         521   cmp_op ==                          
-         522   pop_jump_if_false +2               (to 524)
-         523   jump +20                           (to 543)
-         524   load_var 11                        (event)
-         525   load_field 4                       (message)
-         526   load_field 3                       (3)
-         527   load_const 8                       (null)
-         528   cmp_op ==                          
-         529   pop_jump_if_false +2               (to 531)
-         530   jump +13                           (to 543)
-         531   load_var 11                        (event)
-         532   load_field 4                       (message)
-         533   load_const 8                       (null)
-         534   cmp_op ==                          
-         535   pop_jump_if_false +2               (to 537)
-         536   jump +7                            (to 543)
-         537   load_var 11                        (event)
-         538   load_field 4                       (message)
-         539   load_field 3                       (3)
-         540   load_field 1                       (1)
-         541   store_var 23                       (_61)
-         542   jump +3                            (to 545)
-         543   load_const 8                       (null)
-         544   store_var 23                       (_61)
+  1061   538   call 4 ntypeargs=1                 (baml.Array.push)
+         539   pop 1                              
+         540   jump -531                          (to 9)
 
-  1061   545   load_type 0                        
-         546   load_var 3                         (out)
+  1042   541   load_var 11                        (event)
+         542   load_field 6                       (error)
+         543   load_var 8                         (data)
+         544   call 1196 ntypeargs=0              (anthropic.internal._anth_stream_failure)
+         545   throw                              
 
-  1062   547   load_const 8                       (null)
-         548   load_var2 22 23                    
-         549   init_instance 4                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
-
-  1061   550   call 4 ntypeargs=1                 (baml.Array.push)
-         551   pop 1                              
-         552   jump -543                          (to 9)
-
-  1042   553   load_var 11                        (event)
-         554   load_field 6                       (error)
-         555   load_var 8                         (data)
-         556   call 1196 ntypeargs=0              (anthropic.internal._anth_stream_failure)
-         557   throw                              
-
-  1185   558   load_var 3                         (out)
-         559   return                             
+  1185   546   load_var 3                         (out)
+         547   return                             
 }
 
 function anthropic.internal.anthropic_messages_body(params: anthropic.internal.AnthropicBodyParams, input: ai.ModelTurnInput, stream: bool) -> string {
@@ -9494,182 +9459,179 @@ function anthropic.internal.anthropic_parse(resp: anthropic.internal.AnthropicRe
         14    load_var 4                         (_5)
         15    is_type 5                          
         16    pop_jump_if_false +2               (to 18)
-        17    jump +84                           (to 101)
+        17    jump +81                           (to 98)
         18    load_var 4                         (_5)
         19    store_var 5                        (b)
 
   810   20    load_var 5                         (b)
         21    load_field 0                       (type)
         22    store_var_load_var 6               (_9)
-        23    load_const 6                       ("text")
-        24    cmp_op ==                          
-        25    pop_jump_if_false +2               (to 27)
-        26    jump +61                           (to 87)
-        27    load_var 6                         (_9)
-        28    load_const 7                       ("thinking")
-        29    cmp_op ==                          
-        30    pop_jump_if_false +2               (to 32)
-        31    jump +42                           (to 73)
-        32    load_var 6                         (_9)
-        33    load_const 8                       ("tool_use")
-        34    cmp_op ==                          
-        35    pop_jump_if_false -26              (to 9)
+        23    is_type 6                          
+        24    pop_jump_if_false +2               (to 26)
+        25    jump +59                           (to 84)
+        26    load_var 6                         (_9)
+        27    is_type 7                          
+        28    pop_jump_if_false +2               (to 30)
+        29    jump +41                           (to 70)
+        30    load_var 6                         (_9)
+        31    is_type 8                          
+        32    pop_jump_if_false -23              (to 9)
 
-  823   36    load_var 5                         (b)
-        37    load_field 4                       (id)
-        38    store_var_load_var 10              (_31)
-        39    load_const 9                       (null)
-        40    cmp_op ==                          
-        41    pop_jump_if_false +3               (to 44)
-        42    load_const 10                      ("")
-        43    store_var 10                       (_31)
-        44    load_var 10                        (_31)
-        45    store_var 9                        (_30)
+  823   33    load_var 5                         (b)
+        34    load_field 4                       (id)
+        35    store_var_load_var 10              (_31)
+        36    load_const 9                       (null)
+        37    cmp_op ==                          
+        38    pop_jump_if_false +3               (to 41)
+        39    load_const 10                      ("")
+        40    store_var 10                       (_31)
+        41    load_var 10                        (_31)
+        42    store_var 9                        (_30)
 
-  824   46    load_var 5                         (b)
-        47    load_field 5                       (name)
-        48    store_var_load_var 12              (_35)
-        49    load_const 9                       (null)
-        50    cmp_op ==                          
-        51    pop_jump_if_false +3               (to 54)
-        52    load_const 11                      ("")
-        53    store_var 12                       (_35)
-        54    load_var 12                        (_35)
-        55    store_var 11                       (_34)
+  824   43    load_var 5                         (b)
+        44    load_field 5                       (name)
+        45    store_var_load_var 12              (_35)
+        46    load_const 9                       (null)
+        47    cmp_op ==                          
+        48    pop_jump_if_false +3               (to 51)
+        49    load_const 11                      ("")
+        50    store_var 12                       (_35)
+        51    load_var 12                        (_35)
+        52    store_var 11                       (_34)
 
-  825   56    load_var 5                         (b)
-        57    load_field 6                       (input)
-        58    store_var_load_var 13              (_39)
-        59    load_const 9                       (null)
-        60    cmp_op ==                          
-        61    pop_jump_if_false +5               (to 66)
+  825   53    load_var 5                         (b)
+        54    load_field 6                       (input)
+        55    store_var_load_var 13              (_39)
+        56    load_const 9                       (null)
+        57    cmp_op ==                          
+        58    pop_jump_if_false +5               (to 63)
 
-  820   62    load_type 12                       
-        63    load_type 13                       
-        64    alloc_map 0                        
-        65    store_var 13                       (_39)
+  820   59    load_type 12                       
+        60    load_type 13                       
+        61    alloc_map 0                        
+        62    store_var 13                       (_39)
 
-  821   66    load_type 0                        
-        67    load_var2 2 9                      
+  821   63    load_type 0                        
+        64    load_var2 2 9                      
 
-  822   68    load_var2 11 13                    
+  822   65    load_var2 11 13                    
 
-  825   69    init_instance 0                    (ai.content.ToolUse .id, .name, .args)
+  825   66    init_instance 0                    (ai.content.ToolUse .id, .name, .args)
 
-  821   70    call 4 ntypeargs=1                 (baml.Array.push)
-        71    pop 1                              
-        72    jump -63                           (to 9)
+  821   67    call 4 ntypeargs=1                 (baml.Array.push)
+        68    pop 1                              
+        69    jump -60                           (to 9)
 
-  816   73    load_var 5                         (b)
-        74    load_field 2                       (thinking)
-        75    store_var_load_var 8               (_22)
-        76    load_const 9                       (null)
-        77    cmp_op ==                          
-        78    pop_jump_if_false +3               (to 81)
-        79    load_const 14                      ("")
-        80    store_var 8                        (_22)
-        81    load_type 0                        
-        82    load_var2 2 8                      
-        83    init_instance 1                    (ai.content.Reasoning .summary)
-        84    call 4 ntypeargs=1                 (baml.Array.push)
-        85    pop 1                              
-        86    jump -77                           (to 9)
+  816   70    load_var 5                         (b)
+        71    load_field 2                       (thinking)
+        72    store_var_load_var 8               (_22)
+        73    load_const 9                       (null)
+        74    cmp_op ==                          
+        75    pop_jump_if_false +3               (to 78)
+        76    load_const 14                      ("")
+        77    store_var 8                        (_22)
+        78    load_type 0                        
+        79    load_var2 2 8                      
+        80    init_instance 1                    (ai.content.Reasoning .summary)
+        81    call 4 ntypeargs=1                 (baml.Array.push)
+        82    pop 1                              
+        83    jump -74                           (to 9)
 
-  812   87    load_var 5                         (b)
-        88    load_field 1                       (text)
-        89    store_var_load_var 7               (_14)
-        90    load_const 9                       (null)
-        91    cmp_op ==                          
-        92    pop_jump_if_false +3               (to 95)
-        93    load_const 15                      ("")
-        94    store_var 7                        (_14)
-        95    load_type 0                        
-        96    load_var2 2 7                      
-        97    init_instance 2                    (ai.content.Text .text)
-        98    call 4 ntypeargs=1                 (baml.Array.push)
-        99    pop 1                              
-        100   jump -91                           (to 9)
+  812   84    load_var 5                         (b)
+        85    load_field 1                       (text)
+        86    store_var_load_var 7               (_14)
+        87    load_const 9                       (null)
+        88    cmp_op ==                          
+        89    pop_jump_if_false +3               (to 92)
+        90    load_const 15                      ("")
+        91    store_var 7                        (_14)
+        92    load_type 0                        
+        93    load_var2 2 7                      
+        94    init_instance 2                    (ai.content.Text .text)
+        95    call 4 ntypeargs=1                 (baml.Array.push)
+        96    pop 1                              
+        97    jump -88                           (to 9)
 
-  836   101   load_var 1                         (resp)
-        102   load_field 5                       (stop_reason)
-        103   store_var_load_var 15              (_44)
-        104   load_const 9                       (null)
-        105   cmp_op ==                          
-        106   pop_jump_if_false +2               (to 108)
-        107   jump +5                            (to 112)
-        108   load_var 15                        (_44)
+  836   98    load_var 1                         (resp)
+        99    load_field 5                       (stop_reason)
+        100   store_var_load_var 15              (_44)
+        101   load_const 9                       (null)
+        102   cmp_op ==                          
+        103   pop_jump_if_false +2               (to 105)
+        104   jump +5                            (to 109)
+        105   load_var 15                        (_44)
 
-  838   109   call 1190 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
-        110   store_var 14                       (stop)
-        111   jump +4                            (to 115)
+  838   106   call 1190 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
+        107   store_var 14                       (stop)
+        108   jump +4                            (to 112)
 
-  837   112   load_const 16                      (ai.content.StopReason.Complete)
-        113   alloc_variant 774                  (ai.content.StopReason)
-        114   store_var 14                       (stop)
+  837   109   load_const 16                      (ai.content.StopReason.Complete)
+        110   alloc_variant 774                  (ai.content.StopReason)
+        111   store_var 14                       (stop)
 
-  841   115   load_var 1                         (resp)
-        116   load_field 7                       (usage)
-        117   store_var 17                       (_50)
-        118   load_var 17                        (_50)
-        119   narrow_bind 17 17                  
-        120   pop_jump_if_false +2               (to 122)
-        121   jump +4                            (to 125)
+  841   112   load_var 1                         (resp)
+        113   load_field 7                       (usage)
+        114   store_var 17                       (_50)
+        115   load_var 17                        (_50)
+        116   narrow_bind 17 17                  
+        117   pop_jump_if_false +2               (to 119)
+        118   jump +4                            (to 122)
 
-  855   122   load_const 9                       (null)
-        123   store_var 16                       (usage)
+  855   119   load_const 9                       (null)
+        120   store_var 16                       (usage)
 
-  841   124   jump +42                           (to 166)
-        125   load_var 17                        (_50)
-        126   store_var_load_var 18              (u)
+  841   121   jump +42                           (to 163)
+        122   load_var 17                        (_50)
+        123   store_var_load_var 18              (u)
 
-  844   127   load_field 0                       (input_tokens)
-        128   store_var_load_var 20              (_53)
-        129   load_const 9                       (null)
-        130   cmp_op ==                          
-        131   pop_jump_if_false +3               (to 134)
-        132   load_const 16                      (0)
-        133   store_var 20                       (_53)
-        134   load_var 20                        (_53)
-        135   store_var 19                       (_52)
+  844   124   load_field 0                       (input_tokens)
+        125   store_var_load_var 20              (_53)
+        126   load_const 9                       (null)
+        127   cmp_op ==                          
+        128   pop_jump_if_false +3               (to 131)
+        129   load_const 16                      (0)
+        130   store_var 20                       (_53)
+        131   load_var 20                        (_53)
+        132   store_var 19                       (_52)
 
-  845   136   load_var 18                        (u)
-        137   load_field 1                       (output_tokens)
-        138   store_var_load_var 22              (_57)
-        139   load_const 9                       (null)
-        140   cmp_op ==                          
-        141   pop_jump_if_false +3               (to 144)
-        142   load_const 16                      (0)
-        143   store_var 22                       (_57)
-        144   load_var 22                        (_57)
-        145   store_var 21                       (_56)
+  845   133   load_var 18                        (u)
+        134   load_field 1                       (output_tokens)
+        135   store_var_load_var 22              (_57)
+        136   load_const 9                       (null)
+        137   cmp_op ==                          
+        138   pop_jump_if_false +3               (to 141)
+        139   load_const 16                      (0)
+        140   store_var 22                       (_57)
+        141   load_var 22                        (_57)
+        142   store_var 21                       (_56)
 
-  850   146   load_var 18                        (u)
-        147   load_field 3                       (cache_read_input_tokens)
-        148   store_var 23                       (_60)
+  850   143   load_var 18                        (u)
+        144   load_field 3                       (cache_read_input_tokens)
+        145   store_var 23                       (_60)
 
-  852   149   load_var 18                        (u)
-        150   load_field 2                       (output_tokens_details)
-        151   load_const 9                       (null)
-        152   cmp_op ==                          
-        153   pop_jump_if_false +2               (to 155)
-        154   jump +6                            (to 160)
-        155   load_var 18                        (u)
-        156   load_field 2                       (output_tokens_details)
-        157   load_field 0                       (0)
+  852   146   load_var 18                        (u)
+        147   load_field 2                       (output_tokens_details)
+        148   load_const 9                       (null)
+        149   cmp_op ==                          
+        150   pop_jump_if_false +2               (to 152)
+        151   jump +6                            (to 157)
+        152   load_var 18                        (u)
+        153   load_field 2                       (output_tokens_details)
+        154   load_field 0                       (0)
+        155   store_var 24                       (_61)
+        156   jump +3                            (to 159)
+        157   load_const 9                       (null)
         158   store_var 24                       (_61)
-        159   jump +3                            (to 162)
-        160   load_const 9                       (null)
-        161   store_var 24                       (_61)
 
-  843   162   load_var2 19 21                    
-        163   load_var2 23 24                    
-        164   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
-        165   store_var 16                       (usage)
+  843   159   load_var2 19 21                    
+        160   load_var2 23 24                    
+        161   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
+        162   store_var 16                       (usage)
 
-  858   166   load_var2 2 14                     
-        167   load_var 16                        (usage)
-        168   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
-        169   return                             
+  858   163   load_var2 2 14                     
+        164   load_var 16                        (usage)
+        165   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
+        166   return                             
 }
 
 function anthropic.internal.anthropic_render(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> baml.http.Request {
@@ -9745,7 +9707,7 @@ function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: a
 
   1238   40   load_var2 3 7           
 
-  1239   41   make_closure 3362 1     
+  1239   41   make_closure 3279 1     
          42   load_const 8            ("anthropic")
 
   1237   43   call 959 ntypeargs=0    (ai.stream.TurnStream.from_sse)
@@ -10506,194 +10468,174 @@ function aws.internal._audio_block(audio: baml.media.Audio) -> aws.internal.Cont
 
 function aws.internal._audio_format(mime: string) -> string {
   443   0     load_var 1              (mime)
-        1     load_const 0            ("audio/mpeg")
-        2     cmp_op ==               
-        3     pop_jump_if_false +2    (to 5)
-        4     jump +143               (to 147)
-        5     load_var 1              (mime)
-        6     load_const 1            ("audio/mp3")
-        7     cmp_op ==               
-        8     pop_jump_if_false +2    (to 10)
-        9     jump +136               (to 145)
-        10    load_var 1              (mime)
-        11    load_const 2            ("audio/wav")
-        12    cmp_op ==               
-        13    pop_jump_if_false +2    (to 15)
-        14    jump +129               (to 143)
-        15    load_var 1              (mime)
-        16    load_const 3            ("audio/x-wav")
-        17    cmp_op ==               
+        1     is_type 0               
+        2     pop_jump_if_false +2    (to 4)
+        3     jump +124               (to 127)
+        4     load_var 1              (mime)
+        5     is_type 1               
+        6     pop_jump_if_false +2    (to 8)
+        7     jump +118               (to 125)
+        8     load_var 1              (mime)
+        9     is_type 2               
+        10    pop_jump_if_false +2    (to 12)
+        11    jump +112               (to 123)
+        12    load_var 1              (mime)
+        13    is_type 3               
+        14    pop_jump_if_false +2    (to 16)
+        15    jump +106               (to 121)
+        16    load_var 1              (mime)
+        17    is_type 4               
         18    pop_jump_if_false +2    (to 20)
-        19    jump +122               (to 141)
+        19    jump +100               (to 119)
         20    load_var 1              (mime)
-        21    load_const 4            ("audio/wave")
-        22    cmp_op ==               
-        23    pop_jump_if_false +2    (to 25)
-        24    jump +115               (to 139)
-        25    load_var 1              (mime)
-        26    load_const 5            ("audio/flac")
-        27    cmp_op ==               
-        28    pop_jump_if_false +2    (to 30)
-        29    jump +108               (to 137)
-        30    load_var 1              (mime)
-        31    load_const 6            ("audio/x-flac")
-        32    cmp_op ==               
-        33    pop_jump_if_false +2    (to 35)
-        34    jump +101               (to 135)
-        35    load_var 1              (mime)
-        36    load_const 7            ("audio/ogg")
-        37    cmp_op ==               
+        21    is_type 5               
+        22    pop_jump_if_false +2    (to 24)
+        23    jump +94                (to 117)
+        24    load_var 1              (mime)
+        25    is_type 6               
+        26    pop_jump_if_false +2    (to 28)
+        27    jump +88                (to 115)
+        28    load_var 1              (mime)
+        29    is_type 7               
+        30    pop_jump_if_false +2    (to 32)
+        31    jump +82                (to 113)
+        32    load_var 1              (mime)
+        33    is_type 8               
+        34    pop_jump_if_false +2    (to 36)
+        35    jump +76                (to 111)
+        36    load_var 1              (mime)
+        37    is_type 9               
         38    pop_jump_if_false +2    (to 40)
-        39    jump +94                (to 133)
+        39    jump +70                (to 109)
         40    load_var 1              (mime)
-        41    load_const 8            ("audio/opus")
-        42    cmp_op ==               
-        43    pop_jump_if_false +2    (to 45)
-        44    jump +87                (to 131)
-        45    load_var 1              (mime)
-        46    load_const 9            ("audio/aac")
-        47    cmp_op ==               
-        48    pop_jump_if_false +2    (to 50)
-        49    jump +80                (to 129)
-        50    load_var 1              (mime)
-        51    load_const 10           ("audio/x-aac")
-        52    cmp_op ==               
-        53    pop_jump_if_false +2    (to 55)
-        54    jump +73                (to 127)
-        55    load_var 1              (mime)
-        56    load_const 11           ("audio/mp4")
-        57    cmp_op ==               
+        41    is_type 10              
+        42    pop_jump_if_false +2    (to 44)
+        43    jump +64                (to 107)
+        44    load_var 1              (mime)
+        45    is_type 11              
+        46    pop_jump_if_false +2    (to 48)
+        47    jump +58                (to 105)
+        48    load_var 1              (mime)
+        49    is_type 12              
+        50    pop_jump_if_false +2    (to 52)
+        51    jump +52                (to 103)
+        52    load_var 1              (mime)
+        53    is_type 13              
+        54    pop_jump_if_false +2    (to 56)
+        55    jump +46                (to 101)
+        56    load_var 1              (mime)
+        57    is_type 14              
         58    pop_jump_if_false +2    (to 60)
-        59    jump +66                (to 125)
+        59    jump +40                (to 99)
         60    load_var 1              (mime)
-        61    load_const 12           ("audio/m4a")
-        62    cmp_op ==               
-        63    pop_jump_if_false +2    (to 65)
-        64    jump +59                (to 123)
-        65    load_var 1              (mime)
-        66    load_const 13           ("audio/x-m4a")
-        67    cmp_op ==               
-        68    pop_jump_if_false +2    (to 70)
-        69    jump +52                (to 121)
-        70    load_var 1              (mime)
-        71    load_const 14           ("audio/x-matroska")
-        72    cmp_op ==               
-        73    pop_jump_if_false +2    (to 75)
-        74    jump +45                (to 119)
-        75    load_var 1              (mime)
-        76    load_const 15           ("audio/mpga")
-        77    cmp_op ==               
+        61    is_type 15              
+        62    pop_jump_if_false +2    (to 64)
+        63    jump +34                (to 97)
+        64    load_var 1              (mime)
+        65    is_type 16              
+        66    pop_jump_if_false +2    (to 68)
+        67    jump +28                (to 95)
+        68    load_var 1              (mime)
+        69    is_type 17              
+        70    pop_jump_if_false +2    (to 72)
+        71    jump +22                (to 93)
+        72    load_var 1              (mime)
+        73    is_type 18              
+        74    pop_jump_if_false +2    (to 76)
+        75    jump +16                (to 91)
+        76    load_var 1              (mime)
+        77    is_type 19              
         78    pop_jump_if_false +2    (to 80)
-        79    jump +38                (to 117)
-        80    load_var 1              (mime)
-        81    load_const 16           ("audio/pcm")
-        82    cmp_op ==               
-        83    pop_jump_if_false +2    (to 85)
-        84    jump +31                (to 115)
-        85    load_var 1              (mime)
-        86    load_const 17           ("audio/x-pcm")
-        87    cmp_op ==               
-        88    pop_jump_if_false +2    (to 90)
-        89    jump +24                (to 113)
-        90    load_var 1              (mime)
-        91    load_const 18           ("audio/L16")
-        92    cmp_op ==               
-        93    pop_jump_if_false +2    (to 95)
-        94    jump +17                (to 111)
-        95    load_var 1              (mime)
-        96    load_const 19           ("audio/webm")
-        97    cmp_op ==               
-        98    pop_jump_if_false +2    (to 100)
-        99    jump +10                (to 109)
+        79    jump +10                (to 89)
 
-  457   100   load_type 20            
-        101   load_var 1              (mime)
-        102   call 138 ntypeargs=1    (baml.String.from)
-        103   store_var 2             (_24)
-        104   load_const 21           ("unsupported audio format for Bedrock: ")
-        105   load_var 2              (_24)
-        106   bin_op +                
-        107   call 1294 ntypeargs=0   (aws.internal._reject)
-        108   throw                   
+  457   80    load_type 20            
+        81    load_var 1              (mime)
+        82    call 138 ntypeargs=1    (baml.String.from)
+        83    store_var 2             (_24)
+        84    load_const 21           ("unsupported audio format for Bedrock: ")
+        85    load_var 2              (_24)
+        86    bin_op +                
+        87    call 1294 ntypeargs=0   (aws.internal._reject)
+        88    throw                   
 
-  456   109   load_const 22           ("webm")
+  456   89    load_const 22           ("webm")
 
-  443   110   jump +38                (to 148)
+  443   90    jump +38                (to 128)
 
-  455   111   load_const 23           ("pcm")
+  455   91    load_const 23           ("pcm")
 
-  443   112   jump +36                (to 148)
+  443   92    jump +36                (to 128)
 
-  455   113   load_const 24           ("pcm")
+  455   93    load_const 24           ("pcm")
 
-  443   114   jump +34                (to 148)
+  443   94    jump +34                (to 128)
 
-  455   115   load_const 25           ("pcm")
+  455   95    load_const 25           ("pcm")
 
-  443   116   jump +32                (to 148)
+  443   96    jump +32                (to 128)
 
-  454   117   load_const 26           ("mpga")
+  454   97    load_const 26           ("mpga")
 
-  443   118   jump +30                (to 148)
+  443   98    jump +30                (to 128)
 
-  453   119   load_const 27           ("mka")
+  453   99    load_const 27           ("mka")
 
-  443   120   jump +28                (to 148)
+  443   100   jump +28                (to 128)
 
-  452   121   load_const 28           ("m4a")
+  452   101   load_const 28           ("m4a")
 
-  443   122   jump +26                (to 148)
+  443   102   jump +26                (to 128)
 
-  452   123   load_const 29           ("m4a")
+  452   103   load_const 29           ("m4a")
 
-  443   124   jump +24                (to 148)
+  443   104   jump +24                (to 128)
 
-  451   125   load_const 30           ("mp4")
+  451   105   load_const 30           ("mp4")
 
-  443   126   jump +22                (to 148)
+  443   106   jump +22                (to 128)
 
-  450   127   load_const 31           ("x-aac")
+  450   107   load_const 31           ("x-aac")
 
-  443   128   jump +20                (to 148)
+  443   108   jump +20                (to 128)
 
-  449   129   load_const 32           ("aac")
+  449   109   load_const 32           ("aac")
 
-  443   130   jump +18                (to 148)
+  443   110   jump +18                (to 128)
 
-  448   131   load_const 33           ("opus")
+  448   111   load_const 33           ("opus")
 
-  443   132   jump +16                (to 148)
+  443   112   jump +16                (to 128)
 
-  447   133   load_const 34           ("ogg")
+  447   113   load_const 34           ("ogg")
 
-  443   134   jump +14                (to 148)
+  443   114   jump +14                (to 128)
 
-  446   135   load_const 35           ("flac")
+  446   115   load_const 35           ("flac")
 
-  443   136   jump +12                (to 148)
+  443   116   jump +12                (to 128)
 
-  446   137   load_const 36           ("flac")
+  446   117   load_const 36           ("flac")
 
-  443   138   jump +10                (to 148)
+  443   118   jump +10                (to 128)
 
-  445   139   load_const 37           ("wav")
+  445   119   load_const 37           ("wav")
 
-  443   140   jump +8                 (to 148)
+  443   120   jump +8                 (to 128)
 
-  445   141   load_const 38           ("wav")
+  445   121   load_const 38           ("wav")
 
-  443   142   jump +6                 (to 148)
+  443   122   jump +6                 (to 128)
 
-  445   143   load_const 39           ("wav")
+  445   123   load_const 39           ("wav")
 
-  443   144   jump +4                 (to 148)
+  443   124   jump +4                 (to 128)
 
-  444   145   load_const 40           ("mp3")
+  444   125   load_const 40           ("mp3")
 
-  443   146   jump +2                 (to 148)
+  443   126   jump +2                 (to 128)
 
-  444   147   load_const 41           ("mp3")
-        148   return                  
+  444   127   load_const 41           ("mp3")
+        128   return                  
 }
 
 function aws.internal._conversation_role(role: string) -> string {
@@ -10792,59 +10734,54 @@ function aws.internal._image_block(image: baml.media.Image) -> aws.internal.Cont
 
 function aws.internal._image_format(mime: string) -> string {
   411   0    load_var 1              (mime)
-        1    load_const 0            ("image/png")
-        2    cmp_op ==               
-        3    pop_jump_if_false +2    (to 5)
-        4    jump +38                (to 42)
-        5    load_var 1              (mime)
-        6    load_const 1            ("image/jpeg")
-        7    cmp_op ==               
-        8    pop_jump_if_false +2    (to 10)
-        9    jump +31                (to 40)
-        10   load_var 1              (mime)
-        11   load_const 2            ("image/jpg")
-        12   cmp_op ==               
-        13   pop_jump_if_false +2    (to 15)
-        14   jump +24                (to 38)
-        15   load_var 1              (mime)
-        16   load_const 3            ("image/gif")
-        17   cmp_op ==               
+        1    is_type 0               
+        2    pop_jump_if_false +2    (to 4)
+        3    jump +34                (to 37)
+        4    load_var 1              (mime)
+        5    is_type 1               
+        6    pop_jump_if_false +2    (to 8)
+        7    jump +28                (to 35)
+        8    load_var 1              (mime)
+        9    is_type 2               
+        10   pop_jump_if_false +2    (to 12)
+        11   jump +22                (to 33)
+        12   load_var 1              (mime)
+        13   is_type 3               
+        14   pop_jump_if_false +2    (to 16)
+        15   jump +16                (to 31)
+        16   load_var 1              (mime)
+        17   is_type 4               
         18   pop_jump_if_false +2    (to 20)
-        19   jump +17                (to 36)
-        20   load_var 1              (mime)
-        21   load_const 4            ("image/webp")
-        22   cmp_op ==               
-        23   pop_jump_if_false +2    (to 25)
-        24   jump +10                (to 34)
+        19   jump +10                (to 29)
 
-  416   25   load_type 5             
-        26   load_var 1              (mime)
-        27   call 138 ntypeargs=1    (baml.String.from)
-        28   store_var 2             (_9)
-        29   load_const 6            ("unsupported image format for Bedrock: ")
-        30   load_var 2              (_9)
-        31   bin_op +                
-        32   call 1294 ntypeargs=0   (aws.internal._reject)
-        33   throw                   
+  416   20   load_type 5             
+        21   load_var 1              (mime)
+        22   call 138 ntypeargs=1    (baml.String.from)
+        23   store_var 2             (_9)
+        24   load_const 6            ("unsupported image format for Bedrock: ")
+        25   load_var 2              (_9)
+        26   bin_op +                
+        27   call 1294 ntypeargs=0   (aws.internal._reject)
+        28   throw                   
 
-  415   34   load_const 7            ("webp")
+  415   29   load_const 7            ("webp")
 
-  411   35   jump +8                 (to 43)
+  411   30   jump +8                 (to 38)
 
-  414   36   load_const 8            ("gif")
+  414   31   load_const 8            ("gif")
 
-  411   37   jump +6                 (to 43)
+  411   32   jump +6                 (to 38)
 
-  413   38   load_const 9            ("jpeg")
+  413   33   load_const 9            ("jpeg")
 
-  411   39   jump +4                 (to 43)
+  411   34   jump +4                 (to 38)
 
-  413   40   load_const 10           ("jpeg")
+  413   35   load_const 10           ("jpeg")
 
-  411   41   jump +2                 (to 43)
+  411   36   jump +2                 (to 38)
 
-  412   42   load_const 11           ("png")
-        43   return                  
+  412   37   load_const 11           ("png")
+        38   return                  
 }
 
 function aws.internal._inference_config(client: aws.BedrockClient) -> aws.internal.InferenceConfig | null {
@@ -12041,48 +11978,45 @@ function aws.internal._tool_choice(choice: string) -> aws.internal.ToolChoice {
         3    store_var 2            (empty)
 
   821   4    load_var 1             (choice)
-        5    load_const 2           ("auto")
-        6    cmp_op ==              
-        7    pop_jump_if_false +2   (to 9)
-        8    jump +27               (to 35)
-        9    load_var 1             (choice)
-        10   load_const 3           ("any")
-        11   cmp_op ==              
-        12   pop_jump_if_false +2   (to 14)
-        13   jump +17               (to 30)
-        14   load_var 1             (choice)
-        15   load_const 4           ("required")
-        16   cmp_op ==              
-        17   pop_jump_if_false +2   (to 19)
-        18   jump +7                (to 25)
+        5    is_type 2              
+        6    pop_jump_if_false +2   (to 8)
+        7    jump +25               (to 32)
+        8    load_var 1             (choice)
+        9    is_type 3              
+        10   pop_jump_if_false +2   (to 12)
+        11   jump +16               (to 27)
+        12   load_var 1             (choice)
+        13   is_type 4              
+        14   pop_jump_if_false +2   (to 16)
+        15   jump +7                (to 22)
 
-  824   19   load_const 5           (null)
-        20   load_const 5           (null)
-        21   load_var 1             (choice)
-        22   init_instance 0        (aws.internal.SpecificToolChoice .name)
-        23   init_instance 1        (aws.internal.ToolChoice .auto, .any, .tool)
+  824   16   load_const 5           (null)
+        17   load_const 5           (null)
+        18   load_var 1             (choice)
+        19   init_instance 0        (aws.internal.SpecificToolChoice .name)
+        20   init_instance 1        (aws.internal.ToolChoice .auto, .any, .tool)
 
-  821   24   jump +15               (to 39)
+  821   21   jump +15               (to 36)
 
-  823   25   load_const 5           (null)
-        26   load_var 2             (empty)
-        27   load_const 5           (null)
-        28   init_instance 2        (aws.internal.ToolChoice .auto, .any, .tool)
+  823   22   load_const 5           (null)
+        23   load_var 2             (empty)
+        24   load_const 5           (null)
+        25   init_instance 2        (aws.internal.ToolChoice .auto, .any, .tool)
 
-  821   29   jump +10               (to 39)
+  821   26   jump +10               (to 36)
 
-  823   30   load_const 5           (null)
-        31   load_var 2             (empty)
-        32   load_const 5           (null)
-        33   init_instance 3        (aws.internal.ToolChoice .auto, .any, .tool)
+  823   27   load_const 5           (null)
+        28   load_var 2             (empty)
+        29   load_const 5           (null)
+        30   init_instance 3        (aws.internal.ToolChoice .auto, .any, .tool)
 
-  821   34   jump +5                (to 39)
+  821   31   jump +5                (to 36)
 
-  822   35   load_var 2             (empty)
-        36   load_const 5           (null)
-        37   load_const 5           (null)
-        38   init_instance 4        (aws.internal.ToolChoice .auto, .any, .tool)
-        39   return                 
+  822   32   load_var 2             (empty)
+        33   load_const 5           (null)
+        34   load_const 5           (null)
+        35   init_instance 4        (aws.internal.ToolChoice .auto, .any, .tool)
+        36   return                 
 }
 
 function aws.internal._tool_config(toolbox: ai.tools.Toolbox, tool_choice: string | null, cache_tools: bool) -> aws.internal.ToolConfig | null {
@@ -12196,113 +12130,102 @@ function aws.internal._video_block(video: baml.media.Video) -> aws.internal.Cont
 
 function aws.internal._video_format(mime: string) -> string {
   424   0    load_var 1              (mime)
-        1    load_const 0            ("video/mp4")
-        2    cmp_op ==               
-        3    pop_jump_if_false +2    (to 5)
-        4    jump +80                (to 84)
-        5    load_var 1              (mime)
-        6    load_const 1            ("video/mpeg")
-        7    cmp_op ==               
-        8    pop_jump_if_false +2    (to 10)
-        9    jump +73                (to 82)
-        10   load_var 1              (mime)
-        11   load_const 2            ("video/mpg")
-        12   cmp_op ==               
-        13   pop_jump_if_false +2    (to 15)
-        14   jump +66                (to 80)
-        15   load_var 1              (mime)
-        16   load_const 3            ("video/x-mpg")
-        17   cmp_op ==               
+        1    is_type 0               
+        2    pop_jump_if_false +2    (to 4)
+        3    jump +70                (to 73)
+        4    load_var 1              (mime)
+        5    is_type 1               
+        6    pop_jump_if_false +2    (to 8)
+        7    jump +64                (to 71)
+        8    load_var 1              (mime)
+        9    is_type 2               
+        10   pop_jump_if_false +2    (to 12)
+        11   jump +58                (to 69)
+        12   load_var 1              (mime)
+        13   is_type 3               
+        14   pop_jump_if_false +2    (to 16)
+        15   jump +52                (to 67)
+        16   load_var 1              (mime)
+        17   is_type 4               
         18   pop_jump_if_false +2    (to 20)
-        19   jump +59                (to 78)
+        19   jump +46                (to 65)
         20   load_var 1              (mime)
-        21   load_const 4            ("video/x-ms-wmv")
-        22   cmp_op ==               
-        23   pop_jump_if_false +2    (to 25)
-        24   jump +52                (to 76)
-        25   load_var 1              (mime)
-        26   load_const 5            ("video/wmv")
-        27   cmp_op ==               
-        28   pop_jump_if_false +2    (to 30)
-        29   jump +45                (to 74)
-        30   load_var 1              (mime)
-        31   load_const 6            ("video/x-matroska")
-        32   cmp_op ==               
-        33   pop_jump_if_false +2    (to 35)
-        34   jump +38                (to 72)
-        35   load_var 1              (mime)
-        36   load_const 7            ("video/quicktime")
-        37   cmp_op ==               
+        21   is_type 5               
+        22   pop_jump_if_false +2    (to 24)
+        23   jump +40                (to 63)
+        24   load_var 1              (mime)
+        25   is_type 6               
+        26   pop_jump_if_false +2    (to 28)
+        27   jump +34                (to 61)
+        28   load_var 1              (mime)
+        29   is_type 7               
+        30   pop_jump_if_false +2    (to 32)
+        31   jump +28                (to 59)
+        32   load_var 1              (mime)
+        33   is_type 8               
+        34   pop_jump_if_false +2    (to 36)
+        35   jump +22                (to 57)
+        36   load_var 1              (mime)
+        37   is_type 9               
         38   pop_jump_if_false +2    (to 40)
-        39   jump +31                (to 70)
+        39   jump +16                (to 55)
         40   load_var 1              (mime)
-        41   load_const 8            ("video/x-flv")
-        42   cmp_op ==               
-        43   pop_jump_if_false +2    (to 45)
-        44   jump +24                (to 68)
+        41   is_type 10              
+        42   pop_jump_if_false +2    (to 44)
+        43   jump +10                (to 53)
+
+  434   44   load_type 11            
         45   load_var 1              (mime)
-        46   load_const 9            ("video/webm")
-        47   cmp_op ==               
-        48   pop_jump_if_false +2    (to 50)
-        49   jump +17                (to 66)
-        50   load_var 1              (mime)
-        51   load_const 10           ("video/3gpp")
-        52   cmp_op ==               
-        53   pop_jump_if_false +2    (to 55)
-        54   jump +10                (to 64)
+        46   call 138 ntypeargs=1    (baml.String.from)
+        47   store_var 2             (_15)
+        48   load_const 12           ("unsupported video format for Bedrock: ")
+        49   load_var 2              (_15)
+        50   bin_op +                
+        51   call 1294 ntypeargs=0   (aws.internal._reject)
+        52   throw                   
 
-  434   55   load_type 11            
-        56   load_var 1              (mime)
-        57   call 138 ntypeargs=1    (baml.String.from)
-        58   store_var 2             (_15)
-        59   load_const 12           ("unsupported video format for Bedrock: ")
-        60   load_var 2              (_15)
-        61   bin_op +                
-        62   call 1294 ntypeargs=0   (aws.internal._reject)
-        63   throw                   
+  433   53   load_const 13           ("three_gp")
 
-  433   64   load_const 13           ("three_gp")
+  424   54   jump +20                (to 74)
 
-  424   65   jump +20                (to 85)
+  432   55   load_const 14           ("webm")
 
-  432   66   load_const 14           ("webm")
+  424   56   jump +18                (to 74)
 
-  424   67   jump +18                (to 85)
+  431   57   load_const 15           ("flv")
 
-  431   68   load_const 15           ("flv")
+  424   58   jump +16                (to 74)
 
-  424   69   jump +16                (to 85)
+  430   59   load_const 16           ("mov")
 
-  430   70   load_const 16           ("mov")
+  424   60   jump +14                (to 74)
 
-  424   71   jump +14                (to 85)
+  429   61   load_const 17           ("mkv")
 
-  429   72   load_const 17           ("mkv")
+  424   62   jump +12                (to 74)
 
-  424   73   jump +12                (to 85)
+  428   63   load_const 18           ("wmv")
 
-  428   74   load_const 18           ("wmv")
+  424   64   jump +10                (to 74)
 
-  424   75   jump +10                (to 85)
+  428   65   load_const 19           ("wmv")
 
-  428   76   load_const 19           ("wmv")
+  424   66   jump +8                 (to 74)
 
-  424   77   jump +8                 (to 85)
+  427   67   load_const 20           ("mpg")
 
-  427   78   load_const 20           ("mpg")
+  424   68   jump +6                 (to 74)
 
-  424   79   jump +6                 (to 85)
+  427   69   load_const 21           ("mpg")
 
-  427   80   load_const 21           ("mpg")
+  424   70   jump +4                 (to 74)
 
-  424   81   jump +4                 (to 85)
+  426   71   load_const 22           ("mpeg")
 
-  426   82   load_const 22           ("mpeg")
+  424   72   jump +2                 (to 74)
 
-  424   83   jump +2                 (to 85)
-
-  425   84   load_const 23           ("mp4")
-        85   return                  
+  425   73   load_const 23           ("mp4")
+        74   return                  
 }
 
 function aws.internal._wants_cache_point(message: ai.PromptMessage) -> bool {
@@ -13197,70 +13120,65 @@ function aws.internal.sign_request(req: baml.http.Request, opts: aws.internal.Aw
 
 function aws.internal.stop_reason(raw: string) -> ai.content.StopReason {
   1230   0    load_var 1              (raw)
-         1    load_const 0            ("tool_use")
-         2    cmp_op ==               
-         3    pop_jump_if_false +2    (to 5)
-         4    jump +43                (to 47)
-         5    load_var 1              (raw)
-         6    load_const 1            ("max_tokens")
-         7    cmp_op ==               
-         8    pop_jump_if_false +2    (to 10)
-         9    jump +35                (to 44)
-         10   load_var 1              (raw)
-         11   load_const 2            ("model_context_window_exceeded")
-         12   cmp_op ==               
-         13   pop_jump_if_false +2    (to 15)
-         14   jump +27                (to 41)
-         15   load_var 1              (raw)
-         16   load_const 3            ("content_filtered")
-         17   cmp_op ==               
+         1    is_type 0               
+         2    pop_jump_if_false +2    (to 4)
+         3    jump +39                (to 42)
+         4    load_var 1              (raw)
+         5    is_type 1               
+         6    pop_jump_if_false +2    (to 8)
+         7    jump +32                (to 39)
+         8    load_var 1              (raw)
+         9    is_type 2               
+         10   pop_jump_if_false +2    (to 12)
+         11   jump +25                (to 36)
+         12   load_var 1              (raw)
+         13   is_type 3               
+         14   pop_jump_if_false +2    (to 16)
+         15   jump +18                (to 33)
+         16   load_var 1              (raw)
+         17   is_type 4               
          18   pop_jump_if_false +2    (to 20)
-         19   jump +19                (to 38)
-         20   load_var 1              (raw)
-         21   load_const 4            ("guardrail_intervened")
-         22   cmp_op ==               
-         23   pop_jump_if_false +2    (to 25)
-         24   jump +11                (to 35)
+         19   jump +11                (to 30)
 
-  1240   25   load_var 1              (raw)
-         26   call 1324 ntypeargs=0   (aws.internal._is_malformed_stop)
+  1240   20   load_var 1              (raw)
+         21   call 1324 ntypeargs=0   (aws.internal._is_malformed_stop)
 
-  1230   27   pop_jump_if_false +2    (to 29)
-         28   jump +4                 (to 32)
+  1230   22   pop_jump_if_false +2    (to 24)
+         23   jump +4                 (to 27)
 
-  1242   29   load_const 5            (ai.content.StopReason.Complete)
-         30   alloc_variant 774       (ai.content.StopReason)
+  1242   24   load_const 5            (ai.content.StopReason.Complete)
+         25   alloc_variant 774       (ai.content.StopReason)
 
-  1230   31   jump +18                (to 49)
+  1230   26   jump +18                (to 44)
 
-  1240   32   load_const 6            (ai.content.StopReason.Refused)
-         33   alloc_variant 774       (ai.content.StopReason)
+  1240   27   load_const 6            (ai.content.StopReason.Refused)
+         28   alloc_variant 774       (ai.content.StopReason)
 
-  1230   34   jump +15                (to 49)
+  1230   29   jump +15                (to 44)
 
-  1236   35   load_const 6            (ai.content.StopReason.Refused)
-         36   alloc_variant 774       (ai.content.StopReason)
+  1236   30   load_const 6            (ai.content.StopReason.Refused)
+         31   alloc_variant 774       (ai.content.StopReason)
 
-  1230   37   jump +12                (to 49)
+  1230   32   jump +12                (to 44)
 
-  1236   38   load_const 6            (ai.content.StopReason.Refused)
-         39   alloc_variant 774       (ai.content.StopReason)
+  1236   33   load_const 6            (ai.content.StopReason.Refused)
+         34   alloc_variant 774       (ai.content.StopReason)
 
-  1230   40   jump +9                 (to 49)
+  1230   35   jump +9                 (to 44)
 
-  1235   41   load_const 7            (ai.content.StopReason.MaxTokens)
-         42   alloc_variant 774       (ai.content.StopReason)
+  1235   36   load_const 7            (ai.content.StopReason.MaxTokens)
+         37   alloc_variant 774       (ai.content.StopReason)
 
-  1230   43   jump +6                 (to 49)
+  1230   38   jump +6                 (to 44)
 
-  1235   44   load_const 7            (ai.content.StopReason.MaxTokens)
-         45   alloc_variant 774       (ai.content.StopReason)
+  1235   39   load_const 7            (ai.content.StopReason.MaxTokens)
+         40   alloc_variant 774       (ai.content.StopReason)
 
-  1230   46   jump +3                 (to 49)
+  1230   41   jump +3                 (to 44)
 
-  1231   47   load_const 8            (ai.content.StopReason.ToolUse)
-         48   alloc_variant 774       (ai.content.StopReason)
-         49   return                  
+  1231   42   load_const 8            (ai.content.StopReason.ToolUse)
+         43   alloc_variant 774       (ai.content.StopReason)
+         44   return                  
 }
 
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
@@ -13378,444 +13296,432 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> void {
         5     store_var 2                        (kind)
 
   164   6     load_var 2                         (kind)
-        7     load_const 3                       ("system")
-        8     cmp_op ==                          
-        9     pop_jump_if_false +2               (to 11)
-        10    jump +331                          (to 341)
-        11    load_var 2                         (kind)
-        12    load_const 4                       ("assistant")
-        13    cmp_op ==                          
-        14    pop_jump_if_false +2               (to 16)
-        15    jump +177                          (to 192)
-        16    load_var 2                         (kind)
-        17    load_const 5                       ("user")
-        18    cmp_op ==                          
-        19    pop_jump_if_false +2               (to 21)
-        20    jump +23                           (to 43)
-        21    load_var 2                         (kind)
-        22    load_const 6                       ("result")
-        23    cmp_op ==                          
-        24    pop_jump_if_false +2               (to 26)
-        25    jump +382                          (to 407)
+        7     is_type 3                          
+        8     pop_jump_if_false +2               (to 10)
+        9     jump +320                          (to 329)
+        10    load_var 2                         (kind)
+        11    is_type 4                          
+        12    pop_jump_if_false +2               (to 14)
+        13    jump +171                          (to 184)
+        14    load_var 2                         (kind)
+        15    is_type 5                          
+        16    pop_jump_if_false +2               (to 18)
+        17    jump +22                           (to 39)
+        18    load_var 2                         (kind)
+        19    is_type 6                          
+        20    pop_jump_if_false +2               (to 22)
+        21    jump +374                          (to 395)
 
-  203   26    load_type 0                        
-        27    load_var 2                         (kind)
-        28    call 138 ntypeargs=1               (baml.String.from)
-        29    store_var 37                       (_141)
-        30    load_const 7                       ("$baml_log")
-        31    load_const 8                       ("info")
-        32    load_const 9                       ("cc event: ")
-        33    load_var 37                        (_141)
-        34    bin_op +                           
-        35    load_const 10                      ("level")
-        36    load_const 11                      ("data")
-        37    load_type 0                        
-        38    load_type 12                       
-        39    alloc_map 2                        
-        40    send_event                         
-        41    pop 1                              
-        42    jump +365                          (to 407)
+  203   22    load_type 0                        
+        23    load_var 2                         (kind)
+        24    call 138 ntypeargs=1               (baml.String.from)
+        25    store_var 37                       (_141)
+        26    load_const 7                       ("$baml_log")
+        27    load_const 8                       ("info")
+        28    load_const 9                       ("cc event: ")
+        29    load_var 37                        (_141)
+        30    bin_op +                           
+        31    load_const 10                      ("level")
+        32    load_const 11                      ("data")
+        33    load_type 0                        
+        34    load_type 12                       
+        35    alloc_map 2                        
+        36    send_event                         
+        37    pop 1                              
+        38    jump +357                          (to 395)
 
-  178   43    load_type 0                        
-        44    alloc_array 0                      
-        45    store_var 23                       (parts)
+  178   39    load_type 0                        
+        40    alloc_array 0                      
+        41    store_var 23                       (parts)
 
-  179   46    load_type 13                       
-        47    load_var 1                         (raw)
-        48    load_const 14                      (".message.content")
-        49    load_type 15                       
-        50    alloc_array 0                      
-        51    call 364 ntypeargs=1               (baml.json.path_or)
+  179   42    load_type 13                       
+        43    load_var 1                         (raw)
+        44    load_const 14                      (".message.content")
+        45    load_type 15                       
+        46    alloc_array 0                      
+        47    call 364 ntypeargs=1               (baml.json.path_or)
 
-  180   52    load_type 16                       
-        53    load_const 17                      ("iter")
-        54    virtual_call nargs=1 ntypeargs=0   
-        55    store_var 24                       (_89)
-        56    load_var 24                        (_89)
-        57    load_type 18                       
-        58    load_const 19                      ("next")
-        59    virtual_call nargs=1 ntypeargs=0   
-        60    store_var 25                       (_90)
+  180   48    load_type 16                       
+        49    load_const 17                      ("iter")
+        50    virtual_call nargs=1 ntypeargs=0   
+        51    store_var 24                       (_89)
+        52    load_var 24                        (_89)
+        53    load_type 18                       
+        54    load_const 19                      ("next")
+        55    virtual_call nargs=1 ntypeargs=0   
+        56    store_var 25                       (_90)
+        57    load_var 25                        (_90)
+        58    is_type 20                         
+        59    pop_jump_if_false +2               (to 61)
+        60    jump +92                           (to 152)
         61    load_var 25                        (_90)
-        62    is_type 20                         
-        63    pop_jump_if_false +2               (to 65)
-        64    jump +96                           (to 160)
-        65    load_var 25                        (_90)
-        66    store_var 26                       (b)
+        62    store_var 26                       (b)
 
-  181   67    load_type 0                        
-        68    load_var 26                        (b)
-        69    load_const 21                      (".type")
-        70    load_const 22                      ("?")
-        71    call 364 ntypeargs=1               (baml.json.path_or)
-        72    store_var 27                       (bt)
+  181   63    load_type 0                        
+        64    load_var 26                        (b)
+        65    load_const 21                      (".type")
+        66    load_const 22                      ("?")
+        67    call 364 ntypeargs=1               (baml.json.path_or)
+        68    store_var 27                       (bt)
 
-  182   73    load_var 27                        (bt)
-        74    load_const 23                      ("text")
-        75    cmp_op ==                          
-        76    pop_jump_if_false +2               (to 78)
-        77    jump +64                           (to 141)
-        78    load_var 27                        (bt)
-        79    load_const 24                      ("thinking")
-        80    cmp_op ==                          
-        81    pop_jump_if_false +2               (to 83)
-        82    jump +40                           (to 122)
-        83    load_var 27                        (bt)
-        84    load_const 25                      ("tool_use")
-        85    cmp_op ==                          
-        86    pop_jump_if_false +2               (to 88)
-        87    jump +17                           (to 104)
-        88    load_var 27                        (bt)
-        89    load_const 26                      ("tool_result")
-        90    cmp_op ==                          
-        91    pop_jump_if_false +2               (to 93)
-        92    jump +6                            (to 98)
+  182   69    load_var 27                        (bt)
+        70    is_type 23                         
+        71    pop_jump_if_false +2               (to 73)
+        72    jump +61                           (to 133)
+        73    load_var 27                        (bt)
+        74    is_type 24                         
+        75    pop_jump_if_false +2               (to 77)
+        76    jump +38                           (to 114)
+        77    load_var 27                        (bt)
+        78    is_type 25                         
+        79    pop_jump_if_false +2               (to 81)
+        80    jump +16                           (to 96)
+        81    load_var 27                        (bt)
+        82    is_type 26                         
+        83    pop_jump_if_false +2               (to 85)
+        84    jump +6                            (to 90)
 
-  195   93    load_type 0                        
-        94    load_var2 23 27                    
-        95    call 4 ntypeargs=1                 (baml.Array.push)
-        96    pop 1                              
-        97    jump -41                           (to 56)
+  195   85    load_type 0                        
+        86    load_var2 23 27                    
+        87    call 4 ntypeargs=1                 (baml.Array.push)
+        88    pop 1                              
+        89    jump -37                           (to 52)
 
-  194   98    load_type 0                        
-        99    load_var 23                        (parts)
-        100   load_const 27                      ("tool_result")
-        101   call 4 ntypeargs=1                 (baml.Array.push)
-        102   pop 1                              
-        103   jump -47                           (to 56)
+  194   90    load_type 0                        
+        91    load_var 23                        (parts)
+        92    load_const 27                      ("tool_result")
+        93    call 4 ntypeargs=1                 (baml.Array.push)
+        94    pop 1                              
+        95    jump -43                           (to 52)
 
-  192   104   load_type 0                        
-        105   load_var 26                        (b)
-        106   load_const 28                      (".name")
-        107   load_const 29                      ("?")
-        108   call 364 ntypeargs=1               (baml.json.path_or)
-        109   store_var 33                       (_119)
-        110   load_type 0                        
-        111   load_var 33                        (_119)
-        112   call 138 ntypeargs=1               (baml.String.from)
-        113   store_var 32                       (_118)
-        114   load_type 0                        
-        115   load_var 23                        (parts)
-        116   load_const 30                      ("tool_use: ")
-        117   load_var 32                        (_118)
-        118   bin_op +                           
-        119   call 4 ntypeargs=1                 (baml.Array.push)
-        120   pop 1                              
-        121   jump -65                           (to 56)
+  192   96    load_type 0                        
+        97    load_var 26                        (b)
+        98    load_const 28                      (".name")
+        99    load_const 29                      ("?")
+        100   call 364 ntypeargs=1               (baml.json.path_or)
+        101   store_var 33                       (_119)
+        102   load_type 0                        
+        103   load_var 33                        (_119)
+        104   call 138 ntypeargs=1               (baml.String.from)
+        105   store_var 32                       (_118)
+        106   load_type 0                        
+        107   load_var 23                        (parts)
+        108   load_const 30                      ("tool_use: ")
+        109   load_var 32                        (_118)
+        110   bin_op +                           
+        111   call 4 ntypeargs=1                 (baml.Array.push)
+        112   pop 1                              
+        113   jump -61                           (to 52)
 
-  188   122   load_type 0                        
-        123   load_var 26                        (b)
-        124   load_const 31                      (".thinking")
-        125   load_const 32                      ("")
-        126   call 364 ntypeargs=1               (baml.json.path_or)
-        127   call 1359 ntypeargs=0              (claude_code.internal._preview)
-        128   store_var 31                       (_110)
-        129   load_type 0                        
-        130   load_var 31                        (_110)
-        131   call 138 ntypeargs=1               (baml.String.from)
-        132   store_var 30                       (_109)
+  188   114   load_type 0                        
+        115   load_var 26                        (b)
+        116   load_const 31                      (".thinking")
+        117   load_const 32                      ("")
+        118   call 364 ntypeargs=1               (baml.json.path_or)
+        119   call 1359 ntypeargs=0              (claude_code.internal._preview)
+        120   store_var 31                       (_110)
+        121   load_type 0                        
+        122   load_var 31                        (_110)
+        123   call 138 ntypeargs=1               (baml.String.from)
+        124   store_var 30                       (_109)
 
-  187   133   load_type 0                        
-        134   load_var 23                        (parts)
+  187   125   load_type 0                        
+        126   load_var 23                        (parts)
 
-  188   135   load_const 33                      ("thinking: ")
-        136   load_var 30                        (_109)
-        137   bin_op +                           
+  188   127   load_const 33                      ("thinking: ")
+        128   load_var 30                        (_109)
+        129   bin_op +                           
 
-  187   138   call 4 ntypeargs=1                 (baml.Array.push)
-        139   pop 1                              
-        140   jump -84                           (to 56)
+  187   130   call 4 ntypeargs=1                 (baml.Array.push)
+        131   pop 1                              
+        132   jump -80                           (to 52)
 
-  184   141   load_type 0                        
-        142   load_var 26                        (b)
-        143   load_const 34                      (".text")
-        144   load_const 35                      ("")
-        145   call 364 ntypeargs=1               (baml.json.path_or)
-        146   call 1359 ntypeargs=0              (claude_code.internal._preview)
-        147   store_var 29                       (_101)
-        148   load_type 0                        
-        149   load_var 29                        (_101)
-        150   call 138 ntypeargs=1               (baml.String.from)
-        151   store_var 28                       (_100)
-        152   load_type 0                        
-        153   load_var 23                        (parts)
-        154   load_const 36                      ("text: ")
-        155   load_var 28                        (_100)
-        156   bin_op +                           
-        157   call 4 ntypeargs=1                 (baml.Array.push)
-        158   pop 1                              
-        159   jump -103                          (to 56)
+  184   133   load_type 0                        
+        134   load_var 26                        (b)
+        135   load_const 34                      (".text")
+        136   load_const 35                      ("")
+        137   call 364 ntypeargs=1               (baml.json.path_or)
+        138   call 1359 ntypeargs=0              (claude_code.internal._preview)
+        139   store_var 29                       (_101)
+        140   load_type 0                        
+        141   load_var 29                        (_101)
+        142   call 138 ntypeargs=1               (baml.String.from)
+        143   store_var 28                       (_100)
+        144   load_type 0                        
+        145   load_var 23                        (parts)
+        146   load_const 36                      ("text: ")
+        147   load_var 28                        (_100)
+        148   bin_op +                           
+        149   call 4 ntypeargs=1                 (baml.Array.push)
+        150   pop 1                              
+        151   jump -99                           (to 52)
 
-  198   160   load_type 37                       
-        161   load_var 2                         (kind)
-        162   call 138 ntypeargs=1               (baml.String.from)
-        163   store_var 34                       (_132)
-        164   load_type 0                        
-        165   load_var 23                        (parts)
-        166   load_const 38                      (" | ")
-        167   call 15 ntypeargs=1                (baml.Array.join)
-        168   store_var 36                       (_136)
-        169   load_type 0                        
-        170   load_var 36                        (_136)
-        171   call 138 ntypeargs=1               (baml.String.from)
-        172   store_var 35                       (_135)
-        173   load_const 39                      ("$baml_log")
-        174   load_const 40                      ("info")
-        175   load_const 41                      ("cc event: ")
-        176   load_var 34                        (_132)
-        177   bin_op +                           
-        178   load_const 42                      (" [")
-        179   bin_op +                           
-        180   load_var 35                        (_135)
-        181   bin_op +                           
-        182   load_const 43                      ("]")
-        183   bin_op +                           
-        184   load_const 44                      ("level")
-        185   load_const 45                      ("data")
-        186   load_type 0                        
-        187   load_type 12                       
-        188   alloc_map 2                        
-        189   send_event                         
-        190   pop 1                              
-        191   jump +216                          (to 407)
+  198   152   load_type 37                       
+        153   load_var 2                         (kind)
+        154   call 138 ntypeargs=1               (baml.String.from)
+        155   store_var 34                       (_132)
+        156   load_type 0                        
+        157   load_var 23                        (parts)
+        158   load_const 38                      (" | ")
+        159   call 15 ntypeargs=1                (baml.Array.join)
+        160   store_var 36                       (_136)
+        161   load_type 0                        
+        162   load_var 36                        (_136)
+        163   call 138 ntypeargs=1               (baml.String.from)
+        164   store_var 35                       (_135)
+        165   load_const 39                      ("$baml_log")
+        166   load_const 40                      ("info")
+        167   load_const 41                      ("cc event: ")
+        168   load_var 34                        (_132)
+        169   bin_op +                           
+        170   load_const 42                      (" [")
+        171   bin_op +                           
+        172   load_var 35                        (_135)
+        173   bin_op +                           
+        174   load_const 43                      ("]")
+        175   bin_op +                           
+        176   load_const 44                      ("level")
+        177   load_const 45                      ("data")
+        178   load_type 0                        
+        179   load_type 12                       
+        180   alloc_map 2                        
+        181   send_event                         
+        182   pop 1                              
+        183   jump +212                          (to 395)
 
-  178   192   load_type 0                        
-        193   alloc_array 0                      
-        194   store_var 9                        (parts)
+  178   184   load_type 0                        
+        185   alloc_array 0                      
+        186   store_var 9                        (parts)
 
-  179   195   load_type 13                       
-        196   load_var 1                         (raw)
-        197   load_const 46                      (".message.content")
-        198   load_type 15                       
-        199   alloc_array 0                      
-        200   call 364 ntypeargs=1               (baml.json.path_or)
+  179   187   load_type 13                       
+        188   load_var 1                         (raw)
+        189   load_const 46                      (".message.content")
+        190   load_type 15                       
+        191   alloc_array 0                      
+        192   call 364 ntypeargs=1               (baml.json.path_or)
 
-  180   201   load_type 16                       
-        202   load_const 47                      ("iter")
-        203   virtual_call nargs=1 ntypeargs=0   
-        204   store_var 10                       (_33)
-        205   load_var 10                        (_33)
-        206   load_type 18                       
-        207   load_const 48                      ("next")
-        208   virtual_call nargs=1 ntypeargs=0   
-        209   store_var 11                       (_34)
-        210   load_var 11                        (_34)
-        211   is_type 20                         
-        212   pop_jump_if_false +2               (to 214)
-        213   jump +96                           (to 309)
-        214   load_var 11                        (_34)
-        215   store_var 12                       (b)
+  180   193   load_type 16                       
+        194   load_const 47                      ("iter")
+        195   virtual_call nargs=1 ntypeargs=0   
+        196   store_var 10                       (_33)
+        197   load_var 10                        (_33)
+        198   load_type 18                       
+        199   load_const 48                      ("next")
+        200   virtual_call nargs=1 ntypeargs=0   
+        201   store_var 11                       (_34)
+        202   load_var 11                        (_34)
+        203   is_type 20                         
+        204   pop_jump_if_false +2               (to 206)
+        205   jump +92                           (to 297)
+        206   load_var 11                        (_34)
+        207   store_var 12                       (b)
 
-  181   216   load_type 0                        
-        217   load_var 12                        (b)
-        218   load_const 49                      (".type")
-        219   load_const 50                      ("?")
-        220   call 364 ntypeargs=1               (baml.json.path_or)
-        221   store_var 13                       (bt)
+  181   208   load_type 0                        
+        209   load_var 12                        (b)
+        210   load_const 49                      (".type")
+        211   load_const 50                      ("?")
+        212   call 364 ntypeargs=1               (baml.json.path_or)
+        213   store_var 13                       (bt)
 
-  182   222   load_var 13                        (bt)
-        223   load_const 51                      ("text")
-        224   cmp_op ==                          
-        225   pop_jump_if_false +2               (to 227)
-        226   jump +64                           (to 290)
-        227   load_var 13                        (bt)
-        228   load_const 52                      ("thinking")
-        229   cmp_op ==                          
-        230   pop_jump_if_false +2               (to 232)
-        231   jump +40                           (to 271)
-        232   load_var 13                        (bt)
-        233   load_const 53                      ("tool_use")
-        234   cmp_op ==                          
-        235   pop_jump_if_false +2               (to 237)
-        236   jump +17                           (to 253)
-        237   load_var 13                        (bt)
-        238   load_const 54                      ("tool_result")
-        239   cmp_op ==                          
-        240   pop_jump_if_false +2               (to 242)
-        241   jump +6                            (to 247)
+  182   214   load_var 13                        (bt)
+        215   is_type 23                         
+        216   pop_jump_if_false +2               (to 218)
+        217   jump +61                           (to 278)
+        218   load_var 13                        (bt)
+        219   is_type 24                         
+        220   pop_jump_if_false +2               (to 222)
+        221   jump +38                           (to 259)
+        222   load_var 13                        (bt)
+        223   is_type 25                         
+        224   pop_jump_if_false +2               (to 226)
+        225   jump +16                           (to 241)
+        226   load_var 13                        (bt)
+        227   is_type 26                         
+        228   pop_jump_if_false +2               (to 230)
+        229   jump +6                            (to 235)
 
-  195   242   load_type 0                        
-        243   load_var2 9 13                     
-        244   call 4 ntypeargs=1                 (baml.Array.push)
-        245   pop 1                              
-        246   jump -41                           (to 205)
+  195   230   load_type 0                        
+        231   load_var2 9 13                     
+        232   call 4 ntypeargs=1                 (baml.Array.push)
+        233   pop 1                              
+        234   jump -37                           (to 197)
 
-  194   247   load_type 0                        
-        248   load_var 9                         (parts)
-        249   load_const 55                      ("tool_result")
-        250   call 4 ntypeargs=1                 (baml.Array.push)
-        251   pop 1                              
-        252   jump -47                           (to 205)
+  194   235   load_type 0                        
+        236   load_var 9                         (parts)
+        237   load_const 51                      ("tool_result")
+        238   call 4 ntypeargs=1                 (baml.Array.push)
+        239   pop 1                              
+        240   jump -43                           (to 197)
 
-  192   253   load_type 0                        
-        254   load_var 12                        (b)
-        255   load_const 56                      (".name")
-        256   load_const 57                      ("?")
-        257   call 364 ntypeargs=1               (baml.json.path_or)
-        258   store_var 19                       (_63)
-        259   load_type 0                        
-        260   load_var 19                        (_63)
-        261   call 138 ntypeargs=1               (baml.String.from)
-        262   store_var 18                       (_62)
-        263   load_type 0                        
-        264   load_var 9                         (parts)
-        265   load_const 58                      ("tool_use: ")
-        266   load_var 18                        (_62)
-        267   bin_op +                           
-        268   call 4 ntypeargs=1                 (baml.Array.push)
-        269   pop 1                              
-        270   jump -65                           (to 205)
+  192   241   load_type 0                        
+        242   load_var 12                        (b)
+        243   load_const 52                      (".name")
+        244   load_const 53                      ("?")
+        245   call 364 ntypeargs=1               (baml.json.path_or)
+        246   store_var 19                       (_63)
+        247   load_type 0                        
+        248   load_var 19                        (_63)
+        249   call 138 ntypeargs=1               (baml.String.from)
+        250   store_var 18                       (_62)
+        251   load_type 0                        
+        252   load_var 9                         (parts)
+        253   load_const 54                      ("tool_use: ")
+        254   load_var 18                        (_62)
+        255   bin_op +                           
+        256   call 4 ntypeargs=1                 (baml.Array.push)
+        257   pop 1                              
+        258   jump -61                           (to 197)
 
-  188   271   load_type 0                        
-        272   load_var 12                        (b)
-        273   load_const 59                      (".thinking")
-        274   load_const 60                      ("")
-        275   call 364 ntypeargs=1               (baml.json.path_or)
-        276   call 1359 ntypeargs=0              (claude_code.internal._preview)
-        277   store_var 17                       (_54)
-        278   load_type 0                        
-        279   load_var 17                        (_54)
-        280   call 138 ntypeargs=1               (baml.String.from)
-        281   store_var 16                       (_53)
+  188   259   load_type 0                        
+        260   load_var 12                        (b)
+        261   load_const 55                      (".thinking")
+        262   load_const 56                      ("")
+        263   call 364 ntypeargs=1               (baml.json.path_or)
+        264   call 1359 ntypeargs=0              (claude_code.internal._preview)
+        265   store_var 17                       (_54)
+        266   load_type 0                        
+        267   load_var 17                        (_54)
+        268   call 138 ntypeargs=1               (baml.String.from)
+        269   store_var 16                       (_53)
 
-  187   282   load_type 0                        
-        283   load_var 9                         (parts)
+  187   270   load_type 0                        
+        271   load_var 9                         (parts)
 
-  188   284   load_const 61                      ("thinking: ")
-        285   load_var 16                        (_53)
-        286   bin_op +                           
+  188   272   load_const 57                      ("thinking: ")
+        273   load_var 16                        (_53)
+        274   bin_op +                           
 
-  187   287   call 4 ntypeargs=1                 (baml.Array.push)
-        288   pop 1                              
-        289   jump -84                           (to 205)
+  187   275   call 4 ntypeargs=1                 (baml.Array.push)
+        276   pop 1                              
+        277   jump -80                           (to 197)
 
-  184   290   load_type 0                        
-        291   load_var 12                        (b)
-        292   load_const 62                      (".text")
-        293   load_const 63                      ("")
-        294   call 364 ntypeargs=1               (baml.json.path_or)
-        295   call 1359 ntypeargs=0              (claude_code.internal._preview)
-        296   store_var 15                       (_45)
-        297   load_type 0                        
-        298   load_var 15                        (_45)
+  184   278   load_type 0                        
+        279   load_var 12                        (b)
+        280   load_const 58                      (".text")
+        281   load_const 59                      ("")
+        282   call 364 ntypeargs=1               (baml.json.path_or)
+        283   call 1359 ntypeargs=0              (claude_code.internal._preview)
+        284   store_var 15                       (_45)
+        285   load_type 0                        
+        286   load_var 15                        (_45)
+        287   call 138 ntypeargs=1               (baml.String.from)
+        288   store_var 14                       (_44)
+        289   load_type 0                        
+        290   load_var 9                         (parts)
+        291   load_const 60                      ("text: ")
+        292   load_var 14                        (_44)
+        293   bin_op +                           
+        294   call 4 ntypeargs=1                 (baml.Array.push)
+        295   pop 1                              
+        296   jump -99                           (to 197)
+
+  198   297   load_type 37                       
+        298   load_var 2                         (kind)
         299   call 138 ntypeargs=1               (baml.String.from)
-        300   store_var 14                       (_44)
+        300   store_var 20                       (_76)
         301   load_type 0                        
         302   load_var 9                         (parts)
-        303   load_const 64                      ("text: ")
-        304   load_var 14                        (_44)
-        305   bin_op +                           
-        306   call 4 ntypeargs=1                 (baml.Array.push)
-        307   pop 1                              
-        308   jump -103                          (to 205)
+        303   load_const 61                      (" | ")
+        304   call 15 ntypeargs=1                (baml.Array.join)
+        305   store_var 22                       (_80)
+        306   load_type 0                        
+        307   load_var 22                        (_80)
+        308   call 138 ntypeargs=1               (baml.String.from)
+        309   store_var 21                       (_79)
+        310   load_const 62                      ("$baml_log")
+        311   load_const 63                      ("info")
+        312   load_const 64                      ("cc event: ")
+        313   load_var 20                        (_76)
+        314   bin_op +                           
+        315   load_const 65                      (" [")
+        316   bin_op +                           
+        317   load_var 21                        (_79)
+        318   bin_op +                           
+        319   load_const 66                      ("]")
+        320   bin_op +                           
+        321   load_const 67                      ("level")
+        322   load_const 68                      ("data")
+        323   load_type 0                        
+        324   load_type 12                       
+        325   alloc_map 2                        
+        326   send_event                         
+        327   pop 1                              
+        328   jump +67                           (to 395)
 
-  198   309   load_type 37                       
-        310   load_var 2                         (kind)
-        311   call 138 ntypeargs=1               (baml.String.from)
-        312   store_var 20                       (_76)
-        313   load_type 0                        
-        314   load_var 9                         (parts)
-        315   load_const 65                      (" | ")
-        316   call 15 ntypeargs=1                (baml.Array.join)
-        317   store_var 22                       (_80)
-        318   load_type 0                        
-        319   load_var 22                        (_80)
-        320   call 138 ntypeargs=1               (baml.String.from)
-        321   store_var 21                       (_79)
-        322   load_const 66                      ("$baml_log")
-        323   load_const 67                      ("info")
-        324   load_const 68                      ("cc event: ")
-        325   load_var 20                        (_76)
-        326   bin_op +                           
-        327   load_const 69                      (" [")
-        328   bin_op +                           
-        329   load_var 21                        (_79)
-        330   bin_op +                           
-        331   load_const 70                      ("]")
-        332   bin_op +                           
-        333   load_const 71                      ("level")
-        334   load_const 72                      ("data")
-        335   load_type 0                        
-        336   load_type 12                       
-        337   alloc_map 2                        
-        338   send_event                         
-        339   pop 1                              
-        340   jump +67                           (to 407)
+  166   329   load_type 0                        
+        330   load_var 1                         (raw)
+        331   load_const 69                      (".subtype")
+        332   load_const 70                      ("?")
+        333   call 364 ntypeargs=1               (baml.json.path_or)
+        334   store_var 3                        (subtype)
 
-  166   341   load_type 0                        
-        342   load_var 1                         (raw)
-        343   load_const 73                      (".subtype")
-        344   load_const 74                      ("?")
-        345   call 364 ntypeargs=1               (baml.json.path_or)
-        346   store_var 3                        (subtype)
+  167   335   load_var 3                         (subtype)
+        336   load_const 71                      ("thinking_tokens")
+        337   cmp_op ==                          
+        338   pop_jump_if_false +2               (to 340)
+        339   jump +32                           (to 371)
 
-  167   347   load_var 3                         (subtype)
-        348   load_const 75                      ("thinking_tokens")
-        349   cmp_op ==                          
-        350   pop_jump_if_false +2               (to 352)
-        351   jump +32                           (to 383)
+  173   340   load_type 0                        
+        341   load_var 1                         (raw)
+        342   load_const 72                      (".model")
+        343   load_const 73                      ("?")
+        344   call 364 ntypeargs=1               (baml.json.path_or)
+        345   store_var 6                        (model)
 
-  173   352   load_type 0                        
-        353   load_var 1                         (raw)
-        354   load_const 76                      (".model")
-        355   load_const 77                      ("?")
-        356   call 364 ntypeargs=1               (baml.json.path_or)
-        357   store_var 6                        (model)
+  174   346   load_type 0                        
+        347   load_var 3                         (subtype)
+        348   call 138 ntypeargs=1               (baml.String.from)
+        349   store_var 7                        (_21)
+        350   load_type 0                        
+        351   load_var 6                         (model)
+        352   call 138 ntypeargs=1               (baml.String.from)
+        353   store_var 8                        (_24)
+        354   load_const 74                      ("$baml_log")
+        355   load_const 75                      ("info")
+        356   load_const 76                      ("cc event: system/")
+        357   load_var 7                         (_21)
+        358   bin_op +                           
+        359   load_const 77                      (" model=")
+        360   bin_op +                           
+        361   load_var 8                         (_24)
+        362   bin_op +                           
+        363   load_const 78                      ("level")
+        364   load_const 79                      ("data")
+        365   load_type 0                        
+        366   load_type 12                       
+        367   alloc_map 2                        
+        368   send_event                         
+        369   pop 1                              
+        370   jump +25                           (to 395)
 
-  174   358   load_type 0                        
-        359   load_var 3                         (subtype)
-        360   call 138 ntypeargs=1               (baml.String.from)
-        361   store_var 7                        (_21)
-        362   load_type 0                        
-        363   load_var 6                         (model)
-        364   call 138 ntypeargs=1               (baml.String.from)
-        365   store_var 8                        (_24)
-        366   load_const 78                      ("$baml_log")
-        367   load_const 79                      ("info")
-        368   load_const 80                      ("cc event: system/")
-        369   load_var 7                         (_21)
-        370   bin_op +                           
-        371   load_const 81                      (" model=")
-        372   bin_op +                           
-        373   load_var 8                         (_24)
-        374   bin_op +                           
-        375   load_const 82                      ("level")
-        376   load_const 83                      ("data")
-        377   load_type 0                        
-        378   load_type 12                       
-        379   alloc_map 2                        
-        380   send_event                         
-        381   pop 1                              
-        382   jump +25                           (to 407)
+  170   371   load_type 80                       
+        372   load_var 1                         (raw)
+        373   load_const 81                      (".estimated_tokens")
+        374   load_const 82                      (0)
+        375   call 364 ntypeargs=1               (baml.json.path_or)
+        376   store_var 4                        (estimated)
 
-  170   383   load_type 84                       
-        384   load_var 1                         (raw)
-        385   load_const 85                      (".estimated_tokens")
-        386   load_const 86                      (0)
-        387   call 364 ntypeargs=1               (baml.json.path_or)
-        388   store_var 4                        (estimated)
+  171   377   load_type 80                       
+        378   load_var 4                         (estimated)
+        379   call 138 ntypeargs=1               (baml.String.from)
+        380   store_var 5                        (_13)
+        381   load_const 83                      ("$baml_log")
+        382   load_const 84                      ("debug")
+        383   load_const 85                      ("cc event: thinking ~")
+        384   load_var 5                         (_13)
+        385   bin_op +                           
+        386   load_const 86                      (" tokens")
+        387   bin_op +                           
+        388   load_const 87                      ("level")
+        389   load_const 88                      ("data")
+        390   load_type 0                        
+        391   load_type 12                       
+        392   alloc_map 2                        
+        393   send_event                         
+        394   pop 1                              
 
-  171   389   load_type 84                       
-        390   load_var 4                         (estimated)
-        391   call 138 ntypeargs=1               (baml.String.from)
-        392   store_var 5                        (_13)
-        393   load_const 87                      ("$baml_log")
-        394   load_const 88                      ("debug")
-        395   load_const 89                      ("cc event: thinking ~")
-        396   load_var 5                         (_13)
-        397   bin_op +                           
-        398   load_const 90                      (" tokens")
-        399   bin_op +                           
-        400   load_const 91                      ("level")
-        401   load_const 92                      ("data")
-        402   load_type 0                        
-        403   load_type 12                       
-        404   alloc_map 2                        
-        405   send_event                         
-        406   pop 1                              
-
-  162   407   load_const 93                      (null)
-        408   return                             
+  162   395   load_const 89                      (null)
+        396   return                             
 }
 
 function claude_code.internal._preview(text: string) -> string {
@@ -13948,7 +13854,7 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
         8    load_type 2           
         9    load_var 3            (_3)
 
-  224   10   make_closure 4219 0   
+  224   10   make_closure 4076 0   
 
   223   11   call 16 ntypeargs=3   (baml.Array.map)
         12   store_var 2           (_2)
@@ -16864,7 +16770,7 @@ function google.internal._gm_strip_nulls(value: baml.json.json, opaque: bool) ->
 
   274   20   load_var 12                        (_27)
 
-  289   21   make_closure 3397 0                
+  289   21   make_closure 3314 0                
         22   call 16 ntypeargs=3                (baml.Array.map)
         23   jump +52                           (to 75)
 
@@ -18824,7 +18730,7 @@ function google.internal.vertex_invoke_stream(c: google.VertexClient, input: ai.
 
   362   22   load_var2 3 4           
 
-  363   23   make_closure 3637 1     
+  363   23   make_closure 3554 1     
         24   load_const 5            ("vertex")
 
   361   25   call 959 ntypeargs=0    (ai.stream.TurnStream.from_sse)
@@ -21037,7 +20943,7 @@ function openai.internal.ChatStreamDecoder._absorb_call(self: openai.internal.Ch
          16    load_field 1            (calls)
 
   1398   17    load_var 4              (index)
-         18    make_closure 3026 1     
+         18    make_closure 2970 1     
 
   1397   19    call 19 ntypeargs=2     (baml.Array.find)
 
@@ -21631,7 +21537,7 @@ function openai.internal._chat_apply_directives(j: baml.json.json) -> baml.json.
 
   835   17    load_var 17                        (_47)
 
-  854   18    make_closure 2936 0                
+  854   18    make_closure 2885 0                
         19    call 16 ntypeargs=3                (baml.Array.map)
         20    jump +88                           (to 108)
 
@@ -21808,35 +21714,32 @@ function openai.internal._chat_audio_format(mime_type: string) -> string {
         15   store_var 2            (subtype)
 
   498   16   load_var 2             (subtype)
-        17   load_const 2           ("mpeg")
-        18   cmp_op ==              
-        19   pop_jump_if_false +2   (to 21)
-        20   jump +17               (to 37)
-        21   load_var 2             (subtype)
-        22   load_const 3           ("mp3")
-        23   cmp_op ==              
-        24   pop_jump_if_false +2   (to 26)
-        25   jump +10               (to 35)
-        26   load_var 2             (subtype)
-        27   load_const 4           ("x-wav")
-        28   cmp_op ==              
-        29   pop_jump_if_false +2   (to 31)
-        30   jump +3                (to 33)
+        17   is_type 2              
+        18   pop_jump_if_false +2   (to 20)
+        19   jump +15               (to 34)
+        20   load_var 2             (subtype)
+        21   is_type 3              
+        22   pop_jump_if_false +2   (to 24)
+        23   jump +9                (to 32)
+        24   load_var 2             (subtype)
+        25   is_type 4              
+        26   pop_jump_if_false +2   (to 28)
+        27   jump +3                (to 30)
 
-  501   31   load_var 2             (subtype)
+  501   28   load_var 2             (subtype)
 
-  498   32   jump +6                (to 38)
+  498   29   jump +6                (to 35)
 
-  500   33   load_const 5           ("wav")
+  500   30   load_const 5           ("wav")
 
-  498   34   jump +4                (to 38)
+  498   31   jump +4                (to 35)
 
-  499   35   load_const 6           ("mp3")
+  499   32   load_const 6           ("mp3")
 
-  498   36   jump +2                (to 38)
+  498   33   jump +2                (to 35)
 
-  499   37   load_const 7           ("mp3")
-        38   return                 
+  499   34   load_const 7           ("mp3")
+        35   return                 
 }
 
 function openai.internal._chat_audio_output_mime(request_body: baml.json.json | null) -> string {
@@ -21848,32 +21751,30 @@ function openai.internal._chat_audio_output_mime(request_body: baml.json.json | 
         5    store_var 2            (format)
 
   513   6    load_var 2             (format)
-        7    load_const 3           ("mp3")
-        8    cmp_op ==              
-        9    pop_jump_if_false +2   (to 11)
-        10   jump +16               (to 26)
-        11   load_var 2             (format)
-        12   load_const 4           ("pcm16")
-        13   cmp_op ==              
-        14   pop_jump_if_false +2   (to 16)
-        15   jump +9                (to 24)
+        7    is_type 3              
+        8    pop_jump_if_false +2   (to 10)
+        9    jump +15               (to 24)
+        10   load_var 2             (format)
+        11   is_type 4              
+        12   pop_jump_if_false +2   (to 14)
+        13   jump +9                (to 22)
 
-  516   16   load_type 0            
-        17   load_var 2             (format)
-        18   call 138 ntypeargs=1   (baml.String.from)
-        19   store_var 3            (_6)
-        20   load_const 5           ("audio/")
-        21   load_var 3             (_6)
-        22   bin_op +               
+  516   14   load_type 0            
+        15   load_var 2             (format)
+        16   call 138 ntypeargs=1   (baml.String.from)
+        17   store_var 3            (_6)
+        18   load_const 5           ("audio/")
+        19   load_var 3             (_6)
+        20   bin_op +               
 
-  513   23   jump +4                (to 27)
+  513   21   jump +4                (to 25)
 
-  515   24   load_const 6           ("audio/pcm")
+  515   22   load_const 6           ("audio/pcm")
 
-  513   25   jump +2                (to 27)
+  513   23   jump +2                (to 25)
 
-  514   26   load_const 7           ("audio/mpeg")
-        27   return                 
+  514   24   load_const 7           ("audio/mpeg")
+        25   return                 
 }
 
 function openai.internal._chat_body_mentions(overrides: baml.json.json | null, key: string) -> bool {
@@ -22593,7 +22494,7 @@ function openai.internal._chat_prune_nulls(j: baml.json.json) -> baml.json.json 
 
   865   17   load_var 10                        (_31)
 
-  885   18   make_closure 2942 0                
+  885   18   make_closure 2891 0                
         19   call 16 ntypeargs=3                (baml.Array.map)
         20   jump +58                           (to 78)
 
@@ -23638,44 +23539,40 @@ function openai.internal._oai_images_mime(format: string | null) -> string {
         9    store_var 2            (normalized)
 
   308   10   load_var 2             (normalized)
-        11   load_const 2           ("jpeg")
-        12   cmp_op ==              
-        13   pop_jump_if_false +2   (to 15)
-        14   jump +24               (to 38)
-        15   load_var 2             (normalized)
-        16   load_const 3           ("jpg")
-        17   cmp_op ==              
-        18   pop_jump_if_false +2   (to 20)
-        19   jump +17               (to 36)
-        20   load_var 2             (normalized)
-        21   load_const 4           ("webp")
-        22   cmp_op ==              
-        23   pop_jump_if_false +2   (to 25)
-        24   jump +10               (to 34)
-        25   load_var 2             (normalized)
-        26   load_const 5           ("gif")
-        27   cmp_op ==              
-        28   pop_jump_if_false +2   (to 30)
-        29   jump +3                (to 32)
+        11   is_type 2              
+        12   pop_jump_if_false +2   (to 14)
+        13   jump +21               (to 34)
+        14   load_var 2             (normalized)
+        15   is_type 3              
+        16   pop_jump_if_false +2   (to 18)
+        17   jump +15               (to 32)
+        18   load_var 2             (normalized)
+        19   is_type 4              
+        20   pop_jump_if_false +2   (to 22)
+        21   jump +9                (to 30)
+        22   load_var 2             (normalized)
+        23   is_type 5              
+        24   pop_jump_if_false +2   (to 26)
+        25   jump +3                (to 28)
 
-  312   30   load_const 6           ("image/png")
+  312   26   load_const 6           ("image/png")
 
-  308   31   jump +8                (to 39)
+  308   27   jump +8                (to 35)
 
-  311   32   load_const 7           ("image/gif")
+  311   28   load_const 7           ("image/gif")
 
-  308   33   jump +6                (to 39)
+  308   29   jump +6                (to 35)
 
-  310   34   load_const 8           ("image/webp")
+  310   30   load_const 8           ("image/webp")
 
-  308   35   jump +4                (to 39)
+  308   31   jump +4                (to 35)
 
-  309   36   load_const 9           ("image/jpeg")
+  309   32   load_const 9           ("image/jpeg")
 
-  308   37   jump +2                (to 39)
+  308   33   jump +2                (to 35)
 
-  309   38   load_const 10          ("image/jpeg")
-        39   return                 
+  309   34   load_const 10          ("image/jpeg")
+        35   return                 
 }
 
 function openai.internal._oai_images_prompt_text(prompt: ai.Prompt, journal: ai.Journal) -> string {
@@ -24072,80 +23969,72 @@ function openai.internal._openai_apply_message_metadata(body: baml.json.json, me
 
 function openai.internal._openai_audio_format(mime_type: string) -> string {
   327   0    load_var 1             (mime_type)
-        1    load_const 0           ("audio/wav")
-        2    cmp_op ==              
-        3    pop_jump_if_false +2   (to 5)
-        4    jump +52               (to 56)
-        5    load_var 1             (mime_type)
-        6    load_const 1           ("audio/x-wav")
-        7    cmp_op ==              
-        8    pop_jump_if_false +2   (to 10)
-        9    jump +45               (to 54)
-        10   load_var 1             (mime_type)
-        11   load_const 2           ("audio/mpeg")
-        12   cmp_op ==              
-        13   pop_jump_if_false +2   (to 15)
-        14   jump +38               (to 52)
-        15   load_var 1             (mime_type)
-        16   load_const 3           ("audio/mp3")
-        17   cmp_op ==              
+        1    is_type 0              
+        2    pop_jump_if_false +2   (to 4)
+        3    jump +45               (to 48)
+        4    load_var 1             (mime_type)
+        5    is_type 1              
+        6    pop_jump_if_false +2   (to 8)
+        7    jump +39               (to 46)
+        8    load_var 1             (mime_type)
+        9    is_type 2              
+        10   pop_jump_if_false +2   (to 12)
+        11   jump +33               (to 44)
+        12   load_var 1             (mime_type)
+        13   is_type 3              
+        14   pop_jump_if_false +2   (to 16)
+        15   jump +27               (to 42)
+        16   load_var 1             (mime_type)
+        17   is_type 4              
         18   pop_jump_if_false +2   (to 20)
-        19   jump +31               (to 50)
+        19   jump +21               (to 40)
         20   load_var 1             (mime_type)
-        21   load_const 4           ("audio/flac")
-        22   cmp_op ==              
-        23   pop_jump_if_false +2   (to 25)
-        24   jump +24               (to 48)
-        25   load_var 1             (mime_type)
-        26   load_const 5           ("audio/x-flac")
-        27   cmp_op ==              
-        28   pop_jump_if_false +2   (to 30)
-        29   jump +17               (to 46)
-        30   load_var 1             (mime_type)
-        31   load_const 6           ("audio/ogg")
-        32   cmp_op ==              
-        33   pop_jump_if_false +2   (to 35)
-        34   jump +10               (to 44)
-        35   load_var 1             (mime_type)
-        36   load_const 7           ("audio/webm")
-        37   cmp_op ==              
-        38   pop_jump_if_false +2   (to 40)
-        39   jump +3                (to 42)
+        21   is_type 5              
+        22   pop_jump_if_false +2   (to 24)
+        23   jump +15               (to 38)
+        24   load_var 1             (mime_type)
+        25   is_type 6              
+        26   pop_jump_if_false +2   (to 28)
+        27   jump +9                (to 36)
+        28   load_var 1             (mime_type)
+        29   is_type 7              
+        30   pop_jump_if_false +2   (to 32)
+        31   jump +3                (to 34)
 
-  333   40   load_var 1             (mime_type)
+  333   32   load_var 1             (mime_type)
 
-  327   41   jump +16               (to 57)
+  327   33   jump +16               (to 49)
 
-  332   42   load_const 8           ("webm")
+  332   34   load_const 8           ("webm")
 
-  327   43   jump +14               (to 57)
+  327   35   jump +14               (to 49)
 
-  331   44   load_const 9           ("ogg")
+  331   36   load_const 9           ("ogg")
 
-  327   45   jump +12               (to 57)
+  327   37   jump +12               (to 49)
 
-  330   46   load_const 10          ("flac")
+  330   38   load_const 10          ("flac")
 
-  327   47   jump +10               (to 57)
+  327   39   jump +10               (to 49)
 
-  330   48   load_const 11          ("flac")
+  330   40   load_const 11          ("flac")
 
-  327   49   jump +8                (to 57)
+  327   41   jump +8                (to 49)
 
-  329   50   load_const 12          ("mp3")
+  329   42   load_const 12          ("mp3")
 
-  327   51   jump +6                (to 57)
+  327   43   jump +6                (to 49)
 
-  329   52   load_const 13          ("mp3")
+  329   44   load_const 13          ("mp3")
 
-  327   53   jump +4                (to 57)
+  327   45   jump +4                (to 49)
 
-  328   54   load_const 14          ("wav")
+  328   46   load_const 14          ("wav")
 
-  327   55   jump +2                (to 57)
+  327   47   jump +2                (to 49)
 
-  328   56   load_const 15          ("wav")
-        57   return                 
+  328   48   load_const 15          ("wav")
+        49   return                 
 }
 
 function openai.internal._openai_decode_batch(batch: string, state: openai.internal.OaStreamState) -> (ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone)[] {
@@ -24555,35 +24444,32 @@ function openai.internal._openai_image_mime(output_format: string | null) -> str
         10   store_var 2            (format)
 
   756   11   load_var 2             (format)
-        12   load_const 2           ("jpeg")
-        13   cmp_op ==              
-        14   pop_jump_if_false +2   (to 16)
-        15   jump +17               (to 32)
-        16   load_var 2             (format)
-        17   load_const 3           ("jpg")
-        18   cmp_op ==              
-        19   pop_jump_if_false +2   (to 21)
-        20   jump +10               (to 30)
-        21   load_var 2             (format)
-        22   load_const 4           ("webp")
-        23   cmp_op ==              
-        24   pop_jump_if_false +2   (to 26)
-        25   jump +3                (to 28)
+        12   is_type 2              
+        13   pop_jump_if_false +2   (to 15)
+        14   jump +15               (to 29)
+        15   load_var 2             (format)
+        16   is_type 3              
+        17   pop_jump_if_false +2   (to 19)
+        18   jump +9                (to 27)
+        19   load_var 2             (format)
+        20   is_type 4              
+        21   pop_jump_if_false +2   (to 23)
+        22   jump +3                (to 25)
 
-  759   26   load_const 5           ("image/png")
+  759   23   load_const 5           ("image/png")
 
-  756   27   jump +6                (to 33)
+  756   24   jump +6                (to 30)
 
-  758   28   load_const 6           ("image/webp")
+  758   25   load_const 6           ("image/webp")
 
-  756   29   jump +4                (to 33)
+  756   26   jump +4                (to 30)
 
-  757   30   load_const 7           ("image/jpeg")
+  757   27   load_const 7           ("image/jpeg")
 
-  756   31   jump +2                (to 33)
+  756   28   jump +2                (to 30)
 
-  757   32   load_const 8           ("image/jpeg")
-        33   return                 
+  757   29   load_const 8           ("image/jpeg")
+        30   return                 
 }
 
 function openai.internal._openai_media_role_error(kind: string, role: string) -> ai.errors.Failure {
@@ -25690,352 +25576,342 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          31    load_var 8                       (_17)
          32    narrow_bind 5 8                  
          33    pop_jump_if_false +2             (to 35)
-         34    jump +298                        (to 332)
+         34    jump +288                        (to 322)
 
   1026   35    load_var 5                       (kind)
-         36    load_const 6                     ("response.created")
-         37    cmp_op ==                        
-         38    pop_jump_if_false +2             (to 40)
-         39    jump +282                        (to 321)
-         40    load_var 5                       (kind)
-         41    load_const 7                     ("response.in_progress")
-         42    cmp_op ==                        
-         43    pop_jump_if_false +2             (to 45)
-         44    jump +267                        (to 311)
-         45    load_var 5                       (kind)
-         46    load_const 8                     ("response.output_text.delta")
-         47    cmp_op ==                        
-         48    pop_jump_if_false +2             (to 50)
-         49    jump +236                        (to 285)
-         50    load_var 5                       (kind)
-         51    load_const 9                     ("response.output_text.done")
-         52    cmp_op ==                        
+         36    is_type 6                        
+         37    pop_jump_if_false +2             (to 39)
+         38    jump +273                        (to 311)
+         39    load_var 5                       (kind)
+         40    is_type 7                        
+         41    pop_jump_if_false +2             (to 43)
+         42    jump +259                        (to 301)
+         43    load_var 5                       (kind)
+         44    is_type 8                        
+         45    pop_jump_if_false +2             (to 47)
+         46    jump +229                        (to 275)
+         47    load_var 5                       (kind)
+         48    is_type 9                        
+         49    pop_jump_if_false +2             (to 51)
+         50    jump +185                        (to 235)
+         51    load_var 5                       (kind)
+         52    is_type 10                       
          53    pop_jump_if_false +2             (to 55)
-         54    jump +191                        (to 245)
+         54    jump +147                        (to 201)
          55    load_var 5                       (kind)
-         56    load_const 10                    ("response.function_call_arguments.delta")
-         57    cmp_op ==                        
-         58    pop_jump_if_false +2             (to 60)
-         59    jump +152                        (to 211)
-         60    load_var 5                       (kind)
-         61    load_const 11                    ("response.function_call_arguments.done")
-         62    cmp_op ==                        
-         63    pop_jump_if_false +2             (to 65)
-         64    jump +126                        (to 190)
-         65    load_var 5                       (kind)
-         66    load_const 12                    ("response.failed")
-         67    cmp_op ==                        
-         68    pop_jump_if_false +2             (to 70)
-         69    jump +118                        (to 187)
-         70    load_var 5                       (kind)
-         71    load_const 13                    ("error")
-         72    cmp_op ==                        
-         73    pop_jump_if_false +2             (to 75)
-         74    jump +110                        (to 184)
-         75    load_var 5                       (kind)
-         76    load_const 14                    ("response.completed")
-         77    cmp_op ==                        
-         78    pop_jump_if_false +2             (to 80)
-         79    jump +55                         (to 134)
-         80    load_var 5                       (kind)
-         81    load_const 15                    ("response.incomplete")
-         82    cmp_op ==                        
-         83    pop_jump_if_false +247           (to 330)
+         56    is_type 11                       
+         57    pop_jump_if_false +2             (to 59)
+         58    jump +122                        (to 180)
+         59    load_var 5                       (kind)
+         60    is_type 12                       
+         61    pop_jump_if_false +2             (to 63)
+         62    jump +115                        (to 177)
+         63    load_var 5                       (kind)
+         64    is_type 13                       
+         65    pop_jump_if_false +2             (to 67)
+         66    jump +108                        (to 174)
+         67    load_var 5                       (kind)
+         68    is_type 14                       
+         69    pop_jump_if_false +2             (to 71)
+         70    jump +54                         (to 124)
+         71    load_var 5                       (kind)
+         72    is_type 15                       
+         73    pop_jump_if_false +247           (to 320)
 
-  1078   84    load_var 1                       (event)
-         85    load_field 8                     (response)
-         86    store_var 33                     (_122)
-         87    load_var 33                      (_122)
-         88    narrow_bind 16 33                
-         89    pop_jump_if_false +39            (to 128)
-         90    load_var 33                      (_122)
+  1078   74    load_var 1                       (event)
+         75    load_field 8                     (response)
+         76    store_var 33                     (_122)
+         77    load_var 33                      (_122)
+         78    narrow_bind 16 33                
+         79    pop_jump_if_false +39            (to 118)
+         80    load_var 33                      (_122)
 
-  1079   91    call 1042 ntypeargs=0            (openai.internal.openai_parse)
-         92    store_var 34                     (turn)
+  1079   81    call 1042 ntypeargs=0            (openai.internal.openai_parse)
+         82    store_var 34                     (turn)
 
-  1082   93    load_var 34                      (turn)
-         94    load_field 1                     (stop_reason)
-         95    store_var 35                     (_128)
+  1082   83    load_var 34                      (turn)
+         84    load_field 1                     (stop_reason)
+         85    store_var 35                     (_128)
 
-  1083   96    load_var 34                      (turn)
-         97    load_field 2                     (usage)
-         98    load_const 1                     (null)
-         99    cmp_op ==                        
-         100   pop_jump_if_false +2             (to 102)
-         101   jump +6                          (to 107)
-         102   load_var 34                      (turn)
-         103   load_field 2                     (usage)
-         104   load_field 0                     (0)
-         105   store_var 36                     (_129)
-         106   jump +3                          (to 109)
-         107   load_const 1                     (null)
-         108   store_var 36                     (_129)
+  1083   86    load_var 34                      (turn)
+         87    load_field 2                     (usage)
+         88    load_const 1                     (null)
+         89    cmp_op ==                        
+         90    pop_jump_if_false +2             (to 92)
+         91    jump +6                          (to 97)
+         92    load_var 34                      (turn)
+         93    load_field 2                     (usage)
+         94    load_field 0                     (0)
+         95    store_var 36                     (_129)
+         96    jump +3                          (to 99)
+         97    load_const 1                     (null)
+         98    store_var 36                     (_129)
 
-  1084   109   load_var 34                      (turn)
-         110   load_field 2                     (usage)
-         111   load_const 1                     (null)
-         112   cmp_op ==                        
-         113   pop_jump_if_false +2             (to 115)
-         114   jump +6                          (to 120)
-         115   load_var 34                      (turn)
-         116   load_field 2                     (usage)
-         117   load_field 1                     (1)
-         118   store_var 37                     (_133)
-         119   jump +3                          (to 122)
-         120   load_const 1                     (null)
-         121   store_var 37                     (_133)
+  1084   99    load_var 34                      (turn)
+         100   load_field 2                     (usage)
+         101   load_const 1                     (null)
+         102   cmp_op ==                        
+         103   pop_jump_if_false +2             (to 105)
+         104   jump +6                          (to 110)
+         105   load_var 34                      (turn)
+         106   load_field 2                     (usage)
+         107   load_field 1                     (1)
+         108   store_var 37                     (_133)
+         109   jump +3                          (to 112)
+         110   load_const 1                     (null)
+         111   store_var 37                     (_133)
 
-  1080   122   load_type 0                      
-         123   load_var2 4 35                   
+  1080   112   load_type 0                      
+         113   load_var2 4 35                   
 
-  1081   124   load_var2 36 37                  
-         125   init_instance 0                  (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
+  1081   114   load_var2 36 37                  
+         115   init_instance 0                  (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
 
-  1080   126   call 4 ntypeargs=1               (baml.Array.push)
-         127   pop 1                            
+  1080   116   call 4 ntypeargs=1               (baml.Array.push)
+         117   pop 1                            
 
-  1088   128   load_type 0                      
-         129   load_var 4                       (out)
-         130   alloc_instance 410 ntypeargs=0   (ai.stream.TurnDone)
-         131   call 4 ntypeargs=1               (baml.Array.push)
-         132   pop 1                            
-         133   jump +197                        (to 330)
+  1088   118   load_type 0                      
+         119   load_var 4                       (out)
+         120   alloc_instance 410 ntypeargs=0   (ai.stream.TurnDone)
+         121   call 4 ntypeargs=1               (baml.Array.push)
+         122   pop 1                            
+         123   jump +197                        (to 320)
 
-  1078   134   load_var 1                       (event)
-         135   load_field 8                     (response)
-         136   store_var 28                     (_101)
-         137   load_var 28                      (_101)
-         138   narrow_bind 16 28                
-         139   pop_jump_if_false +39            (to 178)
-         140   load_var 28                      (_101)
+  1078   124   load_var 1                       (event)
+         125   load_field 8                     (response)
+         126   store_var 28                     (_101)
+         127   load_var 28                      (_101)
+         128   narrow_bind 16 28                
+         129   pop_jump_if_false +39            (to 168)
+         130   load_var 28                      (_101)
 
-  1079   141   call 1042 ntypeargs=0            (openai.internal.openai_parse)
-         142   store_var 29                     (turn)
+  1079   131   call 1042 ntypeargs=0            (openai.internal.openai_parse)
+         132   store_var 29                     (turn)
 
-  1082   143   load_var 29                      (turn)
-         144   load_field 1                     (stop_reason)
-         145   store_var 30                     (_107)
+  1082   133   load_var 29                      (turn)
+         134   load_field 1                     (stop_reason)
+         135   store_var 30                     (_107)
 
-  1083   146   load_var 29                      (turn)
-         147   load_field 2                     (usage)
-         148   load_const 1                     (null)
-         149   cmp_op ==                        
-         150   pop_jump_if_false +2             (to 152)
-         151   jump +6                          (to 157)
-         152   load_var 29                      (turn)
-         153   load_field 2                     (usage)
-         154   load_field 0                     (0)
-         155   store_var 31                     (_108)
-         156   jump +3                          (to 159)
-         157   load_const 1                     (null)
-         158   store_var 31                     (_108)
+  1083   136   load_var 29                      (turn)
+         137   load_field 2                     (usage)
+         138   load_const 1                     (null)
+         139   cmp_op ==                        
+         140   pop_jump_if_false +2             (to 142)
+         141   jump +6                          (to 147)
+         142   load_var 29                      (turn)
+         143   load_field 2                     (usage)
+         144   load_field 0                     (0)
+         145   store_var 31                     (_108)
+         146   jump +3                          (to 149)
+         147   load_const 1                     (null)
+         148   store_var 31                     (_108)
 
-  1084   159   load_var 29                      (turn)
-         160   load_field 2                     (usage)
-         161   load_const 1                     (null)
-         162   cmp_op ==                        
-         163   pop_jump_if_false +2             (to 165)
-         164   jump +6                          (to 170)
-         165   load_var 29                      (turn)
-         166   load_field 2                     (usage)
-         167   load_field 1                     (1)
-         168   store_var 32                     (_112)
-         169   jump +3                          (to 172)
-         170   load_const 1                     (null)
-         171   store_var 32                     (_112)
+  1084   149   load_var 29                      (turn)
+         150   load_field 2                     (usage)
+         151   load_const 1                     (null)
+         152   cmp_op ==                        
+         153   pop_jump_if_false +2             (to 155)
+         154   jump +6                          (to 160)
+         155   load_var 29                      (turn)
+         156   load_field 2                     (usage)
+         157   load_field 1                     (1)
+         158   store_var 32                     (_112)
+         159   jump +3                          (to 162)
+         160   load_const 1                     (null)
+         161   store_var 32                     (_112)
 
-  1080   172   load_type 0                      
-         173   load_var2 4 30                   
+  1080   162   load_type 0                      
+         163   load_var2 4 30                   
 
-  1081   174   load_var2 31 32                  
-         175   init_instance 1                  (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
+  1081   164   load_var2 31 32                  
+         165   init_instance 1                  (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
 
-  1080   176   call 4 ntypeargs=1               (baml.Array.push)
-         177   pop 1                            
+  1080   166   call 4 ntypeargs=1               (baml.Array.push)
+         167   pop 1                            
 
-  1088   178   load_type 0                      
-         179   load_var 4                       (out)
-         180   alloc_instance 410 ntypeargs=0   (ai.stream.TurnDone)
-         181   call 4 ntypeargs=1               (baml.Array.push)
-         182   pop 1                            
-         183   jump +147                        (to 330)
+  1088   168   load_type 0                      
+         169   load_var 4                       (out)
+         170   alloc_instance 410 ntypeargs=0   (ai.stream.TurnDone)
+         171   call 4 ntypeargs=1               (baml.Array.push)
+         172   pop 1                            
+         173   jump +147                        (to 320)
 
-  1076   184   load_var 1                       (event)
-         185   call 1046 ntypeargs=0            (openai.internal._openai_stream_failure)
-         186   throw                            
-         187   load_var 1                       (event)
-         188   call 1046 ntypeargs=0            (openai.internal._openai_stream_failure)
-         189   throw                            
+  1076   174   load_var 1                       (event)
+         175   call 1046 ntypeargs=0            (openai.internal._openai_stream_failure)
+         176   throw                            
+         177   load_var 1                       (event)
+         178   call 1046 ntypeargs=0            (openai.internal._openai_stream_failure)
+         179   throw                            
 
-  1071   190   load_var 1                       (event)
-         191   load_field 3                     (arguments)
-         192   store_var 24                     (_87)
-         193   load_var 24                      (_87)
-         194   narrow_bind 17 24                
-         195   pop_jump_if_false +135           (to 330)
-         196   load_var 24                      (_87)
-         197   store_var 25                     (full)
+  1071   180   load_var 1                       (event)
+         181   load_field 3                     (arguments)
+         182   store_var 24                     (_87)
+         183   load_var 24                      (_87)
+         184   narrow_bind 17 24                
+         185   pop_jump_if_false +135           (to 320)
+         186   load_var 24                      (_87)
+         187   store_var 25                     (full)
 
-  1072   198   load_var 3                       (state)
-         199   load_field 2                     (call_arguments)
-         200   store_var 26                     (_90)
-         201   load_var 1                       (event)
-         202   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
-         203   store_var 27                     (_91)
-         204   load_type 18                     
-         205   load_type 18                     
-         206   load_var2 26 27                  
-         207   load_var 25                      (full)
-         208   call 37 ntypeargs=2              (baml.Map.set)
-         209   pop 1                            
-         210   jump +120                        (to 330)
+  1072   188   load_var 3                       (state)
+         189   load_field 2                     (call_arguments)
+         190   store_var 26                     (_90)
+         191   load_var 1                       (event)
+         192   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
+         193   store_var 27                     (_91)
+         194   load_type 18                     
+         195   load_type 18                     
+         196   load_var2 26 27                  
+         197   load_var 25                      (full)
+         198   call 37 ntypeargs=2              (baml.Map.set)
+         199   pop 1                            
+         200   jump +120                        (to 320)
 
-  1061   211   load_var 1                       (event)
-         212   load_field 1                     (delta)
-         213   store_var 19                     (_67)
-         214   load_var 19                      (_67)
-         215   narrow_bind 17 19                
-         216   pop_jump_if_false +114           (to 330)
-         217   load_var 19                      (_67)
-         218   store_var 20                     (delta)
+  1061   201   load_var 1                       (event)
+         202   load_field 1                     (delta)
+         203   store_var 19                     (_67)
+         204   load_var 19                      (_67)
+         205   narrow_bind 17 19                
+         206   pop_jump_if_false +114           (to 320)
+         207   load_var 19                      (_67)
+         208   store_var 20                     (delta)
 
-  1062   219   load_var 1                       (event)
-         220   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
-         221   store_var 21                     (key)
+  1062   209   load_var 1                       (event)
+         210   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
+         211   store_var 21                     (key)
 
-  1063   222   load_var 3                       (state)
-         223   load_field 2                     (call_arguments)
-         224   store_var 22                     (_71)
+  1063   212   load_var 3                       (state)
+         213   load_field 2                     (call_arguments)
+         214   store_var 22                     (_71)
 
-  1065   225   load_type 18                     
-         226   load_type 18                     
-         227   load_var 3                       (state)
-         228   load_field 2                     (call_arguments)
-         229   load_var 21                      (key)
-         230   call 38 ntypeargs=2              (baml.Map.get)
-         231   store_var_load_var 23            (_75)
-         232   load_const 1                     (null)
-         233   cmp_op ==                        
-         234   pop_jump_if_false +3             (to 237)
-         235   load_const 19                    ("")
-         236   store_var 23                     (_75)
+  1065   215   load_type 18                     
+         216   load_type 18                     
+         217   load_var 3                       (state)
+         218   load_field 2                     (call_arguments)
+         219   load_var 21                      (key)
+         220   call 38 ntypeargs=2              (baml.Map.get)
+         221   store_var_load_var 23            (_75)
+         222   load_const 1                     (null)
+         223   cmp_op ==                        
+         224   pop_jump_if_false +3             (to 227)
+         225   load_const 19                    ("")
+         226   store_var 23                     (_75)
 
-  1063   237   load_type 18                     
-         238   load_type 18                     
-         239   load_var2 22 21                  
+  1063   227   load_type 18                     
+         228   load_type 18                     
+         229   load_var2 22 21                  
 
-  1065   240   load_var2 23 20                  
-         241   bin_op +                         
+  1065   230   load_var2 23 20                  
+         231   bin_op +                         
 
-  1063   242   call 37 ntypeargs=2              (baml.Map.set)
-         243   pop 1                            
-         244   jump +86                         (to 330)
+  1063   232   call 37 ntypeargs=2              (baml.Map.set)
+         233   pop 1                            
+         234   jump +86                         (to 320)
 
-  1045   245   load_var 1                       (event)
-         246   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
-         247   store_var 15                     (key)
+  1045   235   load_var 1                       (event)
+         236   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
+         237   store_var 15                     (key)
 
-  1046   248   load_type 18                     
-         249   load_type 20                     
-         250   load_var 3                       (state)
-         251   load_field 1                     (text_started)
-         252   load_var 15                      (key)
-         253   call 38 ntypeargs=2              (baml.Map.get)
-         254   store_var_load_var 16            (_46)
-         255   load_const 1                     (null)
-         256   cmp_op ==                        
-         257   pop_jump_if_false +3             (to 260)
-         258   load_const 21                    (false)
-         259   store_var 16                     (_46)
-         260   load_var 16                      (_46)
-         261   unary_op !                       
-         262   pop_jump_if_false +68            (to 330)
+  1046   238   load_type 18                     
+         239   load_type 20                     
+         240   load_var 3                       (state)
+         241   load_field 1                     (text_started)
+         242   load_var 15                      (key)
+         243   call 38 ntypeargs=2              (baml.Map.get)
+         244   store_var_load_var 16            (_46)
+         245   load_const 1                     (null)
+         246   cmp_op ==                        
+         247   pop_jump_if_false +3             (to 250)
+         248   load_const 21                    (false)
+         249   store_var 16                     (_46)
+         250   load_var 16                      (_46)
+         251   unary_op !                       
+         252   pop_jump_if_false +68            (to 320)
 
-  1047   263   load_var 1                       (event)
-         264   load_field 2                     (text)
-         265   store_var 17                     (_54)
-         266   load_var 17                      (_54)
-         267   narrow_bind 17 17                
-         268   pop_jump_if_false +62            (to 330)
-         269   load_var 17                      (_54)
-         270   store_var 18                     (full)
+  1047   253   load_var 1                       (event)
+         254   load_field 2                     (text)
+         255   store_var 17                     (_54)
+         256   load_var 17                      (_54)
+         257   narrow_bind 17 17                
+         258   pop_jump_if_false +62            (to 320)
+         259   load_var 17                      (_54)
+         260   store_var 18                     (full)
 
-  1048   271   load_type 18                     
-         272   load_type 20                     
-         273   load_var 3                       (state)
-         274   load_field 1                     (text_started)
-         275   load_var 15                      (key)
-         276   load_const 22                    (true)
-         277   call 37 ntypeargs=2              (baml.Map.set)
-         278   pop 1                            
+  1048   261   load_type 18                     
+         262   load_type 20                     
+         263   load_var 3                       (state)
+         264   load_field 1                     (text_started)
+         265   load_var 15                      (key)
+         266   load_const 22                    (true)
+         267   call 37 ntypeargs=2              (baml.Map.set)
+         268   pop 1                            
 
-  1049   279   load_type 0                      
-         280   load_var2 4 18                   
-         281   init_instance 2                  (ai.stream.TextDelta .text)
-         282   call 4 ntypeargs=1               (baml.Array.push)
-         283   pop 1                            
-         284   jump +46                         (to 330)
+  1049   269   load_type 0                      
+         270   load_var2 4 18                   
+         271   init_instance 2                  (ai.stream.TextDelta .text)
+         272   call 4 ntypeargs=1               (baml.Array.push)
+         273   pop 1                            
+         274   jump +46                         (to 320)
 
-  1036   285   load_var 1                       (event)
-         286   load_field 1                     (delta)
-         287   store_var 11                     (_31)
-         288   load_var 11                      (_31)
-         289   narrow_bind 17 11                
-         290   pop_jump_if_false +40            (to 330)
-         291   load_var 11                      (_31)
-         292   store_var 12                     (delta)
+  1036   275   load_var 1                       (event)
+         276   load_field 1                     (delta)
+         277   store_var 11                     (_31)
+         278   load_var 11                      (_31)
+         279   narrow_bind 17 11                
+         280   pop_jump_if_false +40            (to 320)
+         281   load_var 11                      (_31)
+         282   store_var 12                     (delta)
 
-  1037   293   load_var 3                       (state)
-         294   load_field 1                     (text_started)
-         295   store_var 13                     (_34)
-         296   load_var 1                       (event)
-         297   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
-         298   store_var 14                     (_35)
-         299   load_type 18                     
-         300   load_type 20                     
-         301   load_var2 13 14                  
-         302   load_const 22                    (true)
-         303   call 37 ntypeargs=2              (baml.Map.set)
-         304   pop 1                            
+  1037   283   load_var 3                       (state)
+         284   load_field 1                     (text_started)
+         285   store_var 13                     (_34)
+         286   load_var 1                       (event)
+         287   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
+         288   store_var 14                     (_35)
+         289   load_type 18                     
+         290   load_type 20                     
+         291   load_var2 13 14                  
+         292   load_const 22                    (true)
+         293   call 37 ntypeargs=2              (baml.Map.set)
+         294   pop 1                            
 
-  1038   305   load_type 0                      
-         306   load_var2 4 12                   
-         307   init_instance 3                  (ai.stream.TextDelta .text)
-         308   call 4 ntypeargs=1               (baml.Array.push)
-         309   pop 1                            
-         310   jump +20                         (to 330)
+  1038   295   load_type 0                      
+         296   load_var2 4 12                   
+         297   init_instance 3                  (ai.stream.TextDelta .text)
+         298   call 4 ntypeargs=1               (baml.Array.push)
+         299   pop 1                            
+         300   jump +20                         (to 320)
 
-  1030   311   load_var 1                       (event)
+  1030   301   load_var 1                       (event)
+         302   load_field 8                     (response)
+         303   store_var 10                     (_27)
+         304   load_var 10                      (_27)
+         305   narrow_bind 16 10                
+         306   pop_jump_if_false +14            (to 320)
+
+  1031   307   load_var2 3 10                   
+
+  1030   308   load_field 1                     (model)
+         309   store_field 0                    (model)
+         310   jump +10                         (to 320)
+         311   load_var 1                       (event)
          312   load_field 8                     (response)
-         313   store_var 10                     (_27)
-         314   load_var 10                      (_27)
-         315   narrow_bind 16 10                
-         316   pop_jump_if_false +14            (to 330)
+         313   store_var 9                      (_23)
+         314   load_var 9                       (_23)
+         315   narrow_bind 16 9                 
+         316   pop_jump_if_false +4             (to 320)
 
-  1031   317   load_var2 3 10                   
+  1031   317   load_var2 3 9                    
 
   1030   318   load_field 1                     (model)
          319   store_field 0                    (model)
-         320   jump +10                         (to 330)
-         321   load_var 1                       (event)
-         322   load_field 8                     (response)
-         323   store_var 9                      (_23)
-         324   load_var 9                       (_23)
-         325   narrow_bind 16 9                 
-         326   pop_jump_if_false +4             (to 330)
 
-  1031   327   load_var2 3 9                    
+  1093   320   load_var 4                       (out)
+         321   return                           
 
-  1030   328   load_field 1                     (model)
-         329   store_field 0                    (model)
+  1022   322   load_var 8                       (_17)
 
-  1093   330   load_var 4                       (out)
-         331   return                           
-
-  1022   332   load_var 8                       (_17)
-
-  1023   333   call 1040 ntypeargs=0            (openai.internal._openai_error_failure)
-         334   throw                            
+  1023   323   call 1040 ntypeargs=0            (openai.internal._openai_error_failure)
+         324   throw                            
 }
 
 function openai.internal._openai_stream_failure(event: openai.internal.OaStreamEvent) -> ai.errors.Failure {
@@ -26689,7 +26565,7 @@ function openai.internal.chat_invoke_stream(compat: openai.internal.ChatCompat, 
          26   throw                   
 
   1551   27   load_var 5              (decoder)
-         28   make_closure 3049 1     
+         28   make_closure 2993 1     
 
   1552   29   load_var 1              (compat)
          30   load_field 0            (provider)
@@ -26977,156 +26853,154 @@ function openai.internal.chat_lower_prompt(prompt: ai.Prompt, compat: openai.int
         14    load_var 5                         (_6)
         15    is_type 5                          
         16    pop_jump_if_false +2               (to 18)
-        17    jump +85                           (to 102)
+        17    jump +83                           (to 100)
         18    load_var 5                         (_6)
         19    store_var 6                        (message)
 
   672   20    load_var 6                         (message)
         21    load_field 0                       (role)
         22    store_var_load_var 8               (_11)
-        23    load_const 6                       ("")
-        24    cmp_op ==                          
-        25    pop_jump_if_false +2               (to 27)
-        26    jump +13                           (to 39)
-        27    load_var 8                         (_11)
-        28    load_const 7                       ("tool")
-        29    cmp_op ==                          
-        30    pop_jump_if_false +2               (to 32)
-        31    jump +5                            (to 36)
+        23    is_type 6                          
+        24    pop_jump_if_false +2               (to 26)
+        25    jump +12                           (to 37)
+        26    load_var 8                         (_11)
+        27    is_type 7                          
+        28    pop_jump_if_false +2               (to 30)
+        29    jump +5                            (to 34)
 
-  675   32    load_var 6                         (message)
-        33    load_field 0                       (role)
-        34    store_var 7                        (role)
+  675   30    load_var 6                         (message)
+        31    load_field 0                       (role)
+        32    store_var 7                        (role)
 
-  672   35    jump +7                            (to 42)
+  672   33    jump +7                            (to 40)
 
-  674   36    load_const 8                       ("user")
-        37    store_var 7                        (role)
+  674   34    load_const 8                       ("user")
+        35    store_var 7                        (role)
 
-  672   38    jump +4                            (to 42)
+  672   36    jump +4                            (to 40)
 
-  673   39    load_var 2                         (compat)
-        40    load_field 11                      (default_role)
-        41    store_var 7                        (role)
+  673   37    load_var 2                         (compat)
+        38    load_field 11                      (default_role)
+        39    store_var 7                        (role)
 
-  677   42    load_var2 6 2                      
-        43    call 1111 ntypeargs=0              (openai.internal._chat_prompt_parts)
-        44    store_var 9                        (parts)
+  677   40    load_var2 6 2                      
+        41    call 1111 ntypeargs=0              (openai.internal._chat_prompt_parts)
+        42    store_var 9                        (parts)
 
-  681   45    load_var2 9 6                      
-        46    load_field 3                       (metadata)
-        47    call 1112 ntypeargs=0              (openai.internal._chat_apply_metadata)
-        48    pop 1                              
+  681   43    load_var2 9 6                      
+        44    load_field 3                       (metadata)
+        45    call 1112 ntypeargs=0              (openai.internal._chat_apply_metadata)
+        46    pop 1                              
 
-  682   49    load_const 9                       (false)
-        50    store_var 10                       (merged)
+  682   47    load_const 9                       (false)
+        48    store_var 10                       (merged)
 
-  683   51    load_var 3                         (lowered)
-        52    container_len                      
-        53    store_var 11                       (_22)
-        54    load_type 0                        
-        55    load_var2 3 11                     
-        56    load_const 10                      (1)
-        57    sub_int                            
-        58    call 3 ntypeargs=1                 (baml.Array.at)
-        59    store_var 12                       (_24)
-        60    load_var 12                        (_24)
-        61    narrow_bind 11 12                  
-        62    pop_jump_if_false +30              (to 92)
-        63    load_var 12                        (_24)
-        64    store_var_load_var 13              (last)
+  683   49    load_var 3                         (lowered)
+        50    container_len                      
+        51    store_var 11                       (_22)
+        52    load_type 0                        
+        53    load_var2 3 11                     
+        54    load_const 10                      (1)
+        55    sub_int                            
+        56    call 3 ntypeargs=1                 (baml.Array.at)
+        57    store_var 12                       (_24)
+        58    load_var 12                        (_24)
+        59    narrow_bind 11 12                  
+        60    pop_jump_if_false +30              (to 90)
+        61    load_var 12                        (_24)
+        62    store_var_load_var 13              (last)
 
-  684   65    load_field 0                       (role)
-        66    load_var 7                         (role)
-        67    cmp_op ==                          
-        68    pop_jump_if_false +24              (to 92)
+  684   63    load_field 0                       (role)
+        64    load_var 7                         (role)
+        65    cmp_op ==                          
+        66    pop_jump_if_false +24              (to 90)
 
-  685   69    load_var 9                         (parts)
-        70    load_type 12                       
-        71    load_const 13                      ("iter")
-        72    virtual_call nargs=1 ntypeargs=0   
-        73    store_var 14                       (_30)
-        74    load_var 14                        (_30)
-        75    load_type 14                       
-        76    load_const 15                      ("next")
-        77    virtual_call nargs=1 ntypeargs=0   
-        78    store_var 15                       (_31)
-        79    load_var 15                        (_31)
-        80    is_type 5                          
-        81    pop_jump_if_false +2               (to 83)
-        82    jump +8                            (to 90)
+  685   67    load_var 9                         (parts)
+        68    load_type 12                       
+        69    load_const 13                      ("iter")
+        70    virtual_call nargs=1 ntypeargs=0   
+        71    store_var 14                       (_30)
+        72    load_var 14                        (_30)
+        73    load_type 14                       
+        74    load_const 15                      ("next")
+        75    virtual_call nargs=1 ntypeargs=0   
+        76    store_var 15                       (_31)
+        77    load_var 15                        (_31)
+        78    is_type 5                          
+        79    pop_jump_if_false +2               (to 81)
+        80    jump +8                            (to 88)
 
-  686   83    load_type 16                       
-        84    load_var 13                        (last)
-        85    load_field 1                       (parts)
+  686   81    load_type 16                       
+        82    load_var 13                        (last)
+        83    load_field 1                       (parts)
 
-  685   86    load_var 15                        (_31)
+  685   84    load_var 15                        (_31)
 
-  686   87    call 4 ntypeargs=1                 (baml.Array.push)
-        88    pop 1                              
-        89    jump -15                           (to 74)
+  686   85    call 4 ntypeargs=1                 (baml.Array.push)
+        86    pop 1                              
+        87    jump -15                           (to 72)
 
-  688   90    load_const 17                      (true)
-        91    store_var 10                       (merged)
+  688   88    load_const 17                      (true)
+        89    store_var 10                       (merged)
 
-  691   92    load_var 10                        (merged)
-        93    unary_op !                         
-        94    pop_jump_if_false -85              (to 9)
+  691   90    load_var 10                        (merged)
+        91    unary_op !                         
+        92    pop_jump_if_false -83              (to 9)
 
-  692   95    load_type 0                        
-        96    load_var2 3 7                      
-        97    load_var 9                         (parts)
-        98    init_instance 0                    (openai.internal.ChatPromptMessage .role, .parts)
-        99    call 4 ntypeargs=1                 (baml.Array.push)
-        100   pop 1                              
-        101   jump -92                           (to 9)
+  692   93    load_type 0                        
+        94    load_var2 3 7                      
+        95    load_var 9                         (parts)
+        96    init_instance 0                    (openai.internal.ChatPromptMessage .role, .parts)
+        97    call 4 ntypeargs=1                 (baml.Array.push)
+        98    pop 1                              
+        99    jump -90                           (to 9)
 
-  695   102   load_type 18                       
-        103   alloc_array 0                      
-        104   store_var 16                       (out)
+  695   100   load_type 18                       
+        101   alloc_array 0                      
+        102   store_var 16                       (out)
 
-  696   105   load_var 3                         (lowered)
-        106   load_type 19                       
-        107   load_const 20                      ("iter")
-        108   virtual_call nargs=1 ntypeargs=0   
-        109   store_var 17                       (_48)
-        110   load_var 17                        (_48)
-        111   load_type 21                       
-        112   load_const 22                      ("next")
-        113   virtual_call nargs=1 ntypeargs=0   
-        114   store_var 18                       (_49)
-        115   load_var 18                        (_49)
-        116   is_type 5                          
-        117   pop_jump_if_false +2               (to 119)
-        118   jump +21                           (to 139)
-        119   load_var 18                        (_49)
-        120   store_var 19                       (message)
+  696   103   load_var 3                         (lowered)
+        104   load_type 19                       
+        105   load_const 20                      ("iter")
+        106   virtual_call nargs=1 ntypeargs=0   
+        107   store_var 17                       (_48)
+        108   load_var 17                        (_48)
+        109   load_type 21                       
+        110   load_const 22                      ("next")
+        111   virtual_call nargs=1 ntypeargs=0   
+        112   store_var 18                       (_49)
+        113   load_var 18                        (_49)
+        114   is_type 5                          
+        115   pop_jump_if_false +2               (to 117)
+        116   jump +21                           (to 137)
+        117   load_var 18                        (_49)
+        118   store_var 19                       (message)
 
-  699   121   load_var 19                        (message)
-        122   load_field 0                       (role)
-        123   store_var 20                       (_55)
+  699   119   load_var 19                        (message)
+        120   load_field 0                       (role)
+        121   store_var 20                       (_55)
 
-  700   124   load_var 19                        (message)
-        125   load_field 1                       (parts)
-        126   load_var 2                         (compat)
-        127   load_field 6                       (collapse_text_content)
-        128   call 1114 ntypeargs=0              (openai.internal._chat_content)
-        129   store_var 21                       (_56)
+  700   122   load_var 19                        (message)
+        123   load_field 1                       (parts)
+        124   load_var 2                         (compat)
+        125   load_field 6                       (collapse_text_content)
+        126   call 1114 ntypeargs=0              (openai.internal._chat_content)
+        127   store_var 21                       (_56)
 
-  697   130   load_type 18                       
-        131   load_var2 16 20                    
+  697   128   load_type 18                       
+        129   load_var2 16 20                    
 
-  698   132   load_var 21                        (_56)
-        133   load_const 23                      (null)
-        134   load_const 23                      (null)
-        135   init_instance 1                    (openai.internal.ChatMessage .role, .content, .tool_calls, .tool_call_id)
+  698   130   load_var 21                        (_56)
+        131   load_const 23                      (null)
+        132   load_const 23                      (null)
+        133   init_instance 1                    (openai.internal.ChatMessage .role, .content, .tool_calls, .tool_call_id)
 
-  697   136   call 4 ntypeargs=1                 (baml.Array.push)
-        137   pop 1                              
-        138   jump -28                           (to 110)
+  697   134   call 4 ntypeargs=1                 (baml.Array.push)
+        135   pop 1                              
+        136   jump -28                           (to 108)
 
-  706   139   load_var 16                        (out)
-        140   return                             
+  706   137   load_var 16                        (out)
+        138   return                             
 }
 
 function openai.internal.chat_parse(response: openai.internal.CcResponse, provider: string, raw: string, audio_mime: string) -> ai.ModelTurn {
@@ -27608,59 +27482,54 @@ function openai.internal.chat_render_body(compat: openai.internal.ChatCompat, pa
 
 function openai.internal.chat_stop_reason(reason: string) -> ai.content.StopReason {
   1105   0    load_var 1             (reason)
-         1    load_const 0           ("tool_calls")
-         2    cmp_op ==              
-         3    pop_jump_if_false +2   (to 5)
-         4    jump +36               (to 40)
-         5    load_var 1             (reason)
-         6    load_const 1           ("function_call")
-         7    cmp_op ==              
-         8    pop_jump_if_false +2   (to 10)
-         9    jump +28               (to 37)
-         10   load_var 1             (reason)
-         11   load_const 2           ("length")
-         12   cmp_op ==              
-         13   pop_jump_if_false +2   (to 15)
-         14   jump +20               (to 34)
-         15   load_var 1             (reason)
-         16   load_const 3           ("max_tokens")
-         17   cmp_op ==              
+         1    is_type 0              
+         2    pop_jump_if_false +2   (to 4)
+         3    jump +32               (to 35)
+         4    load_var 1             (reason)
+         5    is_type 1              
+         6    pop_jump_if_false +2   (to 8)
+         7    jump +25               (to 32)
+         8    load_var 1             (reason)
+         9    is_type 2              
+         10   pop_jump_if_false +2   (to 12)
+         11   jump +18               (to 29)
+         12   load_var 1             (reason)
+         13   is_type 3              
+         14   pop_jump_if_false +2   (to 16)
+         15   jump +11               (to 26)
+         16   load_var 1             (reason)
+         17   is_type 4              
          18   pop_jump_if_false +2   (to 20)
-         19   jump +12               (to 31)
-         20   load_var 1             (reason)
-         21   load_const 4           ("content_filter")
-         22   cmp_op ==              
-         23   pop_jump_if_false +2   (to 25)
-         24   jump +4                (to 28)
+         19   jump +4                (to 23)
 
-  1109   25   load_const 5           (ai.content.StopReason.Complete)
-         26   alloc_variant 774      (ai.content.StopReason)
+  1109   20   load_const 5           (ai.content.StopReason.Complete)
+         21   alloc_variant 774      (ai.content.StopReason)
 
-  1105   27   jump +15               (to 42)
+  1105   22   jump +15               (to 37)
 
-  1108   28   load_const 6           (ai.content.StopReason.Refused)
-         29   alloc_variant 774      (ai.content.StopReason)
+  1108   23   load_const 6           (ai.content.StopReason.Refused)
+         24   alloc_variant 774      (ai.content.StopReason)
 
-  1105   30   jump +12               (to 42)
+  1105   25   jump +12               (to 37)
 
-  1107   31   load_const 7           (ai.content.StopReason.MaxTokens)
-         32   alloc_variant 774      (ai.content.StopReason)
+  1107   26   load_const 7           (ai.content.StopReason.MaxTokens)
+         27   alloc_variant 774      (ai.content.StopReason)
 
-  1105   33   jump +9                (to 42)
+  1105   28   jump +9                (to 37)
 
-  1107   34   load_const 7           (ai.content.StopReason.MaxTokens)
-         35   alloc_variant 774      (ai.content.StopReason)
+  1107   29   load_const 7           (ai.content.StopReason.MaxTokens)
+         30   alloc_variant 774      (ai.content.StopReason)
 
-  1105   36   jump +6                (to 42)
+  1105   31   jump +6                (to 37)
 
-  1106   37   load_const 8           (ai.content.StopReason.ToolUse)
-         38   alloc_variant 774      (ai.content.StopReason)
+  1106   32   load_const 8           (ai.content.StopReason.ToolUse)
+         33   alloc_variant 774      (ai.content.StopReason)
 
-  1105   39   jump +3                (to 42)
+  1105   34   jump +3                (to 37)
 
-  1106   40   load_const 8           (ai.content.StopReason.ToolUse)
-         41   alloc_variant 774      (ai.content.StopReason)
-         42   return                 
+  1106   35   load_const 8           (ai.content.StopReason.ToolUse)
+         36   alloc_variant 774      (ai.content.StopReason)
+         37   return                 
 }
 
 function openai.internal.images_invoke(c: openai.ImageClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
@@ -27976,7 +27845,7 @@ function openai.internal.invoke_stream(c: openai.ResponsesClient, input: ai.Mode
 
   1163   16   load_var2 3 5           
 
-  1164   17   make_closure 2756 1     
+  1164   17   make_closure 2712 1     
          18   load_const 1            ("openai")
 
   1162   19   call 959 ntypeargs=0    (ai.stream.TurnStream.from_sse)
@@ -28205,52 +28074,50 @@ function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> (openai.inter
         14   load_var 4                         (_5)
         15   is_type 5                          
         16   pop_jump_if_false +2               (to 18)
-        17   jump +36                           (to 53)
+        17   jump +34                           (to 51)
         18   load_var 4                         (_5)
         19   store_var 5                        (message)
 
   440   20   load_var 5                         (message)
         21   load_field 0                       (role)
         22   store_var_load_var 7               (_10)
-        23   load_const 6                       ("")
-        24   cmp_op ==                          
-        25   pop_jump_if_false +2               (to 27)
-        26   jump +13                           (to 39)
-        27   load_var 7                         (_10)
-        28   load_const 7                       ("tool")
-        29   cmp_op ==                          
-        30   pop_jump_if_false +2               (to 32)
-        31   jump +5                            (to 36)
+        23   is_type 6                          
+        24   pop_jump_if_false +2               (to 26)
+        25   jump +12                           (to 37)
+        26   load_var 7                         (_10)
+        27   is_type 7                          
+        28   pop_jump_if_false +2               (to 30)
+        29   jump +5                            (to 34)
 
-  442   32   load_var 5                         (message)
-        33   load_field 0                       (role)
-        34   store_var 6                        (role)
+  442   30   load_var 5                         (message)
+        31   load_field 0                       (role)
+        32   store_var 6                        (role)
 
-  440   35   jump +6                            (to 41)
+  440   33   jump +6                            (to 39)
 
-  441   36   load_const 8                       ("user")
-        37   store_var 6                        (role)
+  441   34   load_const 8                       ("user")
+        35   store_var 6                        (role)
 
-  440   38   jump +3                            (to 41)
+  440   36   jump +3                            (to 39)
 
-  441   39   load_const 9                       ("user")
-        40   store_var 6                        (role)
+  441   37   load_const 9                       ("user")
+        38   store_var 6                        (role)
 
-  444   41   load_var 6                         (role)
-        42   store_var 8                        (_15)
-        43   load_var2 5 6                      
-        44   call 1023 ntypeargs=0              (openai.internal._openai_prompt_content)
-        45   store_var 9                        (_16)
-        46   load_type 0                        
-        47   load_var2 2 8                      
-        48   load_var 9                         (_16)
-        49   init_instance 0                    (openai.internal.OaMessageItem .role, .content)
-        50   call 4 ntypeargs=1                 (baml.Array.push)
-        51   pop 1                              
-        52   jump -43                           (to 9)
+  444   39   load_var 6                         (role)
+        40   store_var 8                        (_15)
+        41   load_var2 5 6                      
+        42   call 1023 ntypeargs=0              (openai.internal._openai_prompt_content)
+        43   store_var 9                        (_16)
+        44   load_type 0                        
+        45   load_var2 2 8                      
+        46   load_var 9                         (_16)
+        47   init_instance 0                    (openai.internal.OaMessageItem .role, .content)
+        48   call 4 ntypeargs=1                 (baml.Array.push)
+        49   pop 1                              
+        50   jump -41                           (to 9)
 
-  446   53   load_var 2                         (items)
-        54   return                             
+  446   51   load_var 2                         (items)
+        52   return                             
 }
 
 function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.ModelTurn {
@@ -28274,7 +28141,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         17    call 672 ntypeargs=0               (baml.ops.equals_equals)
         18    unary_op !                         
         19    pop_jump_if_false +2               (to 21)
-        20    jump +361                          (to 381)
+        20    jump +355                          (to 375)
 
   822   21    load_type 3                        
         22    alloc_array 0                      
@@ -28309,395 +28176,389 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         47    load_var 8                         (_20)
         48    is_type 10                         
         49    pop_jump_if_false +2               (to 51)
-        50    jump +206                          (to 256)
+        50    jump +200                          (to 250)
         51    load_var 8                         (_20)
         52    store_var 9                        (item)
 
   827   53    load_var 9                         (item)
         54    load_field 0                       (type)
         55    store_var_load_var 10              (_24)
-        56    load_const 11                      ("function_call")
-        57    cmp_op ==                          
-        58    pop_jump_if_false +2               (to 60)
-        59    jump +147                          (to 206)
-        60    load_var 10                        (_24)
-        61    load_const 12                      ("message")
-        62    cmp_op ==                          
-        63    pop_jump_if_false +2               (to 65)
-        64    jump +70                           (to 134)
-        65    load_var 10                        (_24)
-        66    load_const 13                      ("reasoning")
-        67    cmp_op ==                          
-        68    pop_jump_if_false +2               (to 70)
-        69    jump +30                           (to 99)
-        70    load_var 10                        (_24)
-        71    load_const 14                      ("image_generation_call")
-        72    cmp_op ==                          
-        73    pop_jump_if_false -31              (to 42)
+        56    is_type 11                         
+        57    pop_jump_if_false +2               (to 59)
+        58    jump +142                          (to 200)
+        59    load_var 10                        (_24)
+        60    is_type 12                         
+        61    pop_jump_if_false +2               (to 63)
+        62    jump +68                           (to 130)
+        63    load_var 10                        (_24)
+        64    is_type 13                         
+        65    pop_jump_if_false +2               (to 67)
+        66    jump +29                           (to 95)
+        67    load_var 10                        (_24)
+        68    is_type 14                         
+        69    pop_jump_if_false -27              (to 42)
 
-  884   74    load_var 9                         (item)
-        75    load_field 8                       (result)
-        76    store_var 30                       (_98)
-        77    load_var 30                        (_98)
-        78    narrow_bind 15 30                  
-        79    pop_jump_if_false -37              (to 42)
-        80    load_var 30                        (_98)
-        81    store_var 31                       (encoded)
+  884   70    load_var 9                         (item)
+        71    load_field 8                       (result)
+        72    store_var 30                       (_98)
+        73    load_var 30                        (_98)
+        74    narrow_bind 15 30                  
+        75    pop_jump_if_false -33              (to 42)
+        76    load_var 30                        (_98)
+        77    store_var 31                       (encoded)
 
-  885   82    load_var 9                         (item)
-        83    load_field 10                      (output_format)
-        84    call 1038 ntypeargs=0              (openai.internal._openai_image_mime)
-        85    store_var 32                       (mime)
+  885   78    load_var 9                         (item)
+        79    load_field 10                      (output_format)
+        80    call 1038 ntypeargs=0              (openai.internal._openai_image_mime)
+        81    store_var 32                       (mime)
 
-  888   86    load_var2 31 32                    
-        87    call 349 ntypeargs=0               (baml.media.Image.from_base64)
+  888   82    load_var2 31 32                    
+        83    call 349 ntypeargs=0               (baml.media.Image.from_base64)
 
-  889   88    load_var 9                         (item)
-        89    load_field 1                       (id)
+  889   84    load_var 9                         (item)
+        85    load_field 1                       (id)
 
-  890   90    load_var 9                         (item)
-        91    load_field 9                       (revised_prompt)
+  890   86    load_var 9                         (item)
+        87    load_field 9                       (revised_prompt)
 
-  887   92    call 904 ntypeargs=0               (ai.content.Media.new)
-        93    store_var 33                       (_103)
+  887   88    call 904 ntypeargs=0               (ai.content.Media.new)
+        89    store_var 33                       (_103)
 
-  886   94    load_type 3                        
-        95    load_var2 3 33                     
-        96    call 4 ntypeargs=1                 (baml.Array.push)
-        97    pop 1                              
-        98    jump -56                           (to 42)
+  886   90    load_type 3                        
+        91    load_var2 3 33                     
+        92    call 4 ntypeargs=1                 (baml.Array.push)
+        93    pop 1                              
+        94    jump -52                           (to 42)
 
-  870   99    load_var 9                         (item)
-        100   load_field 7                       (summary)
-        101   store_var_load_var 26              (_80)
-        102   load_const 0                       (null)
-        103   cmp_op ==                          
-        104   pop_jump_if_false +4               (to 108)
-        105   load_type 16                       
-        106   alloc_array 0                      
-        107   store_var 26                       (_80)
-        108   load_var 26                        (_80)
-        109   load_type 17                       
-        110   load_const 18                      ("iter")
-        111   virtual_call nargs=1 ntypeargs=0   
-        112   store_var 27                       (_84)
+  870   95    load_var 9                         (item)
+        96    load_field 7                       (summary)
+        97    store_var_load_var 26              (_80)
+        98    load_const 0                       (null)
+        99    cmp_op ==                          
+        100   pop_jump_if_false +4               (to 104)
+        101   load_type 16                       
+        102   alloc_array 0                      
+        103   store_var 26                       (_80)
+        104   load_var 26                        (_80)
+        105   load_type 17                       
+        106   load_const 18                      ("iter")
+        107   virtual_call nargs=1 ntypeargs=0   
+        108   store_var 27                       (_84)
 
-  871   113   load_var 27                        (_84)
-        114   load_type 19                       
-        115   load_const 20                      ("next")
-        116   virtual_call nargs=1 ntypeargs=0   
-        117   store_var 28                       (_85)
+  871   109   load_var 27                        (_84)
+        110   load_type 19                       
+        111   load_const 20                      ("next")
+        112   virtual_call nargs=1 ntypeargs=0   
+        113   store_var 28                       (_85)
+        114   load_var 28                        (_85)
+        115   is_type 10                         
+        116   pop_jump_if_false +2               (to 118)
+        117   jump -75                           (to 42)
         118   load_var 28                        (_85)
-        119   is_type 10                         
-        120   pop_jump_if_false +2               (to 122)
-        121   jump -79                           (to 42)
-        122   load_var 28                        (_85)
-        123   load_field 1                       (text)
-        124   store_var 29                       (_90)
+        119   load_field 1                       (text)
+        120   store_var 29                       (_90)
 
-  872   125   load_var 29                        (_90)
-        126   narrow_bind 15 29                  
-        127   pop_jump_if_false -14              (to 113)
+  872   121   load_var 29                        (_90)
+        122   narrow_bind 15 29                  
+        123   pop_jump_if_false -14              (to 109)
 
-  873   128   load_type 3                        
-        129   load_var2 3 29                     
+  873   124   load_type 3                        
+        125   load_var2 3 29                     
 
-  872   130   init_instance 0                    (ai.content.Reasoning .summary)
+  872   126   init_instance 0                    (ai.content.Reasoning .summary)
 
-  873   131   call 4 ntypeargs=1                 (baml.Array.push)
-        132   pop 1                              
-        133   jump -20                           (to 113)
+  873   127   call 4 ntypeargs=1                 (baml.Array.push)
+        128   pop 1                              
+        129   jump -20                           (to 109)
 
-  851   134   load_var 9                         (item)
-        135   load_field 6                       (content)
-        136   store_var_load_var 18              (_49)
-        137   load_const 0                       (null)
-        138   cmp_op ==                          
-        139   pop_jump_if_false +4               (to 143)
-        140   load_type 16                       
-        141   alloc_array 0                      
-        142   store_var 18                       (_49)
-        143   load_var 18                        (_49)
-        144   load_type 17                       
-        145   load_const 21                      ("iter")
-        146   virtual_call nargs=1 ntypeargs=0   
-        147   store_var 19                       (_53)
+  851   130   load_var 9                         (item)
+        131   load_field 6                       (content)
+        132   store_var_load_var 18              (_49)
+        133   load_const 0                       (null)
+        134   cmp_op ==                          
+        135   pop_jump_if_false +4               (to 139)
+        136   load_type 16                       
+        137   alloc_array 0                      
+        138   store_var 18                       (_49)
+        139   load_var 18                        (_49)
+        140   load_type 17                       
+        141   load_const 21                      ("iter")
+        142   virtual_call nargs=1 ntypeargs=0   
+        143   store_var 19                       (_53)
 
-  852   148   load_var 19                        (_53)
-        149   load_type 19                       
-        150   load_const 22                      ("next")
-        151   virtual_call nargs=1 ntypeargs=0   
-        152   store_var 20                       (_54)
+  852   144   load_var 19                        (_53)
+        145   load_type 19                       
+        146   load_const 22                      ("next")
+        147   virtual_call nargs=1 ntypeargs=0   
+        148   store_var 20                       (_54)
+        149   load_var 20                        (_54)
+        150   is_type 10                         
+        151   pop_jump_if_false +2               (to 153)
+        152   jump -110                          (to 42)
         153   load_var 20                        (_54)
-        154   is_type 10                         
-        155   pop_jump_if_false +2               (to 157)
-        156   jump -114                          (to 42)
-        157   load_var 20                        (_54)
-        158   store_var_load_var 21              (part)
+        154   store_var_load_var 21              (part)
 
-  853   159   load_field 0                       (type)
-        160   store_var_load_var 23              (_59)
-        161   load_const 0                       (null)
-        162   cmp_op ==                          
-        163   pop_jump_if_false +3               (to 166)
-        164   load_const 23                      ("")
-        165   store_var 23                       (_59)
-        166   load_var 23                        (_59)
-        167   store_var_load_var 22              (kind)
+  853   155   load_field 0                       (type)
+        156   store_var_load_var 23              (_59)
+        157   load_const 0                       (null)
+        158   cmp_op ==                          
+        159   pop_jump_if_false +3               (to 162)
+        160   load_const 23                      ("")
+        161   store_var 23                       (_59)
+        162   load_var 23                        (_59)
+        163   store_var_load_var 22              (kind)
 
-  854   168   load_const 24                      ("output_text")
-        169   cmp_op ==                          
-        170   pop_jump_if_false +2               (to 172)
-        171   jump +21                           (to 192)
-        172   load_var 22                        (kind)
-        173   load_const 25                      ("refusal")
-        174   cmp_op ==                          
-        175   pop_jump_if_false -27              (to 148)
+  854   164   is_type 24                         
+        165   pop_jump_if_false +2               (to 167)
+        166   jump +20                           (to 186)
+        167   load_var 22                        (kind)
+        168   is_type 25                         
+        169   pop_jump_if_false -25              (to 144)
 
-  860   176   load_const 26                      (true)
-        177   store_var 5                        (refused)
+  860   170   load_const 26                      (true)
+        171   store_var 5                        (refused)
 
-  861   178   load_var 21                        (part)
-        179   load_field 2                       (refusal)
-        180   store_var_load_var 25              (_74)
-        181   load_const 0                       (null)
-        182   cmp_op ==                          
-        183   pop_jump_if_false +3               (to 186)
-        184   load_const 27                      ("")
-        185   store_var 25                       (_74)
-        186   load_type 3                        
-        187   load_var2 3 25                     
-        188   init_instance 1                    (ai.content.Text .text)
-        189   call 4 ntypeargs=1                 (baml.Array.push)
-        190   pop 1                              
-        191   jump -43                           (to 148)
+  861   172   load_var 21                        (part)
+        173   load_field 2                       (refusal)
+        174   store_var_load_var 25              (_74)
+        175   load_const 0                       (null)
+        176   cmp_op ==                          
+        177   pop_jump_if_false +3               (to 180)
+        178   load_const 27                      ("")
+        179   store_var 25                       (_74)
+        180   load_type 3                        
+        181   load_var2 3 25                     
+        182   init_instance 1                    (ai.content.Text .text)
+        183   call 4 ntypeargs=1                 (baml.Array.push)
+        184   pop 1                              
+        185   jump -41                           (to 144)
 
-  856   192   load_var 21                        (part)
-        193   load_field 1                       (text)
-        194   store_var_load_var 24              (_66)
-        195   load_const 0                       (null)
-        196   cmp_op ==                          
-        197   pop_jump_if_false +3               (to 200)
-        198   load_const 28                      ("")
-        199   store_var 24                       (_66)
-        200   load_type 3                        
-        201   load_var2 3 24                     
-        202   init_instance 2                    (ai.content.Text .text)
-        203   call 4 ntypeargs=1                 (baml.Array.push)
-        204   pop 1                              
-        205   jump -57                           (to 148)
+  856   186   load_var 21                        (part)
+        187   load_field 1                       (text)
+        188   store_var_load_var 24              (_66)
+        189   load_const 0                       (null)
+        190   cmp_op ==                          
+        191   pop_jump_if_false +3               (to 194)
+        192   load_const 28                      ("")
+        193   store_var 24                       (_66)
+        194   load_type 3                        
+        195   load_var2 3 24                     
+        196   init_instance 2                    (ai.content.Text .text)
+        197   call 4 ntypeargs=1                 (baml.Array.push)
+        198   pop 1                              
+        199   jump -55                           (to 144)
 
-  829   206   load_const 26                      (true)
-        207   store_var 4                        (has_call)
+  829   200   load_const 26                      (true)
+        201   store_var 4                        (has_call)
 
-  830   208   load_type 29                       
-        209   load_type 30                       
-        210   alloc_map 0                        
-        211   store_var 11                       (args)
+  830   202   load_type 29                       
+        203   load_type 30                       
+        204   alloc_map 0                        
+        205   store_var 11                       (args)
 
-  831   212   load_var 9                         (item)
-        213   load_field 5                       (arguments)
-        214   store_var 12                       (_28)
-        215   load_var 12                        (_28)
-        216   narrow_bind 15 12                  
-        217   pop_jump_if_false +14              (to 231)
-        218   load_var 12                        (_28)
-        219   store_var 13                       (s)
+  831   206   load_var 9                         (item)
+        207   load_field 5                       (arguments)
+        208   store_var 12                       (_28)
+        209   load_var 12                        (_28)
+        210   narrow_bind 15 12                  
+        211   pop_jump_if_false +14              (to 225)
+        212   load_var 12                        (_28)
+        213   store_var 13                       (s)
 
-  837   220   load_type 31                       
-        221   load_var 13                        (s)
-        222   call 357 ntypeargs=1               (baml.json.from_string)
-        223   store_var 11                       (args)
-        224   jump +7                            (to 231)
-        225   load_var 14                        (e)
-        226   throw_if_panic                     
+  837   214   load_type 31                       
+        215   load_var 13                        (s)
+        216   call 357 ntypeargs=1               (baml.json.from_string)
+        217   store_var 11                       (args)
+        218   jump +7                            (to 225)
+        219   load_var 14                        (e)
+        220   throw_if_panic                     
 
-  838   227   load_const 32                      ("openai")
-        228   load_var 13                        (s)
-        229   init_instance 3                    (ai.errors.ParseFailed .provider, .raw_output)
-        230   throw                              
+  838   221   load_const 32                      ("openai")
+        222   load_var 13                        (s)
+        223   init_instance 3                    (ai.errors.ParseFailed .provider, .raw_output)
+        224   throw                              
 
-  843   231   load_var 9                         (item)
-        232   load_field 3                       (call_id)
-        233   store_var_load_var 16              (_38)
-        234   load_const 0                       (null)
-        235   cmp_op ==                          
-        236   pop_jump_if_false +3               (to 239)
-        237   load_const 33                      ("")
-        238   store_var 16                       (_38)
-        239   load_var 16                        (_38)
-        240   store_var 15                       (_37)
+  843   225   load_var 9                         (item)
+        226   load_field 3                       (call_id)
+        227   store_var_load_var 16              (_38)
+        228   load_const 0                       (null)
+        229   cmp_op ==                          
+        230   pop_jump_if_false +3               (to 233)
+        231   load_const 33                      ("")
+        232   store_var 16                       (_38)
+        233   load_var 16                        (_38)
+        234   store_var 15                       (_37)
 
-  844   241   load_var 9                         (item)
-        242   load_field 4                       (name)
-        243   store_var_load_var 17              (_42)
-        244   load_const 0                       (null)
-        245   cmp_op ==                          
-        246   pop_jump_if_false +3               (to 249)
-        247   load_const 34                      ("")
-        248   store_var 17                       (_42)
+  844   235   load_var 9                         (item)
+        236   load_field 4                       (name)
+        237   store_var_load_var 17              (_42)
+        238   load_const 0                       (null)
+        239   cmp_op ==                          
+        240   pop_jump_if_false +3               (to 243)
+        241   load_const 34                      ("")
+        242   store_var 17                       (_42)
 
-  841   249   load_type 3                        
-        250   load_var2 3 15                     
+  841   243   load_type 3                        
+        244   load_var2 3 15                     
 
-  844   251   load_var2 17 11                    
+  844   245   load_var2 17 11                    
 
-  845   252   init_instance 4                    (ai.content.ToolUse .id, .name, .args)
+  845   246   init_instance 4                    (ai.content.ToolUse .id, .name, .args)
 
-  841   253   call 4 ntypeargs=1                 (baml.Array.push)
-        254   pop 1                              
-        255   jump -213                          (to 42)
+  841   247   call 4 ntypeargs=1                 (baml.Array.push)
+        248   pop 1                              
+        249   jump -207                          (to 42)
 
-  902   256   load_var 4                         (has_call)
-        257   pop_jump_if_false +2               (to 259)
-        258   jump +55                           (to 313)
+  902   250   load_var 4                         (has_call)
+        251   pop_jump_if_false +2               (to 253)
+        252   jump +55                           (to 307)
 
-  904   259   load_var 5                         (refused)
-        260   pop_jump_if_false +2               (to 262)
-        261   jump +48                           (to 309)
+  904   253   load_var 5                         (refused)
+        254   pop_jump_if_false +2               (to 256)
+        255   jump +48                           (to 303)
 
-  906   262   load_var 1                         (resp)
-        263   load_field 2                       (status)
-        264   store_var_load_var 35              (_115)
-        265   load_const 0                       (null)
+  906   256   load_var 1                         (resp)
+        257   load_field 2                       (status)
+        258   store_var_load_var 35              (_115)
+        259   load_const 0                       (null)
+        260   cmp_op ==                          
+        261   pop_jump_if_false +3               (to 264)
+        262   load_const 35                      ("")
+        263   store_var 35                       (_115)
+        264   load_var 35                        (_115)
+        265   load_const 36                      ("incomplete")
         266   cmp_op ==                          
-        267   pop_jump_if_false +3               (to 270)
-        268   load_const 35                      ("")
-        269   store_var 35                       (_115)
-        270   load_var 35                        (_115)
-        271   load_const 36                      ("incomplete")
-        272   cmp_op ==                          
-        273   pop_jump_if_false +2               (to 275)
-        274   jump +5                            (to 279)
+        267   pop_jump_if_false +2               (to 269)
+        268   jump +5                            (to 273)
 
-  913   275   load_const 37                      (ai.content.StopReason.Complete)
-        276   alloc_variant 774                  (ai.content.StopReason)
-        277   store_var 34                       (stop)
+  913   269   load_const 37                      (ai.content.StopReason.Complete)
+        270   alloc_variant 774                  (ai.content.StopReason)
+        271   store_var 34                       (stop)
 
-  906   278   jump +38                           (to 316)
+  906   272   jump +38                           (to 310)
 
-  907   279   load_var 1                         (resp)
+  907   273   load_var 1                         (resp)
+        274   load_field 5                       (incomplete_details)
+        275   load_const 0                       (null)
+        276   cmp_op ==                          
+        277   pop_jump_if_false +2               (to 279)
+        278   jump +5                            (to 283)
+        279   load_var 1                         (resp)
         280   load_field 5                       (incomplete_details)
-        281   load_const 0                       (null)
-        282   cmp_op ==                          
-        283   pop_jump_if_false +2               (to 285)
-        284   jump +5                            (to 289)
-        285   load_var 1                         (resp)
-        286   load_field 5                       (incomplete_details)
-        287   load_field 0                       (0)
-        288   jump +2                            (to 290)
-        289   load_const 0                       (null)
-        290   store_var_load_var 36              (_120)
-        291   load_const 0                       (null)
+        281   load_field 0                       (0)
+        282   jump +2                            (to 284)
+        283   load_const 0                       (null)
+        284   store_var_load_var 36              (_120)
+        285   load_const 0                       (null)
+        286   cmp_op ==                          
+        287   pop_jump_if_false +3               (to 290)
+        288   load_const 38                      ("")
+        289   store_var 36                       (_120)
+        290   load_var 36                        (_120)
+        291   load_const 39                      ("content_filter")
         292   cmp_op ==                          
-        293   pop_jump_if_false +3               (to 296)
-        294   load_const 38                      ("")
-        295   store_var 36                       (_120)
-        296   load_var 36                        (_120)
-        297   load_const 39                      ("content_filter")
-        298   cmp_op ==                          
-        299   pop_jump_if_false +2               (to 301)
-        300   jump +5                            (to 305)
+        293   pop_jump_if_false +2               (to 295)
+        294   jump +5                            (to 299)
 
-  910   301   load_const 40                      (ai.content.StopReason.MaxTokens)
-        302   alloc_variant 774                  (ai.content.StopReason)
-        303   store_var 34                       (stop)
+  910   295   load_const 40                      (ai.content.StopReason.MaxTokens)
+        296   alloc_variant 774                  (ai.content.StopReason)
+        297   store_var 34                       (stop)
 
-  907   304   jump +12                           (to 316)
+  907   298   jump +12                           (to 310)
 
-  908   305   load_const 41                      (ai.content.StopReason.Refused)
-        306   alloc_variant 774                  (ai.content.StopReason)
-        307   store_var 34                       (stop)
+  908   299   load_const 41                      (ai.content.StopReason.Refused)
+        300   alloc_variant 774                  (ai.content.StopReason)
+        301   store_var 34                       (stop)
 
-  907   308   jump +8                            (to 316)
+  907   302   jump +8                            (to 310)
 
-  905   309   load_const 41                      (ai.content.StopReason.Refused)
-        310   alloc_variant 774                  (ai.content.StopReason)
-        311   store_var 34                       (stop)
+  905   303   load_const 41                      (ai.content.StopReason.Refused)
+        304   alloc_variant 774                  (ai.content.StopReason)
+        305   store_var 34                       (stop)
 
-  904   312   jump +4                            (to 316)
+  904   306   jump +4                            (to 310)
 
-  903   313   load_const 15                      (ai.content.StopReason.ToolUse)
-        314   alloc_variant 774                  (ai.content.StopReason)
-        315   store_var 34                       (stop)
+  903   307   load_const 15                      (ai.content.StopReason.ToolUse)
+        308   alloc_variant 774                  (ai.content.StopReason)
+        309   store_var 34                       (stop)
 
-  915   316   load_var 1                         (resp)
-        317   load_field 4                       (usage)
-        318   store_var 38                       (_128)
-        319   load_var 38                        (_128)
-        320   narrow_bind 42 38                  
-        321   pop_jump_if_false +2               (to 323)
-        322   jump +4                            (to 326)
+  915   310   load_var 1                         (resp)
+        311   load_field 4                       (usage)
+        312   store_var 38                       (_128)
+        313   load_var 38                        (_128)
+        314   narrow_bind 42 38                  
+        315   pop_jump_if_false +2               (to 317)
+        316   jump +4                            (to 320)
 
-  923   323   load_const 0                       (null)
-        324   store_var 37                       (usage)
+  923   317   load_const 0                       (null)
+        318   store_var 37                       (usage)
 
-  915   325   jump +52                           (to 377)
-        326   load_var 38                        (_128)
-        327   store_var_load_var 39              (u)
+  915   319   jump +52                           (to 371)
+        320   load_var 38                        (_128)
+        321   store_var_load_var 39              (u)
 
-  917   328   load_field 0                       (input_tokens)
-        329   store_var_load_var 41              (_131)
-        330   load_const 0                       (null)
-        331   cmp_op ==                          
-        332   pop_jump_if_false +3               (to 335)
-        333   load_const 37                      (0)
-        334   store_var 41                       (_131)
-        335   load_var 41                        (_131)
-        336   store_var 40                       (_130)
+  917   322   load_field 0                       (input_tokens)
+        323   store_var_load_var 41              (_131)
+        324   load_const 0                       (null)
+        325   cmp_op ==                          
+        326   pop_jump_if_false +3               (to 329)
+        327   load_const 37                      (0)
+        328   store_var 41                       (_131)
+        329   load_var 41                        (_131)
+        330   store_var 40                       (_130)
 
-  918   337   load_var 39                        (u)
-        338   load_field 1                       (output_tokens)
-        339   store_var_load_var 43              (_135)
-        340   load_const 0                       (null)
-        341   cmp_op ==                          
-        342   pop_jump_if_false +3               (to 345)
-        343   load_const 37                      (0)
-        344   store_var 43                       (_135)
-        345   load_var 43                        (_135)
-        346   store_var 42                       (_134)
+  918   331   load_var 39                        (u)
+        332   load_field 1                       (output_tokens)
+        333   store_var_load_var 43              (_135)
+        334   load_const 0                       (null)
+        335   cmp_op ==                          
+        336   pop_jump_if_false +3               (to 339)
+        337   load_const 37                      (0)
+        338   store_var 43                       (_135)
+        339   load_var 43                        (_135)
+        340   store_var 42                       (_134)
 
-  919   347   load_var 39                        (u)
+  919   341   load_var 39                        (u)
+        342   load_field 3                       (input_tokens_details)
+        343   load_const 0                       (null)
+        344   cmp_op ==                          
+        345   pop_jump_if_false +2               (to 347)
+        346   jump +6                            (to 352)
+        347   load_var 39                        (u)
         348   load_field 3                       (input_tokens_details)
-        349   load_const 0                       (null)
-        350   cmp_op ==                          
-        351   pop_jump_if_false +2               (to 353)
-        352   jump +6                            (to 358)
-        353   load_var 39                        (u)
-        354   load_field 3                       (input_tokens_details)
-        355   load_field 0                       (0)
-        356   store_var 44                       (_138)
-        357   jump +3                            (to 360)
-        358   load_const 0                       (null)
-        359   store_var 44                       (_138)
+        349   load_field 0                       (0)
+        350   store_var 44                       (_138)
+        351   jump +3                            (to 354)
+        352   load_const 0                       (null)
+        353   store_var 44                       (_138)
 
-  920   360   load_var 39                        (u)
+  920   354   load_var 39                        (u)
+        355   load_field 4                       (output_tokens_details)
+        356   load_const 0                       (null)
+        357   cmp_op ==                          
+        358   pop_jump_if_false +2               (to 360)
+        359   jump +6                            (to 365)
+        360   load_var 39                        (u)
         361   load_field 4                       (output_tokens_details)
-        362   load_const 0                       (null)
-        363   cmp_op ==                          
-        364   pop_jump_if_false +2               (to 366)
-        365   jump +6                            (to 371)
-        366   load_var 39                        (u)
-        367   load_field 4                       (output_tokens_details)
-        368   load_field 0                       (0)
-        369   store_var 45                       (_142)
-        370   jump +3                            (to 373)
-        371   load_const 0                       (null)
-        372   store_var 45                       (_142)
+        362   load_field 0                       (0)
+        363   store_var 45                       (_142)
+        364   jump +3                            (to 367)
+        365   load_const 0                       (null)
+        366   store_var 45                       (_142)
 
-  916   373   load_var2 40 42                    
-        374   load_var2 44 45                    
-        375   init_instance 5                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
-        376   store_var 37                       (usage)
+  916   367   load_var2 40 42                    
+        368   load_var2 44 45                    
+        369   init_instance 5                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
+        370   store_var 37                       (usage)
 
-  925   377   load_var2 3 34                     
-        378   load_var 37                        (usage)
-        379   init_instance 6                    (ai.ModelTurn .content, .stop_reason, .usage)
-        380   return                             
+  925   371   load_var2 3 34                     
+        372   load_var 37                        (usage)
+        373   init_instance 6                    (ai.ModelTurn .content, .stop_reason, .usage)
+        374   return                             
 
-  820   381   load_var 1                         (resp)
-        382   call 1041 ntypeargs=0              (openai.internal._openai_response_failure)
-        383   throw                              
+  820   375   load_var 1                         (resp)
+        376   call 1041 ntypeargs=0              (openai.internal._openai_response_failure)
+        377   throw                              
 }
 
 function openai.internal.openai_prompt_metadata(prompt: ai.Prompt) -> map<string, baml.json.json>[] {
@@ -32030,7 +31891,7 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
        36    load_var 8              (_13)
        37    load_field 2            (role)
        38    discriminant            
-       39    jump_table 0            ([to 49, to 46, to 43, to 40], default to 102)
+       39    jump_table 0            ([to 49, to 46, to 43, to 40], default to 101)
 
   60   40    load_var 2              (threshold)
        41    store_var 7             (role_mult)
@@ -32076,46 +31937,45 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
 
   73   69    load_var 2              (threshold)
        70    cmp_int_op >            
-       71    load_const 2            (true)
-       72    cmp_op ==               
-       73    pop_jump_if_false +2    (to 75)
-       74    jump +4                 (to 78)
+       71    is_type 2               
+       72    pop_jump_if_false +2    (to 74)
+       73    jump +4                 (to 77)
 
-  75   75    load_const 3            (" [LOW]")
-       76    store_var 12            (suffix)
+  75   74    load_const 3            (" [LOW]")
+       75    store_var 12            (suffix)
 
-  73   77    jump +3                 (to 80)
+  73   76    jump +3                 (to 79)
 
-  74   78    load_const 4            (" [HIGH]")
-       79    store_var 12            (suffix)
+  74   77    load_const 4            (" [HIGH]")
+       78    store_var 12            (suffix)
 
-  79   80    load_var2 9 10          
-       81    load_var 11             (total)
-       82    load_type 5             
-       83    alloc_array 3           
-       84    store_var 13            (scores)
+  79   79    load_var2 9 10          
+       80    load_var 11             (total)
+       81    load_type 5             
+       82    alloc_array 3           
+       83    store_var 13            (scores)
 
-  80   85    load_var 13             (scores)
-       86    load_const 6            (0)
-       87    load_var 11             (total)
-       88    store_array_element     
+  80   84    load_var 13             (scores)
+       85    load_const 6            (0)
+       86    load_var 11             (total)
+       87    store_array_element     
 
-  81   89    load_var 13             (scores)
-       90    load_const 6            (0)
-       91    load_array_element      
+  81   88    load_var 13             (scores)
+       89    load_const 6            (0)
+       90    load_array_element      
 
-  77   92    load_var2 3 12          
-       93    bin_op +                
+  77   91    load_var2 3 12          
+       92    bin_op +                
 
-  83   94    load_var2 9 7           
-       95    load_const 7            ("base")
-       96    load_const 8            ("role")
-       97    load_type 9             
-       98    load_type 5             
-       99    alloc_map 2             
-       100   init_instance 0         (user.Report .score, .label, .breakdown)
-       101   return                  
-       102   unreachable             
+  83   93    load_var2 9 7           
+       94    load_const 7            ("base")
+       95    load_const 8            ("role")
+       96    load_type 9             
+       97    load_type 5             
+       98    alloc_map 2             
+       99    init_instance 0         (user.Report .score, .label, .breakdown)
+       100   return                  
+       101   unreachable             
 }
 
 function vercel.AiGatewayImageClient.ai.Client.id(self: vercel.AiGatewayImageClient) -> string {
@@ -32820,44 +32680,40 @@ function vercel.internal._gw_images_mime(format: string | null) -> string {
         9    store_var 2            (normalized)
 
   351   10   load_var 2             (normalized)
-        11   load_const 2           ("jpeg")
-        12   cmp_op ==              
-        13   pop_jump_if_false +2   (to 15)
-        14   jump +24               (to 38)
-        15   load_var 2             (normalized)
-        16   load_const 3           ("jpg")
-        17   cmp_op ==              
-        18   pop_jump_if_false +2   (to 20)
-        19   jump +17               (to 36)
-        20   load_var 2             (normalized)
-        21   load_const 4           ("webp")
-        22   cmp_op ==              
-        23   pop_jump_if_false +2   (to 25)
-        24   jump +10               (to 34)
-        25   load_var 2             (normalized)
-        26   load_const 5           ("gif")
-        27   cmp_op ==              
-        28   pop_jump_if_false +2   (to 30)
-        29   jump +3                (to 32)
+        11   is_type 2              
+        12   pop_jump_if_false +2   (to 14)
+        13   jump +21               (to 34)
+        14   load_var 2             (normalized)
+        15   is_type 3              
+        16   pop_jump_if_false +2   (to 18)
+        17   jump +15               (to 32)
+        18   load_var 2             (normalized)
+        19   is_type 4              
+        20   pop_jump_if_false +2   (to 22)
+        21   jump +9                (to 30)
+        22   load_var 2             (normalized)
+        23   is_type 5              
+        24   pop_jump_if_false +2   (to 26)
+        25   jump +3                (to 28)
 
-  355   30   load_const 6           ("image/png")
+  355   26   load_const 6           ("image/png")
 
-  351   31   jump +8                (to 39)
+  351   27   jump +8                (to 35)
 
-  354   32   load_const 7           ("image/gif")
+  354   28   load_const 7           ("image/gif")
 
-  351   33   jump +6                (to 39)
+  351   29   jump +6                (to 35)
 
-  353   34   load_const 8           ("image/webp")
+  353   30   load_const 8           ("image/webp")
 
-  351   35   jump +4                (to 39)
+  351   31   jump +4                (to 35)
 
-  352   36   load_const 9           ("image/jpeg")
+  352   32   load_const 9           ("image/jpeg")
 
-  351   37   jump +2                (to 39)
+  351   33   jump +2                (to 35)
 
-  352   38   load_const 10          ("image/jpeg")
-        39   return                 
+  352   34   load_const 10          ("image/jpeg")
+        35   return                 
 }
 
 function vercel.internal._gw_images_trim_slash(url: string) -> string {

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -202,7 +202,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         169   load_type 1                                
         170   load_var2 1 2                              
         171   load_var 5                                 (j)
-        172   make_closure 2263 captures=3 ntypeargs=1   
+        172   make_closure 2260 captures=3 ntypeargs=1   
         173   call 16 ntypeargs=3                        (baml.Array.map)
         174   store_var 14                               (futures)
 
@@ -251,7 +251,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         211   load_var 11                                (calls)
         212   load_type 1                                
         213   load_var 20                                (f)
-        214   make_closure 2264 captures=1 ntypeargs=1   
+        214   make_closure 2261 captures=1 ntypeargs=1   
         215   call 19 ntypeargs=2                        (baml.Array.find)
 
   327   216   store_var 21                               (_59)
@@ -822,294 +822,291 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
         36    store_var 9                        (kind)
 
   123   37    load_var 6                         (form)
-        38    load_const 9                       ("mixedlist")
-        39    cmp_op ==                          
-        40    pop_jump_if_false +2               (to 42)
-        41    jump +205                          (to 246)
-        42    load_var 6                         (form)
-        43    load_const 10                      ("mixed")
-        44    cmp_op ==                          
-        45    pop_jump_if_false +2               (to 47)
-        46    jump +131                          (to 177)
-        47    load_var 6                         (form)
-        48    load_const 11                      ("list")
-        49    cmp_op ==                          
-        50    pop_jump_if_false +2               (to 52)
-        51    jump +118                          (to 169)
+        38    is_type 9                          
+        39    pop_jump_if_false +2               (to 41)
+        40    jump +203                          (to 243)
+        41    load_var 6                         (form)
+        42    is_type 10                         
+        43    pop_jump_if_false +2               (to 45)
+        44    jump +130                          (to 174)
+        45    load_var 6                         (form)
+        46    is_type 11                         
+        47    pop_jump_if_false +2               (to 49)
+        48    jump +118                          (to 166)
 
-  152   52    load_var2 2 9                      
-        53    call 987 ntypeargs=0               (ai.internal._media_of_kind)
-        54    store_var 23                       (parts)
+  152   49    load_var2 2 9                      
+        50    call 987 ntypeargs=0               (ai.internal._media_of_kind)
+        51    store_var 23                       (parts)
 
-  153   55    load_var2 2 9                      
-        56    load_var 3                         (provider)
-        57    call 991 ntypeargs=0               (ai.internal._media_reject_mixed)
-        58    pop 1                              
+  153   52    load_var2 2 9                      
+        53    load_var 3                         (provider)
+        54    call 991 ntypeargs=0               (ai.internal._media_reject_mixed)
+        55    pop 1                              
 
-  154   59    load_var 23                        (parts)
-        60    container_len                      
-        61    store_var 24                       (_57)
-        62    load_var 24                        (_57)
-        63    load_const 7                       (1)
-        64    cmp_int_op !=                      
-        65    pop_jump_if_false +2               (to 67)
-        66    jump +25                           (to 91)
+  154   56    load_var 23                        (parts)
+        57    container_len                      
+        58    store_var 24                       (_57)
+        59    load_var 24                        (_57)
+        60    load_const 7                       (1)
+        61    cmp_int_op !=                      
+        62    pop_jump_if_false +2               (to 64)
+        63    jump +25                           (to 88)
 
-  164   67    load_const 4                       (null)
-        68    store_var 36                       (only)
+  164   64    load_const 4                       (null)
+        65    store_var 36                       (only)
 
-  165   69    load_var 23                        (parts)
-        70    load_type 12                       
-        71    load_const 13                      ("iter")
-        72    virtual_call nargs=1 ntypeargs=0   
-        73    store_var 37                       (_97)
-        74    load_var 37                        (_97)
-        75    load_type 14                       
-        76    load_const 15                      ("next")
-        77    virtual_call nargs=1 ntypeargs=0   
-        78    store_var 38                       (_98)
-        79    load_var 38                        (_98)
-        80    is_type 16                         
-        81    pop_jump_if_false +2               (to 83)
-        82    jump +6                            (to 88)
-        83    load_var 38                        (_98)
-        84    store_var 39                       (p)
+  165   66    load_var 23                        (parts)
+        67    load_type 12                       
+        68    load_const 13                      ("iter")
+        69    virtual_call nargs=1 ntypeargs=0   
+        70    store_var 37                       (_97)
+        71    load_var 37                        (_97)
+        72    load_type 14                       
+        73    load_const 15                      ("next")
+        74    virtual_call nargs=1 ntypeargs=0   
+        75    store_var 38                       (_98)
+        76    load_var 38                        (_98)
+        77    is_type 16                         
+        78    pop_jump_if_false +2               (to 80)
+        79    jump +6                            (to 85)
+        80    load_var 38                        (_98)
+        81    store_var 39                       (p)
 
-  166   85    load_var 39                        (p)
-        86    store_var 36                       (only)
+  166   82    load_var 39                        (p)
+        83    store_var 36                       (only)
 
-  165   87    jump -13                           (to 74)
+  165   84    jump -13                           (to 71)
 
-  168   88    load_var 36                        (only)
-        89    store_var 12                       (payload)
+  168   85    load_var 36                        (only)
+        86    store_var 12                       (payload)
 
-  123   90    jump +159                          (to 249)
+  123   87    jump +159                          (to 246)
 
-  157   91    load_var 6                         (form)
-        92    load_const 17                      ("one")
-        93    cmp_op ==                          
-        94    pop_jump_if_false +2               (to 96)
-        95    jump +42                           (to 137)
+  157   88    load_var 6                         (form)
+        89    load_const 17                      ("one")
+        90    cmp_op ==                          
+        91    pop_jump_if_false +2               (to 93)
+        92    jump +42                           (to 134)
 
-  160   96    load_type 2                        
-        97    load_var 9                         (kind)
-        98    call 138 ntypeargs=1               (baml.String.from)
-        99    store_var 30                       (_83)
-        100   load_var 4                         (t)
-        101   call 217 ntypeargs=0               (baml.TypeValue.baml.ToString.to_string)
-        102   store_var 32                       (_87)
-        103   load_type 2                        
-        104   load_var 32                        (_87)
-        105   call 138 ntypeargs=1               (baml.String.from)
-        106   store_var 31                       (_86)
-        107   load_var 23                        (parts)
-        108   container_len                      
-        109   store_var 34                       (_90)
-        110   load_type 18                       
-        111   load_var 34                        (_90)
-        112   call 138 ntypeargs=1               (baml.String.from)
-        113   store_var 33                       (_89)
-        114   load_type 2                        
-        115   load_var 9                         (kind)
-        116   call 138 ntypeargs=1               (baml.String.from)
-        117   store_var 35                       (_92)
-        118   load_const 19                      ("Expected zero or one ")
-        119   load_var 30                        (_83)
-        120   bin_op +                           
-        121   load_const 20                      (" output for ")
-        122   bin_op +                           
-        123   load_var 31                        (_86)
-        124   bin_op +                           
-        125   load_const 21                      (", got ")
-        126   bin_op +                           
-        127   load_var 33                        (_89)
-        128   bin_op +                           
-        129   load_const 22                      (". Use ")
-        130   bin_op +                           
-        131   load_var 35                        (_92)
-        132   bin_op +                           
-        133   load_const 23                      ("[] for multiple outputs.")
-        134   bin_op +                           
-        135   store_var 25                       (_59)
+  160   93    load_type 2                        
+        94    load_var 9                         (kind)
+        95    call 138 ntypeargs=1               (baml.String.from)
+        96    store_var 30                       (_83)
+        97    load_var 4                         (t)
+        98    call 217 ntypeargs=0               (baml.TypeValue.baml.ToString.to_string)
+        99    store_var 32                       (_87)
+        100   load_type 2                        
+        101   load_var 32                        (_87)
+        102   call 138 ntypeargs=1               (baml.String.from)
+        103   store_var 31                       (_86)
+        104   load_var 23                        (parts)
+        105   container_len                      
+        106   store_var 34                       (_90)
+        107   load_type 18                       
+        108   load_var 34                        (_90)
+        109   call 138 ntypeargs=1               (baml.String.from)
+        110   store_var 33                       (_89)
+        111   load_type 2                        
+        112   load_var 9                         (kind)
+        113   call 138 ntypeargs=1               (baml.String.from)
+        114   store_var 35                       (_92)
+        115   load_const 19                      ("Expected zero or one ")
+        116   load_var 30                        (_83)
+        117   bin_op +                           
+        118   load_const 20                      (" output for ")
+        119   bin_op +                           
+        120   load_var 31                        (_86)
+        121   bin_op +                           
+        122   load_const 21                      (", got ")
+        123   bin_op +                           
+        124   load_var 33                        (_89)
+        125   bin_op +                           
+        126   load_const 22                      (". Use ")
+        127   bin_op +                           
+        128   load_var 35                        (_92)
+        129   bin_op +                           
+        130   load_const 23                      ("[] for multiple outputs.")
+        131   bin_op +                           
+        132   store_var 25                       (_59)
 
-  157   136   jump +30                           (to 166)
+  157   133   jump +30                           (to 163)
 
-  158   137   load_type 2                        
-        138   load_var 9                         (kind)
-        139   call 138 ntypeargs=1               (baml.String.from)
-        140   store_var 26                       (_67)
-        141   load_var 23                        (parts)
-        142   container_len                      
-        143   store_var 28                       (_71)
-        144   load_type 18                       
-        145   load_var 28                        (_71)
-        146   call 138 ntypeargs=1               (baml.String.from)
-        147   store_var 27                       (_70)
-        148   load_type 2                        
-        149   load_var 9                         (kind)
-        150   call 138 ntypeargs=1               (baml.String.from)
-        151   store_var 29                       (_73)
-        152   load_const 24                      ("Expected exactly one ")
-        153   load_var 26                        (_67)
-        154   bin_op +                           
-        155   load_const 25                      (" output, got ")
-        156   bin_op +                           
-        157   load_var 27                        (_70)
-        158   bin_op +                           
-        159   load_const 26                      (". Use ")
-        160   bin_op +                           
-        161   load_var 29                        (_73)
-        162   bin_op +                           
-        163   load_const 27                      ("[] for multiple outputs.")
-        164   bin_op +                           
-        165   store_var 25                       (_59)
+  158   134   load_type 2                        
+        135   load_var 9                         (kind)
+        136   call 138 ntypeargs=1               (baml.String.from)
+        137   store_var 26                       (_67)
+        138   load_var 23                        (parts)
+        139   container_len                      
+        140   store_var 28                       (_71)
+        141   load_type 18                       
+        142   load_var 28                        (_71)
+        143   call 138 ntypeargs=1               (baml.String.from)
+        144   store_var 27                       (_70)
+        145   load_type 2                        
+        146   load_var 9                         (kind)
+        147   call 138 ntypeargs=1               (baml.String.from)
+        148   store_var 29                       (_73)
+        149   load_const 24                      ("Expected exactly one ")
+        150   load_var 26                        (_67)
+        151   bin_op +                           
+        152   load_const 25                      (" output, got ")
+        153   bin_op +                           
+        154   load_var 27                        (_70)
+        155   bin_op +                           
+        156   load_const 26                      (". Use ")
+        157   bin_op +                           
+        158   load_var 29                        (_73)
+        159   bin_op +                           
+        160   load_const 27                      ("[] for multiple outputs.")
+        161   bin_op +                           
+        162   store_var 25                       (_59)
 
-  155   166   load_var2 3 25                     
-        167   init_instance 0                    (ai.errors.ParseFailed .provider, .raw_output)
-        168   throw                              
+  155   163   load_var2 3 25                     
+        164   init_instance 0                    (ai.errors.ParseFailed .provider, .raw_output)
+        165   throw                              
 
-  147   169   load_var2 2 9                      
-        170   load_var 3                         (provider)
-        171   call 991 ntypeargs=0               (ai.internal._media_reject_mixed)
-        172   pop 1                              
+  147   166   load_var2 2 9                      
+        167   load_var 3                         (provider)
+        168   call 991 ntypeargs=0               (ai.internal._media_reject_mixed)
+        169   pop 1                              
 
-  148   173   load_var2 2 9                      
-        174   call 987 ntypeargs=0               (ai.internal._media_of_kind)
+  148   170   load_var2 2 9                      
+        171   call 987 ntypeargs=0               (ai.internal._media_of_kind)
 
-  149   175   store_var 12                       (payload)
+  149   172   store_var 12                       (payload)
 
-  123   176   jump +73                           (to 249)
+  123   173   jump +73                           (to 246)
 
-  129   177   load_var 2                         (turn)
-        178   call 988 ntypeargs=0               (ai.internal._media_mixed_parts)
-        179   store_var 13                       (items)
+  129   174   load_var 2                         (turn)
+        175   call 988 ntypeargs=0               (ai.internal._media_mixed_parts)
+        176   store_var 13                       (items)
 
-  130   180   load_var 13                        (items)
-        181   container_len                      
-        182   store_var 14                       (_25)
-        183   load_var 14                        (_25)
-        184   load_const 7                       (1)
-        185   cmp_int_op ==                      
-        186   pop_jump_if_false +2               (to 188)
-        187   jump +35                           (to 222)
+  130   177   load_var 13                        (items)
+        178   container_len                      
+        179   store_var 14                       (_25)
+        180   load_var 14                        (_25)
+        181   load_const 7                       (1)
+        182   cmp_int_op ==                      
+        183   pop_jump_if_false +2               (to 185)
+        184   jump +35                           (to 219)
 
-  136   188   load_var 13                        (items)
-        189   call 989 ntypeargs=0               (ai.internal._media_all_text)
-        190   pop_jump_if_false +2               (to 192)
-        191   jump +27                           (to 218)
+  136   185   load_var 13                        (items)
+        186   call 989 ntypeargs=0               (ai.internal._media_all_text)
+        187   pop_jump_if_false +2               (to 189)
+        188   jump +27                           (to 215)
 
-  142   192   load_var 4                         (t)
-        193   call 217 ntypeargs=0               (baml.TypeValue.baml.ToString.to_string)
-        194   store_var 20                       (_42)
-        195   load_type 2                        
-        196   load_var 20                        (_42)
-        197   call 138 ntypeargs=1               (baml.String.from)
-        198   store_var 19                       (_41)
-        199   load_var 13                        (items)
-        200   container_len                      
-        201   store_var 22                       (_45)
-        202   load_type 18                       
-        203   load_var 22                        (_45)
-        204   call 138 ntypeargs=1               (baml.String.from)
-        205   store_var 21                       (_44)
+  142   189   load_var 4                         (t)
+        190   call 217 ntypeargs=0               (baml.TypeValue.baml.ToString.to_string)
+        191   store_var 20                       (_42)
+        192   load_type 2                        
+        193   load_var 20                        (_42)
+        194   call 138 ntypeargs=1               (baml.String.from)
+        195   store_var 19                       (_41)
+        196   load_var 13                        (items)
+        197   container_len                      
+        198   store_var 22                       (_45)
+        199   load_type 18                       
+        200   load_var 22                        (_45)
+        201   call 138 ntypeargs=1               (baml.String.from)
+        202   store_var 21                       (_44)
 
-  140   206   load_var 3                         (provider)
+  140   203   load_var 3                         (provider)
 
-  142   207   load_const 28                      ("Expected one text or image output for ")
-        208   load_var 19                        (_41)
-        209   bin_op +                           
-        210   load_const 29                      (", got ")
-        211   bin_op +                           
-        212   load_var 21                        (_44)
-        213   bin_op +                           
-        214   load_const 30                      (" parts. Use (image | string)[] to preserve mixed outputs.")
-        215   bin_op +                           
-        216   init_instance 1                    (ai.errors.ParseFailed .provider, .raw_output)
-        217   throw                              
+  142   204   load_const 28                      ("Expected one text or image output for ")
+        205   load_var 19                        (_41)
+        206   bin_op +                           
+        207   load_const 29                      (", got ")
+        208   bin_op +                           
+        209   load_var 21                        (_44)
+        210   bin_op +                           
+        211   load_const 30                      (" parts. Use (image | string)[] to preserve mixed outputs.")
+        212   bin_op +                           
+        213   init_instance 1                    (ai.errors.ParseFailed .provider, .raw_output)
+        214   throw                              
 
-  138   218   load_var 13                        (items)
-        219   call 990 ntypeargs=0               (ai.internal._media_join_text)
-        220   store_var 12                       (payload)
-        221   jump +28                           (to 249)
+  138   215   load_var 13                        (items)
+        216   call 990 ntypeargs=0               (ai.internal._media_join_text)
+        217   store_var 12                       (payload)
+        218   jump +28                           (to 246)
 
-  131   222   load_const 4                       (null)
-        223   store_var 15                       (only)
+  131   219   load_const 4                       (null)
+        220   store_var 15                       (only)
 
-  132   224   load_var 13                        (items)
-        225   load_type 12                       
-        226   load_const 31                      ("iter")
-        227   virtual_call nargs=1 ntypeargs=0   
-        228   store_var 16                       (_28)
-        229   load_var 16                        (_28)
-        230   load_type 14                       
-        231   load_const 32                      ("next")
-        232   virtual_call nargs=1 ntypeargs=0   
-        233   store_var 17                       (_29)
-        234   load_var 17                        (_29)
-        235   is_type 16                         
-        236   pop_jump_if_false +2               (to 238)
-        237   jump +6                            (to 243)
-        238   load_var 17                        (_29)
-        239   store_var 18                       (i)
+  132   221   load_var 13                        (items)
+        222   load_type 12                       
+        223   load_const 31                      ("iter")
+        224   virtual_call nargs=1 ntypeargs=0   
+        225   store_var 16                       (_28)
+        226   load_var 16                        (_28)
+        227   load_type 14                       
+        228   load_const 32                      ("next")
+        229   virtual_call nargs=1 ntypeargs=0   
+        230   store_var 17                       (_29)
+        231   load_var 17                        (_29)
+        232   is_type 16                         
+        233   pop_jump_if_false +2               (to 235)
+        234   jump +6                            (to 240)
+        235   load_var 17                        (_29)
+        236   store_var 18                       (i)
 
-  133   240   load_var 18                        (i)
-        241   store_var 15                       (only)
+  133   237   load_var 18                        (i)
+        238   store_var 15                       (only)
 
-  132   242   jump -13                           (to 229)
+  132   239   jump -13                           (to 226)
 
-  135   243   load_var 15                        (only)
-        244   store_var 12                       (payload)
+  135   240   load_var 15                        (only)
+        241   store_var 12                       (payload)
 
-  130   245   jump +4                            (to 249)
+  130   242   jump +4                            (to 246)
 
-  125   246   load_var 2                         (turn)
-        247   call 988 ntypeargs=0               (ai.internal._media_mixed_parts)
+  125   243   load_var 2                         (turn)
+        244   call 988 ntypeargs=0               (ai.internal._media_mixed_parts)
 
-  126   248   store_var 12                       (payload)
+  126   245   store_var 12                       (payload)
 
-  171   249   load_type 0                        
-        250   load_var 12                        (payload)
-        251   call 358 ntypeargs=1               (baml.json.from_json)
-        252   jump +36                           (to 288)
-        253   load_var 40                        (e)
-        254   throw_if_panic                     
+  171   246   load_type 0                        
+        247   load_var 12                        (payload)
+        248   call 358 ntypeargs=1               (baml.json.from_json)
+        249   jump +36                           (to 285)
+        250   load_var 40                        (e)
+        251   throw_if_panic                     
 
-  175   255   load_type 2                        
-        256   load_var 9                         (kind)
-        257   call 138 ntypeargs=1               (baml.String.from)
-        258   store_var 41                       (_111)
-        259   load_var 4                         (t)
-        260   call 217 ntypeargs=0               (baml.TypeValue.baml.ToString.to_string)
-        261   store_var 43                       (_115)
-        262   load_type 2                        
-        263   load_var 43                        (_115)
-        264   call 138 ntypeargs=1               (baml.String.from)
-        265   store_var 42                       (_114)
-        266   load_type 33                       
-        267   load_var 40                        (e)
-        268   call 138 ntypeargs=1               (baml.String.from)
-        269   store_var 45                       (_118)
-        270   load_type 2                        
-        271   load_var 45                        (_118)
-        272   call 138 ntypeargs=1               (baml.String.from)
-        273   store_var 44                       (_117)
+  175   252   load_type 2                        
+        253   load_var 9                         (kind)
+        254   call 138 ntypeargs=1               (baml.String.from)
+        255   store_var 41                       (_111)
+        256   load_var 4                         (t)
+        257   call 217 ntypeargs=0               (baml.TypeValue.baml.ToString.to_string)
+        258   store_var 43                       (_115)
+        259   load_type 2                        
+        260   load_var 43                        (_115)
+        261   call 138 ntypeargs=1               (baml.String.from)
+        262   store_var 42                       (_114)
+        263   load_type 33                       
+        264   load_var 40                        (e)
+        265   call 138 ntypeargs=1               (baml.String.from)
+        266   store_var 45                       (_118)
+        267   load_type 2                        
+        268   load_var 45                        (_118)
+        269   call 138 ntypeargs=1               (baml.String.from)
+        270   store_var 44                       (_117)
 
-  173   274   load_var 3                         (provider)
+  173   271   load_var 3                         (provider)
 
-  175   275   load_const 34                      ("the ")
-        276   load_var 41                        (_111)
-        277   bin_op +                           
-        278   load_const 35                      (" output did not fit ")
-        279   bin_op +                           
-        280   load_var 42                        (_114)
-        281   bin_op +                           
-        282   load_const 36                      (": ")
-        283   bin_op +                           
-        284   load_var 44                        (_117)
-        285   bin_op +                           
-        286   init_instance 2                    (ai.errors.ParseFailed .provider, .raw_output)
-        287   throw                              
-        288   return                             
+  175   272   load_const 34                      ("the ")
+        273   load_var 41                        (_111)
+        274   bin_op +                           
+        275   load_const 35                      (" output did not fit ")
+        276   bin_op +                           
+        277   load_var 42                        (_114)
+        278   bin_op +                           
+        279   load_const 36                      (": ")
+        280   bin_op +                           
+        281   load_var 44                        (_117)
+        282   bin_op +                           
+        283   init_instance 2                    (ai.errors.ParseFailed .provider, .raw_output)
+        284   throw                              
+        285   return                             
 }
 
 function ai.Agent._parses(self: ai.Agent<#0>, turn: ai.ModelTurn, candidate: string) -> bool {
@@ -2552,81 +2549,82 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        47    store_var 5             (model)
 
   38   48    load_var 4              (prefix)
-       49    load_const 8            ("openai")
-       50    cmp_op ==               
-       51    pop_jump_if_false +2    (to 53)
-       52    jump +223               (to 275)
-       53    load_var 4              (prefix)
-       54    load_const 9            ("openai-chat")
-       55    cmp_op ==               
-       56    pop_jump_if_false +2    (to 58)
-       57    jump +204               (to 261)
-       58    load_var 4              (prefix)
-       59    load_const 10           ("openai-images")
-       60    cmp_op ==               
-       61    pop_jump_if_false +2    (to 63)
-       62    jump +181               (to 243)
-       63    load_var 4              (prefix)
-       64    load_const 11           ("azure")
-       65    cmp_op ==               
+       49    is_type 8               
+       50    pop_jump_if_false +2    (to 52)
+       51    jump +212               (to 263)
+       52    load_var 4              (prefix)
+       53    is_type 9               
+       54    pop_jump_if_false +2    (to 56)
+       55    jump +194               (to 249)
+       56    load_var 4              (prefix)
+       57    is_type 10              
+       58    pop_jump_if_false +2    (to 60)
+       59    jump +172               (to 231)
+       60    load_var 4              (prefix)
+       61    is_type 11              
+       62    pop_jump_if_false +2    (to 64)
+       63    jump +151               (to 214)
+       64    load_var 4              (prefix)
+       65    is_type 12              
        66    pop_jump_if_false +2    (to 68)
-       67    jump +159               (to 226)
+       67    jump +134               (to 201)
        68    load_var 4              (prefix)
-       69    load_const 12           ("ollama")
-       70    cmp_op ==               
-       71    pop_jump_if_false +2    (to 73)
-       72    jump +141               (to 213)
-       73    load_var 4              (prefix)
-       74    load_const 13           ("openrouter")
-       75    cmp_op ==               
-       76    pop_jump_if_false +2    (to 78)
-       77    jump +123               (to 200)
-       78    load_var 4              (prefix)
-       79    load_const 14           ("anthropic")
-       80    cmp_op ==               
-       81    pop_jump_if_false +2    (to 83)
-       82    jump +103               (to 185)
-       83    load_var 4              (prefix)
-       84    load_const 15           ("google")
-       85    cmp_op ==               
+       69    is_type 13              
+       70    pop_jump_if_false +2    (to 72)
+       71    jump +117               (to 188)
+       72    load_var 4              (prefix)
+       73    is_type 14              
+       74    pop_jump_if_false +2    (to 76)
+       75    jump +98                (to 173)
+       76    load_var 4              (prefix)
+       77    is_type 15              
+       78    pop_jump_if_false +2    (to 80)
+       79    jump +79                (to 158)
+       80    load_var 4              (prefix)
+       81    is_type 16              
+       82    pop_jump_if_false +2    (to 84)
+       83    jump +56                (to 139)
+       84    load_var 4              (prefix)
+       85    is_type 17              
        86    pop_jump_if_false +2    (to 88)
-       87    jump +83                (to 170)
+       87    jump +32                (to 119)
        88    load_var 4              (prefix)
-       89    load_const 16           ("vertex")
-       90    cmp_op ==               
-       91    pop_jump_if_false +2    (to 93)
-       92    jump +59                (to 151)
-       93    load_var 4              (prefix)
-       94    load_const 17           ("bedrock")
-       95    cmp_op ==               
-       96    pop_jump_if_false +2    (to 98)
-       97    jump +34                (to 131)
-       98    load_var 4              (prefix)
-       99    load_const 18           ("ai-gateway-images")
-       100   cmp_op ==               
-       101   pop_jump_if_false +2    (to 103)
-       102   jump +17                (to 119)
-       103   load_var 4              (prefix)
-       104   load_const 19           ("claude-code")
-       105   cmp_op ==               
-       106   pop_jump_if_false +2    (to 108)
-       107   jump +3                 (to 110)
+       89    is_type 18              
+       90    pop_jump_if_false +2    (to 92)
+       91    jump +16                (to 107)
+       92    load_var 4              (prefix)
+       93    is_type 19              
+       94    pop_jump_if_false +2    (to 96)
+       95    jump +3                 (to 98)
 
-  51   108   load_const 4            (null)
+  51   96    load_const 4            (null)
 
-  38   109   jump +181               (to 290)
+  38   97    jump +181               (to 278)
 
-  50   110   load_var 5              (model)
+  50   98    load_var 5              (model)
+       99    load_const 20           (<omitted>)
+       100   load_const 20           (<omitted>)
+       101   load_const 20           (<omitted>)
+       102   load_const 20           (<omitted>)
+       103   load_const 20           (<omitted>)
+       104   load_const 20           (<omitted>)
+       105   call 1351 ntypeargs=0   (claude_code.ClaudeCodeClient.new)
+       106   jump +172               (to 278)
+
+  49   107   load_var 5              (model)
+       108   load_const 20           (<omitted>)
+       109   load_const 20           (<omitted>)
+       110   load_const 20           (<omitted>)
        111   load_const 20           (<omitted>)
        112   load_const 20           (<omitted>)
        113   load_const 20           (<omitted>)
        114   load_const 20           (<omitted>)
        115   load_const 20           (<omitted>)
        116   load_const 20           (<omitted>)
-       117   call 1351 ntypeargs=0   (claude_code.ClaudeCodeClient.new)
-       118   jump +172               (to 290)
+       117   call 1330 ntypeargs=0   (vercel.AiGatewayImageClient.new)
+       118   jump +160               (to 278)
 
-  49   119   load_var 5              (model)
+  48   119   load_var 5              (model)
        120   load_const 20           (<omitted>)
        121   load_const 20           (<omitted>)
        122   load_const 20           (<omitted>)
@@ -2636,18 +2634,18 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        126   load_const 20           (<omitted>)
        127   load_const 20           (<omitted>)
        128   load_const 20           (<omitted>)
-       129   call 1330 ntypeargs=0   (vercel.AiGatewayImageClient.new)
-       130   jump +160               (to 290)
-
-  48   131   load_var 5              (model)
+       129   load_const 20           (<omitted>)
+       130   load_const 20           (<omitted>)
+       131   load_const 20           (<omitted>)
        132   load_const 20           (<omitted>)
        133   load_const 20           (<omitted>)
        134   load_const 20           (<omitted>)
        135   load_const 20           (<omitted>)
        136   load_const 20           (<omitted>)
-       137   load_const 20           (<omitted>)
-       138   load_const 20           (<omitted>)
-       139   load_const 20           (<omitted>)
+       137   call 1271 ntypeargs=0   (aws.BedrockClient.new)
+       138   jump +140               (to 278)
+
+  47   139   load_var 5              (model)
        140   load_const 20           (<omitted>)
        141   load_const 20           (<omitted>)
        142   load_const 20           (<omitted>)
@@ -2657,17 +2655,17 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        146   load_const 20           (<omitted>)
        147   load_const 20           (<omitted>)
        148   load_const 20           (<omitted>)
-       149   call 1271 ntypeargs=0   (aws.BedrockClient.new)
-       150   jump +140               (to 290)
-
-  47   151   load_var 5              (model)
+       149   load_const 20           (<omitted>)
+       150   load_const 20           (<omitted>)
+       151   load_const 20           (<omitted>)
        152   load_const 20           (<omitted>)
        153   load_const 20           (<omitted>)
        154   load_const 20           (<omitted>)
        155   load_const 20           (<omitted>)
-       156   load_const 20           (<omitted>)
-       157   load_const 20           (<omitted>)
-       158   load_const 20           (<omitted>)
+       156   call 1207 ntypeargs=0   (google.VertexClient.new)
+       157   jump +121               (to 278)
+
+  46   158   load_var 5              (model)
        159   load_const 20           (<omitted>)
        160   load_const 20           (<omitted>)
        161   load_const 20           (<omitted>)
@@ -2677,13 +2675,13 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        165   load_const 20           (<omitted>)
        166   load_const 20           (<omitted>)
        167   load_const 20           (<omitted>)
-       168   call 1207 ntypeargs=0   (google.VertexClient.new)
-       169   jump +121               (to 290)
+       168   load_const 20           (<omitted>)
+       169   load_const 20           (<omitted>)
+       170   load_const 20           (<omitted>)
+       171   call 1201 ntypeargs=0   (google.GoogleClient.new)
+       172   jump +106               (to 278)
 
-  46   170   load_var 5              (model)
-       171   load_const 20           (<omitted>)
-       172   load_const 20           (<omitted>)
-       173   load_const 20           (<omitted>)
+  45   173   load_var 5              (model)
        174   load_const 20           (<omitted>)
        175   load_const 20           (<omitted>)
        176   load_const 20           (<omitted>)
@@ -2693,13 +2691,13 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        180   load_const 20           (<omitted>)
        181   load_const 20           (<omitted>)
        182   load_const 20           (<omitted>)
-       183   call 1201 ntypeargs=0   (google.GoogleClient.new)
-       184   jump +106               (to 290)
+       183   load_const 20           (<omitted>)
+       184   load_const 20           (<omitted>)
+       185   load_const 20           (<omitted>)
+       186   call 1162 ntypeargs=0   (anthropic.AnthropicClient.new)
+       187   jump +91                (to 278)
 
-  45   185   load_var 5              (model)
-       186   load_const 20           (<omitted>)
-       187   load_const 20           (<omitted>)
-       188   load_const 20           (<omitted>)
+  44   188   load_var 5              (model)
        189   load_const 20           (<omitted>)
        190   load_const 20           (<omitted>)
        191   load_const 20           (<omitted>)
@@ -2709,11 +2707,11 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        195   load_const 20           (<omitted>)
        196   load_const 20           (<omitted>)
        197   load_const 20           (<omitted>)
-       198   call 1162 ntypeargs=0   (anthropic.AnthropicClient.new)
-       199   jump +91                (to 290)
+       198   load_const 20           (<omitted>)
+       199   call 1084 ntypeargs=0   (openai.OpenRouterClient.new)
+       200   jump +78                (to 278)
 
-  44   200   load_var 5              (model)
-       201   load_const 20           (<omitted>)
+  43   201   load_var 5              (model)
        202   load_const 20           (<omitted>)
        203   load_const 20           (<omitted>)
        204   load_const 20           (<omitted>)
@@ -2723,11 +2721,11 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        208   load_const 20           (<omitted>)
        209   load_const 20           (<omitted>)
        210   load_const 20           (<omitted>)
-       211   call 1084 ntypeargs=0   (openai.OpenRouterClient.new)
-       212   jump +78                (to 290)
+       211   load_const 20           (<omitted>)
+       212   call 1076 ntypeargs=0   (openai.OllamaClient.new)
+       213   jump +65                (to 278)
 
-  43   213   load_var 5              (model)
-       214   load_const 20           (<omitted>)
+  42   214   load_var 5              (model)
        215   load_const 20           (<omitted>)
        216   load_const 20           (<omitted>)
        217   load_const 20           (<omitted>)
@@ -2737,15 +2735,15 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        221   load_const 20           (<omitted>)
        222   load_const 20           (<omitted>)
        223   load_const 20           (<omitted>)
-       224   call 1076 ntypeargs=0   (openai.OllamaClient.new)
-       225   jump +65                (to 290)
-
-  42   226   load_var 5              (model)
+       224   load_const 20           (<omitted>)
+       225   load_const 20           (<omitted>)
+       226   load_const 20           (<omitted>)
        227   load_const 20           (<omitted>)
        228   load_const 20           (<omitted>)
-       229   load_const 20           (<omitted>)
-       230   load_const 20           (<omitted>)
-       231   load_const 20           (<omitted>)
+       229   call 1067 ntypeargs=0   (openai.AzureClient.new)
+       230   jump +48                (to 278)
+
+  41   231   load_var 5              (model)
        232   load_const 20           (<omitted>)
        233   load_const 20           (<omitted>)
        234   load_const 20           (<omitted>)
@@ -2755,16 +2753,16 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        238   load_const 20           (<omitted>)
        239   load_const 20           (<omitted>)
        240   load_const 20           (<omitted>)
-       241   call 1067 ntypeargs=0   (openai.AzureClient.new)
-       242   jump +48                (to 290)
-
-  41   243   load_var 5              (model)
+       241   load_const 20           (<omitted>)
+       242   load_const 20           (<omitted>)
+       243   load_const 20           (<omitted>)
        244   load_const 20           (<omitted>)
        245   load_const 20           (<omitted>)
        246   load_const 20           (<omitted>)
-       247   load_const 20           (<omitted>)
-       248   load_const 20           (<omitted>)
-       249   load_const 20           (<omitted>)
+       247   call 1092 ntypeargs=0   (openai.ImageClient.new)
+       248   jump +30                (to 278)
+
+  40   249   load_var 5              (model)
        250   load_const 20           (<omitted>)
        251   load_const 20           (<omitted>)
        252   load_const 20           (<omitted>)
@@ -2774,12 +2772,12 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        256   load_const 20           (<omitted>)
        257   load_const 20           (<omitted>)
        258   load_const 20           (<omitted>)
-       259   call 1092 ntypeargs=0   (openai.ImageClient.new)
-       260   jump +30                (to 290)
+       259   load_const 20           (<omitted>)
+       260   load_const 20           (<omitted>)
+       261   call 1051 ntypeargs=0   (openai.ChatClient.new)
+       262   jump +16                (to 278)
 
-  40   261   load_var 5              (model)
-       262   load_const 20           (<omitted>)
-       263   load_const 20           (<omitted>)
+  39   263   load_var 5              (model)
        264   load_const 20           (<omitted>)
        265   load_const 20           (<omitted>)
        266   load_const 20           (<omitted>)
@@ -2789,79 +2787,66 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        270   load_const 20           (<omitted>)
        271   load_const 20           (<omitted>)
        272   load_const 20           (<omitted>)
-       273   call 1051 ntypeargs=0   (openai.ChatClient.new)
-       274   jump +16                (to 290)
-
-  39   275   load_var 5              (model)
+       273   load_const 20           (<omitted>)
+       274   load_const 20           (<omitted>)
+       275   load_const 20           (<omitted>)
        276   load_const 20           (<omitted>)
-       277   load_const 20           (<omitted>)
-       278   load_const 20           (<omitted>)
-       279   load_const 20           (<omitted>)
-       280   load_const 20           (<omitted>)
-       281   load_const 20           (<omitted>)
-       282   load_const 20           (<omitted>)
-       283   load_const 20           (<omitted>)
-       284   load_const 20           (<omitted>)
-       285   load_const 20           (<omitted>)
-       286   load_const 20           (<omitted>)
-       287   load_const 20           (<omitted>)
-       288   load_const 20           (<omitted>)
-       289   call 1011 ntypeargs=0   (openai.ResponsesClient.new)
+       277   call 1011 ntypeargs=0   (openai.ResponsesClient.new)
 
-  53   290   store_var 8             (_36)
-       291   load_var 8              (_36)
-       292   narrow_bind 21 8        
-       293   pop_jump_if_false +2    (to 295)
-       294   jump +41                (to 335)
+  53   278   store_var 8             (_36)
+       279   load_var 8              (_36)
+       280   narrow_bind 21 8        
+       281   pop_jump_if_false +2    (to 283)
+       282   jump +41                (to 323)
 
-  59   295   load_type 2             
-       296   load_var 4              (prefix)
-       297   call 138 ntypeargs=1    (baml.String.from)
-       298   store_var 10            (_47)
-       299   load_type 2             
-       300   load_var 1              (shorthand)
-       301   call 138 ntypeargs=1    (baml.String.from)
-       302   store_var 11            (_50)
-       303   call 1001 ntypeargs=0   (ai.internal._shorthand_prefixes)
-       304   store_var 13            (_53)
-       305   load_type 2             
-       306   load_var 13             (_53)
-       307   call 138 ntypeargs=1    (baml.String.from)
-       308   store_var 12            (_52)
-       309   load_type 2             
-       310   load_var 5              (model)
-       311   call 138 ntypeargs=1    (baml.String.from)
-       312   store_var 14            (_55)
+  59   283   load_type 2             
+       284   load_var 4              (prefix)
+       285   call 138 ntypeargs=1    (baml.String.from)
+       286   store_var 10            (_47)
+       287   load_type 2             
+       288   load_var 1              (shorthand)
+       289   call 138 ntypeargs=1    (baml.String.from)
+       290   store_var 11            (_50)
+       291   call 1001 ntypeargs=0   (ai.internal._shorthand_prefixes)
+       292   store_var 13            (_53)
+       293   load_type 2             
+       294   load_var 13             (_53)
+       295   call 138 ntypeargs=1    (baml.String.from)
+       296   store_var 12            (_52)
+       297   load_type 2             
+       298   load_var 5              (model)
+       299   call 138 ntypeargs=1    (baml.String.from)
+       300   store_var 14            (_55)
 
-  56   313   load_const 22           ("ai.clients")
-       314   load_const 4            (null)
+  56   301   load_const 22           ("ai.clients")
+       302   load_const 4            (null)
 
-  59   315   load_const 23           ("no builtin provider for prefix \"")
-       316   load_var 10             (_47)
+  59   303   load_const 23           ("no builtin provider for prefix \"")
+       304   load_var 10             (_47)
+       305   bin_op +                
+       306   load_const 24           ("\" in client \"")
+       307   bin_op +                
+       308   load_var 11             (_50)
+       309   bin_op +                
+       310   load_const 25           ("\"; valid prefixes are ")
+       311   bin_op +                
+       312   load_var 12             (_52)
+       313   bin_op +                
+       314   load_const 26           (" (for any other OpenAI-compatible endpoint, build openai.GenericClient.new(base_url = ..., model = \"")
+       315   bin_op +                
+       316   load_var 14             (_55)
        317   bin_op +                
-       318   load_const 24           ("\" in client \"")
+       318   load_const 27           ("\"))")
        319   bin_op +                
-       320   load_var 11             (_50)
-       321   bin_op +                
-       322   load_const 25           ("\"; valid prefixes are ")
-       323   bin_op +                
-       324   load_var 12             (_52)
-       325   bin_op +                
-       326   load_const 26           (" (for any other OpenAI-compatible endpoint, build openai.GenericClient.new(base_url = ..., model = \"")
-       327   bin_op +                
-       328   load_var 14             (_55)
-       329   bin_op +                
-       330   load_const 27           ("\"))")
-       331   bin_op +                
-       332   load_const 4            (null)
-       333   init_instance 1         (ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body)
-       334   throw                   
+       320   load_const 4            (null)
+       321   init_instance 1         (ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body)
+       322   throw                   
 
-  53   335   load_var 8              (_36)
-       336   store_var 9             (built)
+  53   323   load_var 8              (_36)
+       324   store_var 9             (built)
 
-  54   337   load_var 9              (built)
-       338   return                  
+  54   325   load_var 9              (built)
+       326   return                  
 }
 
 function ai.internal._gcp_access_token(credentials_json: string | null, scope: string) -> string {
@@ -3752,7 +3737,7 @@ function ai.internal._proxy(conn: ai.mcp.McpConnection, name: string) -> (map<st
        5    store_var 2           
 
   12   6    load_var2 1 2         
-       7    make_closure 4341 2   
+       7    make_closure 4198 2   
        8    store_var 3           (_0)
        9    load_var 3            (_0)
        10   return                
@@ -5845,7 +5830,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
   436   81    load_type 8                                
         82    load_type 2                                
         83    load_var 14                                (turns)
-        84    make_closure 2290 captures=1 ntypeargs=2   
+        84    make_closure 2287 captures=1 ntypeargs=2   
         85    load_var 19                                (_36)
         86    load_const 9                               ("")
         87    load_const 10                              (false)
@@ -7426,116 +7411,112 @@ function anthropic.internal._anth_stream_failure(error: anthropic.internal.AnthS
          33    store_var 5            (detail)
 
   1007   34    load_var 3             (kind)
-         35    load_const 2           ("rate_limit_error")
-         36    cmp_op ==              
-         37    pop_jump_if_false +2   (to 39)
-         38    jump +85               (to 123)
-         39    load_var 3             (kind)
-         40    load_const 3           ("overloaded_error")
-         41    cmp_op ==              
-         42    pop_jump_if_false +2   (to 44)
-         43    jump +63               (to 106)
-         44    load_var 3             (kind)
-         45    load_const 4           ("api_error")
-         46    cmp_op ==              
-         47    pop_jump_if_false +2   (to 49)
-         48    jump +41               (to 89)
-         49    load_var 3             (kind)
-         50    load_const 5           ("timeout_error")
-         51    cmp_op ==              
-         52    pop_jump_if_false +2   (to 54)
-         53    jump +19               (to 72)
+         35    is_type 2              
+         36    pop_jump_if_false +2   (to 38)
+         37    jump +82               (to 119)
+         38    load_var 3             (kind)
+         39    is_type 3              
+         40    pop_jump_if_false +2   (to 42)
+         41    jump +61               (to 102)
+         42    load_var 3             (kind)
+         43    is_type 4              
+         44    pop_jump_if_false +2   (to 46)
+         45    jump +40               (to 85)
+         46    load_var 3             (kind)
+         47    is_type 5              
+         48    pop_jump_if_false +2   (to 50)
+         49    jump +19               (to 68)
 
-  1023   54    load_type 6            
-         55    load_var 3             (kind)
+  1023   50    load_type 6            
+         51    load_var 3             (kind)
+         52    call 138 ntypeargs=1   (baml.String.from)
+         53    store_var 13           (_45)
+         54    load_type 6            
+         55    load_var 5             (detail)
          56    call 138 ntypeargs=1   (baml.String.from)
-         57    store_var 13           (_45)
-         58    load_type 6            
-         59    load_var 5             (detail)
-         60    call 138 ntypeargs=1   (baml.String.from)
-         61    store_var 14           (_48)
+         57    store_var 14           (_48)
 
-  1020   62    load_const 7           ("anthropic")
-         63    load_const 0           (null)
+  1020   58    load_const 7           ("anthropic")
+         59    load_const 0           (null)
 
-  1023   64    load_var 13            (_45)
-         65    load_const 8           (": ")
-         66    bin_op +               
-         67    load_var 14            (_48)
-         68    bin_op +               
-         69    load_var 2             (raw)
-         70    init_instance 0        (ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body)
+  1023   60    load_var 13            (_45)
+         61    load_const 8           (": ")
+         62    bin_op +               
+         63    load_var 14            (_48)
+         64    bin_op +               
+         65    load_var 2             (raw)
+         66    init_instance 0        (ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body)
 
-  1007   71    jump +56               (to 127)
+  1007   67    jump +56               (to 123)
 
-  1015   72    load_type 9            
-         73    load_var 3             (kind)
+  1015   68    load_type 9            
+         69    load_var 3             (kind)
+         70    call 138 ntypeargs=1   (baml.String.from)
+         71    store_var 11           (_37)
+         72    load_type 6            
+         73    load_var 5             (detail)
          74    call 138 ntypeargs=1   (baml.String.from)
-         75    store_var 11           (_37)
-         76    load_type 6            
-         77    load_var 5             (detail)
-         78    call 138 ntypeargs=1   (baml.String.from)
-         79    store_var 12           (_40)
+         75    store_var 12           (_40)
 
-  1013   80    load_const 10          ("anthropic")
+  1013   76    load_const 10          ("anthropic")
 
-  1015   81    load_var 11            (_37)
-         82    load_const 11          (": ")
-         83    bin_op +               
-         84    load_var 12            (_40)
-         85    bin_op +               
-         86    load_var 2             (raw)
-         87    init_instance 1        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
+  1015   77    load_var 11            (_37)
+         78    load_const 11          (": ")
+         79    bin_op +               
+         80    load_var 12            (_40)
+         81    bin_op +               
+         82    load_var 2             (raw)
+         83    init_instance 1        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
 
-  1007   88    jump +39               (to 127)
+  1007   84    jump +39               (to 123)
 
-  1015   89    load_type 9            
-         90    load_var 3             (kind)
+  1015   85    load_type 9            
+         86    load_var 3             (kind)
+         87    call 138 ntypeargs=1   (baml.String.from)
+         88    store_var 9            (_28)
+         89    load_type 6            
+         90    load_var 5             (detail)
          91    call 138 ntypeargs=1   (baml.String.from)
-         92    store_var 9            (_28)
-         93    load_type 6            
-         94    load_var 5             (detail)
-         95    call 138 ntypeargs=1   (baml.String.from)
-         96    store_var 10           (_31)
+         92    store_var 10           (_31)
 
-  1013   97    load_const 12          ("anthropic")
+  1013   93    load_const 12          ("anthropic")
 
-  1015   98    load_var 9             (_28)
-         99    load_const 13          (": ")
-         100   bin_op +               
-         101   load_var 10            (_31)
-         102   bin_op +               
-         103   load_var 2             (raw)
-         104   init_instance 2        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
+  1015   94    load_var 9             (_28)
+         95    load_const 13          (": ")
+         96    bin_op +               
+         97    load_var 10            (_31)
+         98    bin_op +               
+         99    load_var 2             (raw)
+         100   init_instance 2        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
 
-  1007   105   jump +22               (to 127)
+  1007   101   jump +22               (to 123)
 
-  1015   106   load_type 9            
-         107   load_var 3             (kind)
+  1015   102   load_type 9            
+         103   load_var 3             (kind)
+         104   call 138 ntypeargs=1   (baml.String.from)
+         105   store_var 7            (_19)
+         106   load_type 6            
+         107   load_var 5             (detail)
          108   call 138 ntypeargs=1   (baml.String.from)
-         109   store_var 7            (_19)
-         110   load_type 6            
-         111   load_var 5             (detail)
-         112   call 138 ntypeargs=1   (baml.String.from)
-         113   store_var 8            (_22)
+         109   store_var 8            (_22)
 
-  1013   114   load_const 14          ("anthropic")
+  1013   110   load_const 14          ("anthropic")
 
-  1015   115   load_var 7             (_19)
-         116   load_const 15          (": ")
-         117   bin_op +               
-         118   load_var 8             (_22)
-         119   bin_op +               
-         120   load_var 2             (raw)
-         121   init_instance 3        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
+  1015   111   load_var 7             (_19)
+         112   load_const 15          (": ")
+         113   bin_op +               
+         114   load_var 8             (_22)
+         115   bin_op +               
+         116   load_var 2             (raw)
+         117   init_instance 3        (ai.errors.NetworkFailure .provider, .detail, .raw_body)
 
-  1007   122   jump +5                (to 127)
+  1007   118   jump +5                (to 123)
 
-  1008   123   load_const 16          ("anthropic")
-         124   load_const 0           (null)
-         125   load_var 2             (raw)
-         126   init_instance 4        (ai.errors.RateLimited .provider, .retry_after_ms, .raw_body)
-         127   return                 
+  1008   119   load_const 16          ("anthropic")
+         120   load_const 0           (null)
+         121   load_var 2             (raw)
+         122   init_instance 4        (ai.errors.RateLimited .provider, .retry_after_ms, .raw_body)
+         123   return                 
 }
 
 function anthropic.internal._anth_supported_image_mime(mime: string) -> bool {
@@ -8667,49 +8648,45 @@ function anthropic.internal._anthropic_sse_failure(message: string) -> ai.errors
 
 function anthropic.internal._anthropic_stop_reason(s: string) -> ai.content.StopReason {
   797   0    load_var 1             (s)
-        1    load_const 0           ("end_turn")
-        2    cmp_op ==              
-        3    pop_jump_if_false +2   (to 5)
-        4    jump +28               (to 32)
-        5    load_var 1             (s)
-        6    load_const 1           ("stop_sequence")
-        7    cmp_op ==              
-        8    pop_jump_if_false +2   (to 10)
-        9    jump +20               (to 29)
-        10   load_var 1             (s)
-        11   load_const 2           ("tool_use")
-        12   cmp_op ==              
-        13   pop_jump_if_false +2   (to 15)
-        14   jump +12               (to 26)
-        15   load_var 1             (s)
-        16   load_const 3           ("refusal")
-        17   cmp_op ==              
-        18   pop_jump_if_false +2   (to 20)
-        19   jump +4                (to 23)
+        1    is_type 0              
+        2    pop_jump_if_false +2   (to 4)
+        3    jump +25               (to 28)
+        4    load_var 1             (s)
+        5    is_type 1              
+        6    pop_jump_if_false +2   (to 8)
+        7    jump +18               (to 25)
+        8    load_var 1             (s)
+        9    is_type 2              
+        10   pop_jump_if_false +2   (to 12)
+        11   jump +11               (to 22)
+        12   load_var 1             (s)
+        13   is_type 3              
+        14   pop_jump_if_false +2   (to 16)
+        15   jump +4                (to 19)
 
-  802   20   load_const 4           (ai.content.StopReason.MaxTokens)
-        21   alloc_variant 774      (ai.content.StopReason)
+  802   16   load_const 4           (ai.content.StopReason.MaxTokens)
+        17   alloc_variant 774      (ai.content.StopReason)
 
-  797   22   jump +12               (to 34)
+  797   18   jump +12               (to 30)
 
-  800   23   load_const 5           (ai.content.StopReason.Refused)
-        24   alloc_variant 774      (ai.content.StopReason)
+  800   19   load_const 5           (ai.content.StopReason.Refused)
+        20   alloc_variant 774      (ai.content.StopReason)
 
-  797   25   jump +9                (to 34)
+  797   21   jump +9                (to 30)
 
-  799   26   load_const 6           (ai.content.StopReason.ToolUse)
-        27   alloc_variant 774      (ai.content.StopReason)
+  799   22   load_const 6           (ai.content.StopReason.ToolUse)
+        23   alloc_variant 774      (ai.content.StopReason)
 
-  797   28   jump +6                (to 34)
+  797   24   jump +6                (to 30)
 
-  798   29   load_const 7           (ai.content.StopReason.Complete)
-        30   alloc_variant 774      (ai.content.StopReason)
+  798   25   load_const 7           (ai.content.StopReason.Complete)
+        26   alloc_variant 774      (ai.content.StopReason)
 
-  797   31   jump +3                (to 34)
+  797   27   jump +3                (to 30)
 
-  798   32   load_const 7           (ai.content.StopReason.Complete)
-        33   alloc_variant 774      (ai.content.StopReason)
-        34   return                 
+  798   28   load_const 7           (ai.content.StopReason.Complete)
+        29   alloc_variant 774      (ai.content.StopReason)
+        30   return                 
 }
 
 function anthropic.internal._anthropic_thinking_param(thinking: anthropic.ThinkingConfig | null) -> anthropic.internal.AnthThinkingParam | null {
@@ -8843,7 +8820,7 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
          14    load_var 6                         (_6)
          15    is_type 5                          
          16    pop_jump_if_false +2               (to 18)
-         17    jump +543                          (to 560)
+         17    jump +531                          (to 548)
          18    load_var 6                         (_6)
          19    store_var_load_var 7               (raw)
 
@@ -8889,579 +8866,567 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
          55    load_var 14                        (_20)
          56    store_var_load_var 13              (t)
 
-  1040   57    load_const 11                      ("error")
-         58    cmp_op ==                          
-         59    pop_jump_if_false +2               (to 61)
-         60    jump +495                          (to 555)
-         61    load_var 13                        (t)
-         62    load_const 12                      ("message_start")
-         63    cmp_op ==                          
-         64    pop_jump_if_false +2               (to 66)
-         65    jump +368                          (to 433)
-         66    load_var 13                        (t)
-         67    load_const 13                      ("content_block_start")
-         68    cmp_op ==                          
-         69    pop_jump_if_false +2               (to 71)
-         70    jump +257                          (to 327)
-         71    load_var 13                        (t)
-         72    load_const 14                      ("content_block_delta")
-         73    cmp_op ==                          
+  1040   57    is_type 11                         
+         58    pop_jump_if_false +2               (to 60)
+         59    jump +484                          (to 543)
+         60    load_var 13                        (t)
+         61    is_type 12                         
+         62    pop_jump_if_false +2               (to 64)
+         63    jump +358                          (to 421)
+         64    load_var 13                        (t)
+         65    is_type 13                         
+         66    pop_jump_if_false +2               (to 68)
+         67    jump +250                          (to 317)
+         68    load_var 13                        (t)
+         69    is_type 14                         
+         70    pop_jump_if_false +2               (to 72)
+         71    jump +126                          (to 197)
+         72    load_var 13                        (t)
+         73    is_type 15                         
          74    pop_jump_if_false +2               (to 76)
-         75    jump +128                          (to 203)
+         75    jump +10                           (to 85)
          76    load_var 13                        (t)
-         77    load_const 15                      ("message_delta")
-         78    cmp_op ==                          
-         79    pop_jump_if_false +2               (to 81)
-         80    jump +11                           (to 91)
-         81    load_var 13                        (t)
-         82    load_const 16                      ("message_stop")
-         83    cmp_op ==                          
-         84    pop_jump_if_false -75              (to 9)
+         77    is_type 16                         
+         78    pop_jump_if_false -69              (to 9)
 
-  1170   85    load_type 0                        
-         86    load_var 4                         (out)
-         87    alloc_instance 410 ntypeargs=0     (ai.stream.TurnDone)
-         88    call 4 ntypeargs=1                 (baml.Array.push)
-         89    pop 1                              
-         90    jump -81                           (to 9)
+  1170   79    load_type 0                        
+         80    load_var 4                         (out)
+         81    alloc_instance 410 ntypeargs=0     (ai.stream.TurnDone)
+         82    call 4 ntypeargs=1                 (baml.Array.push)
+         83    pop 1                              
+         84    jump -75                           (to 9)
 
-  1143   91    load_var 12                        (event)
-         92    load_field 5                       (usage)
-         93    store_var 57                       (_169)
-         94    load_var 57                        (_169)
-         95    narrow_bind 17 57                  
-         96    pop_jump_if_false +44              (to 140)
-         97    load_var 57                        (_169)
-         98    store_var_load_var 58              (usage)
+  1143   85    load_var 12                        (event)
+         86    load_field 5                       (usage)
+         87    store_var 57                       (_169)
+         88    load_var 57                        (_169)
+         89    narrow_bind 17 57                  
+         90    pop_jump_if_false +44              (to 134)
+         91    load_var 57                        (_169)
+         92    store_var_load_var 58              (usage)
 
-  1145   99    load_field 2                       (cache_read_input_tokens)
-         100   store_var_load_var 59              (_171)
-         101   load_const 8                       (null)
-         102   cmp_op ==                          
-         103   pop_jump_if_false +4               (to 107)
-         104   load_var 2                         (state)
-         105   load_field 3                       (cache_read_input_tokens)
-         106   store_var 59                       (_171)
-         107   load_var2 2 59                     
-         108   store_field 3                      (cache_read_input_tokens)
+  1145   93    load_field 2                       (cache_read_input_tokens)
+         94    store_var_load_var 59              (_171)
+         95    load_const 8                       (null)
+         96    cmp_op ==                          
+         97    pop_jump_if_false +4               (to 101)
+         98    load_var 2                         (state)
+         99    load_field 3                       (cache_read_input_tokens)
+         100   store_var 59                       (_171)
+         101   load_var2 2 59                     
+         102   store_field 3                      (cache_read_input_tokens)
 
-  1147   109   load_var 58                        (usage)
-         110   load_field 3                       (cache_creation_input_tokens)
-         111   store_var_load_var 60              (_174)
+  1147   103   load_var 58                        (usage)
+         104   load_field 3                       (cache_creation_input_tokens)
+         105   store_var_load_var 60              (_174)
 
-  1148   112   load_const 8                       (null)
-         113   cmp_op ==                          
-         114   pop_jump_if_false +4               (to 118)
-         115   load_var 2                         (state)
-         116   load_field 4                       (cache_creation_input_tokens)
-         117   store_var 60                       (_174)
+  1148   106   load_const 8                       (null)
+         107   cmp_op ==                          
+         108   pop_jump_if_false +4               (to 112)
+         109   load_var 2                         (state)
+         110   load_field 4                       (cache_creation_input_tokens)
+         111   store_var 60                       (_174)
 
-  1147   118   load_var2 2 60                     
-         119   store_field 4                      (cache_creation_input_tokens)
+  1147   112   load_var2 2 60                     
+         113   store_field 4                      (cache_creation_input_tokens)
 
-  1150   120   load_var 58                        (usage)
+  1150   114   load_var 58                        (usage)
+         115   load_field 4                       (output_tokens_details)
+         116   load_const 8                       (null)
+         117   cmp_op ==                          
+         118   pop_jump_if_false +2               (to 120)
+         119   jump +5                            (to 124)
+         120   load_var 58                        (usage)
          121   load_field 4                       (output_tokens_details)
-         122   load_const 8                       (null)
-         123   cmp_op ==                          
-         124   pop_jump_if_false +2               (to 126)
-         125   jump +5                            (to 130)
-         126   load_var 58                        (usage)
-         127   load_field 4                       (output_tokens_details)
-         128   load_field 0                       (0)
-         129   jump +2                            (to 131)
-         130   load_const 8                       (null)
-         131   store_var_load_var 61              (_177)
-         132   load_const 8                       (null)
-         133   cmp_op ==                          
-         134   pop_jump_if_false +4               (to 138)
+         122   load_field 0                       (0)
+         123   jump +2                            (to 125)
+         124   load_const 8                       (null)
+         125   store_var_load_var 61              (_177)
+         126   load_const 8                       (null)
+         127   cmp_op ==                          
+         128   pop_jump_if_false +4               (to 132)
 
-  1151   135   load_var 2                         (state)
-         136   load_field 5                       (reasoning_tokens)
-         137   store_var 61                       (_177)
+  1151   129   load_var 2                         (state)
+         130   load_field 5                       (reasoning_tokens)
+         131   store_var 61                       (_177)
 
-  1150   138   load_var2 2 61                     
-         139   store_field 5                      (reasoning_tokens)
+  1150   132   load_var2 2 61                     
+         133   store_field 5                      (reasoning_tokens)
 
-  1153   140   load_var 12                        (event)
+  1153   134   load_var 12                        (event)
+         135   load_field 2                       (delta)
+         136   load_const 8                       (null)
+         137   cmp_op ==                          
+         138   pop_jump_if_false +2               (to 140)
+         139   jump +6                            (to 145)
+         140   load_var 12                        (event)
          141   load_field 2                       (delta)
-         142   load_const 8                       (null)
-         143   cmp_op ==                          
-         144   pop_jump_if_false +2               (to 146)
-         145   jump +6                            (to 151)
-         146   load_var 12                        (event)
-         147   load_field 2                       (delta)
-         148   load_field 5                       (5)
-         149   store_var 63                       (_184)
-         150   jump +3                            (to 153)
-         151   load_const 8                       (null)
-         152   store_var 63                       (_184)
-         153   load_var 63                        (_184)
-         154   load_const 8                       (null)
-         155   cmp_op ==                          
-         156   pop_jump_if_false +2               (to 158)
-         157   jump +9                            (to 166)
-         158   load_var 63                        (_184)
-         159   store_var 64                       (s)
+         142   load_field 5                       (5)
+         143   store_var 63                       (_184)
+         144   jump +3                            (to 147)
+         145   load_const 8                       (null)
+         146   store_var 63                       (_184)
+         147   load_var 63                        (_184)
+         148   load_const 8                       (null)
+         149   cmp_op ==                          
+         150   pop_jump_if_false +2               (to 152)
+         151   jump +9                            (to 160)
+         152   load_var 63                        (_184)
+         153   store_var 64                       (s)
 
-  1156   160   load_var2 2 64                     
-         161   store_field 6                      (stop_reason_raw)
+  1156   154   load_var2 2 64                     
+         155   store_field 6                      (stop_reason_raw)
 
-  1157   162   load_var 64                        (s)
-         163   call 1190 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
-         164   store_var 62                       (stop)
-         165   jump +3                            (to 168)
+  1157   156   load_var 64                        (s)
+         157   call 1190 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
+         158   store_var 62                       (stop)
+         159   jump +3                            (to 162)
 
-  1154   166   load_const 8                       (null)
-         167   store_var 62                       (stop)
+  1154   160   load_const 8                       (null)
+         161   store_var 62                       (stop)
 
-  1162   168   load_var 62                        (stop)
-         169   store_var 65                       (_193)
+  1162   162   load_var 62                        (stop)
+         163   store_var 65                       (_193)
 
-  1163   170   load_var 12                        (event)
+  1163   164   load_var 12                        (event)
+         165   load_field 5                       (usage)
+         166   load_const 8                       (null)
+         167   cmp_op ==                          
+         168   pop_jump_if_false +2               (to 170)
+         169   jump +6                            (to 175)
+         170   load_var 12                        (event)
          171   load_field 5                       (usage)
-         172   load_const 8                       (null)
-         173   cmp_op ==                          
-         174   pop_jump_if_false +2               (to 176)
-         175   jump +6                            (to 181)
-         176   load_var 12                        (event)
-         177   load_field 5                       (usage)
-         178   load_field 0                       (0)
-         179   store_var 66                       (_194)
-         180   jump +3                            (to 183)
-         181   load_const 8                       (null)
-         182   store_var 66                       (_194)
+         172   load_field 0                       (0)
+         173   store_var 66                       (_194)
+         174   jump +3                            (to 177)
+         175   load_const 8                       (null)
+         176   store_var 66                       (_194)
 
-  1164   183   load_var 12                        (event)
+  1164   177   load_var 12                        (event)
+         178   load_field 5                       (usage)
+         179   load_const 8                       (null)
+         180   cmp_op ==                          
+         181   pop_jump_if_false +2               (to 183)
+         182   jump +6                            (to 188)
+         183   load_var 12                        (event)
          184   load_field 5                       (usage)
-         185   load_const 8                       (null)
-         186   cmp_op ==                          
-         187   pop_jump_if_false +2               (to 189)
-         188   jump +6                            (to 194)
-         189   load_var 12                        (event)
-         190   load_field 5                       (usage)
-         191   load_field 1                       (1)
-         192   store_var 67                       (_198)
-         193   jump +3                            (to 196)
-         194   load_const 8                       (null)
-         195   store_var 67                       (_198)
+         185   load_field 1                       (1)
+         186   store_var 67                       (_198)
+         187   jump +3                            (to 190)
+         188   load_const 8                       (null)
+         189   store_var 67                       (_198)
 
-  1160   196   load_type 0                        
-         197   load_var2 4 65                     
+  1160   190   load_type 0                        
+         191   load_var2 4 65                     
 
-  1161   198   load_var2 66 67                    
-         199   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
+  1161   192   load_var2 66 67                    
+         193   init_instance 0                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
 
-  1160   200   call 4 ntypeargs=1                 (baml.Array.push)
-         201   pop 1                              
-         202   jump -193                          (to 9)
+  1160   194   call 4 ntypeargs=1                 (baml.Array.push)
+         195   pop 1                              
+         196   jump -187                          (to 9)
 
-  1106   203   load_var 12                        (event)
-         204   load_field 2                       (delta)
-         205   store_var 40                       (_119)
-         206   load_var 40                        (_119)
-         207   narrow_bind 18 40                  
-         208   pop_jump_if_false -199             (to 9)
-         209   load_var 40                        (_119)
-         210   store_var_load_var 41              (d)
+  1106   197   load_var 12                        (event)
+         198   load_field 2                       (delta)
+         199   store_var 40                       (_119)
+         200   load_var 40                        (_119)
+         201   narrow_bind 18 40                  
+         202   pop_jump_if_false -193             (to 9)
+         203   load_var 40                        (_119)
+         204   store_var_load_var 41              (d)
 
-  1107   211   load_field 0                       (type)
-         212   store_var_load_var 43              (_122)
-         213   load_const 8                       (null)
-         214   cmp_op ==                          
-         215   pop_jump_if_false +3               (to 218)
-         216   load_const 19                      ("")
-         217   store_var 43                       (_122)
-         218   load_var 43                        (_122)
-         219   store_var_load_var 42              (kind)
+  1107   205   load_field 0                       (type)
+         206   store_var_load_var 43              (_122)
+         207   load_const 8                       (null)
+         208   cmp_op ==                          
+         209   pop_jump_if_false +3               (to 212)
+         210   load_const 19                      ("")
+         211   store_var 43                       (_122)
+         212   load_var 43                        (_122)
+         213   store_var_load_var 42              (kind)
 
-  1108   220   load_const 20                      ("text_delta")
-         221   cmp_op ==                          
-         222   pop_jump_if_false +2               (to 224)
-         223   jump +90                           (to 313)
-         224   load_var 42                        (kind)
-         225   load_const 21                      ("input_json_delta")
-         226   cmp_op ==                          
-         227   pop_jump_if_false +2               (to 229)
-         228   jump +54                           (to 282)
-         229   load_var 42                        (kind)
-         230   load_const 22                      ("thinking_delta")
-         231   cmp_op ==                          
-         232   pop_jump_if_false +2               (to 234)
-         233   jump +27                           (to 260)
-         234   load_var 42                        (kind)
-         235   load_const 23                      ("signature_delta")
-         236   cmp_op ==                          
-         237   pop_jump_if_false -228             (to 9)
+  1108   214   is_type 20                         
+         215   pop_jump_if_false +2               (to 217)
+         216   jump +87                           (to 303)
+         217   load_var 42                        (kind)
+         218   is_type 21                         
+         219   pop_jump_if_false +2               (to 221)
+         220   jump +52                           (to 272)
+         221   load_var 42                        (kind)
+         222   is_type 22                         
+         223   pop_jump_if_false +2               (to 225)
+         224   jump +26                           (to 250)
+         225   load_var 42                        (kind)
+         226   is_type 23                         
+         227   pop_jump_if_false -218             (to 9)
 
-  1131   238   load_type 24                       
-         239   load_var 2                         (state)
-         240   load_field 1                       (signature)
-         241   call 138 ntypeargs=1               (baml.String.from)
-         242   store_var 54                       (_158)
-         243   load_var 41                        (d)
-         244   load_field 4                       (signature)
-         245   store_var_load_var 56              (_163)
-         246   load_const 8                       (null)
-         247   cmp_op ==                          
-         248   pop_jump_if_false +3               (to 251)
-         249   load_const 25                      ("")
-         250   store_var 56                       (_163)
-         251   load_type 24                       
-         252   load_var 56                        (_163)
+  1131   228   load_type 24                       
+         229   load_var 2                         (state)
+         230   load_field 1                       (signature)
+         231   call 138 ntypeargs=1               (baml.String.from)
+         232   store_var 54                       (_158)
+         233   load_var 41                        (d)
+         234   load_field 4                       (signature)
+         235   store_var_load_var 56              (_163)
+         236   load_const 8                       (null)
+         237   cmp_op ==                          
+         238   pop_jump_if_false +3               (to 241)
+         239   load_const 25                      ("")
+         240   store_var 56                       (_163)
+         241   load_type 24                       
+         242   load_var 56                        (_163)
+         243   call 138 ntypeargs=1               (baml.String.from)
+         244   store_var 55                       (_161)
+         245   load_var2 2 54                     
+         246   load_var 55                        (_161)
+         247   bin_op +                           
+         248   store_field 1                      (signature)
+
+  1108   249   jump -240                          (to 9)
+
+  1127   250   load_type 24                       
+         251   load_var 2                         (state)
+         252   load_field 0                       (thinking)
          253   call 138 ntypeargs=1               (baml.String.from)
-         254   store_var 55                       (_161)
-         255   load_var2 2 54                     
-         256   load_var 55                        (_161)
-         257   bin_op +                           
-         258   store_field 1                      (signature)
+         254   store_var 51                       (_148)
+         255   load_var 41                        (d)
+         256   load_field 3                       (thinking)
+         257   store_var_load_var 53              (_153)
+         258   load_const 8                       (null)
+         259   cmp_op ==                          
+         260   pop_jump_if_false +3               (to 263)
+         261   load_const 26                      ("")
+         262   store_var 53                       (_153)
+         263   load_type 24                       
+         264   load_var 53                        (_153)
+         265   call 138 ntypeargs=1               (baml.String.from)
+         266   store_var 52                       (_151)
+         267   load_var2 2 51                     
+         268   load_var 52                        (_151)
+         269   bin_op +                           
+         270   store_field 0                      (thinking)
 
-  1108   259   jump -250                          (to 9)
+  1108   271   jump -262                          (to 9)
 
-  1127   260   load_type 24                       
-         261   load_var 2                         (state)
-         262   load_field 0                       (thinking)
-         263   call 138 ntypeargs=1               (baml.String.from)
-         264   store_var 51                       (_148)
-         265   load_var 41                        (d)
-         266   load_field 3                       (thinking)
-         267   store_var_load_var 53              (_153)
-         268   load_const 8                       (null)
-         269   cmp_op ==                          
-         270   pop_jump_if_false +3               (to 273)
-         271   load_const 26                      ("")
-         272   store_var 53                       (_153)
-         273   load_type 24                       
-         274   load_var 53                        (_153)
-         275   call 138 ntypeargs=1               (baml.String.from)
-         276   store_var 52                       (_151)
-         277   load_var2 2 51                     
-         278   load_var 52                        (_151)
-         279   bin_op +                           
-         280   store_field 0                      (thinking)
+  1116   272   load_var2 2 12                     
 
-  1108   281   jump -272                          (to 9)
+  1118   273   load_field 1                       (index)
 
-  1116   282   load_var2 2 12                     
+  1116   274   call 1195 ntypeargs=0              (anthropic.internal._anth_stream_call_at)
+         275   store_var 46                       (_136)
+         276   load_var 46                        (_136)
+         277   narrow_bind 27 46                  
+         278   pop_jump_if_false -269             (to 9)
+         279   load_var 46                        (_136)
+         280   store_var 47                       (call)
 
-  1118   283   load_field 1                       (index)
+  1120   281   load_type 24                       
+         282   load_var 47                        (call)
+         283   load_field 3                       (args_json)
+         284   call 138 ntypeargs=1               (baml.String.from)
+         285   store_var 48                       (_138)
+         286   load_var 41                        (d)
+         287   load_field 2                       (partial_json)
+         288   store_var_load_var 50              (_143)
+         289   load_const 8                       (null)
+         290   cmp_op ==                          
+         291   pop_jump_if_false +3               (to 294)
+         292   load_const 28                      ("")
+         293   store_var 50                       (_143)
+         294   load_type 24                       
+         295   load_var 50                        (_143)
+         296   call 138 ntypeargs=1               (baml.String.from)
+         297   store_var 49                       (_141)
+         298   load_var2 47 48                    
+         299   load_var 49                        (_141)
+         300   bin_op +                           
+         301   store_field 3                      (args_json)
 
-  1116   284   call 1195 ntypeargs=0              (anthropic.internal._anth_stream_call_at)
-         285   store_var 46                       (_136)
-         286   load_var 46                        (_136)
-         287   narrow_bind 27 46                  
-         288   pop_jump_if_false -279             (to 9)
-         289   load_var 46                        (_136)
-         290   store_var 47                       (call)
+  1116   302   jump -293                          (to 9)
 
-  1120   291   load_type 24                       
-         292   load_var 47                        (call)
-         293   load_field 3                       (args_json)
-         294   call 138 ntypeargs=1               (baml.String.from)
-         295   store_var 48                       (_138)
-         296   load_var 41                        (d)
-         297   load_field 2                       (partial_json)
-         298   store_var_load_var 50              (_143)
-         299   load_const 8                       (null)
-         300   cmp_op ==                          
-         301   pop_jump_if_false +3               (to 304)
-         302   load_const 28                      ("")
-         303   store_var 50                       (_143)
-         304   load_type 24                       
-         305   load_var 50                        (_143)
-         306   call 138 ntypeargs=1               (baml.String.from)
-         307   store_var 49                       (_141)
-         308   load_var2 47 48                    
-         309   load_var 49                        (_141)
-         310   bin_op +                           
-         311   store_field 3                      (args_json)
+  1110   303   load_var 41                        (d)
+         304   load_field 1                       (text)
+         305   store_var 44                       (_127)
+         306   load_var 44                        (_127)
+         307   narrow_bind 6 44                   
+         308   pop_jump_if_false -299             (to 9)
+         309   load_var 44                        (_127)
+         310   store_var 45                       (text)
 
-  1116   312   jump -303                          (to 9)
+  1111   311   load_type 0                        
+         312   load_var2 4 45                     
+         313   init_instance 1                    (ai.stream.TextDelta .text)
+         314   call 4 ntypeargs=1                 (baml.Array.push)
+         315   pop 1                              
+         316   jump -307                          (to 9)
 
-  1110   313   load_var 41                        (d)
-         314   load_field 1                       (text)
-         315   store_var 44                       (_127)
-         316   load_var 44                        (_127)
-         317   narrow_bind 6 44                   
-         318   pop_jump_if_false -309             (to 9)
-         319   load_var 44                        (_127)
-         320   store_var 45                       (text)
+  1071   317   load_var 12                        (event)
+         318   load_field 3                       (content_block)
+         319   store_var 25                       (_74)
+         320   load_var 25                        (_74)
+         321   narrow_bind 29 25                  
+         322   pop_jump_if_false -313             (to 9)
+         323   load_var 25                        (_74)
+         324   store_var_load_var 26              (block)
 
-  1111   321   load_type 0                        
-         322   load_var2 4 45                     
-         323   init_instance 1                    (ai.stream.TextDelta .text)
-         324   call 4 ntypeargs=1                 (baml.Array.push)
-         325   pop 1                              
-         326   jump -317                          (to 9)
+  1072   325   load_field 0                       (type)
+         326   store_var_load_var 28              (_77)
+         327   load_const 8                       (null)
+         328   cmp_op ==                          
+         329   pop_jump_if_false +3               (to 332)
+         330   load_const 30                      ("")
+         331   store_var 28                       (_77)
+         332   load_var 28                        (_77)
+         333   store_var_load_var 27              (kind)
 
-  1071   327   load_var 12                        (event)
-         328   load_field 3                       (content_block)
-         329   store_var 25                       (_74)
-         330   load_var 25                        (_74)
-         331   narrow_bind 29 25                  
-         332   pop_jump_if_false -323             (to 9)
-         333   load_var 25                        (_74)
-         334   store_var_load_var 26              (block)
+  1073   334   is_type 31                         
+         335   pop_jump_if_false +2               (to 337)
+         336   jump +44                           (to 380)
+         337   load_var 27                        (kind)
+         338   is_type 32                         
+         339   pop_jump_if_false +2               (to 341)
+         340   jump +18                           (to 358)
 
-  1072   335   load_field 0                       (type)
-         336   store_var_load_var 28              (_77)
-         337   load_const 8                       (null)
-         338   cmp_op ==                          
-         339   pop_jump_if_false +3               (to 342)
-         340   load_const 30                      ("")
-         341   store_var 28                       (_77)
-         342   load_var 28                        (_77)
-         343   store_var_load_var 27              (kind)
+  1091   341   load_var 26                        (block)
+         342   load_field 3                       (text)
+         343   store_var 38                       (_109)
+         344   load_var 38                        (_109)
+         345   narrow_bind 6 38                   
+         346   pop_jump_if_false -337             (to 9)
+         347   load_var 38                        (_109)
+         348   store_var_load_var 39              (text)
 
-  1073   344   load_const 31                      ("tool_use")
-         345   cmp_op ==                          
-         346   pop_jump_if_false +2               (to 348)
-         347   jump +45                           (to 392)
-         348   load_var 27                        (kind)
-         349   load_const 32                      ("thinking")
-         350   cmp_op ==                          
-         351   pop_jump_if_false +2               (to 353)
-         352   jump +18                           (to 370)
+  1092   349   load_const 33                      ("")
+         350   cmp_op !=                          
+         351   pop_jump_if_false -342             (to 9)
 
-  1091   353   load_var 26                        (block)
-         354   load_field 3                       (text)
-         355   store_var 38                       (_109)
-         356   load_var 38                        (_109)
-         357   narrow_bind 6 38                   
-         358   pop_jump_if_false -349             (to 9)
-         359   load_var 38                        (_109)
-         360   store_var_load_var 39              (text)
+  1093   352   load_type 0                        
+         353   load_var2 4 39                     
+         354   init_instance 2                    (ai.stream.TextDelta .text)
+         355   call 4 ntypeargs=1                 (baml.Array.push)
+         356   pop 1                              
+         357   jump -348                          (to 9)
 
-  1092   361   load_const 33                      ("")
-         362   cmp_op !=                          
-         363   pop_jump_if_false -354             (to 9)
-
-  1093   364   load_type 0                        
-         365   load_var2 4 39                     
-         366   init_instance 2                    (ai.stream.TextDelta .text)
-         367   call 4 ntypeargs=1                 (baml.Array.push)
-         368   pop 1                              
-         369   jump -360                          (to 9)
-
-  1086   370   load_type 24                       
-         371   load_var 2                         (state)
-         372   load_field 0                       (thinking)
+  1086   358   load_type 24                       
+         359   load_var 2                         (state)
+         360   load_field 0                       (thinking)
+         361   call 138 ntypeargs=1               (baml.String.from)
+         362   store_var 35                       (_99)
+         363   load_var 26                        (block)
+         364   load_field 4                       (thinking)
+         365   store_var_load_var 37              (_104)
+         366   load_const 8                       (null)
+         367   cmp_op ==                          
+         368   pop_jump_if_false +3               (to 371)
+         369   load_const 34                      ("")
+         370   store_var 37                       (_104)
+         371   load_type 24                       
+         372   load_var 37                        (_104)
          373   call 138 ntypeargs=1               (baml.String.from)
-         374   store_var 35                       (_99)
-         375   load_var 26                        (block)
-         376   load_field 4                       (thinking)
-         377   store_var_load_var 37              (_104)
-         378   load_const 8                       (null)
-         379   cmp_op ==                          
-         380   pop_jump_if_false +3               (to 383)
-         381   load_const 34                      ("")
-         382   store_var 37                       (_104)
-         383   load_type 24                       
-         384   load_var 37                        (_104)
-         385   call 138 ntypeargs=1               (baml.String.from)
-         386   store_var 36                       (_102)
-         387   load_var2 2 35                     
-         388   load_var 36                        (_102)
-         389   bin_op +                           
-         390   store_field 0                      (thinking)
+         374   store_var 36                       (_102)
+         375   load_var2 2 35                     
+         376   load_var 36                        (_102)
+         377   bin_op +                           
+         378   store_field 0                      (thinking)
 
-  1073   391   jump -382                          (to 9)
+  1073   379   jump -370                          (to 9)
 
-  1075   392   load_var 2                         (state)
-         393   load_field 2                       (tool_calls)
-         394   store_var 29                       (_82)
+  1075   380   load_var 2                         (state)
+         381   load_field 2                       (tool_calls)
+         382   store_var 29                       (_82)
 
-  1077   395   load_var 12                        (event)
-         396   load_field 1                       (index)
-         397   store_var_load_var 31              (_85)
+  1077   383   load_var 12                        (event)
+         384   load_field 1                       (index)
+         385   store_var_load_var 31              (_85)
+         386   load_const 8                       (null)
+         387   cmp_op ==                          
+         388   pop_jump_if_false +5               (to 393)
+         389   load_var 2                         (state)
+         390   load_field 2                       (tool_calls)
+         391   container_len                      
+         392   store_var 31                       (_85)
+         393   load_var 31                        (_85)
+         394   store_var 30                       (_84)
+
+  1078   395   load_var 26                        (block)
+         396   load_field 1                       (id)
+         397   store_var_load_var 33              (_90)
          398   load_const 8                       (null)
          399   cmp_op ==                          
-         400   pop_jump_if_false +5               (to 405)
-         401   load_var 2                         (state)
-         402   load_field 2                       (tool_calls)
-         403   container_len                      
-         404   store_var 31                       (_85)
-         405   load_var 31                        (_85)
-         406   store_var 30                       (_84)
+         400   pop_jump_if_false +3               (to 403)
+         401   load_const 35                      ("")
+         402   store_var 33                       (_90)
+         403   load_var 33                        (_90)
+         404   store_var 32                       (_89)
 
-  1078   407   load_var 26                        (block)
-         408   load_field 1                       (id)
-         409   store_var_load_var 33              (_90)
-         410   load_const 8                       (null)
-         411   cmp_op ==                          
-         412   pop_jump_if_false +3               (to 415)
-         413   load_const 35                      ("")
-         414   store_var 33                       (_90)
-         415   load_var 33                        (_90)
-         416   store_var 32                       (_89)
+  1079   405   load_var 26                        (block)
+         406   load_field 2                       (name)
+         407   store_var_load_var 34              (_94)
+         408   load_const 8                       (null)
+         409   cmp_op ==                          
+         410   pop_jump_if_false +3               (to 413)
+         411   load_const 36                      ("")
+         412   store_var 34                       (_94)
 
-  1079   417   load_var 26                        (block)
-         418   load_field 2                       (name)
-         419   store_var_load_var 34              (_94)
-         420   load_const 8                       (null)
-         421   cmp_op ==                          
-         422   pop_jump_if_false +3               (to 425)
-         423   load_const 36                      ("")
-         424   store_var 34                       (_94)
+  1075   413   load_type 37                       
+         414   load_var2 29 30                    
 
-  1075   425   load_type 37                       
-         426   load_var2 29 30                    
+  1076   415   load_var2 32 34                    
 
-  1076   427   load_var2 32 34                    
+  1079   416   load_const 38                      ("")
+         417   init_instance 3                    (anthropic.internal.AnthStreamToolCall .index, .id, .name, .args_json)
 
-  1079   428   load_const 38                      ("")
-         429   init_instance 3                    (anthropic.internal.AnthStreamToolCall .index, .id, .name, .args_json)
+  1075   418   call 4 ntypeargs=1                 (baml.Array.push)
+         419   pop 1                              
+         420   jump -411                          (to 9)
 
-  1075   430   call 4 ntypeargs=1                 (baml.Array.push)
-         431   pop 1                              
-         432   jump -423                          (to 9)
+  1045   421   load_var 12                        (event)
+         422   load_field 4                       (message)
+         423   store_var 16                       (_32)
+         424   load_var 16                        (_32)
+         425   narrow_bind 39 16                  
+         426   pop_jump_if_false +55              (to 481)
+         427   load_var 16                        (_32)
+         428   store_var 17                       (message)
 
-  1045   433   load_var 12                        (event)
-         434   load_field 4                       (message)
-         435   store_var 16                       (_32)
-         436   load_var 16                        (_32)
-         437   narrow_bind 39 16                  
-         438   pop_jump_if_false +55              (to 493)
-         439   load_var 16                        (_32)
-         440   store_var 17                       (message)
+  1046   429   load_var2 2 17                     
+         430   load_field 1                       (model)
+         431   store_field 7                      (model)
 
-  1046   441   load_var2 2 17                     
-         442   load_field 1                       (model)
-         443   store_field 7                      (model)
+  1047   432   load_var 17                        (message)
+         433   load_field 3                       (usage)
+         434   store_var 18                       (_35)
+         435   load_var 18                        (_35)
+         436   narrow_bind 17 18                  
+         437   pop_jump_if_false +44              (to 481)
+         438   load_var 18                        (_35)
+         439   store_var_load_var 19              (usage)
 
-  1047   444   load_var 17                        (message)
-         445   load_field 3                       (usage)
-         446   store_var 18                       (_35)
-         447   load_var 18                        (_35)
-         448   narrow_bind 17 18                  
-         449   pop_jump_if_false +44              (to 493)
-         450   load_var 18                        (_35)
-         451   store_var_load_var 19              (usage)
+  1049   440   load_field 2                       (cache_read_input_tokens)
+         441   store_var_load_var 20              (_37)
+         442   load_const 8                       (null)
+         443   cmp_op ==                          
+         444   pop_jump_if_false +4               (to 448)
+         445   load_var 2                         (state)
+         446   load_field 3                       (cache_read_input_tokens)
+         447   store_var 20                       (_37)
+         448   load_var2 2 20                     
+         449   store_field 3                      (cache_read_input_tokens)
 
-  1049   452   load_field 2                       (cache_read_input_tokens)
-         453   store_var_load_var 20              (_37)
-         454   load_const 8                       (null)
-         455   cmp_op ==                          
-         456   pop_jump_if_false +4               (to 460)
-         457   load_var 2                         (state)
-         458   load_field 3                       (cache_read_input_tokens)
-         459   store_var 20                       (_37)
-         460   load_var2 2 20                     
-         461   store_field 3                      (cache_read_input_tokens)
+  1051   450   load_var 19                        (usage)
+         451   load_field 3                       (cache_creation_input_tokens)
+         452   store_var_load_var 21              (_40)
 
-  1051   462   load_var 19                        (usage)
-         463   load_field 3                       (cache_creation_input_tokens)
-         464   store_var_load_var 21              (_40)
+  1052   453   load_const 8                       (null)
+         454   cmp_op ==                          
+         455   pop_jump_if_false +4               (to 459)
+         456   load_var 2                         (state)
+         457   load_field 4                       (cache_creation_input_tokens)
+         458   store_var 21                       (_40)
 
-  1052   465   load_const 8                       (null)
-         466   cmp_op ==                          
-         467   pop_jump_if_false +4               (to 471)
-         468   load_var 2                         (state)
-         469   load_field 4                       (cache_creation_input_tokens)
-         470   store_var 21                       (_40)
+  1051   459   load_var2 2 21                     
+         460   store_field 4                      (cache_creation_input_tokens)
 
-  1051   471   load_var2 2 21                     
-         472   store_field 4                      (cache_creation_input_tokens)
+  1054   461   load_var 19                        (usage)
+         462   load_field 4                       (output_tokens_details)
+         463   load_const 8                       (null)
+         464   cmp_op ==                          
+         465   pop_jump_if_false +2               (to 467)
+         466   jump +5                            (to 471)
+         467   load_var 19                        (usage)
+         468   load_field 4                       (output_tokens_details)
+         469   load_field 0                       (0)
+         470   jump +2                            (to 472)
+         471   load_const 8                       (null)
+         472   store_var_load_var 22              (_43)
+         473   load_const 8                       (null)
+         474   cmp_op ==                          
+         475   pop_jump_if_false +4               (to 479)
 
-  1054   473   load_var 19                        (usage)
-         474   load_field 4                       (output_tokens_details)
-         475   load_const 8                       (null)
-         476   cmp_op ==                          
-         477   pop_jump_if_false +2               (to 479)
-         478   jump +5                            (to 483)
-         479   load_var 19                        (usage)
-         480   load_field 4                       (output_tokens_details)
-         481   load_field 0                       (0)
-         482   jump +2                            (to 484)
+  1055   476   load_var 2                         (state)
+         477   load_field 5                       (reasoning_tokens)
+         478   store_var 22                       (_43)
+
+  1054   479   load_var2 2 22                     
+         480   store_field 5                      (reasoning_tokens)
+
+  1064   481   load_var 12                        (event)
+         482   load_field 4                       (message)
          483   load_const 8                       (null)
-         484   store_var_load_var 22              (_43)
-         485   load_const 8                       (null)
-         486   cmp_op ==                          
-         487   pop_jump_if_false +4               (to 491)
+         484   cmp_op ==                          
+         485   pop_jump_if_false +2               (to 487)
+         486   jump +20                           (to 506)
+         487   load_var 12                        (event)
+         488   load_field 4                       (message)
+         489   load_field 3                       (3)
+         490   load_const 8                       (null)
+         491   cmp_op ==                          
+         492   pop_jump_if_false +2               (to 494)
+         493   jump +13                           (to 506)
+         494   load_var 12                        (event)
+         495   load_field 4                       (message)
+         496   load_const 8                       (null)
+         497   cmp_op ==                          
+         498   pop_jump_if_false +2               (to 500)
+         499   jump +7                            (to 506)
+         500   load_var 12                        (event)
+         501   load_field 4                       (message)
+         502   load_field 3                       (3)
+         503   load_field 0                       (0)
+         504   store_var 23                       (_51)
+         505   jump +3                            (to 508)
+         506   load_const 8                       (null)
+         507   store_var 23                       (_51)
 
-  1055   488   load_var 2                         (state)
-         489   load_field 5                       (reasoning_tokens)
-         490   store_var 22                       (_43)
+  1065   508   load_var 12                        (event)
+         509   load_field 4                       (message)
+         510   load_const 8                       (null)
+         511   cmp_op ==                          
+         512   pop_jump_if_false +2               (to 514)
+         513   jump +20                           (to 533)
+         514   load_var 12                        (event)
+         515   load_field 4                       (message)
+         516   load_field 3                       (3)
+         517   load_const 8                       (null)
+         518   cmp_op ==                          
+         519   pop_jump_if_false +2               (to 521)
+         520   jump +13                           (to 533)
+         521   load_var 12                        (event)
+         522   load_field 4                       (message)
+         523   load_const 8                       (null)
+         524   cmp_op ==                          
+         525   pop_jump_if_false +2               (to 527)
+         526   jump +7                            (to 533)
+         527   load_var 12                        (event)
+         528   load_field 4                       (message)
+         529   load_field 3                       (3)
+         530   load_field 1                       (1)
+         531   store_var 24                       (_61)
+         532   jump +3                            (to 535)
+         533   load_const 8                       (null)
+         534   store_var 24                       (_61)
 
-  1054   491   load_var2 2 22                     
-         492   store_field 5                      (reasoning_tokens)
+  1061   535   load_type 0                        
+         536   load_var 4                         (out)
 
-  1064   493   load_var 12                        (event)
-         494   load_field 4                       (message)
-         495   load_const 8                       (null)
-         496   cmp_op ==                          
-         497   pop_jump_if_false +2               (to 499)
-         498   jump +20                           (to 518)
-         499   load_var 12                        (event)
-         500   load_field 4                       (message)
-         501   load_field 3                       (3)
-         502   load_const 8                       (null)
-         503   cmp_op ==                          
-         504   pop_jump_if_false +2               (to 506)
-         505   jump +13                           (to 518)
-         506   load_var 12                        (event)
-         507   load_field 4                       (message)
-         508   load_const 8                       (null)
-         509   cmp_op ==                          
-         510   pop_jump_if_false +2               (to 512)
-         511   jump +7                            (to 518)
-         512   load_var 12                        (event)
-         513   load_field 4                       (message)
-         514   load_field 3                       (3)
-         515   load_field 0                       (0)
-         516   store_var 23                       (_51)
-         517   jump +3                            (to 520)
-         518   load_const 8                       (null)
-         519   store_var 23                       (_51)
+  1062   537   load_const 8                       (null)
+         538   load_var2 23 24                    
+         539   init_instance 4                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
 
-  1065   520   load_var 12                        (event)
-         521   load_field 4                       (message)
-         522   load_const 8                       (null)
-         523   cmp_op ==                          
-         524   pop_jump_if_false +2               (to 526)
-         525   jump +20                           (to 545)
-         526   load_var 12                        (event)
-         527   load_field 4                       (message)
-         528   load_field 3                       (3)
-         529   load_const 8                       (null)
-         530   cmp_op ==                          
-         531   pop_jump_if_false +2               (to 533)
-         532   jump +13                           (to 545)
-         533   load_var 12                        (event)
-         534   load_field 4                       (message)
-         535   load_const 8                       (null)
-         536   cmp_op ==                          
-         537   pop_jump_if_false +2               (to 539)
-         538   jump +7                            (to 545)
-         539   load_var 12                        (event)
-         540   load_field 4                       (message)
-         541   load_field 3                       (3)
-         542   load_field 1                       (1)
-         543   store_var 24                       (_61)
-         544   jump +3                            (to 547)
-         545   load_const 8                       (null)
-         546   store_var 24                       (_61)
+  1061   540   call 4 ntypeargs=1                 (baml.Array.push)
+         541   pop 1                              
+         542   jump -533                          (to 9)
 
-  1061   547   load_type 0                        
-         548   load_var 4                         (out)
+  1042   543   load_var 12                        (event)
+         544   load_field 6                       (error)
+         545   load_var 9                         (data)
+         546   call 1196 ntypeargs=0              (anthropic.internal._anth_stream_failure)
+         547   throw                              
 
-  1062   549   load_const 8                       (null)
-         550   load_var2 23 24                    
-         551   init_instance 4                    (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
-
-  1061   552   call 4 ntypeargs=1                 (baml.Array.push)
-         553   pop 1                              
-         554   jump -545                          (to 9)
-
-  1042   555   load_var 12                        (event)
-         556   load_field 6                       (error)
-         557   load_var 9                         (data)
-         558   call 1196 ntypeargs=0              (anthropic.internal._anth_stream_failure)
-         559   throw                              
-
-  1185   560   load_var 4                         (out)
-         561   store_var 3                        (_0)
-         562   load_var 3                         (_0)
-         563   return                             
+  1185   548   load_var 4                         (out)
+         549   store_var 3                        (_0)
+         550   load_var 3                         (_0)
+         551   return                             
 }
 
 function anthropic.internal.anthropic_messages_body(params: anthropic.internal.AnthropicBodyParams, input: ai.ModelTurnInput, stream: bool) -> string {
@@ -9786,185 +9751,182 @@ function anthropic.internal.anthropic_parse(resp: anthropic.internal.AnthropicRe
         14    load_var 4                         (_5)
         15    is_type 5                          
         16    pop_jump_if_false +2               (to 18)
-        17    jump +86                           (to 103)
+        17    jump +83                           (to 100)
         18    load_var 4                         (_5)
         19    store_var 5                        (b)
 
   810   20    load_var 5                         (b)
         21    load_field 0                       (type)
         22    store_var_load_var 6               (_9)
-        23    load_const 6                       ("text")
-        24    cmp_op ==                          
-        25    pop_jump_if_false +2               (to 27)
-        26    jump +63                           (to 89)
-        27    load_var 6                         (_9)
-        28    load_const 7                       ("thinking")
-        29    cmp_op ==                          
-        30    pop_jump_if_false +2               (to 32)
-        31    jump +44                           (to 75)
-        32    load_var 6                         (_9)
-        33    load_const 8                       ("tool_use")
-        34    cmp_op ==                          
-        35    pop_jump_if_false -26              (to 9)
+        23    is_type 6                          
+        24    pop_jump_if_false +2               (to 26)
+        25    jump +61                           (to 86)
+        26    load_var 6                         (_9)
+        27    is_type 7                          
+        28    pop_jump_if_false +2               (to 30)
+        29    jump +43                           (to 72)
+        30    load_var 6                         (_9)
+        31    is_type 8                          
+        32    pop_jump_if_false -23              (to 9)
 
-  820   36    load_type 9                        
-        37    load_type 10                       
-        38    alloc_map 0                        
-        39    store_var 9                        (empty_args)
+  820   33    load_type 9                        
+        34    load_type 10                       
+        35    alloc_map 0                        
+        36    store_var 9                        (empty_args)
 
-  823   40    load_var 5                         (b)
-        41    load_field 4                       (id)
-        42    store_var_load_var 11              (_31)
-        43    load_const 11                      (null)
-        44    cmp_op ==                          
-        45    pop_jump_if_false +3               (to 48)
-        46    load_const 12                      ("")
-        47    store_var 11                       (_31)
-        48    load_var 11                        (_31)
-        49    store_var 10                       (_30)
+  823   37    load_var 5                         (b)
+        38    load_field 4                       (id)
+        39    store_var_load_var 11              (_31)
+        40    load_const 11                      (null)
+        41    cmp_op ==                          
+        42    pop_jump_if_false +3               (to 45)
+        43    load_const 12                      ("")
+        44    store_var 11                       (_31)
+        45    load_var 11                        (_31)
+        46    store_var 10                       (_30)
 
-  824   50    load_var 5                         (b)
-        51    load_field 5                       (name)
-        52    store_var_load_var 13              (_35)
-        53    load_const 11                      (null)
-        54    cmp_op ==                          
-        55    pop_jump_if_false +3               (to 58)
-        56    load_const 13                      ("")
-        57    store_var 13                       (_35)
-        58    load_var 13                        (_35)
-        59    store_var 12                       (_34)
+  824   47    load_var 5                         (b)
+        48    load_field 5                       (name)
+        49    store_var_load_var 13              (_35)
+        50    load_const 11                      (null)
+        51    cmp_op ==                          
+        52    pop_jump_if_false +3               (to 55)
+        53    load_const 13                      ("")
+        54    store_var 13                       (_35)
+        55    load_var 13                        (_35)
+        56    store_var 12                       (_34)
 
-  825   60    load_var 5                         (b)
-        61    load_field 6                       (input)
-        62    store_var_load_var 14              (_39)
-        63    load_const 11                      (null)
-        64    cmp_op ==                          
-        65    pop_jump_if_false +3               (to 68)
-        66    load_var 9                         (empty_args)
-        67    store_var 14                       (_39)
+  825   57    load_var 5                         (b)
+        58    load_field 6                       (input)
+        59    store_var_load_var 14              (_39)
+        60    load_const 11                      (null)
+        61    cmp_op ==                          
+        62    pop_jump_if_false +3               (to 65)
+        63    load_var 9                         (empty_args)
+        64    store_var 14                       (_39)
 
-  821   68    load_type 0                        
-        69    load_var2 2 10                     
+  821   65    load_type 0                        
+        66    load_var2 2 10                     
 
-  822   70    load_var2 12 14                    
+  822   67    load_var2 12 14                    
 
-  825   71    init_instance 0                    (ai.content.ToolUse .id, .name, .args)
+  825   68    init_instance 0                    (ai.content.ToolUse .id, .name, .args)
 
-  821   72    call 4 ntypeargs=1                 (baml.Array.push)
-        73    pop 1                              
-        74    jump -65                           (to 9)
+  821   69    call 4 ntypeargs=1                 (baml.Array.push)
+        70    pop 1                              
+        71    jump -62                           (to 9)
 
-  816   75    load_var 5                         (b)
-        76    load_field 2                       (thinking)
-        77    store_var_load_var 8               (_22)
-        78    load_const 11                      (null)
-        79    cmp_op ==                          
-        80    pop_jump_if_false +3               (to 83)
-        81    load_const 14                      ("")
-        82    store_var 8                        (_22)
-        83    load_type 0                        
-        84    load_var2 2 8                      
-        85    init_instance 1                    (ai.content.Reasoning .summary)
-        86    call 4 ntypeargs=1                 (baml.Array.push)
-        87    pop 1                              
-        88    jump -79                           (to 9)
+  816   72    load_var 5                         (b)
+        73    load_field 2                       (thinking)
+        74    store_var_load_var 8               (_22)
+        75    load_const 11                      (null)
+        76    cmp_op ==                          
+        77    pop_jump_if_false +3               (to 80)
+        78    load_const 14                      ("")
+        79    store_var 8                        (_22)
+        80    load_type 0                        
+        81    load_var2 2 8                      
+        82    init_instance 1                    (ai.content.Reasoning .summary)
+        83    call 4 ntypeargs=1                 (baml.Array.push)
+        84    pop 1                              
+        85    jump -76                           (to 9)
 
-  812   89    load_var 5                         (b)
-        90    load_field 1                       (text)
-        91    store_var_load_var 7               (_14)
-        92    load_const 11                      (null)
-        93    cmp_op ==                          
-        94    pop_jump_if_false +3               (to 97)
-        95    load_const 15                      ("")
-        96    store_var 7                        (_14)
-        97    load_type 0                        
-        98    load_var2 2 7                      
-        99    init_instance 2                    (ai.content.Text .text)
-        100   call 4 ntypeargs=1                 (baml.Array.push)
-        101   pop 1                              
-        102   jump -93                           (to 9)
+  812   86    load_var 5                         (b)
+        87    load_field 1                       (text)
+        88    store_var_load_var 7               (_14)
+        89    load_const 11                      (null)
+        90    cmp_op ==                          
+        91    pop_jump_if_false +3               (to 94)
+        92    load_const 15                      ("")
+        93    store_var 7                        (_14)
+        94    load_type 0                        
+        95    load_var2 2 7                      
+        96    init_instance 2                    (ai.content.Text .text)
+        97    call 4 ntypeargs=1                 (baml.Array.push)
+        98    pop 1                              
+        99    jump -90                           (to 9)
 
-  836   103   load_var 1                         (resp)
-        104   load_field 5                       (stop_reason)
-        105   store_var_load_var 16              (_44)
-        106   load_const 11                      (null)
-        107   cmp_op ==                          
-        108   pop_jump_if_false +2               (to 110)
-        109   jump +6                            (to 115)
-        110   load_var 16                        (_44)
-        111   store_var_load_var 17              (s)
+  836   100   load_var 1                         (resp)
+        101   load_field 5                       (stop_reason)
+        102   store_var_load_var 16              (_44)
+        103   load_const 11                      (null)
+        104   cmp_op ==                          
+        105   pop_jump_if_false +2               (to 107)
+        106   jump +6                            (to 112)
+        107   load_var 16                        (_44)
+        108   store_var_load_var 17              (s)
 
-  838   112   call 1190 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
-        113   store_var 15                       (stop)
-        114   jump +4                            (to 118)
+  838   109   call 1190 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
+        110   store_var 15                       (stop)
+        111   jump +4                            (to 115)
 
-  837   115   load_const 16                      (ai.content.StopReason.Complete)
-        116   alloc_variant 774                  (ai.content.StopReason)
-        117   store_var 15                       (stop)
+  837   112   load_const 16                      (ai.content.StopReason.Complete)
+        113   alloc_variant 774                  (ai.content.StopReason)
+        114   store_var 15                       (stop)
 
-  841   118   load_var 1                         (resp)
-        119   load_field 7                       (usage)
-        120   store_var 19                       (_50)
-        121   load_var 19                        (_50)
-        122   narrow_bind 17 19                  
-        123   pop_jump_if_false +2               (to 125)
-        124   jump +4                            (to 128)
+  841   115   load_var 1                         (resp)
+        116   load_field 7                       (usage)
+        117   store_var 19                       (_50)
+        118   load_var 19                        (_50)
+        119   narrow_bind 17 19                  
+        120   pop_jump_if_false +2               (to 122)
+        121   jump +4                            (to 125)
 
-  855   125   load_const 11                      (null)
-        126   store_var 18                       (usage)
+  855   122   load_const 11                      (null)
+        123   store_var 18                       (usage)
 
-  841   127   jump +42                           (to 169)
-        128   load_var 19                        (_50)
-        129   store_var_load_var 20              (u)
+  841   124   jump +42                           (to 166)
+        125   load_var 19                        (_50)
+        126   store_var_load_var 20              (u)
 
-  844   130   load_field 0                       (input_tokens)
-        131   store_var_load_var 22              (_53)
-        132   load_const 11                      (null)
-        133   cmp_op ==                          
-        134   pop_jump_if_false +3               (to 137)
-        135   load_const 16                      (0)
-        136   store_var 22                       (_53)
-        137   load_var 22                        (_53)
-        138   store_var 21                       (_52)
+  844   127   load_field 0                       (input_tokens)
+        128   store_var_load_var 22              (_53)
+        129   load_const 11                      (null)
+        130   cmp_op ==                          
+        131   pop_jump_if_false +3               (to 134)
+        132   load_const 16                      (0)
+        133   store_var 22                       (_53)
+        134   load_var 22                        (_53)
+        135   store_var 21                       (_52)
 
-  845   139   load_var 20                        (u)
-        140   load_field 1                       (output_tokens)
-        141   store_var_load_var 24              (_57)
-        142   load_const 11                      (null)
-        143   cmp_op ==                          
-        144   pop_jump_if_false +3               (to 147)
-        145   load_const 16                      (0)
-        146   store_var 24                       (_57)
-        147   load_var 24                        (_57)
-        148   store_var 23                       (_56)
+  845   136   load_var 20                        (u)
+        137   load_field 1                       (output_tokens)
+        138   store_var_load_var 24              (_57)
+        139   load_const 11                      (null)
+        140   cmp_op ==                          
+        141   pop_jump_if_false +3               (to 144)
+        142   load_const 16                      (0)
+        143   store_var 24                       (_57)
+        144   load_var 24                        (_57)
+        145   store_var 23                       (_56)
 
-  850   149   load_var 20                        (u)
-        150   load_field 3                       (cache_read_input_tokens)
-        151   store_var 25                       (_60)
+  850   146   load_var 20                        (u)
+        147   load_field 3                       (cache_read_input_tokens)
+        148   store_var 25                       (_60)
 
-  852   152   load_var 20                        (u)
-        153   load_field 2                       (output_tokens_details)
-        154   load_const 11                      (null)
-        155   cmp_op ==                          
-        156   pop_jump_if_false +2               (to 158)
-        157   jump +6                            (to 163)
-        158   load_var 20                        (u)
-        159   load_field 2                       (output_tokens_details)
-        160   load_field 0                       (0)
+  852   149   load_var 20                        (u)
+        150   load_field 2                       (output_tokens_details)
+        151   load_const 11                      (null)
+        152   cmp_op ==                          
+        153   pop_jump_if_false +2               (to 155)
+        154   jump +6                            (to 160)
+        155   load_var 20                        (u)
+        156   load_field 2                       (output_tokens_details)
+        157   load_field 0                       (0)
+        158   store_var 26                       (_61)
+        159   jump +3                            (to 162)
+        160   load_const 11                      (null)
         161   store_var 26                       (_61)
-        162   jump +3                            (to 165)
-        163   load_const 11                      (null)
-        164   store_var 26                       (_61)
 
-  843   165   load_var2 21 23                    
-        166   load_var2 25 26                    
-        167   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
-        168   store_var 18                       (usage)
+  843   162   load_var2 21 23                    
+        163   load_var2 25 26                    
+        164   init_instance 3                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
+        165   store_var 18                       (usage)
 
-  858   169   load_var2 2 15                     
-        170   load_var 18                        (usage)
-        171   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
-        172   return                             
+  858   166   load_var2 2 15                     
+        167   load_var 18                        (usage)
+        168   init_instance 4                    (ai.ModelTurn .content, .stop_reason, .usage)
+        169   return                             
 }
 
 function anthropic.internal.anthropic_render(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> baml.http.Request {
@@ -10040,7 +10002,7 @@ function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: a
 
   1238   40   load_var2 3 7           
 
-  1239   41   make_closure 3356 1     
+  1239   41   make_closure 3273 1     
          42   load_const 8            ("anthropic")
 
   1237   43   call 959 ntypeargs=0    (ai.stream.TurnStream.from_sse)
@@ -10820,194 +10782,174 @@ function aws.internal._audio_block(audio: baml.media.Audio) -> aws.internal.Cont
 
 function aws.internal._audio_format(mime: string) -> string {
   443   0     load_var 1              (mime)
-        1     load_const 0            ("audio/mpeg")
-        2     cmp_op ==               
-        3     pop_jump_if_false +2    (to 5)
-        4     jump +143               (to 147)
-        5     load_var 1              (mime)
-        6     load_const 1            ("audio/mp3")
-        7     cmp_op ==               
-        8     pop_jump_if_false +2    (to 10)
-        9     jump +136               (to 145)
-        10    load_var 1              (mime)
-        11    load_const 2            ("audio/wav")
-        12    cmp_op ==               
-        13    pop_jump_if_false +2    (to 15)
-        14    jump +129               (to 143)
-        15    load_var 1              (mime)
-        16    load_const 3            ("audio/x-wav")
-        17    cmp_op ==               
+        1     is_type 0               
+        2     pop_jump_if_false +2    (to 4)
+        3     jump +124               (to 127)
+        4     load_var 1              (mime)
+        5     is_type 1               
+        6     pop_jump_if_false +2    (to 8)
+        7     jump +118               (to 125)
+        8     load_var 1              (mime)
+        9     is_type 2               
+        10    pop_jump_if_false +2    (to 12)
+        11    jump +112               (to 123)
+        12    load_var 1              (mime)
+        13    is_type 3               
+        14    pop_jump_if_false +2    (to 16)
+        15    jump +106               (to 121)
+        16    load_var 1              (mime)
+        17    is_type 4               
         18    pop_jump_if_false +2    (to 20)
-        19    jump +122               (to 141)
+        19    jump +100               (to 119)
         20    load_var 1              (mime)
-        21    load_const 4            ("audio/wave")
-        22    cmp_op ==               
-        23    pop_jump_if_false +2    (to 25)
-        24    jump +115               (to 139)
-        25    load_var 1              (mime)
-        26    load_const 5            ("audio/flac")
-        27    cmp_op ==               
-        28    pop_jump_if_false +2    (to 30)
-        29    jump +108               (to 137)
-        30    load_var 1              (mime)
-        31    load_const 6            ("audio/x-flac")
-        32    cmp_op ==               
-        33    pop_jump_if_false +2    (to 35)
-        34    jump +101               (to 135)
-        35    load_var 1              (mime)
-        36    load_const 7            ("audio/ogg")
-        37    cmp_op ==               
+        21    is_type 5               
+        22    pop_jump_if_false +2    (to 24)
+        23    jump +94                (to 117)
+        24    load_var 1              (mime)
+        25    is_type 6               
+        26    pop_jump_if_false +2    (to 28)
+        27    jump +88                (to 115)
+        28    load_var 1              (mime)
+        29    is_type 7               
+        30    pop_jump_if_false +2    (to 32)
+        31    jump +82                (to 113)
+        32    load_var 1              (mime)
+        33    is_type 8               
+        34    pop_jump_if_false +2    (to 36)
+        35    jump +76                (to 111)
+        36    load_var 1              (mime)
+        37    is_type 9               
         38    pop_jump_if_false +2    (to 40)
-        39    jump +94                (to 133)
+        39    jump +70                (to 109)
         40    load_var 1              (mime)
-        41    load_const 8            ("audio/opus")
-        42    cmp_op ==               
-        43    pop_jump_if_false +2    (to 45)
-        44    jump +87                (to 131)
-        45    load_var 1              (mime)
-        46    load_const 9            ("audio/aac")
-        47    cmp_op ==               
-        48    pop_jump_if_false +2    (to 50)
-        49    jump +80                (to 129)
-        50    load_var 1              (mime)
-        51    load_const 10           ("audio/x-aac")
-        52    cmp_op ==               
-        53    pop_jump_if_false +2    (to 55)
-        54    jump +73                (to 127)
-        55    load_var 1              (mime)
-        56    load_const 11           ("audio/mp4")
-        57    cmp_op ==               
+        41    is_type 10              
+        42    pop_jump_if_false +2    (to 44)
+        43    jump +64                (to 107)
+        44    load_var 1              (mime)
+        45    is_type 11              
+        46    pop_jump_if_false +2    (to 48)
+        47    jump +58                (to 105)
+        48    load_var 1              (mime)
+        49    is_type 12              
+        50    pop_jump_if_false +2    (to 52)
+        51    jump +52                (to 103)
+        52    load_var 1              (mime)
+        53    is_type 13              
+        54    pop_jump_if_false +2    (to 56)
+        55    jump +46                (to 101)
+        56    load_var 1              (mime)
+        57    is_type 14              
         58    pop_jump_if_false +2    (to 60)
-        59    jump +66                (to 125)
+        59    jump +40                (to 99)
         60    load_var 1              (mime)
-        61    load_const 12           ("audio/m4a")
-        62    cmp_op ==               
-        63    pop_jump_if_false +2    (to 65)
-        64    jump +59                (to 123)
-        65    load_var 1              (mime)
-        66    load_const 13           ("audio/x-m4a")
-        67    cmp_op ==               
-        68    pop_jump_if_false +2    (to 70)
-        69    jump +52                (to 121)
-        70    load_var 1              (mime)
-        71    load_const 14           ("audio/x-matroska")
-        72    cmp_op ==               
-        73    pop_jump_if_false +2    (to 75)
-        74    jump +45                (to 119)
-        75    load_var 1              (mime)
-        76    load_const 15           ("audio/mpga")
-        77    cmp_op ==               
+        61    is_type 15              
+        62    pop_jump_if_false +2    (to 64)
+        63    jump +34                (to 97)
+        64    load_var 1              (mime)
+        65    is_type 16              
+        66    pop_jump_if_false +2    (to 68)
+        67    jump +28                (to 95)
+        68    load_var 1              (mime)
+        69    is_type 17              
+        70    pop_jump_if_false +2    (to 72)
+        71    jump +22                (to 93)
+        72    load_var 1              (mime)
+        73    is_type 18              
+        74    pop_jump_if_false +2    (to 76)
+        75    jump +16                (to 91)
+        76    load_var 1              (mime)
+        77    is_type 19              
         78    pop_jump_if_false +2    (to 80)
-        79    jump +38                (to 117)
-        80    load_var 1              (mime)
-        81    load_const 16           ("audio/pcm")
-        82    cmp_op ==               
-        83    pop_jump_if_false +2    (to 85)
-        84    jump +31                (to 115)
-        85    load_var 1              (mime)
-        86    load_const 17           ("audio/x-pcm")
-        87    cmp_op ==               
-        88    pop_jump_if_false +2    (to 90)
-        89    jump +24                (to 113)
-        90    load_var 1              (mime)
-        91    load_const 18           ("audio/L16")
-        92    cmp_op ==               
-        93    pop_jump_if_false +2    (to 95)
-        94    jump +17                (to 111)
-        95    load_var 1              (mime)
-        96    load_const 19           ("audio/webm")
-        97    cmp_op ==               
-        98    pop_jump_if_false +2    (to 100)
-        99    jump +10                (to 109)
+        79    jump +10                (to 89)
 
-  457   100   load_type 20            
-        101   load_var 1              (mime)
-        102   call 138 ntypeargs=1    (baml.String.from)
-        103   store_var 2             (_24)
-        104   load_const 21           ("unsupported audio format for Bedrock: ")
-        105   load_var 2              (_24)
-        106   bin_op +                
-        107   call 1294 ntypeargs=0   (aws.internal._reject)
-        108   throw                   
+  457   80    load_type 20            
+        81    load_var 1              (mime)
+        82    call 138 ntypeargs=1    (baml.String.from)
+        83    store_var 2             (_24)
+        84    load_const 21           ("unsupported audio format for Bedrock: ")
+        85    load_var 2              (_24)
+        86    bin_op +                
+        87    call 1294 ntypeargs=0   (aws.internal._reject)
+        88    throw                   
 
-  456   109   load_const 22           ("webm")
+  456   89    load_const 22           ("webm")
 
-  443   110   jump +38                (to 148)
+  443   90    jump +38                (to 128)
 
-  455   111   load_const 23           ("pcm")
+  455   91    load_const 23           ("pcm")
 
-  443   112   jump +36                (to 148)
+  443   92    jump +36                (to 128)
 
-  455   113   load_const 24           ("pcm")
+  455   93    load_const 24           ("pcm")
 
-  443   114   jump +34                (to 148)
+  443   94    jump +34                (to 128)
 
-  455   115   load_const 25           ("pcm")
+  455   95    load_const 25           ("pcm")
 
-  443   116   jump +32                (to 148)
+  443   96    jump +32                (to 128)
 
-  454   117   load_const 26           ("mpga")
+  454   97    load_const 26           ("mpga")
 
-  443   118   jump +30                (to 148)
+  443   98    jump +30                (to 128)
 
-  453   119   load_const 27           ("mka")
+  453   99    load_const 27           ("mka")
 
-  443   120   jump +28                (to 148)
+  443   100   jump +28                (to 128)
 
-  452   121   load_const 28           ("m4a")
+  452   101   load_const 28           ("m4a")
 
-  443   122   jump +26                (to 148)
+  443   102   jump +26                (to 128)
 
-  452   123   load_const 29           ("m4a")
+  452   103   load_const 29           ("m4a")
 
-  443   124   jump +24                (to 148)
+  443   104   jump +24                (to 128)
 
-  451   125   load_const 30           ("mp4")
+  451   105   load_const 30           ("mp4")
 
-  443   126   jump +22                (to 148)
+  443   106   jump +22                (to 128)
 
-  450   127   load_const 31           ("x-aac")
+  450   107   load_const 31           ("x-aac")
 
-  443   128   jump +20                (to 148)
+  443   108   jump +20                (to 128)
 
-  449   129   load_const 32           ("aac")
+  449   109   load_const 32           ("aac")
 
-  443   130   jump +18                (to 148)
+  443   110   jump +18                (to 128)
 
-  448   131   load_const 33           ("opus")
+  448   111   load_const 33           ("opus")
 
-  443   132   jump +16                (to 148)
+  443   112   jump +16                (to 128)
 
-  447   133   load_const 34           ("ogg")
+  447   113   load_const 34           ("ogg")
 
-  443   134   jump +14                (to 148)
+  443   114   jump +14                (to 128)
 
-  446   135   load_const 35           ("flac")
+  446   115   load_const 35           ("flac")
 
-  443   136   jump +12                (to 148)
+  443   116   jump +12                (to 128)
 
-  446   137   load_const 36           ("flac")
+  446   117   load_const 36           ("flac")
 
-  443   138   jump +10                (to 148)
+  443   118   jump +10                (to 128)
 
-  445   139   load_const 37           ("wav")
+  445   119   load_const 37           ("wav")
 
-  443   140   jump +8                 (to 148)
+  443   120   jump +8                 (to 128)
 
-  445   141   load_const 38           ("wav")
+  445   121   load_const 38           ("wav")
 
-  443   142   jump +6                 (to 148)
+  443   122   jump +6                 (to 128)
 
-  445   143   load_const 39           ("wav")
+  445   123   load_const 39           ("wav")
 
-  443   144   jump +4                 (to 148)
+  443   124   jump +4                 (to 128)
 
-  444   145   load_const 40           ("mp3")
+  444   125   load_const 40           ("mp3")
 
-  443   146   jump +2                 (to 148)
+  443   126   jump +2                 (to 128)
 
-  444   147   load_const 41           ("mp3")
-        148   return                  
+  444   127   load_const 41           ("mp3")
+        128   return                  
 }
 
 function aws.internal._conversation_role(role: string) -> string {
@@ -11108,59 +11050,54 @@ function aws.internal._image_block(image: baml.media.Image) -> aws.internal.Cont
 
 function aws.internal._image_format(mime: string) -> string {
   411   0    load_var 1              (mime)
-        1    load_const 0            ("image/png")
-        2    cmp_op ==               
-        3    pop_jump_if_false +2    (to 5)
-        4    jump +38                (to 42)
-        5    load_var 1              (mime)
-        6    load_const 1            ("image/jpeg")
-        7    cmp_op ==               
-        8    pop_jump_if_false +2    (to 10)
-        9    jump +31                (to 40)
-        10   load_var 1              (mime)
-        11   load_const 2            ("image/jpg")
-        12   cmp_op ==               
-        13   pop_jump_if_false +2    (to 15)
-        14   jump +24                (to 38)
-        15   load_var 1              (mime)
-        16   load_const 3            ("image/gif")
-        17   cmp_op ==               
+        1    is_type 0               
+        2    pop_jump_if_false +2    (to 4)
+        3    jump +34                (to 37)
+        4    load_var 1              (mime)
+        5    is_type 1               
+        6    pop_jump_if_false +2    (to 8)
+        7    jump +28                (to 35)
+        8    load_var 1              (mime)
+        9    is_type 2               
+        10   pop_jump_if_false +2    (to 12)
+        11   jump +22                (to 33)
+        12   load_var 1              (mime)
+        13   is_type 3               
+        14   pop_jump_if_false +2    (to 16)
+        15   jump +16                (to 31)
+        16   load_var 1              (mime)
+        17   is_type 4               
         18   pop_jump_if_false +2    (to 20)
-        19   jump +17                (to 36)
-        20   load_var 1              (mime)
-        21   load_const 4            ("image/webp")
-        22   cmp_op ==               
-        23   pop_jump_if_false +2    (to 25)
-        24   jump +10                (to 34)
+        19   jump +10                (to 29)
 
-  416   25   load_type 5             
-        26   load_var 1              (mime)
-        27   call 138 ntypeargs=1    (baml.String.from)
-        28   store_var 2             (_9)
-        29   load_const 6            ("unsupported image format for Bedrock: ")
-        30   load_var 2              (_9)
-        31   bin_op +                
-        32   call 1294 ntypeargs=0   (aws.internal._reject)
-        33   throw                   
+  416   20   load_type 5             
+        21   load_var 1              (mime)
+        22   call 138 ntypeargs=1    (baml.String.from)
+        23   store_var 2             (_9)
+        24   load_const 6            ("unsupported image format for Bedrock: ")
+        25   load_var 2              (_9)
+        26   bin_op +                
+        27   call 1294 ntypeargs=0   (aws.internal._reject)
+        28   throw                   
 
-  415   34   load_const 7            ("webp")
+  415   29   load_const 7            ("webp")
 
-  411   35   jump +8                 (to 43)
+  411   30   jump +8                 (to 38)
 
-  414   36   load_const 8            ("gif")
+  414   31   load_const 8            ("gif")
 
-  411   37   jump +6                 (to 43)
+  411   32   jump +6                 (to 38)
 
-  413   38   load_const 9            ("jpeg")
+  413   33   load_const 9            ("jpeg")
 
-  411   39   jump +4                 (to 43)
+  411   34   jump +4                 (to 38)
 
-  413   40   load_const 10           ("jpeg")
+  413   35   load_const 10           ("jpeg")
 
-  411   41   jump +2                 (to 43)
+  411   36   jump +2                 (to 38)
 
-  412   42   load_const 11           ("png")
-        43   return                  
+  412   37   load_const 11           ("png")
+        38   return                  
 }
 
 function aws.internal._inference_config(client: aws.BedrockClient) -> aws.internal.InferenceConfig | null {
@@ -12393,48 +12330,45 @@ function aws.internal._tool_choice(choice: string) -> aws.internal.ToolChoice {
         3    store_var 2            (empty)
 
   821   4    load_var 1             (choice)
-        5    load_const 2           ("auto")
-        6    cmp_op ==              
-        7    pop_jump_if_false +2   (to 9)
-        8    jump +27               (to 35)
-        9    load_var 1             (choice)
-        10   load_const 3           ("any")
-        11   cmp_op ==              
-        12   pop_jump_if_false +2   (to 14)
-        13   jump +17               (to 30)
-        14   load_var 1             (choice)
-        15   load_const 4           ("required")
-        16   cmp_op ==              
-        17   pop_jump_if_false +2   (to 19)
-        18   jump +7                (to 25)
+        5    is_type 2              
+        6    pop_jump_if_false +2   (to 8)
+        7    jump +25               (to 32)
+        8    load_var 1             (choice)
+        9    is_type 3              
+        10   pop_jump_if_false +2   (to 12)
+        11   jump +16               (to 27)
+        12   load_var 1             (choice)
+        13   is_type 4              
+        14   pop_jump_if_false +2   (to 16)
+        15   jump +7                (to 22)
 
-  824   19   load_const 5           (null)
-        20   load_const 5           (null)
-        21   load_var 1             (choice)
-        22   init_instance 0        (aws.internal.SpecificToolChoice .name)
-        23   init_instance 1        (aws.internal.ToolChoice .auto, .any, .tool)
+  824   16   load_const 5           (null)
+        17   load_const 5           (null)
+        18   load_var 1             (choice)
+        19   init_instance 0        (aws.internal.SpecificToolChoice .name)
+        20   init_instance 1        (aws.internal.ToolChoice .auto, .any, .tool)
 
-  821   24   jump +15               (to 39)
+  821   21   jump +15               (to 36)
 
-  823   25   load_const 5           (null)
-        26   load_var 2             (empty)
-        27   load_const 5           (null)
-        28   init_instance 2        (aws.internal.ToolChoice .auto, .any, .tool)
+  823   22   load_const 5           (null)
+        23   load_var 2             (empty)
+        24   load_const 5           (null)
+        25   init_instance 2        (aws.internal.ToolChoice .auto, .any, .tool)
 
-  821   29   jump +10               (to 39)
+  821   26   jump +10               (to 36)
 
-  823   30   load_const 5           (null)
-        31   load_var 2             (empty)
-        32   load_const 5           (null)
-        33   init_instance 3        (aws.internal.ToolChoice .auto, .any, .tool)
+  823   27   load_const 5           (null)
+        28   load_var 2             (empty)
+        29   load_const 5           (null)
+        30   init_instance 3        (aws.internal.ToolChoice .auto, .any, .tool)
 
-  821   34   jump +5                (to 39)
+  821   31   jump +5                (to 36)
 
-  822   35   load_var 2             (empty)
-        36   load_const 5           (null)
-        37   load_const 5           (null)
-        38   init_instance 4        (aws.internal.ToolChoice .auto, .any, .tool)
-        39   return                 
+  822   32   load_var 2             (empty)
+        33   load_const 5           (null)
+        34   load_const 5           (null)
+        35   init_instance 4        (aws.internal.ToolChoice .auto, .any, .tool)
+        36   return                 
 }
 
 function aws.internal._tool_config(toolbox: ai.tools.Toolbox, tool_choice: string | null, cache_tools: bool) -> aws.internal.ToolConfig | null {
@@ -12549,113 +12483,102 @@ function aws.internal._video_block(video: baml.media.Video) -> aws.internal.Cont
 
 function aws.internal._video_format(mime: string) -> string {
   424   0    load_var 1              (mime)
-        1    load_const 0            ("video/mp4")
-        2    cmp_op ==               
-        3    pop_jump_if_false +2    (to 5)
-        4    jump +80                (to 84)
-        5    load_var 1              (mime)
-        6    load_const 1            ("video/mpeg")
-        7    cmp_op ==               
-        8    pop_jump_if_false +2    (to 10)
-        9    jump +73                (to 82)
-        10   load_var 1              (mime)
-        11   load_const 2            ("video/mpg")
-        12   cmp_op ==               
-        13   pop_jump_if_false +2    (to 15)
-        14   jump +66                (to 80)
-        15   load_var 1              (mime)
-        16   load_const 3            ("video/x-mpg")
-        17   cmp_op ==               
+        1    is_type 0               
+        2    pop_jump_if_false +2    (to 4)
+        3    jump +70                (to 73)
+        4    load_var 1              (mime)
+        5    is_type 1               
+        6    pop_jump_if_false +2    (to 8)
+        7    jump +64                (to 71)
+        8    load_var 1              (mime)
+        9    is_type 2               
+        10   pop_jump_if_false +2    (to 12)
+        11   jump +58                (to 69)
+        12   load_var 1              (mime)
+        13   is_type 3               
+        14   pop_jump_if_false +2    (to 16)
+        15   jump +52                (to 67)
+        16   load_var 1              (mime)
+        17   is_type 4               
         18   pop_jump_if_false +2    (to 20)
-        19   jump +59                (to 78)
+        19   jump +46                (to 65)
         20   load_var 1              (mime)
-        21   load_const 4            ("video/x-ms-wmv")
-        22   cmp_op ==               
-        23   pop_jump_if_false +2    (to 25)
-        24   jump +52                (to 76)
-        25   load_var 1              (mime)
-        26   load_const 5            ("video/wmv")
-        27   cmp_op ==               
-        28   pop_jump_if_false +2    (to 30)
-        29   jump +45                (to 74)
-        30   load_var 1              (mime)
-        31   load_const 6            ("video/x-matroska")
-        32   cmp_op ==               
-        33   pop_jump_if_false +2    (to 35)
-        34   jump +38                (to 72)
-        35   load_var 1              (mime)
-        36   load_const 7            ("video/quicktime")
-        37   cmp_op ==               
+        21   is_type 5               
+        22   pop_jump_if_false +2    (to 24)
+        23   jump +40                (to 63)
+        24   load_var 1              (mime)
+        25   is_type 6               
+        26   pop_jump_if_false +2    (to 28)
+        27   jump +34                (to 61)
+        28   load_var 1              (mime)
+        29   is_type 7               
+        30   pop_jump_if_false +2    (to 32)
+        31   jump +28                (to 59)
+        32   load_var 1              (mime)
+        33   is_type 8               
+        34   pop_jump_if_false +2    (to 36)
+        35   jump +22                (to 57)
+        36   load_var 1              (mime)
+        37   is_type 9               
         38   pop_jump_if_false +2    (to 40)
-        39   jump +31                (to 70)
+        39   jump +16                (to 55)
         40   load_var 1              (mime)
-        41   load_const 8            ("video/x-flv")
-        42   cmp_op ==               
-        43   pop_jump_if_false +2    (to 45)
-        44   jump +24                (to 68)
+        41   is_type 10              
+        42   pop_jump_if_false +2    (to 44)
+        43   jump +10                (to 53)
+
+  434   44   load_type 11            
         45   load_var 1              (mime)
-        46   load_const 9            ("video/webm")
-        47   cmp_op ==               
-        48   pop_jump_if_false +2    (to 50)
-        49   jump +17                (to 66)
-        50   load_var 1              (mime)
-        51   load_const 10           ("video/3gpp")
-        52   cmp_op ==               
-        53   pop_jump_if_false +2    (to 55)
-        54   jump +10                (to 64)
+        46   call 138 ntypeargs=1    (baml.String.from)
+        47   store_var 2             (_15)
+        48   load_const 12           ("unsupported video format for Bedrock: ")
+        49   load_var 2              (_15)
+        50   bin_op +                
+        51   call 1294 ntypeargs=0   (aws.internal._reject)
+        52   throw                   
 
-  434   55   load_type 11            
-        56   load_var 1              (mime)
-        57   call 138 ntypeargs=1    (baml.String.from)
-        58   store_var 2             (_15)
-        59   load_const 12           ("unsupported video format for Bedrock: ")
-        60   load_var 2              (_15)
-        61   bin_op +                
-        62   call 1294 ntypeargs=0   (aws.internal._reject)
-        63   throw                   
+  433   53   load_const 13           ("three_gp")
 
-  433   64   load_const 13           ("three_gp")
+  424   54   jump +20                (to 74)
 
-  424   65   jump +20                (to 85)
+  432   55   load_const 14           ("webm")
 
-  432   66   load_const 14           ("webm")
+  424   56   jump +18                (to 74)
 
-  424   67   jump +18                (to 85)
+  431   57   load_const 15           ("flv")
 
-  431   68   load_const 15           ("flv")
+  424   58   jump +16                (to 74)
 
-  424   69   jump +16                (to 85)
+  430   59   load_const 16           ("mov")
 
-  430   70   load_const 16           ("mov")
+  424   60   jump +14                (to 74)
 
-  424   71   jump +14                (to 85)
+  429   61   load_const 17           ("mkv")
 
-  429   72   load_const 17           ("mkv")
+  424   62   jump +12                (to 74)
 
-  424   73   jump +12                (to 85)
+  428   63   load_const 18           ("wmv")
 
-  428   74   load_const 18           ("wmv")
+  424   64   jump +10                (to 74)
 
-  424   75   jump +10                (to 85)
+  428   65   load_const 19           ("wmv")
 
-  428   76   load_const 19           ("wmv")
+  424   66   jump +8                 (to 74)
 
-  424   77   jump +8                 (to 85)
+  427   67   load_const 20           ("mpg")
 
-  427   78   load_const 20           ("mpg")
+  424   68   jump +6                 (to 74)
 
-  424   79   jump +6                 (to 85)
+  427   69   load_const 21           ("mpg")
 
-  427   80   load_const 21           ("mpg")
+  424   70   jump +4                 (to 74)
 
-  424   81   jump +4                 (to 85)
+  426   71   load_const 22           ("mpeg")
 
-  426   82   load_const 22           ("mpeg")
+  424   72   jump +2                 (to 74)
 
-  424   83   jump +2                 (to 85)
-
-  425   84   load_const 23           ("mp4")
-        85   return                  
+  425   73   load_const 23           ("mp4")
+        74   return                  
 }
 
 function aws.internal._wants_cache_point(message: ai.PromptMessage) -> bool {
@@ -13565,71 +13488,66 @@ function aws.internal.sign_request(req: baml.http.Request, opts: aws.internal.Aw
 
 function aws.internal.stop_reason(raw: string) -> ai.content.StopReason {
   1230   0    load_var 1              (raw)
-         1    load_const 0            ("tool_use")
-         2    cmp_op ==               
-         3    pop_jump_if_false +2    (to 5)
-         4    jump +44                (to 48)
-         5    load_var 1              (raw)
-         6    load_const 1            ("max_tokens")
-         7    cmp_op ==               
-         8    pop_jump_if_false +2    (to 10)
-         9    jump +36                (to 45)
-         10   load_var 1              (raw)
-         11   load_const 2            ("model_context_window_exceeded")
-         12   cmp_op ==               
-         13   pop_jump_if_false +2    (to 15)
-         14   jump +28                (to 42)
-         15   load_var 1              (raw)
-         16   load_const 3            ("content_filtered")
-         17   cmp_op ==               
+         1    is_type 0               
+         2    pop_jump_if_false +2    (to 4)
+         3    jump +40                (to 43)
+         4    load_var 1              (raw)
+         5    is_type 1               
+         6    pop_jump_if_false +2    (to 8)
+         7    jump +33                (to 40)
+         8    load_var 1              (raw)
+         9    is_type 2               
+         10   pop_jump_if_false +2    (to 12)
+         11   jump +26                (to 37)
+         12   load_var 1              (raw)
+         13   is_type 3               
+         14   pop_jump_if_false +2    (to 16)
+         15   jump +19                (to 34)
+         16   load_var 1              (raw)
+         17   is_type 4               
          18   pop_jump_if_false +2    (to 20)
-         19   jump +20                (to 39)
+         19   jump +12                (to 31)
          20   load_var 1              (raw)
-         21   load_const 4            ("guardrail_intervened")
-         22   cmp_op ==               
-         23   pop_jump_if_false +2    (to 25)
-         24   jump +12                (to 36)
-         25   load_var 1              (raw)
-         26   store_var_load_var 2    (r)
+         21   store_var_load_var 2    (r)
 
-  1240   27   call 1324 ntypeargs=0   (aws.internal._is_malformed_stop)
+  1240   22   call 1324 ntypeargs=0   (aws.internal._is_malformed_stop)
 
-  1230   28   pop_jump_if_false +2    (to 30)
-         29   jump +4                 (to 33)
+  1230   23   pop_jump_if_false +2    (to 25)
+         24   jump +4                 (to 28)
 
-  1242   30   load_const 5            (ai.content.StopReason.Complete)
-         31   alloc_variant 774       (ai.content.StopReason)
+  1242   25   load_const 5            (ai.content.StopReason.Complete)
+         26   alloc_variant 774       (ai.content.StopReason)
 
-  1230   32   jump +18                (to 50)
+  1230   27   jump +18                (to 45)
 
-  1240   33   load_const 6            (ai.content.StopReason.Refused)
-         34   alloc_variant 774       (ai.content.StopReason)
+  1240   28   load_const 6            (ai.content.StopReason.Refused)
+         29   alloc_variant 774       (ai.content.StopReason)
 
-  1230   35   jump +15                (to 50)
+  1230   30   jump +15                (to 45)
 
-  1236   36   load_const 6            (ai.content.StopReason.Refused)
-         37   alloc_variant 774       (ai.content.StopReason)
+  1236   31   load_const 6            (ai.content.StopReason.Refused)
+         32   alloc_variant 774       (ai.content.StopReason)
 
-  1230   38   jump +12                (to 50)
+  1230   33   jump +12                (to 45)
 
-  1236   39   load_const 6            (ai.content.StopReason.Refused)
-         40   alloc_variant 774       (ai.content.StopReason)
+  1236   34   load_const 6            (ai.content.StopReason.Refused)
+         35   alloc_variant 774       (ai.content.StopReason)
 
-  1230   41   jump +9                 (to 50)
+  1230   36   jump +9                 (to 45)
 
-  1235   42   load_const 7            (ai.content.StopReason.MaxTokens)
-         43   alloc_variant 774       (ai.content.StopReason)
+  1235   37   load_const 7            (ai.content.StopReason.MaxTokens)
+         38   alloc_variant 774       (ai.content.StopReason)
 
-  1230   44   jump +6                 (to 50)
+  1230   39   jump +6                 (to 45)
 
-  1235   45   load_const 7            (ai.content.StopReason.MaxTokens)
-         46   alloc_variant 774       (ai.content.StopReason)
+  1235   40   load_const 7            (ai.content.StopReason.MaxTokens)
+         41   alloc_variant 774       (ai.content.StopReason)
 
-  1230   47   jump +3                 (to 50)
+  1230   42   jump +3                 (to 45)
 
-  1231   48   load_const 8            (ai.content.StopReason.ToolUse)
-         49   alloc_variant 774       (ai.content.StopReason)
-         50   return                  
+  1231   43   load_const 8            (ai.content.StopReason.ToolUse)
+         44   alloc_variant 774       (ai.content.StopReason)
+         45   return                  
 }
 
 function boundary.LocalId.capture(self: boundary.LocalId, inputs: bool | null, output: bool | null, error: bool | null) -> boundary.LocalId {
@@ -13751,446 +13669,434 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> void {
         5     store_var 3                        (kind)
 
   164   6     load_var 3                         (kind)
-        7     load_const 3                       ("system")
-        8     cmp_op ==                          
-        9     pop_jump_if_false +2               (to 11)
-        10    jump +331                          (to 341)
-        11    load_var 3                         (kind)
-        12    load_const 4                       ("assistant")
-        13    cmp_op ==                          
-        14    pop_jump_if_false +2               (to 16)
-        15    jump +177                          (to 192)
-        16    load_var 3                         (kind)
-        17    load_const 5                       ("user")
-        18    cmp_op ==                          
-        19    pop_jump_if_false +2               (to 21)
-        20    jump +23                           (to 43)
-        21    load_var 3                         (kind)
-        22    load_const 6                       ("result")
-        23    cmp_op ==                          
-        24    pop_jump_if_false +2               (to 26)
-        25    jump +382                          (to 407)
+        7     is_type 3                          
+        8     pop_jump_if_false +2               (to 10)
+        9     jump +320                          (to 329)
+        10    load_var 3                         (kind)
+        11    is_type 4                          
+        12    pop_jump_if_false +2               (to 14)
+        13    jump +171                          (to 184)
+        14    load_var 3                         (kind)
+        15    is_type 5                          
+        16    pop_jump_if_false +2               (to 18)
+        17    jump +22                           (to 39)
+        18    load_var 3                         (kind)
+        19    is_type 6                          
+        20    pop_jump_if_false +2               (to 22)
+        21    jump +374                          (to 395)
 
-  203   26    load_type 0                        
-        27    load_var 3                         (kind)
-        28    call 138 ntypeargs=1               (baml.String.from)
-        29    store_var 38                       (_141)
-        30    load_const 7                       ("$baml_log")
-        31    load_const 8                       ("info")
-        32    load_const 9                       ("cc event: ")
-        33    load_var 38                        (_141)
-        34    bin_op +                           
-        35    load_const 10                      ("level")
-        36    load_const 11                      ("data")
-        37    load_type 0                        
-        38    load_type 12                       
-        39    alloc_map 2                        
-        40    send_event                         
-        41    pop 1                              
-        42    jump +365                          (to 407)
+  203   22    load_type 0                        
+        23    load_var 3                         (kind)
+        24    call 138 ntypeargs=1               (baml.String.from)
+        25    store_var 38                       (_141)
+        26    load_const 7                       ("$baml_log")
+        27    load_const 8                       ("info")
+        28    load_const 9                       ("cc event: ")
+        29    load_var 38                        (_141)
+        30    bin_op +                           
+        31    load_const 10                      ("level")
+        32    load_const 11                      ("data")
+        33    load_type 0                        
+        34    load_type 12                       
+        35    alloc_map 2                        
+        36    send_event                         
+        37    pop 1                              
+        38    jump +357                          (to 395)
 
-  178   43    load_type 0                        
-        44    alloc_array 0                      
-        45    store_var 24                       (parts)
+  178   39    load_type 0                        
+        40    alloc_array 0                      
+        41    store_var 24                       (parts)
 
-  179   46    load_type 13                       
-        47    load_var 1                         (raw)
-        48    load_const 14                      (".message.content")
-        49    load_type 15                       
-        50    alloc_array 0                      
-        51    call 364 ntypeargs=1               (baml.json.path_or)
+  179   42    load_type 13                       
+        43    load_var 1                         (raw)
+        44    load_const 14                      (".message.content")
+        45    load_type 15                       
+        46    alloc_array 0                      
+        47    call 364 ntypeargs=1               (baml.json.path_or)
 
-  180   52    load_type 16                       
-        53    load_const 17                      ("iter")
-        54    virtual_call nargs=1 ntypeargs=0   
-        55    store_var 25                       (_89)
-        56    load_var 25                        (_89)
-        57    load_type 18                       
-        58    load_const 19                      ("next")
-        59    virtual_call nargs=1 ntypeargs=0   
-        60    store_var 26                       (_90)
+  180   48    load_type 16                       
+        49    load_const 17                      ("iter")
+        50    virtual_call nargs=1 ntypeargs=0   
+        51    store_var 25                       (_89)
+        52    load_var 25                        (_89)
+        53    load_type 18                       
+        54    load_const 19                      ("next")
+        55    virtual_call nargs=1 ntypeargs=0   
+        56    store_var 26                       (_90)
+        57    load_var 26                        (_90)
+        58    is_type 20                         
+        59    pop_jump_if_false +2               (to 61)
+        60    jump +92                           (to 152)
         61    load_var 26                        (_90)
-        62    is_type 20                         
-        63    pop_jump_if_false +2               (to 65)
-        64    jump +96                           (to 160)
-        65    load_var 26                        (_90)
-        66    store_var 27                       (b)
+        62    store_var 27                       (b)
 
-  181   67    load_type 0                        
-        68    load_var 27                        (b)
-        69    load_const 21                      (".type")
-        70    load_const 22                      ("?")
-        71    call 364 ntypeargs=1               (baml.json.path_or)
-        72    store_var 28                       (bt)
+  181   63    load_type 0                        
+        64    load_var 27                        (b)
+        65    load_const 21                      (".type")
+        66    load_const 22                      ("?")
+        67    call 364 ntypeargs=1               (baml.json.path_or)
+        68    store_var 28                       (bt)
 
-  182   73    load_var 28                        (bt)
-        74    load_const 23                      ("text")
-        75    cmp_op ==                          
-        76    pop_jump_if_false +2               (to 78)
-        77    jump +64                           (to 141)
-        78    load_var 28                        (bt)
-        79    load_const 24                      ("thinking")
-        80    cmp_op ==                          
-        81    pop_jump_if_false +2               (to 83)
-        82    jump +40                           (to 122)
-        83    load_var 28                        (bt)
-        84    load_const 25                      ("tool_use")
-        85    cmp_op ==                          
-        86    pop_jump_if_false +2               (to 88)
-        87    jump +17                           (to 104)
-        88    load_var 28                        (bt)
-        89    load_const 26                      ("tool_result")
-        90    cmp_op ==                          
-        91    pop_jump_if_false +2               (to 93)
-        92    jump +6                            (to 98)
+  182   69    load_var 28                        (bt)
+        70    is_type 23                         
+        71    pop_jump_if_false +2               (to 73)
+        72    jump +61                           (to 133)
+        73    load_var 28                        (bt)
+        74    is_type 24                         
+        75    pop_jump_if_false +2               (to 77)
+        76    jump +38                           (to 114)
+        77    load_var 28                        (bt)
+        78    is_type 25                         
+        79    pop_jump_if_false +2               (to 81)
+        80    jump +16                           (to 96)
+        81    load_var 28                        (bt)
+        82    is_type 26                         
+        83    pop_jump_if_false +2               (to 85)
+        84    jump +6                            (to 90)
 
-  195   93    load_type 0                        
-        94    load_var2 24 28                    
-        95    call 4 ntypeargs=1                 (baml.Array.push)
-        96    pop 1                              
-        97    jump -41                           (to 56)
+  195   85    load_type 0                        
+        86    load_var2 24 28                    
+        87    call 4 ntypeargs=1                 (baml.Array.push)
+        88    pop 1                              
+        89    jump -37                           (to 52)
 
-  194   98    load_type 0                        
-        99    load_var 24                        (parts)
-        100   load_const 27                      ("tool_result")
-        101   call 4 ntypeargs=1                 (baml.Array.push)
-        102   pop 1                              
-        103   jump -47                           (to 56)
+  194   90    load_type 0                        
+        91    load_var 24                        (parts)
+        92    load_const 27                      ("tool_result")
+        93    call 4 ntypeargs=1                 (baml.Array.push)
+        94    pop 1                              
+        95    jump -43                           (to 52)
 
-  192   104   load_type 0                        
-        105   load_var 27                        (b)
-        106   load_const 28                      (".name")
-        107   load_const 29                      ("?")
-        108   call 364 ntypeargs=1               (baml.json.path_or)
-        109   store_var 34                       (_119)
-        110   load_type 0                        
-        111   load_var 34                        (_119)
-        112   call 138 ntypeargs=1               (baml.String.from)
-        113   store_var 33                       (_118)
-        114   load_type 0                        
-        115   load_var 24                        (parts)
-        116   load_const 30                      ("tool_use: ")
-        117   load_var 33                        (_118)
-        118   bin_op +                           
-        119   call 4 ntypeargs=1                 (baml.Array.push)
-        120   pop 1                              
-        121   jump -65                           (to 56)
+  192   96    load_type 0                        
+        97    load_var 27                        (b)
+        98    load_const 28                      (".name")
+        99    load_const 29                      ("?")
+        100   call 364 ntypeargs=1               (baml.json.path_or)
+        101   store_var 34                       (_119)
+        102   load_type 0                        
+        103   load_var 34                        (_119)
+        104   call 138 ntypeargs=1               (baml.String.from)
+        105   store_var 33                       (_118)
+        106   load_type 0                        
+        107   load_var 24                        (parts)
+        108   load_const 30                      ("tool_use: ")
+        109   load_var 33                        (_118)
+        110   bin_op +                           
+        111   call 4 ntypeargs=1                 (baml.Array.push)
+        112   pop 1                              
+        113   jump -61                           (to 52)
 
-  188   122   load_type 0                        
-        123   load_var 27                        (b)
-        124   load_const 31                      (".thinking")
-        125   load_const 32                      ("")
-        126   call 364 ntypeargs=1               (baml.json.path_or)
-        127   call 1359 ntypeargs=0              (claude_code.internal._preview)
-        128   store_var 32                       (_110)
-        129   load_type 0                        
-        130   load_var 32                        (_110)
-        131   call 138 ntypeargs=1               (baml.String.from)
-        132   store_var 31                       (_109)
+  188   114   load_type 0                        
+        115   load_var 27                        (b)
+        116   load_const 31                      (".thinking")
+        117   load_const 32                      ("")
+        118   call 364 ntypeargs=1               (baml.json.path_or)
+        119   call 1359 ntypeargs=0              (claude_code.internal._preview)
+        120   store_var 32                       (_110)
+        121   load_type 0                        
+        122   load_var 32                        (_110)
+        123   call 138 ntypeargs=1               (baml.String.from)
+        124   store_var 31                       (_109)
 
-  187   133   load_type 0                        
-        134   load_var 24                        (parts)
+  187   125   load_type 0                        
+        126   load_var 24                        (parts)
 
-  188   135   load_const 33                      ("thinking: ")
-        136   load_var 31                        (_109)
-        137   bin_op +                           
+  188   127   load_const 33                      ("thinking: ")
+        128   load_var 31                        (_109)
+        129   bin_op +                           
 
-  187   138   call 4 ntypeargs=1                 (baml.Array.push)
-        139   pop 1                              
-        140   jump -84                           (to 56)
+  187   130   call 4 ntypeargs=1                 (baml.Array.push)
+        131   pop 1                              
+        132   jump -80                           (to 52)
 
-  184   141   load_type 0                        
-        142   load_var 27                        (b)
-        143   load_const 34                      (".text")
-        144   load_const 35                      ("")
-        145   call 364 ntypeargs=1               (baml.json.path_or)
-        146   call 1359 ntypeargs=0              (claude_code.internal._preview)
-        147   store_var 30                       (_101)
-        148   load_type 0                        
-        149   load_var 30                        (_101)
-        150   call 138 ntypeargs=1               (baml.String.from)
-        151   store_var 29                       (_100)
-        152   load_type 0                        
-        153   load_var 24                        (parts)
-        154   load_const 36                      ("text: ")
-        155   load_var 29                        (_100)
-        156   bin_op +                           
-        157   call 4 ntypeargs=1                 (baml.Array.push)
-        158   pop 1                              
-        159   jump -103                          (to 56)
+  184   133   load_type 0                        
+        134   load_var 27                        (b)
+        135   load_const 34                      (".text")
+        136   load_const 35                      ("")
+        137   call 364 ntypeargs=1               (baml.json.path_or)
+        138   call 1359 ntypeargs=0              (claude_code.internal._preview)
+        139   store_var 30                       (_101)
+        140   load_type 0                        
+        141   load_var 30                        (_101)
+        142   call 138 ntypeargs=1               (baml.String.from)
+        143   store_var 29                       (_100)
+        144   load_type 0                        
+        145   load_var 24                        (parts)
+        146   load_const 36                      ("text: ")
+        147   load_var 29                        (_100)
+        148   bin_op +                           
+        149   call 4 ntypeargs=1                 (baml.Array.push)
+        150   pop 1                              
+        151   jump -99                           (to 52)
 
-  198   160   load_type 37                       
-        161   load_var 3                         (kind)
-        162   call 138 ntypeargs=1               (baml.String.from)
-        163   store_var 35                       (_132)
-        164   load_type 0                        
-        165   load_var 24                        (parts)
-        166   load_const 38                      (" | ")
-        167   call 15 ntypeargs=1                (baml.Array.join)
-        168   store_var 37                       (_136)
-        169   load_type 0                        
-        170   load_var 37                        (_136)
-        171   call 138 ntypeargs=1               (baml.String.from)
-        172   store_var 36                       (_135)
-        173   load_const 39                      ("$baml_log")
-        174   load_const 40                      ("info")
-        175   load_const 41                      ("cc event: ")
-        176   load_var 35                        (_132)
-        177   bin_op +                           
-        178   load_const 42                      (" [")
-        179   bin_op +                           
-        180   load_var 36                        (_135)
-        181   bin_op +                           
-        182   load_const 43                      ("]")
-        183   bin_op +                           
-        184   load_const 44                      ("level")
-        185   load_const 45                      ("data")
-        186   load_type 0                        
-        187   load_type 12                       
-        188   alloc_map 2                        
-        189   send_event                         
-        190   pop 1                              
-        191   jump +216                          (to 407)
+  198   152   load_type 37                       
+        153   load_var 3                         (kind)
+        154   call 138 ntypeargs=1               (baml.String.from)
+        155   store_var 35                       (_132)
+        156   load_type 0                        
+        157   load_var 24                        (parts)
+        158   load_const 38                      (" | ")
+        159   call 15 ntypeargs=1                (baml.Array.join)
+        160   store_var 37                       (_136)
+        161   load_type 0                        
+        162   load_var 37                        (_136)
+        163   call 138 ntypeargs=1               (baml.String.from)
+        164   store_var 36                       (_135)
+        165   load_const 39                      ("$baml_log")
+        166   load_const 40                      ("info")
+        167   load_const 41                      ("cc event: ")
+        168   load_var 35                        (_132)
+        169   bin_op +                           
+        170   load_const 42                      (" [")
+        171   bin_op +                           
+        172   load_var 36                        (_135)
+        173   bin_op +                           
+        174   load_const 43                      ("]")
+        175   bin_op +                           
+        176   load_const 44                      ("level")
+        177   load_const 45                      ("data")
+        178   load_type 0                        
+        179   load_type 12                       
+        180   alloc_map 2                        
+        181   send_event                         
+        182   pop 1                              
+        183   jump +212                          (to 395)
 
-  178   192   load_type 0                        
-        193   alloc_array 0                      
-        194   store_var 10                       (parts)
+  178   184   load_type 0                        
+        185   alloc_array 0                      
+        186   store_var 10                       (parts)
 
-  179   195   load_type 13                       
-        196   load_var 1                         (raw)
-        197   load_const 46                      (".message.content")
-        198   load_type 15                       
-        199   alloc_array 0                      
-        200   call 364 ntypeargs=1               (baml.json.path_or)
+  179   187   load_type 13                       
+        188   load_var 1                         (raw)
+        189   load_const 46                      (".message.content")
+        190   load_type 15                       
+        191   alloc_array 0                      
+        192   call 364 ntypeargs=1               (baml.json.path_or)
 
-  180   201   load_type 16                       
-        202   load_const 47                      ("iter")
-        203   virtual_call nargs=1 ntypeargs=0   
-        204   store_var 11                       (_33)
-        205   load_var 11                        (_33)
-        206   load_type 18                       
-        207   load_const 48                      ("next")
-        208   virtual_call nargs=1 ntypeargs=0   
-        209   store_var 12                       (_34)
-        210   load_var 12                        (_34)
-        211   is_type 20                         
-        212   pop_jump_if_false +2               (to 214)
-        213   jump +96                           (to 309)
-        214   load_var 12                        (_34)
-        215   store_var 13                       (b)
+  180   193   load_type 16                       
+        194   load_const 47                      ("iter")
+        195   virtual_call nargs=1 ntypeargs=0   
+        196   store_var 11                       (_33)
+        197   load_var 11                        (_33)
+        198   load_type 18                       
+        199   load_const 48                      ("next")
+        200   virtual_call nargs=1 ntypeargs=0   
+        201   store_var 12                       (_34)
+        202   load_var 12                        (_34)
+        203   is_type 20                         
+        204   pop_jump_if_false +2               (to 206)
+        205   jump +92                           (to 297)
+        206   load_var 12                        (_34)
+        207   store_var 13                       (b)
 
-  181   216   load_type 0                        
-        217   load_var 13                        (b)
-        218   load_const 49                      (".type")
-        219   load_const 50                      ("?")
-        220   call 364 ntypeargs=1               (baml.json.path_or)
-        221   store_var 14                       (bt)
+  181   208   load_type 0                        
+        209   load_var 13                        (b)
+        210   load_const 49                      (".type")
+        211   load_const 50                      ("?")
+        212   call 364 ntypeargs=1               (baml.json.path_or)
+        213   store_var 14                       (bt)
 
-  182   222   load_var 14                        (bt)
-        223   load_const 51                      ("text")
-        224   cmp_op ==                          
-        225   pop_jump_if_false +2               (to 227)
-        226   jump +64                           (to 290)
-        227   load_var 14                        (bt)
-        228   load_const 52                      ("thinking")
-        229   cmp_op ==                          
-        230   pop_jump_if_false +2               (to 232)
-        231   jump +40                           (to 271)
-        232   load_var 14                        (bt)
-        233   load_const 53                      ("tool_use")
-        234   cmp_op ==                          
-        235   pop_jump_if_false +2               (to 237)
-        236   jump +17                           (to 253)
-        237   load_var 14                        (bt)
-        238   load_const 54                      ("tool_result")
-        239   cmp_op ==                          
-        240   pop_jump_if_false +2               (to 242)
-        241   jump +6                            (to 247)
+  182   214   load_var 14                        (bt)
+        215   is_type 23                         
+        216   pop_jump_if_false +2               (to 218)
+        217   jump +61                           (to 278)
+        218   load_var 14                        (bt)
+        219   is_type 24                         
+        220   pop_jump_if_false +2               (to 222)
+        221   jump +38                           (to 259)
+        222   load_var 14                        (bt)
+        223   is_type 25                         
+        224   pop_jump_if_false +2               (to 226)
+        225   jump +16                           (to 241)
+        226   load_var 14                        (bt)
+        227   is_type 26                         
+        228   pop_jump_if_false +2               (to 230)
+        229   jump +6                            (to 235)
 
-  195   242   load_type 0                        
-        243   load_var2 10 14                    
-        244   call 4 ntypeargs=1                 (baml.Array.push)
-        245   pop 1                              
-        246   jump -41                           (to 205)
+  195   230   load_type 0                        
+        231   load_var2 10 14                    
+        232   call 4 ntypeargs=1                 (baml.Array.push)
+        233   pop 1                              
+        234   jump -37                           (to 197)
 
-  194   247   load_type 0                        
-        248   load_var 10                        (parts)
-        249   load_const 55                      ("tool_result")
-        250   call 4 ntypeargs=1                 (baml.Array.push)
-        251   pop 1                              
-        252   jump -47                           (to 205)
+  194   235   load_type 0                        
+        236   load_var 10                        (parts)
+        237   load_const 51                      ("tool_result")
+        238   call 4 ntypeargs=1                 (baml.Array.push)
+        239   pop 1                              
+        240   jump -43                           (to 197)
 
-  192   253   load_type 0                        
-        254   load_var 13                        (b)
-        255   load_const 56                      (".name")
-        256   load_const 57                      ("?")
-        257   call 364 ntypeargs=1               (baml.json.path_or)
-        258   store_var 20                       (_63)
-        259   load_type 0                        
-        260   load_var 20                        (_63)
-        261   call 138 ntypeargs=1               (baml.String.from)
-        262   store_var 19                       (_62)
-        263   load_type 0                        
-        264   load_var 10                        (parts)
-        265   load_const 58                      ("tool_use: ")
-        266   load_var 19                        (_62)
-        267   bin_op +                           
-        268   call 4 ntypeargs=1                 (baml.Array.push)
-        269   pop 1                              
-        270   jump -65                           (to 205)
+  192   241   load_type 0                        
+        242   load_var 13                        (b)
+        243   load_const 52                      (".name")
+        244   load_const 53                      ("?")
+        245   call 364 ntypeargs=1               (baml.json.path_or)
+        246   store_var 20                       (_63)
+        247   load_type 0                        
+        248   load_var 20                        (_63)
+        249   call 138 ntypeargs=1               (baml.String.from)
+        250   store_var 19                       (_62)
+        251   load_type 0                        
+        252   load_var 10                        (parts)
+        253   load_const 54                      ("tool_use: ")
+        254   load_var 19                        (_62)
+        255   bin_op +                           
+        256   call 4 ntypeargs=1                 (baml.Array.push)
+        257   pop 1                              
+        258   jump -61                           (to 197)
 
-  188   271   load_type 0                        
-        272   load_var 13                        (b)
-        273   load_const 59                      (".thinking")
-        274   load_const 60                      ("")
-        275   call 364 ntypeargs=1               (baml.json.path_or)
-        276   call 1359 ntypeargs=0              (claude_code.internal._preview)
-        277   store_var 18                       (_54)
-        278   load_type 0                        
-        279   load_var 18                        (_54)
-        280   call 138 ntypeargs=1               (baml.String.from)
-        281   store_var 17                       (_53)
+  188   259   load_type 0                        
+        260   load_var 13                        (b)
+        261   load_const 55                      (".thinking")
+        262   load_const 56                      ("")
+        263   call 364 ntypeargs=1               (baml.json.path_or)
+        264   call 1359 ntypeargs=0              (claude_code.internal._preview)
+        265   store_var 18                       (_54)
+        266   load_type 0                        
+        267   load_var 18                        (_54)
+        268   call 138 ntypeargs=1               (baml.String.from)
+        269   store_var 17                       (_53)
 
-  187   282   load_type 0                        
-        283   load_var 10                        (parts)
+  187   270   load_type 0                        
+        271   load_var 10                        (parts)
 
-  188   284   load_const 61                      ("thinking: ")
-        285   load_var 17                        (_53)
-        286   bin_op +                           
+  188   272   load_const 57                      ("thinking: ")
+        273   load_var 17                        (_53)
+        274   bin_op +                           
 
-  187   287   call 4 ntypeargs=1                 (baml.Array.push)
-        288   pop 1                              
-        289   jump -84                           (to 205)
+  187   275   call 4 ntypeargs=1                 (baml.Array.push)
+        276   pop 1                              
+        277   jump -80                           (to 197)
 
-  184   290   load_type 0                        
-        291   load_var 13                        (b)
-        292   load_const 62                      (".text")
-        293   load_const 63                      ("")
-        294   call 364 ntypeargs=1               (baml.json.path_or)
-        295   call 1359 ntypeargs=0              (claude_code.internal._preview)
-        296   store_var 16                       (_45)
-        297   load_type 0                        
-        298   load_var 16                        (_45)
+  184   278   load_type 0                        
+        279   load_var 13                        (b)
+        280   load_const 58                      (".text")
+        281   load_const 59                      ("")
+        282   call 364 ntypeargs=1               (baml.json.path_or)
+        283   call 1359 ntypeargs=0              (claude_code.internal._preview)
+        284   store_var 16                       (_45)
+        285   load_type 0                        
+        286   load_var 16                        (_45)
+        287   call 138 ntypeargs=1               (baml.String.from)
+        288   store_var 15                       (_44)
+        289   load_type 0                        
+        290   load_var 10                        (parts)
+        291   load_const 60                      ("text: ")
+        292   load_var 15                        (_44)
+        293   bin_op +                           
+        294   call 4 ntypeargs=1                 (baml.Array.push)
+        295   pop 1                              
+        296   jump -99                           (to 197)
+
+  198   297   load_type 37                       
+        298   load_var 3                         (kind)
         299   call 138 ntypeargs=1               (baml.String.from)
-        300   store_var 15                       (_44)
+        300   store_var 21                       (_76)
         301   load_type 0                        
         302   load_var 10                        (parts)
-        303   load_const 64                      ("text: ")
-        304   load_var 15                        (_44)
-        305   bin_op +                           
-        306   call 4 ntypeargs=1                 (baml.Array.push)
-        307   pop 1                              
-        308   jump -103                          (to 205)
+        303   load_const 61                      (" | ")
+        304   call 15 ntypeargs=1                (baml.Array.join)
+        305   store_var 23                       (_80)
+        306   load_type 0                        
+        307   load_var 23                        (_80)
+        308   call 138 ntypeargs=1               (baml.String.from)
+        309   store_var 22                       (_79)
+        310   load_const 62                      ("$baml_log")
+        311   load_const 63                      ("info")
+        312   load_const 64                      ("cc event: ")
+        313   load_var 21                        (_76)
+        314   bin_op +                           
+        315   load_const 65                      (" [")
+        316   bin_op +                           
+        317   load_var 22                        (_79)
+        318   bin_op +                           
+        319   load_const 66                      ("]")
+        320   bin_op +                           
+        321   load_const 67                      ("level")
+        322   load_const 68                      ("data")
+        323   load_type 0                        
+        324   load_type 12                       
+        325   alloc_map 2                        
+        326   send_event                         
+        327   pop 1                              
+        328   jump +67                           (to 395)
 
-  198   309   load_type 37                       
-        310   load_var 3                         (kind)
-        311   call 138 ntypeargs=1               (baml.String.from)
-        312   store_var 21                       (_76)
-        313   load_type 0                        
-        314   load_var 10                        (parts)
-        315   load_const 65                      (" | ")
-        316   call 15 ntypeargs=1                (baml.Array.join)
-        317   store_var 23                       (_80)
-        318   load_type 0                        
-        319   load_var 23                        (_80)
-        320   call 138 ntypeargs=1               (baml.String.from)
-        321   store_var 22                       (_79)
-        322   load_const 66                      ("$baml_log")
-        323   load_const 67                      ("info")
-        324   load_const 68                      ("cc event: ")
-        325   load_var 21                        (_76)
-        326   bin_op +                           
-        327   load_const 69                      (" [")
-        328   bin_op +                           
-        329   load_var 22                        (_79)
-        330   bin_op +                           
-        331   load_const 70                      ("]")
-        332   bin_op +                           
-        333   load_const 71                      ("level")
-        334   load_const 72                      ("data")
-        335   load_type 0                        
-        336   load_type 12                       
-        337   alloc_map 2                        
-        338   send_event                         
-        339   pop 1                              
-        340   jump +67                           (to 407)
+  166   329   load_type 0                        
+        330   load_var 1                         (raw)
+        331   load_const 69                      (".subtype")
+        332   load_const 70                      ("?")
+        333   call 364 ntypeargs=1               (baml.json.path_or)
+        334   store_var 4                        (subtype)
 
-  166   341   load_type 0                        
-        342   load_var 1                         (raw)
-        343   load_const 73                      (".subtype")
-        344   load_const 74                      ("?")
-        345   call 364 ntypeargs=1               (baml.json.path_or)
-        346   store_var 4                        (subtype)
+  167   335   load_var 4                         (subtype)
+        336   load_const 71                      ("thinking_tokens")
+        337   cmp_op ==                          
+        338   pop_jump_if_false +2               (to 340)
+        339   jump +32                           (to 371)
 
-  167   347   load_var 4                         (subtype)
-        348   load_const 75                      ("thinking_tokens")
-        349   cmp_op ==                          
-        350   pop_jump_if_false +2               (to 352)
-        351   jump +32                           (to 383)
+  173   340   load_type 0                        
+        341   load_var 1                         (raw)
+        342   load_const 72                      (".model")
+        343   load_const 73                      ("?")
+        344   call 364 ntypeargs=1               (baml.json.path_or)
+        345   store_var 7                        (model)
 
-  173   352   load_type 0                        
-        353   load_var 1                         (raw)
-        354   load_const 76                      (".model")
-        355   load_const 77                      ("?")
-        356   call 364 ntypeargs=1               (baml.json.path_or)
-        357   store_var 7                        (model)
+  174   346   load_type 0                        
+        347   load_var 4                         (subtype)
+        348   call 138 ntypeargs=1               (baml.String.from)
+        349   store_var 8                        (_21)
+        350   load_type 0                        
+        351   load_var 7                         (model)
+        352   call 138 ntypeargs=1               (baml.String.from)
+        353   store_var 9                        (_24)
+        354   load_const 74                      ("$baml_log")
+        355   load_const 75                      ("info")
+        356   load_const 76                      ("cc event: system/")
+        357   load_var 8                         (_21)
+        358   bin_op +                           
+        359   load_const 77                      (" model=")
+        360   bin_op +                           
+        361   load_var 9                         (_24)
+        362   bin_op +                           
+        363   load_const 78                      ("level")
+        364   load_const 79                      ("data")
+        365   load_type 0                        
+        366   load_type 12                       
+        367   alloc_map 2                        
+        368   send_event                         
+        369   pop 1                              
+        370   jump +25                           (to 395)
 
-  174   358   load_type 0                        
-        359   load_var 4                         (subtype)
-        360   call 138 ntypeargs=1               (baml.String.from)
-        361   store_var 8                        (_21)
-        362   load_type 0                        
-        363   load_var 7                         (model)
-        364   call 138 ntypeargs=1               (baml.String.from)
-        365   store_var 9                        (_24)
-        366   load_const 78                      ("$baml_log")
-        367   load_const 79                      ("info")
-        368   load_const 80                      ("cc event: system/")
-        369   load_var 8                         (_21)
-        370   bin_op +                           
-        371   load_const 81                      (" model=")
-        372   bin_op +                           
-        373   load_var 9                         (_24)
-        374   bin_op +                           
-        375   load_const 82                      ("level")
-        376   load_const 83                      ("data")
-        377   load_type 0                        
-        378   load_type 12                       
-        379   alloc_map 2                        
-        380   send_event                         
-        381   pop 1                              
-        382   jump +25                           (to 407)
+  170   371   load_type 80                       
+        372   load_var 1                         (raw)
+        373   load_const 81                      (".estimated_tokens")
+        374   load_const 82                      (0)
+        375   call 364 ntypeargs=1               (baml.json.path_or)
+        376   store_var 5                        (estimated)
 
-  170   383   load_type 84                       
-        384   load_var 1                         (raw)
-        385   load_const 85                      (".estimated_tokens")
-        386   load_const 86                      (0)
-        387   call 364 ntypeargs=1               (baml.json.path_or)
-        388   store_var 5                        (estimated)
+  171   377   load_type 80                       
+        378   load_var 5                         (estimated)
+        379   call 138 ntypeargs=1               (baml.String.from)
+        380   store_var 6                        (_13)
+        381   load_const 83                      ("$baml_log")
+        382   load_const 84                      ("debug")
+        383   load_const 85                      ("cc event: thinking ~")
+        384   load_var 6                         (_13)
+        385   bin_op +                           
+        386   load_const 86                      (" tokens")
+        387   bin_op +                           
+        388   load_const 87                      ("level")
+        389   load_const 88                      ("data")
+        390   load_type 0                        
+        391   load_type 12                       
+        392   alloc_map 2                        
+        393   send_event                         
+        394   pop 1                              
 
-  171   389   load_type 84                       
-        390   load_var 5                         (estimated)
-        391   call 138 ntypeargs=1               (baml.String.from)
-        392   store_var 6                        (_13)
-        393   load_const 87                      ("$baml_log")
-        394   load_const 88                      ("debug")
-        395   load_const 89                      ("cc event: thinking ~")
-        396   load_var 6                         (_13)
-        397   bin_op +                           
-        398   load_const 90                      (" tokens")
-        399   bin_op +                           
-        400   load_const 91                      ("level")
-        401   load_const 92                      ("data")
-        402   load_type 0                        
-        403   load_type 12                       
-        404   alloc_map 2                        
-        405   send_event                         
-        406   pop 1                              
-
-  162   407   load_const 93                      (null)
-        408   store_var 2                        (_0)
-        409   load_var 2                         (_0)
-        410   return                             
+  162   395   load_const 89                      (null)
+        396   store_var 2                        (_0)
+        397   load_var 2                         (_0)
+        398   return                             
 }
 
 function claude_code.internal._preview(text: string) -> string {
@@ -14327,7 +14233,7 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
         8    load_type 2           
         9    load_var 3            (_3)
 
-  224   10   make_closure 4211 0   
+  224   10   make_closure 4068 0   
 
   223   11   call 16 ntypeargs=3   (baml.Array.map)
         12   store_var 2           (_2)
@@ -17311,7 +17217,7 @@ function google.internal._gm_strip_nulls(value: baml.json.json, opaque: bool) ->
         20   load_type 2                        
         21   load_type 3                        
         22   load_var 13                        (items)
-        23   make_closure 3391 0                
+        23   make_closure 3308 0                
         24   call 16 ntypeargs=3                (baml.Array.map)
         25   jump +52                           (to 77)
 
@@ -19307,7 +19213,7 @@ function google.internal.vertex_invoke_stream(c: google.VertexClient, input: ai.
 
   362   22   load_var2 3 4           
 
-  363   23   make_closure 3630 1     
+  363   23   make_closure 3547 1     
         24   load_const 5            ("vertex")
 
   361   25   call 959 ntypeargs=0    (ai.stream.TurnStream.from_sse)
@@ -21554,7 +21460,7 @@ function openai.internal.ChatStreamDecoder._absorb_call(self: openai.internal.Ch
          16    load_field 1            (calls)
 
   1398   17    load_var 4              (index)
-         18    make_closure 3022 1     
+         18    make_closure 2966 1     
 
   1397   19    call 19 ntypeargs=2     (baml.Array.find)
 
@@ -22178,7 +22084,7 @@ function openai.internal._chat_apply_directives(j: baml.json.json) -> baml.json.
         17    load_type 2                        
         18    load_type 3                        
         19    load_var 18                        (items)
-        20    make_closure 2932 0                
+        20    make_closure 2881 0                
         21    call 16 ntypeargs=3                (baml.Array.map)
         22    jump +88                           (to 110)
 
@@ -22355,35 +22261,32 @@ function openai.internal._chat_audio_format(mime_type: string) -> string {
         15   store_var 2            (subtype)
 
   498   16   load_var 2             (subtype)
-        17   load_const 2           ("mpeg")
-        18   cmp_op ==              
-        19   pop_jump_if_false +2   (to 21)
-        20   jump +17               (to 37)
-        21   load_var 2             (subtype)
-        22   load_const 3           ("mp3")
-        23   cmp_op ==              
-        24   pop_jump_if_false +2   (to 26)
-        25   jump +10               (to 35)
-        26   load_var 2             (subtype)
-        27   load_const 4           ("x-wav")
-        28   cmp_op ==              
-        29   pop_jump_if_false +2   (to 31)
-        30   jump +3                (to 33)
+        17   is_type 2              
+        18   pop_jump_if_false +2   (to 20)
+        19   jump +15               (to 34)
+        20   load_var 2             (subtype)
+        21   is_type 3              
+        22   pop_jump_if_false +2   (to 24)
+        23   jump +9                (to 32)
+        24   load_var 2             (subtype)
+        25   is_type 4              
+        26   pop_jump_if_false +2   (to 28)
+        27   jump +3                (to 30)
 
-  501   31   load_var 2             (subtype)
+  501   28   load_var 2             (subtype)
 
-  498   32   jump +6                (to 38)
+  498   29   jump +6                (to 35)
 
-  500   33   load_const 5           ("wav")
+  500   30   load_const 5           ("wav")
 
-  498   34   jump +4                (to 38)
+  498   31   jump +4                (to 35)
 
-  499   35   load_const 6           ("mp3")
+  499   32   load_const 6           ("mp3")
 
-  498   36   jump +2                (to 38)
+  498   33   jump +2                (to 35)
 
-  499   37   load_const 7           ("mp3")
-        38   return                 
+  499   34   load_const 7           ("mp3")
+        35   return                 
 }
 
 function openai.internal._chat_audio_output_mime(request_body: baml.json.json | null) -> string {
@@ -22395,32 +22298,30 @@ function openai.internal._chat_audio_output_mime(request_body: baml.json.json | 
         5    store_var 2            (format)
 
   513   6    load_var 2             (format)
-        7    load_const 3           ("mp3")
-        8    cmp_op ==              
-        9    pop_jump_if_false +2   (to 11)
-        10   jump +16               (to 26)
-        11   load_var 2             (format)
-        12   load_const 4           ("pcm16")
-        13   cmp_op ==              
-        14   pop_jump_if_false +2   (to 16)
-        15   jump +9                (to 24)
+        7    is_type 3              
+        8    pop_jump_if_false +2   (to 10)
+        9    jump +15               (to 24)
+        10   load_var 2             (format)
+        11   is_type 4              
+        12   pop_jump_if_false +2   (to 14)
+        13   jump +9                (to 22)
 
-  516   16   load_type 0            
-        17   load_var 2             (format)
-        18   call 138 ntypeargs=1   (baml.String.from)
-        19   store_var 3            (_6)
-        20   load_const 5           ("audio/")
-        21   load_var 3             (_6)
-        22   bin_op +               
+  516   14   load_type 0            
+        15   load_var 2             (format)
+        16   call 138 ntypeargs=1   (baml.String.from)
+        17   store_var 3            (_6)
+        18   load_const 5           ("audio/")
+        19   load_var 3             (_6)
+        20   bin_op +               
 
-  513   23   jump +4                (to 27)
+  513   21   jump +4                (to 25)
 
-  515   24   load_const 6           ("audio/pcm")
+  515   22   load_const 6           ("audio/pcm")
 
-  513   25   jump +2                (to 27)
+  513   23   jump +2                (to 25)
 
-  514   26   load_const 7           ("audio/mpeg")
-        27   return                 
+  514   24   load_const 7           ("audio/mpeg")
+        25   return                 
 }
 
 function openai.internal._chat_body_mentions(overrides: baml.json.json | null, key: string) -> bool {
@@ -23167,7 +23068,7 @@ function openai.internal._chat_prune_nulls(j: baml.json.json) -> baml.json.json 
         17   load_type 2                        
         18   load_type 3                        
         19   load_var 11                        (items)
-        20   make_closure 2938 0                
+        20   make_closure 2887 0                
         21   call 16 ntypeargs=3                (baml.Array.map)
         22   jump +58                           (to 80)
 
@@ -24234,44 +24135,40 @@ function openai.internal._oai_images_mime(format: string | null) -> string {
         9    store_var 2            (normalized)
 
   308   10   load_var 2             (normalized)
-        11   load_const 2           ("jpeg")
-        12   cmp_op ==              
-        13   pop_jump_if_false +2   (to 15)
-        14   jump +24               (to 38)
-        15   load_var 2             (normalized)
-        16   load_const 3           ("jpg")
-        17   cmp_op ==              
-        18   pop_jump_if_false +2   (to 20)
-        19   jump +17               (to 36)
-        20   load_var 2             (normalized)
-        21   load_const 4           ("webp")
-        22   cmp_op ==              
-        23   pop_jump_if_false +2   (to 25)
-        24   jump +10               (to 34)
-        25   load_var 2             (normalized)
-        26   load_const 5           ("gif")
-        27   cmp_op ==              
-        28   pop_jump_if_false +2   (to 30)
-        29   jump +3                (to 32)
+        11   is_type 2              
+        12   pop_jump_if_false +2   (to 14)
+        13   jump +21               (to 34)
+        14   load_var 2             (normalized)
+        15   is_type 3              
+        16   pop_jump_if_false +2   (to 18)
+        17   jump +15               (to 32)
+        18   load_var 2             (normalized)
+        19   is_type 4              
+        20   pop_jump_if_false +2   (to 22)
+        21   jump +9                (to 30)
+        22   load_var 2             (normalized)
+        23   is_type 5              
+        24   pop_jump_if_false +2   (to 26)
+        25   jump +3                (to 28)
 
-  312   30   load_const 6           ("image/png")
+  312   26   load_const 6           ("image/png")
 
-  308   31   jump +8                (to 39)
+  308   27   jump +8                (to 35)
 
-  311   32   load_const 7           ("image/gif")
+  311   28   load_const 7           ("image/gif")
 
-  308   33   jump +6                (to 39)
+  308   29   jump +6                (to 35)
 
-  310   34   load_const 8           ("image/webp")
+  310   30   load_const 8           ("image/webp")
 
-  308   35   jump +4                (to 39)
+  308   31   jump +4                (to 35)
 
-  309   36   load_const 9           ("image/jpeg")
+  309   32   load_const 9           ("image/jpeg")
 
-  308   37   jump +2                (to 39)
+  308   33   jump +2                (to 35)
 
-  309   38   load_const 10          ("image/jpeg")
-        39   return                 
+  309   34   load_const 10          ("image/jpeg")
+        35   return                 
 }
 
 function openai.internal._oai_images_prompt_text(prompt: ai.Prompt, journal: ai.Journal) -> string {
@@ -24681,80 +24578,72 @@ function openai.internal._openai_apply_message_metadata(body: baml.json.json, me
 
 function openai.internal._openai_audio_format(mime_type: string) -> string {
   327   0    load_var 1             (mime_type)
-        1    load_const 0           ("audio/wav")
-        2    cmp_op ==              
-        3    pop_jump_if_false +2   (to 5)
-        4    jump +52               (to 56)
-        5    load_var 1             (mime_type)
-        6    load_const 1           ("audio/x-wav")
-        7    cmp_op ==              
-        8    pop_jump_if_false +2   (to 10)
-        9    jump +45               (to 54)
-        10   load_var 1             (mime_type)
-        11   load_const 2           ("audio/mpeg")
-        12   cmp_op ==              
-        13   pop_jump_if_false +2   (to 15)
-        14   jump +38               (to 52)
-        15   load_var 1             (mime_type)
-        16   load_const 3           ("audio/mp3")
-        17   cmp_op ==              
+        1    is_type 0              
+        2    pop_jump_if_false +2   (to 4)
+        3    jump +45               (to 48)
+        4    load_var 1             (mime_type)
+        5    is_type 1              
+        6    pop_jump_if_false +2   (to 8)
+        7    jump +39               (to 46)
+        8    load_var 1             (mime_type)
+        9    is_type 2              
+        10   pop_jump_if_false +2   (to 12)
+        11   jump +33               (to 44)
+        12   load_var 1             (mime_type)
+        13   is_type 3              
+        14   pop_jump_if_false +2   (to 16)
+        15   jump +27               (to 42)
+        16   load_var 1             (mime_type)
+        17   is_type 4              
         18   pop_jump_if_false +2   (to 20)
-        19   jump +31               (to 50)
+        19   jump +21               (to 40)
         20   load_var 1             (mime_type)
-        21   load_const 4           ("audio/flac")
-        22   cmp_op ==              
-        23   pop_jump_if_false +2   (to 25)
-        24   jump +24               (to 48)
-        25   load_var 1             (mime_type)
-        26   load_const 5           ("audio/x-flac")
-        27   cmp_op ==              
-        28   pop_jump_if_false +2   (to 30)
-        29   jump +17               (to 46)
-        30   load_var 1             (mime_type)
-        31   load_const 6           ("audio/ogg")
-        32   cmp_op ==              
-        33   pop_jump_if_false +2   (to 35)
-        34   jump +10               (to 44)
-        35   load_var 1             (mime_type)
-        36   load_const 7           ("audio/webm")
-        37   cmp_op ==              
-        38   pop_jump_if_false +2   (to 40)
-        39   jump +3                (to 42)
+        21   is_type 5              
+        22   pop_jump_if_false +2   (to 24)
+        23   jump +15               (to 38)
+        24   load_var 1             (mime_type)
+        25   is_type 6              
+        26   pop_jump_if_false +2   (to 28)
+        27   jump +9                (to 36)
+        28   load_var 1             (mime_type)
+        29   is_type 7              
+        30   pop_jump_if_false +2   (to 32)
+        31   jump +3                (to 34)
 
-  333   40   load_var 1             (mime_type)
+  333   32   load_var 1             (mime_type)
 
-  327   41   jump +16               (to 57)
+  327   33   jump +16               (to 49)
 
-  332   42   load_const 8           ("webm")
+  332   34   load_const 8           ("webm")
 
-  327   43   jump +14               (to 57)
+  327   35   jump +14               (to 49)
 
-  331   44   load_const 9           ("ogg")
+  331   36   load_const 9           ("ogg")
 
-  327   45   jump +12               (to 57)
+  327   37   jump +12               (to 49)
 
-  330   46   load_const 10          ("flac")
+  330   38   load_const 10          ("flac")
 
-  327   47   jump +10               (to 57)
+  327   39   jump +10               (to 49)
 
-  330   48   load_const 11          ("flac")
+  330   40   load_const 11          ("flac")
 
-  327   49   jump +8                (to 57)
+  327   41   jump +8                (to 49)
 
-  329   50   load_const 12          ("mp3")
+  329   42   load_const 12          ("mp3")
 
-  327   51   jump +6                (to 57)
+  327   43   jump +6                (to 49)
 
-  329   52   load_const 13          ("mp3")
+  329   44   load_const 13          ("mp3")
 
-  327   53   jump +4                (to 57)
+  327   45   jump +4                (to 49)
 
-  328   54   load_const 14          ("wav")
+  328   46   load_const 14          ("wav")
 
-  327   55   jump +2                (to 57)
+  327   47   jump +2                (to 49)
 
-  328   56   load_const 15          ("wav")
-        57   return                 
+  328   48   load_const 15          ("wav")
+        49   return                 
 }
 
 function openai.internal._openai_decode_batch(batch: string, state: openai.internal.OaStreamState) -> (ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone)[] {
@@ -25177,35 +25066,32 @@ function openai.internal._openai_image_mime(output_format: string | null) -> str
         10   store_var 2            (format)
 
   756   11   load_var 2             (format)
-        12   load_const 2           ("jpeg")
-        13   cmp_op ==              
-        14   pop_jump_if_false +2   (to 16)
-        15   jump +17               (to 32)
-        16   load_var 2             (format)
-        17   load_const 3           ("jpg")
-        18   cmp_op ==              
-        19   pop_jump_if_false +2   (to 21)
-        20   jump +10               (to 30)
-        21   load_var 2             (format)
-        22   load_const 4           ("webp")
-        23   cmp_op ==              
-        24   pop_jump_if_false +2   (to 26)
-        25   jump +3                (to 28)
+        12   is_type 2              
+        13   pop_jump_if_false +2   (to 15)
+        14   jump +15               (to 29)
+        15   load_var 2             (format)
+        16   is_type 3              
+        17   pop_jump_if_false +2   (to 19)
+        18   jump +9                (to 27)
+        19   load_var 2             (format)
+        20   is_type 4              
+        21   pop_jump_if_false +2   (to 23)
+        22   jump +3                (to 25)
 
-  759   26   load_const 5           ("image/png")
+  759   23   load_const 5           ("image/png")
 
-  756   27   jump +6                (to 33)
+  756   24   jump +6                (to 30)
 
-  758   28   load_const 6           ("image/webp")
+  758   25   load_const 6           ("image/webp")
 
-  756   29   jump +4                (to 33)
+  756   26   jump +4                (to 30)
 
-  757   30   load_const 7           ("image/jpeg")
+  757   27   load_const 7           ("image/jpeg")
 
-  756   31   jump +2                (to 33)
+  756   28   jump +2                (to 30)
 
-  757   32   load_const 8           ("image/jpeg")
-        33   return                 
+  757   29   load_const 8           ("image/jpeg")
+        30   return                 
 }
 
 function openai.internal._openai_media_role_error(kind: string, role: string) -> ai.errors.Failure {
@@ -26336,360 +26222,350 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          31    load_var 9                       (_17)
          32    narrow_bind 5 9                  
          33    pop_jump_if_false +2             (to 35)
-         34    jump +306                        (to 340)
+         34    jump +296                        (to 330)
 
   1026   35    load_var 6                       (kind)
-         36    load_const 6                     ("response.created")
-         37    cmp_op ==                        
-         38    pop_jump_if_false +2             (to 40)
-         39    jump +286                        (to 325)
-         40    load_var 6                       (kind)
-         41    load_const 7                     ("response.in_progress")
-         42    cmp_op ==                        
-         43    pop_jump_if_false +2             (to 45)
-         44    jump +269                        (to 313)
-         45    load_var 6                       (kind)
-         46    load_const 8                     ("response.output_text.delta")
-         47    cmp_op ==                        
-         48    pop_jump_if_false +2             (to 50)
-         49    jump +238                        (to 287)
-         50    load_var 6                       (kind)
-         51    load_const 9                     ("response.output_text.done")
-         52    cmp_op ==                        
+         36    is_type 6                        
+         37    pop_jump_if_false +2             (to 39)
+         38    jump +277                        (to 315)
+         39    load_var 6                       (kind)
+         40    is_type 7                        
+         41    pop_jump_if_false +2             (to 43)
+         42    jump +261                        (to 303)
+         43    load_var 6                       (kind)
+         44    is_type 8                        
+         45    pop_jump_if_false +2             (to 47)
+         46    jump +231                        (to 277)
+         47    load_var 6                       (kind)
+         48    is_type 9                        
+         49    pop_jump_if_false +2             (to 51)
+         50    jump +187                        (to 237)
+         51    load_var 6                       (kind)
+         52    is_type 10                       
          53    pop_jump_if_false +2             (to 55)
-         54    jump +193                        (to 247)
+         54    jump +149                        (to 203)
          55    load_var 6                       (kind)
-         56    load_const 10                    ("response.function_call_arguments.delta")
-         57    cmp_op ==                        
-         58    pop_jump_if_false +2             (to 60)
-         59    jump +154                        (to 213)
-         60    load_var 6                       (kind)
-         61    load_const 11                    ("response.function_call_arguments.done")
-         62    cmp_op ==                        
-         63    pop_jump_if_false +2             (to 65)
-         64    jump +128                        (to 192)
-         65    load_var 6                       (kind)
-         66    load_const 12                    ("response.failed")
-         67    cmp_op ==                        
-         68    pop_jump_if_false +2             (to 70)
-         69    jump +120                        (to 189)
-         70    load_var 6                       (kind)
-         71    load_const 13                    ("error")
-         72    cmp_op ==                        
-         73    pop_jump_if_false +2             (to 75)
-         74    jump +112                        (to 186)
-         75    load_var 6                       (kind)
-         76    load_const 14                    ("response.completed")
-         77    cmp_op ==                        
-         78    pop_jump_if_false +2             (to 80)
-         79    jump +56                         (to 135)
-         80    load_var 6                       (kind)
-         81    load_const 15                    ("response.incomplete")
-         82    cmp_op ==                        
-         83    pop_jump_if_false +253           (to 336)
+         56    is_type 11                       
+         57    pop_jump_if_false +2             (to 59)
+         58    jump +124                        (to 182)
+         59    load_var 6                       (kind)
+         60    is_type 12                       
+         61    pop_jump_if_false +2             (to 63)
+         62    jump +117                        (to 179)
+         63    load_var 6                       (kind)
+         64    is_type 13                       
+         65    pop_jump_if_false +2             (to 67)
+         66    jump +110                        (to 176)
+         67    load_var 6                       (kind)
+         68    is_type 14                       
+         69    pop_jump_if_false +2             (to 71)
+         70    jump +55                         (to 125)
+         71    load_var 6                       (kind)
+         72    is_type 15                       
+         73    pop_jump_if_false +253           (to 326)
 
-  1078   84    load_var 1                       (event)
-         85    load_field 8                     (response)
-         86    store_var 38                     (_122)
-         87    load_var 38                      (_122)
-         88    narrow_bind 16 38                
-         89    pop_jump_if_false +40            (to 129)
-         90    load_var 38                      (_122)
-         91    store_var_load_var 39            (final_response)
+  1078   74    load_var 1                       (event)
+         75    load_field 8                     (response)
+         76    store_var 38                     (_122)
+         77    load_var 38                      (_122)
+         78    narrow_bind 16 38                
+         79    pop_jump_if_false +40            (to 119)
+         80    load_var 38                      (_122)
+         81    store_var_load_var 39            (final_response)
 
-  1079   92    call 1042 ntypeargs=0            (openai.internal.openai_parse)
-         93    store_var 40                     (turn)
+  1079   82    call 1042 ntypeargs=0            (openai.internal.openai_parse)
+         83    store_var 40                     (turn)
 
-  1082   94    load_var 40                      (turn)
-         95    load_field 1                     (stop_reason)
-         96    store_var 41                     (_128)
+  1082   84    load_var 40                      (turn)
+         85    load_field 1                     (stop_reason)
+         86    store_var 41                     (_128)
 
-  1083   97    load_var 40                      (turn)
-         98    load_field 2                     (usage)
-         99    load_const 1                     (null)
-         100   cmp_op ==                        
-         101   pop_jump_if_false +2             (to 103)
-         102   jump +6                          (to 108)
-         103   load_var 40                      (turn)
-         104   load_field 2                     (usage)
-         105   load_field 0                     (0)
-         106   store_var 42                     (_129)
-         107   jump +3                          (to 110)
-         108   load_const 1                     (null)
-         109   store_var 42                     (_129)
+  1083   87    load_var 40                      (turn)
+         88    load_field 2                     (usage)
+         89    load_const 1                     (null)
+         90    cmp_op ==                        
+         91    pop_jump_if_false +2             (to 93)
+         92    jump +6                          (to 98)
+         93    load_var 40                      (turn)
+         94    load_field 2                     (usage)
+         95    load_field 0                     (0)
+         96    store_var 42                     (_129)
+         97    jump +3                          (to 100)
+         98    load_const 1                     (null)
+         99    store_var 42                     (_129)
 
-  1084   110   load_var 40                      (turn)
-         111   load_field 2                     (usage)
-         112   load_const 1                     (null)
-         113   cmp_op ==                        
-         114   pop_jump_if_false +2             (to 116)
-         115   jump +6                          (to 121)
-         116   load_var 40                      (turn)
-         117   load_field 2                     (usage)
-         118   load_field 1                     (1)
-         119   store_var 43                     (_133)
-         120   jump +3                          (to 123)
-         121   load_const 1                     (null)
-         122   store_var 43                     (_133)
+  1084   100   load_var 40                      (turn)
+         101   load_field 2                     (usage)
+         102   load_const 1                     (null)
+         103   cmp_op ==                        
+         104   pop_jump_if_false +2             (to 106)
+         105   jump +6                          (to 111)
+         106   load_var 40                      (turn)
+         107   load_field 2                     (usage)
+         108   load_field 1                     (1)
+         109   store_var 43                     (_133)
+         110   jump +3                          (to 113)
+         111   load_const 1                     (null)
+         112   store_var 43                     (_133)
 
-  1080   123   load_type 0                      
-         124   load_var2 5 41                   
+  1080   113   load_type 0                      
+         114   load_var2 5 41                   
 
-  1081   125   load_var2 42 43                  
-         126   init_instance 0                  (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
+  1081   115   load_var2 42 43                  
+         116   init_instance 0                  (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
 
-  1080   127   call 4 ntypeargs=1               (baml.Array.push)
-         128   pop 1                            
+  1080   117   call 4 ntypeargs=1               (baml.Array.push)
+         118   pop 1                            
 
-  1088   129   load_type 0                      
-         130   load_var 5                       (out)
-         131   alloc_instance 410 ntypeargs=0   (ai.stream.TurnDone)
-         132   call 4 ntypeargs=1               (baml.Array.push)
-         133   pop 1                            
-         134   jump +202                        (to 336)
+  1088   119   load_type 0                      
+         120   load_var 5                       (out)
+         121   alloc_instance 410 ntypeargs=0   (ai.stream.TurnDone)
+         122   call 4 ntypeargs=1               (baml.Array.push)
+         123   pop 1                            
+         124   jump +202                        (to 326)
 
-  1078   135   load_var 1                       (event)
-         136   load_field 8                     (response)
-         137   store_var 32                     (_101)
-         138   load_var 32                      (_101)
-         139   narrow_bind 16 32                
-         140   pop_jump_if_false +40            (to 180)
-         141   load_var 32                      (_101)
-         142   store_var_load_var 33            (final_response)
+  1078   125   load_var 1                       (event)
+         126   load_field 8                     (response)
+         127   store_var 32                     (_101)
+         128   load_var 32                      (_101)
+         129   narrow_bind 16 32                
+         130   pop_jump_if_false +40            (to 170)
+         131   load_var 32                      (_101)
+         132   store_var_load_var 33            (final_response)
 
-  1079   143   call 1042 ntypeargs=0            (openai.internal.openai_parse)
-         144   store_var 34                     (turn)
+  1079   133   call 1042 ntypeargs=0            (openai.internal.openai_parse)
+         134   store_var 34                     (turn)
 
-  1082   145   load_var 34                      (turn)
-         146   load_field 1                     (stop_reason)
-         147   store_var 35                     (_107)
+  1082   135   load_var 34                      (turn)
+         136   load_field 1                     (stop_reason)
+         137   store_var 35                     (_107)
 
-  1083   148   load_var 34                      (turn)
-         149   load_field 2                     (usage)
-         150   load_const 1                     (null)
-         151   cmp_op ==                        
-         152   pop_jump_if_false +2             (to 154)
-         153   jump +6                          (to 159)
-         154   load_var 34                      (turn)
-         155   load_field 2                     (usage)
-         156   load_field 0                     (0)
-         157   store_var 36                     (_108)
-         158   jump +3                          (to 161)
-         159   load_const 1                     (null)
-         160   store_var 36                     (_108)
+  1083   138   load_var 34                      (turn)
+         139   load_field 2                     (usage)
+         140   load_const 1                     (null)
+         141   cmp_op ==                        
+         142   pop_jump_if_false +2             (to 144)
+         143   jump +6                          (to 149)
+         144   load_var 34                      (turn)
+         145   load_field 2                     (usage)
+         146   load_field 0                     (0)
+         147   store_var 36                     (_108)
+         148   jump +3                          (to 151)
+         149   load_const 1                     (null)
+         150   store_var 36                     (_108)
 
-  1084   161   load_var 34                      (turn)
-         162   load_field 2                     (usage)
-         163   load_const 1                     (null)
-         164   cmp_op ==                        
-         165   pop_jump_if_false +2             (to 167)
-         166   jump +6                          (to 172)
-         167   load_var 34                      (turn)
-         168   load_field 2                     (usage)
-         169   load_field 1                     (1)
-         170   store_var 37                     (_112)
-         171   jump +3                          (to 174)
-         172   load_const 1                     (null)
-         173   store_var 37                     (_112)
+  1084   151   load_var 34                      (turn)
+         152   load_field 2                     (usage)
+         153   load_const 1                     (null)
+         154   cmp_op ==                        
+         155   pop_jump_if_false +2             (to 157)
+         156   jump +6                          (to 162)
+         157   load_var 34                      (turn)
+         158   load_field 2                     (usage)
+         159   load_field 1                     (1)
+         160   store_var 37                     (_112)
+         161   jump +3                          (to 164)
+         162   load_const 1                     (null)
+         163   store_var 37                     (_112)
 
-  1080   174   load_type 0                      
-         175   load_var2 5 35                   
+  1080   164   load_type 0                      
+         165   load_var2 5 35                   
 
-  1081   176   load_var2 36 37                  
-         177   init_instance 1                  (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
+  1081   166   load_var2 36 37                  
+         167   init_instance 1                  (ai.stream.TurnMeta .stop_reason, .input_tokens, .output_tokens)
 
-  1080   178   call 4 ntypeargs=1               (baml.Array.push)
-         179   pop 1                            
+  1080   168   call 4 ntypeargs=1               (baml.Array.push)
+         169   pop 1                            
 
-  1088   180   load_type 0                      
-         181   load_var 5                       (out)
-         182   alloc_instance 410 ntypeargs=0   (ai.stream.TurnDone)
-         183   call 4 ntypeargs=1               (baml.Array.push)
-         184   pop 1                            
-         185   jump +151                        (to 336)
+  1088   170   load_type 0                      
+         171   load_var 5                       (out)
+         172   alloc_instance 410 ntypeargs=0   (ai.stream.TurnDone)
+         173   call 4 ntypeargs=1               (baml.Array.push)
+         174   pop 1                            
+         175   jump +151                        (to 326)
 
-  1076   186   load_var 1                       (event)
-         187   call 1046 ntypeargs=0            (openai.internal._openai_stream_failure)
-         188   throw                            
-         189   load_var 1                       (event)
-         190   call 1046 ntypeargs=0            (openai.internal._openai_stream_failure)
-         191   throw                            
+  1076   176   load_var 1                       (event)
+         177   call 1046 ntypeargs=0            (openai.internal._openai_stream_failure)
+         178   throw                            
+         179   load_var 1                       (event)
+         180   call 1046 ntypeargs=0            (openai.internal._openai_stream_failure)
+         181   throw                            
 
-  1071   192   load_var 1                       (event)
-         193   load_field 3                     (arguments)
-         194   store_var 28                     (_87)
-         195   load_var 28                      (_87)
-         196   narrow_bind 17 28                
-         197   pop_jump_if_false +139           (to 336)
-         198   load_var 28                      (_87)
-         199   store_var 29                     (full)
+  1071   182   load_var 1                       (event)
+         183   load_field 3                     (arguments)
+         184   store_var 28                     (_87)
+         185   load_var 28                      (_87)
+         186   narrow_bind 17 28                
+         187   pop_jump_if_false +139           (to 326)
+         188   load_var 28                      (_87)
+         189   store_var 29                     (full)
 
-  1072   200   load_var 3                       (state)
-         201   load_field 2                     (call_arguments)
-         202   store_var 30                     (_90)
-         203   load_var 1                       (event)
-         204   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
-         205   store_var 31                     (_91)
-         206   load_type 18                     
-         207   load_type 18                     
-         208   load_var2 30 31                  
-         209   load_var 29                      (full)
-         210   call 37 ntypeargs=2              (baml.Map.set)
-         211   pop 1                            
-         212   jump +124                        (to 336)
+  1072   190   load_var 3                       (state)
+         191   load_field 2                     (call_arguments)
+         192   store_var 30                     (_90)
+         193   load_var 1                       (event)
+         194   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
+         195   store_var 31                     (_91)
+         196   load_type 18                     
+         197   load_type 18                     
+         198   load_var2 30 31                  
+         199   load_var 29                      (full)
+         200   call 37 ntypeargs=2              (baml.Map.set)
+         201   pop 1                            
+         202   jump +124                        (to 326)
 
-  1061   213   load_var 1                       (event)
-         214   load_field 1                     (delta)
-         215   store_var 23                     (_67)
-         216   load_var 23                      (_67)
-         217   narrow_bind 17 23                
-         218   pop_jump_if_false +118           (to 336)
-         219   load_var 23                      (_67)
-         220   store_var 24                     (delta)
+  1061   203   load_var 1                       (event)
+         204   load_field 1                     (delta)
+         205   store_var 23                     (_67)
+         206   load_var 23                      (_67)
+         207   narrow_bind 17 23                
+         208   pop_jump_if_false +118           (to 326)
+         209   load_var 23                      (_67)
+         210   store_var 24                     (delta)
 
-  1062   221   load_var 1                       (event)
-         222   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
-         223   store_var 25                     (key)
+  1062   211   load_var 1                       (event)
+         212   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
+         213   store_var 25                     (key)
 
-  1063   224   load_var 3                       (state)
-         225   load_field 2                     (call_arguments)
-         226   store_var 26                     (_71)
+  1063   214   load_var 3                       (state)
+         215   load_field 2                     (call_arguments)
+         216   store_var 26                     (_71)
 
-  1065   227   load_type 18                     
-         228   load_type 18                     
-         229   load_var 3                       (state)
-         230   load_field 2                     (call_arguments)
-         231   load_var 25                      (key)
-         232   call 38 ntypeargs=2              (baml.Map.get)
-         233   store_var_load_var 27            (_75)
-         234   load_const 1                     (null)
-         235   cmp_op ==                        
-         236   pop_jump_if_false +3             (to 239)
-         237   load_const 19                    ("")
-         238   store_var 27                     (_75)
+  1065   217   load_type 18                     
+         218   load_type 18                     
+         219   load_var 3                       (state)
+         220   load_field 2                     (call_arguments)
+         221   load_var 25                      (key)
+         222   call 38 ntypeargs=2              (baml.Map.get)
+         223   store_var_load_var 27            (_75)
+         224   load_const 1                     (null)
+         225   cmp_op ==                        
+         226   pop_jump_if_false +3             (to 229)
+         227   load_const 19                    ("")
+         228   store_var 27                     (_75)
 
-  1063   239   load_type 18                     
-         240   load_type 18                     
-         241   load_var2 26 25                  
+  1063   229   load_type 18                     
+         230   load_type 18                     
+         231   load_var2 26 25                  
 
-  1065   242   load_var2 27 24                  
-         243   bin_op +                         
+  1065   232   load_var2 27 24                  
+         233   bin_op +                         
 
-  1063   244   call 37 ntypeargs=2              (baml.Map.set)
-         245   pop 1                            
-         246   jump +90                         (to 336)
+  1063   234   call 37 ntypeargs=2              (baml.Map.set)
+         235   pop 1                            
+         236   jump +90                         (to 326)
 
-  1045   247   load_var 1                       (event)
-         248   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
-         249   store_var 19                     (key)
+  1045   237   load_var 1                       (event)
+         238   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
+         239   store_var 19                     (key)
 
-  1046   250   load_type 18                     
-         251   load_type 20                     
-         252   load_var 3                       (state)
-         253   load_field 1                     (text_started)
-         254   load_var 19                      (key)
-         255   call 38 ntypeargs=2              (baml.Map.get)
-         256   store_var_load_var 20            (_46)
-         257   load_const 1                     (null)
-         258   cmp_op ==                        
-         259   pop_jump_if_false +3             (to 262)
-         260   load_const 21                    (false)
-         261   store_var 20                     (_46)
-         262   load_var 20                      (_46)
-         263   unary_op !                       
-         264   pop_jump_if_false +72            (to 336)
+  1046   240   load_type 18                     
+         241   load_type 20                     
+         242   load_var 3                       (state)
+         243   load_field 1                     (text_started)
+         244   load_var 19                      (key)
+         245   call 38 ntypeargs=2              (baml.Map.get)
+         246   store_var_load_var 20            (_46)
+         247   load_const 1                     (null)
+         248   cmp_op ==                        
+         249   pop_jump_if_false +3             (to 252)
+         250   load_const 21                    (false)
+         251   store_var 20                     (_46)
+         252   load_var 20                      (_46)
+         253   unary_op !                       
+         254   pop_jump_if_false +72            (to 326)
 
-  1047   265   load_var 1                       (event)
-         266   load_field 2                     (text)
-         267   store_var 21                     (_54)
-         268   load_var 21                      (_54)
-         269   narrow_bind 17 21                
-         270   pop_jump_if_false +66            (to 336)
-         271   load_var 21                      (_54)
-         272   store_var 22                     (full)
+  1047   255   load_var 1                       (event)
+         256   load_field 2                     (text)
+         257   store_var 21                     (_54)
+         258   load_var 21                      (_54)
+         259   narrow_bind 17 21                
+         260   pop_jump_if_false +66            (to 326)
+         261   load_var 21                      (_54)
+         262   store_var 22                     (full)
 
-  1048   273   load_type 18                     
-         274   load_type 20                     
-         275   load_var 3                       (state)
-         276   load_field 1                     (text_started)
-         277   load_var 19                      (key)
-         278   load_const 22                    (true)
-         279   call 37 ntypeargs=2              (baml.Map.set)
-         280   pop 1                            
+  1048   263   load_type 18                     
+         264   load_type 20                     
+         265   load_var 3                       (state)
+         266   load_field 1                     (text_started)
+         267   load_var 19                      (key)
+         268   load_const 22                    (true)
+         269   call 37 ntypeargs=2              (baml.Map.set)
+         270   pop 1                            
 
-  1049   281   load_type 0                      
-         282   load_var2 5 22                   
-         283   init_instance 2                  (ai.stream.TextDelta .text)
-         284   call 4 ntypeargs=1               (baml.Array.push)
-         285   pop 1                            
-         286   jump +50                         (to 336)
+  1049   271   load_type 0                      
+         272   load_var2 5 22                   
+         273   init_instance 2                  (ai.stream.TextDelta .text)
+         274   call 4 ntypeargs=1               (baml.Array.push)
+         275   pop 1                            
+         276   jump +50                         (to 326)
 
-  1036   287   load_var 1                       (event)
-         288   load_field 1                     (delta)
-         289   store_var 15                     (_31)
-         290   load_var 15                      (_31)
-         291   narrow_bind 17 15                
-         292   pop_jump_if_false +44            (to 336)
-         293   load_var 15                      (_31)
-         294   store_var 16                     (delta)
+  1036   277   load_var 1                       (event)
+         278   load_field 1                     (delta)
+         279   store_var 15                     (_31)
+         280   load_var 15                      (_31)
+         281   narrow_bind 17 15                
+         282   pop_jump_if_false +44            (to 326)
+         283   load_var 15                      (_31)
+         284   store_var 16                     (delta)
 
-  1037   295   load_var 3                       (state)
-         296   load_field 1                     (text_started)
-         297   store_var 17                     (_34)
-         298   load_var 1                       (event)
-         299   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
-         300   store_var 18                     (_35)
-         301   load_type 18                     
-         302   load_type 20                     
-         303   load_var2 17 18                  
-         304   load_const 22                    (true)
-         305   call 37 ntypeargs=2              (baml.Map.set)
-         306   pop 1                            
+  1037   285   load_var 3                       (state)
+         286   load_field 1                     (text_started)
+         287   store_var 17                     (_34)
+         288   load_var 1                       (event)
+         289   call 1045 ntypeargs=0            (openai.internal._openai_event_key)
+         290   store_var 18                     (_35)
+         291   load_type 18                     
+         292   load_type 20                     
+         293   load_var2 17 18                  
+         294   load_const 22                    (true)
+         295   call 37 ntypeargs=2              (baml.Map.set)
+         296   pop 1                            
 
-  1038   307   load_type 0                      
-         308   load_var2 5 16                   
-         309   init_instance 3                  (ai.stream.TextDelta .text)
-         310   call 4 ntypeargs=1               (baml.Array.push)
-         311   pop 1                            
-         312   jump +24                         (to 336)
+  1038   297   load_type 0                      
+         298   load_var2 5 16                   
+         299   init_instance 3                  (ai.stream.TextDelta .text)
+         300   call 4 ntypeargs=1               (baml.Array.push)
+         301   pop 1                            
+         302   jump +24                         (to 326)
 
-  1030   313   load_var 1                       (event)
-         314   load_field 8                     (response)
-         315   store_var 13                     (_27)
-         316   load_var 13                      (_27)
-         317   narrow_bind 16 13                
-         318   pop_jump_if_false +18            (to 336)
-         319   load_var 13                      (_27)
-         320   store_var 14                     (started)
+  1030   303   load_var 1                       (event)
+         304   load_field 8                     (response)
+         305   store_var 13                     (_27)
+         306   load_var 13                      (_27)
+         307   narrow_bind 16 13                
+         308   pop_jump_if_false +18            (to 326)
+         309   load_var 13                      (_27)
+         310   store_var 14                     (started)
 
-  1031   321   load_var2 3 14                   
-         322   load_field 1                     (model)
-         323   store_field 0                    (model)
+  1031   311   load_var2 3 14                   
+         312   load_field 1                     (model)
+         313   store_field 0                    (model)
 
-  1030   324   jump +12                         (to 336)
-         325   load_var 1                       (event)
-         326   load_field 8                     (response)
-         327   store_var 11                     (_23)
-         328   load_var 11                      (_23)
-         329   narrow_bind 16 11                
-         330   pop_jump_if_false +6             (to 336)
-         331   load_var 11                      (_23)
-         332   store_var 12                     (started)
+  1030   314   jump +12                         (to 326)
+         315   load_var 1                       (event)
+         316   load_field 8                     (response)
+         317   store_var 11                     (_23)
+         318   load_var 11                      (_23)
+         319   narrow_bind 16 11                
+         320   pop_jump_if_false +6             (to 326)
+         321   load_var 11                      (_23)
+         322   store_var 12                     (started)
 
-  1031   333   load_var2 3 12                   
-         334   load_field 1                     (model)
-         335   store_field 0                    (model)
+  1031   323   load_var2 3 12                   
+         324   load_field 1                     (model)
+         325   store_field 0                    (model)
 
-  1093   336   load_var 5                       (out)
-         337   store_var 4                      (_0)
-         338   load_var 4                       (_0)
-         339   return                           
+  1093   326   load_var 5                       (out)
+         327   store_var 4                      (_0)
+         328   load_var 4                       (_0)
+         329   return                           
 
-  1022   340   load_var 9                       (_17)
-         341   store_var_load_var 10            (nested)
+  1022   330   load_var 9                       (_17)
+         331   store_var_load_var 10            (nested)
 
-  1023   342   call 1040 ntypeargs=0            (openai.internal._openai_error_failure)
-         343   throw                            
+  1023   332   call 1040 ntypeargs=0            (openai.internal._openai_error_failure)
+         333   throw                            
 }
 
 function openai.internal._openai_stream_failure(event: openai.internal.OaStreamEvent) -> ai.errors.Failure {
@@ -27351,7 +27227,7 @@ function openai.internal.chat_invoke_stream(compat: openai.internal.ChatCompat, 
          26   throw                   
 
   1551   27   load_var 5              (decoder)
-         28   make_closure 3044 1     
+         28   make_closure 2988 1     
 
   1552   29   load_var 1              (compat)
          30   load_field 0            (provider)
@@ -27646,158 +27522,156 @@ function openai.internal.chat_lower_prompt(prompt: ai.Prompt, compat: openai.int
         14    load_var 6                         (_6)
         15    is_type 5                          
         16    pop_jump_if_false +2               (to 18)
-        17    jump +87                           (to 104)
+        17    jump +85                           (to 102)
         18    load_var 6                         (_6)
         19    store_var 7                        (message)
 
   672   20    load_var 7                         (message)
         21    load_field 0                       (role)
         22    store_var_load_var 9               (_11)
-        23    load_const 6                       ("")
-        24    cmp_op ==                          
-        25    pop_jump_if_false +2               (to 27)
-        26    jump +13                           (to 39)
-        27    load_var 9                         (_11)
-        28    load_const 7                       ("tool")
-        29    cmp_op ==                          
-        30    pop_jump_if_false +2               (to 32)
-        31    jump +5                            (to 36)
+        23    is_type 6                          
+        24    pop_jump_if_false +2               (to 26)
+        25    jump +12                           (to 37)
+        26    load_var 9                         (_11)
+        27    is_type 7                          
+        28    pop_jump_if_false +2               (to 30)
+        29    jump +5                            (to 34)
 
-  675   32    load_var 7                         (message)
-        33    load_field 0                       (role)
-        34    store_var 8                        (role)
+  675   30    load_var 7                         (message)
+        31    load_field 0                       (role)
+        32    store_var 8                        (role)
 
-  672   35    jump +7                            (to 42)
+  672   33    jump +7                            (to 40)
 
-  674   36    load_const 8                       ("user")
-        37    store_var 8                        (role)
+  674   34    load_const 8                       ("user")
+        35    store_var 8                        (role)
 
-  672   38    jump +4                            (to 42)
+  672   36    jump +4                            (to 40)
 
-  673   39    load_var 2                         (compat)
-        40    load_field 11                      (default_role)
-        41    store_var 8                        (role)
+  673   37    load_var 2                         (compat)
+        38    load_field 11                      (default_role)
+        39    store_var 8                        (role)
 
-  677   42    load_var2 7 2                      
-        43    call 1111 ntypeargs=0              (openai.internal._chat_prompt_parts)
-        44    store_var 10                       (parts)
+  677   40    load_var2 7 2                      
+        41    call 1111 ntypeargs=0              (openai.internal._chat_prompt_parts)
+        42    store_var 10                       (parts)
 
-  681   45    load_var2 10 7                     
-        46    load_field 3                       (metadata)
-        47    call 1112 ntypeargs=0              (openai.internal._chat_apply_metadata)
-        48    pop 1                              
+  681   43    load_var2 10 7                     
+        44    load_field 3                       (metadata)
+        45    call 1112 ntypeargs=0              (openai.internal._chat_apply_metadata)
+        46    pop 1                              
 
-  682   49    load_const 9                       (false)
-        50    store_var 11                       (merged)
+  682   47    load_const 9                       (false)
+        48    store_var 11                       (merged)
 
-  683   51    load_var 4                         (lowered)
-        52    container_len                      
-        53    store_var 12                       (_22)
-        54    load_type 0                        
-        55    load_var2 4 12                     
-        56    load_const 10                      (1)
-        57    sub_int                            
-        58    call 3 ntypeargs=1                 (baml.Array.at)
-        59    store_var 13                       (_24)
-        60    load_var 13                        (_24)
-        61    narrow_bind 11 13                  
-        62    pop_jump_if_false +32              (to 94)
-        63    load_var 13                        (_24)
-        64    store_var_load_var 14              (last)
+  683   49    load_var 4                         (lowered)
+        50    container_len                      
+        51    store_var 12                       (_22)
+        52    load_type 0                        
+        53    load_var2 4 12                     
+        54    load_const 10                      (1)
+        55    sub_int                            
+        56    call 3 ntypeargs=1                 (baml.Array.at)
+        57    store_var 13                       (_24)
+        58    load_var 13                        (_24)
+        59    narrow_bind 11 13                  
+        60    pop_jump_if_false +32              (to 92)
+        61    load_var 13                        (_24)
+        62    store_var_load_var 14              (last)
 
-  684   65    load_field 0                       (role)
-        66    load_var 8                         (role)
-        67    cmp_op ==                          
-        68    pop_jump_if_false +26              (to 94)
+  684   63    load_field 0                       (role)
+        64    load_var 8                         (role)
+        65    cmp_op ==                          
+        66    pop_jump_if_false +26              (to 92)
 
-  685   69    load_var 10                        (parts)
-        70    load_type 12                       
-        71    load_const 13                      ("iter")
-        72    virtual_call nargs=1 ntypeargs=0   
-        73    store_var 15                       (_30)
-        74    load_var 15                        (_30)
-        75    load_type 14                       
-        76    load_const 15                      ("next")
-        77    virtual_call nargs=1 ntypeargs=0   
-        78    store_var 16                       (_31)
-        79    load_var 16                        (_31)
-        80    is_type 5                          
-        81    pop_jump_if_false +2               (to 83)
-        82    jump +10                           (to 92)
-        83    load_var 16                        (_31)
-        84    store_var 17                       (part)
+  685   67    load_var 10                        (parts)
+        68    load_type 12                       
+        69    load_const 13                      ("iter")
+        70    virtual_call nargs=1 ntypeargs=0   
+        71    store_var 15                       (_30)
+        72    load_var 15                        (_30)
+        73    load_type 14                       
+        74    load_const 15                      ("next")
+        75    virtual_call nargs=1 ntypeargs=0   
+        76    store_var 16                       (_31)
+        77    load_var 16                        (_31)
+        78    is_type 5                          
+        79    pop_jump_if_false +2               (to 81)
+        80    jump +10                           (to 90)
+        81    load_var 16                        (_31)
+        82    store_var 17                       (part)
 
-  686   85    load_type 16                       
-        86    load_var 14                        (last)
-        87    load_field 1                       (parts)
-        88    load_var 17                        (part)
-        89    call 4 ntypeargs=1                 (baml.Array.push)
-        90    pop 1                              
-        91    jump -17                           (to 74)
+  686   83    load_type 16                       
+        84    load_var 14                        (last)
+        85    load_field 1                       (parts)
+        86    load_var 17                        (part)
+        87    call 4 ntypeargs=1                 (baml.Array.push)
+        88    pop 1                              
+        89    jump -17                           (to 72)
 
-  688   92    load_const 17                      (true)
-        93    store_var 11                       (merged)
+  688   90    load_const 17                      (true)
+        91    store_var 11                       (merged)
 
-  691   94    load_var 11                        (merged)
-        95    unary_op !                         
-        96    pop_jump_if_false -87              (to 9)
+  691   92    load_var 11                        (merged)
+        93    unary_op !                         
+        94    pop_jump_if_false -85              (to 9)
 
-  692   97    load_type 0                        
-        98    load_var2 4 8                      
-        99    load_var 10                        (parts)
-        100   init_instance 0                    (openai.internal.ChatPromptMessage .role, .parts)
-        101   call 4 ntypeargs=1                 (baml.Array.push)
-        102   pop 1                              
-        103   jump -94                           (to 9)
+  692   95    load_type 0                        
+        96    load_var2 4 8                      
+        97    load_var 10                        (parts)
+        98    init_instance 0                    (openai.internal.ChatPromptMessage .role, .parts)
+        99    call 4 ntypeargs=1                 (baml.Array.push)
+        100   pop 1                              
+        101   jump -92                           (to 9)
 
-  695   104   load_type 18                       
-        105   alloc_array 0                      
-        106   store_var 18                       (out)
+  695   102   load_type 18                       
+        103   alloc_array 0                      
+        104   store_var 18                       (out)
 
-  696   107   load_var 4                         (lowered)
-        108   load_type 19                       
-        109   load_const 20                      ("iter")
-        110   virtual_call nargs=1 ntypeargs=0   
-        111   store_var 19                       (_48)
-        112   load_var 19                        (_48)
-        113   load_type 21                       
-        114   load_const 22                      ("next")
-        115   virtual_call nargs=1 ntypeargs=0   
-        116   store_var 20                       (_49)
-        117   load_var 20                        (_49)
-        118   is_type 5                          
-        119   pop_jump_if_false +2               (to 121)
-        120   jump +21                           (to 141)
-        121   load_var 20                        (_49)
-        122   store_var 21                       (message)
+  696   105   load_var 4                         (lowered)
+        106   load_type 19                       
+        107   load_const 20                      ("iter")
+        108   virtual_call nargs=1 ntypeargs=0   
+        109   store_var 19                       (_48)
+        110   load_var 19                        (_48)
+        111   load_type 21                       
+        112   load_const 22                      ("next")
+        113   virtual_call nargs=1 ntypeargs=0   
+        114   store_var 20                       (_49)
+        115   load_var 20                        (_49)
+        116   is_type 5                          
+        117   pop_jump_if_false +2               (to 119)
+        118   jump +21                           (to 139)
+        119   load_var 20                        (_49)
+        120   store_var 21                       (message)
 
-  699   123   load_var 21                        (message)
-        124   load_field 0                       (role)
-        125   store_var 22                       (_55)
+  699   121   load_var 21                        (message)
+        122   load_field 0                       (role)
+        123   store_var 22                       (_55)
 
-  700   126   load_var 21                        (message)
-        127   load_field 1                       (parts)
-        128   load_var 2                         (compat)
-        129   load_field 6                       (collapse_text_content)
-        130   call 1114 ntypeargs=0              (openai.internal._chat_content)
-        131   store_var 23                       (_56)
+  700   124   load_var 21                        (message)
+        125   load_field 1                       (parts)
+        126   load_var 2                         (compat)
+        127   load_field 6                       (collapse_text_content)
+        128   call 1114 ntypeargs=0              (openai.internal._chat_content)
+        129   store_var 23                       (_56)
 
-  697   132   load_type 18                       
-        133   load_var2 18 22                    
+  697   130   load_type 18                       
+        131   load_var2 18 22                    
 
-  698   134   load_var 23                        (_56)
-        135   load_const 23                      (null)
-        136   load_const 23                      (null)
-        137   init_instance 1                    (openai.internal.ChatMessage .role, .content, .tool_calls, .tool_call_id)
+  698   132   load_var 23                        (_56)
+        133   load_const 23                      (null)
+        134   load_const 23                      (null)
+        135   init_instance 1                    (openai.internal.ChatMessage .role, .content, .tool_calls, .tool_call_id)
 
-  697   138   call 4 ntypeargs=1                 (baml.Array.push)
-        139   pop 1                              
-        140   jump -28                           (to 112)
+  697   136   call 4 ntypeargs=1                 (baml.Array.push)
+        137   pop 1                              
+        138   jump -28                           (to 110)
 
-  706   141   load_var 18                        (out)
-        142   store_var 3                        (_0)
-        143   load_var 3                         (_0)
-        144   return                             
+  706   139   load_var 18                        (out)
+        140   store_var 3                        (_0)
+        141   load_var 3                         (_0)
+        142   return                             
 }
 
 function openai.internal.chat_parse(response: openai.internal.CcResponse, provider: string, raw: string, audio_mime: string) -> ai.ModelTurn {
@@ -28295,59 +28169,54 @@ function openai.internal.chat_render_body(compat: openai.internal.ChatCompat, pa
 
 function openai.internal.chat_stop_reason(reason: string) -> ai.content.StopReason {
   1105   0    load_var 1             (reason)
-         1    load_const 0           ("tool_calls")
-         2    cmp_op ==              
-         3    pop_jump_if_false +2   (to 5)
-         4    jump +36               (to 40)
-         5    load_var 1             (reason)
-         6    load_const 1           ("function_call")
-         7    cmp_op ==              
-         8    pop_jump_if_false +2   (to 10)
-         9    jump +28               (to 37)
-         10   load_var 1             (reason)
-         11   load_const 2           ("length")
-         12   cmp_op ==              
-         13   pop_jump_if_false +2   (to 15)
-         14   jump +20               (to 34)
-         15   load_var 1             (reason)
-         16   load_const 3           ("max_tokens")
-         17   cmp_op ==              
+         1    is_type 0              
+         2    pop_jump_if_false +2   (to 4)
+         3    jump +32               (to 35)
+         4    load_var 1             (reason)
+         5    is_type 1              
+         6    pop_jump_if_false +2   (to 8)
+         7    jump +25               (to 32)
+         8    load_var 1             (reason)
+         9    is_type 2              
+         10   pop_jump_if_false +2   (to 12)
+         11   jump +18               (to 29)
+         12   load_var 1             (reason)
+         13   is_type 3              
+         14   pop_jump_if_false +2   (to 16)
+         15   jump +11               (to 26)
+         16   load_var 1             (reason)
+         17   is_type 4              
          18   pop_jump_if_false +2   (to 20)
-         19   jump +12               (to 31)
-         20   load_var 1             (reason)
-         21   load_const 4           ("content_filter")
-         22   cmp_op ==              
-         23   pop_jump_if_false +2   (to 25)
-         24   jump +4                (to 28)
+         19   jump +4                (to 23)
 
-  1109   25   load_const 5           (ai.content.StopReason.Complete)
-         26   alloc_variant 774      (ai.content.StopReason)
+  1109   20   load_const 5           (ai.content.StopReason.Complete)
+         21   alloc_variant 774      (ai.content.StopReason)
 
-  1105   27   jump +15               (to 42)
+  1105   22   jump +15               (to 37)
 
-  1108   28   load_const 6           (ai.content.StopReason.Refused)
-         29   alloc_variant 774      (ai.content.StopReason)
+  1108   23   load_const 6           (ai.content.StopReason.Refused)
+         24   alloc_variant 774      (ai.content.StopReason)
 
-  1105   30   jump +12               (to 42)
+  1105   25   jump +12               (to 37)
 
-  1107   31   load_const 7           (ai.content.StopReason.MaxTokens)
-         32   alloc_variant 774      (ai.content.StopReason)
+  1107   26   load_const 7           (ai.content.StopReason.MaxTokens)
+         27   alloc_variant 774      (ai.content.StopReason)
 
-  1105   33   jump +9                (to 42)
+  1105   28   jump +9                (to 37)
 
-  1107   34   load_const 7           (ai.content.StopReason.MaxTokens)
-         35   alloc_variant 774      (ai.content.StopReason)
+  1107   29   load_const 7           (ai.content.StopReason.MaxTokens)
+         30   alloc_variant 774      (ai.content.StopReason)
 
-  1105   36   jump +6                (to 42)
+  1105   31   jump +6                (to 37)
 
-  1106   37   load_const 8           (ai.content.StopReason.ToolUse)
-         38   alloc_variant 774      (ai.content.StopReason)
+  1106   32   load_const 8           (ai.content.StopReason.ToolUse)
+         33   alloc_variant 774      (ai.content.StopReason)
 
-  1105   39   jump +3                (to 42)
+  1105   34   jump +3                (to 37)
 
-  1106   40   load_const 8           (ai.content.StopReason.ToolUse)
-         41   alloc_variant 774      (ai.content.StopReason)
-         42   return                 
+  1106   35   load_const 8           (ai.content.StopReason.ToolUse)
+         36   alloc_variant 774      (ai.content.StopReason)
+         37   return                 
 }
 
 function openai.internal.images_invoke(c: openai.ImageClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
@@ -28671,7 +28540,7 @@ function openai.internal.invoke_stream(c: openai.ResponsesClient, input: ai.Mode
 
   1163   16   load_var2 3 5           
 
-  1164   17   make_closure 2752 1     
+  1164   17   make_closure 2708 1     
          18   load_const 1            ("openai")
 
   1162   19   call 959 ntypeargs=0    (ai.stream.TurnStream.from_sse)
@@ -28907,54 +28776,52 @@ function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> (openai.inter
         14   load_var 5                         (_5)
         15   is_type 5                          
         16   pop_jump_if_false +2               (to 18)
-        17   jump +36                           (to 53)
+        17   jump +34                           (to 51)
         18   load_var 5                         (_5)
         19   store_var 6                        (message)
 
   440   20   load_var 6                         (message)
         21   load_field 0                       (role)
         22   store_var_load_var 8               (_10)
-        23   load_const 6                       ("")
-        24   cmp_op ==                          
-        25   pop_jump_if_false +2               (to 27)
-        26   jump +13                           (to 39)
-        27   load_var 8                         (_10)
-        28   load_const 7                       ("tool")
-        29   cmp_op ==                          
-        30   pop_jump_if_false +2               (to 32)
-        31   jump +5                            (to 36)
+        23   is_type 6                          
+        24   pop_jump_if_false +2               (to 26)
+        25   jump +12                           (to 37)
+        26   load_var 8                         (_10)
+        27   is_type 7                          
+        28   pop_jump_if_false +2               (to 30)
+        29   jump +5                            (to 34)
 
-  442   32   load_var 6                         (message)
-        33   load_field 0                       (role)
-        34   store_var 7                        (role)
+  442   30   load_var 6                         (message)
+        31   load_field 0                       (role)
+        32   store_var 7                        (role)
 
-  440   35   jump +6                            (to 41)
+  440   33   jump +6                            (to 39)
 
-  441   36   load_const 8                       ("user")
-        37   store_var 7                        (role)
+  441   34   load_const 8                       ("user")
+        35   store_var 7                        (role)
 
-  440   38   jump +3                            (to 41)
+  440   36   jump +3                            (to 39)
 
-  441   39   load_const 9                       ("user")
-        40   store_var 7                        (role)
+  441   37   load_const 9                       ("user")
+        38   store_var 7                        (role)
 
-  444   41   load_var 7                         (role)
-        42   store_var 9                        (_15)
-        43   load_var2 6 7                      
-        44   call 1023 ntypeargs=0              (openai.internal._openai_prompt_content)
-        45   store_var 10                       (_16)
-        46   load_type 0                        
-        47   load_var2 3 9                      
-        48   load_var 10                        (_16)
-        49   init_instance 0                    (openai.internal.OaMessageItem .role, .content)
-        50   call 4 ntypeargs=1                 (baml.Array.push)
-        51   pop 1                              
-        52   jump -43                           (to 9)
+  444   39   load_var 7                         (role)
+        40   store_var 9                        (_15)
+        41   load_var2 6 7                      
+        42   call 1023 ntypeargs=0              (openai.internal._openai_prompt_content)
+        43   store_var 10                       (_16)
+        44   load_type 0                        
+        45   load_var2 3 9                      
+        46   load_var 10                        (_16)
+        47   init_instance 0                    (openai.internal.OaMessageItem .role, .content)
+        48   call 4 ntypeargs=1                 (baml.Array.push)
+        49   pop 1                              
+        50   jump -41                           (to 9)
 
-  446   53   load_var 3                         (items)
-        54   store_var 2                        (_0)
-        55   load_var 2                         (_0)
-        56   return                             
+  446   51   load_var 3                         (items)
+        52   store_var 2                        (_0)
+        53   load_var 2                         (_0)
+        54   return                             
 }
 
 function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.ModelTurn {
@@ -28978,7 +28845,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         17    call 672 ntypeargs=0               (baml.ops.equals_equals)
         18    unary_op !                         
         19    pop_jump_if_false +2               (to 21)
-        20    jump +367                          (to 387)
+        20    jump +361                          (to 381)
 
   822   21    load_type 3                        
         22    alloc_array 0                      
@@ -29014,398 +28881,392 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         48    load_var 9                         (_20)
         49    is_type 10                         
         50    pop_jump_if_false +2               (to 52)
-        51    jump +211                          (to 262)
+        51    jump +205                          (to 256)
         52    load_var 9                         (_20)
         53    store_var 10                       (item)
 
   827   54    load_var 10                        (item)
         55    load_field 0                       (type)
         56    store_var_load_var 11              (_24)
-        57    load_const 11                      ("function_call")
-        58    cmp_op ==                          
-        59    pop_jump_if_false +2               (to 61)
-        60    jump +152                          (to 212)
-        61    load_var 11                        (_24)
-        62    load_const 12                      ("message")
-        63    cmp_op ==                          
-        64    pop_jump_if_false +2               (to 66)
-        65    jump +74                           (to 139)
-        66    load_var 11                        (_24)
-        67    load_const 13                      ("reasoning")
-        68    cmp_op ==                          
-        69    pop_jump_if_false +2               (to 71)
-        70    jump +30                           (to 100)
-        71    load_var 11                        (_24)
-        72    load_const 14                      ("image_generation_call")
-        73    cmp_op ==                          
-        74    pop_jump_if_false -31              (to 43)
+        57    is_type 11                         
+        58    pop_jump_if_false +2               (to 60)
+        59    jump +147                          (to 206)
+        60    load_var 11                        (_24)
+        61    is_type 12                         
+        62    pop_jump_if_false +2               (to 64)
+        63    jump +72                           (to 135)
+        64    load_var 11                        (_24)
+        65    is_type 13                         
+        66    pop_jump_if_false +2               (to 68)
+        67    jump +29                           (to 96)
+        68    load_var 11                        (_24)
+        69    is_type 14                         
+        70    pop_jump_if_false -27              (to 43)
 
-  884   75    load_var 10                        (item)
-        76    load_field 8                       (result)
-        77    store_var 35                       (_98)
-        78    load_var 35                        (_98)
-        79    narrow_bind 15 35                  
-        80    pop_jump_if_false -37              (to 43)
-        81    load_var 35                        (_98)
-        82    store_var 36                       (encoded)
+  884   71    load_var 10                        (item)
+        72    load_field 8                       (result)
+        73    store_var 35                       (_98)
+        74    load_var 35                        (_98)
+        75    narrow_bind 15 35                  
+        76    pop_jump_if_false -33              (to 43)
+        77    load_var 35                        (_98)
+        78    store_var 36                       (encoded)
 
-  885   83    load_var 10                        (item)
-        84    load_field 10                      (output_format)
-        85    call 1038 ntypeargs=0              (openai.internal._openai_image_mime)
-        86    store_var 37                       (mime)
+  885   79    load_var 10                        (item)
+        80    load_field 10                      (output_format)
+        81    call 1038 ntypeargs=0              (openai.internal._openai_image_mime)
+        82    store_var 37                       (mime)
 
-  888   87    load_var2 36 37                    
-        88    call 349 ntypeargs=0               (baml.media.Image.from_base64)
+  888   83    load_var2 36 37                    
+        84    call 349 ntypeargs=0               (baml.media.Image.from_base64)
 
-  889   89    load_var 10                        (item)
-        90    load_field 1                       (id)
+  889   85    load_var 10                        (item)
+        86    load_field 1                       (id)
 
-  890   91    load_var 10                        (item)
-        92    load_field 9                       (revised_prompt)
+  890   87    load_var 10                        (item)
+        88    load_field 9                       (revised_prompt)
 
-  887   93    call 904 ntypeargs=0               (ai.content.Media.new)
-        94    store_var 38                       (_103)
+  887   89    call 904 ntypeargs=0               (ai.content.Media.new)
+        90    store_var 38                       (_103)
 
-  886   95    load_type 3                        
-        96    load_var2 3 38                     
-        97    call 4 ntypeargs=1                 (baml.Array.push)
-        98    pop 1                              
-        99    jump -56                           (to 43)
+  886   91    load_type 3                        
+        92    load_var2 3 38                     
+        93    call 4 ntypeargs=1                 (baml.Array.push)
+        94    pop 1                              
+        95    jump -52                           (to 43)
 
-  870   100   load_var 10                        (item)
-        101   load_field 7                       (summary)
-        102   store_var_load_var 29              (_80)
-        103   load_const 0                       (null)
-        104   cmp_op ==                          
-        105   pop_jump_if_false +4               (to 109)
-        106   load_type 16                       
-        107   alloc_array 0                      
-        108   store_var 29                       (_80)
-        109   load_var 29                        (_80)
-        110   store_var_load_var 28              (parts)
+  870   96    load_var 10                        (item)
+        97    load_field 7                       (summary)
+        98    store_var_load_var 29              (_80)
+        99    load_const 0                       (null)
+        100   cmp_op ==                          
+        101   pop_jump_if_false +4               (to 105)
+        102   load_type 16                       
+        103   alloc_array 0                      
+        104   store_var 29                       (_80)
+        105   load_var 29                        (_80)
+        106   store_var_load_var 28              (parts)
 
-  871   111   load_type 17                       
-        112   load_const 18                      ("iter")
-        113   virtual_call nargs=1 ntypeargs=0   
-        114   store_var 30                       (_84)
-        115   load_var 30                        (_84)
-        116   load_type 19                       
-        117   load_const 20                      ("next")
-        118   virtual_call nargs=1 ntypeargs=0   
-        119   store_var 31                       (_85)
+  871   107   load_type 17                       
+        108   load_const 18                      ("iter")
+        109   virtual_call nargs=1 ntypeargs=0   
+        110   store_var 30                       (_84)
+        111   load_var 30                        (_84)
+        112   load_type 19                       
+        113   load_const 20                      ("next")
+        114   virtual_call nargs=1 ntypeargs=0   
+        115   store_var 31                       (_85)
+        116   load_var 31                        (_85)
+        117   is_type 10                         
+        118   pop_jump_if_false +2               (to 120)
+        119   jump -76                           (to 43)
         120   load_var 31                        (_85)
-        121   is_type 10                         
-        122   pop_jump_if_false +2               (to 124)
-        123   jump -80                           (to 43)
-        124   load_var 31                        (_85)
-        125   store_var_load_var 32              (part)
+        121   store_var_load_var 32              (part)
 
-  872   126   load_field 1                       (text)
-        127   store_var 33                       (_90)
-        128   load_var 33                        (_90)
-        129   narrow_bind 15 33                  
-        130   pop_jump_if_false -15              (to 115)
-        131   load_var 33                        (_90)
-        132   store_var 34                       (txt)
+  872   122   load_field 1                       (text)
+        123   store_var 33                       (_90)
+        124   load_var 33                        (_90)
+        125   narrow_bind 15 33                  
+        126   pop_jump_if_false -15              (to 111)
+        127   load_var 33                        (_90)
+        128   store_var 34                       (txt)
 
-  873   133   load_type 3                        
-        134   load_var2 3 34                     
-        135   init_instance 0                    (ai.content.Reasoning .summary)
-        136   call 4 ntypeargs=1                 (baml.Array.push)
-        137   pop 1                              
-        138   jump -23                           (to 115)
+  873   129   load_type 3                        
+        130   load_var2 3 34                     
+        131   init_instance 0                    (ai.content.Reasoning .summary)
+        132   call 4 ntypeargs=1                 (baml.Array.push)
+        133   pop 1                              
+        134   jump -23                           (to 111)
 
-  851   139   load_var 10                        (item)
-        140   load_field 6                       (content)
-        141   store_var_load_var 20              (_49)
-        142   load_const 0                       (null)
-        143   cmp_op ==                          
-        144   pop_jump_if_false +4               (to 148)
-        145   load_type 16                       
-        146   alloc_array 0                      
-        147   store_var 20                       (_49)
-        148   load_var 20                        (_49)
-        149   store_var_load_var 19              (parts)
+  851   135   load_var 10                        (item)
+        136   load_field 6                       (content)
+        137   store_var_load_var 20              (_49)
+        138   load_const 0                       (null)
+        139   cmp_op ==                          
+        140   pop_jump_if_false +4               (to 144)
+        141   load_type 16                       
+        142   alloc_array 0                      
+        143   store_var 20                       (_49)
+        144   load_var 20                        (_49)
+        145   store_var_load_var 19              (parts)
 
-  852   150   load_type 17                       
-        151   load_const 21                      ("iter")
-        152   virtual_call nargs=1 ntypeargs=0   
-        153   store_var 21                       (_53)
-        154   load_var 21                        (_53)
-        155   load_type 19                       
-        156   load_const 22                      ("next")
-        157   virtual_call nargs=1 ntypeargs=0   
-        158   store_var 22                       (_54)
+  852   146   load_type 17                       
+        147   load_const 21                      ("iter")
+        148   virtual_call nargs=1 ntypeargs=0   
+        149   store_var 21                       (_53)
+        150   load_var 21                        (_53)
+        151   load_type 19                       
+        152   load_const 22                      ("next")
+        153   virtual_call nargs=1 ntypeargs=0   
+        154   store_var 22                       (_54)
+        155   load_var 22                        (_54)
+        156   is_type 10                         
+        157   pop_jump_if_false +2               (to 159)
+        158   jump -115                          (to 43)
         159   load_var 22                        (_54)
-        160   is_type 10                         
-        161   pop_jump_if_false +2               (to 163)
-        162   jump -119                          (to 43)
-        163   load_var 22                        (_54)
-        164   store_var_load_var 23              (part)
+        160   store_var_load_var 23              (part)
 
-  853   165   load_field 0                       (type)
-        166   store_var_load_var 25              (_59)
-        167   load_const 0                       (null)
-        168   cmp_op ==                          
-        169   pop_jump_if_false +3               (to 172)
-        170   load_const 23                      ("")
-        171   store_var 25                       (_59)
-        172   load_var 25                        (_59)
-        173   store_var_load_var 24              (kind)
+  853   161   load_field 0                       (type)
+        162   store_var_load_var 25              (_59)
+        163   load_const 0                       (null)
+        164   cmp_op ==                          
+        165   pop_jump_if_false +3               (to 168)
+        166   load_const 23                      ("")
+        167   store_var 25                       (_59)
+        168   load_var 25                        (_59)
+        169   store_var_load_var 24              (kind)
 
-  854   174   load_const 24                      ("output_text")
-        175   cmp_op ==                          
-        176   pop_jump_if_false +2               (to 178)
-        177   jump +21                           (to 198)
-        178   load_var 24                        (kind)
-        179   load_const 25                      ("refusal")
-        180   cmp_op ==                          
-        181   pop_jump_if_false -27              (to 154)
+  854   170   is_type 24                         
+        171   pop_jump_if_false +2               (to 173)
+        172   jump +20                           (to 192)
+        173   load_var 24                        (kind)
+        174   is_type 25                         
+        175   pop_jump_if_false -25              (to 150)
 
-  860   182   load_const 26                      (true)
-        183   store_var 5                        (refused)
+  860   176   load_const 26                      (true)
+        177   store_var 5                        (refused)
 
-  861   184   load_var 23                        (part)
-        185   load_field 2                       (refusal)
-        186   store_var_load_var 27              (_74)
-        187   load_const 0                       (null)
-        188   cmp_op ==                          
-        189   pop_jump_if_false +3               (to 192)
-        190   load_const 27                      ("")
-        191   store_var 27                       (_74)
-        192   load_type 3                        
-        193   load_var2 3 27                     
-        194   init_instance 1                    (ai.content.Text .text)
-        195   call 4 ntypeargs=1                 (baml.Array.push)
-        196   pop 1                              
-        197   jump -43                           (to 154)
+  861   178   load_var 23                        (part)
+        179   load_field 2                       (refusal)
+        180   store_var_load_var 27              (_74)
+        181   load_const 0                       (null)
+        182   cmp_op ==                          
+        183   pop_jump_if_false +3               (to 186)
+        184   load_const 27                      ("")
+        185   store_var 27                       (_74)
+        186   load_type 3                        
+        187   load_var2 3 27                     
+        188   init_instance 1                    (ai.content.Text .text)
+        189   call 4 ntypeargs=1                 (baml.Array.push)
+        190   pop 1                              
+        191   jump -41                           (to 150)
 
-  856   198   load_var 23                        (part)
-        199   load_field 1                       (text)
-        200   store_var_load_var 26              (_66)
-        201   load_const 0                       (null)
-        202   cmp_op ==                          
-        203   pop_jump_if_false +3               (to 206)
-        204   load_const 28                      ("")
-        205   store_var 26                       (_66)
-        206   load_type 3                        
-        207   load_var2 3 26                     
-        208   init_instance 2                    (ai.content.Text .text)
-        209   call 4 ntypeargs=1                 (baml.Array.push)
-        210   pop 1                              
-        211   jump -57                           (to 154)
+  856   192   load_var 23                        (part)
+        193   load_field 1                       (text)
+        194   store_var_load_var 26              (_66)
+        195   load_const 0                       (null)
+        196   cmp_op ==                          
+        197   pop_jump_if_false +3               (to 200)
+        198   load_const 28                      ("")
+        199   store_var 26                       (_66)
+        200   load_type 3                        
+        201   load_var2 3 26                     
+        202   init_instance 2                    (ai.content.Text .text)
+        203   call 4 ntypeargs=1                 (baml.Array.push)
+        204   pop 1                              
+        205   jump -55                           (to 150)
 
-  829   212   load_const 26                      (true)
-        213   store_var 4                        (has_call)
+  829   206   load_const 26                      (true)
+        207   store_var 4                        (has_call)
 
-  830   214   load_type 29                       
-        215   load_type 30                       
-        216   alloc_map 0                        
-        217   store_var 12                       (args)
+  830   208   load_type 29                       
+        209   load_type 30                       
+        210   alloc_map 0                        
+        211   store_var 12                       (args)
 
-  831   218   load_var 10                        (item)
-        219   load_field 5                       (arguments)
-        220   store_var 13                       (_28)
-        221   load_var 13                        (_28)
-        222   narrow_bind 15 13                  
-        223   pop_jump_if_false +14              (to 237)
-        224   load_var 13                        (_28)
-        225   store_var 14                       (s)
+  831   212   load_var 10                        (item)
+        213   load_field 5                       (arguments)
+        214   store_var 13                       (_28)
+        215   load_var 13                        (_28)
+        216   narrow_bind 15 13                  
+        217   pop_jump_if_false +14              (to 231)
+        218   load_var 13                        (_28)
+        219   store_var 14                       (s)
 
-  837   226   load_type 31                       
-        227   load_var 14                        (s)
-        228   call 357 ntypeargs=1               (baml.json.from_string)
-        229   store_var 12                       (args)
-        230   jump +7                            (to 237)
-        231   load_var 15                        (e)
-        232   throw_if_panic                     
+  837   220   load_type 31                       
+        221   load_var 14                        (s)
+        222   call 357 ntypeargs=1               (baml.json.from_string)
+        223   store_var 12                       (args)
+        224   jump +7                            (to 231)
+        225   load_var 15                        (e)
+        226   throw_if_panic                     
 
-  838   233   load_const 32                      ("openai")
-        234   load_var 14                        (s)
-        235   init_instance 3                    (ai.errors.ParseFailed .provider, .raw_output)
-        236   throw                              
+  838   227   load_const 32                      ("openai")
+        228   load_var 14                        (s)
+        229   init_instance 3                    (ai.errors.ParseFailed .provider, .raw_output)
+        230   throw                              
 
-  843   237   load_var 10                        (item)
-        238   load_field 3                       (call_id)
-        239   store_var_load_var 17              (_38)
-        240   load_const 0                       (null)
-        241   cmp_op ==                          
-        242   pop_jump_if_false +3               (to 245)
-        243   load_const 33                      ("")
-        244   store_var 17                       (_38)
-        245   load_var 17                        (_38)
-        246   store_var 16                       (_37)
+  843   231   load_var 10                        (item)
+        232   load_field 3                       (call_id)
+        233   store_var_load_var 17              (_38)
+        234   load_const 0                       (null)
+        235   cmp_op ==                          
+        236   pop_jump_if_false +3               (to 239)
+        237   load_const 33                      ("")
+        238   store_var 17                       (_38)
+        239   load_var 17                        (_38)
+        240   store_var 16                       (_37)
 
-  844   247   load_var 10                        (item)
-        248   load_field 4                       (name)
-        249   store_var_load_var 18              (_42)
-        250   load_const 0                       (null)
-        251   cmp_op ==                          
-        252   pop_jump_if_false +3               (to 255)
-        253   load_const 34                      ("")
-        254   store_var 18                       (_42)
+  844   241   load_var 10                        (item)
+        242   load_field 4                       (name)
+        243   store_var_load_var 18              (_42)
+        244   load_const 0                       (null)
+        245   cmp_op ==                          
+        246   pop_jump_if_false +3               (to 249)
+        247   load_const 34                      ("")
+        248   store_var 18                       (_42)
 
-  841   255   load_type 3                        
-        256   load_var2 3 16                     
+  841   249   load_type 3                        
+        250   load_var2 3 16                     
 
-  844   257   load_var2 18 12                    
+  844   251   load_var2 18 12                    
 
-  845   258   init_instance 4                    (ai.content.ToolUse .id, .name, .args)
+  845   252   init_instance 4                    (ai.content.ToolUse .id, .name, .args)
 
-  841   259   call 4 ntypeargs=1                 (baml.Array.push)
-        260   pop 1                              
-        261   jump -218                          (to 43)
+  841   253   call 4 ntypeargs=1                 (baml.Array.push)
+        254   pop 1                              
+        255   jump -212                          (to 43)
 
-  902   262   load_var 4                         (has_call)
-        263   pop_jump_if_false +2               (to 265)
-        264   jump +55                           (to 319)
+  902   256   load_var 4                         (has_call)
+        257   pop_jump_if_false +2               (to 259)
+        258   jump +55                           (to 313)
 
-  904   265   load_var 5                         (refused)
-        266   pop_jump_if_false +2               (to 268)
-        267   jump +48                           (to 315)
+  904   259   load_var 5                         (refused)
+        260   pop_jump_if_false +2               (to 262)
+        261   jump +48                           (to 309)
 
-  906   268   load_var 1                         (resp)
-        269   load_field 2                       (status)
-        270   store_var_load_var 40              (_115)
-        271   load_const 0                       (null)
+  906   262   load_var 1                         (resp)
+        263   load_field 2                       (status)
+        264   store_var_load_var 40              (_115)
+        265   load_const 0                       (null)
+        266   cmp_op ==                          
+        267   pop_jump_if_false +3               (to 270)
+        268   load_const 35                      ("")
+        269   store_var 40                       (_115)
+        270   load_var 40                        (_115)
+        271   load_const 36                      ("incomplete")
         272   cmp_op ==                          
-        273   pop_jump_if_false +3               (to 276)
-        274   load_const 35                      ("")
-        275   store_var 40                       (_115)
-        276   load_var 40                        (_115)
-        277   load_const 36                      ("incomplete")
-        278   cmp_op ==                          
-        279   pop_jump_if_false +2               (to 281)
-        280   jump +5                            (to 285)
+        273   pop_jump_if_false +2               (to 275)
+        274   jump +5                            (to 279)
 
-  913   281   load_const 37                      (ai.content.StopReason.Complete)
-        282   alloc_variant 774                  (ai.content.StopReason)
-        283   store_var 39                       (stop)
+  913   275   load_const 37                      (ai.content.StopReason.Complete)
+        276   alloc_variant 774                  (ai.content.StopReason)
+        277   store_var 39                       (stop)
 
-  906   284   jump +38                           (to 322)
+  906   278   jump +38                           (to 316)
 
-  907   285   load_var 1                         (resp)
+  907   279   load_var 1                         (resp)
+        280   load_field 5                       (incomplete_details)
+        281   load_const 0                       (null)
+        282   cmp_op ==                          
+        283   pop_jump_if_false +2               (to 285)
+        284   jump +5                            (to 289)
+        285   load_var 1                         (resp)
         286   load_field 5                       (incomplete_details)
-        287   load_const 0                       (null)
-        288   cmp_op ==                          
-        289   pop_jump_if_false +2               (to 291)
-        290   jump +5                            (to 295)
-        291   load_var 1                         (resp)
-        292   load_field 5                       (incomplete_details)
-        293   load_field 0                       (0)
-        294   jump +2                            (to 296)
-        295   load_const 0                       (null)
-        296   store_var_load_var 41              (_120)
-        297   load_const 0                       (null)
+        287   load_field 0                       (0)
+        288   jump +2                            (to 290)
+        289   load_const 0                       (null)
+        290   store_var_load_var 41              (_120)
+        291   load_const 0                       (null)
+        292   cmp_op ==                          
+        293   pop_jump_if_false +3               (to 296)
+        294   load_const 38                      ("")
+        295   store_var 41                       (_120)
+        296   load_var 41                        (_120)
+        297   load_const 39                      ("content_filter")
         298   cmp_op ==                          
-        299   pop_jump_if_false +3               (to 302)
-        300   load_const 38                      ("")
-        301   store_var 41                       (_120)
-        302   load_var 41                        (_120)
-        303   load_const 39                      ("content_filter")
-        304   cmp_op ==                          
-        305   pop_jump_if_false +2               (to 307)
-        306   jump +5                            (to 311)
+        299   pop_jump_if_false +2               (to 301)
+        300   jump +5                            (to 305)
 
-  910   307   load_const 40                      (ai.content.StopReason.MaxTokens)
-        308   alloc_variant 774                  (ai.content.StopReason)
-        309   store_var 39                       (stop)
+  910   301   load_const 40                      (ai.content.StopReason.MaxTokens)
+        302   alloc_variant 774                  (ai.content.StopReason)
+        303   store_var 39                       (stop)
 
-  907   310   jump +12                           (to 322)
+  907   304   jump +12                           (to 316)
 
-  908   311   load_const 41                      (ai.content.StopReason.Refused)
-        312   alloc_variant 774                  (ai.content.StopReason)
-        313   store_var 39                       (stop)
+  908   305   load_const 41                      (ai.content.StopReason.Refused)
+        306   alloc_variant 774                  (ai.content.StopReason)
+        307   store_var 39                       (stop)
 
-  907   314   jump +8                            (to 322)
+  907   308   jump +8                            (to 316)
 
-  905   315   load_const 41                      (ai.content.StopReason.Refused)
-        316   alloc_variant 774                  (ai.content.StopReason)
-        317   store_var 39                       (stop)
+  905   309   load_const 41                      (ai.content.StopReason.Refused)
+        310   alloc_variant 774                  (ai.content.StopReason)
+        311   store_var 39                       (stop)
 
-  904   318   jump +4                            (to 322)
+  904   312   jump +4                            (to 316)
 
-  903   319   load_const 15                      (ai.content.StopReason.ToolUse)
-        320   alloc_variant 774                  (ai.content.StopReason)
-        321   store_var 39                       (stop)
+  903   313   load_const 15                      (ai.content.StopReason.ToolUse)
+        314   alloc_variant 774                  (ai.content.StopReason)
+        315   store_var 39                       (stop)
 
-  915   322   load_var 1                         (resp)
-        323   load_field 4                       (usage)
-        324   store_var 43                       (_128)
-        325   load_var 43                        (_128)
-        326   narrow_bind 42 43                  
-        327   pop_jump_if_false +2               (to 329)
-        328   jump +4                            (to 332)
+  915   316   load_var 1                         (resp)
+        317   load_field 4                       (usage)
+        318   store_var 43                       (_128)
+        319   load_var 43                        (_128)
+        320   narrow_bind 42 43                  
+        321   pop_jump_if_false +2               (to 323)
+        322   jump +4                            (to 326)
 
-  923   329   load_const 0                       (null)
-        330   store_var 42                       (usage)
+  923   323   load_const 0                       (null)
+        324   store_var 42                       (usage)
 
-  915   331   jump +52                           (to 383)
-        332   load_var 43                        (_128)
-        333   store_var_load_var 44              (u)
+  915   325   jump +52                           (to 377)
+        326   load_var 43                        (_128)
+        327   store_var_load_var 44              (u)
 
-  917   334   load_field 0                       (input_tokens)
-        335   store_var_load_var 46              (_131)
-        336   load_const 0                       (null)
-        337   cmp_op ==                          
-        338   pop_jump_if_false +3               (to 341)
-        339   load_const 37                      (0)
-        340   store_var 46                       (_131)
-        341   load_var 46                        (_131)
-        342   store_var 45                       (_130)
+  917   328   load_field 0                       (input_tokens)
+        329   store_var_load_var 46              (_131)
+        330   load_const 0                       (null)
+        331   cmp_op ==                          
+        332   pop_jump_if_false +3               (to 335)
+        333   load_const 37                      (0)
+        334   store_var 46                       (_131)
+        335   load_var 46                        (_131)
+        336   store_var 45                       (_130)
 
-  918   343   load_var 44                        (u)
-        344   load_field 1                       (output_tokens)
-        345   store_var_load_var 48              (_135)
-        346   load_const 0                       (null)
-        347   cmp_op ==                          
-        348   pop_jump_if_false +3               (to 351)
-        349   load_const 37                      (0)
-        350   store_var 48                       (_135)
-        351   load_var 48                        (_135)
-        352   store_var 47                       (_134)
+  918   337   load_var 44                        (u)
+        338   load_field 1                       (output_tokens)
+        339   store_var_load_var 48              (_135)
+        340   load_const 0                       (null)
+        341   cmp_op ==                          
+        342   pop_jump_if_false +3               (to 345)
+        343   load_const 37                      (0)
+        344   store_var 48                       (_135)
+        345   load_var 48                        (_135)
+        346   store_var 47                       (_134)
 
-  919   353   load_var 44                        (u)
+  919   347   load_var 44                        (u)
+        348   load_field 3                       (input_tokens_details)
+        349   load_const 0                       (null)
+        350   cmp_op ==                          
+        351   pop_jump_if_false +2               (to 353)
+        352   jump +6                            (to 358)
+        353   load_var 44                        (u)
         354   load_field 3                       (input_tokens_details)
-        355   load_const 0                       (null)
-        356   cmp_op ==                          
-        357   pop_jump_if_false +2               (to 359)
-        358   jump +6                            (to 364)
-        359   load_var 44                        (u)
-        360   load_field 3                       (input_tokens_details)
-        361   load_field 0                       (0)
-        362   store_var 49                       (_138)
-        363   jump +3                            (to 366)
-        364   load_const 0                       (null)
-        365   store_var 49                       (_138)
+        355   load_field 0                       (0)
+        356   store_var 49                       (_138)
+        357   jump +3                            (to 360)
+        358   load_const 0                       (null)
+        359   store_var 49                       (_138)
 
-  920   366   load_var 44                        (u)
+  920   360   load_var 44                        (u)
+        361   load_field 4                       (output_tokens_details)
+        362   load_const 0                       (null)
+        363   cmp_op ==                          
+        364   pop_jump_if_false +2               (to 366)
+        365   jump +6                            (to 371)
+        366   load_var 44                        (u)
         367   load_field 4                       (output_tokens_details)
-        368   load_const 0                       (null)
-        369   cmp_op ==                          
-        370   pop_jump_if_false +2               (to 372)
-        371   jump +6                            (to 377)
-        372   load_var 44                        (u)
-        373   load_field 4                       (output_tokens_details)
-        374   load_field 0                       (0)
-        375   store_var 50                       (_142)
-        376   jump +3                            (to 379)
-        377   load_const 0                       (null)
-        378   store_var 50                       (_142)
+        368   load_field 0                       (0)
+        369   store_var 50                       (_142)
+        370   jump +3                            (to 373)
+        371   load_const 0                       (null)
+        372   store_var 50                       (_142)
 
-  916   379   load_var2 45 47                    
-        380   load_var2 49 50                    
-        381   init_instance 5                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
-        382   store_var 42                       (usage)
+  916   373   load_var2 45 47                    
+        374   load_var2 49 50                    
+        375   init_instance 5                    (ai.events.Usage .input_tokens, .output_tokens, .cached_input_tokens, .reasoning_tokens)
+        376   store_var 42                       (usage)
 
-  925   383   load_var2 3 39                     
-        384   load_var 42                        (usage)
-        385   init_instance 6                    (ai.ModelTurn .content, .stop_reason, .usage)
-        386   return                             
+  925   377   load_var2 3 39                     
+        378   load_var 42                        (usage)
+        379   init_instance 6                    (ai.ModelTurn .content, .stop_reason, .usage)
+        380   return                             
 
-  820   387   load_var 1                         (resp)
-        388   call 1041 ntypeargs=0              (openai.internal._openai_response_failure)
-        389   throw                              
+  820   381   load_var 1                         (resp)
+        382   call 1041 ntypeargs=0              (openai.internal._openai_response_failure)
+        383   throw                              
 }
 
 function openai.internal.openai_prompt_metadata(prompt: ai.Prompt) -> map<string, baml.json.json>[] {
@@ -32864,7 +32725,7 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
 
   56   45    load_field 2            (role)
        46    discriminant            
-       47    jump_table 0            ([to 57, to 54, to 51, to 48], default to 115)
+       47    jump_table 0            ([to 57, to 54, to 51, to 48], default to 114)
 
   60   48    load_var 2              (threshold)
        49    store_var 11            (role_mult)
@@ -32910,53 +32771,52 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
 
   73   77    load_var 2              (threshold)
        78    cmp_int_op >            
-       79    load_const 2            (true)
-       80    cmp_op ==               
-       81    pop_jump_if_false +2    (to 83)
-       82    jump +4                 (to 86)
+       79    is_type 2               
+       80    pop_jump_if_false +2    (to 82)
+       81    jump +4                 (to 85)
 
-  75   83    load_const 3            (" [LOW]")
-       84    store_var 17            (suffix)
+  75   82    load_const 3            (" [LOW]")
+       83    store_var 17            (suffix)
 
-  73   85    jump +3                 (to 88)
+  73   84    jump +3                 (to 87)
 
-  74   86    load_const 4            (" [HIGH]")
-       87    store_var 17            (suffix)
+  74   85    load_const 4            (" [HIGH]")
+       86    store_var 17            (suffix)
 
-  77   88    load_var2 3 17          
-       89    bin_op +                
-       90    store_var 18            (label)
+  77   87    load_var2 3 17          
+       88    bin_op +                
+       89    store_var 18            (label)
 
-  79   91    load_var2 14 15         
-       92    load_var 16             (total)
-       93    load_type 5             
-       94    alloc_array 3           
-       95    store_var 19            (scores)
+  79   90    load_var2 14 15         
+       91    load_var 16             (total)
+       92    load_type 5             
+       93    alloc_array 3           
+       94    store_var 19            (scores)
 
-  80   96    load_var 19             (scores)
-       97    load_const 6            (0)
-       98    load_var 16             (total)
-       99    store_array_element     
+  80   95    load_var 19             (scores)
+       96    load_const 6            (0)
+       97    load_var 16             (total)
+       98    store_array_element     
 
-  81   100   load_var 19             (scores)
-       101   load_const 6            (0)
-       102   load_array_element      
-       103   store_var 20            (top)
+  81   99    load_var 19             (scores)
+       100   load_const 6            (0)
+       101   load_array_element      
+       102   store_var 20            (top)
 
-  83   104   load_var2 14 11         
-       105   load_const 7            ("base")
-       106   load_const 8            ("role")
-       107   load_type 9             
-       108   load_type 5             
-       109   alloc_map 2             
-       110   store_var 21            (breakdown)
+  83   103   load_var2 14 11         
+       104   load_const 7            ("base")
+       105   load_const 8            ("role")
+       106   load_type 9             
+       107   load_type 5             
+       108   alloc_map 2             
+       109   store_var 21            (breakdown)
 
-  86   111   load_var2 20 18         
+  86   110   load_var2 20 18         
 
-  88   112   load_var 21             (breakdown)
-       113   init_instance 0         (user.Report .score, .label, .breakdown)
-       114   return                  
-       115   unreachable             
+  88   111   load_var 21             (breakdown)
+       112   init_instance 0         (user.Report .score, .label, .breakdown)
+       113   return                  
+       114   unreachable             
 }
 
 function vercel.AiGatewayImageClient.ai.Client.id(self: vercel.AiGatewayImageClient) -> string {
@@ -33696,44 +33556,40 @@ function vercel.internal._gw_images_mime(format: string | null) -> string {
         9    store_var 2            (normalized)
 
   351   10   load_var 2             (normalized)
-        11   load_const 2           ("jpeg")
-        12   cmp_op ==              
-        13   pop_jump_if_false +2   (to 15)
-        14   jump +24               (to 38)
-        15   load_var 2             (normalized)
-        16   load_const 3           ("jpg")
-        17   cmp_op ==              
-        18   pop_jump_if_false +2   (to 20)
-        19   jump +17               (to 36)
-        20   load_var 2             (normalized)
-        21   load_const 4           ("webp")
-        22   cmp_op ==              
-        23   pop_jump_if_false +2   (to 25)
-        24   jump +10               (to 34)
-        25   load_var 2             (normalized)
-        26   load_const 5           ("gif")
-        27   cmp_op ==              
-        28   pop_jump_if_false +2   (to 30)
-        29   jump +3                (to 32)
+        11   is_type 2              
+        12   pop_jump_if_false +2   (to 14)
+        13   jump +21               (to 34)
+        14   load_var 2             (normalized)
+        15   is_type 3              
+        16   pop_jump_if_false +2   (to 18)
+        17   jump +15               (to 32)
+        18   load_var 2             (normalized)
+        19   is_type 4              
+        20   pop_jump_if_false +2   (to 22)
+        21   jump +9                (to 30)
+        22   load_var 2             (normalized)
+        23   is_type 5              
+        24   pop_jump_if_false +2   (to 26)
+        25   jump +3                (to 28)
 
-  355   30   load_const 6           ("image/png")
+  355   26   load_const 6           ("image/png")
 
-  351   31   jump +8                (to 39)
+  351   27   jump +8                (to 35)
 
-  354   32   load_const 7           ("image/gif")
+  354   28   load_const 7           ("image/gif")
 
-  351   33   jump +6                (to 39)
+  351   29   jump +6                (to 35)
 
-  353   34   load_const 8           ("image/webp")
+  353   30   load_const 8           ("image/webp")
 
-  351   35   jump +4                (to 39)
+  351   31   jump +4                (to 35)
 
-  352   36   load_const 9           ("image/jpeg")
+  352   32   load_const 9           ("image/jpeg")
 
-  351   37   jump +2                (to 39)
+  351   33   jump +2                (to 35)
 
-  352   38   load_const 10          ("image/jpeg")
-        39   return                 
+  352   34   load_const 10          ("image/jpeg")
+        35   return                 
 }
 
 function vercel.internal._gw_images_trim_slash(url: string) -> string {

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_textual.snap
@@ -841,22 +841,19 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
     load_var _14
     store_var kind
     load_var form
-    load_const "mixedlist"
-    cmp_op ==
+    is_type "mixedlist"
     pop_jump_if_false L2
     jump L22
 
   L2:
     load_var form
-    load_const "mixed"
-    cmp_op ==
+    is_type "mixed"
     pop_jump_if_false L3
     jump L14
 
   L3:
     load_var form
-    load_const "list"
-    cmp_op ==
+    is_type "list"
     pop_jump_if_false L4
     jump L13
 
@@ -2573,85 +2570,73 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
     call baml.String.slice
     store_var model
     load_var prefix
-    load_const "openai"
-    cmp_op ==
+    is_type "openai"
     pop_jump_if_false L2
     jump L25
 
   L2:
     load_var prefix
-    load_const "openai-chat"
-    cmp_op ==
+    is_type "openai-chat"
     pop_jump_if_false L3
     jump L24
 
   L3:
     load_var prefix
-    load_const "openai-images"
-    cmp_op ==
+    is_type "openai-images"
     pop_jump_if_false L4
     jump L23
 
   L4:
     load_var prefix
-    load_const "azure"
-    cmp_op ==
+    is_type "azure"
     pop_jump_if_false L5
     jump L22
 
   L5:
     load_var prefix
-    load_const "ollama"
-    cmp_op ==
+    is_type "ollama"
     pop_jump_if_false L6
     jump L21
 
   L6:
     load_var prefix
-    load_const "openrouter"
-    cmp_op ==
+    is_type "openrouter"
     pop_jump_if_false L7
     jump L20
 
   L7:
     load_var prefix
-    load_const "anthropic"
-    cmp_op ==
+    is_type "anthropic"
     pop_jump_if_false L8
     jump L19
 
   L8:
     load_var prefix
-    load_const "google"
-    cmp_op ==
+    is_type "google"
     pop_jump_if_false L9
     jump L18
 
   L9:
     load_var prefix
-    load_const "vertex"
-    cmp_op ==
+    is_type "vertex"
     pop_jump_if_false L10
     jump L17
 
   L10:
     load_var prefix
-    load_const "bedrock"
-    cmp_op ==
+    is_type "bedrock"
     pop_jump_if_false L11
     jump L16
 
   L11:
     load_var prefix
-    load_const "ai-gateway-images"
-    cmp_op ==
+    is_type "ai-gateway-images"
     pop_jump_if_false L12
     jump L15
 
   L12:
     load_var prefix
-    load_const "claude-code"
-    cmp_op ==
+    is_type "claude-code"
     pop_jump_if_false L13
     jump L14
 
@@ -7521,29 +7506,25 @@ function anthropic.internal._anth_stream_failure(error: anthropic.internal.AnthS
     load_var _10
     store_var detail
     load_var kind
-    load_const "rate_limit_error"
-    cmp_op ==
+    is_type "rate_limit_error"
     pop_jump_if_false L8
     jump L15
 
   L8:
     load_var kind
-    load_const "overloaded_error"
-    cmp_op ==
+    is_type "overloaded_error"
     pop_jump_if_false L9
     jump L14
 
   L9:
     load_var kind
-    load_const "api_error"
-    cmp_op ==
+    is_type "api_error"
     pop_jump_if_false L10
     jump L13
 
   L10:
     load_var kind
-    load_const "timeout_error"
-    cmp_op ==
+    is_type "timeout_error"
     pop_jump_if_false L11
     jump L12
 
@@ -8767,29 +8748,25 @@ function anthropic.internal._anthropic_sse_failure(message: string) -> ai.errors
 
 function anthropic.internal._anthropic_stop_reason(s: string) -> ai.content.StopReason {
     load_var s
-    load_const "end_turn"
-    cmp_op ==
+    is_type "end_turn"
     pop_jump_if_false L0
     jump L7
 
   L0:
     load_var s
-    load_const "stop_sequence"
-    cmp_op ==
+    is_type "stop_sequence"
     pop_jump_if_false L1
     jump L6
 
   L1:
     load_var s
-    load_const "tool_use"
-    cmp_op ==
+    is_type "tool_use"
     pop_jump_if_false L2
     jump L5
 
   L2:
     load_var s
-    load_const "refusal"
-    cmp_op ==
+    is_type "refusal"
     pop_jump_if_false L3
     jump L4
 
@@ -8997,43 +8974,37 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
   L4:
     load_var _20
     store_var_load_var t
-    load_const "error"
-    cmp_op ==
+    is_type "error"
     pop_jump_if_false L5
     jump L69
 
   L5:
     load_var t
-    load_const "message_start"
-    cmp_op ==
+    is_type "message_start"
     pop_jump_if_false L6
     jump L51
 
   L6:
     load_var t
-    load_const "content_block_start"
-    cmp_op ==
+    is_type "content_block_start"
     pop_jump_if_false L7
     jump L41
 
   L7:
     load_var t
-    load_const "content_block_delta"
-    cmp_op ==
+    is_type "content_block_delta"
     pop_jump_if_false L8
     jump L30
 
   L8:
     load_var t
-    load_const "message_delta"
-    cmp_op ==
+    is_type "message_delta"
     pop_jump_if_false L9
     jump L10
 
   L9:
     load_var t
-    load_const "message_stop"
-    cmp_op ==
+    is_type "message_stop"
     pop_jump_if_false L0
     load_type ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone
     load_var out
@@ -9214,29 +9185,25 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
   L31:
     load_var _122
     store_var_load_var kind
-    load_const "text_delta"
-    cmp_op ==
+    is_type "text_delta"
     pop_jump_if_false L32
     jump L40
 
   L32:
     load_var kind
-    load_const "input_json_delta"
-    cmp_op ==
+    is_type "input_json_delta"
     pop_jump_if_false L33
     jump L38
 
   L33:
     load_var kind
-    load_const "thinking_delta"
-    cmp_op ==
+    is_type "thinking_delta"
     pop_jump_if_false L34
     jump L36
 
   L34:
     load_var kind
-    load_const "signature_delta"
-    cmp_op ==
+    is_type "signature_delta"
     pop_jump_if_false L0
     load_type string
     load_var state
@@ -9358,15 +9325,13 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
   L42:
     load_var _77
     store_var_load_var kind
-    load_const "tool_use"
-    cmp_op ==
+    is_type "tool_use"
     pop_jump_if_false L43
     jump L47
 
   L43:
     load_var kind
-    load_const "thinking"
-    cmp_op ==
+    is_type "thinking"
     pop_jump_if_false L44
     jump L45
 
@@ -9975,22 +9940,19 @@ function anthropic.internal.anthropic_parse(resp: anthropic.internal.AnthropicRe
     load_var b
     load_field .type
     store_var_load_var _9
-    load_const "text"
-    cmp_op ==
+    is_type "text"
     pop_jump_if_false L2
     jump L9
 
   L2:
     load_var _9
-    load_const "thinking"
-    cmp_op ==
+    is_type "thinking"
     pop_jump_if_false L3
     jump L7
 
   L3:
     load_var _9
-    load_const "tool_use"
-    cmp_op ==
+    is_type "tool_use"
     pop_jump_if_false L0
     load_var b
     load_field .id
@@ -11056,141 +11018,121 @@ function aws.internal._audio_block(audio: baml.media.Audio) -> aws.internal.Cont
 
 function aws.internal._audio_format(mime: string) -> string {
     load_var mime
-    load_const "audio/mpeg"
-    cmp_op ==
+    is_type "audio/mpeg"
     pop_jump_if_false L0
     jump L39
 
   L0:
     load_var mime
-    load_const "audio/mp3"
-    cmp_op ==
+    is_type "audio/mp3"
     pop_jump_if_false L1
     jump L38
 
   L1:
     load_var mime
-    load_const "audio/wav"
-    cmp_op ==
+    is_type "audio/wav"
     pop_jump_if_false L2
     jump L37
 
   L2:
     load_var mime
-    load_const "audio/x-wav"
-    cmp_op ==
+    is_type "audio/x-wav"
     pop_jump_if_false L3
     jump L36
 
   L3:
     load_var mime
-    load_const "audio/wave"
-    cmp_op ==
+    is_type "audio/wave"
     pop_jump_if_false L4
     jump L35
 
   L4:
     load_var mime
-    load_const "audio/flac"
-    cmp_op ==
+    is_type "audio/flac"
     pop_jump_if_false L5
     jump L34
 
   L5:
     load_var mime
-    load_const "audio/x-flac"
-    cmp_op ==
+    is_type "audio/x-flac"
     pop_jump_if_false L6
     jump L33
 
   L6:
     load_var mime
-    load_const "audio/ogg"
-    cmp_op ==
+    is_type "audio/ogg"
     pop_jump_if_false L7
     jump L32
 
   L7:
     load_var mime
-    load_const "audio/opus"
-    cmp_op ==
+    is_type "audio/opus"
     pop_jump_if_false L8
     jump L31
 
   L8:
     load_var mime
-    load_const "audio/aac"
-    cmp_op ==
+    is_type "audio/aac"
     pop_jump_if_false L9
     jump L30
 
   L9:
     load_var mime
-    load_const "audio/x-aac"
-    cmp_op ==
+    is_type "audio/x-aac"
     pop_jump_if_false L10
     jump L29
 
   L10:
     load_var mime
-    load_const "audio/mp4"
-    cmp_op ==
+    is_type "audio/mp4"
     pop_jump_if_false L11
     jump L28
 
   L11:
     load_var mime
-    load_const "audio/m4a"
-    cmp_op ==
+    is_type "audio/m4a"
     pop_jump_if_false L12
     jump L27
 
   L12:
     load_var mime
-    load_const "audio/x-m4a"
-    cmp_op ==
+    is_type "audio/x-m4a"
     pop_jump_if_false L13
     jump L26
 
   L13:
     load_var mime
-    load_const "audio/x-matroska"
-    cmp_op ==
+    is_type "audio/x-matroska"
     pop_jump_if_false L14
     jump L25
 
   L14:
     load_var mime
-    load_const "audio/mpga"
-    cmp_op ==
+    is_type "audio/mpga"
     pop_jump_if_false L15
     jump L24
 
   L15:
     load_var mime
-    load_const "audio/pcm"
-    cmp_op ==
+    is_type "audio/pcm"
     pop_jump_if_false L16
     jump L23
 
   L16:
     load_var mime
-    load_const "audio/x-pcm"
-    cmp_op ==
+    is_type "audio/x-pcm"
     pop_jump_if_false L17
     jump L22
 
   L17:
     load_var mime
-    load_const "audio/L16"
-    cmp_op ==
+    is_type "audio/L16"
     pop_jump_if_false L18
     jump L21
 
   L18:
     load_var mime
-    load_const "audio/webm"
-    cmp_op ==
+    is_type "audio/webm"
     pop_jump_if_false L19
     jump L20
 
@@ -11382,36 +11324,31 @@ function aws.internal._image_block(image: baml.media.Image) -> aws.internal.Cont
 
 function aws.internal._image_format(mime: string) -> string {
     load_var mime
-    load_const "image/png"
-    cmp_op ==
+    is_type "image/png"
     pop_jump_if_false L0
     jump L9
 
   L0:
     load_var mime
-    load_const "image/jpeg"
-    cmp_op ==
+    is_type "image/jpeg"
     pop_jump_if_false L1
     jump L8
 
   L1:
     load_var mime
-    load_const "image/jpg"
-    cmp_op ==
+    is_type "image/jpg"
     pop_jump_if_false L2
     jump L7
 
   L2:
     load_var mime
-    load_const "image/gif"
-    cmp_op ==
+    is_type "image/gif"
     pop_jump_if_false L3
     jump L6
 
   L3:
     load_var mime
-    load_const "image/webp"
-    cmp_op ==
+    is_type "image/webp"
     pop_jump_if_false L4
     jump L5
 
@@ -12739,22 +12676,19 @@ function aws.internal._tool_choice(choice: string) -> aws.internal.ToolChoice {
     alloc_map 0
     store_var empty
     load_var choice
-    load_const "auto"
-    cmp_op ==
+    is_type "auto"
     pop_jump_if_false L0
     jump L5
 
   L0:
     load_var choice
-    load_const "any"
-    cmp_op ==
+    is_type "any"
     pop_jump_if_false L1
     jump L4
 
   L1:
     load_var choice
-    load_const "required"
-    cmp_op ==
+    is_type "required"
     pop_jump_if_false L2
     jump L3
 
@@ -12901,78 +12835,67 @@ function aws.internal._video_block(video: baml.media.Video) -> aws.internal.Cont
 
 function aws.internal._video_format(mime: string) -> string {
     load_var mime
-    load_const "video/mp4"
-    cmp_op ==
+    is_type "video/mp4"
     pop_jump_if_false L0
     jump L21
 
   L0:
     load_var mime
-    load_const "video/mpeg"
-    cmp_op ==
+    is_type "video/mpeg"
     pop_jump_if_false L1
     jump L20
 
   L1:
     load_var mime
-    load_const "video/mpg"
-    cmp_op ==
+    is_type "video/mpg"
     pop_jump_if_false L2
     jump L19
 
   L2:
     load_var mime
-    load_const "video/x-mpg"
-    cmp_op ==
+    is_type "video/x-mpg"
     pop_jump_if_false L3
     jump L18
 
   L3:
     load_var mime
-    load_const "video/x-ms-wmv"
-    cmp_op ==
+    is_type "video/x-ms-wmv"
     pop_jump_if_false L4
     jump L17
 
   L4:
     load_var mime
-    load_const "video/wmv"
-    cmp_op ==
+    is_type "video/wmv"
     pop_jump_if_false L5
     jump L16
 
   L5:
     load_var mime
-    load_const "video/x-matroska"
-    cmp_op ==
+    is_type "video/x-matroska"
     pop_jump_if_false L6
     jump L15
 
   L6:
     load_var mime
-    load_const "video/quicktime"
-    cmp_op ==
+    is_type "video/quicktime"
     pop_jump_if_false L7
     jump L14
 
   L7:
     load_var mime
-    load_const "video/x-flv"
-    cmp_op ==
+    is_type "video/x-flv"
     pop_jump_if_false L8
     jump L13
 
   L8:
     load_var mime
-    load_const "video/webm"
-    cmp_op ==
+    is_type "video/webm"
     pop_jump_if_false L9
     jump L12
 
   L9:
     load_var mime
-    load_const "video/3gpp"
-    cmp_op ==
+    is_type "video/3gpp"
     pop_jump_if_false L10
     jump L11
 
@@ -13954,36 +13877,31 @@ function aws.internal.sign_request(req: baml.http.Request, opts: aws.internal.Aw
 
 function aws.internal.stop_reason(raw: string) -> ai.content.StopReason {
     load_var raw
-    load_const "tool_use"
-    cmp_op ==
+    is_type "tool_use"
     pop_jump_if_false L0
     jump L11
 
   L0:
     load_var raw
-    load_const "max_tokens"
-    cmp_op ==
+    is_type "max_tokens"
     pop_jump_if_false L1
     jump L10
 
   L1:
     load_var raw
-    load_const "model_context_window_exceeded"
-    cmp_op ==
+    is_type "model_context_window_exceeded"
     pop_jump_if_false L2
     jump L9
 
   L2:
     load_var raw
-    load_const "content_filtered"
-    cmp_op ==
+    is_type "content_filtered"
     pop_jump_if_false L3
     jump L8
 
   L3:
     load_var raw
-    load_const "guardrail_intervened"
-    cmp_op ==
+    is_type "guardrail_intervened"
     pop_jump_if_false L4
     jump L7
 
@@ -14151,29 +14069,25 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> void {
     call baml.json.path_or
     store_var kind
     load_var kind
-    load_const "system"
-    cmp_op ==
+    is_type "system"
     pop_jump_if_false L0
     jump L28
 
   L0:
     load_var kind
-    load_const "assistant"
-    cmp_op ==
+    is_type "assistant"
     pop_jump_if_false L1
     jump L16
 
   L1:
     load_var kind
-    load_const "user"
-    cmp_op ==
+    is_type "user"
     pop_jump_if_false L2
     jump L4
 
   L2:
     load_var kind
-    load_const "result"
-    cmp_op ==
+    is_type "result"
     pop_jump_if_false L3
     jump L31
 
@@ -14232,29 +14146,25 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> void {
     call baml.json.path_or
     store_var bt
     load_var bt
-    load_const "text"
-    cmp_op ==
+    is_type "text"
     pop_jump_if_false L7
     jump L14
 
   L7:
     load_var bt
-    load_const "thinking"
-    cmp_op ==
+    is_type "thinking"
     pop_jump_if_false L8
     jump L13
 
   L8:
     load_var bt
-    load_const "tool_use"
-    cmp_op ==
+    is_type "tool_use"
     pop_jump_if_false L9
     jump L12
 
   L9:
     load_var bt
-    load_const "tool_result"
-    cmp_op ==
+    is_type "tool_result"
     pop_jump_if_false L10
     jump L11
 
@@ -14405,29 +14315,25 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> void {
     call baml.json.path_or
     store_var bt
     load_var bt
-    load_const "text"
-    cmp_op ==
+    is_type "text"
     pop_jump_if_false L19
     jump L26
 
   L19:
     load_var bt
-    load_const "thinking"
-    cmp_op ==
+    is_type "thinking"
     pop_jump_if_false L20
     jump L25
 
   L20:
     load_var bt
-    load_const "tool_use"
-    cmp_op ==
+    is_type "tool_use"
     pop_jump_if_false L21
     jump L24
 
   L21:
     load_var bt
-    load_const "tool_result"
-    cmp_op ==
+    is_type "tool_result"
     pop_jump_if_false L22
     jump L23
 
@@ -22906,22 +22812,19 @@ function openai.internal._chat_audio_format(mime_type: string) -> string {
 
   L2:
     load_var subtype
-    load_const "mpeg"
-    cmp_op ==
+    is_type "mpeg"
     pop_jump_if_false L3
     jump L8
 
   L3:
     load_var subtype
-    load_const "mp3"
-    cmp_op ==
+    is_type "mp3"
     pop_jump_if_false L4
     jump L7
 
   L4:
     load_var subtype
-    load_const "x-wav"
-    cmp_op ==
+    is_type "x-wav"
     pop_jump_if_false L5
     jump L6
 
@@ -22952,15 +22855,13 @@ function openai.internal._chat_audio_output_mime(request_body: baml.json.json | 
     call baml.json.path_or
     store_var format
     load_var format
-    load_const "mp3"
-    cmp_op ==
+    is_type "mp3"
     pop_jump_if_false L0
     jump L3
 
   L0:
     load_var format
-    load_const "pcm16"
-    cmp_op ==
+    is_type "pcm16"
     pop_jump_if_false L1
     jump L2
 
@@ -24832,29 +24733,25 @@ function openai.internal._oai_images_mime(format: string | null) -> string {
     call baml.String.to_lower_case
     store_var normalized
     load_var normalized
-    load_const "jpeg"
-    cmp_op ==
+    is_type "jpeg"
     pop_jump_if_false L1
     jump L8
 
   L1:
     load_var normalized
-    load_const "jpg"
-    cmp_op ==
+    is_type "jpg"
     pop_jump_if_false L2
     jump L7
 
   L2:
     load_var normalized
-    load_const "webp"
-    cmp_op ==
+    is_type "webp"
     pop_jump_if_false L3
     jump L6
 
   L3:
     load_var normalized
-    load_const "gif"
-    cmp_op ==
+    is_type "gif"
     pop_jump_if_false L4
     jump L5
 
@@ -25306,57 +25203,49 @@ function openai.internal._openai_apply_message_metadata(body: baml.json.json, me
 
 function openai.internal._openai_audio_format(mime_type: string) -> string {
     load_var mime_type
-    load_const "audio/wav"
-    cmp_op ==
+    is_type "audio/wav"
     pop_jump_if_false L0
     jump L15
 
   L0:
     load_var mime_type
-    load_const "audio/x-wav"
-    cmp_op ==
+    is_type "audio/x-wav"
     pop_jump_if_false L1
     jump L14
 
   L1:
     load_var mime_type
-    load_const "audio/mpeg"
-    cmp_op ==
+    is_type "audio/mpeg"
     pop_jump_if_false L2
     jump L13
 
   L2:
     load_var mime_type
-    load_const "audio/mp3"
-    cmp_op ==
+    is_type "audio/mp3"
     pop_jump_if_false L3
     jump L12
 
   L3:
     load_var mime_type
-    load_const "audio/flac"
-    cmp_op ==
+    is_type "audio/flac"
     pop_jump_if_false L4
     jump L11
 
   L4:
     load_var mime_type
-    load_const "audio/x-flac"
-    cmp_op ==
+    is_type "audio/x-flac"
     pop_jump_if_false L5
     jump L10
 
   L5:
     load_var mime_type
-    load_const "audio/ogg"
-    cmp_op ==
+    is_type "audio/ogg"
     pop_jump_if_false L6
     jump L9
 
   L6:
     load_var mime_type
-    load_const "audio/webm"
-    cmp_op ==
+    is_type "audio/webm"
     pop_jump_if_false L7
     jump L8
 
@@ -25842,22 +25731,19 @@ function openai.internal._openai_image_mime(output_format: string | null) -> str
     call baml.String.to_lower_case
     store_var format
     load_var format
-    load_const "jpeg"
-    cmp_op ==
+    is_type "jpeg"
     pop_jump_if_false L1
     jump L6
 
   L1:
     load_var format
-    load_const "jpg"
-    cmp_op ==
+    is_type "jpg"
     pop_jump_if_false L2
     jump L5
 
   L2:
     load_var format
-    load_const "webp"
-    cmp_op ==
+    is_type "webp"
     pop_jump_if_false L3
     jump L4
 
@@ -27016,71 +26902,61 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
 
   L3:
     load_var kind
-    load_const "response.created"
-    cmp_op ==
+    is_type "response.created"
     pop_jump_if_false L4
     jump L37
 
   L4:
     load_var kind
-    load_const "response.in_progress"
-    cmp_op ==
+    is_type "response.in_progress"
     pop_jump_if_false L5
     jump L36
 
   L5:
     load_var kind
-    load_const "response.output_text.delta"
-    cmp_op ==
+    is_type "response.output_text.delta"
     pop_jump_if_false L6
     jump L35
 
   L6:
     load_var kind
-    load_const "response.output_text.done"
-    cmp_op ==
+    is_type "response.output_text.done"
     pop_jump_if_false L7
     jump L33
 
   L7:
     load_var kind
-    load_const "response.function_call_arguments.delta"
-    cmp_op ==
+    is_type "response.function_call_arguments.delta"
     pop_jump_if_false L8
     jump L31
 
   L8:
     load_var kind
-    load_const "response.function_call_arguments.done"
-    cmp_op ==
+    is_type "response.function_call_arguments.done"
     pop_jump_if_false L9
     jump L30
 
   L9:
     load_var kind
-    load_const "response.failed"
-    cmp_op ==
+    is_type "response.failed"
     pop_jump_if_false L10
     jump L29
 
   L10:
     load_var kind
-    load_const "error"
-    cmp_op ==
+    is_type "error"
     pop_jump_if_false L11
     jump L28
 
   L11:
     load_var kind
-    load_const "response.completed"
-    cmp_op ==
+    is_type "response.completed"
     pop_jump_if_false L12
     jump L20
 
   L12:
     load_var kind
-    load_const "response.incomplete"
-    cmp_op ==
+    is_type "response.incomplete"
     pop_jump_if_false L38
     load_var event
     load_field .response
@@ -28358,15 +28234,13 @@ function openai.internal.chat_lower_prompt(prompt: ai.Prompt, compat: openai.int
     load_var message
     load_field .role
     store_var_load_var _11
-    load_const ""
-    cmp_op ==
+    is_type ""
     pop_jump_if_false L2
     jump L5
 
   L2:
     load_var _11
-    load_const "tool"
-    cmp_op ==
+    is_type "tool"
     pop_jump_if_false L3
     jump L4
 
@@ -29010,36 +28884,31 @@ function openai.internal.chat_render_body(compat: openai.internal.ChatCompat, pa
 
 function openai.internal.chat_stop_reason(reason: string) -> ai.content.StopReason {
     load_var reason
-    load_const "tool_calls"
-    cmp_op ==
+    is_type "tool_calls"
     pop_jump_if_false L0
     jump L9
 
   L0:
     load_var reason
-    load_const "function_call"
-    cmp_op ==
+    is_type "function_call"
     pop_jump_if_false L1
     jump L8
 
   L1:
     load_var reason
-    load_const "length"
-    cmp_op ==
+    is_type "length"
     pop_jump_if_false L2
     jump L7
 
   L2:
     load_var reason
-    load_const "max_tokens"
-    cmp_op ==
+    is_type "max_tokens"
     pop_jump_if_false L3
     jump L6
 
   L3:
     load_var reason
-    load_const "content_filter"
-    cmp_op ==
+    is_type "content_filter"
     pop_jump_if_false L4
     jump L5
 
@@ -29596,15 +29465,13 @@ function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> (openai.inter
     load_var message
     load_field .role
     store_var_load_var _10
-    load_const ""
-    cmp_op ==
+    is_type ""
     pop_jump_if_false L2
     jump L5
 
   L2:
     load_var _10
-    load_const "tool"
-    cmp_op ==
+    is_type "tool"
     pop_jump_if_false L3
     jump L4
 
@@ -29713,29 +29580,25 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
     load_var item
     load_field .type
     store_var_load_var _24
-    load_const "function_call"
-    cmp_op ==
+    is_type "function_call"
     pop_jump_if_false L7
     jump L23
 
   L7:
     load_var _24
-    load_const "message"
-    cmp_op ==
+    is_type "message"
     pop_jump_if_false L8
     jump L14
 
   L8:
     load_var _24
-    load_const "reasoning"
-    cmp_op ==
+    is_type "reasoning"
     pop_jump_if_false L9
     jump L10
 
   L9:
     load_var _24
-    load_const "image_generation_call"
-    cmp_op ==
+    is_type "image_generation_call"
     pop_jump_if_false L5
     load_var item
     load_field .result
@@ -29849,15 +29712,13 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
   L18:
     load_var _59
     store_var_load_var kind
-    load_const "output_text"
-    cmp_op ==
+    is_type "output_text"
     pop_jump_if_false L19
     jump L21
 
   L19:
     load_var kind
-    load_const "refusal"
-    cmp_op ==
+    is_type "refusal"
     pop_jump_if_false L16
     load_const true
     store_var refused
@@ -33755,8 +33616,7 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
     store_var_load_var total
     load_var threshold
     cmp_int_op >
-    load_const true
-    cmp_op ==
+    is_type true
     pop_jump_if_false L16
     jump L17
 
@@ -34540,29 +34400,25 @@ function vercel.internal._gw_images_mime(format: string | null) -> string {
     call baml.String.to_lower_case
     store_var normalized
     load_var normalized
-    load_const "jpeg"
-    cmp_op ==
+    is_type "jpeg"
     pop_jump_if_false L1
     jump L8
 
   L1:
     load_var normalized
-    load_const "jpg"
-    cmp_op ==
+    is_type "jpg"
     pop_jump_if_false L2
     jump L7
 
   L2:
     load_var normalized
-    load_const "webp"
-    cmp_op ==
+    is_type "webp"
     pop_jump_if_false L3
     jump L6
 
   L3:
     load_var normalized
-    load_const "gif"
-    cmp_op ==
+    is_type "gif"
     pop_jump_if_false L4
     jump L5
 

--- a/baml_language/crates/bex_heap/src/heap.rs
+++ b/baml_language/crates/bex_heap/src/heap.rs
@@ -434,11 +434,11 @@ impl BexHeap {
                     .iter()
                     .map(|cv| match cv {
                         bex_vm_types::ConstValue::Type(_) => bex_vm_types::Value::NULL,
-                        // ClassWithTypeArgs is NOT pre-resolved: `IsType` reads it
-                        // directly from `constants` at execution time.
-                        bex_vm_types::ConstValue::ClassWithTypeArgs { .. } => {
-                            bex_vm_types::Value::NULL
-                        }
+                        // ClassWithTypeArgs and Literal are NOT pre-resolved:
+                        // `IsType` reads them directly from `constants` at
+                        // execution time.
+                        bex_vm_types::ConstValue::ClassWithTypeArgs { .. }
+                        | bex_vm_types::ConstValue::Literal(_) => bex_vm_types::Value::NULL,
                         other => other.to_value(resolve_idx),
                     })
                     .collect();

--- a/baml_language/crates/bex_vm/src/debug.rs
+++ b/baml_language/crates/bex_vm/src/debug.rs
@@ -301,6 +301,7 @@ fn display_const_value(value: &bex_vm_types::ConstValue, objects: Option<&Object
             }
         }
         bex_vm_types::ConstValue::Type(template) => format!("<type_template {template}>"),
+        bex_vm_types::ConstValue::Literal(literal) => format!("<literal {literal}>"),
         bex_vm_types::ConstValue::ClassWithTypeArgs {
             class_obj,
             type_args_templates,

--- a/baml_language/crates/bex_vm/src/package_baml/reflect.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/reflect.rs
@@ -771,7 +771,8 @@ impl BamlClassReflectPackage for PackageBamlImpl {
             for constant in constants {
                 let value = match constant {
                     bex_vm_types::ConstValue::Type(_)
-                    | bex_vm_types::ConstValue::ClassWithTypeArgs { .. } => Value::NULL,
+                    | bex_vm_types::ConstValue::ClassWithTypeArgs { .. }
+                    | bex_vm_types::ConstValue::Literal(_) => Value::NULL,
                     bex_vm_types::ConstValue::Float(value) => {
                         let ptr = vm.alloc_float(value);
                         objects.push(ptr);
@@ -1548,7 +1549,8 @@ fn graft_session_submission(
         for constant in constants {
             let value = match constant {
                 bex_vm_types::ConstValue::Type(_)
-                | bex_vm_types::ConstValue::ClassWithTypeArgs { .. } => Value::NULL,
+                | bex_vm_types::ConstValue::ClassWithTypeArgs { .. }
+                | bex_vm_types::ConstValue::Literal(_) => Value::NULL,
                 bex_vm_types::ConstValue::Float(value) => {
                     let pointer = vm.alloc_float(value);
                     extra_owned.push(pointer);

--- a/baml_language/crates/bex_vm/src/type_match.rs
+++ b/baml_language/crates/bex_vm/src/type_match.rs
@@ -44,12 +44,15 @@ pub(crate) fn value_matches_template(
     // realized frame the value carries (a bound method's drops the applied
     // receiver), so one minted in a generic frame is as precise as any other;
     // futures reconstruct at the `Future<T, E>` their spawn site was typed at.
-    let Some(value_ty) = vm.value_concrete_ty(value) else {
+    //
+    // The reconstruction is the singleton-precise one: a literal type holds a
+    // single value, so nothing decides membership in it short of the value
+    // reporting the type of exactly itself.
+    let Some(value_ty) = vm.value_singleton_ty(value) else {
         return Ok(false);
     };
-    // The canonical algebra operates over `Ty`; a value's concrete type widens
-    // into it (a shallow structural conversion — `ConcreteRealizedTy` is not a
-    // deep, transmute-compatible family member with a borrowed upcast).
+    // The canonical algebra operates over `Ty`; a value's realized type widens
+    // into it.
     let value_ty: Ty = value_ty.into();
     // Resolve frame references into a realized type, then let the canonical
     // algebra do the work.
@@ -266,6 +269,53 @@ mod tests {
             baml_type::TyAttr::default(),
         );
         assert!(matches(&int_arm, &[], &one));
+    }
+
+    /// The algebra half of literal membership: the relation
+    /// `ConstValue::Literal` specializes must give the same answers the
+    /// specialization does, or the fast path and the general path disagree.
+    ///
+    /// Each case below is exactly one `value_is_literal` arm: a singleton
+    /// admits itself, no other value of its base type, and — the B-1073 case —
+    /// nothing from a neighbouring rung of the numeric tower, which the `==`
+    /// operator deliberately widens across and this relation deliberately does
+    /// not.
+    #[test]
+    fn literal_membership_agrees_with_algebra() {
+        fn lit(l: baml_type::Literal) -> RuntimeTy {
+            RuntimeTy::Literal(
+                l,
+                baml_type::Freshness::Regular,
+                baml_type::TyAttr::default(),
+            )
+        }
+        fn lit_realized(l: baml_type::Literal) -> RealizedTy {
+            RealizedTy::Literal(
+                l,
+                baml_type::Freshness::Regular,
+                baml_type::TyAttr::default(),
+            )
+        }
+        let one = leaf(lit_realized(baml_type::Literal::Int(1)));
+
+        // A singleton admits exactly itself.
+        assert!(matches(&one, &[], &lit(baml_type::Literal::Int(1))));
+        assert!(!matches(&one, &[], &lit(baml_type::Literal::Int(2))));
+
+        // ...and nothing from another rung of the tower, at either precision.
+        assert!(!matches(&one, &[], &RuntimeTy::float()));
+        assert!(!matches(
+            &one,
+            &[],
+            &lit(baml_type::Literal::Bigint(1.into()))
+        ));
+        assert!(!matches(&one, &[], &lit(baml_type::Literal::Bool(true))));
+
+        // The base type is not a member of its own singleton: `int` includes
+        // values other than `1`. This is why the value matcher must reconstruct
+        // the *singleton* type of a value (`value_singleton_ty`) rather than
+        // its base — with the base it reports, no value inhabits any literal.
+        assert!(!matches(&one, &[], &RuntimeTy::int()));
     }
 
     // ── Class-arg (invariant) checks — the `ClassWithTypeArgs` per-arg relation ──

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -2357,6 +2357,15 @@ impl BexVm {
             ConstValue::Type(template) => {
                 crate::type_match::value_matches_template(self, value, template, frame_type_args)
             }
+            // Membership in a singleton type. Decided against the value's own
+            // identity rather than against the type it reconstructs, because
+            // `value_concrete_ty`-style reconstruction is what the general
+            // algebra needs and this is the one type whose inhabitants are
+            // enumerated rather than described. Equality here is *exact* — same
+            // representation, same contents — never the numeric-tower widening
+            // `==` applies (B-1073): `1` and `1.0` are disjoint types, so no
+            // float inhabits the int-literal singleton.
+            ConstValue::Literal(literal) => Ok(self.value_is_literal(value, literal)),
             ConstValue::ClassWithTypeArgs {
                 class_obj,
                 type_args_templates,
@@ -2488,6 +2497,85 @@ impl BexVm {
         }
     }
 
+    /// Whether `value` inhabits the singleton type denoted by `literal`.
+    ///
+    /// The runtime counterpart of `TyTemplate::Literal`: exact representation
+    /// *and* exact contents. A heap `Float` is not the int literal `1` however
+    /// close its magnitude, and a `bigint` is not an `int` — those are disjoint
+    /// types (`TYPE_SYSTEM.md` "Concrete Types": no concrete type is a subtype
+    /// of another), even though the `==` operator deliberately widens across
+    /// all three.
+    ///
+    /// Float equality is exact here by construction, not by oversight: a
+    /// singleton holds one value, so membership is identity and a tolerance
+    /// would admit values the type excludes.
+    #[allow(clippy::float_cmp)]
+    pub(crate) fn value_is_literal(&self, value: Value, literal: &baml_type::Literal) -> bool {
+        match literal {
+            baml_type::Literal::Int(n) => value.as_int() == Some(*n),
+            baml_type::Literal::Bool(b) => value.as_bool() == Some(*b),
+            baml_type::Literal::String(s) => match value.as_object_ptr() {
+                Some(ptr) => matches!(self.get_object(ptr), Object::String(v) if **v == **s),
+                None => false,
+            },
+            baml_type::Literal::Bigint(n) => match value.as_object_ptr() {
+                Some(ptr) => matches!(self.get_object(ptr), Object::Bigint(v) if **v == *n),
+                None => false,
+            },
+            // No surface syntax produces a float literal *type* (the parser
+            // rejects `1.0` in type position), so this arm is unreachable from
+            // BAML source. It is still answered exactly rather than defaulted,
+            // so a future float-literal type cannot inherit a silent `false`.
+            baml_type::Literal::Float(repr) => match value.as_object_ptr() {
+                Some(ptr) => match self.get_object(ptr) {
+                    Object::Float(v) => repr.parse::<f64>().is_ok_and(|expected| *v == expected),
+                    _ => false,
+                },
+                None => false,
+            },
+        }
+    }
+
+    /// The value's type at maximum precision — its *singleton* type where it
+    /// has one, otherwise the same leaf [`Self::value_concrete_ty`] reports.
+    ///
+    /// `TYPE_SYSTEM.md` "Values and membership" defines membership as "`v` is a
+    /// member of `T` iff `v`'s concrete type is a subtype of `T`". That only
+    /// decides literal types if the reconstructed type is the value's *most
+    /// precise* one:
+    /// reporting the int `1` as `int` makes `is_subtype(int, 1)` false and no
+    /// value would ever inhabit a literal type. Precision costs nothing at the
+    /// other end — `Literal(Int, 1) <: int` holds — so every test the coarser
+    /// reconstruction passed still passes.
+    ///
+    /// Deliberately separate from [`Self::value_concrete_ty`] rather than
+    /// replacing it: impl-registry dispatch keys on that one, and `implement I
+    /// for int` must resolve for every int, not for the singleton `1`.
+    pub(crate) fn value_singleton_ty(&self, value: Value) -> Option<baml_type::RealizedTy> {
+        use baml_type::{Freshness, RealizedTy, TyAttr};
+        let literal = |lit| RealizedTy::Literal(lit, Freshness::Regular, TyAttr::default());
+        if let Some(n) = value.as_int() {
+            return Some(literal(baml_type::Literal::Int(n)));
+        }
+        if let Some(b) = value.as_bool() {
+            return Some(literal(baml_type::Literal::Bool(b)));
+        }
+        if let Some(ptr) = value.as_object_ptr() {
+            match self.get_object(ptr) {
+                Object::String(s) => {
+                    return Some(literal(baml_type::Literal::String((**s).to_owned())));
+                }
+                Object::Bigint(n) => {
+                    return Some(literal(baml_type::Literal::Bigint((**n).clone())));
+                }
+                // A float has no literal type to be precise about, and every
+                // other object's precise type is already its concrete one.
+                _ => {}
+            }
+        }
+        Some(self.value_concrete_ty(value)?.into())
+    }
+
     /// The value's concrete type as a [`ConcreteRealizedTy`] — the invariant every
     /// runtime value's type satisfies (a concrete top with realized arguments, no
     /// type variables) made explicit in the type. `None` for a value kind that
@@ -2502,8 +2590,9 @@ impl BexVm {
     /// fails (→ `None`) only if a residual type variable leaked in — a bug.
     ///
     /// The interface resolver wants the loose `RuntimeTy`, so the sole such caller
-    /// widens the result back; the `IsType` value matcher wants the invariant made
-    /// explicit and uses it directly.
+    /// widens the result back. The `IsType` value matcher goes through
+    /// [`Self::value_singleton_ty`] instead — it needs the value's *most precise*
+    /// type, which for a primitive is its singleton, not its base leaf.
     pub(crate) fn value_concrete_ty(&self, value: Value) -> Option<baml_type::ConcreteRealizedTy> {
         use baml_type::{ConcreteRealizedTy, TyAttr};
         if value.as_int().is_some() {

--- a/baml_language/crates/bex_vm_types/src/relink.rs
+++ b/baml_language/crates/bex_vm_types/src/relink.rs
@@ -169,7 +169,8 @@ macro_rules! visit_bytecode_index_operands {
                 | ConstValue::Int(_)
                 | ConstValue::Float(_)
                 | ConstValue::Bool(_)
-                | ConstValue::Type(_) => {}
+                | ConstValue::Type(_)
+                | ConstValue::Literal(_) => {}
             }
         }
         // Each class-init plan carries one class-object reference.

--- a/baml_language/crates/bex_vm_types/src/types/const_value.rs
+++ b/baml_language/crates/bex_vm_types/src/types/const_value.rs
@@ -44,6 +44,21 @@ pub enum ConstValue {
         /// no match-any holes).
         type_args_templates: Vec<baml_type::TyTemplate>,
     },
+    /// A singleton-type `IsType` check constant: membership in the literal
+    /// type `1`, `"go"`, `true`, `1n`.
+    ///
+    /// Membership in a singleton is decided by the value's *own* identity, so
+    /// unlike every other `IsType` constant this one is compared against the
+    /// value rather than against a type the value reconstructs. It is a
+    /// specialization of `ConstValue::Type(TyTemplate::Literal(..))`, which
+    /// decides the same question through the canonical algebra: the two must
+    /// agree, and `literal_membership_agrees_with_algebra` in `type_match`
+    /// pins that.
+    ///
+    /// Like `Type` and `ClassWithTypeArgs`, this constant is **not**
+    /// pre-resolved at load time — the `IsType` dispatch reads it straight from
+    /// the raw constant pool.
+    Literal(baml_base::Literal),
 }
 
 impl ConstValue {
@@ -77,6 +92,12 @@ impl ConstValue {
             ConstValue::ClassWithTypeArgs { .. } => {
                 panic!(
                     "ConstValue::ClassWithTypeArgs must not be pre-resolved via to_value — \
+                     use the IsType instruction instead"
+                )
+            }
+            ConstValue::Literal(_) => {
+                panic!(
+                    "ConstValue::Literal must not be pre-resolved via to_value — \
                      use the IsType instruction instead"
                 )
             }


### PR DESCRIPTION
## Issue Reference

[B-1073](https://linear.app/boundaryml2/issue/B-1073)

## Changes

A literal pattern is a membership test against a singleton type, but it lowered to `BinOp::Eq` — the arithmetic equality operator, which widens across the numeric tower on purpose. So `x is 1` fired for `1.0`, while the type system holds `1`, `1.0` and `1n` disjoint.

The same construct had four lowerings and they disagreed:

| lowering | reached by | behaviour on `1.0` vs pattern `1` |
| --- | --- | --- |
| `BinOp::Eq` | `is`, guarded match arm | matched (unsound) |
| `SwitchKind::Integer` chain | sparse int match | correct |
| `JumpTable` | dense int match (>=4 arms) | `VM internal error: expected int, got float` |
| `IsType` + type tag | `x is One` for `type One = 1` | matched **every** int |

The last row is a second, independent bug found while fixing this one: `realized_type_tag` mapped `Literal(Int, 1)` to the base `INT` tag, so the one path that was already a membership test discarded the literal's value.

All four now go through one relation — `IsType` → `is_subtype` — which is what every other pattern kind already used.

- `lower.rs`: literal patterns emit `emit_is_type_branch` against `RuntimeTy::Literal` instead of `Rvalue::BinaryOp { op: Eq }`.
- `vm.rs`: new `value_singleton_ty` reconstructs a value's *most precise* type (the int `1` reports `Literal(Int, 1)`, not `int`). Without it `is_subtype(value_ty, literal)` is false for every literal and nothing would inhabit a literal type. Kept separate from `value_concrete_ty` because impl-registry dispatch keys on that one and `implement I for int` must resolve for every int.
- `vm.rs`: new `value_is_literal` — exact representation and contents, never the tower widening.
- `const_value.rs` / `emit.rs`: new `ConstValue::Literal`, the fifth constant shape for the existing overloaded `IsType` instruction (alongside class pointer, class+args, enum pointer, type tag). Keeps the hot path a direct identity check instead of a full `is_subtype` call — no new opcode.
- `emit.rs`: `realized_type_tag` returns `None` for a literal. A tag names a base type and a literal is a strict subset of its base, so a base tag over-accepts.
- `lower.rs`: an integer `Switch` over a scrutinee that is not provably int-only is now guarded by an `INT` tag test that falls through to `otherwise`. A non-int reaching an integer switch is a match failure, not a broken invariant.

### Note beyond the ticket

The wrong arm was not the worst consequence. In the then-branch the compiler narrows `x` to the int literal type, so `let y: int = x` is accepted while the value is a heap `Float`, and `y % 2` emits `OpCode::ModInt`, which does `std::hint::unreachable_unchecked()` on a non-int (`vm.rs:8695`). That is UB in release, reachable from safe BAML source. This PR removes the way in; it does not change those preconditions, which stay sound only as long as narrowing is. Worth a separate look.

## Testing

- `crates/baml_tests/baml_src/ns_literal_pattern_membership/literal_pattern_membership.baml` — 22 native tests covering all four lowerings against the same value, both directions of int/bigint, bool, and string literals.
- `crates/bex_vm/src/type_match.rs` — `literal_membership_agrees_with_algebra` pins the relation `ConstValue::Literal` specializes, so the fast path and the general path cannot drift.

Bytecode display snapshots churn as expected: `load_const X` + `cmp_op ==` becomes `is_type X` (or `narrow_bind` at bind sites) in the MIR/codegen stages of `is_operator`, `match_basics`, `match_types`, `patterns_new_runtime`, `patterns_class_destructure_namespaces`, `lambda_advanced`, `generic_intersection_bounds`, `__ai_std__`, and the `bytecode_format` displays. Every changed snapshot line is that substitution.

```
mise run fmt
mise run stow
mise run clippy                 # -D warnings
mise run clippy-wasm            # -D warnings
cargo nextest run --all-features --workspace --exclude baml_tests --exclude baml_cli \
  --exclude baml_lsp2_actions --exclude "sdk_test_*" --exclude baml_bridge
      # 4495 passed, 0 failed
cargo test -p baml_tests -p baml_cli -p baml_lsp2_actions -p baml_lsp2_actions_tests -p bex_engine
      # all pass except perf_large_int_array_uses_native_fast_path (comparable_sort),
      # a wall-clock-bounded perf test that also fails on baseline canary on the same
      # machine (96.9s baseline vs 82s this branch, 60s bound; 5.0s isolated on this
      # branch) -- pre-existing thread-contention flake, not introduced here
SKIP=no-commit-to-branch prek run --all-files --hook-stage manual
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed literal type checks so values match only their exact literal, rather than any value of the underlying type.
  * Improved pattern matching for integer, boolean, string, bigint, and floating-point literals.
  * Preserved distinctions such as `1` versus `1.0`, and prevented cross-type matches.
  * Corrected guarded, sparse, and dense matches to safely route non-matching values to fallback branches.

* **Tests**
  * Added comprehensive coverage for literal membership, aliases, unions, and cross-type matching scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->