### PR TITLE
chore: refresh size-gate baselines

### DIFF
--- a/baml_language/.cargo/size-gate.toml
+++ b/baml_language/.cargo/size-gate.toml
@@ -43,13 +43,13 @@ policy.max_delta_pct = 3.0
 # Reclaiming the `syn` cost would mean dropping prettyplease (raw,
 # unformatted generated SDK output).
 [artifacts.baml-cli.platform.aarch64-apple-darwin]
-max_file_bytes = "25.4 MiB"
+max_file_bytes = "25.5 MiB"
 
 [artifacts.baml-cli.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = "31.5 MiB"
+max_file_bytes = "31.7 MiB"
 
 [artifacts.baml-cli.platform.x86_64-pc-windows-msvc]
-max_file_bytes = "27.1 MiB"
+max_file_bytes = "27.2 MiB"
 
 [artifacts.packed-program]
 kind = "pack"
@@ -64,13 +64,13 @@ policy.max_delta_pct = 3.0
 # bytecode ships in every packed program. Each ceiling is ~3% above the
 # re-recorded baseline in `.ci/size-gate`.
 [artifacts.packed-program.platform.aarch64-apple-darwin]
-max_file_bytes = "20.8 MiB"
+max_file_bytes = "20.9 MiB"
 
 [artifacts.packed-program.platform.x86_64-unknown-linux-gnu]
-max_file_bytes = "25.0 MiB"
+max_file_bytes = "25.1 MiB"
 
 [artifacts.packed-program.platform.x86_64-pc-windows-msvc]
-max_file_bytes = "21.9 MiB"
+max_file_bytes = "22.0 MiB"
 
 [artifacts.packed-program.pack]
 cli_package = "baml_cli"

--- a/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
+++ b/baml_language/.ci/size-gate/aarch64-apple-darwin.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-08-19T21:48:47Z"
-git_sha = "ab8a840de290a614ed2ea5d33dbcee206511a799"
+recorded_at = "2026-08-20T09:29:11Z"
+git_sha = "54fc33b4fc1f5d82448e8634374e08088e127ecc"
 
 [artifacts.baml-cli]
-file_bytes = "24.6 MiB"
-stripped_bytes = "24.6 MiB"
+file_bytes = "24.7 MiB"
+stripped_bytes = "24.7 MiB"
 gzip_bytes = "10.7 MiB"
 
 [artifacts.packed-program]
-file_bytes = "20.2 MiB"
+file_bytes = "20.3 MiB"
 gzip_bytes = "7.9 MiB"

--- a/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
+++ b/baml_language/.ci/size-gate/wasm32-unknown-unknown.toml
@@ -1,7 +1,7 @@
 version = 1
-recorded_at = "2026-08-19T21:48:47Z"
-git_sha = "ab8a840de290a614ed2ea5d33dbcee206511a799"
+recorded_at = "2026-08-20T09:29:11Z"
+git_sha = "54fc33b4fc1f5d82448e8634374e08088e127ecc"
 
 [artifacts.bridge_wasm]
-file_bytes = "20.7 MiB"
+file_bytes = "20.8 MiB"
 gzip_bytes = "5.2 MiB"

--- a/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
+++ b/baml_language/.ci/size-gate/x86_64-pc-windows-msvc.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-08-19T21:48:47Z"
-git_sha = "ab8a840de290a614ed2ea5d33dbcee206511a799"
+recorded_at = "2026-08-20T09:29:11Z"
+git_sha = "54fc33b4fc1f5d82448e8634374e08088e127ecc"
 
 [artifacts.baml-cli]
-file_bytes = "26.3 MiB"
-stripped_bytes = "26.3 MiB"
+file_bytes = "26.4 MiB"
+stripped_bytes = "26.4 MiB"
 gzip_bytes = "10.9 MiB"
 
 [artifacts.packed-program]
-file_bytes = "21.2 MiB"
+file_bytes = "21.4 MiB"
 gzip_bytes = "8.0 MiB"

--- a/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
+++ b/baml_language/.ci/size-gate/x86_64-unknown-linux-gnu.toml
@@ -1,12 +1,12 @@
 version = 1
-recorded_at = "2026-08-19T21:48:47Z"
-git_sha = "ab8a840de290a614ed2ea5d33dbcee206511a799"
+recorded_at = "2026-08-20T09:29:11Z"
+git_sha = "54fc33b4fc1f5d82448e8634374e08088e127ecc"
 
 [artifacts.baml-cli]
-file_bytes = "30.6 MiB"
-stripped_bytes = "30.6 MiB"
+file_bytes = "30.7 MiB"
+stripped_bytes = "30.7 MiB"
 gzip_bytes = "12.1 MiB"
 
 [artifacts.packed-program]
-file_bytes = "24.3 MiB"
-gzip_bytes = "8.8 MiB"
+file_bytes = "24.4 MiB"
+gzip_bytes = "8.9 MiB"


### PR DESCRIPTION
Adopted from CI run [`54fc33b4fc1f5d82448e8634374e08088e127ecc`](https://github.com/BoundaryML/baml/actions/runs/32335256251).

# Binary size checks passed

✅ **7** passed

| | Artifact | Platform | File | Gzip | Gated on | Baseline | Delta | Status |
|---|----------|----------|------|------|----------|----------|-------|--------|
| :white_check_mark: | `baml-cli` | Linux | 🔒 32.2 MB | 12.7 MB | **file** | 32.1 MB | +138.4 KB (+0.4%) | OK |
| :white_check_mark: | `packed-program` | Linux | 🔒 25.6 MB | 9.3 MB | **file** | 25.5 MB | +114.6 KB (+0.4%) | OK |
| :white_check_mark: | `baml-cli` | macOS | 🔒 25.9 MB | 11.2 MB | **file** | 25.8 MB | +147.3 KB (+0.6%) | OK |
| :white_check_mark: | `packed-program` | macOS | 🔒 21.3 MB | 8.3 MB | **file** | 21.2 MB | +90.0 KB (+0.4%) | OK |
| :white_check_mark: | `bridge_wasm` | WASM | 21.8 MB | 🔒 5.5 MB | **gzip** | 5.5 MB | +42.6 KB (+0.8%) | OK |
| :white_check_mark: | `baml-cli` | Windows | 🔒 27.7 MB | 11.4 MB | **file** | 27.6 MB | +131.9 KB (+0.5%) | OK |
| :white_check_mark: | `packed-program` | Windows | 🔒 22.4 MB | 8.4 MB | **file** | 22.2 MB | +188.0 KB (+0.8%) | OK |

> 🔒 = the size this artifact is GATED on (ceiling + delta). Binaries gate on **file** size (installed binary); WASM gates on **gzip** (download size). The other size is shown for information only.

---
*Generated by `cargo size-gate`*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated platform-specific size thresholds for native command-line tools and packed programs.
  - Refreshed recorded build metadata and size measurements across macOS, Linux, Windows, and WebAssembly artifacts.
  - Accommodated small increases in distributed artifact sizes while preserving existing compression targets where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->