### PR TITLE
Websocket server and API improvements

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_http/server.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_http/server.baml
@@ -125,12 +125,20 @@ class Server {
 /// // Echo every frame back until the peer closes.
 /// spawn {
 ///     server.serve(my_handler, websocket = (req) -> {
-///         // always accept websocket requests:
+///         // Accept every upgrade. `WsAccept` is `throws never`, so the
+///         // socket's `Io` errors end the loop here rather than escaping.
 ///         (socket) -> {
 ///             while (true) {
-///                 match (socket.next()) {
+///                 let frame = socket.next() catch (_) {
+///                     baml.errors.Io => { break; },
+///                 };
+///                 match (frame) {
 ///                     baml.ws.CloseEvent => { break; },
-///                     let frame: string | uint8array => socket.send(frame),
+///                     let data: string | uint8array => {
+///                         socket.send(data) catch (_) {
+///                             baml.errors.Io => { break; },
+///                         };
+///                     },
 ///                 }
 ///             }
 ///         }
@@ -146,7 +154,7 @@ type WsAccept = (socket: root.ws.WebSocket) -> void throws never;
 /// status here says specifically that this server implements no WebSocket
 /// endpoint, rather than blaming the request.
 function reject_websocket(req: Request) -> Response throws never {
-    Response.new(501, { }, "websocket upgrade is not supported".to_utf8())
+    Response.new(501, {}, "websocket upgrade is not supported".to_utf8())
 }
 
 /// Used to convert an HTTP server into an HTTPS server for secure connections.

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_http/server.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_http/server.baml
@@ -41,6 +41,10 @@ class Server {
     ///
     /// # Parameters
     /// - `handler`: Turns each incoming `Request` into a `Response`.
+    /// - `websocket`: Handles WebSocket upgrade requests (see `WsAccept`). Returning a
+    ///   `Response` refuses the upgrade and serves that response; returning a `WsAccept`
+    ///   completes the handshake and runs it with the connected socket. The default
+    ///   refuses every upgrade with `501`.
     /// - `tls_config`: Optional TLS configuration. If provided, the server behaves as an HTTPS server.
     /// - `allow_http1` / `allow_http2`: Which HTTP versions to accept (at least one must be true).
     /// - `max_body_size`: Maximum request body size, in bytes, buffered per request
@@ -49,9 +53,22 @@ class Server {
     /// - `max_connections`: Maximum number of connections served concurrently
     ///   (default 1024). At the cap the accept loop applies backpressure (new
     ///   connections wait in the kernel backlog) rather than spawning unbounded tasks.
+    ///   An accepted WebSocket holds its slot for as long as the socket lives, not
+    ///   just for the handshake.
     /// - `header_read_timeout`: How long a client has to send the complete request
     ///   headers before the connection is closed (default 30s) — a Slowloris defense.
     ///   A non-positive duration disables it. (HTTP/1 only; HTTP/2 frames its headers.)
+    ///
+    /// # WebSockets
+    /// A request is dispatched to `websocket` instead of `handler` only when it is a
+    /// complete RFC 6455 handshake — an HTTP/1.1 `GET` carrying `Connection: Upgrade`,
+    /// `Upgrade: websocket`, and `Sec-WebSocket-Version: 13`. Anything short of that,
+    /// including WebSocket over HTTP/2 (RFC 8441 extended CONNECT, unsupported here),
+    /// is an ordinary request and goes to `handler`.
+    ///
+    /// The handshake response is built by the server, so a `WsAccept` cannot add
+    /// headers to it: `Sec-WebSocket-Protocol` subprotocols and extensions are not
+    /// negotiated.
     ///
     /// # Panics
     /// - Calling `serve` on an unsupported platform (e.g. in the browser) will panic.
@@ -60,6 +77,7 @@ class Server {
     function serve(
         self,
         handler: (req: Request) -> Response throws never,
+        websocket: (req: Request) -> Response | WsAccept throws never = reject_websocket,
         tls_config: TlsConfig? = null,
         allow_http1: bool = true,
         allow_http2: bool = true,
@@ -72,6 +90,7 @@ class Server {
         // sys-op (whose params are all required).
         self._serve(
             handler,
+            websocket,
             tls_config,
             allow_http1,
             allow_http2,
@@ -84,6 +103,7 @@ class Server {
     function _serve(
         self,
         handler: (req: Request) -> Response throws never,
+        websocket: (req: Request) -> Response | WsAccept throws never,
         tls_config: TlsConfig?,
         allow_http1: bool,
         allow_http2: bool,
@@ -93,6 +113,40 @@ class Server {
     ) -> never throws root.errors.Io {
         $rust_io_function
     }
+}
+
+/// Takes over an accepted WebSocket connection.
+///
+/// A `serve` `websocket` handler returns one of these to complete the upgrade.
+/// It runs on its own BAML thread once the handshake finishes, and owns the
+/// connection: when it returns, the socket is closed.
+///
+/// ```baml
+/// // Echo every frame back until the peer closes.
+/// spawn {
+///     server.serve(my_handler, websocket = (req) -> {
+///         // always accept websocket requests:
+///         (socket) -> {
+///             while (true) {
+///                 match (socket.next()) {
+///                     baml.ws.CloseEvent => { break; },
+///                     let frame: string | uint8array => socket.send(frame),
+///                 }
+///             }
+///         }
+///     })
+/// };
+/// ```
+type WsAccept = (socket: root.ws.WebSocket) -> void throws never;
+
+/// The `websocket` handler `serve` uses when none is supplied: refuse every
+/// upgrade, leaving the server HTTP-only.
+///
+/// RFC 6455 §4.1 fails the client handshake on any status other than `101`; the
+/// status here says specifically that this server implements no WebSocket
+/// endpoint, rather than blaming the request.
+function reject_websocket(req: Request) -> Response throws never {
+    Response.new(501, { }, "websocket upgrade is not supported".to_utf8())
 }
 
 /// Used to convert an HTTP server into an HTTPS server for secure connections.

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_ws/ws.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_ws/ws.baml
@@ -38,9 +38,9 @@ class WebSocket {
     /// # Throws
     ///
     /// - `baml.errors.InvalidArgument` if `code` is not one an endpoint may
-    ///   send: RFC 6455 allows 1000-1003, 1007-1013, 3000-3999, and 4000-4999.
-    ///   The rest are undefined, or are codes a peer can only ever infer
-    ///   (1004, 1005, 1006, 1015).
+    ///   send (RFC 6455: 1000-1003, 1007-1013, 3000-3999, 4000-4999; not the
+    ///   undefined codes or the inferred-only 1004/1005/1006/1015), or if
+    ///   `reason` exceeds 123 bytes, the most a close frame can carry.
     function close(self, code: int, reason: string) -> void throws root.errors.InvalidArgument {
         $rust_io_function
     }

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_ws/ws.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_ws/ws.baml
@@ -1,31 +1,73 @@
-// Minimal text-oriented WebSocket client surface for realtime providers.
+// Minimal WebSocket client surface for realtime providers.
 
 /// A WebSocket connection.
-class WsStream {
+class WebSocket {
     _handle: $rust_type,
 
-    /// Send a text frame.
-    function send(self, text: string) -> null throws root.errors.Io {
+    /// Send one frame: a `string` becomes a text frame, a `uint8array` a
+    /// binary one.
+    ///
+    /// # Throws
+    ///
+    /// - `baml.errors.Io` if the connection is already closed, or the send
+    ///   fails.
+    function send(self, data: string | uint8array) -> void throws root.errors.Io {
         $rust_io_function
     }
 
-    /// Receive the next text frame, or `null` after the connection closes.
-    function next(self) -> string? throws root.errors.Io {
+    /// Block until the next frame arrives.
+    ///
+    /// A text frame is a `string` and a binary frame a `uint8array`. Pings are
+    /// answered here automatically, and neither ping nor pong frames surface.
+    /// Once the connection ends — closed by either party, or dropped — this
+    /// returns the same `CloseEvent` on every call, so a receive loop
+    /// terminates on the first one rather than blocking forever.
+    ///
+    /// # Throws
+    ///
+    /// - `baml.errors.Io` if the connection fails while receiving.
+    function next(self) -> string | uint8array | CloseEvent throws root.errors.Io {
         $rust_io_function
     }
 
-    /// Close the connection.
-    function close(self) -> null throws never {
+    /// Begin the closing handshake, sending `code` and `reason` to the peer.
+    ///
+    /// This returns as soon as the close frame is queued. The connection ends
+    /// when the peer echoes it, which `next` reports as a `CloseEvent`.
+    ///
+    /// # Throws
+    ///
+    /// - `baml.errors.InvalidArgument` if `code` is not one an endpoint may
+    ///   send: RFC 6455 allows 1000-1003, 1007-1013, 3000-3999, and 4000-4999.
+    ///   The rest are undefined, or are codes a peer can only ever infer
+    ///   (1004, 1005, 1006, 1015).
+    function close(self, code: int, reason: string) -> void throws root.errors.InvalidArgument {
         $rust_io_function
     }
 }
 
+/// How a connection ended, as reported by `WebSocket.next`. Mirrors the
+/// browser's [`CloseEvent`](https://developer.mozilla.org/en-US/docs/Web/API/CloseEvent).
+class CloseEvent {
+    /// The RFC 6455 status code. Two are synthesized rather than received:
+    /// `1005` when the peer's close frame carried no code, and `1006` when the
+    /// connection dropped with no closing handshake at all.
+    code: int,
+    /// The peer's reason, or `""` if it gave none.
+    reason: string,
+}
+
 /// Open a WebSocket connection with additional request headers.
+///
+/// # Throws
+///
+/// - `baml.errors.Io` if the connection or the opening handshake fails.
+/// - `baml.errors.Timeout` if neither completes within `timeout`.
 function connect(
     url: string,
     headers: map<string, string>,
     timeout: root.time.Duration = root.time.Duration.from_seconds(30),
-) -> WsStream throws root.errors.Io | root.errors.Timeout {
+) -> WebSocket throws root.errors.Io | root.errors.Timeout {
     _connect(url, headers, timeout.to_nanoseconds())
 }
 
@@ -33,6 +75,6 @@ function _connect(
     url: string,
     headers: map<string, string>,
     timeout_nanos: bigint,
-) -> WsStream throws root.errors.Io | root.errors.Timeout {
+) -> WebSocket throws root.errors.Io | root.errors.Timeout {
     $rust_io_function
 }

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -143,9 +143,9 @@ function         baml.http._send                  <builtin>/baml/ns_http/http.ba
 function         baml.http.fetch_sse              <builtin>/baml/ns_http/http.baml:191
 function         baml.http._fetch_sse             <builtin>/baml/ns_http/http.baml:199
 class            baml.http.Server                 <builtin>/baml/ns_http/server.baml:10
-type             baml.http.WsAccept               <builtin>/baml/ns_http/server.baml:140
-function         baml.http.reject_websocket       <builtin>/baml/ns_http/server.baml:148
-class            baml.http.TlsConfig              <builtin>/baml/ns_http/server.baml:164
+type             baml.http.WsAccept               <builtin>/baml/ns_http/server.baml:148
+function         baml.http.reject_websocket       <builtin>/baml/ns_http/server.baml:156
+class            baml.http.TlsConfig              <builtin>/baml/ns_http/server.baml:172
 function         baml.id.current                  <builtin>/baml/ns_id/id.baml:6
 function         baml.id.new                      <builtin>/baml/ns_id/id.baml:13
 function         baml.id.set                      <builtin>/baml/ns_id/id.baml:25

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -143,7 +143,9 @@ function         baml.http._send                  <builtin>/baml/ns_http/http.ba
 function         baml.http.fetch_sse              <builtin>/baml/ns_http/http.baml:191
 function         baml.http._fetch_sse             <builtin>/baml/ns_http/http.baml:199
 class            baml.http.Server                 <builtin>/baml/ns_http/server.baml:10
-class            baml.http.TlsConfig              <builtin>/baml/ns_http/server.baml:110
+type             baml.http.WsAccept               <builtin>/baml/ns_http/server.baml:140
+function         baml.http.reject_websocket       <builtin>/baml/ns_http/server.baml:148
+class            baml.http.TlsConfig              <builtin>/baml/ns_http/server.baml:164
 function         baml.id.current                  <builtin>/baml/ns_id/id.baml:6
 function         baml.id.new                      <builtin>/baml/ns_id/id.baml:13
 function         baml.id.set                      <builtin>/baml/ns_id/id.baml:25

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -294,9 +294,10 @@ function         baml.toml.table_from_json        <builtin>/baml/ns_toml/toml.ba
 function         baml.toml.item_to_json           <builtin>/baml/ns_toml/toml.baml:118
 function         baml.toml.item_from_json         <builtin>/baml/ns_toml/toml.baml:142
 class            baml.toml.ParseError             <builtin>/baml/ns_toml/toml.baml:157
-class            baml.ws.WsStream                 <builtin>/baml/ns_ws/ws.baml:4
-function         baml.ws.connect                  <builtin>/baml/ns_ws/ws.baml:24
-function         baml.ws._connect                 <builtin>/baml/ns_ws/ws.baml:32
+class            baml.ws.WebSocket                <builtin>/baml/ns_ws/ws.baml:4
+class            baml.ws.CloseEvent               <builtin>/baml/ns_ws/ws.baml:51
+function         baml.ws.connect                  <builtin>/baml/ns_ws/ws.baml:66
+function         baml.ws._connect                 <builtin>/baml/ns_ws/ws.baml:74
 class            baml.yaml.ParseError             <builtin>/baml/ns_yaml/yaml.baml:5
 function         baml.yaml.parse                  <builtin>/baml/ns_yaml/yaml.baml:29
 function         baml.yaml.deserialize            <builtin>/baml/ns_yaml/yaml.baml:45

--- a/baml_language/crates/baml_lsp_server/src/playground_http.rs
+++ b/baml_language/crates/baml_lsp_server/src/playground_http.rs
@@ -267,6 +267,7 @@ impl io::IoClassHttpServer for PlaygroundHttp {
         _call_id: CallId,
         _server: owned::http::Server,
         _handler: sys_types::Handle,
+        _websocket: sys_types::Handle,
         _tls_config: Option<owned::http::TlsConfig>,
         _allow_http1: bool,
         _allow_http2: bool,

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
@@ -7864,19 +7864,19 @@ function baml.toml.table_from_json(j: baml.json.json) -> baml.toml.Table {
     return
 }
 
-function baml.ws.WsStream.close(self: baml.ws.WsStream) -> null {
+function baml.ws.WebSocket.close(self: baml.ws.WebSocket, code: int, reason: string) -> void {
 }
 
-function baml.ws.WsStream.next(self: baml.ws.WsStream) -> string | null {
+function baml.ws.WebSocket.next(self: baml.ws.WebSocket) -> string | uint8array | baml.ws.CloseEvent {
 }
 
-function baml.ws.WsStream.send(self: baml.ws.WsStream, text: string) -> null {
+function baml.ws.WebSocket.send(self: baml.ws.WebSocket, data: string | uint8array) -> void {
 }
 
-function baml.ws._connect(url: string, headers: map<string, string>, timeout_nanos: bigint) -> baml.ws.WsStream {
+function baml.ws._connect(url: string, headers: map<string, string>, timeout_nanos: bigint) -> baml.ws.WebSocket {
 }
 
-function baml.ws.connect(url: string, headers: map<string, string>, timeout: baml.time.Duration) -> baml.ws.WsStream {
+function baml.ws.connect(url: string, headers: map<string, string>, timeout: baml.time.Duration) -> baml.ws.WebSocket {
     load_var timeout
     load_const <omitted>
     cmp_op ==

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
@@ -2800,79 +2800,90 @@ function baml.http.Response.text(self: baml.http.Response) -> string {
 function baml.http.Response.write(self: baml.http.Response, data: uint8array) -> null {
 }
 
-function baml.http.Server._serve(self: baml.http.Server, handler: (baml.http.Request) -> baml.http.Response throws never, tls_config: baml.http.TlsConfig | null, allow_http1: bool, allow_http2: bool, max_body_size: int, max_connections: int, header_read_timeout_nanos: bigint) -> never {
+function baml.http.Server._serve(self: baml.http.Server, handler: (baml.http.Request) -> baml.http.Response throws never, websocket: (baml.http.Request) -> baml.http.Response | ((baml.ws.WebSocket) -> void throws never) throws never, tls_config: baml.http.TlsConfig | null, allow_http1: bool, allow_http2: bool, max_body_size: int, max_connections: int, header_read_timeout_nanos: bigint) -> never {
 }
 
 function baml.http.Server.bind(addr: string) -> baml.http.Server {
 }
 
-function baml.http.Server.serve(self: baml.http.Server, handler: (baml.http.Request) -> baml.http.Response throws never, tls_config: baml.http.TlsConfig | null, allow_http1: bool, allow_http2: bool, max_body_size: int, max_connections: int, header_read_timeout: baml.time.Duration) -> never {
-    load_var tls_config
+function baml.http.Server.serve(self: baml.http.Server, handler: (baml.http.Request) -> baml.http.Response throws never, websocket: (baml.http.Request) -> baml.http.Response | ((baml.ws.WebSocket) -> void throws never) throws never, tls_config: baml.http.TlsConfig | null, allow_http1: bool, allow_http2: bool, max_body_size: int, max_connections: int, header_read_timeout: baml.time.Duration) -> never {
+    load_var websocket
     load_const <omitted>
     cmp_op ==
     pop_jump_if_false L0
-    load_const null
-    store_var tls_config
+    load_const baml.http.reject_websocket
+    store_var websocket
 
   L0:
-    load_var allow_http1
+    load_var tls_config
     load_const <omitted>
     cmp_op ==
     pop_jump_if_false L1
-    load_const true
-    store_var allow_http1
+    load_const null
+    store_var tls_config
 
   L1:
-    load_var allow_http2
+    load_var allow_http1
     load_const <omitted>
     cmp_op ==
     pop_jump_if_false L2
     load_const true
-    store_var allow_http2
+    store_var allow_http1
 
   L2:
-    load_var max_body_size
+    load_var allow_http2
     load_const <omitted>
     cmp_op ==
     pop_jump_if_false L3
-    load_const 104857600
-    store_var max_body_size
+    load_const true
+    store_var allow_http2
 
   L3:
-    load_var max_connections
+    load_var max_body_size
     load_const <omitted>
     cmp_op ==
     pop_jump_if_false L4
-    load_const 1024
-    store_var max_connections
+    load_const 104857600
+    store_var max_body_size
 
   L4:
-    load_var header_read_timeout
+    load_var max_connections
     load_const <omitted>
     cmp_op ==
     pop_jump_if_false L5
+    load_const 1024
+    store_var max_connections
+
+  L5:
+    load_var header_read_timeout
+    load_const <omitted>
+    cmp_op ==
+    pop_jump_if_false L6
     load_const 30n
     call baml.time.Duration.from_seconds
     store_var header_read_timeout
 
-  L5:
-    load_var tls_config
-    store_var _15
-    load_var allow_http1
-    store_var _16
-    load_var allow_http2
+  L6:
+    load_var websocket
     store_var _17
-    load_var max_body_size
+    load_var tls_config
     store_var _18
-    load_var max_connections
+    load_var allow_http1
     store_var _19
+    load_var allow_http2
+    store_var _20
+    load_var max_body_size
+    store_var _21
+    load_var max_connections
+    store_var _22
     load_var header_read_timeout
     call baml.time.Duration.to_nanoseconds
-    store_var _20
+    store_var _23
     load_var2 1 2
-    load_var2 9 10
-    load_var2 11 12
-    load_var2 13 14
+    load_var2 10 11
+    load_var2 12 13
+    load_var2 14 15
+    load_var _23
     sys_op baml.http.Server._serve
     return
 }
@@ -2983,6 +2994,19 @@ function baml.http.fetch_sse(request: baml.http.Request, timeout: baml.time.Dura
     load_var2 1 4
     load_var _7
     sys_op baml.http._fetch_sse
+    return
+}
+
+function baml.http.reject_websocket(req: baml.http.Request) -> baml.http.Response {
+    load_const "websocket upgrade is not supported"
+    call baml.String.to_utf8
+    store_var _3
+    load_const 501
+    load_type string
+    load_type string
+    alloc_map 0
+    load_var _3
+    sys_op baml.http.Response.new
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/mir.snap
@@ -12638,15 +12638,15 @@ fn baml.toml.item_from_json(json: int | float | string | bool | null | baml.json
     }
 }
 
-fn baml.ws.WsStream.send = builtin(io)
+fn baml.ws.WebSocket.send = builtin(io)
 
-fn baml.ws.WsStream.next = builtin(io)
+fn baml.ws.WebSocket.next = builtin(io)
 
-fn baml.ws.WsStream.close = builtin(io)
+fn baml.ws.WebSocket.close = builtin(io)
 
-fn baml.ws.connect(url: string, headers: map<string, string>, timeout: baml.time.Duration) -> baml.ws.WsStream {
+fn baml.ws.connect(url: string, headers: map<string, string>, timeout: baml.time.Duration) -> baml.ws.WebSocket {
     // Locals:
-    let _0: baml.ws.WsStream // _0 // return
+    let _0: baml.ws.WebSocket // _0 // return
     let _1: string // url // param
     let _2: map<string, string> // headers // param
     let _3: baml.time.Duration // timeout // param

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/mir.snap
@@ -4539,53 +4539,56 @@ fn baml.http._fetch_sse = builtin(io)
 
 fn baml.http.Server.bind = builtin(io)
 
-fn baml.http.Server.serve(self: baml.http.Server, handler: (baml.http.Request) -> baml.http.Response throws never, tls_config: null | baml.http.TlsConfig, allow_http1: bool, allow_http2: bool, max_body_size: int, max_connections: int, header_read_timeout: baml.time.Duration) -> never {
+fn baml.http.Server.serve(self: baml.http.Server, handler: (baml.http.Request) -> baml.http.Response throws never, websocket: (baml.http.Request) -> baml.http.Response | ((baml.ws.WebSocket) -> void throws never) throws never, tls_config: null | baml.http.TlsConfig, allow_http1: bool, allow_http2: bool, max_body_size: int, max_connections: int, header_read_timeout: baml.time.Duration) -> never {
     // Locals:
     let _0: never // _0 // return
     let _1: baml.http.Server // self // param
     let _2: (baml.http.Request) -> baml.http.Response throws never // handler // param
-    let _3: null | baml.http.TlsConfig // tls_config // param
-    let _4: bool // allow_http1 // param
-    let _5: bool // allow_http2 // param
-    let _6: int // max_body_size // param
-    let _7: int // max_connections // param
-    let _8: baml.time.Duration // header_read_timeout // param
-    let _9: bool
+    let _3: (baml.http.Request) -> baml.http.Response | ((baml.ws.WebSocket) -> void throws never) throws never // websocket // param
+    let _4: null | baml.http.TlsConfig // tls_config // param
+    let _5: bool // allow_http1 // param
+    let _6: bool // allow_http2 // param
+    let _7: int // max_body_size // param
+    let _8: int // max_connections // param
+    let _9: baml.time.Duration // header_read_timeout // param
     let _10: bool
     let _11: bool
     let _12: bool
     let _13: bool
     let _14: bool
-    let _15: null | baml.http.TlsConfig
+    let _15: bool
     let _16: bool
-    let _17: bool
-    let _18: int
-    let _19: int
-    let _20: bigint
+    let _17: (baml.http.Request) -> baml.http.Response | ((baml.ws.WebSocket) -> void throws never) throws never
+    let _18: null | baml.http.TlsConfig
+    let _19: bool
+    let _20: bool
+    let _21: int
+    let _22: int
+    let _23: bigint
 
     bb0: {
-        _9 = copy _3 == const <omitted>;
-        branch copy _9 -> [bb1, bb2];
+        _10 = copy _3 == const <omitted>;
+        branch copy _10 -> [bb1, bb2];
     }
 
     bb1: {
-        _3 = const null;
+        _3 = const fn baml.http.reject_websocket;
         goto -> bb2;
     }
 
     bb2: {
-        _10 = copy _4 == const <omitted>;
-        branch copy _10 -> [bb3, bb4];
+        _11 = copy _4 == const <omitted>;
+        branch copy _11 -> [bb3, bb4];
     }
 
     bb3: {
-        _4 = const true;
+        _4 = const null;
         goto -> bb4;
     }
 
     bb4: {
-        _11 = copy _5 == const <omitted>;
-        branch copy _11 -> [bb5, bb6];
+        _12 = copy _5 == const <omitted>;
+        branch copy _12 -> [bb5, bb6];
     }
 
     bb5: {
@@ -4594,53 +4597,85 @@ fn baml.http.Server.serve(self: baml.http.Server, handler: (baml.http.Request) -
     }
 
     bb6: {
-        _12 = copy _6 == const <omitted>;
-        branch copy _12 -> [bb7, bb8];
+        _13 = copy _6 == const <omitted>;
+        branch copy _13 -> [bb7, bb8];
     }
 
     bb7: {
-        _6 = const 104857600_i64;
+        _6 = const true;
         goto -> bb8;
     }
 
     bb8: {
-        _13 = copy _7 == const <omitted>;
-        branch copy _13 -> [bb9, bb10];
+        _14 = copy _7 == const <omitted>;
+        branch copy _14 -> [bb9, bb10];
     }
 
     bb9: {
-        _7 = const 1024_i64;
+        _7 = const 104857600_i64;
         goto -> bb10;
     }
 
     bb10: {
-        _14 = copy _8 == const <omitted>;
-        branch copy _14 -> [bb11, bb12];
+        _15 = copy _8 == const <omitted>;
+        branch copy _15 -> [bb11, bb12];
     }
 
     bb11: {
-        _8 = call const fn baml.time.Duration.from_seconds(const 30n) -> [bb12];
+        _8 = const 1024_i64;
+        goto -> bb12;
     }
 
     bb12: {
-        _15 = copy _3;
-        _16 = copy _4;
-        _17 = copy _5;
-        _18 = copy _6;
-        _19 = copy _7;
-        _20 = call const fn baml.time.Duration.to_nanoseconds(copy _8) -> [bb13];
+        _16 = copy _9 == const <omitted>;
+        branch copy _16 -> [bb13, bb14];
     }
 
     bb13: {
-        _0 = sys_op const fn baml.http.Server._serve(copy _1, copy _2, copy _15, copy _16, copy _17, copy _18, copy _19, copy _20) -> bb14;
+        _9 = call const fn baml.time.Duration.from_seconds(const 30n) -> [bb14];
     }
 
     bb14: {
+        _17 = copy _3;
+        _18 = copy _4;
+        _19 = copy _5;
+        _20 = copy _6;
+        _21 = copy _7;
+        _22 = copy _8;
+        _23 = call const fn baml.time.Duration.to_nanoseconds(copy _9) -> [bb15];
+    }
+
+    bb15: {
+        _0 = sys_op const fn baml.http.Server._serve(copy _1, copy _2, copy _17, copy _18, copy _19, copy _20, copy _21, copy _22, copy _23) -> bb16;
+    }
+
+    bb16: {
         return;
     }
 }
 
 fn baml.http.Server._serve = builtin(io)
+
+fn baml.http.reject_websocket(req: baml.http.Request) -> baml.http.Response {
+    // Locals:
+    let _0: baml.http.Response // _0 // return
+    let _1: baml.http.Request // req // param
+    let _2: map<string, string>
+    let _3: uint8array
+
+    bb0: {
+        _2 = {  }: map<string, string>;
+        _3 = call const fn baml.String.to_utf8(const "websocket upgrade is not supported") -> [bb1];
+    }
+
+    bb1: {
+        _0 = sys_op const fn baml.http.Response.new(const 501_i64, copy _2, copy _3) -> bb2;
+    }
+
+    bb2: {
+        return;
+    }
+}
 
 fn baml.http.TlsConfig.new(cert_pem: uint8array, key_pem: uint8array, allow_tls1_2: bool, handshake_timeout: baml.time.Duration) -> baml.http.TlsConfig {
     // Locals:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/ppir.snap
@@ -974,14 +974,19 @@ class baml.http.TlsConfig$stream {
   _private_key: $rust_type
   _handshake_timeout_nanos: bigint | null
 }
+type baml.http.WsAccept = (socket: root.ws.WebSocket) -> void throws never
+type baml.http.WsAccept$stream = unknown
 function baml.http._new(cert_pem: uint8array, key_pem: uint8array, allow_tls1_2: bool, handshake_timeout_nanos: bigint) -> baml.http.TlsConfig  [builtin]
-function baml.http._serve(self: ?, handler: (req: Request) -> Response throws never, tls_config: baml.http.TlsConfig?, allow_http1: bool, allow_http2: bool, max_body_size: int, max_connections: int, header_read_timeout_nanos: bigint) -> never  [builtin]
+function baml.http._serve(self: ?, handler: (req: Request) -> Response throws never, websocket: (req: Request) -> Response | baml.http.WsAccept throws never, tls_config: baml.http.TlsConfig?, allow_http1: bool, allow_http2: bool, max_body_size: int, max_connections: int, header_read_timeout_nanos: bigint) -> never  [builtin]
 function baml.http.bind(addr: string) -> baml.http.Server  [builtin]
 function baml.http.new(cert_pem: uint8array, key_pem: uint8array, allow_tls1_2: bool = true, handshake_timeout: root.time.Duration = root.time.Duration.from_seconds(10n)) -> baml.http.TlsConfig  [expr] {
   {  } TlsConfig._new(cert_pem, key_pem, allow_tls1_2, handshake_timeout.to_nanoseconds())
 }
-function baml.http.serve(self: ?, handler: (req: Request) -> Response throws never, tls_config: baml.http.TlsConfig? = null, allow_http1: bool = true, allow_http2: bool = true, max_body_size: int = 104857600, max_connections: int = 1024, header_read_timeout: root.time.Duration = root.time.Duration.from_seconds(30n)) -> never  [expr] {
-  {  } self._serve(handler, tls_config, allow_http1, allow_http2, max_body_size, max_connections, header_read_timeout.to_nanoseconds())
+function baml.http.reject_websocket(req: Request) -> Response  [expr] {
+  {  } Response.new(501, map {  }, "websocket upgrade...".to_utf8())
+}
+function baml.http.serve(self: ?, handler: (req: Request) -> Response throws never, websocket: (req: Request) -> Response | baml.http.WsAccept throws never = reject_websocket, tls_config: baml.http.TlsConfig? = null, allow_http1: bool = true, allow_http2: bool = true, max_body_size: int = 104857600, max_connections: int = 1024, header_read_timeout: root.time.Duration = root.time.Duration.from_seconds(30n)) -> never  [expr] {
+  {  } self._serve(handler, websocket, tls_config, allow_http1, allow_http2, max_body_size, max_connections, header_read_timeout.to_nanoseconds())
 }
 
 --- <builtin>/baml/ns_id/id.baml ---

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/ppir.snap
@@ -2402,19 +2402,27 @@ function baml.toml.to_json(self: ?) -> baml.json.json  [expr] {
 }
 
 --- <builtin>/baml/ns_ws/ws.baml ---
-class baml.ws.WsStream {
+class baml.ws.CloseEvent {
+  code: int
+  reason: string
+}
+class baml.ws.CloseEvent$stream {
+  code: int | null
+  reason: string | null
+}
+class baml.ws.WebSocket {
   _handle: $rust_type
 }
-class baml.ws.WsStream$stream {
+class baml.ws.WebSocket$stream {
   _handle: $rust_type
 }
-function baml.ws._connect(url: string, headers: map<string, string>, timeout_nanos: bigint) -> baml.ws.WsStream  [builtin]
-function baml.ws.close(self: ?) -> null  [builtin]
-function baml.ws.connect(url: string, headers: map<string, string>, timeout: root.time.Duration = root.time.Duration.from_seconds(30)) -> baml.ws.WsStream  [expr] {
+function baml.ws._connect(url: string, headers: map<string, string>, timeout_nanos: bigint) -> baml.ws.WebSocket  [builtin]
+function baml.ws.close(self: ?, code: int, reason: string) -> void  [builtin]
+function baml.ws.connect(url: string, headers: map<string, string>, timeout: root.time.Duration = root.time.Duration.from_seconds(30)) -> baml.ws.WebSocket  [expr] {
   {  } _connect(url, headers, timeout.to_nanoseconds())
 }
-function baml.ws.next(self: ?) -> string?  [builtin]
-function baml.ws.send(self: ?, text: string) -> null  [builtin]
+function baml.ws.next(self: ?) -> string | uint8array | baml.ws.CloseEvent  [builtin]
+function baml.ws.send(self: ?, data: string | uint8array) -> void  [builtin]
 
 --- <builtin>/baml/ns_yaml/yaml.baml ---
 class baml.yaml.ParseError {

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -148,12 +148,14 @@ namespace baml.http:
   class Server { methods: [bind, serve, _serve] }
   class SseStream { methods: [next, close] }
   class TlsConfig { methods: [new, _new] }
+  type WsAccept
   function _fetch
   function _fetch_sse
   function _send
   function _timeout_nanos
   function fetch
   function fetch_sse
+  function reject_websocket
   function send
 namespace baml.id:
   function current

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -320,7 +320,8 @@ namespace baml.toml:
   function item_to_json
   function table_from_json
 namespace baml.ws:
-  class WsStream { methods: [send, next, close] }
+  class CloseEvent { methods: [] }
+  class WebSocket { methods: [send, next, close] }
   function _connect
   function connect
 namespace baml.yaml:

--- a/baml_language/crates/bridge_wasm/src/wasm_http.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_http.rs
@@ -431,6 +431,7 @@ impl io::IoClassHttpServer for WasmHttp {
         _call_id: CallId,
         _server: io::owned::http::Server,
         _handler: sys_types::Handle,
+        _websocket: sys_types::Handle,
         _tls_config: Option<io::owned::http::TlsConfig>,
         _allow_http1: bool,
         _allow_http2: bool,

--- a/baml_language/crates/sys_native/src/http_server.rs
+++ b/baml_language/crates/sys_native/src/http_server.rs
@@ -8,6 +8,12 @@
 //! thread. The closure reaches native code as a rooted [`Handle`]; it is never
 //! serialized.
 //!
+//! An HTTP/1.1 WebSocket handshake (RFC 6455) is routed to the separate
+//! `websocket` closure instead. That one returns either a `Response` refusing
+//! the upgrade or a `WsAccept` callable; accepting hands hyper's upgraded IO to
+//! `tokio_tungstenite` and registers it as a `baml.ws.WebSocket`, so a served
+//! socket and a `baml.ws.connect` socket are the same BAML value.
+//!
 //! Also hosts the `TlsConfig.new` / `Response.new` constructors and the unified
 //! [`HttpBody`] used by both client (`fetch`/`send`) and server responses.
 
@@ -23,12 +29,16 @@ use std::{
     time::Duration,
 };
 
+use bex_external_types::BexExternalAdt;
 use bytes::Bytes;
 use http_body_util::{BodyExt, Full, LengthLimitError, Limited, StreamBody, combinators::BoxBody};
 use hyper::{
     Request as HyperRequest, Response as HyperResponse,
     body::{Frame, Incoming},
-    header::{HeaderName, HeaderValue},
+    header::{
+        CONNECTION, HeaderMap, HeaderName, HeaderValue, SEC_WEBSOCKET_ACCEPT, SEC_WEBSOCKET_KEY,
+        SEC_WEBSOCKET_VERSION, UPGRADE,
+    },
     service::service_fn,
 };
 use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
@@ -49,6 +59,10 @@ use tokio_rustls::{
         self,
         pki_types::{CertificateDer, PrivateKeyDer},
     },
+};
+use tokio_tungstenite::{
+    WebSocketStream,
+    tungstenite::{handshake::derive_accept_key, protocol::Role},
 };
 
 // `timeout_from_nanos` lives in `io_impls` (always compiled) since the net
@@ -200,6 +214,11 @@ pub(crate) fn downcast_body(
 /// can be either fully buffered ([`Full`]) or incrementally streamed
 /// ([`StreamBody`], for [`HttpBody::Streaming`]).
 type WireBody = BoxBody<Bytes, Infallible>;
+
+/// A connection's `max_connections` slot, shared with the request service so a
+/// WebSocket upgrade can take it over from the HTTP connection that carried the
+/// handshake. Empty once taken, or once the connection has ended.
+type ConnPermit = Arc<std::sync::Mutex<Option<tokio::sync::OwnedSemaphorePermit>>>;
 
 /// A plaintext or TLS connection, unified so hyper can serve either.
 enum MaybeTlsStream {
@@ -368,6 +387,7 @@ pub(crate) fn bind(addr: String) -> SysOpOutput<owned::http::Server> {
 pub(crate) fn serve(
     server: owned::http::Server,
     handler: Handle,
+    websocket: Handle,
     tls_config: Option<owned::http::TlsConfig>,
     allow_http1: bool,
     allow_http2: bool,
@@ -463,11 +483,15 @@ pub(crate) fn serve(
 
             let acceptor = acceptor.clone();
             let handler = handler.clone();
+            let websocket = websocket.clone();
             let spawner = Arc::clone(&spawner);
             let cancel = cancel.clone();
             conns.spawn(async move {
-                // Held for the connection's lifetime; dropping it frees the slot.
-                let _permit = permit;
+                // Held for the connection's lifetime; dropping it frees the
+                // slot. A WebSocket upgrade takes it over (see
+                // `handle_websocket`) so a socket that outlives its HTTP
+                // connection keeps counting against `max_connections`.
+                let permit = Arc::new(std::sync::Mutex::new(Some(permit)));
                 let stream = match acceptor {
                     Some((acceptor, handshake_timeout)) => {
                         let handshake = acceptor.accept(stream);
@@ -490,11 +514,22 @@ pub(crate) fn serve(
                 let io = TokioIo::new(stream);
                 let service = service_fn(move |req: HyperRequest<Incoming>| {
                     let handler = handler.clone();
+                    let websocket = websocket.clone();
                     let spawner = Arc::clone(&spawner);
                     let cancel = cancel.child_token();
+                    let permit = Arc::clone(&permit);
                     async move {
                         Ok::<_, Infallible>(
-                            handle_request(req, handler, spawner, cancel, max_body_size).await,
+                            handle_request(
+                                req,
+                                handler,
+                                websocket,
+                                spawner,
+                                cancel,
+                                max_body_size,
+                                permit,
+                            )
+                            .await,
                         )
                     }
                 });
@@ -508,6 +543,11 @@ pub(crate) fn serve(
 /// Serve a single connection with the protocol(s) the server allows. Both
 /// allowed → negotiate automatically (ALPN for TLS, prefix sniffing for
 /// cleartext); otherwise pin to the single allowed protocol.
+///
+/// The HTTP/1 paths are bound with upgrades enabled, without which
+/// `hyper::upgrade::on` never resolves and a WebSocket handshake would answer
+/// `101` and then hang. HTTP/2 has no such mode: it carries WebSocket over
+/// extended CONNECT (RFC 8441), which this server does not implement.
 async fn serve_connection<S>(
     io: TokioIo<MaybeTlsStream>,
     service: S,
@@ -532,13 +572,13 @@ async fn serve_connection<S>(
                 .timer(TokioTimer::new())
                 .header_read_timeout(t);
         }
-        let _ = builder.serve_connection(io, service).await;
+        let _ = builder.serve_connection_with_upgrades(io, service).await;
     } else if allow_http1 {
         let mut builder = hyper::server::conn::http1::Builder::new();
         if let Some(t) = header_read_timeout {
             builder.timer(TokioTimer::new()).header_read_timeout(t);
         }
-        let _ = builder.serve_connection(io, service).await;
+        let _ = builder.serve_connection(io, service).with_upgrades().await;
     } else if allow_http2 {
         let _ = hyper::server::conn::http2::Builder::new(TokioExecutor::new())
             .serve_connection(io, service)
@@ -552,10 +592,16 @@ async fn serve_connection<S>(
 async fn handle_request(
     req: HyperRequest<Incoming>,
     handler: Handle,
+    websocket: Handle,
     spawner: Arc<dyn VmSpawner>,
     cancel: CancellationToken,
     max_body_size: usize,
+    conn_permit: ConnPermit,
 ) -> HyperResponse<WireBody> {
+    if let Some(key) = websocket_key(&req) {
+        return handle_websocket(req, key, websocket, spawner, cancel, conn_permit).await;
+    }
+
     let request = match to_baml_request(req, max_body_size).await {
         Ok(request) => request,
         Err(BadRequest::TooLarge) => return status_response(413, "payload too large"),
@@ -584,6 +630,212 @@ async fn handle_request(
     }
 }
 
+// ============================================================================
+// WebSocket upgrades
+// ============================================================================
+
+/// The `Sec-WebSocket-Key` of an RFC 6455 upgrade handshake, or `None` if `req`
+/// is an ordinary request.
+///
+/// Every condition is required by §4.1, and only all of them together separate
+/// an upgrade from a plain `GET` — so a request that merely looks websocket-ish
+/// falls through to the normal `handler` rather than being refused. HTTP/2
+/// carries WebSocket over extended CONNECT (RFC 8441) instead, which this
+/// server does not implement; the `HTTP_11` check is what excludes it.
+fn websocket_key(req: &HyperRequest<Incoming>) -> Option<HeaderValue> {
+    if req.method() != hyper::Method::GET || req.version() != hyper::Version::HTTP_11 {
+        return None;
+    }
+    if !header_has_token(req.headers(), &CONNECTION, "upgrade")
+        || !header_has_token(req.headers(), &UPGRADE, "websocket")
+    {
+        return None;
+    }
+    // 13 is the only version this (and every current) implementation speaks.
+    if req
+        .headers()
+        .get(SEC_WEBSOCKET_VERSION)
+        .map(HeaderValue::as_bytes)
+        != Some(b"13")
+    {
+        return None;
+    }
+    req.headers().get(SEC_WEBSOCKET_KEY).cloned()
+}
+
+/// Whether any comma-separated token of header `name` equals `token`, ignoring
+/// case. Both `Connection` and `Upgrade` are token lists (`keep-alive, Upgrade`),
+/// and either may also be split across repeated header fields.
+fn header_has_token(headers: &HeaderMap, name: &HeaderName, token: &str) -> bool {
+    headers.get_all(name).iter().any(|value| {
+        value.to_str().is_ok_and(|value| {
+            value
+                .split(',')
+                .any(|part| part.trim().eq_ignore_ascii_case(token))
+        })
+    })
+}
+
+/// What a `websocket` handler decided.
+#[expect(
+    clippy::large_enum_variant,
+    reason = "One short-lived local per handshake, moved straight into the \
+              matching branch; boxing would add an allocation to the refuse \
+              path to shrink a value that is never stored."
+)]
+enum WsOutcome {
+    /// Complete the handshake and run this `WsAccept` with the socket.
+    Accept(Handle),
+    /// Refuse the upgrade and serve this `Response` instead.
+    Refuse(BexExternalValue),
+}
+
+/// Classify a `websocket` handler's `Response | WsAccept` return.
+///
+/// The two arms are told apart by *shape*, not by the declared type: a callable
+/// crosses as a rooted `TaggedHeapHandle` — the same handle
+/// `spawn_with_callable` consumes, so the accept callback can be invoked later
+/// without re-entering the heap — while a `Response` crosses as a plain
+/// `Instance`.
+///
+/// Deliberately not keyed on the handle's `ty`: closures do not participate in
+/// the engine's union discrimination, so a returned `WsAccept` is tagged with
+/// whichever union member happens to come first (here `Response`). The only
+/// other value the engine tags this way is an `ai.stream.Stream` instance,
+/// which this union cannot hold.
+///
+/// Anything that is not a tagged handle is the `Response` arm and is validated
+/// by [`wire_response`], which reports a malformed one as a 500 rather than
+/// guessing.
+fn websocket_outcome(value: BexExternalValue) -> WsOutcome {
+    // A union-typed return arrives wrapped in its union metadata.
+    let value = match value {
+        BexExternalValue::Union { value, .. } => *value,
+        value => value,
+    };
+    match value {
+        BexExternalValue::Adt(BexExternalAdt::TaggedHeapHandle { heap_handle, .. }) => {
+            WsOutcome::Accept(heap_handle)
+        }
+        value => WsOutcome::Refuse(value),
+    }
+}
+
+/// Serve a WebSocket upgrade: run the BAML `websocket` handler, then either
+/// refuse with the `Response` it returned or complete the handshake and hand
+/// the connected socket to its `WsAccept`.
+async fn handle_websocket(
+    mut req: HyperRequest<Incoming>,
+    key: HeaderValue,
+    websocket: Handle,
+    spawner: Arc<dyn VmSpawner>,
+    cancel: CancellationToken,
+    conn_permit: ConnPermit,
+) -> HyperResponse<WireBody> {
+    // A handshake carries no body (RFC 6455 §4.1), and reading one would
+    // consume the stream the upgrade needs, so the handler sees the usual
+    // `Request` shape with an empty body.
+    let request = owned::http::Request {
+        method: req.method().as_str().to_string(),
+        url: req.uri().to_string(),
+        headers: collect_headers(req.headers()),
+        body: String::new(),
+    };
+    let url = request.url.clone();
+
+    // Same isolation as an ordinary request: one failed handshake never stops
+    // the server. See `handle_request` for why this logs at `debug`.
+    let Ok(outcome) = Arc::clone(&spawner)
+        .spawn_with_callable(
+            websocket,
+            vec![request.into_bex_external_value()],
+            cancel.clone(),
+        )
+        .await
+    else {
+        tracing::debug!("WebSocket handler failed (threw, panicked, or was cancelled)");
+        return status_response(500, "websocket handler failed");
+    };
+
+    let accept = match websocket_outcome(outcome) {
+        WsOutcome::Accept(accept) => accept,
+        WsOutcome::Refuse(response) => {
+            return match wire_response(response).await {
+                Ok(resp) => resp,
+                Err(e) => {
+                    tracing::warn!("WebSocket handler returned an invalid response: {e}");
+                    status_response(500, "websocket handler returned an invalid response")
+                }
+            };
+        }
+    };
+
+    // Registered before the response is handed back: hyper resolves this only
+    // once the 101 has been written and the connection released to us.
+    let upgraded = hyper::upgrade::on(&mut req);
+    let handler_cancel = cancel.child_token();
+    // Taken over from the HTTP connection, whose task ends at the upgrade: the
+    // socket, not the exchange that created it, is what occupies the slot.
+    let permit = conn_permit
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .take();
+    tokio::spawn(async move {
+        let _permit = permit;
+        // The socket outlives the request, so it is bounded by the serve's
+        // cancellation rather than by hyper — without this a shut-down server
+        // would leave its sockets running.
+        tokio::select! {
+            () = cancel.cancelled() => {}
+            () = run_websocket(upgraded, url, accept, spawner, handler_cancel) => {}
+        }
+    });
+
+    HyperResponse::builder()
+        .status(101)
+        .header(CONNECTION, "Upgrade")
+        .header(UPGRADE, "websocket")
+        .header(SEC_WEBSOCKET_ACCEPT, derive_accept_key(key.as_bytes()))
+        .body(Full::new(Bytes::new()).boxed())
+        .unwrap_or_else(|_| status_response(500, "could not build the upgrade response"))
+}
+
+/// Complete the upgrade and run the BAML `WsAccept` handler with the connected
+/// socket, which it owns: the connection is hung up once it returns.
+async fn run_websocket(
+    upgraded: hyper::upgrade::OnUpgrade,
+    url: String,
+    accept: Handle,
+    spawner: Arc<dyn VmSpawner>,
+    cancel: CancellationToken,
+) {
+    use futures::StreamExt;
+
+    // The client can still disappear between the 101 and the handover.
+    let Ok(upgraded) = upgraded.await else {
+        return;
+    };
+    let stream = WebSocketStream::from_raw_socket(TokioIo::new(upgraded), Role::Server, None).await;
+    let (sink, source) = stream.split();
+    // Holding `handle` past the call keeps the registry entry alive for the
+    // handler's whole run; dropping it at the end of this function is what
+    // finally releases the socket.
+    let handle =
+        crate::registry::REGISTRY.register_ws_stream(Box::new(sink), Box::new(source), url);
+    let socket = owned::ws::WebSocket {
+        _handle: Arc::new(handle.clone()),
+    };
+
+    let _ = spawner
+        .spawn_with_callable(accept, vec![socket.into_bex_external_value()], cancel)
+        .await;
+
+    // The handler is done with the connection whether it returned or failed.
+    if let Some(resource) = crate::registry::REGISTRY.get_ws_stream(handle.key()) {
+        resource.hangup().await;
+    }
+}
+
 /// Why a request couldn't be turned into a BAML `Request`.
 enum BadRequest {
     /// The body exceeded `max_body_size` → 413.
@@ -602,26 +854,7 @@ async fn to_baml_request(
     let (parts, body) = req.into_parts();
     let method = parts.method.as_str().to_string();
     let url = parts.uri.to_string();
-    // `headers` is `map<string,string>`, but a header name may repeat. Fold
-    // repeated values with ", " (RFC 7230 §3.2.2) — except `Cookie`, which folds
-    // with "; " (RFC 6265 §5.4); HTTP/2 in particular may split it across fields.
-    // Keeping every value means multiple `X-Forwarded-For` / `Via` aren't lost.
-    let mut headers: IndexMap<String, String> = IndexMap::new();
-    for (name, value) in &parts.headers {
-        let value = String::from_utf8_lossy(value.as_bytes());
-        let sep = if name == hyper::header::COOKIE {
-            "; "
-        } else {
-            ", "
-        };
-        headers
-            .entry(name.as_str().to_string())
-            .and_modify(|existing| {
-                existing.push_str(sep);
-                existing.push_str(&value);
-            })
-            .or_insert_with(|| value.into_owned());
-    }
+    let headers = collect_headers(&parts.headers);
     // `Limited` stops reading past the cap, so an oversized (or unbounded
     // chunked) body can't force unbounded allocation: a length overflow is a
     // 413, any other read error a 400.
@@ -640,6 +873,32 @@ async fn to_baml_request(
         headers,
         body,
     })
+}
+
+/// Fold hyper's headers into the `map<string, string>` shape of `Request.headers`.
+///
+/// A header name may repeat, so repeated values are joined with ", " (RFC 7230
+/// §3.2.2) — except `Cookie`, which joins with "; " (RFC 6265 §5.4); HTTP/2 in
+/// particular may split it across fields. Keeping every value means multiple
+/// `X-Forwarded-For` / `Via` aren't lost.
+fn collect_headers(headers: &HeaderMap) -> IndexMap<String, String> {
+    let mut collected: IndexMap<String, String> = IndexMap::new();
+    for (name, value) in headers {
+        let value = String::from_utf8_lossy(value.as_bytes());
+        let sep = if name == hyper::header::COOKIE {
+            "; "
+        } else {
+            ", "
+        };
+        collected
+            .entry(name.as_str().to_string())
+            .and_modify(|existing| {
+                existing.push_str(sep);
+                existing.push_str(&value);
+            })
+            .or_insert_with(|| value.into_owned());
+    }
+    collected
 }
 
 /// Response headers a handler must not set, because hyper owns message framing

--- a/baml_language/crates/sys_native/src/io_impls.rs
+++ b/baml_language/crates/sys_native/src/io_impls.rs
@@ -3335,7 +3335,16 @@ impl io::IoClassWsWebSocket for NativeSysOps {
                         };
                         break Ok(ws_close_event(ws.finish(&mut source, close).await));
                     }
+                    // tokio-tungstenite fuses the stream on any read error —
+                    // every later poll is `None` — so the connection is over
+                    // as of this frame. Publish that now, so `send` and
+                    // `hangup` answer from `close`, then report what ended it.
                     Some(Err(error)) => {
+                        let close = WsClose {
+                            code: 1006,
+                            reason: String::new(),
+                        };
+                        ws.finish(&mut source, close).await;
                         return Err(VmBamlError::Io {
                             message: format!("WebSocket receive failed: {error}"),
                         }
@@ -3412,6 +3421,20 @@ impl io::IoClassWsWebSocket for NativeSysOps {
                 });
             }
         };
+
+        // RFC 6455 §5.5: a control frame carries at most 125 payload bytes,
+        // and a close frame spends two on the status code. Tungstenite checks
+        // this only when reading — `Frame::close` neither checks nor
+        // truncates — so an oversized reason would reach the wire as a
+        // protocol violation for the peer to fail the connection over.
+        if reason.len() > 123 {
+            return SysOpOutput::err(VmBamlError::InvalidArgument {
+                message: format!(
+                    "WebSocket close reason is {} bytes; a close frame carries at most 123",
+                    reason.len()
+                ),
+            });
+        }
 
         SysOpOutput::async_op(async move {
             let ws = ws_resource(&websocket)?;

--- a/baml_language/crates/sys_native/src/io_impls.rs
+++ b/baml_language/crates/sys_native/src/io_impls.rs
@@ -13,6 +13,8 @@ use bex_heap::{BexExternalValue, BexHeap};
 use sys_ops::io::{
     self, CallId, SysOpContext, SysOpOutput, VmBamlError, VmPanic, VmRustFnError, owned,
 };
+#[cfg(feature = "bundle-http")]
+use sys_ops::io::{ObjectType, Type};
 use sys_types::VmInternalError;
 
 const MAX_READ_CHUNK: usize = 64 * 1024;
@@ -3169,40 +3171,110 @@ impl io::IoNamespaceHttp for NativeSysOps {
     }
 }
 
-impl io::IoClassWsWsStream for NativeSysOps {
+/// The VM [`Type`] an owned sys-op argument denotes.
+///
+/// Arguments reach a sys-op through `as_owned_but_very_slow`, so these are the
+/// shapes it can hand back. The reference-like variants have no VM object type
+/// to name here — a `Handle` needs the heap to resolve, a host value has no VM
+/// object at all — so they report [`ObjectType::Any`], the documented top of
+/// the lattice, rather than a fabricated tag.
+#[cfg(feature = "bundle-http")]
+fn arg_value_type(value: &BexExternalValue) -> Type {
+    match value {
+        // `Type::of` likewise reports the lattice top for null.
+        BexExternalValue::Null => Type::Object(ObjectType::Any),
+        BexExternalValue::Int(_) => Type::Int,
+        BexExternalValue::Float(_) => Type::Float,
+        BexExternalValue::Bool(_) => Type::Bool,
+        BexExternalValue::Bigint(_) => Type::Object(ObjectType::Bigint),
+        BexExternalValue::String(_) => Type::Object(ObjectType::String),
+        BexExternalValue::Uint8Array(_) => Type::Object(ObjectType::Uint8Array),
+        BexExternalValue::Array { .. } => Type::Object(ObjectType::Array),
+        BexExternalValue::Map { .. } => Type::Object(ObjectType::Map),
+        BexExternalValue::Instance { .. } => Type::Object(ObjectType::Instance),
+        // `ObjectType::of` folds both enum objects into `Enum`.
+        BexExternalValue::Variant { .. } => Type::Object(ObjectType::Enum),
+        BexExternalValue::RustData(_) => Type::Object(ObjectType::RustData),
+        // A union tag is not itself a runtime type; the payload carries one.
+        BexExternalValue::Union { value, .. } => arg_value_type(value),
+        BexExternalValue::FunctionRef { .. }
+        | BexExternalValue::Handle(_)
+        | BexExternalValue::HostValue(_)
+        | BexExternalValue::Adt(_) => Type::Object(ObjectType::Any),
+    }
+}
+
+/// Resolve the registry resource behind a `baml.ws.WebSocket`'s opaque
+/// `_handle`. Both failure modes are engine bugs — the handle is minted by
+/// `baml.ws._connect` and only ever read back here — so neither is something a
+/// BAML program is expected to catch.
+#[cfg(feature = "bundle-http")]
+fn ws_resource(
+    websocket: &owned::ws::WebSocket,
+) -> Result<Arc<crate::registry::WsStreamResource>, VmInternalError> {
+    let handle = Arc::clone(&websocket._handle)
+        .downcast::<bex_resource_types::ResourceHandle>()
+        .map_err(|handle| VmInternalError::RustTypeError {
+            expected: TypeId::of::<bex_resource_types::ResourceHandle>(),
+            got: handle.as_ref().type_id(),
+        })?;
+    crate::registry::REGISTRY.get_ws_stream(handle.key()).ok_or(
+        VmInternalError::UnresolvedResourceHandle {
+            kind: "WebSocket",
+            key: handle.key(),
+        },
+    )
+}
+
+/// Build the `baml.ws.CloseEvent` that `next` hands back once the connection
+/// has ended.
+#[cfg(feature = "bundle-http")]
+fn ws_close_event(close: &crate::registry::WsClose) -> BexExternalValue {
+    use sys_ops::io::AsBexExternalValue;
+
+    owned::ws::CloseEvent {
+        code: i64::from(close.code),
+        reason: close.reason.clone(),
+    }
+    .into_bex_external_value()
+}
+
+impl io::IoClassWsWebSocket for NativeSysOps {
     #[cfg(feature = "bundle-http")]
     fn send(
         &self,
         _heap: &Arc<BexHeap>,
         _call_id: CallId,
-        stream: owned::ws::WsStream,
-        text: String,
+        websocket: owned::ws::WebSocket,
+        data: BexExternalValue,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<()> {
         use futures::SinkExt;
         use tokio_tungstenite::tungstenite::Message;
 
+        // `data: string | uint8array` is enforced by the compiler, so any other
+        // shape here is a VM/codegen fault rather than a caller error. `Type`
+        // has no union form, so `expected` names the string arm.
+        let frame = match data {
+            BexExternalValue::String(text) => Message::text(text.to_string()),
+            BexExternalValue::Uint8Array(bytes) => Message::binary(bytes),
+            other => {
+                return SysOpOutput::err(VmInternalError::TypeError {
+                    expected: Type::Object(ObjectType::String),
+                    got: arg_value_type(&other),
+                });
+            }
+        };
+
         SysOpOutput::async_op(async move {
-            let handle = stream
-                ._handle
-                .downcast::<bex_resource_types::ResourceHandle>()
-                .map_err(|handle| VmInternalError::RustTypeError {
-                    expected: TypeId::of::<bex_resource_types::ResourceHandle>(),
-                    got: handle.type_id(),
-                })?;
-            let (sink, _) = crate::registry::REGISTRY
-                .get_ws_stream(handle.key())
-                .ok_or(VmInternalError::UnresolvedResourceHandle {
-                    kind: "WebSocket stream",
-                    key: handle.key(),
-                })?;
-            sink.lock()
-                .await
-                .send(Message::text(text))
-                .await
-                .map_err(|error| VmBamlError::Io {
-                    message: format!("WebSocket send failed: {error}"),
-                })?;
+            let ws = ws_resource(&websocket)?;
+            let mut sink = ws.sink.lock().await;
+            let sink = sink.as_mut().ok_or_else(|| VmBamlError::Io {
+                message: "WebSocket send failed: the connection is closed".to_string(),
+            })?;
+            sink.send(frame).await.map_err(|error| VmBamlError::Io {
+                message: format!("WebSocket send failed: {error}"),
+            })?;
             Ok(())
         })
     }
@@ -3212,12 +3284,12 @@ impl io::IoClassWsWsStream for NativeSysOps {
         &self,
         _heap: &Arc<BexHeap>,
         _call_id: CallId,
-        _stream: owned::ws::WsStream,
-        _text: String,
+        _websocket: owned::ws::WebSocket,
+        _data: BexExternalValue,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<()> {
         SysOpOutput::err(VmPanic::HostUnavailable {
-            resource: "ws".to_string(),
+            resource: "websocket".to_string(),
             message: "Operation not supported on this platform".to_string(),
         })
     }
@@ -3227,58 +3299,69 @@ impl io::IoClassWsWsStream for NativeSysOps {
         &self,
         _heap: &Arc<BexHeap>,
         _call_id: CallId,
-        stream: owned::ws::WsStream,
+        websocket: owned::ws::WebSocket,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<Option<String>> {
-        use futures::{SinkExt, StreamExt};
+    ) -> SysOpOutput<BexExternalValue> {
+        use futures::StreamExt;
         use tokio_tungstenite::tungstenite::Message;
 
+        use crate::registry::WsClose;
+
         SysOpOutput::async_op(async move {
-            let handle = stream
-                ._handle
-                .downcast::<bex_resource_types::ResourceHandle>()
-                .map_err(|handle| VmInternalError::RustTypeError {
-                    expected: TypeId::of::<bex_resource_types::ResourceHandle>(),
-                    got: handle.type_id(),
-                })?;
-            let (sink, source) = crate::registry::REGISTRY
-                .get_ws_stream(handle.key())
-                .ok_or(VmInternalError::UnresolvedResourceHandle {
-                    kind: "WebSocket stream",
-                    key: handle.key(),
-                })?;
-            let mut source = source.lock().await;
+            let ws = ws_resource(&websocket)?;
+            if let Some(close) = ws.close.get() {
+                return Ok(ws_close_event(close));
+            }
+            let mut source = ws.source.lock().await;
             loop {
-                match source.next().await {
-                    Some(Ok(Message::Text(text))) => {
-                        return Ok(Some(text.as_str().to_string()));
+                // Re-checked under the lock: a concurrent `next` may have ended
+                // the connection, which publishes the close event and drops the
+                // transport in one step.
+                let Some(stream) = source.as_mut() else {
+                    break Ok(ws_close_event(ws.close.get().unwrap_or_else(|| {
+                        unreachable!("WebSocket transport released without a close event")
+                    })));
+                };
+                let frame = match stream.next().await {
+                    Some(Ok(frame)) => frame,
+                    // End of stream with no closing handshake.
+                    None => {
+                        let close = WsClose {
+                            code: 1006,
+                            reason: String::new(),
+                        };
+                        break Ok(ws_close_event(ws.finish(&mut source, close).await));
                     }
-                    Some(Ok(Message::Binary(bytes))) => {
-                        return Err(VmBamlError::Io {
-                            message: format!(
-                                "received unexpected binary WebSocket frame ({} bytes) on a text-oriented stream",
-                                bytes.len()
-                            ),
-                        }
-                        .into());
-                    }
-                    Some(Ok(Message::Close(_))) | None => return Ok(None),
-                    Some(Ok(Message::Ping(payload))) => {
-                        sink.lock()
-                            .await
-                            .send(Message::Pong(payload))
-                            .await
-                            .map_err(|error| VmBamlError::Io {
-                                message: format!("WebSocket pong failed: {error}"),
-                            })?;
-                    }
-                    Some(Ok(Message::Pong(_) | Message::Frame(_))) => {}
                     Some(Err(error)) => {
                         return Err(VmBamlError::Io {
                             message: format!("WebSocket receive failed: {error}"),
                         }
                         .into());
                     }
+                };
+                match frame {
+                    Message::Text(text) => {
+                        break Ok(BexExternalValue::String(text.as_str().into()));
+                    }
+                    Message::Binary(bytes) => {
+                        break Ok(BexExternalValue::Uint8Array(bytes.to_vec()));
+                    }
+                    Message::Close(frame) => {
+                        let close = frame.map_or(
+                            WsClose {
+                                code: 1005,
+                                reason: String::new(),
+                            },
+                            |frame| WsClose {
+                                code: u16::from(frame.code),
+                                reason: frame.reason.as_str().to_string(),
+                            },
+                        );
+                        break Ok(ws_close_event(ws.finish(&mut source, close).await));
+                    }
+                    // Tungstenite answers pings itself while reading; neither
+                    // control frame is part of the BAML surface.
+                    Message::Ping(_) | Message::Pong(_) | Message::Frame(_) => {}
                 }
             }
         })
@@ -3289,11 +3372,11 @@ impl io::IoClassWsWsStream for NativeSysOps {
         &self,
         _heap: &Arc<BexHeap>,
         _call_id: CallId,
-        _stream: owned::ws::WsStream,
+        _websocket: owned::ws::WebSocket,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<Option<String>> {
+    ) -> SysOpOutput<BexExternalValue> {
         SysOpOutput::err(VmPanic::HostUnavailable {
-            resource: "ws".to_string(),
+            resource: "websocket".to_string(),
             message: "Operation not supported on this platform".to_string(),
         })
     }
@@ -3303,22 +3386,43 @@ impl io::IoClassWsWsStream for NativeSysOps {
         &self,
         _heap: &Arc<BexHeap>,
         _call_id: CallId,
-        stream: owned::ws::WsStream,
+        websocket: owned::ws::WebSocket,
+        code: i64,
+        reason: String,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<()> {
-        use bex_resource_types::ResourceRegistryRef;
         use futures::SinkExt;
-        use tokio_tungstenite::tungstenite::Message;
+        use tokio_tungstenite::tungstenite::{
+            Message,
+            protocol::{CloseFrame, frame::coding::CloseCode},
+        };
+
+        // RFC 6455 §7.4: an endpoint may send 1000-1003, 1007-1013, and the
+        // registered (3000-3999) and private (4000-4999) ranges. The undefined
+        // codes and the four a peer may only ever infer (1004/1005/1006/1015)
+        // are caller errors — `is_allowed` draws exactly that line.
+        let close_code = match u16::try_from(code).map(CloseCode::from) {
+            Ok(close_code) if close_code.is_allowed() => close_code,
+            Ok(_) | Err(_) => {
+                return SysOpOutput::err(VmBamlError::InvalidArgument {
+                    message: format!("{code} is not a valid WebSocket close code"),
+                });
+            }
+        };
 
         SysOpOutput::async_op(async move {
-            if let Ok(handle) = stream
-                ._handle
-                .downcast::<bex_resource_types::ResourceHandle>()
-            {
-                if let Some((sink, _)) = crate::registry::REGISTRY.get_ws_stream(handle.key()) {
-                    let _ = sink.lock().await.send(Message::Close(None)).await;
-                }
-                crate::registry::REGISTRY.remove(handle.key());
+            let ws = ws_resource(&websocket)?;
+            // Best effort from here on: `close` declares only
+            // `InvalidArgument`, and a peer that has already gone away is not a
+            // caller error. The socket itself is released by `next` when the
+            // peer's echo (or the end of the stream) arrives.
+            if let Some(sink) = ws.sink.lock().await.as_mut() {
+                let _ = sink
+                    .send(Message::Close(Some(CloseFrame {
+                        code: close_code,
+                        reason: reason.into(),
+                    })))
+                    .await;
             }
             Ok(())
         })
@@ -3329,18 +3433,15 @@ impl io::IoClassWsWsStream for NativeSysOps {
         &self,
         _heap: &Arc<BexHeap>,
         _call_id: CallId,
-        stream: owned::ws::WsStream,
+        _websocket: owned::ws::WebSocket,
+        _code: i64,
+        _reason: String,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<()> {
-        use bex_resource_types::ResourceRegistryRef;
-
-        if let Ok(handle) = stream
-            ._handle
-            .downcast::<bex_resource_types::ResourceHandle>()
-        {
-            crate::registry::REGISTRY.remove(handle.key());
-        }
-        SysOpOutput::ok(())
+        SysOpOutput::err(VmPanic::HostUnavailable {
+            resource: "websocket".to_string(),
+            message: "Operation not supported on this platform".to_string(),
+        })
     }
 }
 
@@ -3354,9 +3455,8 @@ impl io::IoNamespaceWs for NativeSysOps {
         headers: indexmap::IndexMap<String, String>,
         timeout_nanos: Arc<num_bigint::BigInt>,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<owned::ws::WsStream> {
+    ) -> SysOpOutput<owned::ws::WebSocket> {
         use futures::StreamExt;
-        use tokio::sync::Mutex;
         use tokio_tungstenite::tungstenite::{
             client::IntoClientRequest,
             http::{HeaderName, HeaderValue},
@@ -3401,12 +3501,8 @@ impl io::IoNamespaceWs for NativeSysOps {
                 message: format!("WebSocket connect failed: {error}"),
             })?;
             let (sink, source) = transport.split();
-            let handle = crate::registry::REGISTRY.register_ws_stream(
-                Arc::new(Mutex::new(sink)),
-                Arc::new(Mutex::new(source)),
-                url,
-            );
-            Ok(owned::ws::WsStream {
+            let handle = crate::registry::REGISTRY.register_ws_stream(sink, source, url);
+            Ok(owned::ws::WebSocket {
                 _handle: Arc::new(handle),
             })
         })
@@ -3421,9 +3517,9 @@ impl io::IoNamespaceWs for NativeSysOps {
         _headers: indexmap::IndexMap<String, String>,
         _timeout_nanos: Arc<num_bigint::BigInt>,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<owned::ws::WsStream> {
+    ) -> SysOpOutput<owned::ws::WebSocket> {
         SysOpOutput::err(VmPanic::HostUnavailable {
-            resource: "ws".to_string(),
+            resource: "websocket".to_string(),
             message: "Operation not supported on this platform".to_string(),
         })
     }

--- a/baml_language/crates/sys_native/src/io_impls.rs
+++ b/baml_language/crates/sys_native/src/io_impls.rs
@@ -2662,6 +2662,7 @@ impl io::IoClassHttpServer for NativeSysOps {
         _call_id: CallId,
         server: owned::http::Server,
         handler: bex_external_types::Handle,
+        websocket: bex_external_types::Handle,
         tls_config: Option<owned::http::TlsConfig>,
         allow_http1: bool,
         allow_http2: bool,
@@ -2673,6 +2674,7 @@ impl io::IoClassHttpServer for NativeSysOps {
         crate::http_server::serve(
             server,
             handler,
+            websocket,
             tls_config,
             allow_http1,
             allow_http2,
@@ -2706,6 +2708,7 @@ impl io::IoClassHttpServer for NativeSysOps {
         _call_id: CallId,
         _server: owned::http::Server,
         _handler: bex_external_types::Handle,
+        _websocket: bex_external_types::Handle,
         _tls_config: Option<owned::http::TlsConfig>,
         _allow_http1: bool,
         _allow_http2: bool,
@@ -3501,7 +3504,8 @@ impl io::IoNamespaceWs for NativeSysOps {
                 message: format!("WebSocket connect failed: {error}"),
             })?;
             let (sink, source) = transport.split();
-            let handle = crate::registry::REGISTRY.register_ws_stream(sink, source, url);
+            let handle =
+                crate::registry::REGISTRY.register_ws_stream(Box::new(sink), Box::new(source), url);
             Ok(owned::ws::WebSocket {
                 _handle: Arc::new(handle),
             })

--- a/baml_language/crates/sys_native/src/registry.rs
+++ b/baml_language/crates/sys_native/src/registry.rs
@@ -16,6 +16,8 @@ use sys_types::sse::SseEvent;
 use tokio::sync::Mutex as TokioMutex;
 #[cfg(feature = "bundle-http")]
 use tokio::{sync::Notify, task::AbortHandle};
+#[cfg(feature = "bundle-http")]
+use tokio_tungstenite::tungstenite::{Error as WsError, Message as WsMessage};
 
 /// Buffer for SSE events accumulated by a background task.
 pub struct SseBuffer {
@@ -37,13 +39,18 @@ pub struct SseStreamResource {
 #[cfg(feature = "bundle-http")]
 type SseStreamParts = (Arc<TokioMutex<SseBuffer>>, Arc<Notify>, Arc<AtomicBool>);
 
+/// The write half of a connected WebSocket.
+///
+/// Type-erased rather than tied to one transport: a client socket
+/// (`baml.ws.connect`) splits a plain-or-TLS TCP stream, while a server socket
+/// (an HTTP upgrade inside `baml.http.Server.serve`) splits hyper's upgraded
+/// IO. Both reach the registry — and therefore the whole `baml.ws.WebSocket`
+/// surface — through this one type.
 #[cfg(feature = "bundle-http")]
-pub type WsTransport =
-    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+pub type WsSink = Box<dyn futures::Sink<WsMessage, Error = WsError> + Send + Unpin>;
+/// The read half of a connected WebSocket. See [`WsSink`].
 #[cfg(feature = "bundle-http")]
-pub type WsSink = futures::stream::SplitSink<WsTransport, tokio_tungstenite::tungstenite::Message>;
-#[cfg(feature = "bundle-http")]
-pub type WsSource = futures::stream::SplitStream<WsTransport>;
+pub type WsSource = Box<dyn futures::Stream<Item = Result<WsMessage, WsError>> + Send + Unpin>;
 
 /// How a WebSocket connection ended, as reported to BAML by
 /// `baml.ws.WebSocket.next` (a `baml.ws.CloseEvent`).
@@ -95,6 +102,42 @@ impl WsStreamResource {
         }
         *source = None;
         self.close.get_or_init(|| close)
+    }
+
+    /// Hang up: the side that owns this connection is done with it.
+    ///
+    /// Used by the HTTP server when a `WsAccept` handler returns, so a served
+    /// connection's lifetime is the handler's rather than the garbage
+    /// collector's.
+    ///
+    /// Takes the full teardown when nothing else is reading. If a `next` is in
+    /// flight it closes only the write half and leaves that reader to publish
+    /// the close event when the peer's echo (or EOF) arrives — waiting on the
+    /// read lock here would block until a frame that may never come.
+    pub async fn hangup(&self) {
+        use futures::SinkExt;
+
+        match self.source.try_lock() {
+            Ok(mut source) => {
+                if self.close.get().is_none() {
+                    // `SinkExt::close` sends a status-less close frame, so
+                    // `1005` is what both ends observe.
+                    self.finish(
+                        &mut source,
+                        WsClose {
+                            code: 1005,
+                            reason: String::new(),
+                        },
+                    )
+                    .await;
+                }
+            }
+            Err(_) => {
+                if let Some(mut sink) = self.sink.lock().await.take() {
+                    let _ = sink.close().await;
+                }
+            }
+        }
     }
 }
 

--- a/baml_language/crates/sys_native/src/registry.rs
+++ b/baml_language/crates/sys_native/src/registry.rs
@@ -1,7 +1,7 @@
 //! Resource registry for managing native Tokio resources.
 
 #[cfg(feature = "bundle-http")]
-use std::sync::atomic::AtomicBool;
+use std::sync::{OnceLock, atomic::AtomicBool};
 use std::{
     collections::HashMap,
     sync::{
@@ -38,29 +38,72 @@ pub struct SseStreamResource {
 type SseStreamParts = (Arc<TokioMutex<SseBuffer>>, Arc<Notify>, Arc<AtomicBool>);
 
 #[cfg(feature = "bundle-http")]
-type WsTransport =
+pub type WsTransport =
     tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
 #[cfg(feature = "bundle-http")]
-type WsSink = futures::stream::SplitSink<WsTransport, tokio_tungstenite::tungstenite::Message>;
+pub type WsSink = futures::stream::SplitSink<WsTransport, tokio_tungstenite::tungstenite::Message>;
 #[cfg(feature = "bundle-http")]
-type WsSource = futures::stream::SplitStream<WsTransport>;
+pub type WsSource = futures::stream::SplitStream<WsTransport>;
 
+/// How a WebSocket connection ended, as reported to BAML by
+/// `baml.ws.WebSocket.next` (a `baml.ws.CloseEvent`).
+#[cfg(feature = "bundle-http")]
+#[derive(Clone, Debug)]
+pub struct WsClose {
+    /// RFC 6455 status code. `1005` ("no status received") when the peer's
+    /// close frame carried no code and `1006` ("abnormal closure") when the
+    /// stream ended with no closing handshake at all — the same two synthetic
+    /// codes a browser reports on its `CloseEvent`.
+    pub code: u16,
+    pub reason: String,
+}
+
+/// A connected WebSocket.
+///
+/// Both transport halves are `Option` because the closing handshake releases
+/// the socket eagerly: [`WsStreamResource::finish`] publishes `close` and drops
+/// the halves together, so a terminated stream is never polled again and every
+/// later `send`/`next` answers from `close` alone.
 #[cfg(feature = "bundle-http")]
 pub struct WsStreamResource {
-    pub sink: Arc<TokioMutex<WsSink>>,
-    pub source: Arc<TokioMutex<WsSource>>,
+    pub sink: TokioMutex<Option<WsSink>>,
+    pub source: TokioMutex<Option<WsSource>>,
+    pub close: OnceLock<WsClose>,
     pub url: String,
 }
 
 #[cfg(feature = "bundle-http")]
-type WsStreamParts = (Arc<TokioMutex<WsSink>>, Arc<TokioMutex<WsSource>>);
+impl WsStreamResource {
+    /// End the connection: complete the closing handshake, release the socket,
+    /// and publish `close`.
+    ///
+    /// Closing the sink flushes the close frame tungstenite queues in reply to
+    /// the peer's, which `read` alone leaves pending — without it the peer sees
+    /// the connection vanish mid-handshake.
+    ///
+    /// The read half calls this the moment the connection ends, handing over
+    /// its own `source` guard. Holding that guard across the whole call is what
+    /// makes "the transport is gone" and "the close event is published"
+    /// inseparable: no other caller can reach the source without the guard, and
+    /// by then `close` is set.
+    pub async fn finish(&self, source: &mut Option<WsSource>, close: WsClose) -> &WsClose {
+        use futures::SinkExt;
+
+        if let Some(mut sink) = self.sink.lock().await.take() {
+            // Best effort — the peer may already be gone.
+            let _ = sink.close().await;
+        }
+        *source = None;
+        self.close.get_or_init(|| close)
+    }
+}
 
 /// Registry entry for a resource.
 pub enum RegistryEntry {
     #[cfg(feature = "bundle-http")]
     SseStream(SseStreamResource),
     #[cfg(feature = "bundle-http")]
-    WsStream(WsStreamResource),
+    WsStream(Arc<WsStreamResource>),
 }
 
 /// Global resource registry.
@@ -116,8 +159,8 @@ impl ResourceRegistry {
     #[cfg(feature = "bundle-http")]
     pub fn register_ws_stream(
         self: &Arc<Self>,
-        sink: Arc<TokioMutex<WsSink>>,
-        source: Arc<TokioMutex<WsSource>>,
+        sink: WsSink,
+        source: WsSource,
         url: String,
     ) -> ResourceHandle {
         let key = self.next_key.fetch_add(1, Ordering::SeqCst);
@@ -126,11 +169,12 @@ impl ResourceRegistry {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .insert(
                 key,
-                RegistryEntry::WsStream(WsStreamResource {
-                    sink,
-                    source,
+                RegistryEntry::WsStream(Arc::new(WsStreamResource {
+                    sink: TokioMutex::new(Some(sink)),
+                    source: TokioMutex::new(Some(source)),
+                    close: OnceLock::new(),
                     url: url.clone(),
-                }),
+                })),
             );
 
         ResourceHandle::new(
@@ -142,15 +186,13 @@ impl ResourceRegistry {
     }
 
     #[cfg(feature = "bundle-http")]
-    pub fn get_ws_stream(&self, key: usize) -> Option<WsStreamParts> {
+    pub fn get_ws_stream(&self, key: usize) -> Option<Arc<WsStreamResource>> {
         let entries = self
             .entries
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         match entries.get(&key) {
-            Some(RegistryEntry::WsStream(stream)) => {
-                Some((stream.sink.clone(), stream.source.clone()))
-            }
+            Some(RegistryEntry::WsStream(stream)) => Some(Arc::clone(stream)),
             _ => None,
         }
     }

--- a/baml_language/crates/sys_ops/src/lib.rs
+++ b/baml_language/crates/sys_ops/src/lib.rs
@@ -25,13 +25,13 @@ pub mod io {
     use std::sync::Arc;
 
     pub use bex_heap::{AccessError, BexClass, BexValue, BuiltinClass, PermitProof};
-    pub use bex_vm_types::SysOp;
+    pub use bex_vm_types::{ObjectType, SysOp, types::Type};
     // Owned structs are generated once in sys_types and re-exported here
     // so that `io::owned::ai::*` paths continue to work.
     pub use sys_types::generated::owned;
     pub use sys_types::{
         AsBexExternalValue, BexExternalValue, BexHeap, CallId, OpError, SysOpContext, SysOpFn,
-        SysOpOutput, SysOpResult, VmBamlError, VmPanic, VmRustFnError,
+        SysOpOutput, SysOpResult, VmBamlError, VmInternalError, VmPanic, VmRustFnError,
     };
 
     include!(concat!(env!("OUT_DIR"), "/io_generated.rs"));
@@ -1484,13 +1484,13 @@ impl io::IoNamespaceHttp for DefaultIoOps {
     }
 }
 
-impl io::IoClassWsWsStream for DefaultIoOps {
+impl io::IoClassWsWebSocket for DefaultIoOps {
     fn send(
         &self,
         _h: &Arc<BexHeap>,
         _c: CallId,
-        _stream: io::owned::ws::WsStream,
-        _text: String,
+        _websocket: io::owned::ws::WebSocket,
+        _data: BexExternalValue,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<()> {
         SysOpOutput::err(VmPanic::HostUnavailable {
@@ -1503,9 +1503,9 @@ impl io::IoClassWsWsStream for DefaultIoOps {
         &self,
         _h: &Arc<BexHeap>,
         _c: CallId,
-        _stream: io::owned::ws::WsStream,
+        _websocket: io::owned::ws::WebSocket,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<Option<String>> {
+    ) -> SysOpOutput<BexExternalValue> {
         SysOpOutput::err(VmPanic::HostUnavailable {
             resource: "websocket".to_string(),
             message: "Operation not supported on this platform".to_string(),
@@ -1516,7 +1516,9 @@ impl io::IoClassWsWsStream for DefaultIoOps {
         &self,
         _h: &Arc<BexHeap>,
         _c: CallId,
-        _stream: io::owned::ws::WsStream,
+        _websocket: io::owned::ws::WebSocket,
+        _code: i64,
+        _reason: String,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<()> {
         SysOpOutput::err(VmPanic::HostUnavailable {
@@ -1535,7 +1537,7 @@ impl io::IoNamespaceWs for DefaultIoOps {
         _headers: indexmap::IndexMap<String, String>,
         _timeout_nanos: Arc<num_bigint::BigInt>,
         _ctx: &SysOpContext,
-    ) -> SysOpOutput<io::owned::ws::WsStream> {
+    ) -> SysOpOutput<io::owned::ws::WebSocket> {
         SysOpOutput::err(VmPanic::HostUnavailable {
             resource: "websocket".to_string(),
             message: "Operation not supported on this platform".to_string(),

--- a/baml_language/crates/sys_ops/src/lib.rs
+++ b/baml_language/crates/sys_ops/src/lib.rs
@@ -1399,6 +1399,7 @@ impl io::IoClassHttpServer for DefaultIoOps {
         _c: CallId,
         _server: io::owned::http::Server,
         _handler: bex_external_types::Handle,
+        _websocket: bex_external_types::Handle,
         _tls_config: Option<io::owned::http::TlsConfig>,
         _allow_http1: bool,
         _allow_http2: bool,

--- a/baml_language/crates/sys_wasm/src/web_sysops.rs
+++ b/baml_language/crates/sys_wasm/src/web_sysops.rs
@@ -255,6 +255,7 @@ impl io::IoClassHttpServer for WebHttp {
         _call_id: CallId,
         _server: io::owned::http::Server,
         _handler: Handle,
+        _websocket: Handle,
         _tls_config: Option<io::owned::http::TlsConfig>,
         _allow_http1: bool,
         _allow_http2: bool,

--- a/baml_language/sdks/csharp/sdkgen_csharp/src/semantic.rs
+++ b/baml_language/sdks/csharp/sdkgen_csharp/src/semantic.rs
@@ -232,7 +232,8 @@ fn builtin_projection(name: &Name) -> Option<BuiltinProjection> {
         | "baml.csv.Error"
         | "baml.csv.Position"
         | "baml.csv.ReaderOptions"
-        | "baml.csv.WriterOptions" => Some(BuiltinProjection::StructuralClass),
+        | "baml.csv.WriterOptions"
+        | "baml.ws.CloseEvent" => Some(BuiltinProjection::StructuralClass),
         "baml.csv.ErrorKind" => Some(BuiltinProjection::StructuralEnum),
         "baml.spawn.TaskGroup"
         | "baml.spawn.CancelToken"
@@ -249,7 +250,8 @@ fn builtin_projection(name: &Name) -> Option<BuiltinProjection> {
         | "baml.csv.Writer"
         | "baml.net.TcpStream"
         | "baml.net.TcpListener"
-        | "baml.net.UdpSocket" => Some(BuiltinProjection::Resource),
+        | "baml.net.UdpSocket"
+        | "baml.ws.WebSocket" => Some(BuiltinProjection::Resource),
         "ai.FunctionSpec" => Some(BuiltinProjection::FunctionSpec),
         "ai.Prompt" => Some(BuiltinProjection::Prompt),
         "baml.csv._NeedData"


### PR DESCRIPTION
- `baml.http.Server` can now accept websocket upgrade requests.
- Renamed `baml.ws.WsStream` to `baml.ws.WebSocket`
- Improved the `baml.ws.WebSocket` API to handle both text and binary modes (per websocket spec) and also report close reasons.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added HTTP/1.1 WebSocket upgrade support with configurable connection handlers.
  * Added support for sending and receiving text and binary WebSocket messages.
  * Added connection close events with status codes and reasons.
  * Added configurable WebSocket closing with validation.
* **Bug Fixes**
  * WebSocket connections remain counted within connection limits and shut down cleanly.
  * Unsupported upgrade requests receive a clear rejection response.
  * Non-WebSocket HTTP requests continue using their regular handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->