### PR TITLE
fmt: strip redundant same-precedence parens in binary chains and call args (B-1562)

### DIFF
--- a/baml_language/crates/baml_fmt/src/ast/expressions.rs
+++ b/baml_language/crates/baml_fmt/src/ast/expressions.rs
@@ -9,7 +9,7 @@ use crate::{
         Token, Type, UnaryOp, tokens as t,
     },
     printer::{PrintInfo, PrintMultiLine, Printable, Printer, Shape},
-    trivia_classifier::{EmittableTrivia, TriviaSliceExt},
+    trivia_classifier::{EmittableTrivia, TriviaInfo, TriviaSliceExt},
 };
 
 #[derive(Debug)]
@@ -782,6 +782,21 @@ impl ParenExpr {
             .sum::<Option<usize>>()?;
         Some(const { "()".len() } + inner + trivia_len)
     }
+
+    /// Whether no comments are attached to either paren token or to the inner
+    /// expression's boundary. Peeling a transparent paren cannot lose trivia:
+    /// every span a parent context queries around it is empty.
+    fn is_transparent(&self, trivia: &TriviaInfo) -> bool {
+        let (open_leading, open_trailing) = trivia.get_for_range_split(self.open_paren.span());
+        let (close_leading, close_trailing) = trivia.get_for_range_split(self.close_paren.span());
+        let (expr_leading, expr_trailing) = trivia.get_for_element(&*self.expr);
+        open_leading.is_empty()
+            && open_trailing.is_empty()
+            && close_leading.is_empty()
+            && close_trailing.is_empty()
+            && expr_leading.is_empty()
+            && expr_trailing.is_empty()
+    }
 }
 
 impl PrintMultiLine for ParenExpr {
@@ -862,6 +877,23 @@ impl Printable for ParenExpr {
     }
 }
 
