### PR TITLE
chore(vscode): remove explorer.sortOrder mixed setting

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -60,6 +60,5 @@
       "editor.tabSize": 2
   },
   "baml.enablePlaygroundProxy": true,
-  "explorer.sortOrder": "mixed",
   "nixEnvSelector.suggestion": false,
 }


### PR DESCRIPTION
Removes the checked-in `explorer.sortOrder: mixed` override from `.vscode/settings.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed a development environment setting controlling Explorer file sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->