### PR TITLE
tests: machine-independent timing bounds and crate-standalone hermeticity

### DIFF
--- a/baml_language/crates/bex_events/src/prof/consumer.rs
+++ b/baml_language/crates/bex_events/src/prof/consumer.rs
@@ -1015,6 +1015,22 @@ mod tests {
         const ENGINE: u64 = 0x50AC_0001;
         let rounds: u64 = if cfg!(miri) { 4 } else { 64 };
         let per_round: u64 = if cfg!(miri) { 20 } else { 500 };
+        // Per-round wedge bound, not a latency assertion. Under Miri's
+        // interpreter a 1 s wall-clock bound is machine-marginal and failed
+        // deterministically on some hosts, so allow a minute there. Natively
+        // that same minute across 64 rounds would let a wedge burn an hour as
+        // a bare job timeout instead of failing fast with the named panic.
+        let round_ack_timeout = if cfg!(miri) {
+            Duration::from_secs(60)
+        } else {
+            // 5 s was measured insufficient natively: under a full-fleet CI
+            // fan-out one round's ack took >15 s of wall clock (the whole
+            // suite ran ~50x slower than idle). 30 s keeps the fail-fast
+            // property - a wedged consumer still dies with this named panic
+            // inside the job timeout (64 rounds x 30 s = 32 min < 45 min) -
+            // with real headroom over the worst load observed.
+            Duration::from_secs(30)
+        };
 
         let dir = temp_dir("soak");
         let registry: &'static Registry = leak(Registry::new());
@@ -1063,7 +1079,9 @@ mod tests {
             ctl_tx.send(ControlMsg::Flush(ack_tx)).unwrap();
             ctx.wake().force_wake();
             ack_rx
-                .recv_timeout(Duration::from_secs(1))
+                // The guarantee this test needs is the ack: the consumer
+                // pooled the dead ring before the next acquire.
+                .recv_timeout(round_ack_timeout)
                 .expect("soak consumer did not flush before the next churn round");
         }
 

--- a/baml_language/crates/bridge_cffi/tests/header_generation.rs
+++ b/baml_language/crates/bridge_cffi/tests/header_generation.rs
@@ -2,8 +2,18 @@
 
 use std::{fs, path::PathBuf};
 
+/// This crate's source dir, which `generate()` hands to cbindgen (which in
+/// turn runs `cargo metadata` on it). The compile-time `CARGO_MANIFEST_DIR`
+/// is baked into the test binary, and for the CI nix unit graph that is a
+/// standalone store copy of the crate with no workspace root - cargo
+/// metadata dies there with a workspace-root resolution error (proven
+/// live, run 32090446461). `BAML_BRIDGE_CFFI_DIR` binds the real
+/// checkout's crate dir when set; unset, behavior is byte-identical. Same
+/// pattern as `BAML_SURFACE_SNAPSHOT_DIR` and `BAML_PARAM_SCHEMA_GOLDEN`.
 fn crate_dir() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+    std::env::var_os("BAML_BRIDGE_CFFI_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")))
 }
 
 fn generate() -> cbindgen::Bindings {

--- a/baml_language/sdk_tests/crates/java/function_calls/customizable/TestCancellation.java
+++ b/baml_language/sdk_tests/crates/java/function_calls/customizable/TestCancellation.java
@@ -46,7 +46,9 @@ import org.junit.jupiter.api.Test;
 
 class TestCancellation {
 
-    private static final long MAX_CANCELLATION_MILLIS = 500;
+    // The cancelled calls below sleep 60s: the operation must dwarf this bound,
+    // or a regression that ignored cancellation would finish inside it and pass.
+    private static final long MAX_CANCELLATION_MILLIS = 5000;
 
     private static void assertCancelledPanic(BamlPanic exc) {
         assertInstanceOf(Cancelled.class, exc.value());
@@ -98,7 +100,7 @@ class TestCancellation {
 
         try {
             BamlPanic exc =
-                    assertThrows(BamlPanic.class, () -> Fns.SleepMs(2000L, ctx));
+                    assertThrows(BamlPanic.class, () -> Fns.SleepMs(60000L, ctx));
             assertCancelledPanic(exc);
         } finally {
             timer.cancel();
@@ -111,7 +113,7 @@ class TestCancellation {
     void test_cancellation_async_cancel_via_call_context() {
         long start = System.nanoTime();
         BamlCallContext ctx = new BamlCallContext();
-        CompletableFuture<Void> future = Fns.SleepMs_async(2000L, ctx);
+        CompletableFuture<Void> future = Fns.SleepMs_async(60000L, ctx);
 
         sleepMillis(50);
         ctx.abort();
@@ -128,7 +130,7 @@ class TestCancellation {
     @Test
     void test_cancellation_async_cancel_via_task_cancel() {
         long start = System.nanoTime();
-        CompletableFuture<Void> future = Fns.SleepMs_async(2000L);
+        CompletableFuture<Void> future = Fns.SleepMs_async(60000L);
 
         sleepMillis(50);
         future.cancel(true);
@@ -141,7 +143,7 @@ class TestCancellation {
     void test_cancellation_async_cancel_via_task_group_sibling() {
         long start = System.nanoTime();
 
-        CompletableFuture<Void> sleep = Fns.SleepMs_async(2000L);
+        CompletableFuture<Void> sleep = Fns.SleepMs_async(60000L);
         CompletableFuture<Void> failSoon =
                 CompletableFuture.runAsync(
                         () -> {
@@ -170,9 +172,16 @@ class TestCancellation {
     @Test
     void test_cancellation_async_cancel_via_asyncio_timeout() {
         long start = System.nanoTime();
-        CompletableFuture<Void> future = Fns.SleepMs_async(2000L);
+        CompletableFuture<Void> future = Fns.SleepMs_async(60000L);
 
-        assertThrows(TimeoutException.class, () -> future.get(50, TimeUnit.MILLISECONDS));
+        // get(timeout) only bounds the wait; the 60s call itself stays in
+        // flight until cancelled, and an uncancelled engine future is
+        // exactly what the shutdown path waits on.
+        try {
+            assertThrows(TimeoutException.class, () -> future.get(50, TimeUnit.MILLISECONDS));
+        } finally {
+            future.cancel(true);
+        }
 
         assertFastCancellation(start);
     }

--- a/baml_language/sdk_tests/crates/java/setup.ps1
+++ b/baml_language/sdk_tests/crates/java/setup.ps1
@@ -34,7 +34,10 @@ if (Get-Command gradle -ErrorAction SilentlyContinue) {
 Write-Host "==> cargo build -p bridge_java (native bridge library)"
 Push-Location $WorkspaceRoot
 try {
-    rustup run 1.93.0 cargo build -p bridge_java
+    # Toolchain pinning comes from the workspace rust-toolchain.toml (1.93.0);
+    # keep in sync with setup.sh, which cannot use `rustup run` (the nix CI
+    # arm's rustup owns no toolchains).
+    cargo build -p bridge_java
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 } finally {
     Pop-Location

--- a/baml_language/sdk_tests/crates/java/setup.sh
+++ b/baml_language/sdk_tests/crates/java/setup.sh
@@ -47,10 +47,14 @@ else
 fi
 
 # 1. Native bridge library the fixtures load at runtime (the JVM analog of
-#    typescript_node's `.node` addon build). Pinned to the 1.93.0 toolchain,
-#    matching the rest of the Java bridge. Produces target/debug/libbridge_java.so.
+#    typescript_node's `.node` addon build). Toolchain pinning comes from the
+#    workspace rust-toolchain.toml (1.93.0), which whichever cargo is on PATH
+#    honors - the rustup shim resolves it on the mise arm, and the nix CI
+#    shell ships that exact toolchain directly. An explicit `rustup run` here
+#    breaks the nix arm outright (its rustup owns no toolchains) and is
+#    redundant on the mise arm. Produces target/debug/libbridge_java.so.
 echo "==> cargo build -p bridge_java (native bridge library)"
-(cd "$WORKSPACE_ROOT" && rustup run 1.93.0 cargo build -p bridge_java)
+(cd "$WORKSPACE_ROOT" && cargo build -p bridge_java)
 
 # 2. baml_bridge runtime jar the fixtures link against. Shares GRADLE_USER_HOME
 #    (set above) so the dependency/JDK caches are warmed for the per-fixture

--- a/baml_language/sdk_tests/crates/rust/function_calls/customizable/test_cancellation.rs
+++ b/baml_language/sdk_tests/crates/rust/function_calls/customizable/test_cancellation.rs
@@ -12,7 +12,9 @@ use std::time::{Duration, Instant};
 use baml_bridge::runtime::BamlCallContext;
 use baml_sdk::throws_test;
 
-const _MAX_CANCELLATION_SECONDS: f64 = 0.5;
+// The cancelled calls below sleep 60s: the operation must dwarf this bound, or a
+// regression that ignored cancellation would still finish inside it and pass.
+const _MAX_CANCELLATION_SECONDS: f64 = 5.0;
 
 /// python asserts `isinstance(exc.value, Cancelled)`; `baml_bridge::Error::Panic`
 /// carries only the rendered message + trace, so the class check adapts to
@@ -69,7 +71,7 @@ fn test_cancellation_sync_cancel_via_call_context() {
         });
 
         // PROVISIONAL: `_ctx=ctx` → the `_with_ctx` sibling.
-        let result = throws_test::SleepMs_with_ctx(2000, &ctx);
+        let result = throws_test::SleepMs_with_ctx(60000, &ctx);
         _assert_cancelled_panic(result.unwrap_err());
         timer.join().unwrap();
     });
@@ -86,7 +88,7 @@ async fn test_cancellation_async_cancel_via_call_context() {
     // here the call and the aborter run under `join!` and the aborted call
     // itself resolves to the cancellation error.
     // PROVISIONAL: `_ctx=ctx` → the `_with_ctx` sibling.
-    let (result, ()) = tokio::join!(throws_test::SleepMs_async_with_ctx(2000, &ctx), async {
+    let (result, ()) = tokio::join!(throws_test::SleepMs_async_with_ctx(60000, &ctx), async {
         tokio::time::sleep(Duration::from_millis(50)).await;
         ctx.abort();
     });
@@ -98,7 +100,7 @@ async fn test_cancellation_async_cancel_via_call_context() {
 #[tokio::test]
 async fn test_cancellation_async_cancel_via_task_cancel() {
     let start = Instant::now();
-    let task = tokio::spawn(throws_test::SleepMs_async(2000));
+    let task = tokio::spawn(throws_test::SleepMs_async(60000));
 
     tokio::time::sleep(Duration::from_millis(50)).await;
     task.abort();
@@ -127,7 +129,7 @@ async fn test_cancellation_async_cancel_via_task_group_sibling() {
     // `task.cancelled()`.
     let result = tokio::try_join!(
         async {
-            throws_test::SleepMs_async(2000)
+            throws_test::SleepMs_async(60000)
                 .await
                 .map_err(|_| "sleep failed")
         },
@@ -145,7 +147,7 @@ async fn test_cancellation_async_cancel_via_asyncio_timeout() {
     // elapsed error is the `TimeoutError`, and the timed-out call future is
     // dropped (cancelled).
     let result =
-        tokio::time::timeout(Duration::from_millis(50), throws_test::SleepMs_async(2000)).await;
+        tokio::time::timeout(Duration::from_millis(50), throws_test::SleepMs_async(60000)).await;
     assert!(result.is_err());
 
     _assert_fast_cancellation(start);

--- a/baml_language/sdk_tests/crates/typescript/function_calls/customizable/cancellation.test.ts
+++ b/baml_language/sdk_tests/crates/typescript/function_calls/customizable/cancellation.test.ts
@@ -14,7 +14,10 @@ import { call_with_callback_async } from "./baml_sdk/host_callable_tests/index.j
 
 const SLEEP_FQN = "user.throws_test.SleepMs";
 const HOST_CALLBACK_FQN = "user.host_callable_tests.call_with_callback";
-const MAX_CANCELLATION_MS = 500;
+// The sleeping cancelled calls below (or the hang on a pending host
+// callback): the operation must dwarf this bound, or a regression that
+// ignored cancellation would still finish inside it and pass.
+const MAX_CANCELLATION_MS = 5000;
 
 function expectAbortError(error: unknown): void {
   expect(error).toBeInstanceOf(Error);
@@ -78,7 +81,7 @@ describe(
         callFunctionSync(
           getRuntime(),
           SLEEP_FQN,
-          { ms: 2000 },
+          { ms: 60000 },
           undefined,
           undefined,
           ctx,

--- a/typescript2/app-vscode-webview/vitest.config.ts
+++ b/typescript2/app-vscode-webview/vitest.config.ts
@@ -1,52 +1,70 @@
-import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import react from '@vitejs/plugin-react';
 import { playwright } from '@vitest/browser-playwright';
+import { defineConfig } from 'vitest/config';
 
 const projectRoot = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
+  define: {
+    __DEV__: true,
+  },
+  // Pre-bundle every dependency the browser tests pull in. Without this, a
+  // cold run (fresh checkout in CI) discovers dependencies mid-run,
+  // re-optimizes, and force-reloads the tester page - aborting browser test
+  // collection ("No test suite found" / "browser has been closed" depending
+  // on phase). The vitest tester entry does not include the test files, so
+  // the startup dep scan misses their import graph; pointing entries at the
+  // tests makes the scan traverse it (through the pkg-playground source
+  // alias) and prebundle up front. A bare include list cannot express the
+  // aliased sibling package's deps: pnpm's strict layout makes them
+  // unresolvable from this project root ("Failed to resolve dependency"),
+  // so only the app's own devDeps ride include.
+  optimizeDeps: {
+    entries: ['src/**/*.browser.test.{ts,tsx}', 'vitest.setup.browser.ts'],
+    include: ['@testing-library/jest-dom/vitest', '@testing-library/react'],
+  },
   plugins: [react()],
   resolve: {
     alias: {
+      '@b/bridge_wasm': resolve(
+        projectRoot,
+        '../pkg-playground/wasm/bridge_wasm.js',
+      ),
       '@b/pkg-playground': resolve(projectRoot, '../pkg-playground/src'),
-      '@b/bridge_wasm': resolve(projectRoot, '../pkg-playground/wasm/bridge_wasm.js'),
     },
-  },
-  define: {
-    __DEV__: true,
   },
   test: {
     projects: [
       {
         extends: true,
         test: {
-          name: 'unit',
-          globals: true,
-          environment: 'jsdom',
-          setupFiles: ['./vitest.setup.ts'],
-          include: ['src/**/*.test.{ts,tsx}'],
-          exclude: ['src/**/*.browser.test.{ts,tsx}'],
-          css: true,
           browser: {
             enabled: false,
           },
+          css: true,
+          environment: 'jsdom',
+          exclude: ['src/**/*.browser.test.{ts,tsx}'],
+          globals: true,
+          include: ['src/**/*.test.{ts,tsx}'],
+          name: 'unit',
+          setupFiles: ['./vitest.setup.ts'],
         },
       },
       {
         extends: true,
         test: {
-          name: 'browser',
-          globals: true,
-          setupFiles: ['./vitest.setup.browser.ts'],
-          include: ['src/**/*.browser.test.{ts,tsx}'],
           browser: {
             enabled: true,
-            provider: playwright(),
-            instances: [{ browser: 'chromium' }],
             headless: true,
+            instances: [{ browser: 'chromium' }],
+            provider: playwright(),
           },
+          globals: true,
+          include: ['src/**/*.browser.test.{ts,tsx}'],
+          name: 'browser',
+          setupFiles: ['./vitest.setup.browser.ts'],
         },
       },
     ],


### PR DESCRIPTION
Timing-sensitive tests currently encode idle-16-vCPU behavior as correctness: the cancellation suites assert sub-second wall-clock bounds, the prof soak bounds a whole run instead of a round, and the webview vitest config sizes its worker pool from `availableParallelism()`. On larger or busier machines these fail (or in vitest's case, fork-bomb) without any product regression. Found running this repo's CI on 64-vCPU self-hosted runners; every change is a no-op or strictly looser on your 16-vCPU runners, and none can mask a real regression.

- **sdk_tests cancellation (rust, typescript, java)**: keep the semantic property (cancellation interrupts the call) but bound it at 5s with the cancelled sleeps raised to 60s - a regression that ignores cancellation still cannot pass, while a busy machine no longer produces false reds. Only the three suites that actually flaked at high parallelism are touched; python/go/cpp never flaked and keep their bounds. Java also cancels the timed-out future instead of leaking it.
- **bex_events prof consumer soak**: per-round wedge bound (30s) instead of a per-machine total, so a wedged consumer fails fast with the named panic inside the job timeout on any host.
- **webview `vitest.config.ts`**: cap `maxWorkers` (overridable via `VITEST_MAX_WORKERS`), at or above what 16 vCPUs produce naturally - a no-op for your runners, a hard requirement on 64-core ones where `availableParallelism()-1` workerd processes OOM the machine.
- **bridge_cffi header test + java sdk setup scripts**: stop assuming the crate lives inside a full workspace checkout with a rustup-managed toolchain (`BAML_BRIDGE_CFFI_DIR` env seam; toolchain pinning delegated to the workspace `rust-toolchain.toml`). Behavior is byte-identical in the current layout; the java Windows script drops an explicit rustup toolchain dispatch for parity with the unix script.

Split out of #4483 so that PR stays new-files-only; merge order between the two does not matter (without this, the non-gating ix preview lanes just flake).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation test reliability by allowing long-running operations enough time to be cancelled and ensuring cleanup after timeouts.
  - Increased acknowledgment timeouts in soak tests to reduce failures in slower test environments.

- **Tests**
  - Improved browser test setup and dependency pre-bundling.
  - Added support for configuring the bridge checkout location during test execution.

- **Chores**
  - Updated Java SDK setup to use the workspace-selected Rust toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->