+impl Expression {
+    /// Strips nested [`ParenExpr`] wrappers that are transparent (no comments
+    /// attached to the parens or the inner expression's boundary), returning
+    /// the innermost expression. Callers decide per context whether printing
+    /// the peeled expression instead of `self` is safe.
+    fn peel_transparent_parens(&self, trivia: &TriviaInfo) -> &Expression {
+        let mut expr = self;
+        while let Expression::Paren(paren) = expr {
+            if !paren.is_transparent(trivia) {
+                break;
+            }
+            expr = &paren.expr;
+        }
+        expr
+    }
+}
+
 /// Corresponds to a [`SyntaxKind::BINARY_EXPR`] node.
 #[derive(Debug)]
 pub struct BinaryExpr {
@@ -922,7 +954,8 @@ impl BinaryExpr {
     /// Returns the width of the expression if it fits on a single line.
     /// Returns `None` if it can never be single-lined.
     pub(crate) fn single_line_width(&self, input: &Printer<'_>) -> Option<usize> {
-        let (left, right) = &*self.sides;
+        let left = self.effective_left(input.trivia);
+        let right = &self.sides.1;
         let left_width = left.single_line_width(input)?;
         let right_width = right.single_line_width(input)?;
         // Must match trivia handled by try_print_single_line
@@ -943,24 +976,54 @@ impl BinaryExpr {
         Some(len)
     }
 
+    /// The left operand with redundant parens peeled.
+    ///
+    /// `(a && b) && c` and `a && b && c` parse to different trees but mean
+    /// the same thing and print identically, so a transparent paren around
+    /// the left operand is dropped when the inner operator sits in the same
+    /// precedence row as this one (reparsing the output yields the printed
+    /// tree, keeping the formatter idempotent). Right operands are never
+    /// peeled: removing those parens would re-associate, as in `a - (b - c)`.
+    /// Mixed-precedence parens like `(a * b) + c` are kept: they are
+    /// redundant to the parser but carry clarity for the reader.
+    fn effective_left(&self, trivia: &TriviaInfo) -> &Expression {
+        let Some(row) = BinaryOpPrecedenceRow::row_for_op(&self.op) else {
+            return &self.sides.0;
+        };
+        let peeled = self.sides.0.peel_transparent_parens(trivia);
+        match peeled {
+            Expression::Binary(inner)
+                if BinaryOpPrecedenceRow::row_for_op(&inner.op) == Some(row) =>
+            {
+                peeled
+            }
+            _ => &self.sides.0,
+        }
+    }
+
     /// Recursively lifts binary expressions in the same chaining group to the top level.
     /// For ops that are not in any chaining groups, return will be the same as the original.
+    /// Redundant parens around left operands are peeled (see [`Self::effective_left`])
+    /// so a fully parenthesized chain flattens like an unparenthesized one.
     ///
     /// The vec will never be empty.
-    fn get_chaining_members(&self) -> (&Expression, Vec<(&BinaryOp, &Expression)>) {
+    fn get_chaining_members(
+        &self,
+        trivia: &TriviaInfo,
+    ) -> (&Expression, Vec<(&BinaryOp, &Expression)>) {
         let mut members = Vec::new();
         let Some(chaining_group) = BinaryOpChainingGroup::group_for_op(&self.op) else {
             members.push((&self.op, &self.sides.1));
             return (&self.sides.0, members);
         };
 
-        match &*self.sides {
+        match (self.effective_left(trivia), &self.sides.1) {
             (Expression::Binary(left), Expression::Binary(right))
                 if BinaryOpChainingGroup::group_for_op(&left.op) == Some(chaining_group)
                     && BinaryOpChainingGroup::group_for_op(&right.op) == Some(chaining_group) =>
             {
-                let (left_first, left_rest) = left.get_chaining_members();
-                let (right_first, right_rest) = right.get_chaining_members();
+                let (left_first, left_rest) = left.get_chaining_members(trivia);
+                let (right_first, right_rest) = right.get_chaining_members(trivia);
 
                 members.extend(left_rest);
                 members.push((&self.op, right_first));
@@ -971,7 +1034,7 @@ impl BinaryExpr {
             (Expression::Binary(left), right)
                 if BinaryOpChainingGroup::group_for_op(&left.op) == Some(chaining_group) =>
             {
-                let (first, left_rest) = left.get_chaining_members();
+                let (first, left_rest) = left.get_chaining_members(trivia);
 
                 members.extend(left_rest);
                 members.push((&self.op, right));
@@ -980,7 +1043,7 @@ impl BinaryExpr {
             (left, Expression::Binary(right))
                 if BinaryOpChainingGroup::group_for_op(&right.op) == Some(chaining_group) =>
             {
-                let (right_first, right_rest) = right.get_chaining_members();
+                let (right_first, right_rest) = right.get_chaining_members(trivia);
 
                 members.push((&self.op, right_first));
                 members.extend(right_rest);
@@ -1028,7 +1091,7 @@ impl PrintMultiLine for BinaryExpr {
     /// ```
     fn print_multi_line(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
         let inner_indent = shape.indent + printer.config.indent_width;
-        let (first, chain_members) = self.get_chaining_members();
+        let (first, chain_members) = self.get_chaining_members(printer.trivia);
         printer.print(first, shape);
         printer.print_trivia_all_trailing_for(first.rightmost_token());
         let num_chain_members = chain_members.len();
@@ -1058,7 +1121,8 @@ impl BinaryExpr {
     /// Should be passed a sub-printer to avoid printing trivia in the outer printer
     /// in the event that the printer is unable to fit the binary expression on a single line.
     fn try_print_single_line(&self, shape: &Shape, printer: &mut Printer) -> Option<PrintInfo> {
-        let (left, right) = &*self.sides;
+        let left = self.effective_left(printer.trivia);
+        let right = &self.sides.1;
 
         if printer
             .print(left, Shape::unlimited_single_line())
@@ -1130,6 +1194,42 @@ impl BinaryOpChainingGroup {
             }
             BinaryOp::And(_) | BinaryOp::Pipe(_) | BinaryOp::Caret(_) => Some(Self::Bitwise),
             BinaryOp::AndAnd(_) | BinaryOp::OrOr(_) => Some(Self::Logical),
+            _ => None,
+        }
+    }
+}
+
+/// Precedence rows whose redundant left-operand parens the formatter strips
+/// (see [`BinaryExpr::effective_left`]). Ops within a row share one binding
+/// power in the parser (`infix_binding_power`), so `(a OP b) OP c` reparses
+/// identically without the parens. Comparisons, equality, shifts, `??`, and
+/// assignments are deliberately absent: chains of those are unusual enough
+/// that explicit parens read as intent.
+///
+/// Finer-grained than [`BinaryOpChainingGroup`], which mixes precedence
+/// levels (`&&` with `||`, `&` with `|`) because it only groups layout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BinaryOpPrecedenceRow {
+    AddSubtract,
+    MultiplyDivideModulo,
+    BitwiseAnd,
+    BitwiseOr,
+    BitwiseXor,
+    LogicalAnd,
+    LogicalOr,
+}
+impl BinaryOpPrecedenceRow {
+    fn row_for_op(op: &BinaryOp) -> Option<Self> {
+        match op {
+            BinaryOp::Plus(_) | BinaryOp::Minus(_) => Some(Self::AddSubtract),
+            BinaryOp::Star(_) | BinaryOp::Slash(_) | BinaryOp::Percent(_) => {
+                Some(Self::MultiplyDivideModulo)
+            }
+            BinaryOp::And(_) => Some(Self::BitwiseAnd),
+            BinaryOp::Pipe(_) => Some(Self::BitwiseOr),
+            BinaryOp::Caret(_) => Some(Self::BitwiseXor),
+            BinaryOp::AndAnd(_) => Some(Self::LogicalAnd),
+            BinaryOp::OrOr(_) => Some(Self::LogicalOr),
             _ => None,
         }
     }
@@ -2601,12 +2701,27 @@ impl CallArg {
         matches!(self.expr, Expression::Lambda(_) | Expression::Spawn(_))
     }
 
+    /// The argument expression with redundant parens peeled: the call's own
+    /// parens already delimit the argument, so a transparent paren wrapping
+    /// the whole expression carries nothing. Lambdas and `spawn` keep their
+    /// parens: peeling one would flip [`Self::is_huggable`] between passes
+    /// and break idempotency.
+    fn effective_expr(&self, trivia: &TriviaInfo) -> &Expression {
+        let peeled = self.expr.peel_transparent_parens(trivia);
+        if matches!(peeled, Expression::Lambda(_) | Expression::Spawn(_)) {
+            &self.expr
+        } else {
+            peeled
+        }
+    }
+
     pub(crate) fn single_line_width(&self, input: &Printer<'_>) -> Option<usize> {
+        let expr = self.effective_expr(input.trivia);
         let mut len = 0;
         if let Some((name, equals)) = &self.label {
             let (_, name_trailing) = input.trivia.get_for_range_split(name.span());
             let (equals_leading, equals_trailing) = input.trivia.get_for_range_split(equals.span());
-            let expr_leading = input.trivia.get_leading_for_element(&self.expr);
+            let expr_leading = input.trivia.get_leading_for_element(expr);
             len += usize::from(name.span().len())
                 + name_trailing.try_squished_len(input.input)?
                 + equals_leading.try_squished_len(input.input)?
@@ -2614,26 +2729,27 @@ impl CallArg {
                 + equals_trailing.try_squished_len(input.input)?
                 + expr_leading.try_squished_len(input.input)?;
         }
-        len += self.expr.single_line_width(input)?;
+        len += expr.single_line_width(input)?;
         Some(len)
     }
 }
 
 impl Printable for CallArg {
     fn print(&self, shape: Shape, printer: &mut Printer) -> PrintInfo {
+        let expr = self.effective_expr(printer.trivia);
         if let Some((name, equals)) = &self.label {
             printer.print_raw_token(name);
             let (_, name_trailing) = printer.trivia.get_for_range_split(name.span());
             let (equals_leading, equals_trailing) =
                 printer.trivia.get_for_range_split(equals.span());
-            let expr_leading = printer.trivia.get_leading_for_element(&self.expr);
+            let expr_leading = printer.trivia.get_leading_for_element(expr);
             printer.print_trivia_squished(name_trailing);
             printer.print_trivia_squished(equals_leading);
             printer.print_str(" = ");
             printer.print_trivia_squished(equals_trailing);
             printer.print_trivia_squished(expr_leading);
         }
-        printer.print(&self.expr, shape)
+        printer.print(expr, shape)
     }
 
     fn leftmost_token(&self) -> TextRange {

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -176,6 +176,63 @@ mod redundant_paren_tests {
         );
     }
 
+    /// The verbatim staircase from the B-1562 screenshot: the old formatter's
+    /// own output for a generated medical-document test, six nested parens
+    /// deep with backtick strings and a `reflect.class.get_field` binding.
+    /// Feeding it back in must collapse to the flat chain.
+    #[test]
+    fn test_b1562_original_example() {
+        let source = concat!(
+            "class MedicalDoc {\n",
+            "    document: string?,\n",
+            "    follow_up: string?,\n",
+            "}\n",
+            "\n",
+            "test \"medical_doc\" {\n",
+            "    let result = MedicalDoc { document: `Shadow`, follow_up: null };\n",
+            "    let output_document = reflect.class.get_field<string?>(result, \"document\");\n",
+            "    let output_follow_up = reflect.class.get_field<string?>(result, \"follow_up\");\n",
+            "\n",
+            "    assert.is_true(\n",
+            "        (\n",
+            "            (\n",
+            "                (\n",
+            "                    (\n",
+            "                        (\n",
+            "                            (\n",
+            "                                (output_document != null)\n",
+            "                                    && (output_document ?? \"\").includes(`Shadow`)\n",
+            "                            )\n",
+            "                                && (output_document ?? \"\").includes(`Amlodipine`)\n",
+            "                        )\n",
+            "                            && (output_document ?? \"\").includes(`Semintra`)\n",
+            "                    )\n",
+            "                        && (output_document ?? \"\").includes(`BUN`)\n",
+            "                )\n",
+            "                    && (output_document ?? \"\").includes(`42 mg/dL`)\n",
+            "            )\n",
+            "                && (output_document ?? \"\").includes(`11/04/2025`)\n",
+            "        ),\n",
+            "    )\n",
+            "}\n",
+        );
+        let formatted = fmt(source);
+        assert!(
+            formatted.contains(concat!(
+                "    assert.is_true(\n",
+                "        (output_document != null)\n",
+                "            && (output_document ?? \"\").includes(`Shadow`)\n",
+                "            && (output_document ?? \"\").includes(`Amlodipine`)\n",
+                "            && (output_document ?? \"\").includes(`Semintra`)\n",
+                "            && (output_document ?? \"\").includes(`BUN`)\n",
+                "            && (output_document ?? \"\").includes(`42 mg/dL`)\n",
+                "            && (output_document ?? \"\").includes(`11/04/2025`),\n",
+                "    )",
+            )),
+            "ticket staircase collapses to a flat chain: {formatted}"
+        );
+    }
+
     #[test]
     fn test_same_row_left_parens_strip_single_line() {
         let formatted = fmt("function f(a: int, b: int, c: int) -> int {\n    ((a + b)) - c\n}\n");

--- a/baml_language/crates/baml_fmt/src/lib.rs
+++ b/baml_language/crates/baml_fmt/src/lib.rs
@@ -134,6 +134,104 @@ mod format_options_tests {
 }
 
 #[cfg(test)]
+mod redundant_paren_tests {
+    use super::*;
+
+    fn fmt(source: &str) -> String {
+        let options = FormatOptions::default();
+        let formatted = format(source, &options).expect("source should format");
+        let second = format(&formatted, &options).expect("formatter should be idempotent");
+        assert_eq!(formatted, second, "formatter should be idempotent");
+        formatted
+    }
+
+    /// B-1562: a left-nested fully parenthesized `&&` chain used to print as
+    /// a staircase, one indent level per redundant paren. The parens peel and
+    /// the chain flattens like an unparenthesized one; the mixed-precedence
+    /// `(x != null)` clause keeps its clarity parens.
+    #[test]
+    fn test_left_nested_logical_parens_flatten() {
+        let source = concat!(
+            "test \"doc\" {\n",
+            "    let output_document: string? = \"doc\";\n",
+            "    assert.is_true(((((output_document != null) && (output_document ?? \"\").includes(\"Shadow\")) && (output_document ?? \"\").includes(\"Amlodipine\")) && (output_document ?? \"\").includes(\"Semintra\")) && (output_document ?? \"\").includes(\"11/04/2025\"))\n",
+            "}\n",
+        );
+        let formatted = fmt(source);
+        assert!(
+            formatted.contains(concat!(
+                "    assert.is_true(\n",
+                "        (output_document != null)\n",
+                "            && (output_document ?? \"\").includes(\"Shadow\")\n",
+                "            && (output_document ?? \"\").includes(\"Amlodipine\")\n",
+                "            && (output_document ?? \"\").includes(\"Semintra\")\n",
+                "            && (output_document ?? \"\").includes(\"11/04/2025\"),\n",
+                "    )",
+            )),
+            "chain flattens to one indent level: {formatted}"
+        );
+        assert!(
+            !formatted.contains("(("),
+            "no nested paren staircase remains: {formatted}"
+        );
+    }
+
+    #[test]
+    fn test_same_row_left_parens_strip_single_line() {
+        let formatted = fmt("function f(a: int, b: int, c: int) -> int {\n    ((a + b)) - c\n}\n");
+        assert!(formatted.contains("    a + b - c\n"), "{formatted}");
+        let formatted =
+            fmt("function f(a: bool, b: bool, c: bool) -> bool {\n    (a && b) && c\n}\n");
+        assert!(formatted.contains("    a && b && c\n"), "{formatted}");
+    }
+
+    /// Mixed-precedence parens are redundant to the parser but carry clarity
+    /// for the reader; they stay.
+    #[test]
+    fn test_clarity_parens_are_kept() {
+        for expr in ["(a * b) + c", "(a && b) || c", "(a != null) && b"] {
+            let source =
+                std::format!("function f(a: bool, b: bool, c: bool) -> bool {{\n    {expr}\n}}\n");
+            let formatted = fmt(&source);
+            assert!(formatted.contains(expr), "kept `{expr}`: {formatted}");
+        }
+    }
+
+    /// Right-operand parens re-associate if removed; they always stay.
+    #[test]
+    fn test_right_operand_parens_are_kept() {
+        for expr in ["a - (b - c)", "a && (b && c)"] {
+            let source =
+                std::format!("function f(a: int, b: int, c: int) -> int {{\n    {expr}\n}}\n");
+            let formatted = fmt(&source);
+            assert!(formatted.contains(expr), "kept `{expr}`: {formatted}");
+        }
+    }
+
+    /// A transparent paren wrapping a whole call argument carries nothing:
+    /// the call's own parens already delimit it.
+    #[test]
+    fn test_call_argument_parens_strip() {
+        let formatted =
+            fmt("function f(x: bool) -> null {\n    assert.is_true((x));\n    null\n}\n");
+        assert!(formatted.contains("assert.is_true(x);"), "{formatted}");
+        let formatted =
+            fmt("function f(x: bool) -> null {\n    assert.is_true(((x && x)));\n    null\n}\n");
+        assert!(formatted.contains("assert.is_true(x && x);"), "{formatted}");
+    }
+
+    /// Parens with a comment on their boundary are not transparent; peeling
+    /// them would drop or move the comment, so they stay.
+    #[test]
+    fn test_comment_bearing_parens_are_kept() {
+        let formatted = fmt(
+            "function f(a: bool, b: bool, c: bool) -> bool {\n    (a && b /* keep */) && c\n}\n",
+        );
+        assert!(formatted.contains("(a && b/* keep */) && c"), "{formatted}");
+    }
+}
+
+#[cfg(test)]
 mod llm_tools_field_tests {
     use super::*;
 

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__10_formatter__binary_expr.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__10_formatter__binary_expr.snap
@@ -70,9 +70,9 @@ function BinaryExprs(a: int, b: int, c: int, d: int, s: string, flag: bool) -> i
     a + (b * (c + d));
 
     // ===== Deeply nested parens =====
-    ((((a + b) * c) + d) * (((a - b) + c) - d)) + ((a * b) + (c * d));
+    ((((a + b) * c) + d) * (a - b + c - d)) + ((a * b) + (c * d));
     (((a + b) * (c + d)) + ((a - b) * (c - d)))
-        * (((a * c * d) + (b * c * d)) - ((a * d) + (b * c * d)));
+        * ((a * c * d) + (b * c * d) - ((a * d) + (b * c * d)));
 
     // ===== Trivia between operands (line comments) =====
     // 1 left leading


### PR DESCRIPTION
## Issue Reference

Closes [B-1562](https://linear.app/boundaryml2/issue/B-1562)

## Changes

A fully parenthesized left-nested chain like `((((a != null) && b) && c) && d)` printed as a staircase, one indent level per redundant paren. The formatter now strips parens whose removal provably round-trips:

- **Binary left operands, same precedence row**: a transparent paren around the left operand peels when the inner operator shares the outer operator's precedence row (`&&`-in-`&&`, `+`/`-` mixes, etc.). Reparsing the output yields the printed tree, so the formatter stays idempotent. Chains then flatten via the existing `get_chaining_members` layout.
- **Whole call arguments**: `f((x && y))` becomes `f(x && y)`; the call's parens already delimit the argument.

Deliberately kept:

- Mixed-precedence clarity parens: `(a * b) + c`, `(a && b) || c`, `(x != null) && y`.
- Right-operand parens (removal would re-associate): `a - (b - c)`, `a && (b && c)`.
- Any paren with a comment attached to its tokens or the inner expression's boundary ("transparent" check), so peeling can never drop trivia.
- Parens around lambda/`spawn` call arguments, which would otherwise flip `is_huggable` between passes and break idempotency.

Blast radius across the repo's 1788 `.baml` files (new formatter vs old, both run over every file): 2 files change, both same-row flattens (`(base + step) - base` -> `base + step - base` in `baml_tests/baml_src/ns_time/time.baml`, similar in `format_checks/binary_expr.baml`). One insta snapshot updated accordingly.

## Testing

- `cargo test -p baml_fmt` (132 tests, includes 6 new regression tests covering the B-1562 staircase, clarity/right-operand/comment-bearing paren preservation, call-arg stripping, and idempotency of each)
- `cargo test -p baml_lsp2_actions -p baml_lsp2_actions_tests` (462 passed)
- `cargo test -p baml_tests -p baml_cli`
- `cargo clippy -p baml_fmt --all-features --all-targets` clean; `mise run fmt`
- Manual: `baml-cli fmt` on the ticket's staircase file produces the flat chain


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved formatting of expressions containing redundant parentheses.
  - Preserves necessary parentheses for operator precedence, right-side expressions, lambdas, and spawned calls.
  - Retains comments attached to parentheses.
  - Ensures formatting remains consistent and idempotent across repeated runs.

- **Tests**
  - Added regression coverage for logical and arithmetic expressions, call arguments, precedence handling, repeated formatting, and comment preservation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->