### PR TITLE
fix(reflect): runtime type definitions through dispatch, nested views, and pending-field metadata (B-1582)

### DIFF
--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_class/class.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_reflect/ns_class/class.baml
@@ -64,11 +64,15 @@ class Builder {
   _resolved type?
 
   /// Append one field in definition order.
+  ///
+  /// A recursive field carries metadata the same way a resolved one does:
+  /// `PendingType.meta(...)` produces the `WithMeta<PendingType>` row, and the
+  /// metadata survives the atomic group build.
   //baml:mut_vm
   function field(
     self,
     name: string,
-    ty: type | baml.reflect.WithMeta<type> | PendingType,
+    ty: type | baml.reflect.WithMeta<type> | PendingType | baml.reflect.WithMeta<PendingType>,
   ) -> Builder throws baml.reflect.errors.CompilationError {
     $rust_function
   }
@@ -125,6 +129,19 @@ class PendingType {
   /// Return the frozen type, or null while any referenced builder is pending.
   //baml:mut_vm
   function resolved(self) -> type? throws never {
+    $rust_function
+  }
+
+  /// Pair this pending reference with schema metadata, mirroring `type.meta`.
+  /// Only `Builder.field` accepts the result.
+  //baml:mut_vm
+  function meta(
+    self,
+    alias: string? = null,
+    description: string? = null,
+    docstring: string? = null,
+    other: map<string, string>? = null,
+  ) -> baml.reflect.WithMeta<PendingType> throws never {
     $rust_function
   }
 }

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -268,9 +268,9 @@ function         baml.reflect.class.new           <builtin>/baml/ns_reflect/ns_c
 function         baml.reflect.class._new          <builtin>/baml/ns_reflect/ns_class/class.baml:43
 function         baml.reflect.class.builder       <builtin>/baml/ns_reflect/ns_class/class.baml:54
 class            baml.reflect.class.Builder       <builtin>/baml/ns_reflect/ns_class/class.baml:60
-class            baml.reflect.class.PendingType   <builtin>/baml/ns_reflect/ns_class/class.baml:102
-function         baml.reflect.class.get_field     <builtin>/baml/ns_reflect/ns_class/class.baml:134
-class            baml.reflect.class.Type          <builtin>/baml/ns_reflect/ns_class/class.baml:139
+class            baml.reflect.class.PendingType   <builtin>/baml/ns_reflect/ns_class/class.baml:106
+function         baml.reflect.class.get_field     <builtin>/baml/ns_reflect/ns_class/class.baml:151
+class            baml.reflect.class.Type          <builtin>/baml/ns_reflect/ns_class/class.baml:156
 class            baml.reflect.enum.Value          <builtin>/baml/ns_reflect/ns_enum/enum.baml:1
 function         baml.reflect.enum.value          <builtin>/baml/ns_reflect/ns_enum/enum.baml:8
 function         baml.reflect.enum.new            <builtin>/baml/ns_reflect/ns_enum/enum.baml:20

--- a/baml_language/crates/baml_compiler_diagnostics/src/runtime_type.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/runtime_type.rs
@@ -103,6 +103,23 @@ pub fn unspecialized_reflected_generic(name: &str) -> Diagnostic {
     )
 }
 
+/// E0165 — a reflected generic callable was invoked without specialization.
+///
+/// The sibling above covers *extraction*: a callable whose signature still
+/// mentions its own type parameters cannot even be handed out. This one covers
+/// the callables that get past that edge — a companion whose signature is free
+/// of `T` but whose body still materializes it. Invoking one would fail inside
+/// the body as an internal error, so reflection refuses it up front.
+pub fn unspecialized_reflected_generic_call(name: &str) -> Diagnostic {
+    Diagnostic::error(
+        DiagnosticId::UnspecializedReflectedGeneric,
+        format!(
+            "generic function `{name}` cannot be invoked through reflection until it is \
+             specialized: its body needs type arguments and reflection cannot supply them yet"
+        ),
+    )
+}
+
 /// E0002 — a value-shaped generic argument omitted the required marker.
 pub fn computed_generic_argument_requires_unreflect(name: &str) -> Diagnostic {
     Diagnostic::error(

--- a/baml_language/crates/baml_compiler_diagnostics/src/runtime_type.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/runtime_type.rs
@@ -250,6 +250,11 @@ mod tests {
                 "generic function `root.Extract` cannot be extracted through reflection: reflected packages cannot supply type arguments yet",
             ),
             (
+                unspecialized_reflected_generic_call("GenericList$render_prompt"),
+                "E0165",
+                "generic function `GenericList$render_prompt` cannot be invoked through reflection until it is specialized: its body needs type arguments and reflection cannot supply them yet",
+            ),
+            (
                 computed_generic_argument_requires_unreflect("runtime_t"),
                 "E0002",
                 "computed type argument `runtime_t` must be written as `unreflect(runtime_t)`",

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____03_ppir.snap
@@ -1783,9 +1783,10 @@ function baml.reflect.class.build(self: ?, implementations: baml.reflect.interfa
   {  } self._build(implementations)
 }
 function baml.reflect.class.builder(name: string) -> baml.reflect.class.Builder  [builtin]
-function baml.reflect.class.field(self: ?, name: string, ty: type | baml.reflect.WithMeta<type> | baml.reflect.class.PendingType) -> baml.reflect.class.Builder  [builtin]
+function baml.reflect.class.field(self: ?, name: string, ty: type | baml.reflect.WithMeta<type> | baml.reflect.class.PendingType | baml.reflect.WithMeta<baml.reflect.class.PendingType>) -> baml.reflect.class.Builder  [builtin]
 function baml.reflect.class.fields(self: ?) -> baml.reflect.class.Field[]  [builtin]
 function baml.reflect.class.get_field(value: unknown, name: string) -> T  [builtin]
+function baml.reflect.class.meta(self: ?, alias: string? = null, description: string? = null, docstring: string? = null, other: map<string, string>? = null) -> baml.reflect.WithMeta<baml.reflect.class.PendingType>  [builtin]
 function baml.reflect.class.meta(self: ?) -> baml.reflect.Meta  [builtin]
 function baml.reflect.class.metadata(self: ?) -> baml.reflect.Meta  [expr] {
   {  } self.meta

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____04_5_mir.snap
@@ -8044,6 +8044,8 @@ fn baml.reflect.class.PendingType.union = builtin(vm)
 
 fn baml.reflect.class.PendingType.resolved = builtin(vm)
 
+fn baml.reflect.class.PendingType.meta = builtin(vm)
+
 fn baml.reflect.class.get_field = builtin(vm)
 
 fn baml.reflect.class.Type.baml.reflect.TypeView.as_type = builtin(vm)

--- a/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
+++ b/baml_language/crates/baml_tests/snapshots/compiles/__baml_std__/baml_tests__compiles____baml_std____06_codegen.snap
@@ -5557,7 +5557,7 @@ function baml.reflect.class.Builder.build(self: baml.reflect.class.Builder, impl
     return
 }
 
-function baml.reflect.class.Builder.field(self: baml.reflect.class.Builder, name: string, ty: type | baml.reflect.WithMeta<type> | baml.reflect.class.PendingType) -> baml.reflect.class.Builder {
+function baml.reflect.class.Builder.field(self: baml.reflect.class.Builder, name: string, ty: type | baml.reflect.WithMeta<type> | baml.reflect.class.PendingType | baml.reflect.WithMeta<baml.reflect.class.PendingType>) -> baml.reflect.class.Builder {
 }
 
 function baml.reflect.class.Builder.type(self: baml.reflect.class.Builder) -> baml.reflect.class.PendingType {
@@ -5608,6 +5608,9 @@ function baml.reflect.class.Field.value(self: baml.reflect.class.Field) -> #0 | 
 }
 
 function baml.reflect.class.PendingType.array(self: baml.reflect.class.PendingType) -> baml.reflect.class.PendingType {
+}
+
+function baml.reflect.class.PendingType.meta(self: baml.reflect.class.PendingType, alias: string | null, description: string | null, docstring: string | null, other: map<string, string> | null) -> baml.reflect.WithMeta<baml.reflect.class.PendingType> {
 }
 
 function baml.reflect.class.PendingType.optional(self: baml.reflect.class.PendingType) -> baml.reflect.class.PendingType {

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -288,7 +288,7 @@ namespace baml.reflect.array:
 namespace baml.reflect.class:
   class Builder { methods: [field, type, build, _build] }
   class Field { methods: [metadata, value] }
-  class PendingType { methods: [array, optional, union, resolved] }
+  class PendingType { methods: [array, optional, union, resolved, meta] }
   class Type { methods: [fields, meta, as_type] }
   function _new
   function builder

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -29,14 +29,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   292   23    load_type 1                                
         24    load_deref 2                               
-        25    call 915 ntypeargs=1                       (ai.Journal.new)
+        25    call 916 ntypeargs=1                       (ai.Journal.new)
         26    store_deref 5                              
 
   293   27    load_type 1                                
         28    load_deref 1                               
         29    load_deref 5                               
         30    load_const 2                               (0)
-        31    call 965 ntypeargs=1                       (ai.Agent._emit_from)
+        31    call 966 ntypeargs=1                       (ai.Agent._emit_from)
         32    store_var 6                                (seen)
 
   294   33    load_const 2                               (0)
@@ -72,7 +72,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         58    load_deref 5                               
         59    load_var 8                                 (total)
         60    load_const 5                               (2)
-        61    call 964 ntypeargs=1                       (ai.Agent._attempt_turn)
+        61    call 965 ntypeargs=1                       (ai.Agent._attempt_turn)
         62    store_var 10                               (turn)
 
   306   63    load_var 7                                 (steps)
@@ -84,11 +84,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         68    load_deref 1                               
         69    load_deref 5                               
         70    load_var 6                                 (seen)
-        71    call 965 ntypeargs=1                       (ai.Agent._emit_from)
+        71    call 966 ntypeargs=1                       (ai.Agent._emit_from)
         72    store_var 6                                (seen)
 
   308   73    load_var 10                                (turn)
-        74    call 936 ntypeargs=0                       (ai.ModelTurn.tool_uses)
+        74    call 937 ntypeargs=0                       (ai.ModelTurn.tool_uses)
         75    store_var 11                               (calls)
 
   309   76    load_var 11                                (calls)
@@ -101,7 +101,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         83    jump +78                                   (to 161)
 
   344   84    load_var 10                                (turn)
-        85    call 934 ntypeargs=0                       (ai.ModelTurn.terminal_text)
+        85    call 935 ntypeargs=0                       (ai.ModelTurn.terminal_text)
         86    store_var_load_var 33                      (_98)
         87    load_const 0                               (null)
         88    cmp_op ==                                  
@@ -114,7 +114,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
   352   94    load_type 1                                
         95    load_deref 1                               
         96    load_var 10                                (turn)
-        97    call 961 ntypeargs=1                       (ai.Agent._has_media_output)
+        97    call 962 ntypeargs=1                       (ai.Agent._has_media_output)
         98    pop_jump_if_false +2                       (to 100)
         99    jump +16                                   (to 115)
 
@@ -143,7 +143,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         120   load_type 1                                
         121   load_deref 1                               
         122   load_var2 10 35                            
-        123   call 962 ntypeargs=1                       (ai.Agent._media_value)
+        123   call 963 ntypeargs=1                       (ai.Agent._media_value)
         124   store_var 34                               (value)
 
   361   125   load_type 1                                
@@ -173,14 +173,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         145   load_type 12                               
         146   alloc_array 1                              
 
-  366   147   call 916 ntypeargs=0                       (ai.Journal.append_all)
+  366   147   call 917 ntypeargs=0                       (ai.Journal.append_all)
         148   pop 1                                      
 
   369   149   load_type 1                                
         150   load_deref 1                               
         151   load_deref 5                               
         152   load_var 6                                 (seen)
-        153   call 965 ntypeargs=1                       (ai.Agent._emit_from)
+        153   call 966 ntypeargs=1                       (ai.Agent._emit_from)
         154   store_var 6                                (seen)
 
   370   155   load_var 34                                (value)
@@ -191,7 +191,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         160   return                                     
 
   310   161   load_deref 5                               
-        162   call 914 ntypeargs=0                       (ai.Journal.entries)
+        162   call 915 ntypeargs=0                       (ai.Journal.entries)
         163   container_len                              
         164   store_var 13                               (before)
 
@@ -202,7 +202,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         169   load_type 1                                
         170   load_var2 1 2                              
         171   load_var 5                                 (j)
-        172   make_closure 2281 captures=3 ntypeargs=1   
+        172   make_closure 2282 captures=3 ntypeargs=1   
         173   call 16 ntypeargs=3                        (baml.Array.map)
         174   store_var 14                               (futures)
 
@@ -217,11 +217,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         182   load_deref 1                               
         183   load_deref 5                               
         184   load_var 6                                 (seen)
-        185   call 965 ntypeargs=1                       (ai.Agent._emit_from)
+        185   call 966 ntypeargs=1                       (ai.Agent._emit_from)
         186   store_var 6                                (seen)
 
   320   187   load_deref 5                               
-        188   call 914 ntypeargs=0                       (ai.Journal.entries)
+        188   call 915 ntypeargs=0                       (ai.Journal.entries)
         189   store_var 15                               (entries)
 
   321   190   load_var 13                                (before)
@@ -251,7 +251,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         211   load_var 11                                (calls)
         212   load_type 1                                
         213   load_var 20                                (f)
-        214   make_closure 2282 captures=1 ntypeargs=1   
+        214   make_closure 2283 captures=1 ntypeargs=1   
         215   call 19 ntypeargs=2                        (baml.Array.find)
 
   327   216   store_var 21                               (_59)
@@ -352,12 +352,12 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   219   3     load_type 0                        
         4     load_var 3                         (spec)
-        5     call 926 ntypeargs=1               (ai.FunctionSpec.tools)
+        5     call 927 ntypeargs=1               (ai.FunctionSpec.tools)
         6     store_var 9                        (_10)
 
   220   7     load_type 0                        
         8     load_var 3                         (spec)
-        9     call 924 ntypeargs=1               (ai.FunctionSpec.output_type)
+        9     call 925 ntypeargs=1               (ai.FunctionSpec.output_type)
         10    store_var 10                       (_12)
 
   215   11    load_var2 2 8                      
@@ -454,7 +454,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         93    store_var 19                       (batch)
 
   235   94    load_var 7                         (turn)
-        95    call 936 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        95    call 937 ntypeargs=0               (ai.ModelTurn.tool_uses)
         96    load_type 8                        
         97    load_const 9                       ("iter")
         98    virtual_call nargs=1 ntypeargs=0   
@@ -496,7 +496,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         131   pop 1                              
 
   241   132   load_var 7                         (turn)
-        133   call 934 ntypeargs=0               (ai.ModelTurn.terminal_text)
+        133   call 935 ntypeargs=0               (ai.ModelTurn.terminal_text)
         134   store_var_load_var 27              (_58)
         135   load_const 5                       (null)
         136   cmp_op ==                          
@@ -507,7 +507,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         141   store_var 26                       (candidate)
 
   242   142   load_var 7                         (turn)
-        143   call 936 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        143   call 937 ntypeargs=0               (ai.ModelTurn.tool_uses)
         144   container_len                      
         145   store_var 28                       (_65)
         146   load_var 28                        (_65)
@@ -540,7 +540,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
   245   168   load_type 0                        
         169   load_var2 1 7                      
         170   load_var 26                        (candidate)
-        171   call 963 ntypeargs=1               (ai.Agent._parses)
+        171   call 964 ntypeargs=1               (ai.Agent._parses)
 
   246   172   pop_jump_if_false +2               (to 174)
         173   jump +34                           (to 207)
@@ -552,7 +552,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         178   jump +12                           (to 190)
 
   268   179   load_var2 4 19                     
-        180   call 916 ntypeargs=0               (ai.Journal.append_all)
+        180   call 917 ntypeargs=0               (ai.Journal.append_all)
         181   pop 1                              
 
   269   182   load_var 2                         (c)
@@ -574,7 +574,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         195   pop 1                              
 
   265   196   load_var2 4 19                     
-        197   call 916 ntypeargs=0               (ai.Journal.append_all)
+        197   call 917 ntypeargs=0               (ai.Journal.append_all)
         198   pop 1                              
 
   266   199   load_type 0                        
@@ -583,11 +583,11 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         202   load_var2 5 6                      
         203   load_const 16                      (1)
         204   sub_int                            
-        205   call 964 ntypeargs=1               (ai.Agent._attempt_turn)
+        205   call 965 ntypeargs=1               (ai.Agent._attempt_turn)
         206   jump +19                           (to 225)
 
   247   207   load_var2 4 19                     
-        208   call 916 ntypeargs=0               (ai.Journal.append_all)
+        208   call 917 ntypeargs=0               (ai.Journal.append_all)
         209   pop 1                              
 
   249   210   load_var 7                         (turn)
@@ -631,7 +631,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
 function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> int {
   275   0    load_var 2             (j)
-        1    call 914 ntypeargs=0   (ai.Journal.entries)
+        1    call 915 ntypeargs=0   (ai.Journal.entries)
         2    store_var 4            (entries)
 
   276   3    load_var 3             (seen)
@@ -702,7 +702,7 @@ function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> in
 
 function ai.Agent._has_media_output(self: ai.Agent<#0>, turn: ai.ModelTurn) -> bool {
   104   0    load_type 0            
-        1    call 994 ntypeargs=0   (ai.internal._media_shape)
+        1    call 995 ntypeargs=0   (ai.internal._media_shape)
         2    store_var 3            (shape)
 
   105   3    load_var 3             (shape)
@@ -754,7 +754,7 @@ function ai.Agent._has_media_output(self: ai.Agent<#0>, turn: ai.ModelTurn) -> b
         46   load_const 11          ("")
         47   store_var 9            (_22)
         48   load_var2 2 9          
-        49   call 996 ntypeargs=0   (ai.internal._media_of_kind)
+        49   call 997 ntypeargs=0   (ai.internal._media_of_kind)
         50   container_len          
         51   store_var 8            (_19)
         52   load_var 8             (_19)
@@ -763,7 +763,7 @@ function ai.Agent._has_media_output(self: ai.Agent<#0>, turn: ai.ModelTurn) -> b
         55   jump +10               (to 65)
 
   110   56   load_var 2             (turn)
-        57   call 997 ntypeargs=0   (ai.internal._media_mixed_parts)
+        57   call 998 ntypeargs=0   (ai.internal._media_mixed_parts)
         58   container_len          
         59   store_var 7            (_17)
         60   load_var 7             (_17)
@@ -780,7 +780,7 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
         1     store_var 4                        (t)
 
   120   2     load_var 4                         (t)
-        3     call 994 ntypeargs=0               (ai.internal._media_shape)
+        3     call 995 ntypeargs=0               (ai.internal._media_shape)
         4     store_var 5                        (shape)
 
   121   5     load_var 5                         (shape)
@@ -831,12 +831,12 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
         48    jump +116                          (to 164)
 
   152   49    load_var2 2 9                      
-        50    call 996 ntypeargs=0               (ai.internal._media_of_kind)
+        50    call 997 ntypeargs=0               (ai.internal._media_of_kind)
         51    store_var 22                       (parts)
 
   153   52    load_var2 2 9                      
         53    load_var 3                         (provider)
-        54    call 1000 ntypeargs=0              (ai.internal._media_reject_mixed)
+        54    call 1001 ntypeargs=0              (ai.internal._media_reject_mixed)
         55    pop 1                              
 
   154   56    load_var 22                        (parts)
@@ -959,18 +959,18 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
 
   147   164   load_var2 2 9                      
         165   load_var 3                         (provider)
-        166   call 1000 ntypeargs=0              (ai.internal._media_reject_mixed)
+        166   call 1001 ntypeargs=0              (ai.internal._media_reject_mixed)
         167   pop 1                              
 
   148   168   load_var2 2 9                      
-        169   call 996 ntypeargs=0               (ai.internal._media_of_kind)
+        169   call 997 ntypeargs=0               (ai.internal._media_of_kind)
 
   149   170   store_var 12                       (payload)
 
   123   171   jump +71                           (to 242)
 
   129   172   load_var 2                         (turn)
-        173   call 997 ntypeargs=0               (ai.internal._media_mixed_parts)
+        173   call 998 ntypeargs=0               (ai.internal._media_mixed_parts)
         174   store_var 13                       (items)
 
   130   175   load_var 13                        (items)
@@ -983,7 +983,7 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
         182   jump +35                           (to 217)
 
   136   183   load_var 13                        (items)
-        184   call 998 ntypeargs=0               (ai.internal._media_all_text)
+        184   call 999 ntypeargs=0               (ai.internal._media_all_text)
         185   pop_jump_if_false +2               (to 187)
         186   jump +27                           (to 213)
 
@@ -1017,7 +1017,7 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
         212   throw                              
 
   138   213   load_var 13                        (items)
-        214   call 999 ntypeargs=0               (ai.internal._media_join_text)
+        214   call 1000 ntypeargs=0              (ai.internal._media_join_text)
         215   store_var 12                       (payload)
         216   jump +26                           (to 242)
 
@@ -1048,7 +1048,7 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
   130   238   jump +4                            (to 242)
 
   125   239   load_var 2                         (turn)
-        240   call 997 ntypeargs=0               (ai.internal._media_mixed_parts)
+        240   call 998 ntypeargs=0               (ai.internal._media_mixed_parts)
 
   126   241   store_var 12                       (payload)
 
@@ -1100,7 +1100,7 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
 function ai.Agent._parses(self: ai.Agent<#0>, turn: ai.ModelTurn, candidate: string) -> bool {
   190   0    load_type 0            
         1    load_var2 1 2          
-        2    call 961 ntypeargs=1   (ai.Agent._has_media_output)
+        2    call 962 ntypeargs=1   (ai.Agent._has_media_output)
         3    pop_jump_if_false +2   (to 5)
         4    jump +12               (to 16)
 
@@ -1125,7 +1125,7 @@ function ai.Agent._parses(self: ai.Agent<#0>, turn: ai.ModelTurn, candidate: str
 function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: ai.content.ToolUse, j: ai.Journal) -> void {
   56   0     load_var2 2 3           
        1     load_field 1            (name)
-       2     call 932 ntypeargs=0    (ai.tools.Toolbox.get)
+       2     call 933 ntypeargs=0    (ai.tools.Toolbox.get)
        3     store_var 5             (_7)
        4     load_var 5              (_7)
        5     narrow_bind 0 5         
@@ -1151,7 +1151,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        21    load_type 3             
        22    alloc_array 1           
 
-  86   23    call 916 ntypeargs=0    (ai.Journal.append_all)
+  86   23    call 917 ntypeargs=0    (ai.Journal.append_all)
        24    pop 1                   
 
   94   25    load_const 4            (null)
@@ -1162,7 +1162,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
 
   58   29    load_var2 6 3           
        30    load_field 2            (args)
-       31    call 927 ntypeargs=0    (ai.tools.Tool.call)
+       31    call 928 ntypeargs=0    (ai.tools.Tool.call)
        32    store_var 7             (outcome)
        33    jump +60                (to 93)
        34    load_var 8              (e)
@@ -1183,7 +1183,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        46    load_type 3             
        47    alloc_array 1           
 
-  60   48    call 916 ntypeargs=0    (ai.Journal.append_all)
+  60   48    call 917 ntypeargs=0    (ai.Journal.append_all)
        49    pop 1                   
 
   64   50    load_var 6              (t)
@@ -1254,7 +1254,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        102   load_type 3             
        103   alloc_array 1           
 
-  81   104   call 916 ntypeargs=0    (ai.Journal.append_all)
+  81   104   call 917 ntypeargs=0    (ai.Journal.append_all)
        105   pop 1                   
 
   83   106   load_const 4            (null)
@@ -1299,7 +1299,7 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
        29   pop_jump_if_false +4                       (to 33)
 
   41   30   load_type 4                                
-       31   make_closure 2230 captures=0 ntypeargs=1   
+       31   make_closure 2231 captures=0 ntypeargs=1   
        32   store_var 5                                (_10)
 
   35   33   load_var2 1 2                              
@@ -1330,7 +1330,7 @@ function ai.FunctionSpec.output_type(self: ai.FunctionSpec<#0>) -> type {
         1   store_var 2             (output_type)
 
   113   2   load_var 2              (output_type)
-        3   call 1015 ntypeargs=0   (ai.internal.validate_output_type)
+        3   call 1016 ntypeargs=0   (ai.internal.validate_output_type)
         4   pop 1                   
 
   114   5   load_var 2              (output_type)
@@ -1397,11 +1397,11 @@ function ai.Journal.entries(self: ai.Journal) -> (ai.events.RunStarted | ai.even
 function ai.Journal.new(spec: ai.FunctionSpec<#0>) -> ai.Journal {
   21   0    load_type 0            
        1    load_var 1             (spec)
-       2    call 922 ntypeargs=1   (ai.FunctionSpec.name)
+       2    call 923 ntypeargs=1   (ai.FunctionSpec.name)
        3    store_var 2            (_4)
        4    load_type 0            
        5    load_var 1             (spec)
-       6    call 923 ntypeargs=1   (ai.FunctionSpec.arguments)
+       6    call 924 ntypeargs=1   (ai.FunctionSpec.arguments)
        7    store_var 3            (_6)
        8    load_var2 2 3          
        9    init_instance 0        (ai.events.RunStarted .spec_name, .arguments)
@@ -1524,7 +1524,7 @@ function ai.ModelTurn.tool_uses(self: ai.ModelTurn) -> ai.content.ToolUse[] {
 
 function ai.Prompt.baml.ToString.to_string(self: ai.Prompt) -> string {
   70   0   load_var 1             (self)
-       1   call 918 ntypeargs=0   (ai.Prompt.text)
+       1   call 919 ntypeargs=0   (ai.Prompt.text)
        2   return                 
 }
 
@@ -1694,7 +1694,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         56   load_var 3                         (index)
         57   load_const 4                       (1)
         58   add_int                            
-        59   call 956 ntypeargs=0               (ai.clients.Fallback._try)
+        59   call 957 ntypeargs=0               (ai.clients.Fallback._try)
         60   return                             
 }
 
@@ -1726,13 +1726,13 @@ function ai.clients.Fallback.root.Client.id(self: ai.clients.Fallback) -> string
 function ai.clients.Fallback.root.Client.invoke(self: ai.clients.Fallback, input: ai.ModelTurnInput) -> ai.ModelTurn {
   229   0   load_var2 1 2          
         1   load_const 0           (0)
-        2   call 956 ntypeargs=0   (ai.clients.Fallback._try)
+        2   call 957 ntypeargs=0   (ai.clients.Fallback._try)
         3   jump +6                (to 9)
         4   load_var 3             (e)
         5   throw_if_panic         
 
   230   6   load_var 3             (e)
-        7   call 977 ntypeargs=0   (ai.errors.normalize)
+        7   call 978 ntypeargs=0   (ai.errors.normalize)
         8   throw                  
         9   return                 
 }
@@ -1800,7 +1800,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
         49   add_int                            
 
   124   50   load_var 6                         (f)
-        51   call 948 ntypeargs=0               (ai.clients.Backoff.delay_ms)
+        51   call 949 ntypeargs=0               (ai.clients.Backoff.delay_ms)
         52   call 528 ntypeargs=0               (baml.time.Duration.from_milliseconds)
 
   123   53   sys_op 282                         (baml.sys.sleep)
@@ -1813,7 +1813,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
         59   load_var 3                         (remaining)
         60   load_const 3                       (1)
         61   sub_int                            
-        62   call 950 ntypeargs=0               (ai.clients.Retry._attempt)
+        62   call 951 ntypeargs=0               (ai.clients.Retry._attempt)
         63   return                             
 }
 
@@ -1858,7 +1858,7 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
         32   load_const 0           (<omitted>)
         33   load_const 0           (<omitted>)
         34   load_const 0           (<omitted>)
-        35   call 947 ntypeargs=0   (ai.clients.Backoff.new)
+        35   call 948 ntypeargs=0   (ai.clients.Backoff.new)
         36   store_var 7            (_12)
 
   105   37   load_var2 1 2          
@@ -1883,13 +1883,13 @@ function ai.clients.Retry.root.Client.invoke(self: ai.clients.Retry, input: ai.M
   143   0    load_var2 1 2          
         1    load_var 1             (self)
         2    load_field 1           (max_attempts)
-        3    call 950 ntypeargs=0   (ai.clients.Retry._attempt)
+        3    call 951 ntypeargs=0   (ai.clients.Retry._attempt)
         4    jump +6                (to 10)
         5    load_var 3             (e)
         6    throw_if_panic         
 
   144   7    load_var 3             (e)
-        8    call 977 ntypeargs=0   (ai.errors.normalize)
+        8    call 978 ntypeargs=0   (ai.errors.normalize)
         9    throw                  
         10   return                 
 }
@@ -1983,7 +1983,7 @@ function ai.clients.RoundRobin.root.Client.invoke(self: ai.clients.RoundRobin, i
         33   throw_if_panic                     
 
   185   34   load_var 4                         (e)
-        35   call 977 ntypeargs=0               (ai.errors.normalize)
+        35   call 978 ntypeargs=0               (ai.errors.normalize)
         36   throw                              
         37   load_var 3                         (_0)
         38   return                             
@@ -2058,7 +2058,7 @@ function ai.clients.resolve(selector: ai.Client | string | baml.env.Ref) -> ai.C
        25   load_field 0            (name)
        26   call 145 ntypeargs=1    (baml.String.from)
        27   store_var 6             (_18)
-       28   call 1010 ntypeargs=0   (ai.internal._shorthand_prefixes)
+       28   call 1011 ntypeargs=0   (ai.internal._shorthand_prefixes)
        29   store_var 8             (_22)
        30   load_type 2             
        31   load_var 8              (_22)
@@ -2092,12 +2092,12 @@ function ai.clients.resolve(selector: ai.Client | string | baml.env.Ref) -> ai.C
 
   33   57   load_var 5              (_8)
 
-  34   58   call 1011 ntypeargs=0   (ai.internal._from_shorthand)
+  34   58   call 1012 ntypeargs=0   (ai.internal._from_shorthand)
        59   jump +3                 (to 62)
 
   30   60   load_var 2              (_2)
 
-  31   61   call 1011 ntypeargs=0   (ai.internal._from_shorthand)
+  31   61   call 1012 ntypeargs=0   (ai.internal._from_shorthand)
        62   return                  
 }
 
@@ -2310,7 +2310,7 @@ function ai.errors.classify_http(provider: string, status_code: int, body: strin
   141   43   jump +7                 (to 50)
 
   138   44   load_var 4              (headers)
-        45   call 1014 ntypeargs=0   (ai.internal._retry_after_ms)
+        45   call 1015 ntypeargs=0   (ai.internal._retry_after_ms)
         46   store_var 5             (_7)
 
   136   47   load_var2 1 5           
@@ -2421,7 +2421,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        9     load_var 1              (shorthand)
        10    call 145 ntypeargs=1    (baml.String.from)
        11    store_var 14            (_62)
-       12    call 1010 ntypeargs=0   (ai.internal._shorthand_prefixes)
+       12    call 1011 ntypeargs=0   (ai.internal._shorthand_prefixes)
        13    store_var 16            (_65)
        14    load_type 2             
        15    load_var 16             (_65)
@@ -2523,7 +2523,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        102   load_const 20           (<omitted>)
        103   load_const 20           (<omitted>)
        104   load_const 20           (<omitted>)
-       105   call 1360 ntypeargs=0   (claude_code.ClaudeCodeClient.new)
+       105   call 1361 ntypeargs=0   (claude_code.ClaudeCodeClient.new)
        106   jump +172               (to 278)
 
   49   107   load_var 5              (model)
@@ -2536,7 +2536,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        114   load_const 20           (<omitted>)
        115   load_const 20           (<omitted>)
        116   load_const 20           (<omitted>)
-       117   call 1339 ntypeargs=0   (vercel.AiGatewayImageClient.new)
+       117   call 1340 ntypeargs=0   (vercel.AiGatewayImageClient.new)
        118   jump +160               (to 278)
 
   48   119   load_var 5              (model)
@@ -2557,7 +2557,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        134   load_const 20           (<omitted>)
        135   load_const 20           (<omitted>)
        136   load_const 20           (<omitted>)
-       137   call 1280 ntypeargs=0   (aws.BedrockClient.new)
+       137   call 1281 ntypeargs=0   (aws.BedrockClient.new)
        138   jump +140               (to 278)
 
   47   139   load_var 5              (model)
@@ -2577,7 +2577,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        153   load_const 20           (<omitted>)
        154   load_const 20           (<omitted>)
        155   load_const 20           (<omitted>)
-       156   call 1216 ntypeargs=0   (google.VertexClient.new)
+       156   call 1217 ntypeargs=0   (google.VertexClient.new)
        157   jump +121               (to 278)
 
   46   158   load_var 5              (model)
@@ -2593,7 +2593,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        168   load_const 20           (<omitted>)
        169   load_const 20           (<omitted>)
        170   load_const 20           (<omitted>)
-       171   call 1210 ntypeargs=0   (google.GoogleClient.new)
+       171   call 1211 ntypeargs=0   (google.GoogleClient.new)
        172   jump +106               (to 278)
 
   45   173   load_var 5              (model)
@@ -2609,7 +2609,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        183   load_const 20           (<omitted>)
        184   load_const 20           (<omitted>)
        185   load_const 20           (<omitted>)
-       186   call 1171 ntypeargs=0   (anthropic.AnthropicClient.new)
+       186   call 1172 ntypeargs=0   (anthropic.AnthropicClient.new)
        187   jump +91                (to 278)
 
   44   188   load_var 5              (model)
@@ -2623,7 +2623,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        196   load_const 20           (<omitted>)
        197   load_const 20           (<omitted>)
        198   load_const 20           (<omitted>)
-       199   call 1093 ntypeargs=0   (openai.OpenRouterClient.new)
+       199   call 1094 ntypeargs=0   (openai.OpenRouterClient.new)
        200   jump +78                (to 278)
 
   43   201   load_var 5              (model)
@@ -2637,7 +2637,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        209   load_const 20           (<omitted>)
        210   load_const 20           (<omitted>)
        211   load_const 20           (<omitted>)
-       212   call 1085 ntypeargs=0   (openai.OllamaClient.new)
+       212   call 1086 ntypeargs=0   (openai.OllamaClient.new)
        213   jump +65                (to 278)
 
   42   214   load_var 5              (model)
@@ -2655,7 +2655,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        226   load_const 20           (<omitted>)
        227   load_const 20           (<omitted>)
        228   load_const 20           (<omitted>)
-       229   call 1076 ntypeargs=0   (openai.AzureClient.new)
+       229   call 1077 ntypeargs=0   (openai.AzureClient.new)
        230   jump +48                (to 278)
 
   41   231   load_var 5              (model)
@@ -2674,7 +2674,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        244   load_const 20           (<omitted>)
        245   load_const 20           (<omitted>)
        246   load_const 20           (<omitted>)
-       247   call 1101 ntypeargs=0   (openai.ImageClient.new)
+       247   call 1102 ntypeargs=0   (openai.ImageClient.new)
        248   jump +30                (to 278)
 
   40   249   load_var 5              (model)
@@ -2689,7 +2689,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        258   load_const 20           (<omitted>)
        259   load_const 20           (<omitted>)
        260   load_const 20           (<omitted>)
-       261   call 1060 ntypeargs=0   (openai.ChatClient.new)
+       261   call 1061 ntypeargs=0   (openai.ChatClient.new)
        262   jump +16                (to 278)
 
   39   263   load_var 5              (model)
@@ -2706,7 +2706,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        274   load_const 20           (<omitted>)
        275   load_const 20           (<omitted>)
        276   load_const 20           (<omitted>)
-       277   call 1020 ntypeargs=0   (openai.ResponsesClient.new)
+       277   call 1021 ntypeargs=0   (openai.ResponsesClient.new)
 
   53   278   store_var 8             (_36)
        279   load_var 8              (_36)
@@ -2722,7 +2722,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        288   load_var 1              (shorthand)
        289   call 145 ntypeargs=1    (baml.String.from)
        290   store_var 10            (_50)
-       291   call 1010 ntypeargs=0   (ai.internal._shorthand_prefixes)
+       291   call 1011 ntypeargs=0   (ai.internal._shorthand_prefixes)
        292   store_var 12            (_53)
        293   load_type 2             
        294   load_var 12             (_53)
@@ -2791,7 +2791,7 @@ function ai.internal._header(headers: map<string, string>, lower: string, canoni
 function ai.internal._int_header(headers: map<string, string>, lower: string, canonical: string) -> int | null {
   14   0    load_var2 1 2           
        1    load_var 3              (canonical)
-       2    call 1012 ntypeargs=0   (ai.internal._header)
+       2    call 1013 ntypeargs=0   (ai.internal._header)
        3    store_var 4             (_5)
        4    load_var 4              (_5)
        5    narrow_bind 0 4         
@@ -3195,13 +3195,13 @@ function ai.internal._media_mixed_parts(turn: ai.ModelTurn) -> baml.json.json[] 
        32   store_var 9                        (m)
 
   91   33   load_var 9                         (m)
-       34   call 912 ntypeargs=0               (ai.content.Media.kind)
+       34   call 913 ntypeargs=0               (ai.content.Media.kind)
        35   load_const 8                       ("image")
        36   cmp_op ==                          
        37   pop_jump_if_false -28              (to 9)
 
   92   38   load_var 9                         (m)
-       39   call 995 ntypeargs=0               (ai.internal._media_envelope)
+       39   call 996 ntypeargs=0               (ai.internal._media_envelope)
        40   store_var 10                       (_22)
        41   load_type 0                        
        42   load_var2 2 10                     
@@ -3259,13 +3259,13 @@ function ai.internal._media_of_kind(turn: ai.ModelTurn, kind: string) -> baml.js
        24   store_var 7                        (m)
 
   69   25   load_var 7                         (m)
-       26   call 912 ntypeargs=0               (ai.content.Media.kind)
+       26   call 913 ntypeargs=0               (ai.content.Media.kind)
        27   load_var 2                         (kind)
        28   cmp_op ==                          
        29   pop_jump_if_false -20              (to 9)
 
   70   30   load_var 7                         (m)
-       31   call 995 ntypeargs=0               (ai.internal._media_envelope)
+       31   call 996 ntypeargs=0               (ai.internal._media_envelope)
        32   store_var 8                        (_15)
        33   load_type 0                        
        34   load_var2 3 8                      
@@ -3327,7 +3327,7 @@ function ai.internal._media_reject_mixed(turn: ai.ModelTurn, kind: string, provi
 
   126   41   load_var 8                         (_11)
 
-  128   42   call 912 ntypeargs=0               (ai.content.Media.kind)
+  128   42   call 913 ntypeargs=0               (ai.content.Media.kind)
         43   load_var 2                         (kind)
         44   cmp_op !=                          
         45   pop_jump_if_false -37              (to 8)
@@ -3598,7 +3598,7 @@ function ai.internal._merge_json(base: baml.json.json, patch: baml.json.json) ->
        83    load_var2 5 14                     
        84    call 38 ntypeargs=2                (baml.Map.get)
        85    load_var 15                        (value)
-       86    call 1006 ntypeargs=0              (ai.internal._merge_json)
+       86    call 1007 ntypeargs=0              (ai.internal._merge_json)
        87    store_var 16                       (_43)
        88    load_type 1                        
        89    load_type 2                        
@@ -3628,7 +3628,7 @@ function ai.internal._proxy(conn: ai.mcp.McpConnection, name: string) -> (map<st
        5   store_var 2           
 
   12   6   load_var2 1 2         
-       7   make_closure 4224 2   
+       7   make_closure 4225 2   
        8   return                
 }
 
@@ -3691,7 +3691,7 @@ function ai.internal._redact_after(text: string, marker: string) -> string {
        44   store_var 9             (tail)
 
   26   45   load_var 9              (tail)
-       46   call 1005 ntypeargs=0   (ai.internal._redact_value_end)
+       46   call 1006 ntypeargs=0   (ai.internal._redact_value_end)
        47   store_var 11            (_16)
        48   load_var 9              (tail)
        49   call 146 ntypeargs=0    (baml.String.length)
@@ -4124,7 +4124,7 @@ function ai.internal._retry_after_ms(headers: map<string, string> | null) -> int
 
   34   7    load_const 1            ("retry-after-ms")
        8    load_const 2            ("Retry-After-Ms")
-       9    call 1013 ntypeargs=0   (ai.internal._int_header)
+       9    call 1014 ntypeargs=0   (ai.internal._int_header)
        10   store_var 4             (_6)
        11   load_var 4              (_6)
        12   narrow_bind 3 4         
@@ -4134,7 +4134,7 @@ function ai.internal._retry_after_ms(headers: map<string, string> | null) -> int
   37   15   load_var 3              (h)
        16   load_const 4            ("retry-after")
        17   load_const 5            ("Retry-After")
-       18   call 1013 ntypeargs=0   (ai.internal._int_header)
+       18   call 1014 ntypeargs=0   (ai.internal._int_header)
        19   store_var 5             (_10)
        20   load_var 5              (_10)
        21   narrow_bind 3 5         
@@ -4357,7 +4357,7 @@ function ai.internal.validate_output_type(return_type: type) -> void {
   11   11   jump +11               (to 22)
        12   load_var 2             (_4)
 
-  13   13   call 804 ntypeargs=0   (baml.reflect.enum.Type.values)
+  13   13   call 805 ntypeargs=0   (baml.reflect.enum.Type.values)
        14   container_len          
        15   store_var 3            (_7)
        16   load_var 3             (_7)
@@ -4403,10 +4403,10 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
 
   88    9     load_var2 4 2                      
         10    load_var 3                         (params)
-        11    call 1373 ntypeargs=0              (ai.mcp.rpc_line)
+        11    call 1374 ntypeargs=0              (ai.mcp.rpc_line)
         12    store_var 5                        (_6)
         13    load_var2 1 5                      
-        14    call 1375 ntypeargs=0              (ai.mcp.McpConnection._send)
+        14    call 1376 ntypeargs=0              (ai.mcp.McpConnection._send)
         15    pop 1                              
 
   89    16    load_const 1                       (true)
@@ -4646,7 +4646,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
         6    load_type 4                        
         7    alloc_map 2                        
 
-  170   8    call 1376 ntypeargs=0              (ai.mcp.McpConnection._request)
+  170   8    call 1377 ntypeargs=0              (ai.mcp.McpConnection._request)
         9    store_var 4                        (result)
 
   171   10   load_type 3                        
@@ -4819,16 +4819,16 @@ function ai.mcp.McpConnection.connect(name: string, command: string, args: strin
        60   load_type 11            
        61   alloc_map 3             
 
-  62   62   call 1376 ntypeargs=0   (ai.mcp.McpConnection._request)
+  62   62   call 1377 ntypeargs=0   (ai.mcp.McpConnection._request)
        63   pop 1                   
 
   63   64   load_const 2            (null)
        65   load_const 19           ("notifications/initialized")
        66   load_const 2            (null)
-       67   call 1373 ntypeargs=0   (ai.mcp.rpc_line)
+       67   call 1374 ntypeargs=0   (ai.mcp.rpc_line)
        68   store_var 11            (_26)
        69   load_var2 10 11         
-       70   call 1375 ntypeargs=0   (ai.mcp.McpConnection._send)
+       70   call 1376 ntypeargs=0   (ai.mcp.McpConnection._send)
        71   pop 1                   
 
   64   72   load_var 10             (conn)
@@ -4841,7 +4841,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         2    load_type 1                        
         3    load_type 2                        
         4    alloc_map 0                        
-        5    call 1376 ntypeargs=0              (ai.mcp.McpConnection._request)
+        5    call 1377 ntypeargs=0              (ai.mcp.McpConnection._request)
         6    store_var 2                        (result)
 
   143   7    load_type 3                        
@@ -4910,14 +4910,14 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         63   store_var 13                       (_31)
 
   159   64   load_var2 1 7                      
-        65   call 1380 ntypeargs=0              (ai.internal._proxy)
+        65   call 1381 ntypeargs=0              (ai.internal._proxy)
         66   store_var 14                       (_32)
 
   156   67   load_var2 7 12                     
         68   load_var2 13 14                    
         69   load_const 18                      (<omitted>)
 
-  155   70   call 929 ntypeargs=0               (ai.tools.raw_tool)
+  155   70   call 930 ntypeargs=0               (ai.tools.raw_tool)
         71   store_var 11                       (_26)
 
   154   72   load_type 3                        
@@ -4985,7 +4985,7 @@ function ai.prompt(body: ((string) -> ai.Role throws never, ai.Context) -> baml.
        2   store_var 1           
 
   84   3   load_var 1            (body)
-       4   make_closure 2130 1   
+       4   make_closure 2131 1   
        5   return                
 }
 
@@ -5174,14 +5174,14 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         1    pop_jump_if_false +7   (to 8)
 
   308   2    load_var 1             (self)
-        3    call 972 ntypeargs=0   (ai.stream.TurnStream.next)
+        3    call 973 ntypeargs=0   (ai.stream.TurnStream.next)
         4    store_var 2            (_3)
         5    load_var 2             (_3)
         6    narrow_bind 1 2        
         7    pop_jump_if_false -7   (to 0)
 
   318   8    load_var 1             (self)
-        9    call 971 ntypeargs=0   (ai.stream.TurnStream._check_terminal)
+        9    call 972 ntypeargs=0   (ai.stream.TurnStream._check_terminal)
         10   pop 1                  
 
   319   11   load_var 1             (self)
@@ -5350,7 +5350,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         38    jump +6                            (to 44)
 
   289   39    load_var 1                         (self)
-        40    call 970 ntypeargs=0               (ai.stream.TurnStream._finish)
+        40    call 971 ntypeargs=0               (ai.stream.TurnStream._finish)
         41    pop 1                              
 
   290   42    alloc_instance 411 ntypeargs=0     (ai.stream.Done)
@@ -5428,11 +5428,11 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         102   jump -15                           (to 87)
 
   262   103   load_var 1                         (self)
-        104   call 970 ntypeargs=0               (ai.stream.TurnStream._finish)
+        104   call 971 ntypeargs=0               (ai.stream.TurnStream._finish)
         105   pop 1                              
 
   263   106   load_var 1                         (self)
-        107   call 971 ntypeargs=0               (ai.stream.TurnStream._check_terminal)
+        107   call 972 ntypeargs=0               (ai.stream.TurnStream._check_terminal)
         108   pop 1                              
 
   264   109   alloc_instance 411 ntypeargs=0     (ai.stream.Done)
@@ -5476,7 +5476,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         143   store_field 12                     (_saw_terminal)
 
   248   144   load_var 1                         (self)
-        145   call 970 ntypeargs=0               (ai.stream.TurnStream._finish)
+        145   call 971 ntypeargs=0               (ai.stream.TurnStream._finish)
         146   pop 1                              
 
   249   147   alloc_instance 411 ntypeargs=0     (ai.stream.Done)
@@ -5565,8 +5565,8 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   402   9     load_type 2                                
         10    load_var 1                                 (spec)
-        11    call 926 ntypeargs=1                       (ai.FunctionSpec.tools)
-        12    call 933 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
+        11    call 927 ntypeargs=1                       (ai.FunctionSpec.tools)
+        12    call 934 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
         13    unary_op !                                 
         14    pop_jump_if_false +2                       (to 16)
         15    jump +71                                   (to 86)
@@ -5616,17 +5616,17 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   427   51    load_type 2                                
         52    load_var 1                                 (spec)
-        53    call 915 ntypeargs=1                       (ai.Journal.new)
+        53    call 916 ntypeargs=1                       (ai.Journal.new)
         54    store_var 12                               (_29)
 
   428   55    load_type 2                                
         56    load_var 1                                 (spec)
-        57    call 926 ntypeargs=1                       (ai.FunctionSpec.tools)
+        57    call 927 ntypeargs=1                       (ai.FunctionSpec.tools)
         58    store_var 13                               (_31)
 
   429   59    load_type 2                                
         60    load_var 1                                 (spec)
-        61    call 924 ntypeargs=1                       (ai.FunctionSpec.output_type)
+        61    call 925 ntypeargs=1                       (ai.FunctionSpec.output_type)
         62    store_var 14                               (_33)
 
   424   63    load_var2 5 11                             
@@ -5647,7 +5647,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
   436   75    load_type 8                                
         76    load_type 2                                
         77    load_var 10                                (turns)
-        78    make_closure 2308 captures=1 ntypeargs=2   
+        78    make_closure 2309 captures=1 ntypeargs=2   
         79    load_var 15                                (_36)
         80    load_const 9                               ("")
         81    load_const 10                              (false)
@@ -5658,7 +5658,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   404   86    load_type 2                                
         87    load_var 1                                 (spec)
-        88    call 922 ntypeargs=1                       (ai.FunctionSpec.name)
+        88    call 923 ntypeargs=1                       (ai.FunctionSpec.name)
         89    store_var 4                                (_12)
         90    load_type 11                               
         91    load_var 4                                 (_12)
@@ -5766,7 +5766,7 @@ function ai.tools.Toolbox.get(self: ai.tools.Toolbox, name: string) -> ai.tools.
         5    load_var 1            (self)
         6    load_field 0          (entries)
         7    load_var 2            (name)
-        8    make_closure 2156 1   
+        8    make_closure 2157 1   
         9    call 19 ntypeargs=2   (baml.Array.find)
         10   return                
 }
@@ -5941,7 +5941,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        60   store_var 9             (_18)
 
   58   61   load_var 1              (handler)
-       62   call 987 ntypeargs=0    (ai.internal._schema_for_signature)
+       62   call 988 ntypeargs=0    (ai.internal._schema_for_signature)
        63   store_var 12            (_24)
 
   56   64   load_var2 8 9           
@@ -6013,7 +6013,7 @@ function ai.wire.merge_request_body(base: baml.json.json, overrides: baml.json.j
         4   jump +4                 (to 8)
 
   210   5   load_var2 1 2           
-        6   call 1006 ntypeargs=0   (ai.internal._merge_json)
+        6   call 1007 ntypeargs=0   (ai.internal._merge_json)
         7   jump +2                 (to 9)
 
   209   8   load_var 1              (base)
@@ -6023,23 +6023,23 @@ function ai.wire.merge_request_body(base: baml.json.json, overrides: baml.json.j
 function ai.wire.redact_url_secrets(text: string) -> string {
   51   0   load_var 1              (text)
        1   load_const 0            ("key=")
-       2   call 1004 ntypeargs=0   (ai.internal._redact_after)
+       2   call 1005 ntypeargs=0   (ai.internal._redact_after)
 
   52   3   load_const 1            ("token=")
-       4   call 1004 ntypeargs=0   (ai.internal._redact_after)
+       4   call 1005 ntypeargs=0   (ai.internal._redact_after)
 
   53   5   load_const 2            ("secret=")
-       6   call 1004 ntypeargs=0   (ai.internal._redact_after)
+       6   call 1005 ntypeargs=0   (ai.internal._redact_after)
        7   return                  
 }
 
 function ai.wire.render_output_format(t: type) -> string {
   115   0   load_var 1              (t)
-        1   call 1015 ntypeargs=0   (ai.internal.validate_output_type)
+        1   call 1016 ntypeargs=0   (ai.internal.validate_output_type)
         2   pop 1                   
 
   116   3   load_var 1              (t)
-        4   sys_op 1016             (ai.internal.render_output_format)
+        4   sys_op 1017             (ai.internal.render_output_format)
         5   return                  
 }
 
@@ -6070,12 +6070,12 @@ function ai.wire.resolve_credential(cred: string | baml.env.Ref | null, env_fall
        20   load_const 3            ("")
        21   store_var 5             (_10)
        22   load_var 5              (_10)
-       23   call 1003 ntypeargs=0   (ai.internal._configured)
+       23   call 1004 ntypeargs=0   (ai.internal._configured)
        24   jump +3                 (to 27)
 
   27   25   load_var 3              (_4)
 
-  28   26   call 1003 ntypeargs=0   (ai.internal._configured)
+  28   26   call 1004 ntypeargs=0   (ai.internal._configured)
 
   32   27   store_var 6             (_13)
        28   load_var 6              (_13)
@@ -6103,7 +6103,7 @@ function ai.wire.resolve_credential(cred: string | baml.env.Ref | null, env_fall
        46   load_const 4            ("")
        47   store_var 8             (_18)
        48   load_var 8              (_18)
-       49   call 1003 ntypeargs=0   (ai.internal._configured)
+       49   call 1004 ntypeargs=0   (ai.internal._configured)
        50   jump +2                 (to 52)
 
   32   51   load_var 6              (_13)
@@ -6165,13 +6165,13 @@ function ai.wire.resolve_media(media: baml.media.Image | baml.media.Audio | baml
         46    call 332 ntypeargs=0    (baml.media.Pdf.mime_type)
         47    load_var 30             (source)
         48    load_const 5            ("pdf")
-        49    call 1001 ntypeargs=0   (ai.internal._media_mime_type)
+        49    call 1002 ntypeargs=0   (ai.internal._media_mime_type)
         50    store_var 36            (_59)
 
   164   51    load_var2 33 34         
         52    load_var2 35 36         
         53    load_var 2              (fetch_url)
-        54    call 1002 ntypeargs=0   (ai.internal._resolve_media_content)
+        54    call 1003 ntypeargs=0   (ai.internal._resolve_media_content)
         55    jump +120               (to 175)
 
   131   56    load_var 21             (_33)
@@ -6212,13 +6212,13 @@ function ai.wire.resolve_media(media: baml.media.Image | baml.media.Audio | baml
         86    call 346 ntypeargs=0    (baml.media.Video.mime_type)
         87    load_var 23             (source)
         88    load_const 7            ("video")
-        89    call 1001 ntypeargs=0   (ai.internal._media_mime_type)
+        89    call 1002 ntypeargs=0   (ai.internal._media_mime_type)
         90    store_var 29            (_45)
 
   154   91    load_var2 26 27         
         92    load_var2 28 29         
         93    load_var 2              (fetch_url)
-        94    call 1002 ntypeargs=0   (ai.internal._resolve_media_content)
+        94    call 1003 ntypeargs=0   (ai.internal._resolve_media_content)
         95    jump +80                (to 175)
 
   131   96    load_var 12             (_18)
@@ -6259,13 +6259,13 @@ function ai.wire.resolve_media(media: baml.media.Image | baml.media.Audio | baml
         126   call 339 ntypeargs=0    (baml.media.Audio.mime_type)
         127   load_var 14             (source)
         128   load_const 9            ("audio")
-        129   call 1001 ntypeargs=0   (ai.internal._media_mime_type)
+        129   call 1002 ntypeargs=0   (ai.internal._media_mime_type)
         130   store_var 20            (_30)
 
   144   131   load_var2 17 18         
         132   load_var2 19 20         
         133   load_var 2              (fetch_url)
-        134   call 1002 ntypeargs=0   (ai.internal._resolve_media_content)
+        134   call 1003 ntypeargs=0   (ai.internal._resolve_media_content)
         135   jump +40                (to 175)
 
   131   136   load_var 3              (_3)
@@ -6306,13 +6306,13 @@ function ai.wire.resolve_media(media: baml.media.Image | baml.media.Audio | baml
         166   call 353 ntypeargs=0    (baml.media.Image.mime_type)
         167   load_var 5              (source)
         168   load_const 11           ("image")
-        169   call 1001 ntypeargs=0   (ai.internal._media_mime_type)
+        169   call 1002 ntypeargs=0   (ai.internal._media_mime_type)
         170   store_var 11            (_15)
 
   134   171   load_var2 8 9           
         172   load_var2 10 11         
         173   load_var 2              (fetch_url)
-        174   call 1002 ntypeargs=0   (ai.internal._resolve_media_content)
+        174   call 1003 ntypeargs=0   (ai.internal._resolve_media_content)
         175   return                  
 }
 
@@ -6326,7 +6326,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
         5     store_var 4                        (pending)
 
   271   6     load_var 1                         (j)
-        7     call 914 ntypeargs=0               (ai.Journal.entries)
+        7     call 915 ntypeargs=0               (ai.Journal.entries)
         8     load_type 2                        
         9     load_const 3                       ("iter")
         10    virtual_call nargs=1 ntypeargs=0   
@@ -6379,7 +6379,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
 
   305   54    load_var2 4 20                     
         55    load_field 0                       (id)
-        56    call 1009 ntypeargs=0              (ai.internal._resolve_pending_call)
+        56    call 1010 ntypeargs=0              (ai.internal._resolve_pending_call)
         57    pop 1                              
 
   306   58    load_type 0                        
@@ -6393,7 +6393,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
 
   300   65    load_var2 4 18                     
         66    load_field 0                       (id)
-        67    call 1009 ntypeargs=0              (ai.internal._resolve_pending_call)
+        67    call 1010 ntypeargs=0              (ai.internal._resolve_pending_call)
         68    pop 1                              
 
   301   69    load_type 0                        
@@ -6406,7 +6406,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
         75    store_var 16                       (user)
 
   295   76    load_var2 3 4                      
-        77    call 1008 ntypeargs=0              (ai.internal._flush_orphaned_calls)
+        77    call 1009 ntypeargs=0              (ai.internal._flush_orphaned_calls)
         78    pop 1                              
 
   296   79    load_type 0                        
@@ -6419,7 +6419,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
         85    store_var 9                        (assistant)
 
   274   86    load_var2 3 4                      
-        87    call 1008 ntypeargs=0              (ai.internal._flush_orphaned_calls)
+        87    call 1009 ntypeargs=0              (ai.internal._flush_orphaned_calls)
         88    pop 1                              
 
   275   89    load_var 9                         (assistant)
@@ -6428,7 +6428,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
         92    load_field 1                       (client_id)
         93    load_var 2                         (client_id)
         94    cmp_op ==                          
-        95    call 1007 ntypeargs=0              (ai.internal._wire_blocks)
+        95    call 1008 ntypeargs=0              (ai.internal._wire_blocks)
         96    store_var 10                       (blocks)
 
   276   97    load_var 10                        (blocks)
@@ -6480,7 +6480,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
         135   jump -19                           (to 116)
 
   315   136   load_var2 3 4                      
-        137   call 1008 ntypeargs=0              (ai.internal._flush_orphaned_calls)
+        137   call 1009 ntypeargs=0              (ai.internal._flush_orphaned_calls)
         138   pop 1                              
 
   316   139   load_var 3                         (out)
@@ -6500,7 +6500,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
   89    7    load_type 1            
         8    load_var 4             (e)
         9    call 145 ntypeargs=1   (baml.String.from)
-        10   call 938 ntypeargs=0   (ai.wire.redact_url_secrets)
+        10   call 939 ntypeargs=0   (ai.wire.redact_url_secrets)
         11   store_var 6            (_8)
         12   load_type 2            
         13   load_var 6             (_8)
@@ -6551,7 +6551,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
         50   load_field 0           (status_code)
         51   load_var2 7 3          
         52   load_field 1           (headers)
-        53   call 986 ntypeargs=0   (ai.errors.classify_http)
+        53   call 987 ntypeargs=0   (ai.errors.classify_http)
         54   throw                  
 }
 
@@ -6569,26 +6569,26 @@ function anthropic.AnthropicClient.ai.Client.id(self: anthropic.AnthropicClient)
 
 function anthropic.AnthropicClient.ai.Client.invoke(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   162   0   load_var2 1 2           
-        1   call 1201 ntypeargs=0   (anthropic.internal.invoke)
+        1   call 1202 ntypeargs=0   (anthropic.internal.invoke)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   163   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
 
 function anthropic.AnthropicClient.ai.stream.StreamingClient.invoke_stream(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   170   0   load_var2 1 2           
-        1   call 1208 ntypeargs=0   (anthropic.internal.invoke_stream)
+        1   call 1209 ntypeargs=0   (anthropic.internal.invoke_stream)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   171   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
@@ -6701,7 +6701,7 @@ function anthropic.AnthropicClient.resolved_api_key(self: anthropic.AnthropicCli
   143   0    load_var 1              (self)
         1    load_field 1            (api_key)
         2    load_const 0            ("ANTHROPIC_API_KEY")
-        3    call 937 ntypeargs=0    (ai.wire.resolve_credential)
+        3    call 938 ntypeargs=0    (ai.wire.resolve_credential)
         4    store_var 2             (_4)
         5    load_var 2              (_4)
         6    narrow_bind 1 2         
@@ -6711,7 +6711,7 @@ function anthropic.AnthropicClient.resolved_api_key(self: anthropic.AnthropicCli
   147   9    load_var 1              (self)
         10   load_field 1            (api_key)
         11   load_const 2            ("ANTHROPIC_API_KEY")
-        12   call 939 ntypeargs=0    (ai.wire.credential_sources)
+        12   call 940 ntypeargs=0    (ai.wire.credential_sources)
         13   store_var 4             (_9)
         14   load_type 3             
         15   load_var 4              (_9)
@@ -6721,7 +6721,7 @@ function anthropic.AnthropicClient.resolved_api_key(self: anthropic.AnthropicCli
         19   load_var 3              (_8)
         20   bin_op +                
 
-  146   21   call 1177 ntypeargs=0   (anthropic.internal._reject)
+  146   21   call 1178 ntypeargs=0   (anthropic.internal._reject)
         22   throw                   
 
   143   23   load_var 2              (_4)
@@ -6732,7 +6732,7 @@ function anthropic.AnthropicClient.resolved_base_url(self: anthropic.AnthropicCl
   153   0   load_var 1             (self)
         1   load_field 2           (base_url)
         2   load_const 0           (null)
-        3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4   return                 
 }
 
@@ -6997,7 +6997,7 @@ function anthropic.internal._anth_drop_nulls(j: baml.json.json) -> baml.json.jso
         30   jump +9                            (to 39)
         31   load_var 13                        (_32)
 
-  237   32   call 1179 ntypeargs=0              (anthropic.internal._anth_drop_nulls)
+  237   32   call 1180 ntypeargs=0              (anthropic.internal._anth_drop_nulls)
         33   store_var 14                       (_37)
         34   load_type 2                        
         35   load_var2 11 14                    
@@ -7049,12 +7049,12 @@ function anthropic.internal._anth_drop_nulls(j: baml.json.json) -> baml.json.jso
         75   jump -20                           (to 55)
 
   222   76   load_var 7                         (key)
-        77   call 1178 ntypeargs=0              (anthropic.internal._anth_verbatim_subtree)
+        77   call 1179 ntypeargs=0              (anthropic.internal._anth_verbatim_subtree)
         78   pop_jump_if_false +2               (to 80)
         79   jump +5                            (to 84)
 
   225   80   load_var 8                         (value)
-        81   call 1179 ntypeargs=0              (anthropic.internal._anth_drop_nulls)
+        81   call 1180 ntypeargs=0              (anthropic.internal._anth_drop_nulls)
         82   store_var 9                        (kept)
         83   jump +3                            (to 86)
 
@@ -7510,7 +7510,7 @@ function anthropic.internal._anthropic_headers(c: anthropic.AnthropicClient) -> 
         54   jump -30                           (to 24)
 
   764   55   load_var 1                         (c)
-        56   call 1172 ntypeargs=0              (anthropic.AnthropicClient.resolved_api_key)
+        56   call 1173 ntypeargs=0              (anthropic.AnthropicClient.resolved_api_key)
         57   store_var 10                       (_26)
         58   load_type 4                        
         59   load_type 4                        
@@ -7530,7 +7530,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         2    store_var 2                        (msgs)
 
   480   3    load_var 1                         (j)
-        4    call 914 ntypeargs=0               (ai.Journal.entries)
+        4    call 915 ntypeargs=0               (ai.Journal.entries)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -7578,7 +7578,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         47   load_var 13                        (f)
         48   load_field 1                       (message)
         49   load_const 10                      (true)
-        50   call 1186 ntypeargs=0              (anthropic.internal._anthropic_push_tool_result)
+        50   call 1187 ntypeargs=0              (anthropic.internal._anthropic_push_tool_result)
         51   pop 1                              
         52   jump -43                           (to 9)
 
@@ -7590,14 +7590,14 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         57   load_var 11                        (c)
         58   load_field 1                       (output)
         59   load_const 11                      (false)
-        60   call 1186 ntypeargs=0              (anthropic.internal._anthropic_push_tool_result)
+        60   call 1187 ntypeargs=0              (anthropic.internal._anthropic_push_tool_result)
         61   pop 1                              
         62   jump -53                           (to 9)
 
   481   63   load_var 7                         (_17)
         64   load_field 0                       (content)
 
-  495   65   call 1185 ntypeargs=0              (anthropic.internal._anthropic_assistant_blocks)
+  495   65   call 1186 ntypeargs=0              (anthropic.internal._anthropic_assistant_blocks)
         66   store_var 8                        (blocks)
 
   500   67   load_var 8                         (blocks)
@@ -7655,7 +7655,7 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
         5    store_var 3                        (messages)
 
   381   6    load_var 1                         (prompt)
-        7    call 919 ntypeargs=0               (ai.Prompt.messages)
+        7    call 920 ntypeargs=0               (ai.Prompt.messages)
         8    load_type 2                        
         9    load_const 3                       ("iter")
         10   virtual_call nargs=1 ntypeargs=0   
@@ -7703,11 +7703,11 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
         46   store_var 11                       (role)
 
   396   47   load_var2 6 11                     
-        48   call 1183 ntypeargs=0              (anthropic.internal._anthropic_prompt_blocks)
+        48   call 1184 ntypeargs=0              (anthropic.internal._anthropic_prompt_blocks)
         49   store_var 12                       (blocks)
 
   397   50   load_var2 12 7                     
-        51   call 1180 ntypeargs=0              (anthropic.internal._anth_apply_cache_control)
+        51   call 1181 ntypeargs=0              (anthropic.internal._anth_apply_cache_control)
         52   pop 1                              
 
   400   53   load_var 12                        (blocks)
@@ -7731,11 +7731,11 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
 
   384   68   load_var 6                         (message)
         69   load_const 16                      ("system")
-        70   call 1183 ntypeargs=0              (anthropic.internal._anthropic_prompt_blocks)
+        70   call 1184 ntypeargs=0              (anthropic.internal._anthropic_prompt_blocks)
         71   store_var 8                        (blocks)
 
   385   72   load_var2 8 7                      
-        73   call 1180 ntypeargs=0              (anthropic.internal._anth_apply_cache_control)
+        73   call 1181 ntypeargs=0              (anthropic.internal._anth_apply_cache_control)
         74   pop 1                              
 
   386   75   load_var 8                         (blocks)
@@ -7767,7 +7767,7 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
 function anthropic.internal._anthropic_media_block(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf, block_type: string) -> anthropic.internal.AnthMediaBlock {
   308   0    load_var 1              (media)
         1    load_const 0            (false)
-        2    call 942 ntypeargs=0    (ai.wire.resolve_media)
+        2    call 943 ntypeargs=0    (ai.wire.resolve_media)
         3    store_var 3             (resolved)
 
   309   4    load_var 3              (resolved)
@@ -7785,7 +7785,7 @@ function anthropic.internal._anthropic_media_block(media: baml.media.Image | bam
         15   pop 1                   
         16   load_var 3              (resolved)
         17   load_field 2            (mime_type)
-        18   call 1181 ntypeargs=0   (anthropic.internal._anth_supported_image_mime)
+        18   call 1182 ntypeargs=0   (anthropic.internal._anth_supported_image_mime)
         19   unary_op !              
         20   pop_jump_if_false +2    (to 22)
         21   jump +18                (to 39)
@@ -7823,7 +7823,7 @@ function anthropic.internal._anthropic_media_block(media: baml.media.Image | bam
         47   load_const 8            (" images: the Messages API supports image/jpeg, image/png, image/gif and image/webp")
         48   bin_op +                
 
-  315   49   call 1177 ntypeargs=0   (anthropic.internal._reject)
+  315   49   call 1178 ntypeargs=0   (anthropic.internal._reject)
         50   throw                   
 
   312   51   load_const 9            ("url")
@@ -7889,7 +7889,7 @@ function anthropic.internal._anthropic_prompt_blocks(message: ai.PromptMessage, 
         43    jump +4                            (to 47)
 
   371   44    load_const 10                      ("Anthropic does not support video prompt input")
-        45    call 1177 ntypeargs=0              (anthropic.internal._reject)
+        45    call 1178 ntypeargs=0              (anthropic.internal._reject)
         46    throw                              
 
   332   47    load_var 14                        (_31)
@@ -7903,7 +7903,7 @@ function anthropic.internal._anthropic_prompt_blocks(message: ai.PromptMessage, 
 
   367   54    load_var 15                        (pdf)
         55    load_const 12                      ("document")
-        56    call 1182 ntypeargs=0              (anthropic.internal._anthropic_media_block)
+        56    call 1183 ntypeargs=0              (anthropic.internal._anthropic_media_block)
         57    store_var 17                       (_39)
         58    load_type 0                        
         59    load_var2 3 17                     
@@ -7919,11 +7919,11 @@ function anthropic.internal._anthropic_prompt_blocks(message: ai.PromptMessage, 
         68    load_var 16                        (_36)
         69    bin_op +                           
 
-  363   70    call 1177 ntypeargs=0              (anthropic.internal._reject)
+  363   70    call 1178 ntypeargs=0              (anthropic.internal._reject)
         71    throw                              
 
   357   72    load_const 15                      ("Anthropic does not support audio prompt input: the Messages API has no audio content block")
-        73    call 1177 ntypeargs=0              (anthropic.internal._reject)
+        73    call 1178 ntypeargs=0              (anthropic.internal._reject)
         74    throw                              
 
   332   75    load_var 9                         (_18)
@@ -7937,7 +7937,7 @@ function anthropic.internal._anthropic_prompt_blocks(message: ai.PromptMessage, 
 
   347   82    load_var 10                        (image)
         83    load_const 17                      ("image")
-        84    call 1182 ntypeargs=0              (anthropic.internal._anthropic_media_block)
+        84    call 1183 ntypeargs=0              (anthropic.internal._anthropic_media_block)
         85    store_var 12                       (_26)
         86    load_type 0                        
         87    load_var2 3 12                     
@@ -7953,7 +7953,7 @@ function anthropic.internal._anthropic_prompt_blocks(message: ai.PromptMessage, 
         96    load_var 11                        (_23)
         97    bin_op +                           
 
-  343   98    call 1177 ntypeargs=0              (anthropic.internal._reject)
+  343   98    call 1178 ntypeargs=0              (anthropic.internal._reject)
         99    throw                              
 
   332   100   load_var 7                         (_10)
@@ -8233,7 +8233,7 @@ function anthropic.internal._anthropic_render_messages(msgs: anthropic.internal.
 
 function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
   775   0    load_var 1              (c)
-        1    call 1173 ntypeargs=0   (anthropic.AnthropicClient.resolved_base_url)
+        1    call 1174 ntypeargs=0   (anthropic.AnthropicClient.resolved_base_url)
         2    store_var_load_var 4    (_5)
         3    load_const 0            (null)
         4    cmp_op ==               
@@ -8249,7 +8249,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         11   store_var 5             (_10)
         12   load_var 1              (c)
         13   load_field 12           (query_params)
-        14   call 1195 ntypeargs=0   (anthropic.internal._anthropic_query_suffix)
+        14   call 1196 ntypeargs=0   (anthropic.internal._anthropic_query_suffix)
         15   store_var 7             (_14)
         16   load_type 2             
         17   load_var 7              (_14)
@@ -8257,13 +8257,13 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         19   store_var 6             (_13)
 
   779   20   load_var 1              (c)
-        21   call 1196 ntypeargs=0   (anthropic.internal._anthropic_headers)
+        21   call 1197 ntypeargs=0   (anthropic.internal._anthropic_headers)
         22   store_var 8             (_17)
 
   780   23   load_var 1              (c)
-        24   call 1189 ntypeargs=0   (anthropic.internal._anthropic_body_params)
+        24   call 1190 ntypeargs=0   (anthropic.internal._anthropic_body_params)
         25   load_var2 2 3           
-        26   call 1194 ntypeargs=0   (anthropic.internal.anthropic_messages_body)
+        26   call 1195 ntypeargs=0   (anthropic.internal.anthropic_messages_body)
         27   store_var 9             (_18)
 
   776   28   load_const 3            ("POST")
@@ -8360,7 +8360,7 @@ function anthropic.internal._anthropic_sse_failure(message: string) -> ai.errors
   1202   64   load_const 9            ("anthropic")
          65   load_var2 9 10          
          66   load_const 10           (<omitted>)
-         67   call 986 ntypeargs=0    (ai.errors.classify_http)
+         67   call 987 ntypeargs=0    (ai.errors.classify_http)
          68   return                  
 }
 
@@ -8458,7 +8458,7 @@ function anthropic.internal._anthropic_tool_params(toolbox: ai.tools.Toolbox) ->
         2    store_var 2                        (out)
 
   587   3    load_var 1                         (toolbox)
-        4    call 931 ntypeargs=0               (ai.tools.Toolbox.list)
+        4    call 932 ntypeargs=0               (ai.tools.Toolbox.list)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -8519,7 +8519,7 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
          2     store_var 3                        (out)
 
   1033   3     load_var 1                         (batch)
-         4     call 967 ntypeargs=0               (ai.stream.decode_sse_batch)
+         4     call 968 ntypeargs=0               (ai.stream.decode_sse_batch)
          5     load_type 1                        
          6     load_const 2                       ("iter")
          7     virtual_call nargs=1 ntypeargs=0   
@@ -8690,7 +8690,7 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
          155   store_field 6                      (stop_reason_raw)
 
   1157   156   load_var 62                        (s)
-         157   call 1199 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
+         157   call 1200 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
          158   store_var 60                       (stop)
          159   jump +3                            (to 162)
 
@@ -8824,7 +8824,7 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
 
   1118   273   load_field 1                       (index)
 
-  1116   274   call 1204 ntypeargs=0              (anthropic.internal._anth_stream_call_at)
+  1116   274   call 1205 ntypeargs=0              (anthropic.internal._anth_stream_call_at)
          275   store_var 44                       (_136)
          276   load_var 44                        (_136)
          277   narrow_bind 27 44                  
@@ -9132,7 +9132,7 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
   1042   541   load_var 11                        (event)
          542   load_field 6                       (error)
          543   load_var 8                         (data)
-         544   call 1205 ntypeargs=0              (anthropic.internal._anth_stream_failure)
+         544   call 1206 ntypeargs=0              (anthropic.internal._anth_stream_failure)
          545   throw                              
 
   1185   546   load_var 3                         (out)
@@ -9142,17 +9142,17 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
 function anthropic.internal.anthropic_messages_body(params: anthropic.internal.AnthropicBodyParams, input: ai.ModelTurnInput, stream: bool) -> string {
   723   0    load_var2 1 2           
         1    load_var 3              (stream)
-        2    call 1193 ntypeargs=0   (anthropic.internal.anthropic_messages_request)
+        2    call 1194 ntypeargs=0   (anthropic.internal.anthropic_messages_request)
         3    store_var 4             (request)
 
   724   4    load_type 0             
         5    load_var 4              (request)
         6    call 362 ntypeargs=1    (baml.json.to_json)
-        7    call 1179 ntypeargs=0   (anthropic.internal._anth_drop_nulls)
+        7    call 1180 ntypeargs=0   (anthropic.internal._anth_drop_nulls)
 
   725   8    load_var 1              (params)
         9    load_field 8            (request_body)
-        10   call 943 ntypeargs=0    (ai.wire.merge_request_body)
+        10   call 944 ntypeargs=0    (ai.wire.merge_request_body)
         11   call 358 ntypeargs=0    (baml.json.stringify)
         12   return                  
 }
@@ -9163,11 +9163,11 @@ function anthropic.internal.anthropic_messages_request(params: anthropic.interna
         2     store_var 4                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 941 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 942 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 4                         (_5)
         7     call_indirect                      
 
-  631   8     call 1184 ntypeargs=0              (anthropic.internal._anthropic_lower_prompt)
+  631   8     call 1185 ntypeargs=0              (anthropic.internal._anthropic_lower_prompt)
         9     store_var 5                        (lowered_prompt)
 
   632   10    load_var 5                         (lowered_prompt)
@@ -9182,9 +9182,9 @@ function anthropic.internal.anthropic_messages_request(params: anthropic.interna
         17    load_field 1                       (journal)
         18    load_var 1                         (params)
         19    load_field 9                       (client_id)
-        20    call 944 ntypeargs=0               (ai.wire.sanitize_for_client)
+        20    call 945 ntypeargs=0               (ai.wire.sanitize_for_client)
 
-  636   21    call 1187 ntypeargs=0              (anthropic.internal._anthropic_lower_journal)
+  636   21    call 1188 ntypeargs=0              (anthropic.internal._anthropic_lower_journal)
         22    load_type 0                        
         23    load_const 1                       ("iter")
         24    virtual_call nargs=1 ntypeargs=0   
@@ -9305,7 +9305,7 @@ function anthropic.internal.anthropic_messages_request(params: anthropic.interna
         125   load_var 7                         (lowered)
         126   call 7 ntypeargs=1                 (baml.Array.concat)
 
-  667   127   call 1188 ntypeargs=0              (anthropic.internal._anthropic_render_messages)
+  667   127   call 1189 ntypeargs=0              (anthropic.internal._anthropic_render_messages)
         128   store_var 16                       (messages)
 
   668   129   load_var 16                        (messages)
@@ -9340,7 +9340,7 @@ function anthropic.internal.anthropic_messages_request(params: anthropic.interna
 
   684   154   load_var 2                         (input)
         155   load_field 2                       (toolbox)
-        156   call 933 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        156   call 934 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         157   unary_op !                         
         158   store_var_load_var 20              (has_tools)
 
@@ -9354,7 +9354,7 @@ function anthropic.internal.anthropic_messages_request(params: anthropic.interna
 
   686   164   load_var 2                         (input)
         165   load_field 2                       (toolbox)
-        166   call 1190 ntypeargs=0              (anthropic.internal._anthropic_tool_params)
+        166   call 1191 ntypeargs=0              (anthropic.internal._anthropic_tool_params)
         167   store_var 21                       (tool_params)
 
   690   168   load_var 20                        (has_tools)
@@ -9368,7 +9368,7 @@ function anthropic.internal.anthropic_messages_request(params: anthropic.interna
 
   691   174   load_var 1                         (params)
         175   load_field 7                       (tool_choice)
-        176   call 1191 ntypeargs=0              (anthropic.internal._anthropic_tool_choice_param)
+        176   call 1192 ntypeargs=0              (anthropic.internal._anthropic_tool_choice_param)
         177   store_var 22                       (choice)
 
   695   178   load_var 3                         (stream)
@@ -9418,7 +9418,7 @@ function anthropic.internal.anthropic_messages_request(params: anthropic.interna
 
   711   210   load_var 1                         (params)
         211   load_field 6                       (thinking)
-        212   call 1192 ntypeargs=0              (anthropic.internal._anthropic_thinking_param)
+        212   call 1193 ntypeargs=0              (anthropic.internal._anthropic_thinking_param)
         213   store_var 33                       (_86)
 
   700   214   load_var2 24 25                    
@@ -9561,7 +9561,7 @@ function anthropic.internal.anthropic_parse(resp: anthropic.internal.AnthropicRe
         104   jump +5                            (to 109)
         105   load_var 15                        (_44)
 
-  838   106   call 1199 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
+  838   106   call 1200 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
         107   store_var 14                       (stop)
         108   jump +4                            (to 112)
 
@@ -9637,22 +9637,22 @@ function anthropic.internal.anthropic_parse(resp: anthropic.internal.AnthropicRe
 function anthropic.internal.anthropic_render(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> baml.http.Request {
   786   0   load_var2 1 2           
         1   load_const 0            (false)
-        2   call 1197 ntypeargs=0   (anthropic.internal._anthropic_request)
+        2   call 1198 ntypeargs=0   (anthropic.internal._anthropic_request)
         3   return                  
 }
 
 function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   863   0   load_var2 1 2           
         1   load_const 0            (false)
-        2   call 1197 ntypeargs=0   (anthropic.internal._anthropic_request)
+        2   call 1198 ntypeargs=0   (anthropic.internal._anthropic_request)
         3   store_var 3             (req)
 
   864   4   load_type 1             
         5   load_var 3              (req)
         6   load_const 2            ("anthropic")
-        7   call 940 ntypeargs=1    (ai.wire.send_as)
+        7   call 941 ntypeargs=1    (ai.wire.send_as)
 
-  865   8   call 1200 ntypeargs=0   (anthropic.internal.anthropic_parse)
+  865   8   call 1201 ntypeargs=0   (anthropic.internal.anthropic_parse)
         9   return                  
 }
 
@@ -9663,7 +9663,7 @@ function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: a
 
   1220   3    load_var2 1 2           
          4    load_const 0            (true)
-         5    call 1197 ntypeargs=0   (anthropic.internal._anthropic_request)
+         5    call 1198 ntypeargs=0   (anthropic.internal._anthropic_request)
 
   1221   6    sys_op 259              (baml.http.fetch_sse)
          7    store_var 3             (sse)
@@ -9699,18 +9699,18 @@ function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: a
 
   1222   34   load_var 4              (e)
          35   load_field 0            (message)
-         36   call 1207 ntypeargs=0   (anthropic.internal._anthropic_sse_failure)
+         36   call 1208 ntypeargs=0   (anthropic.internal._anthropic_sse_failure)
          37   throw                   
 
-  1231   38   call 1202 ntypeargs=0   (anthropic.internal.AnthStreamState.new)
+  1231   38   call 1203 ntypeargs=0   (anthropic.internal.AnthStreamState.new)
          39   store_deref 7           
 
   1238   40   load_var2 3 7           
 
-  1239   41   make_closure 3297 1     
+  1239   41   make_closure 3298 1     
          42   load_const 8            ("anthropic")
 
-  1237   43   call 968 ntypeargs=0    (ai.stream.TurnStream.from_sse)
+  1237   43   call 969 ntypeargs=0    (ai.stream.TurnStream.from_sse)
          44   return                  
 }
 
@@ -9808,14 +9808,14 @@ function assert.equal(actual: unknown, expected: unknown) -> void {
        6    jump +23               (to 29)
 
   57   7    load_var 1             (actual)
-       8    call 907 ntypeargs=0   (assert.format_operand)
+       8    call 908 ntypeargs=0   (assert.format_operand)
        9    store_var 4            (_9)
        10   load_type 1            
        11   load_var 4             (_9)
        12   call 145 ntypeargs=1   (baml.String.from)
        13   store_var 3            (_8)
        14   load_var 2             (expected)
-       15   call 907 ntypeargs=0   (assert.format_operand)
+       15   call 908 ntypeargs=0   (assert.format_operand)
        16   store_var 6            (_12)
        17   load_type 1            
        18   load_var 6             (_12)
@@ -9933,13 +9933,13 @@ function aws.BedrockClient.ai.Client.id(self: aws.BedrockClient) -> string {
 
 function aws.BedrockClient.ai.Client.invoke(self: aws.BedrockClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   150   0   load_var2 1 2           
-        1   call 1336 ntypeargs=0   (aws.internal.invoke)
+        1   call 1337 ntypeargs=0   (aws.internal.invoke)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   151   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
@@ -10082,12 +10082,12 @@ function aws.BedrockClient.resolved_endpoint_url(self: aws.BedrockClient) -> str
   141   0   load_var 1             (self)
         1   load_field 6           (endpoint_url)
         2   load_const 0           (null)
-        3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4   return                 
 }
 
 function aws.internal.ContentBlock.of_audio(audio: aws.internal.AudioBlock) -> aws.internal.ContentBlock {
-  175   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  175   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 2                      (_2)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 2                       (_2)
@@ -10100,7 +10100,7 @@ function aws.internal.ContentBlock.of_audio(audio: aws.internal.AudioBlock) -> a
 }
 
 function aws.internal.ContentBlock.of_cache_point() -> aws.internal.ContentBlock {
-  187   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  187   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 1                      (_1)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 1                       (_1)
@@ -10112,7 +10112,7 @@ function aws.internal.ContentBlock.of_cache_point() -> aws.internal.ContentBlock
 }
 
 function aws.internal.ContentBlock.of_document(document: aws.internal.DocumentBlock) -> aws.internal.ContentBlock {
-  171   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  171   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 2                      (_2)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 2                       (_2)
@@ -10125,7 +10125,7 @@ function aws.internal.ContentBlock.of_document(document: aws.internal.DocumentBl
 }
 
 function aws.internal.ContentBlock.of_image(image: aws.internal.ImageBlock) -> aws.internal.ContentBlock {
-  163   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  163   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 2                      (_2)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 2                       (_2)
@@ -10138,7 +10138,7 @@ function aws.internal.ContentBlock.of_image(image: aws.internal.ImageBlock) -> a
 }
 
 function aws.internal.ContentBlock.of_text(text: string) -> aws.internal.ContentBlock {
-  159   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  159   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 2                      (_2)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 1                       (text)
@@ -10149,7 +10149,7 @@ function aws.internal.ContentBlock.of_text(text: string) -> aws.internal.Content
 }
 
 function aws.internal.ContentBlock.of_tool_result(tool_result: aws.internal.ToolResultBlock) -> aws.internal.ContentBlock {
-  183   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  183   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 2                      (_2)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 2                       (_2)
@@ -10162,7 +10162,7 @@ function aws.internal.ContentBlock.of_tool_result(tool_result: aws.internal.Tool
 }
 
 function aws.internal.ContentBlock.of_tool_use(tool_use: aws.internal.ToolUseBlock) -> aws.internal.ContentBlock {
-  179   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  179   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 2                      (_2)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 2                       (_2)
@@ -10175,7 +10175,7 @@ function aws.internal.ContentBlock.of_tool_use(tool_use: aws.internal.ToolUseBlo
 }
 
 function aws.internal.ContentBlock.of_video(video: aws.internal.VideoBlock) -> aws.internal.ContentBlock {
-  167   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  167   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 2                      (_2)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 2                       (_2)
@@ -10267,7 +10267,7 @@ function aws.internal._apply_query(url: string, params: map<string, string> | nu
          25    load_var 5                         (_10)
          26    store_var_load_var 6               (name)
 
-  1082   27    call 1285 ntypeargs=0              (aws.internal.encode_path_label)
+  1082   27    call 1286 ntypeargs=0              (aws.internal.encode_path_label)
          28    store_var 8                        (_18)
          29    load_type 1                        
          30    load_var 8                         (_18)
@@ -10284,7 +10284,7 @@ function aws.internal._apply_query(url: string, params: map<string, string> | nu
          41    load_const 7                       ("")
          42    store_var 11                       (_24)
          43    load_var 11                        (_24)
-         44    call 1285 ntypeargs=0              (aws.internal.encode_path_label)
+         44    call 1286 ntypeargs=0              (aws.internal.encode_path_label)
          45    store_var 10                       (_22)
          46    load_type 1                        
          47    load_var 10                        (_22)
@@ -10418,7 +10418,7 @@ function aws.internal._assistant_content(content: (ai.content.Text | ai.content.
         43   load_field 2                       (args)
         44   init_instance 0                    (aws.internal.ToolUseBlock .toolUseId, .name, .input)
 
-  700   45   call 1292 ntypeargs=0              (aws.internal.ContentBlock.of_tool_use)
+  700   45   call 1293 ntypeargs=0              (aws.internal.ContentBlock.of_tool_use)
         46   store_var 11                       (_18)
 
   699   47   load_type 0                        
@@ -10430,7 +10430,7 @@ function aws.internal._assistant_content(content: (ai.content.Text | ai.content.
   685   52   load_var 6                         (_8)
         53   load_field 0                       (text)
 
-  687   54   call 1287 ntypeargs=0              (aws.internal.ContentBlock.of_text)
+  687   54   call 1288 ntypeargs=0              (aws.internal.ContentBlock.of_text)
         55   store_var 7                        (_11)
         56   load_type 0                        
         57   load_var2 2 7                      
@@ -10445,24 +10445,24 @@ function aws.internal._assistant_content(content: (ai.content.Text | ai.content.
 function aws.internal._audio_block(audio: baml.media.Audio) -> aws.internal.ContentBlock {
   518   0    load_var 1              (audio)
         1    call 336 ntypeargs=0    (baml.media.Audio.url)
-        2    call 1304 ntypeargs=0   (aws.internal._is_s3_url)
+        2    call 1305 ntypeargs=0   (aws.internal._is_s3_url)
         3    store_var 3             (_4)
         4    load_var2 1 3           
         5    unary_op !              
-        6    call 942 ntypeargs=0    (ai.wire.resolve_media)
+        6    call 943 ntypeargs=0    (ai.wire.resolve_media)
         7    store_var 2             (resolved)
 
   521   8    load_var 2              (resolved)
         9    load_field 2            (mime_type)
-        10   call 1307 ntypeargs=0   (aws.internal._audio_format)
+        10   call 1308 ntypeargs=0   (aws.internal._audio_format)
 
   522   11   load_var 2              (resolved)
         12   load_const 0            ("audio")
-        13   call 1308 ntypeargs=0   (aws.internal._media_source)
+        13   call 1309 ntypeargs=0   (aws.internal._media_source)
 
   520   14   init_instance 0         (aws.internal.AudioBlock .format, .source)
 
-  519   15   call 1291 ntypeargs=0   (aws.internal.ContentBlock.of_audio)
+  519   15   call 1292 ntypeargs=0   (aws.internal.ContentBlock.of_audio)
         16   return                  
 }
 
@@ -10555,7 +10555,7 @@ function aws.internal._audio_format(mime: string) -> string {
         84    load_const 21           ("unsupported audio format for Bedrock: ")
         85    load_var 2              (_24)
         86    bin_op +                
-        87    call 1303 ntypeargs=0   (aws.internal._reject)
+        87    call 1304 ntypeargs=0   (aws.internal._reject)
         88    throw                   
 
   456   89    load_const 22           ("webm")
@@ -10656,11 +10656,11 @@ function aws.internal._conversation_role(role: string) -> string {
 function aws.internal._document_block(pdf: baml.media.Pdf) -> aws.internal.ContentBlock {
   499   0    load_var 1              (pdf)
         1    call 329 ntypeargs=0    (baml.media.Pdf.url)
-        2    call 1304 ntypeargs=0   (aws.internal._is_s3_url)
+        2    call 1305 ntypeargs=0   (aws.internal._is_s3_url)
         3    store_var 3             (_4)
         4    load_var2 1 3           
         5    unary_op !              
-        6    call 942 ntypeargs=0    (ai.wire.resolve_media)
+        6    call 943 ntypeargs=0    (ai.wire.resolve_media)
         7    store_var 2             (resolved)
 
   500   8    load_var 2              (resolved)
@@ -10672,7 +10672,7 @@ function aws.internal._document_block(pdf: baml.media.Pdf) -> aws.internal.Conte
 
   509   14   load_var 2              (resolved)
         15   load_const 1            ("document")
-        16   call 1308 ntypeargs=0   (aws.internal._media_source)
+        16   call 1309 ntypeargs=0   (aws.internal._media_source)
         17   store_var 5             (_14)
 
   504   18   load_const 2            ("pdf")
@@ -10680,7 +10680,7 @@ function aws.internal._document_block(pdf: baml.media.Pdf) -> aws.internal.Conte
         20   load_var 5              (_14)
         21   init_instance 0         (aws.internal.DocumentBlock .format, .name, .source)
 
-  503   22   call 1290 ntypeargs=0   (aws.internal.ContentBlock.of_document)
+  503   22   call 1291 ntypeargs=0   (aws.internal.ContentBlock.of_document)
         23   return                  
 
   501   24   load_type 4             
@@ -10691,7 +10691,7 @@ function aws.internal._document_block(pdf: baml.media.Pdf) -> aws.internal.Conte
         29   load_const 5            ("unsupported document format for Bedrock: ")
         30   load_var 4              (_10)
         31   bin_op +                
-        32   call 1303 ntypeargs=0   (aws.internal._reject)
+        32   call 1304 ntypeargs=0   (aws.internal._reject)
         33   throw                   
 }
 
@@ -10711,24 +10711,24 @@ function aws.internal._empty_content_block() -> aws.internal.ContentBlock {
 function aws.internal._image_block(image: baml.media.Image) -> aws.internal.ContentBlock {
   477   0    load_var 1              (image)
         1    call 350 ntypeargs=0    (baml.media.Image.url)
-        2    call 1304 ntypeargs=0   (aws.internal._is_s3_url)
+        2    call 1305 ntypeargs=0   (aws.internal._is_s3_url)
         3    store_var 3             (_4)
         4    load_var2 1 3           
         5    unary_op !              
-        6    call 942 ntypeargs=0    (ai.wire.resolve_media)
+        6    call 943 ntypeargs=0    (ai.wire.resolve_media)
         7    store_var 2             (resolved)
 
   480   8    load_var 2              (resolved)
         9    load_field 2            (mime_type)
-        10   call 1305 ntypeargs=0   (aws.internal._image_format)
+        10   call 1306 ntypeargs=0   (aws.internal._image_format)
 
   481   11   load_var 2              (resolved)
         12   load_const 0            ("image")
-        13   call 1308 ntypeargs=0   (aws.internal._media_source)
+        13   call 1309 ntypeargs=0   (aws.internal._media_source)
 
   479   14   init_instance 0         (aws.internal.ImageBlock .format, .source)
 
-  478   15   call 1288 ntypeargs=0   (aws.internal.ContentBlock.of_image)
+  478   15   call 1289 ntypeargs=0   (aws.internal.ContentBlock.of_image)
         16   return                  
 }
 
@@ -10761,7 +10761,7 @@ function aws.internal._image_format(mime: string) -> string {
         24   load_const 6            ("unsupported image format for Bedrock: ")
         25   load_var 2              (_9)
         26   bin_op +                
-        27   call 1303 ntypeargs=0   (aws.internal._reject)
+        27   call 1304 ntypeargs=0   (aws.internal._reject)
         28   throw                   
 
   415   29   load_const 7            ("webp")
@@ -10893,7 +10893,7 @@ function aws.internal._inference_config(client: aws.BedrockClient) -> aws.intern
         84   load_const 5            (" is out of the supported range (0..=2147483647)")
         85   bin_op +                
 
-  871   86   call 1303 ntypeargs=0   (aws.internal._reject)
+  871   86   call 1304 ntypeargs=0   (aws.internal._reject)
         87   throw                   
 }
 
@@ -11018,7 +11018,7 @@ function aws.internal._lower_journal(journal: ai.Journal, with_status: bool) -> 
         2     store_var 3                        (pending)
 
   764   3     load_var 1                         (journal)
-        4     call 914 ntypeargs=0               (ai.Journal.entries)
+        4     call 915 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -11067,7 +11067,7 @@ function aws.internal._lower_journal(journal: ai.Journal, with_status: bool) -> 
         48    load_field 1                       (message)
         49    load_const 10                      (true)
         50    load_var 2                         (with_status)
-        51    call 1320 ntypeargs=0              (aws.internal._push_tool_result)
+        51    call 1321 ntypeargs=0              (aws.internal._push_tool_result)
         52    pop 1                              
         53    jump -44                           (to 9)
 
@@ -11080,14 +11080,14 @@ function aws.internal._lower_journal(journal: ai.Journal, with_status: bool) -> 
         59    load_field 1                       (output)
         60    load_const 11                      (false)
         61    load_var 2                         (with_status)
-        62    call 1320 ntypeargs=0              (aws.internal._push_tool_result)
+        62    call 1321 ntypeargs=0              (aws.internal._push_tool_result)
         63    pop 1                              
         64    jump -55                           (to 9)
 
   765   65    load_var 9                         (_19)
         66    load_field 0                       (content)
 
-  779   67    call 1318 ntypeargs=0              (aws.internal._assistant_content)
+  779   67    call 1319 ntypeargs=0              (aws.internal._assistant_content)
         68    store_var 10                       (content)
 
   787   69    load_var 10                        (content)
@@ -11114,7 +11114,7 @@ function aws.internal._lower_journal(journal: ai.Journal, with_status: bool) -> 
   765   86    load_var 7                         (_10)
         87    load_field 0                       (content)
 
-  771   88    call 1287 ntypeargs=0              (aws.internal.ContentBlock.of_text)
+  771   88    call 1288 ntypeargs=0              (aws.internal.ContentBlock.of_text)
         89    store_var 8                        (_16)
 
   767   90    load_type 0                        
@@ -11175,7 +11175,7 @@ function aws.internal._lower_prompt(prompt: ai.Prompt) -> aws.internal.BedrockPr
         5    store_var 3                        (messages)
 
   642   6    load_var 1                         (prompt)
-        7    call 919 ntypeargs=0               (ai.Prompt.messages)
+        7    call 920 ntypeargs=0               (ai.Prompt.messages)
         8    load_type 2                        
         9    load_const 3                       ("iter")
         10   virtual_call nargs=1 ntypeargs=0   
@@ -11199,7 +11199,7 @@ function aws.internal._lower_prompt(prompt: ai.Prompt) -> aws.internal.BedrockPr
         27   jump +31                           (to 58)
 
   652   28   load_var 6                         (message)
-        29   call 1313 ntypeargs=0              (aws.internal._prompt_content)
+        29   call 1314 ntypeargs=0              (aws.internal._prompt_content)
         30   store_var 10                       (content)
 
   656   31   load_var 10                        (content)
@@ -11211,10 +11211,10 @@ function aws.internal._lower_prompt(prompt: ai.Prompt) -> aws.internal.BedrockPr
         37   pop_jump_if_false -25              (to 12)
 
   657   38   load_var 6                         (message)
-        39   call 1315 ntypeargs=0              (aws.internal._wants_cache_point)
+        39   call 1316 ntypeargs=0              (aws.internal._wants_cache_point)
         40   pop_jump_if_false +7               (to 47)
 
-  658   41   call 1294 ntypeargs=0              (aws.internal.ContentBlock.of_cache_point)
+  658   41   call 1295 ntypeargs=0              (aws.internal.ContentBlock.of_cache_point)
         42   store_var 12                       (_34)
         43   load_type 9                        
         44   load_var2 10 12                    
@@ -11223,7 +11223,7 @@ function aws.internal._lower_prompt(prompt: ai.Prompt) -> aws.internal.BedrockPr
 
   660   47   load_var 6                         (message)
         48   load_field 0                       (role)
-        49   call 1316 ntypeargs=0              (aws.internal._conversation_role)
+        49   call 1317 ntypeargs=0              (aws.internal._conversation_role)
         50   store_var 13                       (_38)
         51   load_type 1                        
         52   load_var2 3 13                     
@@ -11234,7 +11234,7 @@ function aws.internal._lower_prompt(prompt: ai.Prompt) -> aws.internal.BedrockPr
         57   jump -45                           (to 12)
 
   644   58   load_var 6                         (message)
-        59   call 1314 ntypeargs=0              (aws.internal._prompt_system)
+        59   call 1315 ntypeargs=0              (aws.internal._prompt_system)
         60   load_type 10                       
         61   load_const 11                      ("iter")
         62   virtual_call nargs=1 ntypeargs=0   
@@ -11256,10 +11256,10 @@ function aws.internal._lower_prompt(prompt: ai.Prompt) -> aws.internal.BedrockPr
         77   jump -13                           (to 64)
 
   647   78   load_var 6                         (message)
-        79   call 1315 ntypeargs=0              (aws.internal._wants_cache_point)
+        79   call 1316 ntypeargs=0              (aws.internal._wants_cache_point)
         80   pop_jump_if_false -68              (to 12)
 
-  648   81   call 1297 ntypeargs=0              (aws.internal.SystemContentBlock.of_cache_point)
+  648   81   call 1298 ntypeargs=0              (aws.internal.SystemContentBlock.of_cache_point)
         82   store_var 9                        (_25)
         83   load_type 0                        
         84   load_var2 2 9                      
@@ -11298,7 +11298,7 @@ function aws.internal._media_source(resolved: ai.wire.ResolvedMedia, kind: strin
         20   bin_op +                
         21   load_const 3            (" content could not be resolved")
         22   bin_op +                
-        23   call 1303 ntypeargs=0   (aws.internal._reject)
+        23   call 1304 ntypeargs=0   (aws.internal._reject)
         24   throw                   
 
   467   25   load_var 4              (_8)
@@ -11325,7 +11325,7 @@ function aws.internal._media_source(resolved: ai.wire.ResolvedMedia, kind: strin
         44   bin_op +                
         45   load_var 7              (_19)
         46   bin_op +                
-        47   call 1303 ntypeargs=0   (aws.internal._reject)
+        47   call 1304 ntypeargs=0   (aws.internal._reject)
         48   throw                   
 
   469   49   load_const 7            (null)
@@ -11580,7 +11580,7 @@ function aws.internal._prompt_content(message: ai.PromptMessage) -> aws.internal
         43   jump +9                            (to 52)
         44   load_var 5                         (part)
 
-  566   45   call 1311 ntypeargs=0              (aws.internal._document_block)
+  566   45   call 1312 ntypeargs=0              (aws.internal._document_block)
         46   store_var 15                       (_37)
         47   load_type 0                        
         48   load_var2 2 15                     
@@ -11590,7 +11590,7 @@ function aws.internal._prompt_content(message: ai.PromptMessage) -> aws.internal
 
   542   52   load_var 13                        (_29)
 
-  562   53   call 1310 ntypeargs=0              (aws.internal._video_block)
+  562   53   call 1311 ntypeargs=0              (aws.internal._video_block)
         54   store_var 14                       (_32)
         55   load_type 0                        
         56   load_var2 2 14                     
@@ -11600,7 +11600,7 @@ function aws.internal._prompt_content(message: ai.PromptMessage) -> aws.internal
 
   542   60   load_var 11                        (_23)
 
-  558   61   call 1312 ntypeargs=0              (aws.internal._audio_block)
+  558   61   call 1313 ntypeargs=0              (aws.internal._audio_block)
         62   store_var 12                       (_26)
         63   load_type 0                        
         64   load_var2 2 12                     
@@ -11610,7 +11610,7 @@ function aws.internal._prompt_content(message: ai.PromptMessage) -> aws.internal
 
   542   68   load_var 9                         (_17)
 
-  554   69   call 1309 ntypeargs=0              (aws.internal._image_block)
+  554   69   call 1310 ntypeargs=0              (aws.internal._image_block)
         70   store_var 10                       (_20)
         71   load_type 0                        
         72   load_var2 2 10                     
@@ -11628,7 +11628,7 @@ function aws.internal._prompt_content(message: ai.PromptMessage) -> aws.internal
         82   pop_jump_if_false -73              (to 9)
 
   549   83   load_var 7                         (text)
-        84   call 1287 ntypeargs=0              (aws.internal.ContentBlock.of_text)
+        84   call 1288 ntypeargs=0              (aws.internal.ContentBlock.of_text)
         85   store_var 8                        (_14)
         86   load_type 0                        
         87   load_var2 2 8                      
@@ -11669,7 +11669,7 @@ function aws.internal._prompt_system(message: ai.PromptMessage) -> aws.internal.
         23   jump +4                            (to 27)
 
   589   24   load_const 7                       ("Bedrock system messages do not support media content")
-        25   call 1303 ntypeargs=0              (aws.internal._reject)
+        25   call 1304 ntypeargs=0              (aws.internal._reject)
         26   throw                              
 
   579   27   load_var 5                         (_9)
@@ -11682,7 +11682,7 @@ function aws.internal._prompt_system(message: ai.PromptMessage) -> aws.internal.
         33   pop_jump_if_false -24              (to 9)
 
   584   34   load_var 6                         (text)
-        35   call 1296 ntypeargs=0              (aws.internal.SystemContentBlock.of_text)
+        35   call 1297 ntypeargs=0              (aws.internal.SystemContentBlock.of_text)
         36   store_var 7                        (_14)
         37   load_type 0                        
         38   load_var2 2 7                      
@@ -11733,7 +11733,7 @@ function aws.internal._prune_nulls(value: baml.json.json) -> baml.json.json {
         30   jump +9                            (to 39)
         31   load_var 13                        (_36)
 
-  365   32   call 1302 ntypeargs=0              (aws.internal._prune_nulls)
+  365   32   call 1303 ntypeargs=0              (aws.internal._prune_nulls)
         33   store_var 14                       (_41)
         34   load_type 2                        
         35   load_var2 11 14                    
@@ -11785,12 +11785,12 @@ function aws.internal._prune_nulls(value: baml.json.json) -> baml.json.json {
         75   jump -20                           (to 55)
 
   350   76   load_var 7                         (key)
-        77   call 1301 ntypeargs=0              (aws.internal._is_opaque_key)
+        77   call 1302 ntypeargs=0              (aws.internal._is_opaque_key)
         78   pop_jump_if_false +2               (to 80)
         79   jump +11                           (to 90)
 
   354   80   load_var 8                         (member)
-        81   call 1302 ntypeargs=0              (aws.internal._prune_nulls)
+        81   call 1303 ntypeargs=0              (aws.internal._prune_nulls)
         82   store_var 9                        (_27)
         83   load_type 8                        
         84   load_type 2                        
@@ -11844,7 +11844,7 @@ function aws.internal._push_tool_result(pending: aws.internal.PendingMessage[], 
   745   19   load_var 6              (status)
         20   init_instance 1         (aws.internal.ToolResultBlock .toolUseId, .content, .status)
 
-  741   21   call 1293 ntypeargs=0   (aws.internal.ContentBlock.of_tool_result)
+  741   21   call 1294 ntypeargs=0   (aws.internal.ContentBlock.of_tool_result)
         22   store_var 7             (block)
 
   749   23   load_var 1              (pending)
@@ -11947,7 +11947,7 @@ function aws.internal._system_as_user(system: aws.internal.SystemContentBlock[])
         22   pop_jump_if_false +2               (to 24)
         23   jump +8                            (to 31)
 
-  911   24   call 1294 ntypeargs=0              (aws.internal.ContentBlock.of_cache_point)
+  911   24   call 1295 ntypeargs=0              (aws.internal.ContentBlock.of_cache_point)
         25   store_var 7                        (_16)
         26   load_type 0                        
         27   load_var2 2 7                      
@@ -11957,7 +11957,7 @@ function aws.internal._system_as_user(system: aws.internal.SystemContentBlock[])
 
   907   31   load_var 5                         (_9)
 
-  908   32   call 1287 ntypeargs=0              (aws.internal.ContentBlock.of_text)
+  908   32   call 1288 ntypeargs=0              (aws.internal.ContentBlock.of_text)
         33   store_var 6                        (_12)
         34   load_type 0                        
         35   load_var2 2 6                      
@@ -12021,7 +12021,7 @@ function aws.internal._tool_choice(choice: string) -> aws.internal.ToolChoice {
 
 function aws.internal._tool_config(toolbox: ai.tools.Toolbox, tool_choice: string | null, cache_tools: bool) -> aws.internal.ToolConfig | null {
   833   0    load_var 1                         (toolbox)
-        1    call 933 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        1    call 934 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         2    pop_jump_if_false +2               (to 4)
         3    jump +65                           (to 68)
 
@@ -12030,7 +12030,7 @@ function aws.internal._tool_config(toolbox: ai.tools.Toolbox, tool_choice: strin
         6    store_var 4                        (entries)
 
   837   7    load_var 1                         (toolbox)
-        8    call 931 ntypeargs=0               (ai.tools.Toolbox.list)
+        8    call 932 ntypeargs=0               (ai.tools.Toolbox.list)
         9    load_type 1                        
         10   load_const 2                       ("iter")
         11   virtual_call nargs=1 ntypeargs=0   
@@ -12067,7 +12067,7 @@ function aws.internal._tool_config(toolbox: ai.tools.Toolbox, tool_choice: strin
         37   init_instance 0                    (aws.internal.ToolInputSchema .json_schema)
         38   init_instance 1                    (aws.internal.ToolSpec .name, .description, .inputSchema)
 
-  839   39   call 1299 ntypeargs=0              (aws.internal.ToolEntry.of_spec)
+  839   39   call 1300 ntypeargs=0              (aws.internal.ToolEntry.of_spec)
         40   store_var 8                        (_13)
 
   838   41   load_type 0                        
@@ -12079,7 +12079,7 @@ function aws.internal._tool_config(toolbox: ai.tools.Toolbox, tool_choice: strin
   848   46   load_var 3                         (cache_tools)
         47   pop_jump_if_false +7               (to 54)
 
-  849   48   call 1300 ntypeargs=0              (aws.internal.ToolEntry.of_cache_point)
+  849   48   call 1301 ntypeargs=0              (aws.internal.ToolEntry.of_cache_point)
         49   store_var 12                       (_23)
         50   load_type 0                        
         51   load_var2 4 12                     
@@ -12093,7 +12093,7 @@ function aws.internal._tool_config(toolbox: ai.tools.Toolbox, tool_choice: strin
         58   jump +5                            (to 63)
 
   856   59   load_var 2                         (tool_choice)
-        60   call 1322 ntypeargs=0              (aws.internal._tool_choice)
+        60   call 1323 ntypeargs=0              (aws.internal._tool_choice)
         61   store_var 13                       (selection)
         62   jump +3                            (to 65)
 
@@ -12111,20 +12111,20 @@ function aws.internal._tool_config(toolbox: ai.tools.Toolbox, tool_choice: strin
 function aws.internal._video_block(video: baml.media.Video) -> aws.internal.ContentBlock {
   489   0    load_var 1              (video)
         1    load_const 0            (false)
-        2    call 942 ntypeargs=0    (ai.wire.resolve_media)
+        2    call 943 ntypeargs=0    (ai.wire.resolve_media)
         3    store_var 2             (resolved)
 
   492   4    load_var 2              (resolved)
         5    load_field 2            (mime_type)
-        6    call 1306 ntypeargs=0   (aws.internal._video_format)
+        6    call 1307 ntypeargs=0   (aws.internal._video_format)
 
   493   7    load_var 2              (resolved)
         8    load_const 1            ("video")
-        9    call 1308 ntypeargs=0   (aws.internal._media_source)
+        9    call 1309 ntypeargs=0   (aws.internal._media_source)
 
   491   10   init_instance 0         (aws.internal.VideoBlock .format, .source)
 
-  490   11   call 1289 ntypeargs=0   (aws.internal.ContentBlock.of_video)
+  490   11   call 1290 ntypeargs=0   (aws.internal.ContentBlock.of_video)
         12   return                  
 }
 
@@ -12181,7 +12181,7 @@ function aws.internal._video_format(mime: string) -> string {
         48   load_const 12           ("unsupported video format for Bedrock: ")
         49   load_var 2              (_15)
         50   bin_op +                
-        51   call 1303 ntypeargs=0   (aws.internal._reject)
+        51   call 1304 ntypeargs=0   (aws.internal._reject)
         52   throw                   
 
   433   53   load_const 13           ("three_gp")
@@ -12250,23 +12250,23 @@ function aws.internal._wants_cache_point(message: ai.PromptMessage) -> bool {
 
 function aws.internal.build_request(client: aws.BedrockClient, input: ai.ModelTurnInput) -> baml.http.Request {
   1101   0    load_var2 1 2           
-         1    call 1327 ntypeargs=0   (aws.internal.converse_request)
+         1    call 1328 ntypeargs=0   (aws.internal.converse_request)
          2    store_var 3             (_5)
          3    load_type 0             
          4    load_var 3              (_5)
          5    call 362 ntypeargs=1    (baml.json.to_json)
-         6    call 1302 ntypeargs=0   (aws.internal._prune_nulls)
+         6    call 1303 ntypeargs=0   (aws.internal._prune_nulls)
 
   1102   7    load_var 1              (client)
          8    load_field 15           (request_body)
-         9    call 943 ntypeargs=0    (ai.wire.merge_request_body)
+         9    call 944 ntypeargs=0    (ai.wire.merge_request_body)
          10   store_var 4             (merged)
 
   1105   11   load_var 1              (client)
-         12   call 1328 ntypeargs=0   (aws.internal.converse_url)
+         12   call 1329 ntypeargs=0   (aws.internal.converse_url)
          13   load_var 1              (client)
          14   load_field 17           (query_params)
-         15   call 1330 ntypeargs=0   (aws.internal._apply_query)
+         15   call 1331 ntypeargs=0   (aws.internal._apply_query)
          16   store_var 5             (_10)
 
   1107   17   load_const 1            ("application/json")
@@ -12280,7 +12280,7 @@ function aws.internal.build_request(client: aws.BedrockClient, input: ai.ModelTu
   1108   24   load_var 1              (client)
          25   load_field 16           (headers)
 
-  1106   26   call 1329 ntypeargs=0   (aws.internal._merge_headers)
+  1106   26   call 1330 ntypeargs=0   (aws.internal._merge_headers)
          27   store_var 6             (_13)
 
   1110   28   load_var 4              (merged)
@@ -12296,7 +12296,7 @@ function aws.internal.build_request(client: aws.BedrockClient, input: ai.ModelTu
 
 function aws.internal.converse_model_path(model_id: string) -> string {
   72   0    load_var 1              (model_id)
-       1    call 1285 ntypeargs=0   (aws.internal.encode_path_label)
+       1    call 1286 ntypeargs=0   (aws.internal.encode_path_label)
        2    store_var 3             (_4)
        3    load_type 0             
        4    load_var 3              (_4)
@@ -12316,10 +12316,10 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
          2     store_var 4                        (_5)
          3     load_var 2                         (input)
          4     load_field 3                       (output_type)
-         5     call 941 ntypeargs=0               (ai.wire.render_output_format)
+         5     call 942 ntypeargs=0               (ai.wire.render_output_format)
          6     load_var 4                         (_5)
          7     call_indirect                      
-         8     call 1317 ntypeargs=0              (aws.internal._lower_prompt)
+         8     call 1318 ntypeargs=0              (aws.internal._lower_prompt)
          9     store_var 3                        (prompt)
 
   952    10    load_var 3                         (prompt)
@@ -12338,7 +12338,7 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
          22    cmp_int_op >                       
          23    pop_jump_if_false +7               (to 30)
 
-  954    24    call 1297 ntypeargs=0              (aws.internal.SystemContentBlock.of_cache_point)
+  954    24    call 1298 ntypeargs=0              (aws.internal.SystemContentBlock.of_cache_point)
          25    store_var 7                        (_13)
          26    load_type 1                        
          27    load_var2 5 7                      
@@ -12358,16 +12358,16 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
          39    virtual_call nargs=1 ntypeargs=0   
          40    store_var 11                       (_19)
          41    load_var2 10 11                    
-         42    call 944 ntypeargs=0               (ai.wire.sanitize_for_client)
+         42    call 945 ntypeargs=0               (ai.wire.sanitize_for_client)
          43    store_var 9                        (_17)
 
   959    44    load_var 1                         (client)
          45    load_field 0                       (model)
-         46    call 1319 ntypeargs=0              (aws.internal._supports_tool_result_status)
+         46    call 1320 ntypeargs=0              (aws.internal._supports_tool_result_status)
          47    store_var 12                       (_20)
 
   957    48    load_var2 9 12                     
-         49    call 1321 ntypeargs=0              (aws.internal._lower_journal)
+         49    call 1322 ntypeargs=0              (aws.internal._lower_journal)
 
   961    50    load_type 4                        
          51    load_const 5                       ("iter")
@@ -12460,7 +12460,7 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
   980    130   jump +24                           (to 154)
 
   981    131   load_const 14                      ("(continue)")
-         132   call 1287 ntypeargs=0              (aws.internal.ContentBlock.of_text)
+         132   call 1288 ntypeargs=0              (aws.internal.ContentBlock.of_text)
          133   store_var 23                       (_62)
          134   load_type 9                        
          135   load_const 15                      ("user")
@@ -12477,7 +12477,7 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
          144   jump +10                           (to 154)
 
   979    145   load_var 5                         (system)
-         146   call 1325 ntypeargs=0              (aws.internal._system_as_user)
+         146   call 1326 ntypeargs=0              (aws.internal._system_as_user)
          147   store_var 22                       (_54)
          148   load_type 9                        
          149   load_var 22                        (_54)
@@ -12486,7 +12486,7 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
          152   load_var 8                         (messages)
          153   call 7 ntypeargs=1                 (baml.Array.concat)
 
-  977    154   call 1326 ntypeargs=0              (aws.internal._merge_adjacent_roles)
+  977    154   call 1327 ntypeargs=0              (aws.internal._merge_adjacent_roles)
          155   store_var 21                       (wire_messages)
 
   988    156   load_var 21                        (wire_messages)
@@ -12520,7 +12520,7 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
   999    179   store_var 26                       (_73)
 
   1000   180   load_var 1                         (client)
-         181   call 1324 ntypeargs=0              (aws.internal._inference_config)
+         181   call 1325 ntypeargs=0              (aws.internal._inference_config)
          182   store_var 27                       (_74)
 
   1001   183   load_var 2                         (input)
@@ -12529,7 +12529,7 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
          186   load_field 11                      (tool_choice)
          187   load_var 1                         (client)
          188   load_field 13                      (cache_tools)
-         189   call 1323 ntypeargs=0              (aws.internal._tool_config)
+         189   call 1324 ntypeargs=0              (aws.internal._tool_config)
          190   store_var 28                       (_75)
 
   998    191   load_var2 21 26                    
@@ -12541,18 +12541,18 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
          196   return                             
 
   989    197   load_const 17                      ("the rendered prompt and journal produced no message content")
-         198   call 1303 ntypeargs=0              (aws.internal._reject)
+         198   call 1304 ntypeargs=0              (aws.internal._reject)
          199   throw                              
 }
 
 function aws.internal.converse_url(client: aws.BedrockClient) -> string {
   1010   0     load_var 1              (client)
          1     load_field 0            (model)
-         2     call 1286 ntypeargs=0   (aws.internal.converse_model_path)
+         2     call 1287 ntypeargs=0   (aws.internal.converse_model_path)
          3     store_var 2             (path)
 
   1011   4     load_var 1              (client)
-         5     call 1281 ntypeargs=0   (aws.BedrockClient.resolved_endpoint_url)
+         5     call 1282 ntypeargs=0   (aws.BedrockClient.resolved_endpoint_url)
          6     store_var 3             (_5)
          7     load_var 3              (_5)
          8     narrow_bind 0 3         
@@ -12570,7 +12570,7 @@ function aws.internal.converse_url(client: aws.BedrockClient) -> string {
   1029   18    load_const 1            (null)
          19    load_var 1              (client)
          20    load_field 2            (profile)
-         21    call 1338 ntypeargs=0   (aws.internal.resolve_region)
+         21    call 1339 ntypeargs=0   (aws.internal.resolve_region)
          22    jump +19                (to 41)
          23    load_var 12             (e)
          24    throw_if_panic          
@@ -12707,7 +12707,7 @@ function aws.internal.encode_path_label(value: string) -> string {
        19   load_var 4                         (_7)
        20   store_var_load_var 5               (byte)
 
-  60   21   call 1284 ntypeargs=0              (aws.internal._is_unreserved_byte)
+  60   21   call 1285 ntypeargs=0              (aws.internal._is_unreserved_byte)
        22   pop_jump_if_false +2               (to 24)
        23   jump +41                           (to 64)
 
@@ -12775,17 +12775,17 @@ function aws.internal.encode_path_label(value: string) -> string {
 
 function aws.internal.invoke(client: aws.BedrockClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   1328   0    load_var2 1 2           
-         1    call 1331 ntypeargs=0   (aws.internal.build_request)
+         1    call 1332 ntypeargs=0   (aws.internal.build_request)
          2    store_var 4             (_4)
          3    load_var2 1 4           
-         4    call 1332 ntypeargs=0   (aws.internal.sign)
+         4    call 1333 ntypeargs=0   (aws.internal.sign)
          5    store_var 3             (request)
 
   1329   6    load_type 0             
          7    load_var 3              (request)
          8    load_const 1            ("aws-bedrock")
-         9    call 940 ntypeargs=1    (ai.wire.send_as)
-         10   call 1335 ntypeargs=0   (aws.internal.parse_response)
+         9    call 941 ntypeargs=1    (ai.wire.send_as)
+         10   call 1336 ntypeargs=0   (aws.internal.parse_response)
          11   return                  
 }
 
@@ -12798,7 +12798,7 @@ function aws.internal.parse_response(response: aws.internal.ConverseResponse) ->
          5     pop_jump_if_false +5               (to 10)
          6     load_var 2                         (_3)
 
-  1258   7     call 1333 ntypeargs=0              (aws.internal._is_malformed_stop)
+  1258   7     call 1334 ntypeargs=0              (aws.internal._is_malformed_stop)
          8     pop_jump_if_false +2               (to 10)
          9     jump +194                          (to 203)
 
@@ -12966,7 +12966,7 @@ function aws.internal.parse_response(response: aws.internal.ConverseResponse) ->
          147   jump +5                            (to 152)
          148   load_var 23                        (_72)
 
-  1303   149   call 1334 ntypeargs=0              (aws.internal.stop_reason)
+  1303   149   call 1335 ntypeargs=0              (aws.internal.stop_reason)
          150   store_var 22                       (stop)
          151   jump +4                            (to 155)
 
@@ -13046,7 +13046,7 @@ function aws.internal.parse_response(response: aws.internal.ConverseResponse) ->
 
 function aws.internal.resolve_region(region: string | null, profile: string | null) -> string | null {
   61   0   load_var2 1 2   
-       1   sys_op 993      (ai.internal._aws_resolve_region)
+       1   sys_op 994      (ai.internal._aws_resolve_region)
        2   return          
 }
 
@@ -13069,7 +13069,7 @@ function aws.internal.sign(client: aws.BedrockClient, request: baml.http.Request
          10   load_const 0            ("bedrock")
          11   init_instance 0         (aws.internal.AwsSignOptions .region, .profile, .access_key_id, .secret_access_key, .session_token, .service)
 
-  1117   12   call 1337 ntypeargs=0   (aws.internal.sign_request)
+  1117   12   call 1338 ntypeargs=0   (aws.internal.sign_request)
          13   jump +19                (to 32)
          14   load_var 3              (e)
          15   throw_if_panic          
@@ -13114,7 +13114,7 @@ function aws.internal.sign_request(req: baml.http.Request, opts: aws.internal.Aw
 
   52   10   load_var 2      (opts)
        11   load_field 4    (session_token)
-       12   sys_op 992      (ai.internal._aws_sign_request)
+       12   sys_op 993      (ai.internal._aws_sign_request)
        13   return          
 }
 
@@ -13141,7 +13141,7 @@ function aws.internal.stop_reason(raw: string) -> ai.content.StopReason {
          19   jump +11                (to 30)
 
   1240   20   load_var 1              (raw)
-         21   call 1333 ntypeargs=0   (aws.internal._is_malformed_stop)
+         21   call 1334 ntypeargs=0   (aws.internal._is_malformed_stop)
 
   1230   22   pop_jump_if_false +2    (to 24)
          23   jump +4                 (to 27)
@@ -13204,13 +13204,13 @@ function claude_code.ClaudeCodeClient.ai.Client.id(self: claude_code.ClaudeCodeC
 
 function claude_code.ClaudeCodeClient.ai.Client.invoke(self: claude_code.ClaudeCodeClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   44   0   load_var2 1 2           
-       1   call 1372 ntypeargs=0   (claude_code.internal.invoke)
+       1   call 1373 ntypeargs=0   (claude_code.internal.invoke)
        2   jump +6                 (to 8)
        3   load_var 3              (e)
        4   throw_if_panic          
 
   45   5   load_var 3              (e)
-       6   call 977 ntypeargs=0    (ai.errors.normalize)
+       6   call 978 ntypeargs=0    (ai.errors.normalize)
        7   throw                   
        8   return                  
 }
@@ -13418,7 +13418,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> void {
         116   load_const 31                      (".thinking")
         117   load_const 32                      ("")
         118   call 371 ntypeargs=1               (baml.json.path_or)
-        119   call 1368 ntypeargs=0              (claude_code.internal._preview)
+        119   call 1369 ntypeargs=0              (claude_code.internal._preview)
         120   store_var 31                       (_110)
         121   load_type 0                        
         122   load_var 31                        (_110)
@@ -13441,7 +13441,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> void {
         135   load_const 34                      (".text")
         136   load_const 35                      ("")
         137   call 371 ntypeargs=1               (baml.json.path_or)
-        138   call 1368 ntypeargs=0              (claude_code.internal._preview)
+        138   call 1369 ntypeargs=0              (claude_code.internal._preview)
         139   store_var 29                       (_101)
         140   load_type 0                        
         141   load_var 29                        (_101)
@@ -13577,7 +13577,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> void {
         261   load_const 55                      (".thinking")
         262   load_const 56                      ("")
         263   call 371 ntypeargs=1               (baml.json.path_or)
-        264   call 1368 ntypeargs=0              (claude_code.internal._preview)
+        264   call 1369 ntypeargs=0              (claude_code.internal._preview)
         265   store_var 17                       (_54)
         266   load_type 0                        
         267   load_var 17                        (_54)
@@ -13600,7 +13600,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> void {
         280   load_const 58                      (".text")
         281   load_const 59                      ("")
         282   call 371 ntypeargs=1               (baml.json.path_or)
-        283   call 1368 ntypeargs=0              (claude_code.internal._preview)
+        283   call 1369 ntypeargs=0              (claude_code.internal._preview)
         284   store_var 15                       (_45)
         285   load_type 0                        
         286   load_var 15                        (_45)
@@ -13792,7 +13792,7 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         34   throw                              
 
   136   35   load_var 6                         (raw)
-        36   call 1369 ntypeargs=0              (claude_code.internal._log_cc_event)
+        36   call 1370 ntypeargs=0              (claude_code.internal._log_cc_event)
         37   pop 1                              
 
   137   38   load_type 8                        
@@ -13854,7 +13854,7 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
         8    load_type 2           
         9    load_var 3            (_3)
 
-  224   10   make_closure 4094 0   
+  224   10   make_closure 4095 0   
 
   223   11   call 16 ntypeargs=3   (baml.Array.map)
         12   store_var 2           (_2)
@@ -13887,7 +13887,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        16    store_var 5             (call_props)
 
   55   17    load_const 4            ("string")
-       18    call 1365 ntypeargs=0   (claude_code.internal._type_schema)
+       18    call 1366 ntypeargs=0   (claude_code.internal._type_schema)
        19    store_var 6             (_10)
        20    load_type 1             
        21    load_type 2             
@@ -13898,7 +13898,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        26    pop 1                   
 
   56   27    load_const 6            ("string")
-       28    call 1365 ntypeargs=0   (claude_code.internal._type_schema)
+       28    call 1366 ntypeargs=0   (claude_code.internal._type_schema)
        29    store_var 7             (_14)
        30    load_type 1             
        31    load_type 2             
@@ -13909,7 +13909,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        36    pop 1                   
 
   57   37    load_const 8            ("object")
-       38    call 1365 ntypeargs=0   (claude_code.internal._type_schema)
+       38    call 1366 ntypeargs=0   (claude_code.internal._type_schema)
        39    store_var 8             (_18)
        40    load_type 1             
        41    load_type 2             
@@ -14131,12 +14131,12 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         1     load_var 2                         (input)
         2     load_field 0                       (prompt)
         3     call_indirect                      
-        4     call 918 ntypeargs=0               (ai.Prompt.text)
+        4     call 919 ntypeargs=0               (ai.Prompt.text)
         5     store_var 4                        (instructions)
 
   238   6     load_var 2                         (input)
         7     load_field 2                       (toolbox)
-        8     call 933 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        8     call 934 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         9     unary_op !                         
         10    store_var_load_var 5               (has_tools)
 
@@ -14151,7 +14151,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 
   240   18    load_var 2                         (input)
         19    load_field 3                       (output_type)
-        20    call 1364 ntypeargs=0              (claude_code.internal.envelope_schema)
+        20    call 1365 ntypeargs=0              (claude_code.internal.envelope_schema)
         21    store_var 7                        (_11)
         22    load_type 1                        
         23    load_var 7                         (_11)
@@ -14168,7 +14168,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         32    store_var 14                       (_29)
         33    load_var 2                         (input)
         34    load_field 1                       (journal)
-        35    call 1363 ntypeargs=0              (claude_code.internal.transcript_text)
+        35    call 1364 ntypeargs=0              (claude_code.internal.transcript_text)
         36    store_var 16                       (_33)
         37    load_type 2                        
         38    load_var 16                        (_33)
@@ -14186,7 +14186,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         48    store_var 9                        (_18)
         49    load_var 2                         (input)
         50    load_field 1                       (journal)
-        51    call 1363 ntypeargs=0              (claude_code.internal.transcript_text)
+        51    call 1364 ntypeargs=0              (claude_code.internal.transcript_text)
         52    store_var 11                       (_22)
         53    load_type 2                        
         54    load_var 11                        (_22)
@@ -14194,7 +14194,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         56    store_var 10                       (_21)
         57    load_var 2                         (input)
         58    load_field 2                       (toolbox)
-        59    call 1366 ntypeargs=0              (claude_code.internal.tool_protocol)
+        59    call 1367 ntypeargs=0              (claude_code.internal.tool_protocol)
         60    store_var 13                       (_26)
         61    load_type 2                        
         62    load_var 13                        (_26)
@@ -14220,7 +14220,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         81    store_var 18                       (_44)
         82    load_var 2                         (input)
         83    load_field 2                       (toolbox)
-        84    call 931 ntypeargs=0               (ai.tools.Toolbox.list)
+        84    call 932 ntypeargs=0               (ai.tools.Toolbox.list)
         85    container_len                      
         86    store_var 21                       (_48)
         87    load_type 3                        
@@ -14327,7 +14327,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         173   pop 1                              
 
   271   174   load_var 1                         (c)
-        175   call 1370 ntypeargs=0              (claude_code.internal.mcp_config_json)
+        175   call 1371 ntypeargs=0              (claude_code.internal.mcp_config_json)
         176   store_var 24                       (_81)
         177   load_var 24                        (_81)
         178   narrow_bind 21 24                  
@@ -14353,7 +14353,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         195   pop 1                              
 
   275   196   load_var 1                         (c)
-        197   call 1371 ntypeargs=0              (claude_code.internal.allowed_mcp_tools)
+        197   call 1372 ntypeargs=0              (claude_code.internal.allowed_mcp_tools)
         198   store_var 27                       (_93)
         199   load_type 2                        
         200   load_var 27                        (_93)
@@ -14431,7 +14431,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         261   throw_if_panic                     
 
   303   262   load_var 29                        (p)
-        263   call 1367 ntypeargs=0              (claude_code.internal._read_result)
+        263   call 1368 ntypeargs=0              (claude_code.internal._read_result)
         264   store_var 36                       (result)
 
   304   265   load_var 29                        (p)
@@ -14651,7 +14651,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 
   363   452   load_var 2                         (input)
         453   load_field 1                       (journal)
-        454   call 914 ntypeargs=0               (ai.Journal.entries)
+        454   call 915 ntypeargs=0               (ai.Journal.entries)
         455   container_len                      
         456   store_var 67                       (_214)
         457   load_type 3                        
@@ -14823,7 +14823,7 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         2    store_var 2                        (catalog)
 
   100   3    load_var 1                         (tb)
-        4    call 931 ntypeargs=0               (ai.tools.Toolbox.list)
+        4    call 932 ntypeargs=0               (ai.tools.Toolbox.list)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -14906,7 +14906,7 @@ function claude_code.internal.transcript_text(j: ai.Journal) -> string {
        2     store_var 2                        (lines)
 
   8    3     load_var 1                         (j)
-       4     call 914 ntypeargs=0               (ai.Journal.entries)
+       4     call 915 ntypeargs=0               (ai.Journal.entries)
        5     load_type 1                        
        6     load_const 2                       ("iter")
        7     virtual_call nargs=1 ntypeargs=0   
@@ -15147,26 +15147,26 @@ function google.GoogleClient.ai.Client.id(self: google.GoogleClient) -> string {
 
 function google.GoogleClient.ai.Client.invoke(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   129   0   load_var2 1 2           
-        1   call 1255 ntypeargs=0   (google.internal.gemini_invoke)
+        1   call 1256 ntypeargs=0   (google.internal.gemini_invoke)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   130   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
 
 function google.GoogleClient.ai.stream.StreamingClient.invoke_stream(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   137   0   load_var2 1 2           
-        1   call 1257 ntypeargs=0   (google.internal.gemini_invoke_stream)
+        1   call 1258 ntypeargs=0   (google.internal.gemini_invoke_stream)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   138   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
@@ -15279,7 +15279,7 @@ function google.GoogleClient.resolved_api_key(self: google.GoogleClient) -> stri
   107   0    load_var 1             (self)
         1    load_field 1           (api_key)
         2    load_const 0           ("GOOGLE_API_KEY")
-        3    call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3    call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4    store_var 2            (_4)
         5    load_var 2             (_4)
         6    narrow_bind 1 2        
@@ -15289,7 +15289,7 @@ function google.GoogleClient.resolved_api_key(self: google.GoogleClient) -> stri
   113   9    load_var 1             (self)
         10   load_field 1           (api_key)
         11   load_const 2           ("GOOGLE_API_KEY")
-        12   call 939 ntypeargs=0   (ai.wire.credential_sources)
+        12   call 940 ntypeargs=0   (ai.wire.credential_sources)
         13   store_var 4            (_9)
         14   load_type 3            
         15   load_var 4             (_9)
@@ -15314,7 +15314,7 @@ function google.GoogleClient.resolved_base_url(self: google.GoogleClient) -> str
   120   0   load_var 1             (self)
         1   load_field 2           (base_url)
         2   load_const 0           (null)
-        3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4   return                 
 }
 
@@ -15338,26 +15338,26 @@ function google.VertexClient.ai.Client.id(self: google.VertexClient) -> string {
 
 function google.VertexClient.ai.Client.invoke(self: google.VertexClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   113   0   load_var2 1 2           
-        1   call 1274 ntypeargs=0   (google.internal.vertex_invoke)
+        1   call 1275 ntypeargs=0   (google.internal.vertex_invoke)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   114   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
 
 function google.VertexClient.ai.stream.StreamingClient.invoke_stream(self: google.VertexClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   121   0   load_var2 1 2           
-        1   call 1276 ntypeargs=0   (google.internal.vertex_invoke_stream)
+        1   call 1277 ntypeargs=0   (google.internal.vertex_invoke_stream)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   122   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
@@ -15500,7 +15500,7 @@ function google.VertexClient.resolved_api_key(self: google.VertexClient) -> stri
   99   0   load_var 1             (self)
        1   load_field 5           (api_key)
        2   load_const 0           (null)
-       3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4   return                 
 }
 
@@ -15508,7 +15508,7 @@ function google.VertexClient.resolved_base_url(self: google.VertexClient) -> str
   104   0   load_var 1             (self)
         1   load_field 6           (base_url)
         2   load_const 0           (null)
-        3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4   return                 
 }
 
@@ -15686,7 +15686,7 @@ function google.internal._gm_apply_query(url: string, params: map<string, string
         47   call 145 ntypeargs=1               (baml.String.from)
         48   store_var 11                       (_22)
         49   load_var 8                         (name)
-        50   call 1229 ntypeargs=0              (google.internal._gm_encode_query)
+        50   call 1230 ntypeargs=0              (google.internal._gm_encode_query)
         51   store_var 13                       (_26)
         52   load_type 1                        
         53   load_var 13                        (_26)
@@ -15703,7 +15703,7 @@ function google.internal._gm_apply_query(url: string, params: map<string, string
         64   load_const 11                      ("")
         65   store_var 16                       (_32)
         66   load_var 16                        (_32)
-        67   call 1229 ntypeargs=0              (google.internal._gm_encode_query)
+        67   call 1230 ntypeargs=0              (google.internal._gm_encode_query)
         68   store_var 15                       (_30)
         69   load_type 1                        
         70   load_var 15                        (_30)
@@ -15726,7 +15726,7 @@ function google.internal._gm_apply_query(url: string, params: map<string, string
 }
 
 function google.internal._gm_call_id_signature(id: string) -> string | null {
-  549   0    call 1239 ntypeargs=0   (google.internal._gm_sig_marker)
+  549   0    call 1240 ntypeargs=0   (google.internal._gm_sig_marker)
         1    store_var 2             (marker)
 
   550   2    load_var2 1 2           
@@ -15763,7 +15763,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          2     store_var 3                        (out)
 
   974    3     load_var 1                         (batch)
-         4     call 967 ntypeargs=0               (ai.stream.decode_sse_batch)
+         4     call 968 ntypeargs=0               (ai.stream.decode_sse_batch)
          5     load_type 1                        
          6     load_const 2                       ("iter")
          7     virtual_call nargs=1 ntypeargs=0   
@@ -15828,11 +15828,11 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          60    cmp_op ==                          
          61    pop_jump_if_false +2               (to 63)
          62    jump +8                            (to 70)
-         63    load_type 12                       
+         63    load_const 12                      (0)
          64    load_var 8                         (resp)
          65    load_field 0                       (candidates)
-         66    load_const 13                      (0)
-         67    call 3 ntypeargs=1                 (baml.Array.at)
+         66    make_bound_method 3                
+         67    call_indirect                      
          68    store_var 15                       (cand)
          69    jump +3                            (to 72)
          70    load_const 6                       (null)
@@ -15863,18 +15863,18 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          94    load_const 6                       (null)
          95    cmp_op ==                          
          96    pop_jump_if_false +4               (to 100)
-         97    load_type 14                       
+         97    load_type 13                       
          98    alloc_array 0                      
          99    store_var 16                       (_43)
          100   load_var 16                        (_43)
-         101   load_type 15                       
-         102   load_const 16                      ("iter")
+         101   load_type 14                       
+         102   load_const 15                      ("iter")
          103   virtual_call nargs=1 ntypeargs=0   
          104   store_var 17                       (_56)
 
   994    105   load_var 17                        (_56)
-         106   load_type 17                       
-         107   load_const 18                      ("next")
+         106   load_type 16                       
+         107   load_const 17                      ("next")
          108   virtual_call nargs=1 ntypeargs=0   
          109   store_var 18                       (_57)
          110   load_var 18                        (_57)
@@ -15887,7 +15887,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
   995    116   load_field 0                       (text)
          117   store_var 20                       (_62)
          118   load_var 20                        (_62)
-         119   narrow_bind 19 20                  
+         119   narrow_bind 18 20                  
          120   pop_jump_if_false -15              (to 105)
          121   load_var 20                        (_62)
          122   store_var 21                       (t)
@@ -15898,7 +15898,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          126   load_const 6                       (null)
          127   cmp_op ==                          
          128   pop_jump_if_false +3               (to 131)
-         129   load_const 20                      (false)
+         129   load_const 19                      (false)
          130   store_var 22                       (_65)
          131   load_var 22                        (_65)
          132   pop_jump_if_false +2               (to 134)
@@ -15924,7 +15924,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          150   load_const 6                       (null)
          151   cmp_op ==                          
          152   pop_jump_if_false +3               (to 155)
-         153   load_const 21                      ("")
+         153   load_const 20                      ("")
          154   store_var 24                       (_73)
          155   load_var 24                        (_73)
          156   store_var 23                       (finish)
@@ -15945,7 +15945,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          170   store_var 25                       (_84)
 
   1008   171   load_var 23                        (finish)
-         172   load_const 22                      ("MAX_TOKENS")
+         172   load_const 21                      ("MAX_TOKENS")
          173   cmp_op ==                          
          174   pop_jump_if_false +2               (to 176)
          175   jump +26                           (to 201)
@@ -15957,12 +15957,12 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          180   pop 1                              
 
   1010   181   load_var 23                        (finish)
-         182   call 1247 ntypeargs=0              (google.internal._gm_is_blocked)
+         182   call 1248 ntypeargs=0              (google.internal._gm_is_blocked)
          183   pop_jump_if_false +2               (to 185)
          184   jump +13                           (to 197)
 
   1012   185   load_var 23                        (finish)
-         186   load_const 23                      ("")
+         186   load_const 22                      ("")
          187   cmp_op !=                          
          188   pop_jump_if_false +2               (to 190)
          189   jump +4                            (to 193)
@@ -15972,19 +15972,19 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
 
   1012   192   jump +12                           (to 204)
 
-  1013   193   load_const 13                      (ai.content.StopReason.Complete)
+  1013   193   load_const 12                      (ai.content.StopReason.Complete)
          194   alloc_variant 774                  (ai.content.StopReason)
          195   store_var 26                       (stop)
 
   1012   196   jump +8                            (to 204)
 
-  1011   197   load_const 24                      (ai.content.StopReason.Refused)
+  1011   197   load_const 23                      (ai.content.StopReason.Refused)
          198   alloc_variant 774                  (ai.content.StopReason)
          199   store_var 26                       (stop)
 
   1010   200   jump +4                            (to 204)
 
-  1009   201   load_const 25                      (ai.content.StopReason.MaxTokens)
+  1009   201   load_const 24                      (ai.content.StopReason.MaxTokens)
          202   alloc_variant 774                  (ai.content.StopReason)
          203   store_var 26                       (stop)
 
@@ -16062,7 +16062,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          264   load_const 6                       (null)
          265   cmp_op ==                          
          266   pop_jump_if_false +3               (to 269)
-         267   load_const 13                      (0)
+         267   load_const 12                      (0)
          268   store_var 13                       (_30)
          269   load_var 13                        (_30)
          270   store_var 12                       (_29)
@@ -16076,8 +16076,8 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          278   store_var 14                       (_34)
          279   load_var2 2 12                     
          280   load_var 14                        (_34)
-         281   load_const 26                      (<omitted>)
-         282   call 986 ntypeargs=0               (ai.errors.classify_http)
+         281   load_const 25                      (<omitted>)
+         282   call 987 ntypeargs=0               (ai.errors.classify_http)
          283   throw                              
 
   1042   284   load_var 3                         (out)
@@ -16102,7 +16102,7 @@ function google.internal._gm_encode_call_id(id: string, signature: string | null
         11   load_var 1              (id)
         12   call 145 ntypeargs=1    (baml.String.from)
         13   store_var 5             (_6)
-        14   call 1239 ntypeargs=0   (google.internal._gm_sig_marker)
+        14   call 1240 ntypeargs=0   (google.internal._gm_sig_marker)
         15   store_var 7             (_9)
         16   load_type 1             
         17   load_var 7              (_9)
@@ -16323,7 +16323,7 @@ function google.internal._gm_is_provider_uri(url: string) -> bool {
 
 function google.internal._gm_media_part(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf, fetch_url: bool) -> google.internal.GmPart {
   431   0    load_var 1              (media)
-        1    call 1233 ntypeargs=0   (google.internal._gm_media_url)
+        1    call 1234 ntypeargs=0   (google.internal._gm_media_url)
 
   432   2    store_var 4             (_5)
         3    load_var 4              (_5)
@@ -16337,7 +16337,7 @@ function google.internal._gm_media_part(media: baml.media.Image | baml.media.Aud
   432   9    jump +4                 (to 13)
         10   load_var 4              (_5)
 
-  433   11   call 1234 ntypeargs=0   (google.internal._gm_is_provider_uri)
+  433   11   call 1235 ntypeargs=0   (google.internal._gm_is_provider_uri)
         12   store_var 3             (passthrough)
 
   437   13   load_var 2              (fetch_url)
@@ -16350,7 +16350,7 @@ function google.internal._gm_media_part(media: baml.media.Image | baml.media.Aud
         20   unary_op !              
         21   store_var 6             (_9)
         22   load_var2 1 6           
-        23   call 942 ntypeargs=0    (ai.wire.resolve_media)
+        23   call 943 ntypeargs=0    (ai.wire.resolve_media)
         24   store_var 5             (resolved)
 
   438   25   load_var 5              (resolved)
@@ -16375,7 +16375,7 @@ function google.internal._gm_media_part(media: baml.media.Image | baml.media.Aud
         43   load_var2 9 10          
         44   init_instance 0         (google.internal.GmInlineData .mimeType, .data)
 
-  443   45   call 1223 ntypeargs=0   (google.internal.GmPart.of_inline_data)
+  443   45   call 1224 ntypeargs=0   (google.internal.GmPart.of_inline_data)
         46   jump +9                 (to 55)
 
   438   47   load_var 7              (_12)
@@ -16383,11 +16383,11 @@ function google.internal._gm_media_part(media: baml.media.Image | baml.media.Aud
 
   440   49   load_var 5              (resolved)
         50   load_field 2            (mime_type)
-        51   call 1235 ntypeargs=0   (google.internal._gm_mime_for_uri)
+        51   call 1236 ntypeargs=0   (google.internal._gm_mime_for_uri)
         52   load_var 8              (url)
         53   init_instance 1         (google.internal.GmFileData .mimeType, .fileUri)
 
-  439   54   call 1224 ntypeargs=0   (google.internal.GmPart.of_file_data)
+  439   54   call 1225 ntypeargs=0   (google.internal.GmPart.of_file_data)
         55   return                  
 }
 
@@ -16464,7 +16464,7 @@ function google.internal._gm_open_sse(req: baml.http.Request, provider: string) 
         4   throw_if_panic          
 
   953   5   load_var2 2 3           
-        6   call 1250 ntypeargs=0   (google.internal._gm_sse_failure)
+        6   call 1251 ntypeargs=0   (google.internal._gm_sse_failure)
         7   throw                   
         8   return                  
 }
@@ -16505,7 +16505,7 @@ function google.internal._gm_output_media(mime: string, data: string) -> ai.cont
 
   794   26   load_const 3           (<omitted>)
         27   load_const 3           (<omitted>)
-        28   call 913 ntypeargs=0   (ai.content.Media.new)
+        28   call 914 ntypeargs=0   (ai.content.Media.new)
         29   return                 
 }
 
@@ -16558,7 +16558,7 @@ function google.internal._gm_prompt_parts(message: ai.PromptMessage, fetch_url: 
         43   jump +9                            (to 52)
         44   load_var2 6 2                      
 
-  470   45   call 1236 ntypeargs=0              (google.internal._gm_media_part)
+  470   45   call 1237 ntypeargs=0              (google.internal._gm_media_part)
         46   store_var 15                       (_36)
         47   load_type 0                        
         48   load_var2 3 15                     
@@ -16568,7 +16568,7 @@ function google.internal._gm_prompt_parts(message: ai.PromptMessage, fetch_url: 
 
   452   52   load_var2 13 2                     
 
-  466   53   call 1236 ntypeargs=0              (google.internal._gm_media_part)
+  466   53   call 1237 ntypeargs=0              (google.internal._gm_media_part)
         54   store_var 14                       (_31)
         55   load_type 0                        
         56   load_var2 3 14                     
@@ -16578,7 +16578,7 @@ function google.internal._gm_prompt_parts(message: ai.PromptMessage, fetch_url: 
 
   452   60   load_var2 11 2                     
 
-  462   61   call 1236 ntypeargs=0              (google.internal._gm_media_part)
+  462   61   call 1237 ntypeargs=0              (google.internal._gm_media_part)
         62   store_var 12                       (_25)
         63   load_type 0                        
         64   load_var2 3 12                     
@@ -16588,7 +16588,7 @@ function google.internal._gm_prompt_parts(message: ai.PromptMessage, fetch_url: 
 
   452   68   load_var2 9 2                      
 
-  458   69   call 1236 ntypeargs=0              (google.internal._gm_media_part)
+  458   69   call 1237 ntypeargs=0              (google.internal._gm_media_part)
         70   store_var 10                       (_19)
         71   load_type 0                        
         72   load_var2 3 10                     
@@ -16598,7 +16598,7 @@ function google.internal._gm_prompt_parts(message: ai.PromptMessage, fetch_url: 
 
   452   76   load_var 7                         (_10)
 
-  454   77   call 1222 ntypeargs=0              (google.internal.GmPart.of_text)
+  454   77   call 1223 ntypeargs=0              (google.internal.GmPart.of_text)
         78   store_var 8                        (_13)
         79   load_type 0                        
         80   load_var2 3 8                      
@@ -16633,7 +16633,7 @@ function google.internal._gm_sse_failure(provider: string, error: unknown) -> ai
         12    load_field 0            (message)
         13    store_var 4             (_4)
         14    load_var 4              (_4)
-        15    call 938 ntypeargs=0    (ai.wire.redact_url_secrets)
+        15    call 939 ntypeargs=0    (ai.wire.redact_url_secrets)
         16    store_var 3             (text)
 
   928   17    load_var 3              (text)
@@ -16738,7 +16738,7 @@ function google.internal._gm_sse_failure(provider: string, error: unknown) -> ai
   940   100   load_var2 1 13          
         101   load_var 15             (body)
         102   load_const 13           (<omitted>)
-        103   call 986 ntypeargs=0    (ai.errors.classify_http)
+        103   call 987 ntypeargs=0    (ai.errors.classify_http)
         104   return                  
 }
 
@@ -16770,7 +16770,7 @@ function google.internal._gm_strip_nulls(value: baml.json.json, opaque: bool) ->
 
   274   20   load_var 12                        (_27)
 
-  289   21   make_closure 3332 0                
+  289   21   make_closure 3333 0                
         22   call 16 ntypeargs=3                (baml.Array.map)
         23   jump +52                           (to 75)
 
@@ -16815,10 +16815,10 @@ function google.internal._gm_strip_nulls(value: baml.json.json, opaque: bool) ->
         58   jump -20                           (to 38)
 
   282   59   load_var 8                         (key)
-        60   call 1227 ntypeargs=0              (google.internal._gm_is_opaque_key)
+        60   call 1228 ntypeargs=0              (google.internal._gm_is_opaque_key)
         61   store_var 11                       (_23)
         62   load_var2 9 11                     
-        63   call 1228 ntypeargs=0              (google.internal._gm_strip_nulls)
+        63   call 1229 ntypeargs=0              (google.internal._gm_strip_nulls)
         64   store_var 10                       (_21)
         65   load_type 4                        
         66   load_type 2                        
@@ -16841,7 +16841,7 @@ function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string 
         1    store_var 3                        (name)
 
   561   2    load_var 1                         (j)
-        3    call 914 ntypeargs=0               (ai.Journal.entries)
+        3    call 915 ntypeargs=0               (ai.Journal.entries)
         4    load_type 1                        
         5    load_const 2                       ("iter")
         6    virtual_call nargs=1 ntypeargs=0   
@@ -16948,7 +16948,7 @@ function google.internal._gm_usage(usage: google.internal.GmUsageMetadata | null
 function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone)[] {
   1097   0   load_var 1              (batch)
          1   load_const 0            ("google")
-         2   call 1252 ntypeargs=0   (google.internal._gm_decode_batch)
+         2   call 1253 ntypeargs=0   (google.internal._gm_decode_batch)
          3   return                  
 }
 
@@ -16977,7 +16977,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
   1069   15   load_var 1                         (c)
          16   load_field 11                      (response_modalities)
 
-  1063   17   call 1232 ntypeargs=0              (google.internal._gm_generation_config)
+  1063   17   call 1233 ntypeargs=0              (google.internal._gm_generation_config)
          18   store_var 6                        (_6)
 
   1060   19   load_var2 2 5                      
@@ -16989,11 +16989,11 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
          23   load_field 3                       (request_body)
          24   load_const 2                       (<omitted>)
 
-  1060   25   call 1244 ntypeargs=0              (google.internal.gemini_build_body)
+  1060   25   call 1245 ntypeargs=0              (google.internal.gemini_build_body)
          26   store_var 4                        (body)
 
   1074   27   load_var 1                         (c)
-         28   call 1212 ntypeargs=0              (google.GoogleClient.resolved_base_url)
+         28   call 1213 ntypeargs=0              (google.GoogleClient.resolved_base_url)
          29   store_var_load_var 7               (_16)
          30   load_const 3                       (null)
          31   cmp_op ==                          
@@ -17013,7 +17013,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
          42   call 145 ntypeargs=1               (baml.String.from)
          43   store_var 10                       (_26)
          44   load_var 3                         (stream)
-         45   call 1245 ntypeargs=0              (google.internal.gemini_method)
+         45   call 1246 ntypeargs=0              (google.internal.gemini_method)
          46   store_var 12                       (_30)
          47   load_type 5                        
          48   load_var 12                        (_30)
@@ -17030,7 +17030,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
   1077   58   load_var 1                         (c)
          59   load_field 5                       (query_params)
 
-  1075   60   call 1230 ntypeargs=0              (google.internal._gm_apply_query)
+  1075   60   call 1231 ntypeargs=0              (google.internal._gm_apply_query)
          61   store_var 8                        (url)
 
   1079   62   load_const 7                       ("application/json")
@@ -17041,11 +17041,11 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   1080   67   load_var 1                         (c)
          68   load_field 4                       (headers)
-         69   call 1231 ntypeargs=0              (google.internal._gm_apply_headers)
+         69   call 1232 ntypeargs=0              (google.internal._gm_apply_headers)
          70   store_var 13                       (with_user)
 
   1081   71   load_var 1                         (c)
-         72   call 1211 ntypeargs=0              (google.GoogleClient.resolved_api_key)
+         72   call 1212 ntypeargs=0              (google.GoogleClient.resolved_api_key)
          73   store_var 14                       (_38)
          74   load_type 5                        
          75   load_type 5                        
@@ -17104,7 +17104,7 @@ function google.internal._vertex_anthropic_body(c: google.VertexClient, input: a
 
   256   32   load_var 1                         (c)
         33   load_field 7                       (request_body)
-        34   call 943 ntypeargs=0               (ai.wire.merge_request_body)
+        34   call 944 ntypeargs=0               (ai.wire.merge_request_body)
         35   store_var 11                       (_15)
 
   257   36   load_var 1                         (c)
@@ -17122,7 +17122,7 @@ function google.internal._vertex_anthropic_body(c: google.VertexClient, input: a
         47   init_instance 0                    (anthropic.internal.AnthropicBodyParams .model, .max_tokens, .temperature, .top_p, .top_k, .stop_sequences, .thinking, .tool_choice, .request_body, .client_id)
         48   load_var2 2 3                      
 
-  259   49   call 1194 ntypeargs=0              (anthropic.internal.anthropic_messages_body)
+  259   49   call 1195 ntypeargs=0              (anthropic.internal.anthropic_messages_body)
         50   return                             
 }
 
@@ -17163,7 +17163,7 @@ function google.internal._vertex_credentials(c: google.VertexClient) -> string |
        29   jump +38                (to 67)
 
   67   30   load_var 10             (from_env)
-       31   call 1259 ntypeargs=0   (google.internal._vertex_unwrap_json)
+       31   call 1260 ntypeargs=0   (google.internal._vertex_unwrap_json)
        32   jump +35                (to 67)
 
   52   33   load_var 3              (_7)
@@ -17201,31 +17201,31 @@ function google.internal._vertex_credentials(c: google.VertexClient) -> string |
        61   init_instance 0         (ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body)
        62   throw                   
 
-  63   63   call 1259 ntypeargs=0   (google.internal._vertex_unwrap_json)
+  63   63   call 1260 ntypeargs=0   (google.internal._vertex_unwrap_json)
        64   jump +3                 (to 67)
 
   49   65   load_var 2              (_3)
 
-  50   66   call 1259 ntypeargs=0   (google.internal._vertex_unwrap_json)
+  50   66   call 1260 ntypeargs=0   (google.internal._vertex_unwrap_json)
        67   return                  
 }
 
 function google.internal._vertex_decode_batch(batch: string) -> (ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone)[] {
   342   0   load_var 1              (batch)
         1   load_const 0            ("vertex")
-        2   call 1252 ntypeargs=0   (google.internal._gm_decode_batch)
+        2   call 1253 ntypeargs=0   (google.internal._gm_decode_batch)
         3   return                  
 }
 
 function google.internal._vertex_express_key(c: google.VertexClient) -> string | null {
   77   0   load_var 1              (c)
-       1   call 1217 ntypeargs=0   (google.VertexClient.resolved_api_key)
+       1   call 1218 ntypeargs=0   (google.VertexClient.resolved_api_key)
        2   return                  
 }
 
 function google.internal._vertex_is_express(c: google.VertexClient) -> bool {
   87   0    load_var 1              (c)
-       1    call 1261 ntypeargs=0   (google.internal._vertex_express_key)
+       1    call 1262 ntypeargs=0   (google.internal._vertex_express_key)
        2    load_const 0            (null)
        3    call 679 ntypeargs=0    (baml.ops.equals_equals)
        4    unary_op !              
@@ -17233,7 +17233,7 @@ function google.internal._vertex_is_express(c: google.VertexClient) -> bool {
        6    jump +4                 (to 10)
        7    pop 1                   
        8    load_var 1              (c)
-       9    call 1262 ntypeargs=0   (google.internal._vertex_key_in_query)
+       9    call 1263 ntypeargs=0   (google.internal._vertex_key_in_query)
        10   return                  
 }
 
@@ -17256,34 +17256,33 @@ function google.internal._vertex_key_in_query(c: google.VertexClient) -> bool {
        2    load_const 0           (null)
        3    cmp_op ==              
        4    pop_jump_if_false +2   (to 6)
-       5    jump +9                (to 14)
-       6    load_type 1            
-       7    load_type 1            
-       8    load_var 1             (c)
-       9    load_field 9           (query_params)
-       10   load_const 2           ("key")
-       11   call 38 ntypeargs=2    (baml.Map.get)
-       12   store_var 2            (_2)
-       13   jump +3                (to 16)
-       14   load_const 0           (null)
-       15   store_var 2            (_2)
-       16   load_var 2             (_2)
-       17   load_const 0           (null)
-       18   call 679 ntypeargs=0   (baml.ops.equals_equals)
-       19   unary_op !             
-       20   return                 
+       5    jump +8                (to 13)
+       6    load_const 1           ("key")
+       7    load_var 1             (c)
+       8    load_field 9           (query_params)
+       9    make_bound_method 38   
+       10   call_indirect          
+       11   store_var 2            (_2)
+       12   jump +3                (to 15)
+       13   load_const 0           (null)
+       14   store_var 2            (_2)
+       15   load_var 2             (_2)
+       16   load_const 0           (null)
+       17   call 679 ntypeargs=0   (baml.ops.equals_equals)
+       18   unary_op !             
+       19   return                 
 }
 
 function google.internal._vertex_method(c: google.VertexClient, stream: bool) -> string {
   202   0    load_var 1              (c)
-        1    call 1266 ntypeargs=0   (google.internal._vertex_publisher)
+        1    call 1267 ntypeargs=0   (google.internal._vertex_publisher)
         2    load_const 0            ("anthropic")
         3    cmp_op ==               
         4    pop_jump_if_false +2    (to 6)
         5    jump +4                 (to 9)
 
   209   6    load_var 2              (stream)
-        7    call 1245 ntypeargs=0   (google.internal.gemini_method)
+        7    call 1246 ntypeargs=0   (google.internal.gemini_method)
         8    jump +7                 (to 15)
 
   203   9    load_var 2              (stream)
@@ -17300,7 +17299,7 @@ function google.internal._vertex_method(c: google.VertexClient, stream: bool) ->
 
 function google.internal._vertex_models_base(c: google.VertexClient) -> string {
   168   0     load_var 1              (c)
-        1     call 1218 ntypeargs=0   (google.VertexClient.resolved_base_url)
+        1     call 1219 ntypeargs=0   (google.VertexClient.resolved_base_url)
         2     store_var 2             (_3)
         3     load_var 2              (_3)
         4     narrow_bind 0 2         
@@ -17308,11 +17307,11 @@ function google.internal._vertex_models_base(c: google.VertexClient) -> string {
         6     jump +99                (to 105)
 
   171   7     load_var 1              (c)
-        8     call 1266 ntypeargs=0   (google.internal._vertex_publisher)
+        8     call 1267 ntypeargs=0   (google.internal._vertex_publisher)
         9     store_var 3             (publisher)
 
   172   10    load_var 1              (c)
-        11    call 1264 ntypeargs=0   (google.internal.vertex_location)
+        11    call 1265 ntypeargs=0   (google.internal.vertex_location)
         12    store_var 4             (location)
 
   173   13    load_var 4              (location)
@@ -17322,7 +17321,7 @@ function google.internal._vertex_models_base(c: google.VertexClient) -> string {
         17    jump +23                (to 40)
 
   175   18    load_var 4              (location)
-        19    call 1267 ntypeargs=0   (google.internal._vertex_is_multi_region)
+        19    call 1268 ntypeargs=0   (google.internal._vertex_is_multi_region)
         20    pop_jump_if_false +2    (to 22)
         21    jump +8                 (to 29)
 
@@ -17352,7 +17351,7 @@ function google.internal._vertex_models_base(c: google.VertexClient) -> string {
         41    store_var 5             (host)
 
   182   42    load_var 1              (c)
-        43    call 1265 ntypeargs=0   (google.internal.vertex_project_id)
+        43    call 1266 ntypeargs=0   (google.internal.vertex_project_id)
 
   183   44    store_var 7             (_20)
         45    load_var 7              (_20)
@@ -17361,7 +17360,7 @@ function google.internal._vertex_models_base(c: google.VertexClient) -> string {
         48    jump +21                (to 69)
 
   185   49    load_var 1              (c)
-        50    call 1263 ntypeargs=0   (google.internal._vertex_is_express)
+        50    call 1264 ntypeargs=0   (google.internal._vertex_is_express)
         51    pop_jump_if_false +2    (to 53)
         52    jump +7                 (to 59)
 
@@ -17445,7 +17444,7 @@ function google.internal._vertex_publisher(c: google.VertexClient) -> string {
 
 function google.internal._vertex_request(c: google.VertexClient, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
   274   0     load_var 1                         (c)
-        1     call 1266 ntypeargs=0              (google.internal._vertex_publisher)
+        1     call 1267 ntypeargs=0              (google.internal._vertex_publisher)
         2     load_const 0                       ("anthropic")
         3     cmp_op ==                          
         4     pop_jump_if_false +2               (to 6)
@@ -17475,7 +17474,7 @@ function google.internal._vertex_request(c: google.VertexClient, input: ai.Model
   286   21    load_var 1                         (c)
         22    load_field 15                      (response_modalities)
 
-  280   23    call 1232 ntypeargs=0              (google.internal._gm_generation_config)
+  280   23    call 1233 ntypeargs=0              (google.internal._gm_generation_config)
         24    store_var 6                        (_8)
 
   277   25    load_var2 2 5                      
@@ -17487,17 +17486,17 @@ function google.internal._vertex_request(c: google.VertexClient, input: ai.Model
         29    load_field 7                       (request_body)
         30    load_const 3                       (false)
 
-  277   31    call 1244 ntypeargs=0              (google.internal.gemini_build_body)
+  277   31    call 1245 ntypeargs=0              (google.internal.gemini_build_body)
         32    store_var 4                        (body)
         33    jump +5                            (to 38)
 
   275   34    load_var2 1 2                      
         35    load_var 3                         (stream)
-        36    call 1271 ntypeargs=0              (google.internal._vertex_anthropic_body)
+        36    call 1272 ntypeargs=0              (google.internal._vertex_anthropic_body)
         37    store_var 4                        (body)
 
   297   38    load_var2 1 3                      
-        39    call 1270 ntypeargs=0              (google.internal.vertex_url)
+        39    call 1271 ntypeargs=0              (google.internal.vertex_url)
         40    store_var 7                        (url)
 
   298   41    load_const 4                       ("application/json")
@@ -17508,22 +17507,22 @@ function google.internal._vertex_request(c: google.VertexClient, input: ai.Model
 
   299   46    load_var 1                         (c)
         47    load_field 8                       (headers)
-        48    call 1231 ntypeargs=0              (google.internal._gm_apply_headers)
+        48    call 1232 ntypeargs=0              (google.internal._gm_apply_headers)
         49    store_var 8                        (with_user)
 
   300   50    load_var 1                         (c)
-        51    call 1263 ntypeargs=0              (google.internal._vertex_is_express)
+        51    call 1264 ntypeargs=0              (google.internal._vertex_is_express)
         52    pop_jump_if_false +2               (to 54)
         53    jump +62                           (to 115)
 
   304   54    load_var 1                         (c)
-        55    call 1260 ntypeargs=0              (google.internal._vertex_credentials)
+        55    call 1261 ntypeargs=0              (google.internal._vertex_credentials)
         56    store_var 9                        (credentials)
 
-  305   57    call 1258 ntypeargs=0              (google.internal._vertex_scope)
+  305   57    call 1259 ntypeargs=0              (google.internal._vertex_scope)
         58    store_var 12                       (_27)
         59    load_var2 9 12                     
-        60    call 1277 ntypeargs=0              (google.internal.gcp_access_token)
+        60    call 1278 ntypeargs=0              (google.internal.gcp_access_token)
         61    store_var 10                       (token)
         62    jump +19                           (to 81)
         63    load_var 11                        (e)
@@ -17572,7 +17571,7 @@ function google.internal._vertex_request(c: google.VertexClient, input: ai.Model
         101   pop_jump_if_false +14              (to 115)
 
   319   102   load_var 9                         (credentials)
-        103   call 1279 ntypeargs=0              (google.internal.gcp_quota_project_id)
+        103   call 1280 ntypeargs=0              (google.internal.gcp_quota_project_id)
         104   store_var 16                       (_47)
         105   load_var 16                        (_47)
         106   narrow_bind 14 16                  
@@ -17628,19 +17627,19 @@ function google.internal._vertex_unwrap_json(document: string) -> string {
 
 function google.internal.gcp_access_token(credentials_json: string | null, scope: string) -> string {
   25   0   load_var2 1 2   
-       1   sys_op 989      (ai.internal._gcp_access_token)
+       1   sys_op 990      (ai.internal._gcp_access_token)
        2   return          
 }
 
 function google.internal.gcp_project_id(credentials_json: string | null) -> string | null {
   33   0   load_var 1   (credentials_json)
-       1   sys_op 990   (ai.internal._gcp_project_id)
+       1   sys_op 991   (ai.internal._gcp_project_id)
        2   return       
 }
 
 function google.internal.gcp_quota_project_id(credentials_json: string | null) -> string | null {
   40   0   load_var 1   (credentials_json)
-       1   sys_op 991   (ai.internal._gcp_quota_project_id)
+       1   sys_op 992   (ai.internal._gcp_quota_project_id)
        2   return       
 }
 
@@ -17658,12 +17657,12 @@ function google.internal.gemini_build_body(input: ai.ModelTurnInput, client_id: 
         8     store_var 7                        (_9)
         9     load_var 1                         (input)
         10    load_field 3                       (output_type)
-        11    call 941 ntypeargs=0               (ai.wire.render_output_format)
+        11    call 942 ntypeargs=0               (ai.wire.render_output_format)
         12    load_var 7                         (_9)
         13    call_indirect                      
 
   699   14    load_var 6                         (fetch_url)
-        15    call 1238 ntypeargs=0              (google.internal.google_lower_prompt)
+        15    call 1239 ntypeargs=0              (google.internal.google_lower_prompt)
         16    store_var 8                        (lowered)
 
   700   17    load_var 8                         (lowered)
@@ -17673,9 +17672,9 @@ function google.internal.gemini_build_body(input: ai.ModelTurnInput, client_id: 
   701   20    load_var 1                         (input)
         21    load_field 1                       (journal)
         22    load_var 2                         (client_id)
-        23    call 944 ntypeargs=0               (ai.wire.sanitize_for_client)
+        23    call 945 ntypeargs=0               (ai.wire.sanitize_for_client)
 
-  702   24    call 1243 ntypeargs=0              (google.internal.google_lower_journal)
+  702   24    call 1244 ntypeargs=0              (google.internal.google_lower_journal)
         25    load_type 2                        
         26    load_const 3                       ("iter")
         27    virtual_call nargs=1 ntypeargs=0   
@@ -17781,7 +17780,7 @@ function google.internal.gemini_build_body(input: ai.ModelTurnInput, client_id: 
 
   736   116   load_var 1                         (input)
         117   load_field 2                       (toolbox)
-        118   call 933 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        118   call 934 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         119   unary_op !                         
         120   pop_jump_if_false +42              (to 162)
 
@@ -17791,7 +17790,7 @@ function google.internal.gemini_build_body(input: ai.ModelTurnInput, client_id: 
 
   738   124   load_var 1                         (input)
         125   load_field 2                       (toolbox)
-        126   call 931 ntypeargs=0               (ai.tools.Toolbox.list)
+        126   call 932 ntypeargs=0               (ai.tools.Toolbox.list)
         127   load_type 14                       
         128   load_const 15                      ("iter")
         129   virtual_call nargs=1 ntypeargs=0   
@@ -17846,10 +17845,10 @@ function google.internal.gemini_build_body(input: ai.ModelTurnInput, client_id: 
 
   764   167   call 362 ntypeargs=1               (baml.json.to_json)
         168   load_const 21                      (false)
-        169   call 1228 ntypeargs=0              (google.internal._gm_strip_nulls)
+        169   call 1229 ntypeargs=0              (google.internal._gm_strip_nulls)
 
   765   170   load_var 5                         (request_body)
-        171   call 943 ntypeargs=0               (ai.wire.merge_request_body)
+        171   call 944 ntypeargs=0               (ai.wire.merge_request_body)
         172   call 358 ntypeargs=0               (baml.json.stringify)
         173   return                             
 
@@ -17864,36 +17863,36 @@ function google.internal.gemini_build_body(input: ai.ModelTurnInput, client_id: 
 function google.internal.gemini_invoke(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   1090   0    load_var 2              (input)
          1    load_field 1            (journal)
-         2    call 914 ntypeargs=0    (ai.Journal.entries)
+         2    call 915 ntypeargs=0    (ai.Journal.entries)
          3    container_len           
          4    store_var 3             (seq)
 
   1091   5    load_var2 1 2           
-         6    call 1253 ntypeargs=0   (google.internal.google_render)
+         6    call 1254 ntypeargs=0   (google.internal.google_render)
          7    store_var 4             (req)
 
   1092   8    load_type 0             
          9    load_var 4              (req)
          10   load_const 1            ("google")
-         11   call 940 ntypeargs=1    (ai.wire.send_as)
+         11   call 941 ntypeargs=1    (ai.wire.send_as)
 
   1093   12   load_var 3              (seq)
          13   load_const 2            (<omitted>)
-         14   call 1249 ntypeargs=0   (google.internal.google_parse)
+         14   call 1250 ntypeargs=0   (google.internal.google_parse)
          15   return                  
 }
 
 function google.internal.gemini_invoke_stream(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   1106   0   load_var2 1 2           
          1   load_const 0            (true)
-         2   call 1254 ntypeargs=0   (google.internal._google_request)
+         2   call 1255 ntypeargs=0   (google.internal._google_request)
 
   1110   3   load_const 1            ("google")
-         4   call 1251 ntypeargs=0   (google.internal._gm_open_sse)
+         4   call 1252 ntypeargs=0   (google.internal._gm_open_sse)
 
   1109   5   load_const 2            (google.internal._google_decode_batch)
          6   load_const 3            ("google")
-         7   call 968 ntypeargs=0    (ai.stream.TurnStream.from_sse)
+         7   call 969 ntypeargs=0    (ai.stream.TurnStream.from_sse)
          8   return                  
 }
 
@@ -17920,7 +17919,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> google.internal.
         5     store_var 3                        (pending)
 
   592   6     load_var 1                         (j)
-        7     call 914 ntypeargs=0               (ai.Journal.entries)
+        7     call 915 ntypeargs=0               (ai.Journal.entries)
         8     load_type 2                        
         9     load_const 3                       ("iter")
         10    virtual_call nargs=1 ntypeargs=0   
@@ -17979,11 +17978,11 @@ function google.internal.google_lower_journal(j: ai.Journal) -> google.internal.
 
   662   60    load_var2 1 31                     
         61    load_field 0                       (id)
-        62    call 1242 ntypeargs=0              (google.internal._gm_tool_name_for)
+        62    call 1243 ntypeargs=0              (google.internal._gm_tool_name_for)
         63    load_var 32                        (response)
         64    init_instance 0                    (google.internal.GmFunctionResponse .name, .response)
 
-  661   65    call 1226 ntypeargs=0              (google.internal.GmPart.of_function_response)
+  661   65    call 1227 ntypeargs=0              (google.internal.GmPart.of_function_response)
         66    store_var 33                       (_83)
 
   660   67    load_type 1                        
@@ -18011,11 +18010,11 @@ function google.internal.google_lower_journal(j: ai.Journal) -> google.internal.
 
   652   86    load_var2 1 27                     
         87    load_field 0                       (id)
-        88    call 1242 ntypeargs=0              (google.internal._gm_tool_name_for)
+        88    call 1243 ntypeargs=0              (google.internal._gm_tool_name_for)
         89    load_var 28                        (response)
         90    init_instance 1                    (google.internal.GmFunctionResponse .name, .response)
 
-  651   91    call 1226 ntypeargs=0              (google.internal.GmPart.of_function_response)
+  651   91    call 1227 ntypeargs=0              (google.internal.GmPart.of_function_response)
         92    store_var 29                       (_69)
 
   650   93    load_type 1                        
@@ -18091,11 +18090,11 @@ function google.internal.google_lower_journal(j: ai.Journal) -> google.internal.
 
   627   155   load_var 21                        (use)
         156   load_field 0                       (id)
-        157   call 1241 ntypeargs=0              (google.internal._gm_call_id_signature)
+        157   call 1242 ntypeargs=0              (google.internal._gm_call_id_signature)
         158   store_var 24                       (_52)
 
   625   159   load_var2 23 24                    
-        160   call 1225 ntypeargs=0              (google.internal.GmPart.of_function_call)
+        160   call 1226 ntypeargs=0              (google.internal.GmPart.of_function_call)
         161   store_var 22                       (_48)
 
   624   162   load_type 1                        
@@ -18107,7 +18106,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> google.internal.
   615   167   load_var 18                        (_39)
         168   load_field 0                       (text)
 
-  617   169   call 1222 ntypeargs=0              (google.internal.GmPart.of_text)
+  617   169   call 1223 ntypeargs=0              (google.internal.GmPart.of_text)
         170   store_var 19                       (_42)
         171   load_type 1                        
         172   load_var2 14 19                    
@@ -18157,7 +18156,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> google.internal.
 
   602   210   load_var 8                         (u)
         211   load_field 0                       (content)
-        212   call 1222 ntypeargs=0              (google.internal.GmPart.of_text)
+        212   call 1223 ntypeargs=0              (google.internal.GmPart.of_text)
         213   store_var 10                       (_21)
         214   load_type 0                        
         215   load_var 2                         (contents)
@@ -18208,7 +18207,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt, fetch_url: bool)
         11   store_var 4                        (contents)
 
   492   12   load_var 1                         (prompt)
-        13   call 919 ntypeargs=0               (ai.Prompt.messages)
+        13   call 920 ntypeargs=0               (ai.Prompt.messages)
         14   load_type 4                        
         15   load_const 5                       ("iter")
         16   virtual_call nargs=1 ntypeargs=0   
@@ -18226,7 +18225,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt, fetch_url: bool)
         28   store_var_load_var 7               (message)
 
   493   29   load_var 2                         (fetch_url)
-        30   call 1237 ntypeargs=0              (google.internal._gm_prompt_parts)
+        30   call 1238 ntypeargs=0              (google.internal._gm_prompt_parts)
         31   store_var 8                        (parts)
 
   494   32   load_var 7                         (message)
@@ -18318,11 +18317,11 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         23    cmp_op ==                          
         24    pop_jump_if_false +2               (to 26)
         25    jump +8                            (to 33)
-        26    load_type 7                        
+        26    load_const 5                       (0)
         27    load_var 1                         (resp)
         28    load_field 0                       (candidates)
-        29    load_const 5                       (0)
-        30    call 3 ntypeargs=1                 (baml.Array.at)
+        29    make_bound_method 3                
+        30    call_indirect                      
         31    store_var 12                       (cand)
         32    jump +3                            (to 35)
         33    load_const 6                       (null)
@@ -18341,7 +18340,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         45    load_const 6                       (null)
         46    cmp_op ==                          
         47    pop_jump_if_false +3               (to 50)
-        48    load_const 8                       ("")
+        48    load_const 7                       ("")
         49    store_var 14                       (_28)
         50    load_var 14                        (_28)
         51    store_var 13                       (finish)
@@ -18371,22 +18370,22 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         74    load_const 6                       (null)
         75    cmp_op ==                          
         76    pop_jump_if_false +4               (to 80)
-        77    load_type 9                        
+        77    load_type 8                        
         78    alloc_array 0                      
         79    store_var 15                       (_35)
         80    load_var 15                        (_35)
-        81    load_type 10                       
-        82    load_const 11                      ("iter")
+        81    load_type 9                        
+        82    load_const 10                      ("iter")
         83    virtual_call nargs=1 ntypeargs=0   
         84    store_var 16                       (_48)
 
   851   85    load_var 16                        (_48)
-        86    load_type 12                       
-        87    load_const 13                      ("next")
+        86    load_type 11                       
+        87    load_const 12                      ("next")
         88    virtual_call nargs=1 ntypeargs=0   
         89    store_var 17                       (_49)
         90    load_var 17                        (_49)
-        91    is_type 14                         
+        91    is_type 13                         
         92    pop_jump_if_false +2               (to 94)
         93    jump +122                          (to 215)
         94    load_var 17                        (_49)
@@ -18395,7 +18394,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
   852   96    load_field 3                       (functionCall)
         97    store_var 19                       (_54)
         98    load_var 19                        (_54)
-        99    narrow_bind 15 19                  
+        99    narrow_bind 14 19                  
         100   pop_jump_if_false +2               (to 102)
         101   jump +66                           (to 167)
 
@@ -18403,7 +18402,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         103   load_field 4                       (inlineData)
         104   store_var 26                       (_76)
         105   load_var 26                        (_76)
-        106   narrow_bind 16 26                  
+        106   narrow_bind 15 26                  
         107   pop_jump_if_false +2               (to 109)
         108   jump +32                           (to 140)
 
@@ -18411,7 +18410,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         110   load_field 0                       (text)
         111   store_var 32                       (_90)
         112   load_var 32                        (_90)
-        113   narrow_bind 17 32                  
+        113   narrow_bind 16 32                  
         114   pop_jump_if_false -29              (to 85)
         115   load_var 32                        (_90)
         116   store_var 33                       (t)
@@ -18450,7 +18449,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         144   load_const 6                       (null)
         145   cmp_op ==                          
         146   pop_jump_if_false +3               (to 149)
-        147   load_const 18                      ("image/png")
+        147   load_const 17                      ("image/png")
         148   store_var 30                       (_81)
         149   load_var 30                        (_81)
         150   store_var 29                       (_80)
@@ -18460,10 +18459,10 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         154   load_const 6                       (null)
         155   cmp_op ==                          
         156   pop_jump_if_false +3               (to 159)
-        157   load_const 19                      ("")
+        157   load_const 18                      ("")
         158   store_var 31                       (_85)
         159   load_var2 29 31                    
-        160   call 1246 ntypeargs=0              (google.internal._gm_output_media)
+        160   call 1247 ntypeargs=0              (google.internal._gm_output_media)
         161   store_var 28                       (_79)
 
   869   162   load_type 3                        
@@ -18475,8 +18474,8 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
   852   167   load_var 19                        (_54)
         168   store_var 20                       (fc)
 
-  853   169   load_type 20                       
-        170   load_type 21                       
+  853   169   load_type 19                       
+        170   load_type 20                       
         171   alloc_map 0                        
         172   store_var 21                       (args)
 
@@ -18484,29 +18483,29 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         174   load_field 1                       (args)
         175   store_var 22                       (_58)
         176   load_var 22                        (_58)
-        177   narrow_bind 22 22                  
+        177   narrow_bind 21 22                  
         178   pop_jump_if_false +3               (to 181)
         179   load_var 22                        (_58)
         180   store_var 21                       (args)
 
-  859   181   load_type 23                       
+  859   181   load_type 22                       
         182   load_var 2                         (seq)
         183   call 145 ntypeargs=1               (baml.String.from)
         184   store_var 24                       (_66)
-        185   load_type 23                       
+        185   load_type 22                       
         186   load_var 11                        (call_index)
         187   call 145 ntypeargs=1               (baml.String.from)
         188   store_var 25                       (_68)
-        189   load_const 24                      ("call_")
+        189   load_const 23                      ("call_")
         190   load_var 24                        (_66)
         191   bin_op +                           
-        192   load_const 25                      ("_")
+        192   load_const 24                      ("_")
         193   bin_op +                           
         194   load_var 25                        (_68)
         195   bin_op +                           
         196   load_var 18                        (p)
         197   load_field 2                       (thoughtSignature)
-        198   call 1240 ntypeargs=0              (google.internal._gm_encode_call_id)
+        198   call 1241 ntypeargs=0              (google.internal._gm_encode_call_id)
         199   store_var 23                       (_62)
 
   857   200   load_type 3                        
@@ -18522,11 +18521,11 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         207   pop 1                              
 
   864   208   load_var 11                        (call_index)
-        209   load_const 17                      (1)
+        209   load_const 16                      (1)
         210   add_int                            
         211   store_var 11                       (call_index)
 
-  865   212   load_const 26                      (true)
+  865   212   load_const 25                      (true)
         213   store_var 10                       (has_call)
 
   852   214   jump -129                          (to 85)
@@ -18556,7 +18555,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         236   jump_if_false +5                   (to 241)
         237   pop 1                              
         238   load_var 13                        (finish)
-        239   load_const 27                      ("")
+        239   load_const 26                      ("")
         240   cmp_op ==                          
         241   jump_if_false +4                   (to 245)
         242   pop 1                              
@@ -18570,7 +18569,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         249   jump +23                           (to 272)
 
   901   250   load_var 13                        (finish)
-        251   load_const 28                      ("MAX_TOKENS")
+        251   load_const 27                      ("MAX_TOKENS")
         252   cmp_op ==                          
         253   pop_jump_if_false +2               (to 255)
         254   jump +15                           (to 269)
@@ -18580,7 +18579,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         257   jump +4                            (to 261)
         258   pop 1                              
         259   load_var 13                        (finish)
-        260   call 1247 ntypeargs=0              (google.internal._gm_is_blocked)
+        260   call 1248 ntypeargs=0              (google.internal._gm_is_blocked)
         261   pop_jump_if_false +2               (to 263)
         262   jump +4                            (to 266)
 
@@ -18589,30 +18588,30 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
 
   903   265   jump +9                            (to 274)
 
-  904   266   load_const 29                      (ai.content.StopReason.Refused)
+  904   266   load_const 28                      (ai.content.StopReason.Refused)
         267   alloc_variant 774                  (ai.content.StopReason)
 
   903   268   jump +6                            (to 274)
 
-  902   269   load_const 30                      (ai.content.StopReason.MaxTokens)
+  902   269   load_const 29                      (ai.content.StopReason.MaxTokens)
         270   alloc_variant 774                  (ai.content.StopReason)
 
   901   271   jump +3                            (to 274)
 
-  900   272   load_const 17                      (ai.content.StopReason.ToolUse)
+  900   272   load_const 16                      (ai.content.StopReason.ToolUse)
         273   alloc_variant 774                  (ai.content.StopReason)
 
   908   274   store_var 38                       (_128)
         275   load_var 1                         (resp)
         276   load_field 1                       (usageMetadata)
-        277   call 1248 ntypeargs=0              (google.internal._gm_usage)
+        277   call 1249 ntypeargs=0              (google.internal._gm_usage)
         278   store_var 39                       (_129)
         279   load_var2 9 38                     
         280   load_var 39                        (_129)
         281   init_instance 3                    (ai.ModelTurn .content, .stop_reason, .usage)
         282   return                             
 
-  896   283   load_type 31                       
+  896   283   load_type 30                       
         284   load_var 1                         (resp)
         285   call 362 ntypeargs=1               (baml.json.to_json)
         286   call 358 ntypeargs=0               (baml.json.stringify)
@@ -18641,7 +18640,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         305   load_const 6                       (null)
         306   cmp_op ==                          
         307   pop_jump_if_false +6               (to 313)
-        308   load_type 31                       
+        308   load_type 30                       
         309   load_var 1                         (resp)
         310   call 362 ntypeargs=1               (baml.json.to_json)
         311   call 358 ntypeargs=0               (baml.json.stringify)
@@ -18652,24 +18651,24 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
   842   314   load_var 8                         (_14)
         315   load_const 0                       (<omitted>)
 
-  839   316   call 986 ntypeargs=0               (ai.errors.classify_http)
+  839   316   call 987 ntypeargs=0               (ai.errors.classify_http)
         317   throw                              
 }
 
 function google.internal.google_render(c: google.GoogleClient, input: ai.ModelTurnInput) -> baml.http.Request {
   1050   0   load_var2 1 2           
          1   load_const 0            (false)
-         2   call 1254 ntypeargs=0   (google.internal._google_request)
+         2   call 1255 ntypeargs=0   (google.internal._google_request)
          3   return                  
 }
 
 function google.internal.vertex_invoke(c: google.VertexClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   331   0    load_var2 1 2           
-        1    call 1272 ntypeargs=0   (google.internal.vertex_render)
+        1    call 1273 ntypeargs=0   (google.internal.vertex_render)
         2    store_var 3             (req)
 
   332   3    load_var 1              (c)
-        4    call 1266 ntypeargs=0   (google.internal._vertex_publisher)
+        4    call 1267 ntypeargs=0   (google.internal._vertex_publisher)
         5    load_const 0            ("anthropic")
         6    cmp_op ==               
         7    pop_jump_if_false +2    (to 9)
@@ -18677,26 +18676,26 @@ function google.internal.vertex_invoke(c: google.VertexClient, input: ai.ModelTu
 
   336   9    load_var 2              (input)
         10   load_field 1            (journal)
-        11   call 914 ntypeargs=0    (ai.Journal.entries)
+        11   call 915 ntypeargs=0    (ai.Journal.entries)
         12   container_len           
         13   store_var 4             (seq)
 
   337   14   load_type 1             
         15   load_var 3              (req)
         16   load_const 2            ("vertex")
-        17   call 940 ntypeargs=1    (ai.wire.send_as)
+        17   call 941 ntypeargs=1    (ai.wire.send_as)
 
   338   18   load_var 4              (seq)
         19   load_const 3            ("vertex")
-        20   call 1249 ntypeargs=0   (google.internal.google_parse)
+        20   call 1250 ntypeargs=0   (google.internal.google_parse)
         21   jump +6                 (to 27)
 
   333   22   load_type 4             
         23   load_var 3              (req)
         24   load_const 5            ("vertex")
-        25   call 940 ntypeargs=1    (ai.wire.send_as)
+        25   call 941 ntypeargs=1    (ai.wire.send_as)
 
-  334   26   call 1200 ntypeargs=0   (anthropic.internal.anthropic_parse)
+  334   26   call 1201 ntypeargs=0   (anthropic.internal.anthropic_parse)
         27   return                  
 }
 
@@ -18707,14 +18706,14 @@ function google.internal.vertex_invoke_stream(c: google.VertexClient, input: ai.
 
   353   3    load_var2 1 2           
         4    load_const 0            (true)
-        5    call 1273 ntypeargs=0   (google.internal._vertex_request)
+        5    call 1274 ntypeargs=0   (google.internal._vertex_request)
 
   354   6    load_const 1            ("vertex")
-        7    call 1251 ntypeargs=0   (google.internal._gm_open_sse)
+        7    call 1252 ntypeargs=0   (google.internal._gm_open_sse)
         8    store_var 3             (sse)
 
   359   9    load_var 1              (c)
-        10   call 1266 ntypeargs=0   (google.internal._vertex_publisher)
+        10   call 1267 ntypeargs=0   (google.internal._vertex_publisher)
         11   load_const 2            ("anthropic")
         12   cmp_op ==               
         13   pop_jump_if_false +2    (to 15)
@@ -18723,18 +18722,18 @@ function google.internal.vertex_invoke_stream(c: google.VertexClient, input: ai.
   369   15   load_var 3              (sse)
         16   load_const 3            (google.internal._vertex_decode_batch)
         17   load_const 4            ("vertex")
-        18   call 968 ntypeargs=0    (ai.stream.TurnStream.from_sse)
+        18   call 969 ntypeargs=0    (ai.stream.TurnStream.from_sse)
         19   jump +7                 (to 26)
 
-  360   20   call 1202 ntypeargs=0   (anthropic.internal.AnthStreamState.new)
+  360   20   call 1203 ntypeargs=0   (anthropic.internal.AnthStreamState.new)
         21   store_deref 4           
 
   362   22   load_var2 3 4           
 
-  363   23   make_closure 3572 1     
+  363   23   make_closure 3573 1     
         24   load_const 5            ("vertex")
 
-  361   25   call 968 ntypeargs=0    (ai.stream.TurnStream.from_sse)
+  361   25   call 969 ntypeargs=0    (ai.stream.TurnStream.from_sse)
         26   return                  
 }
 
@@ -18804,7 +18803,7 @@ function google.internal.vertex_project_id(c: google.VertexClient) -> string | n
         6    jump +45                (to 51)
 
   130   7    load_var 1              (c)
-        8    call 1263 ntypeargs=0   (google.internal._vertex_is_express)
+        8    call 1264 ntypeargs=0   (google.internal._vertex_is_express)
         9    pop_jump_if_false +2    (to 11)
         10   jump +39                (to 49)
 
@@ -18841,8 +18840,8 @@ function google.internal.vertex_project_id(c: google.VertexClient) -> string | n
         38   jump +5                 (to 43)
 
   143   39   load_var 1              (c)
-        40   call 1260 ntypeargs=0   (google.internal._vertex_credentials)
-        41   call 1278 ntypeargs=0   (google.internal.gcp_project_id)
+        40   call 1261 ntypeargs=0   (google.internal._vertex_credentials)
+        41   call 1279 ntypeargs=0   (google.internal.gcp_project_id)
         42   jump +10                (to 52)
 
   140   43   load_var 6              (legacy)
@@ -18863,13 +18862,13 @@ function google.internal.vertex_project_id(c: google.VertexClient) -> string | n
 function google.internal.vertex_render(c: google.VertexClient, input: ai.ModelTurnInput) -> baml.http.Request {
   264   0   load_var2 1 2           
         1   load_const 0            (false)
-        2   call 1273 ntypeargs=0   (google.internal._vertex_request)
+        2   call 1274 ntypeargs=0   (google.internal._vertex_request)
         3   return                  
 }
 
 function google.internal.vertex_url(c: google.VertexClient, stream: bool) -> string {
   216   0    load_var 1              (c)
-        1    call 1268 ntypeargs=0   (google.internal._vertex_models_base)
+        1    call 1269 ntypeargs=0   (google.internal._vertex_models_base)
         2    store_var 5             (_8)
         3    load_type 0             
         4    load_var 5              (_8)
@@ -18881,7 +18880,7 @@ function google.internal.vertex_url(c: google.VertexClient, stream: bool) -> str
         10   call 145 ntypeargs=1    (baml.String.from)
         11   store_var 6             (_10)
         12   load_var2 1 2           
-        13   call 1269 ntypeargs=0   (google.internal._vertex_method)
+        13   call 1270 ntypeargs=0   (google.internal._vertex_method)
         14   store_var 8             (_14)
         15   load_type 0             
         16   load_var 8              (_14)
@@ -18898,11 +18897,11 @@ function google.internal.vertex_url(c: google.VertexClient, stream: bool) -> str
   217   26   load_var 1              (c)
         27   load_field 9            (query_params)
 
-  215   28   call 1230 ntypeargs=0   (google.internal._gm_apply_query)
+  215   28   call 1231 ntypeargs=0   (google.internal._gm_apply_query)
         29   store_var 3             (with_params)
 
   219   30   load_var 1              (c)
-        31   call 1261 ntypeargs=0   (google.internal._vertex_express_key)
+        31   call 1262 ntypeargs=0   (google.internal._vertex_express_key)
         32   store_var 9             (_18)
         33   load_var 9              (_18)
         34   narrow_bind 2 9         
@@ -18920,7 +18919,7 @@ function google.internal.vertex_url(c: google.VertexClient, stream: bool) -> str
         42   load_type 0             
         43   alloc_map 1             
 
-  221   44   call 1230 ntypeargs=0   (google.internal._gm_apply_query)
+  221   44   call 1231 ntypeargs=0   (google.internal._gm_apply_query)
         45   return                  
 }
 
@@ -18938,40 +18937,40 @@ function openai.AzureClient.ai.Client.id(self: openai.AzureClient) -> string {
 
 function openai.AzureClient.ai.Client.invoke(self: openai.AzureClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   191   0    load_var 1              (self)
-        1    call 1080 ntypeargs=0   (openai.AzureClient.compat)
+        1    call 1081 ntypeargs=0   (openai.AzureClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1081 ntypeargs=0   (openai.AzureClient.params)
+        4    call 1082 ntypeargs=0   (openai.AzureClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1143 ntypeargs=0   (openai.internal.chat_invoke)
+        8    call 1144 ntypeargs=0   (openai.internal.chat_invoke)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   192   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
 
 function openai.AzureClient.ai.stream.StreamingClient.invoke_stream(self: openai.AzureClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   199   0    load_var 1              (self)
-        1    call 1080 ntypeargs=0   (openai.AzureClient.compat)
+        1    call 1081 ntypeargs=0   (openai.AzureClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1081 ntypeargs=0   (openai.AzureClient.params)
+        4    call 1082 ntypeargs=0   (openai.AzureClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1149 ntypeargs=0   (openai.internal.chat_invoke_stream)
+        8    call 1150 ntypeargs=0   (openai.internal.chat_invoke_stream)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   200   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
@@ -19000,7 +18999,7 @@ function openai.AzureClient.compat(self: openai.AzureClient) -> openai.internal.
         16   pop 1                   
 
   160   17   load_var 1              (self)
-        18   call 1079 ntypeargs=0   (openai.AzureClient.resolved_base_url)
+        18   call 1080 ntypeargs=0   (openai.AzureClient.resolved_base_url)
         19   store_var 4             (_10)
 
   158   20   load_const 3            ("azure")
@@ -19019,7 +19018,7 @@ function openai.AzureClient.compat(self: openai.AzureClient) -> openai.internal.
 
   165   33   load_var 2              (query)
 
-  158   34   call 1108 ntypeargs=0   (openai.internal.ChatCompat.new)
+  158   34   call 1109 ntypeargs=0   (openai.internal.ChatCompat.new)
         35   return                  
 }
 
@@ -19141,7 +19140,7 @@ function openai.AzureClient.params(self: openai.AzureClient) -> openai.internal.
         2    store_var 2             (_2)
 
   172   3    load_var 1              (self)
-        4    call 1077 ntypeargs=0   (openai.AzureClient.resolved_api_key)
+        4    call 1078 ntypeargs=0   (openai.AzureClient.resolved_api_key)
         5    store_var 3             (_3)
 
   170   6    load_var2 2 3           
@@ -19173,7 +19172,7 @@ function openai.AzureClient.params(self: openai.AzureClient) -> openai.internal.
   181   23   load_var 1              (self)
         24   load_field 6            (request_body)
 
-  170   25   call 1109 ntypeargs=0   (openai.internal.ChatParams.new)
+  170   25   call 1110 ntypeargs=0   (openai.internal.ChatParams.new)
         26   return                  
 }
 
@@ -19181,7 +19180,7 @@ function openai.AzureClient.resolved_api_key(self: openai.AzureClient) -> string
   95   0   load_var 1             (self)
        1   load_field 5           (api_key)
        2   load_const 0           ("AZURE_OPENAI_API_KEY")
-       3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4   return                 
 }
 
@@ -19189,7 +19188,7 @@ function openai.AzureClient.resolved_base_url(self: openai.AzureClient) -> strin
   126   0     load_var 1              (self)
         1     load_field 4            (base_url)
         2     load_const 0            (null)
-        3     call 937 ntypeargs=0    (ai.wire.resolve_credential)
+        3     call 938 ntypeargs=0    (ai.wire.resolve_credential)
         4     store_var 2             (_4)
         5     load_var 2              (_4)
         6     narrow_bind 1 2         
@@ -19197,7 +19196,7 @@ function openai.AzureClient.resolved_base_url(self: openai.AzureClient) -> strin
         8     jump +72                (to 80)
 
   134   9     load_var 1              (self)
-        10    call 1078 ntypeargs=0   (openai.AzureClient.resolved_deployment_id)
+        10    call 1079 ntypeargs=0   (openai.AzureClient.resolved_deployment_id)
         11    store_var 4             (deployment)
 
   135   12    load_var 1              (self)
@@ -19210,7 +19209,7 @@ function openai.AzureClient.resolved_base_url(self: openai.AzureClient) -> strin
 
   140   19    load_const 0            (null)
         20    load_const 2            ("AZURE_OPENAI_ENDPOINT")
-        21    call 937 ntypeargs=0    (ai.wire.resolve_credential)
+        21    call 938 ntypeargs=0    (ai.wire.resolve_credential)
         22    store_var 8             (_26)
         23    load_var 8              (_26)
         24    narrow_bind 1 8         
@@ -19218,7 +19217,7 @@ function openai.AzureClient.resolved_base_url(self: openai.AzureClient) -> strin
         26    jump +4                 (to 30)
 
   148   27    load_const 3            ("openai.AzureClient needs a deployment endpoint: set base_url, or resource_name, or the AZURE_OPENAI_ENDPOINT environment variable")
-        28    call 1107 ntypeargs=0   (openai.internal._azure_reject)
+        28    call 1108 ntypeargs=0   (openai.internal._azure_reject)
         29    throw                   
 
   140   30    load_var 8              (_26)
@@ -19303,7 +19302,7 @@ function openai.AzureClient.resolved_base_url(self: openai.AzureClient) -> strin
         98    return                  
 
   128   99    load_const 10           ("openai.AzureClient takes base_url OR resource_name/deployment_id, not both")
-        100   call 1107 ntypeargs=0   (openai.internal._azure_reject)
+        100   call 1108 ntypeargs=0   (openai.internal._azure_reject)
         101   throw                   
 }
 
@@ -19335,47 +19334,47 @@ function openai.ChatClient.ai.Client.id(self: openai.ChatClient) -> string {
 
 function openai.ChatClient.ai.Client.invoke(self: openai.ChatClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   115   0    load_var 1              (self)
-        1    call 1063 ntypeargs=0   (openai.ChatClient.compat)
+        1    call 1064 ntypeargs=0   (openai.ChatClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1064 ntypeargs=0   (openai.ChatClient.params)
+        4    call 1065 ntypeargs=0   (openai.ChatClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1143 ntypeargs=0   (openai.internal.chat_invoke)
+        8    call 1144 ntypeargs=0   (openai.internal.chat_invoke)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   116   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
 
 function openai.ChatClient.ai.stream.StreamingClient.invoke_stream(self: openai.ChatClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   123   0    load_var 1              (self)
-        1    call 1063 ntypeargs=0   (openai.ChatClient.compat)
+        1    call 1064 ntypeargs=0   (openai.ChatClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1064 ntypeargs=0   (openai.ChatClient.params)
+        4    call 1065 ntypeargs=0   (openai.ChatClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1149 ntypeargs=0   (openai.internal.chat_invoke_stream)
+        8    call 1150 ntypeargs=0   (openai.internal.chat_invoke_stream)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   124   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
 
 function openai.ChatClient.compat(self: openai.ChatClient) -> openai.internal.ChatCompat {
   86   0    load_var 1              (self)
-       1    call 1062 ntypeargs=0   (openai.ChatClient.resolved_base_url)
+       1    call 1063 ntypeargs=0   (openai.ChatClient.resolved_base_url)
        2    store_var 2             (_2)
 
   84   3    load_const 0            ("openai-chat")
@@ -19391,7 +19390,7 @@ function openai.ChatClient.compat(self: openai.ChatClient) -> openai.internal.Ch
        13   load_const 1            (<omitted>)
        14   load_const 1            (<omitted>)
        15   load_const 1            (<omitted>)
-       16   call 1108 ntypeargs=0   (openai.internal.ChatCompat.new)
+       16   call 1109 ntypeargs=0   (openai.internal.ChatCompat.new)
        17   return                  
 }
 
@@ -19497,7 +19496,7 @@ function openai.ChatClient.params(self: openai.ChatClient) -> openai.internal.Ch
         2    store_var 2             (_2)
 
   96    3    load_var 1              (self)
-        4    call 1061 ntypeargs=0   (openai.ChatClient.resolved_api_key)
+        4    call 1062 ntypeargs=0   (openai.ChatClient.resolved_api_key)
         5    store_var 3             (_3)
 
   94    6    load_var2 2 3           
@@ -19529,7 +19528,7 @@ function openai.ChatClient.params(self: openai.ChatClient) -> openai.internal.Ch
   105   23   load_var 1              (self)
         24   load_field 3            (request_body)
 
-  94    25   call 1109 ntypeargs=0   (openai.internal.ChatParams.new)
+  94    25   call 1110 ntypeargs=0   (openai.internal.ChatParams.new)
         26   return                  
 }
 
@@ -19537,7 +19536,7 @@ function openai.ChatClient.resolved_api_key(self: openai.ChatClient) -> string |
   72   0   load_var 1             (self)
        1   load_field 1           (api_key)
        2   load_const 0           ("OPENAI_API_KEY")
-       3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4   return                 
 }
 
@@ -19545,7 +19544,7 @@ function openai.ChatClient.resolved_base_url(self: openai.ChatClient) -> string 
   77   0    load_var 1             (self)
        1    load_field 2           (base_url)
        2    load_const 0           (null)
-       3    call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3    call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4    store_var_load_var 2   (_2)
        5    load_const 0           (null)
        6    cmp_op ==              
@@ -19570,47 +19569,47 @@ function openai.GenericClient.ai.Client.id(self: openai.GenericClient) -> string
 
 function openai.GenericClient.ai.Client.invoke(self: openai.GenericClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   114   0    load_var 1              (self)
-        1    call 1071 ntypeargs=0   (openai.GenericClient.compat)
+        1    call 1072 ntypeargs=0   (openai.GenericClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1072 ntypeargs=0   (openai.GenericClient.params)
+        4    call 1073 ntypeargs=0   (openai.GenericClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1143 ntypeargs=0   (openai.internal.chat_invoke)
+        8    call 1144 ntypeargs=0   (openai.internal.chat_invoke)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   115   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
 
 function openai.GenericClient.ai.stream.StreamingClient.invoke_stream(self: openai.GenericClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   122   0    load_var 1              (self)
-        1    call 1071 ntypeargs=0   (openai.GenericClient.compat)
+        1    call 1072 ntypeargs=0   (openai.GenericClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1072 ntypeargs=0   (openai.GenericClient.params)
+        4    call 1073 ntypeargs=0   (openai.GenericClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1149 ntypeargs=0   (openai.internal.chat_invoke_stream)
+        8    call 1150 ntypeargs=0   (openai.internal.chat_invoke_stream)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   123   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
 
 function openai.GenericClient.compat(self: openai.GenericClient) -> openai.internal.ChatCompat {
   88   0    load_var 1              (self)
-       1    call 1070 ntypeargs=0   (openai.GenericClient.resolved_base_url)
+       1    call 1071 ntypeargs=0   (openai.GenericClient.resolved_base_url)
        2    store_var 2             (_2)
 
   86   3    load_const 0            ("openai-generic")
@@ -19626,7 +19625,7 @@ function openai.GenericClient.compat(self: openai.GenericClient) -> openai.inter
        13   load_const 1            (<omitted>)
        14   load_const 1            (<omitted>)
        15   load_const 1            (<omitted>)
-       16   call 1108 ntypeargs=0   (openai.internal.ChatCompat.new)
+       16   call 1109 ntypeargs=0   (openai.internal.ChatCompat.new)
        17   return                  
 }
 
@@ -19718,7 +19717,7 @@ function openai.GenericClient.params(self: openai.GenericClient) -> openai.inter
         2    store_var 2             (_2)
 
   96    3    load_var 1              (self)
-        4    call 1069 ntypeargs=0   (openai.GenericClient.resolved_api_key)
+        4    call 1070 ntypeargs=0   (openai.GenericClient.resolved_api_key)
         5    store_var 3             (_3)
 
   94    6    load_var2 2 3           
@@ -19748,7 +19747,7 @@ function openai.GenericClient.params(self: openai.GenericClient) -> openai.inter
   104   22   load_var 1              (self)
         23   load_field 3            (request_body)
 
-  94    24   call 1109 ntypeargs=0   (openai.internal.ChatParams.new)
+  94    24   call 1110 ntypeargs=0   (openai.internal.ChatParams.new)
         25   return                  
 }
 
@@ -19756,7 +19755,7 @@ function openai.GenericClient.resolved_api_key(self: openai.GenericClient) -> st
   64   0   load_var 1             (self)
        1   load_field 2           (api_key)
        2   load_const 0           (null)
-       3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4   return                 
 }
 
@@ -19764,7 +19763,7 @@ function openai.GenericClient.resolved_base_url(self: openai.GenericClient) -> s
   72   0    load_var 1              (self)
        1    load_field 1            (base_url)
        2    load_const 0            (null)
-       3    call 937 ntypeargs=0    (ai.wire.resolve_credential)
+       3    call 938 ntypeargs=0    (ai.wire.resolve_credential)
        4    store_var 2             (_4)
        5    load_var 2              (_4)
        6    narrow_bind 1 2         
@@ -19774,7 +19773,7 @@ function openai.GenericClient.resolved_base_url(self: openai.GenericClient) -> s
   81   9    load_var 1              (self)
        10   load_field 1            (base_url)
        11   load_const 0            (null)
-       12   call 939 ntypeargs=0    (ai.wire.credential_sources)
+       12   call 940 ntypeargs=0    (ai.wire.credential_sources)
        13   store_var 4             (_9)
        14   load_type 2             
        15   load_var 4              (_9)
@@ -19787,7 +19786,7 @@ function openai.GenericClient.resolved_base_url(self: openai.GenericClient) -> s
        20   load_var 3              (_8)
        21   bin_op +                
 
-  79   22   call 1106 ntypeargs=0   (openai.internal._reject)
+  79   22   call 1107 ntypeargs=0   (openai.internal._reject)
        23   throw                   
 
   72   24   load_var 2              (_4)
@@ -19796,19 +19795,19 @@ function openai.GenericClient.resolved_base_url(self: openai.GenericClient) -> s
 
 function openai.ImageClient.ai.Client.id(self: openai.ImageClient) -> string {
   133   0   load_var 1              (self)
-        1   call 1150 ntypeargs=0   (openai.internal._oai_images_client_id)
+        1   call 1151 ntypeargs=0   (openai.internal._oai_images_client_id)
         2   return                  
 }
 
 function openai.ImageClient.ai.Client.invoke(self: openai.ImageClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   137   0   load_var2 1 2           
-        1   call 1164 ntypeargs=0   (openai.internal.images_invoke)
+        1   call 1165 ntypeargs=0   (openai.internal.images_invoke)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   138   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
@@ -19943,7 +19942,7 @@ function openai.ImageClient.resolved_api_key(self: openai.ImageClient) -> string
   115   0    load_var 1             (self)
         1    load_field 1           (api_key)
         2    load_const 0           ("OPENAI_API_KEY")
-        3    call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3    call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4    store_var 2            (_4)
         5    load_var 2             (_4)
         6    narrow_bind 1 2        
@@ -19953,7 +19952,7 @@ function openai.ImageClient.resolved_api_key(self: openai.ImageClient) -> string
   121   9    load_var 1             (self)
         10   load_field 1           (api_key)
         11   load_const 2           ("OPENAI_API_KEY")
-        12   call 939 ntypeargs=0   (ai.wire.credential_sources)
+        12   call 940 ntypeargs=0   (ai.wire.credential_sources)
         13   store_var 4            (_9)
         14   load_type 3            
         15   load_var 4             (_9)
@@ -19978,7 +19977,7 @@ function openai.ImageClient.resolved_base_url(self: openai.ImageClient) -> strin
   128   0   load_var 1             (self)
         1   load_field 2           (base_url)
         2   load_const 0           (null)
-        3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4   return                 
 }
 
@@ -19996,47 +19995,47 @@ function openai.OllamaClient.ai.Client.id(self: openai.OllamaClient) -> string {
 
 function openai.OllamaClient.ai.Client.invoke(self: openai.OllamaClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   97   0    load_var 1              (self)
-       1    call 1088 ntypeargs=0   (openai.OllamaClient.compat)
+       1    call 1089 ntypeargs=0   (openai.OllamaClient.compat)
        2    store_var 4             (_4)
        3    load_var 1              (self)
-       4    call 1089 ntypeargs=0   (openai.OllamaClient.params)
+       4    call 1090 ntypeargs=0   (openai.OllamaClient.params)
        5    store_var 5             (_5)
        6    load_var2 4 5           
        7    load_var 2              (input)
-       8    call 1143 ntypeargs=0   (openai.internal.chat_invoke)
+       8    call 1144 ntypeargs=0   (openai.internal.chat_invoke)
        9    jump +6                 (to 15)
        10   load_var 3              (e)
        11   throw_if_panic          
 
   98   12   load_var 3              (e)
-       13   call 977 ntypeargs=0    (ai.errors.normalize)
+       13   call 978 ntypeargs=0    (ai.errors.normalize)
        14   throw                   
        15   return                  
 }
 
 function openai.OllamaClient.ai.stream.StreamingClient.invoke_stream(self: openai.OllamaClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   105   0    load_var 1              (self)
-        1    call 1088 ntypeargs=0   (openai.OllamaClient.compat)
+        1    call 1089 ntypeargs=0   (openai.OllamaClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1089 ntypeargs=0   (openai.OllamaClient.params)
+        4    call 1090 ntypeargs=0   (openai.OllamaClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1149 ntypeargs=0   (openai.internal.chat_invoke_stream)
+        8    call 1150 ntypeargs=0   (openai.internal.chat_invoke_stream)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   106   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
 
 function openai.OllamaClient.compat(self: openai.OllamaClient) -> openai.internal.ChatCompat {
   70   0    load_var 1              (self)
-       1    call 1087 ntypeargs=0   (openai.OllamaClient.resolved_base_url)
+       1    call 1088 ntypeargs=0   (openai.OllamaClient.resolved_base_url)
        2    store_var 2             (_2)
 
   68   3    load_const 0            ("ollama")
@@ -20052,7 +20051,7 @@ function openai.OllamaClient.compat(self: openai.OllamaClient) -> openai.interna
        13   load_const 1            (<omitted>)
        14   load_const 1            (<omitted>)
        15   load_const 1            (<omitted>)
-       16   call 1108 ntypeargs=0   (openai.internal.ChatCompat.new)
+       16   call 1109 ntypeargs=0   (openai.internal.ChatCompat.new)
        17   return                  
 }
 
@@ -20144,7 +20143,7 @@ function openai.OllamaClient.params(self: openai.OllamaClient) -> openai.interna
        2    store_var 2             (_2)
 
   79   3    load_var 1              (self)
-       4    call 1086 ntypeargs=0   (openai.OllamaClient.resolved_api_key)
+       4    call 1087 ntypeargs=0   (openai.OllamaClient.resolved_api_key)
        5    store_var 3             (_3)
 
   77   6    load_var2 2 3           
@@ -20174,7 +20173,7 @@ function openai.OllamaClient.params(self: openai.OllamaClient) -> openai.interna
   87   22   load_var 1              (self)
        23   load_field 3            (request_body)
 
-  77   24   call 1109 ntypeargs=0   (openai.internal.ChatParams.new)
+  77   24   call 1110 ntypeargs=0   (openai.internal.ChatParams.new)
        25   return                  
 }
 
@@ -20182,7 +20181,7 @@ function openai.OllamaClient.resolved_api_key(self: openai.OllamaClient) -> stri
   60   0   load_var 1             (self)
        1   load_field 2           (api_key)
        2   load_const 0           (null)
-       3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4   return                 
 }
 
@@ -20190,7 +20189,7 @@ function openai.OllamaClient.resolved_base_url(self: openai.OllamaClient) -> str
   64   0    load_var 1             (self)
        1    load_field 1           (base_url)
        2    load_const 0           (null)
-       3    call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3    call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4    store_var_load_var 2   (_2)
        5    load_const 0           (null)
        6    cmp_op ==              
@@ -20215,47 +20214,47 @@ function openai.OpenRouterClient.ai.Client.id(self: openai.OpenRouterClient) -> 
 
 function openai.OpenRouterClient.ai.Client.invoke(self: openai.OpenRouterClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   95   0    load_var 1              (self)
-       1    call 1096 ntypeargs=0   (openai.OpenRouterClient.compat)
+       1    call 1097 ntypeargs=0   (openai.OpenRouterClient.compat)
        2    store_var 4             (_4)
        3    load_var 1              (self)
-       4    call 1097 ntypeargs=0   (openai.OpenRouterClient.params)
+       4    call 1098 ntypeargs=0   (openai.OpenRouterClient.params)
        5    store_var 5             (_5)
        6    load_var2 4 5           
        7    load_var 2              (input)
-       8    call 1143 ntypeargs=0   (openai.internal.chat_invoke)
+       8    call 1144 ntypeargs=0   (openai.internal.chat_invoke)
        9    jump +6                 (to 15)
        10   load_var 3              (e)
        11   throw_if_panic          
 
   96   12   load_var 3              (e)
-       13   call 977 ntypeargs=0    (ai.errors.normalize)
+       13   call 978 ntypeargs=0    (ai.errors.normalize)
        14   throw                   
        15   return                  
 }
 
 function openai.OpenRouterClient.ai.stream.StreamingClient.invoke_stream(self: openai.OpenRouterClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   103   0    load_var 1              (self)
-        1    call 1096 ntypeargs=0   (openai.OpenRouterClient.compat)
+        1    call 1097 ntypeargs=0   (openai.OpenRouterClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1097 ntypeargs=0   (openai.OpenRouterClient.params)
+        4    call 1098 ntypeargs=0   (openai.OpenRouterClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1149 ntypeargs=0   (openai.internal.chat_invoke_stream)
+        8    call 1150 ntypeargs=0   (openai.internal.chat_invoke_stream)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   104   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
 
 function openai.OpenRouterClient.compat(self: openai.OpenRouterClient) -> openai.internal.ChatCompat {
   68   0    load_var 1              (self)
-       1    call 1095 ntypeargs=0   (openai.OpenRouterClient.resolved_base_url)
+       1    call 1096 ntypeargs=0   (openai.OpenRouterClient.resolved_base_url)
        2    store_var 2             (_2)
 
   66   3    load_const 0            ("openrouter")
@@ -20271,7 +20270,7 @@ function openai.OpenRouterClient.compat(self: openai.OpenRouterClient) -> openai
        13   load_const 1            (<omitted>)
        14   load_const 1            (<omitted>)
        15   load_const 1            (<omitted>)
-       16   call 1108 ntypeargs=0   (openai.internal.ChatCompat.new)
+       16   call 1109 ntypeargs=0   (openai.internal.ChatCompat.new)
        17   return                  
 }
 
@@ -20363,7 +20362,7 @@ function openai.OpenRouterClient.params(self: openai.OpenRouterClient) -> openai
        2    store_var 2             (_2)
 
   77   3    load_var 1              (self)
-       4    call 1094 ntypeargs=0   (openai.OpenRouterClient.resolved_api_key)
+       4    call 1095 ntypeargs=0   (openai.OpenRouterClient.resolved_api_key)
        5    store_var 3             (_3)
 
   75   6    load_var2 2 3           
@@ -20393,7 +20392,7 @@ function openai.OpenRouterClient.params(self: openai.OpenRouterClient) -> openai
   85   22   load_var 1              (self)
        23   load_field 3            (request_body)
 
-  75   24   call 1109 ntypeargs=0   (openai.internal.ChatParams.new)
+  75   24   call 1110 ntypeargs=0   (openai.internal.ChatParams.new)
        25   return                  
 }
 
@@ -20401,7 +20400,7 @@ function openai.OpenRouterClient.resolved_api_key(self: openai.OpenRouterClient)
   58   0   load_var 1             (self)
        1   load_field 1           (api_key)
        2   load_const 0           ("OPENROUTER_API_KEY")
-       3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4   return                 
 }
 
@@ -20409,7 +20408,7 @@ function openai.OpenRouterClient.resolved_base_url(self: openai.OpenRouterClient
   62   0    load_var 1             (self)
        1    load_field 2           (base_url)
        2    load_const 0           (null)
-       3    call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3    call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4    store_var_load_var 2   (_2)
        5    load_const 0           (null)
        6    cmp_op ==              
@@ -20434,26 +20433,26 @@ function openai.ResponsesClient.ai.Client.id(self: openai.ResponsesClient) -> st
 
 function openai.ResponsesClient.ai.Client.invoke(self: openai.ResponsesClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   127   0   load_var2 1 2           
-        1   call 1052 ntypeargs=0   (openai.internal.invoke)
+        1   call 1053 ntypeargs=0   (openai.internal.invoke)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   128   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
 
 function openai.ResponsesClient.ai.stream.StreamingClient.invoke_stream(self: openai.ResponsesClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   135   0   load_var2 1 2           
-        1   call 1059 ntypeargs=0   (openai.internal.invoke_stream)
+        1   call 1060 ntypeargs=0   (openai.internal.invoke_stream)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   136   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
@@ -20573,7 +20572,7 @@ function openai.ResponsesClient.resolved_api_key(self: openai.ResponsesClient) -
   105   0    load_var 1             (self)
         1    load_field 1           (api_key)
         2    load_const 0           ("OPENAI_API_KEY")
-        3    call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3    call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4    store_var 2            (_4)
         5    load_var 2             (_4)
         6    narrow_bind 1 2        
@@ -20583,7 +20582,7 @@ function openai.ResponsesClient.resolved_api_key(self: openai.ResponsesClient) -
   111   9    load_var 1             (self)
         10   load_field 1           (api_key)
         11   load_const 2           ("OPENAI_API_KEY")
-        12   call 939 ntypeargs=0   (ai.wire.credential_sources)
+        12   call 940 ntypeargs=0   (ai.wire.credential_sources)
         13   store_var 4            (_9)
         14   load_type 3            
         15   load_var 4             (_9)
@@ -20608,7 +20607,7 @@ function openai.ResponsesClient.resolved_base_url(self: openai.ResponsesClient) 
   118   0   load_var 1             (self)
         1   load_field 2           (base_url)
         2   load_const 0           (null)
-        3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4   return                 
 }
 
@@ -20822,7 +20821,7 @@ function openai.internal.ChatExtraPart.baml.ToJson.to_json(self: openai.internal
         59   cmp_int_op >                       
         60   pop_jump_if_false +14              (to 74)
 
-  271   61   call 1112 ntypeargs=0              (openai.internal._chat_directives_key)
+  271   61   call 1113 ntypeargs=0              (openai.internal._chat_directives_key)
         62   store_var 11                       (_31)
         63   load_type 1                        
         64   load_var 1                         (self)
@@ -20944,7 +20943,7 @@ function openai.internal.ChatStreamDecoder._absorb_call(self: openai.internal.Ch
          16    load_field 1            (calls)
 
   1398   17    load_var 4              (index)
-         18    make_closure 2988 1     
+         18    make_closure 2989 1     
 
   1397   19    call 19 ntypeargs=2     (baml.Array.find)
 
@@ -21063,7 +21062,7 @@ function openai.internal.ChatStreamDecoder.decode(self: openai.internal.ChatStre
          2     store_var 3                        (out)
 
   1424   3     load_var 2                         (batch)
-         4     call 967 ntypeargs=0               (ai.stream.decode_sse_batch)
+         4     call 968 ntypeargs=0               (ai.stream.decode_sse_batch)
          5     load_type 1                        
          6     load_const 2                       ("iter")
          7     virtual_call nargs=1 ntypeargs=0   
@@ -21246,7 +21245,7 @@ function openai.internal.ChatStreamDecoder.decode(self: openai.internal.ChatStre
 
   1458   163   load_var2 1 23                     
          164   load_var 21                        (position)
-         165   call 1145 ntypeargs=0              (openai.internal.ChatStreamDecoder._absorb_call)
+         165   call 1146 ntypeargs=0              (openai.internal.ChatStreamDecoder._absorb_call)
          166   pop 1                              
 
   1459   167   load_var 21                        (position)
@@ -21264,7 +21263,7 @@ function openai.internal.ChatStreamDecoder.decode(self: openai.internal.ChatStre
          177   pop_jump_if_false +11              (to 188)
          178   load_var 24                        (_82)
 
-  1464   179   call 1137 ntypeargs=0              (openai.internal.chat_stop_reason)
+  1464   179   call 1138 ntypeargs=0              (openai.internal.chat_stop_reason)
          180   store_var 25                       (_86)
 
   1462   181   load_type 0                        
@@ -21361,7 +21360,7 @@ function openai.internal.ChatStreamDecoder.tool_uses(self: openai.internal.ChatS
          27   load_field 3                       (arguments)
          28   load_var 1                         (self)
          29   load_field 0                       (provider)
-         30   call 1139 ntypeargs=0              (openai.internal._chat_tool_args)
+         30   call 1140 ntypeargs=0              (openai.internal._chat_tool_args)
          31   store_var 6                        (args)
          32   jump +5                            (to 37)
 
@@ -21475,7 +21474,7 @@ function openai.internal.OaStreamState.new() -> openai.internal.OaStreamState {
 function openai.internal._azure_reject(detail: string) -> ai.errors.InvalidRequest {
   49   0   load_const 0            ("azure")
        1   load_var 1              (detail)
-       2   call 1106 ntypeargs=0   (openai.internal._reject)
+       2   call 1107 ntypeargs=0   (openai.internal._reject)
        3   return                  
 }
 
@@ -21538,7 +21537,7 @@ function openai.internal._chat_apply_directives(j: baml.json.json) -> baml.json.
 
   835   17    load_var 17                        (_47)
 
-  854   18    make_closure 2903 0                
+  854   18    make_closure 2904 0                
         19    call 16 ntypeargs=3                (baml.Array.map)
         20    jump +88                           (to 108)
 
@@ -21570,7 +21569,7 @@ function openai.internal._chat_apply_directives(j: baml.json.json) -> baml.json.
         44    load_var 6                         (_9)
         45    store_var 7                        (key)
 
-  839   46    call 1112 ntypeargs=0              (openai.internal._chat_directives_key)
+  839   46    call 1113 ntypeargs=0              (openai.internal._chat_directives_key)
         47    store_var 8                        (_15)
         48    load_var2 7 8                      
         49    cmp_op !=                          
@@ -21580,7 +21579,7 @@ function openai.internal._chat_apply_directives(j: baml.json.json) -> baml.json.
         52    load_type 2                        
         53    load_var2 3 7                      
         54    call 38 ntypeargs=2                (baml.Map.get)
-        55    call 1127 ntypeargs=0              (openai.internal._chat_apply_directives)
+        55    call 1128 ntypeargs=0              (openai.internal._chat_apply_directives)
         56    store_var 9                        (_18)
         57    load_type 4                        
         58    load_type 2                        
@@ -21590,7 +21589,7 @@ function openai.internal._chat_apply_directives(j: baml.json.json) -> baml.json.
         62    pop 1                              
         63    jump -28                           (to 35)
 
-  843   64    call 1112 ntypeargs=0              (openai.internal._chat_directives_key)
+  843   64    call 1113 ntypeargs=0              (openai.internal._chat_directives_key)
         65    store_var 10                       (_26)
         66    load_type 4                        
         67    load_type 2                        
@@ -21804,7 +21803,7 @@ function openai.internal._chat_content(parts: (openai.internal.ChatTextPart | op
         1    jump_if_false +4                   (to 5)
         2    pop 1                              
         3    load_var 1                         (parts)
-        4    call 1122 ntypeargs=0              (openai.internal._chat_all_text)
+        4    call 1123 ntypeargs=0              (openai.internal._chat_all_text)
         5    pop_jump_if_false +2               (to 7)
         6    jump +3                            (to 9)
 
@@ -22011,7 +22010,7 @@ function openai.internal._chat_headers(compat: openai.internal.ChatCompat, param
         132   load_var 14                        (_37)
         133   bin_op +                           
 
-  955   134   call 1106 ntypeargs=0              (openai.internal._reject)
+  955   134   call 1107 ntypeargs=0              (openai.internal._reject)
         135   throw                              
 }
 
@@ -22022,7 +22021,7 @@ function openai.internal._chat_is_opaque_key(key: string) -> bool {
         3    jump_if_false +2        (to 5)
         4    jump +6                 (to 10)
         5    pop 1                   
-        6    call 1112 ntypeargs=0   (openai.internal._chat_directives_key)
+        6    call 1113 ntypeargs=0   (openai.internal._chat_directives_key)
         7    store_var 2             (_3)
         8    load_var2 1 2           
         9    cmp_op ==               
@@ -22049,7 +22048,7 @@ function openai.internal._chat_media_block(url: string) -> ai.content.Media {
          14   call 354 ntypeargs=0   (baml.media.Image.from_url)
          15   load_const 4           (<omitted>)
          16   load_const 4           (<omitted>)
-         17   call 913 ntypeargs=0   (ai.content.Media.new)
+         17   call 914 ntypeargs=0   (ai.content.Media.new)
          18   jump +23               (to 41)
 
   1117   19   load_var 2             (_4)
@@ -22077,7 +22076,7 @@ function openai.internal._chat_media_block(url: string) -> ai.content.Media {
 
   1118   38   load_const 4           (<omitted>)
          39   load_const 4           (<omitted>)
-         40   call 913 ntypeargs=0   (ai.content.Media.new)
+         40   call 914 ntypeargs=0   (ai.content.Media.new)
          41   return                 
 }
 
@@ -22105,14 +22104,14 @@ function openai.internal._chat_media_part(media: baml.media.Image | baml.media.A
         19    load_field 0            (provider)
         20    load_const 3            ("OpenAI Chat Completions has no video input part; extract frames as images, or use the Realtime API")
 
-  576   21    call 1106 ntypeargs=0   (openai.internal._reject)
+  576   21    call 1107 ntypeargs=0   (openai.internal._reject)
         22    throw                   
 
   524   23    load_var 10             (_22)
         24    store_var_load_var 11   (pdf)
 
   552   25    load_const 4            (true)
-        26    call 942 ntypeargs=0    (ai.wire.resolve_media)
+        26    call 943 ntypeargs=0    (ai.wire.resolve_media)
         27    store_var 12            (resolved)
 
   556   28    load_var 12             (resolved)
@@ -22148,7 +22147,7 @@ function openai.internal._chat_media_part(media: baml.media.Image | baml.media.A
         54    load_const 10           (" is not a URL this client can fetch (gs:// and other non-HTTP schemes are not supported here). Pass the PDF as base64 or a local file.")
         55    bin_op +                
 
-  558   56    call 1106 ntypeargs=0   (openai.internal._reject)
+  558   56    call 1107 ntypeargs=0   (openai.internal._reject)
         57    throw                   
 
   556   58    load_var 14             (_28)
@@ -22164,7 +22163,7 @@ function openai.internal._chat_media_part(media: baml.media.Image | baml.media.A
         67    call 329 ntypeargs=0    (baml.media.Pdf.url)
         68    store_var 19            (_43)
         69    load_var 19             (_43)
-        70    call 1029 ntypeargs=0   (openai.internal._openai_file_name)
+        70    call 1030 ntypeargs=0   (openai.internal._openai_file_name)
         71    store_var 18            (_41)
 
   571   72    load_type 8             
@@ -22195,7 +22194,7 @@ function openai.internal._chat_media_part(media: baml.media.Image | baml.media.A
         93    load_var 5              (_11)
         94    load_const 4            (true)
 
-  535   95    call 942 ntypeargs=0    (ai.wire.resolve_media)
+  535   95    call 943 ntypeargs=0    (ai.wire.resolve_media)
         96    store_var 6             (resolved)
 
   539   97    load_var 6              (resolved)
@@ -22211,7 +22210,7 @@ function openai.internal._chat_media_part(media: baml.media.Image | baml.media.A
 
   540   107   load_var 6              (resolved)
         108   load_field 2            (mime_type)
-        109   call 1117 ntypeargs=0   (openai.internal._chat_audio_format)
+        109   call 1118 ntypeargs=0   (openai.internal._chat_audio_format)
         110   store_var 9             (_20)
 
   536   111   load_const 15           ("input_audio")
@@ -22224,9 +22223,9 @@ function openai.internal._chat_media_part(media: baml.media.Image | baml.media.A
         116   load_var2 3 2           
 
   526   117   load_field 7            (inline_image_urls)
-        118   call 942 ntypeargs=0    (ai.wire.resolve_media)
+        118   call 943 ntypeargs=0    (ai.wire.resolve_media)
 
-  529   119   call 1116 ntypeargs=0   (openai.internal._chat_media_url)
+  529   119   call 1117 ntypeargs=0   (openai.internal._chat_media_url)
         120   store_var 4             (_9)
 
   527   121   load_const 16           ("image_url")
@@ -22418,7 +22417,7 @@ function openai.internal._chat_prompt_parts(message: ai.PromptMessage, compat: o
         43   jump +9                            (to 52)
         44   load_var2 6 2                      
 
-  605   45   call 1119 ntypeargs=0              (openai.internal._chat_media_part)
+  605   45   call 1120 ntypeargs=0              (openai.internal._chat_media_part)
         46   store_var 14                       (_36)
         47   load_type 0                        
         48   load_var2 3 14                     
@@ -22428,7 +22427,7 @@ function openai.internal._chat_prompt_parts(message: ai.PromptMessage, compat: o
 
   587   52   load_var2 12 2                     
 
-  601   53   call 1119 ntypeargs=0              (openai.internal._chat_media_part)
+  601   53   call 1120 ntypeargs=0              (openai.internal._chat_media_part)
         54   store_var 13                       (_31)
         55   load_type 0                        
         56   load_var2 3 13                     
@@ -22438,7 +22437,7 @@ function openai.internal._chat_prompt_parts(message: ai.PromptMessage, compat: o
 
   587   60   load_var2 10 2                     
 
-  597   61   call 1119 ntypeargs=0              (openai.internal._chat_media_part)
+  597   61   call 1120 ntypeargs=0              (openai.internal._chat_media_part)
         62   store_var 11                       (_25)
         63   load_type 0                        
         64   load_var2 3 11                     
@@ -22448,7 +22447,7 @@ function openai.internal._chat_prompt_parts(message: ai.PromptMessage, compat: o
 
   587   68   load_var2 8 2                      
 
-  593   69   call 1119 ntypeargs=0              (openai.internal._chat_media_part)
+  593   69   call 1120 ntypeargs=0              (openai.internal._chat_media_part)
         70   store_var 9                        (_19)
         71   load_type 0                        
         72   load_var2 3 9                      
@@ -22495,7 +22494,7 @@ function openai.internal._chat_prune_nulls(j: baml.json.json) -> baml.json.json 
 
   865   17   load_var 10                        (_31)
 
-  885   18   make_closure 2909 0                
+  885   18   make_closure 2910 0                
         19   call 16 ntypeargs=3                (baml.Array.map)
         20   jump +58                           (to 78)
 
@@ -22540,12 +22539,12 @@ function openai.internal._chat_prune_nulls(j: baml.json.json) -> baml.json.json 
         55   jump -20                           (to 35)
 
   873   56   load_var 7                         (key)
-        57   call 1126 ntypeargs=0              (openai.internal._chat_is_opaque_key)
+        57   call 1127 ntypeargs=0              (openai.internal._chat_is_opaque_key)
         58   pop_jump_if_false +2               (to 60)
         59   jump +11                           (to 70)
 
   877   60   load_var 8                         (value)
-        61   call 1128 ntypeargs=0              (openai.internal._chat_prune_nulls)
+        61   call 1129 ntypeargs=0              (openai.internal._chat_prune_nulls)
         62   store_var 9                        (_27)
         63   load_type 4                        
         64   load_type 2                        
@@ -22622,7 +22621,7 @@ function openai.internal._chat_push_tool_uses(content: (ai.content.Text | ai.con
          46   jump +5                            (to 51)
 
   1155   47   load_var2 10 3                     
-         48   call 1139 ntypeargs=0              (openai.internal._chat_tool_args)
+         48   call 1140 ntypeargs=0              (openai.internal._chat_tool_args)
          49   store_var 8                        (args)
          50   jump +3                            (to 53)
 
@@ -22741,7 +22740,7 @@ function openai.internal._chat_send(request: baml.http.Request, provider: string
 
   1319   56   load_var2 2 8           
          57   load_var 3              (audio_mime)
-         58   call 1141 ntypeargs=0   (openai.internal.chat_parse)
+         58   call 1142 ntypeargs=0   (openai.internal.chat_parse)
          59   return                  
 
   1309   60   load_var2 2 4           
@@ -22752,7 +22751,7 @@ function openai.internal._chat_send(request: baml.http.Request, provider: string
 
   1313   63   load_field 1            (headers)
 
-  1309   64   call 986 ntypeargs=0    (ai.errors.classify_http)
+  1309   64   call 987 ntypeargs=0    (ai.errors.classify_http)
          65   throw                   
 }
 
@@ -22845,7 +22844,7 @@ function openai.internal._chat_stream_failure(provider: string, detail: string) 
   1517   71   load_var2 1 12          
          72   load_var 13             (_23)
          73   load_const 8            (<omitted>)
-         74   call 986 ntypeargs=0    (ai.errors.classify_http)
+         74   call 987 ntypeargs=0    (ai.errors.classify_http)
          75   return                  
 }
 
@@ -22865,7 +22864,7 @@ function openai.internal._chat_tool_args(raw: string, provider: string) -> map<s
 
 function openai.internal._chat_tools(toolbox: ai.tools.Toolbox) -> openai.internal.ChatTool[] | null {
   978   0    load_var 1                         (toolbox)
-        1    call 933 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        1    call 934 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         2    pop_jump_if_false +2               (to 4)
         3    jump +44                           (to 47)
 
@@ -22874,7 +22873,7 @@ function openai.internal._chat_tools(toolbox: ai.tools.Toolbox) -> openai.intern
         6    store_var 2                        (tools)
 
   982   7    load_var 1                         (toolbox)
-        8    call 931 ntypeargs=0               (ai.tools.Toolbox.list)
+        8    call 932 ntypeargs=0               (ai.tools.Toolbox.list)
         9    load_type 1                        
         10   load_const 2                       ("iter")
         11   virtual_call nargs=1 ntypeargs=0   
@@ -23070,7 +23069,7 @@ function openai.internal._chat_url(compat: openai.internal.ChatCompat, params: o
         131   load_var 20                        (_64)
         132   store_var_load_var 21              (key)
 
-  939   133   call 1130 ntypeargs=0              (openai.internal._chat_percent_encode)
+  939   133   call 1131 ntypeargs=0              (openai.internal._chat_percent_encode)
         134   store_var 23                       (_72)
         135   load_type 0                        
         136   load_var 23                        (_72)
@@ -23087,7 +23086,7 @@ function openai.internal._chat_url(compat: openai.internal.ChatCompat, params: o
         147   load_const 15                      ("")
         148   store_var 26                       (_78)
         149   load_var 26                        (_78)
-        150   call 1130 ntypeargs=0              (openai.internal._chat_percent_encode)
+        150   call 1131 ntypeargs=0              (openai.internal._chat_percent_encode)
         151   store_var 25                       (_76)
         152   load_type 0                        
         153   load_var 25                        (_76)
@@ -23149,14 +23148,14 @@ function openai.internal._oai_images_block(datum: openai.internal.OaImageDatum, 
 
   354   16   load_var2 4 2           
 
-  356   17   call 1161 ntypeargs=0   (openai.internal._oai_images_fetch_inline)
+  356   17   call 1162 ntypeargs=0   (openai.internal._oai_images_fetch_inline)
 
   355   18   load_const 2            (<omitted>)
 
   357   19   load_var 1              (datum)
         20   load_field 2            (revised_prompt)
 
-  355   21   call 913 ntypeargs=0    (ai.content.Media.new)
+  355   21   call 914 ntypeargs=0    (ai.content.Media.new)
         22   jump +7                 (to 29)
 
   348   23   load_var2 3 2           
@@ -23168,7 +23167,7 @@ function openai.internal._oai_images_block(datum: openai.internal.OaImageDatum, 
   351   26   load_var 1              (datum)
         27   load_field 2            (revised_prompt)
 
-  349   28   call 913 ntypeargs=0    (ai.content.Media.new)
+  349   28   call 914 ntypeargs=0    (ai.content.Media.new)
         29   return                  
 }
 
@@ -23223,7 +23222,7 @@ function openai.internal._oai_images_drop_nulls(value: baml.json.json) -> baml.j
         30   jump +9                            (to 39)
         31   load_var 13                        (_29)
 
-  115   32   call 1151 ntypeargs=0              (openai.internal._oai_images_drop_nulls)
+  115   32   call 1152 ntypeargs=0              (openai.internal._oai_images_drop_nulls)
         33   store_var 14                       (_34)
         34   load_type 2                        
         35   load_var2 11 14                    
@@ -23275,7 +23274,7 @@ function openai.internal._oai_images_drop_nulls(value: baml.json.json) -> baml.j
         75   jump -20                           (to 55)
 
   105   76   load_var 8                         (entry)
-        77   call 1151 ntypeargs=0              (openai.internal._oai_images_drop_nulls)
+        77   call 1152 ntypeargs=0              (openai.internal._oai_images_drop_nulls)
         78   store_var 9                        (_20)
         79   load_type 8                        
         80   load_type 2                        
@@ -23488,7 +23487,7 @@ function openai.internal._oai_images_headers(c: openai.ImageClient) -> map<strin
         52   jump -30                           (to 22)
 
   253   53   load_var 1                         (c)
-        54   call 1102 ntypeargs=0              (openai.ImageClient.resolved_api_key)
+        54   call 1103 ntypeargs=0              (openai.ImageClient.resolved_api_key)
         55   store_var 11                       (_28)
         56   load_type 2                        
         57   load_var 11                        (_28)
@@ -23582,7 +23581,7 @@ function openai.internal._oai_images_prompt_text(prompt: ai.Prompt, journal: ai.
         2     store_var 3                        (parts)
 
   143   3     load_var 1                         (prompt)
-        4     call 919 ntypeargs=0               (ai.Prompt.messages)
+        4     call 920 ntypeargs=0               (ai.Prompt.messages)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -23641,19 +23640,19 @@ function openai.internal._oai_images_prompt_text(prompt: ai.Prompt, journal: ai.
         58    jump +4                            (to 62)
 
   163   59    load_const 14                      ("pdf")
-        60    call 1152 ntypeargs=0              (openai.internal._oai_images_media_rejected)
+        60    call 1153 ntypeargs=0              (openai.internal._oai_images_media_rejected)
         61    throw                              
 
   160   62    load_const 15                      ("video")
-        63    call 1152 ntypeargs=0              (openai.internal._oai_images_media_rejected)
+        63    call 1153 ntypeargs=0              (openai.internal._oai_images_media_rejected)
         64    throw                              
 
   157   65    load_const 16                      ("audio")
-        66    call 1152 ntypeargs=0              (openai.internal._oai_images_media_rejected)
+        66    call 1153 ntypeargs=0              (openai.internal._oai_images_media_rejected)
         67    throw                              
 
   154   68    load_const 17                      ("image")
-        69    call 1152 ntypeargs=0              (openai.internal._oai_images_media_rejected)
+        69    call 1153 ntypeargs=0              (openai.internal._oai_images_media_rejected)
         70    throw                              
 
   145   71    load_var 9                         (_16)
@@ -23673,7 +23672,7 @@ function openai.internal._oai_images_prompt_text(prompt: ai.Prompt, journal: ai.
         82    jump -58                           (to 24)
 
   168   83    load_var 2                         (journal)
-        84    call 914 ntypeargs=0               (ai.Journal.entries)
+        84    call 915 ntypeargs=0               (ai.Journal.entries)
         85    load_type 19                       
         86    load_const 20                      ("iter")
         87    virtual_call nargs=1 ntypeargs=0   
@@ -23812,7 +23811,7 @@ function openai.internal._oai_images_with_query(url: string, params: map<string,
         27    load_var 7                         (_10)
         28    store_var_load_var 8               (key)
 
-  228   29    call 1156 ntypeargs=0              (openai.internal._oai_images_escape_query)
+  228   29    call 1157 ntypeargs=0              (openai.internal._oai_images_escape_query)
         30    store_var 10                       (_18)
         31    load_type 0                        
         32    load_var 10                        (_18)
@@ -23829,7 +23828,7 @@ function openai.internal._oai_images_with_query(url: string, params: map<string,
         43    load_const 8                       ("")
         44    store_var 13                       (_24)
         45    load_var 13                        (_24)
-        46    call 1156 ntypeargs=0              (openai.internal._oai_images_escape_query)
+        46    call 1157 ntypeargs=0              (openai.internal._oai_images_escape_query)
         47    store_var 12                       (_22)
         48    load_type 0                        
         49    load_var 12                        (_22)
@@ -23954,7 +23953,7 @@ function openai.internal._openai_apply_message_metadata(body: baml.json.json, me
         45   load_var2 5 6                      
         46   call 3 ntypeargs=1                 (baml.Array.at)
         47   load_var 9                         (directives)
-        48   call 1035 ntypeargs=0              (openai.internal._openai_merge_onto_last_part)
+        48   call 1036 ntypeargs=0              (openai.internal._openai_merge_onto_last_part)
         49   pop 1                              
 
   506   50   load_var 6                         (index)
@@ -24044,7 +24043,7 @@ function openai.internal._openai_decode_batch(batch: string, state: openai.inter
          2    store_var 3                        (out)
 
   1099   3    load_var 1                         (batch)
-         4    call 967 ntypeargs=0               (ai.stream.decode_sse_batch)
+         4    call 968 ntypeargs=0               (ai.stream.decode_sse_batch)
          5    load_type 1                        
          6    load_const 2                       ("iter")
          7    virtual_call nargs=1 ntypeargs=0   
@@ -24086,7 +24085,7 @@ function openai.internal._openai_decode_batch(batch: string, state: openai.inter
 
   1105   37   load_field 0                       (event)
          38   load_var 2                         (state)
-         39   call 1056 ntypeargs=0              (openai.internal._openai_stream_events)
+         39   call 1057 ntypeargs=0              (openai.internal._openai_stream_events)
          40   load_type 10                       
          41   load_const 11                      ("iter")
          42   virtual_call nargs=1 ntypeargs=0   
@@ -24191,7 +24190,7 @@ function openai.internal._openai_error_failure(err: openai.internal.OaErrorBody)
         72   jump +14                (to 86)
 
   792   73   load_var 2              (code)
-        74   call 1048 ntypeargs=0   (openai.internal._openai_transient_code)
+        74   call 1049 ntypeargs=0   (openai.internal._openai_transient_code)
         75   pop_jump_if_false +2    (to 77)
         76   jump +6                 (to 82)
 
@@ -24411,7 +24410,7 @@ function openai.internal._openai_headers(c: openai.ResponsesClient) -> map<strin
         52   jump -30                           (to 22)
 
   665   53   load_var 1                         (c)
-        54   call 1021 ntypeargs=0              (openai.ResponsesClient.resolved_api_key)
+        54   call 1022 ntypeargs=0              (openai.ResponsesClient.resolved_api_key)
         55   store_var 11                       (_28)
         56   load_type 2                        
         57   load_var 11                        (_28)
@@ -24774,7 +24773,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
 
   394   57    load_var 23                        (pdf)
         58    load_const 14                      (false)
-        59    call 942 ntypeargs=0               (ai.wire.resolve_media)
+        59    call 943 ntypeargs=0               (ai.wire.resolve_media)
         60    store_var 24                       (resolved)
 
   395   61    load_var 23                        (pdf)
@@ -24787,7 +24786,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
         68    call 329 ntypeargs=0               (baml.media.Pdf.url)
         69    store_var 26                       (_70)
         70    load_var 26                        (_70)
-        71    call 1029 ntypeargs=0              (openai.internal._openai_file_name)
+        71    call 1030 ntypeargs=0              (openai.internal._openai_file_name)
         72    store_var 25                       (name)
 
   396   73    load_var 24                        (resolved)
@@ -24856,7 +24855,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
 
   392   125   load_const 21                      ("PDF")
         126   load_var 2                         (role)
-        127   call 1031 ntypeargs=0              (openai.internal._openai_media_role_error)
+        127   call 1032 ntypeargs=0              (openai.internal._openai_media_role_error)
         128   throw                              
 
   346   129   load_var 16                        (_46)
@@ -24870,7 +24869,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
 
   378   136   load_var 17                        (audio)
         137   load_const 23                      (true)
-        138   call 942 ntypeargs=0               (ai.wire.resolve_media)
+        138   call 943 ntypeargs=0               (ai.wire.resolve_media)
         139   store_var 18                       (resolved)
 
   383   140   load_var 18                        (resolved)
@@ -24886,7 +24885,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
 
   384   150   load_var 18                        (resolved)
         151   load_field 2                       (mime_type)
-        152   call 1030 ntypeargs=0              (openai.internal._openai_audio_format)
+        152   call 1031 ntypeargs=0              (openai.internal._openai_audio_format)
         153   store_var 21                       (_59)
 
   379   154   load_type 0                        
@@ -24904,7 +24903,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
 
   375   163   load_const 26                      ("audio")
         164   load_var 2                         (role)
-        165   call 1031 ntypeargs=0              (openai.internal._openai_media_role_error)
+        165   call 1032 ntypeargs=0              (openai.internal._openai_media_role_error)
         166   throw                              
 
   346   167   load_var 9                         (_21)
@@ -24918,7 +24917,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
 
   361   174   load_var 10                        (image)
         175   load_const 14                      (false)
-        176   call 942 ntypeargs=0               (ai.wire.resolve_media)
+        176   call 943 ntypeargs=0               (ai.wire.resolve_media)
         177   store_var 11                       (resolved)
 
   362   178   load_var 11                        (resolved)
@@ -24969,7 +24968,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
 
   359   219   load_const 33                      ("image")
         220   load_var 2                         (role)
-        221   call 1031 ntypeargs=0              (openai.internal._openai_media_role_error)
+        221   call 1032 ntypeargs=0              (openai.internal._openai_media_role_error)
         222   throw                              
 
   346   223   load_var 7                         (_10)
@@ -25042,7 +25041,7 @@ function openai.internal._openai_prune_nulls(value: baml.json.json) -> baml.json
         30   jump +9                            (to 39)
         31   load_var 13                        (_29)
 
-  237   32   call 1026 ntypeargs=0              (openai.internal._openai_prune_nulls)
+  237   32   call 1027 ntypeargs=0              (openai.internal._openai_prune_nulls)
         33   store_var 14                       (_34)
         34   load_type 2                        
         35   load_var2 11 14                    
@@ -25094,7 +25093,7 @@ function openai.internal._openai_prune_nulls(value: baml.json.json) -> baml.json
         75   jump -20                           (to 55)
 
   227   76   load_var 8                         (entry)
-        77   call 1026 ntypeargs=0              (openai.internal._openai_prune_nulls)
+        77   call 1027 ntypeargs=0              (openai.internal._openai_prune_nulls)
         78   store_var 9                        (_20)
         79   load_type 8                        
         80   load_type 2                        
@@ -25140,13 +25139,13 @@ function openai.internal._openai_request(c: openai.ResponsesClient, input: ai.Mo
         2     store_var 5                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 941 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 942 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 5                         (_5)
         7     call_indirect                      
         8     store_var 4                        (prompt)
 
   704   9     load_var 4                         (prompt)
-        10    call 1033 ntypeargs=0              (openai.internal.openai_lower_prompt)
+        10    call 1034 ntypeargs=0              (openai.internal.openai_lower_prompt)
         11    store_var 6                        (items)
 
   707   12    load_var 2                         (input)
@@ -25158,9 +25157,9 @@ function openai.internal._openai_request(c: openai.ResponsesClient, input: ai.Mo
         18    virtual_call nargs=1 ntypeargs=0   
         19    store_var 8                        (_12)
         20    load_var2 7 8                      
-        21    call 944 ntypeargs=0               (ai.wire.sanitize_for_client)
+        21    call 945 ntypeargs=0               (ai.wire.sanitize_for_client)
 
-  708   22    call 1037 ntypeargs=0              (openai.internal.openai_lower_journal)
+  708   22    call 1038 ntypeargs=0              (openai.internal.openai_lower_journal)
         23    load_type 2                        
         24    load_const 3                       ("iter")
         25    virtual_call nargs=1 ntypeargs=0   
@@ -25183,13 +25182,13 @@ function openai.internal._openai_request(c: openai.ResponsesClient, input: ai.Mo
 
   711   41    load_var 2                         (input)
         42    load_field 3                       (output_type)
-        43    call 1038 ntypeargs=0              (openai.internal._openai_wants_image)
+        43    call 1039 ntypeargs=0              (openai.internal._openai_wants_image)
         44    store_var 11                       (wants_image)
 
   712   45    load_var 2                         (input)
         46    load_field 2                       (toolbox)
         47    load_var 11                        (wants_image)
-        48    call 1039 ntypeargs=0              (openai.internal._openai_tools)
+        48    call 1040 ntypeargs=0              (openai.internal._openai_tools)
         49    store_var 12                       (tools)
 
   714   50    load_var 1                         (c)
@@ -25225,11 +25224,11 @@ function openai.internal._openai_request(c: openai.ResponsesClient, input: ai.Mo
         72    store_var 18                       (_35)
 
   725   73    load_var 1                         (c)
-        74    call 1041 ntypeargs=0              (openai.internal._openai_reasoning)
+        74    call 1042 ntypeargs=0              (openai.internal._openai_reasoning)
         75    store_var 19                       (_36)
 
   726   76    load_var 1                         (c)
-        77    call 1042 ntypeargs=0              (openai.internal._openai_text)
+        77    call 1043 ntypeargs=0              (openai.internal._openai_text)
         78    store_var 20                       (_37)
 
   727   79    load_var 1                         (c)
@@ -25237,7 +25236,7 @@ function openai.internal._openai_request(c: openai.ResponsesClient, input: ai.Mo
         81    store_var 21                       (_38)
 
   729   82    load_var2 12 11                    
-        83    call 1040 ntypeargs=0              (openai.internal._openai_tool_choice)
+        83    call 1041 ntypeargs=0              (openai.internal._openai_tool_choice)
         84    store_var 22                       (_40)
 
   735   85    load_type 10                       
@@ -25253,31 +25252,31 @@ function openai.internal._openai_request(c: openai.ResponsesClient, input: ai.Mo
         92    init_instance 0                    (openai.internal.OaResponsesRequest .model, .input, .store, .stream, .temperature, .top_p, .max_output_tokens, .reasoning, .text, .parallel_tool_calls, .tools, .tool_choice)
 
   735   93    call 362 ntypeargs=1               (baml.json.to_json)
-        94    call 1026 ntypeargs=0              (openai.internal._openai_prune_nulls)
+        94    call 1027 ntypeargs=0              (openai.internal._openai_prune_nulls)
 
   736   95    load_var 12                        (tools)
 
-  734   96    call 1027 ntypeargs=0              (openai.internal._openai_restore_tool_schemas)
+  734   96    call 1028 ntypeargs=0              (openai.internal._openai_restore_tool_schemas)
         97    store_var 23                       (pruned)
 
   739   98    load_var 4                         (prompt)
-        99    call 1034 ntypeargs=0              (openai.internal.openai_prompt_metadata)
+        99    call 1035 ntypeargs=0              (openai.internal.openai_prompt_metadata)
         100   store_var 25                       (_52)
         101   load_var2 23 25                    
-        102   call 1036 ntypeargs=0              (openai.internal._openai_apply_message_metadata)
+        102   call 1037 ntypeargs=0              (openai.internal._openai_apply_message_metadata)
 
   740   103   load_var 1                         (c)
         104   load_field 11                      (request_body)
 
-  738   105   call 943 ntypeargs=0               (ai.wire.merge_request_body)
+  738   105   call 944 ntypeargs=0               (ai.wire.merge_request_body)
         106   store_var 24                       (body)
 
   744   107   load_var 1                         (c)
-        108   call 1044 ntypeargs=0              (openai.internal._openai_url)
+        108   call 1045 ntypeargs=0              (openai.internal._openai_url)
         109   store_var 26                       (_55)
 
   745   110   load_var 1                         (c)
-        111   call 1043 ntypeargs=0              (openai.internal._openai_headers)
+        111   call 1044 ntypeargs=0              (openai.internal._openai_headers)
         112   store_var 27                       (_56)
 
   746   113   load_var 24                        (body)
@@ -25319,12 +25318,12 @@ function openai.internal._openai_response_failure(resp: openai.internal.OaRespon
         23   load_const 1            (null)
         24   init_instance 0         (openai.internal.OaErrorBody .code, .message, .type)
 
-  808   25   call 1049 ntypeargs=0   (openai.internal._openai_error_failure)
+  808   25   call 1050 ntypeargs=0   (openai.internal._openai_error_failure)
         26   jump +3                 (to 29)
 
   805   27   load_var 2              (_3)
 
-  806   28   call 1049 ntypeargs=0   (openai.internal._openai_error_failure)
+  806   28   call 1050 ntypeargs=0   (openai.internal._openai_error_failure)
         29   return                  
 }
 
@@ -25535,7 +25534,7 @@ function openai.internal._openai_sse_failure(error: unknown) -> ai.errors.Failur
   1133   86   load_const 11           ("openai")
          87   load_var2 13 14         
          88   load_const 12           (<omitted>)
-         89   call 986 ntypeargs=0    (ai.errors.classify_http)
+         89   call 987 ntypeargs=0    (ai.errors.classify_http)
          90   return                  
 }
 
@@ -25627,7 +25626,7 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          79    pop_jump_if_false +39            (to 118)
          80    load_var 33                      (_122)
 
-  1079   81    call 1051 ntypeargs=0            (openai.internal.openai_parse)
+  1079   81    call 1052 ntypeargs=0            (openai.internal.openai_parse)
          82    store_var 34                     (turn)
 
   1082   83    load_var 34                      (turn)
@@ -25686,7 +25685,7 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          129   pop_jump_if_false +39            (to 168)
          130   load_var 28                      (_101)
 
-  1079   131   call 1051 ntypeargs=0            (openai.internal.openai_parse)
+  1079   131   call 1052 ntypeargs=0            (openai.internal.openai_parse)
          132   store_var 29                     (turn)
 
   1082   133   load_var 29                      (turn)
@@ -25738,10 +25737,10 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          173   jump +147                        (to 320)
 
   1076   174   load_var 1                       (event)
-         175   call 1055 ntypeargs=0            (openai.internal._openai_stream_failure)
+         175   call 1056 ntypeargs=0            (openai.internal._openai_stream_failure)
          176   throw                            
          177   load_var 1                       (event)
-         178   call 1055 ntypeargs=0            (openai.internal._openai_stream_failure)
+         178   call 1056 ntypeargs=0            (openai.internal._openai_stream_failure)
          179   throw                            
 
   1071   180   load_var 1                       (event)
@@ -25757,7 +25756,7 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          189   load_field 2                     (call_arguments)
          190   store_var 26                     (_90)
          191   load_var 1                       (event)
-         192   call 1054 ntypeargs=0            (openai.internal._openai_event_key)
+         192   call 1055 ntypeargs=0            (openai.internal._openai_event_key)
          193   store_var 27                     (_91)
          194   load_type 18                     
          195   load_type 18                     
@@ -25777,7 +25776,7 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          208   store_var 20                     (delta)
 
   1062   209   load_var 1                       (event)
-         210   call 1054 ntypeargs=0            (openai.internal._openai_event_key)
+         210   call 1055 ntypeargs=0            (openai.internal._openai_event_key)
          211   store_var 21                     (key)
 
   1063   212   load_var 3                       (state)
@@ -25809,7 +25808,7 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          234   jump +86                         (to 320)
 
   1045   235   load_var 1                       (event)
-         236   call 1054 ntypeargs=0            (openai.internal._openai_event_key)
+         236   call 1055 ntypeargs=0            (openai.internal._openai_event_key)
          237   store_var 15                     (key)
 
   1046   238   load_type 18                     
@@ -25866,7 +25865,7 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          284   load_field 1                     (text_started)
          285   store_var 13                     (_34)
          286   load_var 1                       (event)
-         287   call 1054 ntypeargs=0            (openai.internal._openai_event_key)
+         287   call 1055 ntypeargs=0            (openai.internal._openai_event_key)
          288   store_var 14                     (_35)
          289   load_type 18                     
          290   load_type 20                     
@@ -25911,7 +25910,7 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
 
   1022   322   load_var 8                       (_17)
 
-  1023   323   call 1049 ntypeargs=0            (openai.internal._openai_error_failure)
+  1023   323   call 1050 ntypeargs=0            (openai.internal._openai_error_failure)
          324   throw                            
 }
 
@@ -25938,17 +25937,17 @@ function openai.internal._openai_stream_failure(event: openai.internal.OaStreamE
          17   load_field 10           (message)
          18   load_const 2            (null)
          19   init_instance 0         (openai.internal.OaErrorBody .code, .message, .type)
-         20   call 1049 ntypeargs=0   (openai.internal._openai_error_failure)
+         20   call 1050 ntypeargs=0   (openai.internal._openai_error_failure)
          21   jump +6                 (to 27)
 
   1005   22   load_var 3              (_7)
 
-  1006   23   call 1049 ntypeargs=0   (openai.internal._openai_error_failure)
+  1006   23   call 1050 ntypeargs=0   (openai.internal._openai_error_failure)
          24   jump +3                 (to 27)
 
   1002   25   load_var 2              (_3)
 
-  1003   26   call 1050 ntypeargs=0   (openai.internal._openai_response_failure)
+  1003   26   call 1051 ntypeargs=0   (openai.internal._openai_response_failure)
          27   return                  
 }
 
@@ -26000,7 +25999,7 @@ function openai.internal._openai_tools(toolbox: ai.tools.Toolbox, wants_image: b
         2    store_var 3                        (tools)
 
   609   3    load_var 1                         (toolbox)
-        4    call 931 ntypeargs=0               (ai.tools.Toolbox.list)
+        4    call 932 ntypeargs=0               (ai.tools.Toolbox.list)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -26119,7 +26118,7 @@ function openai.internal._openai_transient_code(code: string) -> bool {
 
 function openai.internal._openai_url(c: openai.ResponsesClient) -> string {
   670   0     load_var 1                         (c)
-        1     call 1022 ntypeargs=0              (openai.ResponsesClient.resolved_base_url)
+        1     call 1023 ntypeargs=0              (openai.ResponsesClient.resolved_base_url)
         2     store_var_load_var 3               (_3)
         3     load_const 0                       (null)
         4     cmp_op ==                          
@@ -26191,7 +26190,7 @@ function openai.internal._openai_url(c: openai.ResponsesClient) -> string {
         62    load_var 11                        (_22)
         63    store_var_load_var 12              (key)
 
-  681   64    call 1028 ntypeargs=0              (openai.internal._openai_percent_encode)
+  681   64    call 1029 ntypeargs=0              (openai.internal._openai_percent_encode)
         65    store_var 14                       (_30)
         66    load_type 5                        
         67    load_var 14                        (_30)
@@ -26208,7 +26207,7 @@ function openai.internal._openai_url(c: openai.ResponsesClient) -> string {
         78    load_const 13                      ("")
         79    store_var 17                       (_36)
         80    load_var 17                        (_36)
-        81    call 1028 ntypeargs=0              (openai.internal._openai_percent_encode)
+        81    call 1029 ntypeargs=0              (openai.internal._openai_percent_encode)
         82    store_var 16                       (_34)
         83    load_type 5                        
         84    load_var 16                        (_34)
@@ -26262,7 +26261,7 @@ function openai.internal._openai_url(c: openai.ResponsesClient) -> string {
 
 function openai.internal._openai_wants_image(output_type: type) -> bool {
   604   0   load_var 1             (output_type)
-        1   call 994 ntypeargs=0   (ai.internal._media_shape)
+        1   call 995 ntypeargs=0   (ai.internal._media_shape)
         2   load_const 0           (":image")
         3   call 156 ntypeargs=0   (baml.String.ends_with)
         4   return                 
@@ -26283,24 +26282,24 @@ function openai.internal.chat_build_request(compat: openai.internal.ChatCompat, 
          2     store_var 5                        (_6)
          3     load_var 3                         (input)
          4     load_field 3                       (output_type)
-         5     call 941 ntypeargs=0               (ai.wire.render_output_format)
+         5     call 942 ntypeargs=0               (ai.wire.render_output_format)
          6     load_var 5                         (_6)
          7     call_indirect                      
 
   1006   8     load_var 1                         (compat)
-         9     call 1124 ntypeargs=0              (openai.internal.chat_lower_prompt)
+         9     call 1125 ntypeargs=0              (openai.internal.chat_lower_prompt)
          10    store_var 6                        (messages)
 
   1007   11    load_var 3                         (input)
          12    load_field 1                       (journal)
          13    store_var 7                        (_12)
          14    load_var2 1 2                      
-         15    call 1110 ntypeargs=0              (openai.internal.chat_client_id)
+         15    call 1111 ntypeargs=0              (openai.internal.chat_client_id)
          16    store_var 8                        (_13)
          17    load_var2 7 8                      
-         18    call 944 ntypeargs=0               (ai.wire.sanitize_for_client)
+         18    call 945 ntypeargs=0               (ai.wire.sanitize_for_client)
 
-  1008   19    call 1125 ntypeargs=0              (openai.internal.chat_lower_journal)
+  1008   19    call 1126 ntypeargs=0              (openai.internal.chat_lower_journal)
          20    load_type 0                        
          21    load_const 1                       ("iter")
          22    virtual_call nargs=1 ntypeargs=0   
@@ -26378,7 +26377,7 @@ function openai.internal.chat_build_request(compat: openai.internal.ChatCompat, 
   1032   81    load_var 2                         (params)
          82    load_field 10                      (request_body)
          83    load_const 9                       ("max_tokens")
-         84    call 1129 ntypeargs=0              (openai.internal._chat_body_mentions)
+         84    call 1130 ntypeargs=0              (openai.internal._chat_body_mentions)
          85    unary_op !                         
 
   1030   86    jump_if_false +7                   (to 93)
@@ -26387,7 +26386,7 @@ function openai.internal.chat_build_request(compat: openai.internal.ChatCompat, 
   1033   88    load_var 2                         (params)
          89    load_field 10                      (request_body)
          90    load_const 10                      ("max_completion_tokens")
-         91    call 1129 ntypeargs=0              (openai.internal._chat_body_mentions)
+         91    call 1130 ntypeargs=0              (openai.internal._chat_body_mentions)
          92    unary_op !                         
 
   1029   93    pop_jump_if_false +20              (to 113)
@@ -26418,7 +26417,7 @@ function openai.internal.chat_build_request(compat: openai.internal.ChatCompat, 
 
   1044   113   load_var 3                         (input)
          114   load_field 2                       (toolbox)
-         115   call 1133 ntypeargs=0              (openai.internal._chat_tools)
+         115   call 1134 ntypeargs=0              (openai.internal._chat_tools)
          116   store_var 16                       (tools)
 
   1045   117   load_var 16                        (tools)
@@ -26513,7 +26512,7 @@ function openai.internal.chat_invoke(compat: openai.internal.ChatCompat, params:
   1328   0    load_var2 1 2           
          1    load_var 3              (input)
          2    load_const 0            (false)
-         3    call 1136 ntypeargs=0   (openai.internal.chat_render)
+         3    call 1137 ntypeargs=0   (openai.internal.chat_render)
          4    store_var 4             (request)
 
   1331   5    load_var 1              (compat)
@@ -26522,13 +26521,13 @@ function openai.internal.chat_invoke(compat: openai.internal.ChatCompat, params:
 
   1332   8    load_var 2              (params)
          9    load_field 10           (request_body)
-         10   call 1118 ntypeargs=0   (openai.internal._chat_audio_output_mime)
+         10   call 1119 ntypeargs=0   (openai.internal._chat_audio_output_mime)
          11   store_var 6             (_7)
 
   1330   12   load_var2 4 5           
          13   load_var 6              (_7)
 
-  1329   14   call 1142 ntypeargs=0   (openai.internal._chat_send)
+  1329   14   call 1143 ntypeargs=0   (openai.internal._chat_send)
          15   return                  
 }
 
@@ -26540,12 +26539,12 @@ function openai.internal.chat_invoke_stream(compat: openai.internal.ChatCompat, 
   1539   3    load_var2 1 2           
          4    load_var 3              (input)
          5    load_const 0            (true)
-         6    call 1136 ntypeargs=0   (openai.internal.chat_render)
+         6    call 1137 ntypeargs=0   (openai.internal.chat_render)
          7    store_var 4             (request)
 
   1540   8    load_var 1              (compat)
          9    load_field 0            (provider)
-         10   call 1144 ntypeargs=0   (openai.internal.ChatStreamDecoder.new)
+         10   call 1145 ntypeargs=0   (openai.internal.ChatStreamDecoder.new)
          11   store_deref 5           
 
   1541   12   load_var 4              (request)
@@ -26562,16 +26561,16 @@ function openai.internal.chat_invoke_stream(compat: openai.internal.ChatCompat, 
          22   call 145 ntypeargs=1    (baml.String.from)
          23   store_var 8             (_12)
          24   load_var2 7 8           
-         25   call 1148 ntypeargs=0   (openai.internal._chat_stream_failure)
+         25   call 1149 ntypeargs=0   (openai.internal._chat_stream_failure)
          26   throw                   
 
   1551   27   load_var 5              (decoder)
-         28   make_closure 3011 1     
+         28   make_closure 3012 1     
 
   1552   29   load_var 1              (compat)
          30   load_field 0            (provider)
 
-  1549   31   call 968 ntypeargs=0    (ai.stream.TurnStream.from_sse)
+  1549   31   call 969 ntypeargs=0    (ai.stream.TurnStream.from_sse)
          32   return                  
 }
 
@@ -26581,7 +26580,7 @@ function openai.internal.chat_lower_journal(j: ai.Journal) -> openai.internal.Ch
         2     store_var 2                        (out)
 
   722   3     load_var 1                         (j)
-        4     call 914 ntypeargs=0               (ai.Journal.entries)
+        4     call 915 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -26841,7 +26840,7 @@ function openai.internal.chat_lower_prompt(prompt: ai.Prompt, compat: openai.int
         2     store_var 3                        (lowered)
 
   671   3     load_var 1                         (prompt)
-        4     call 919 ntypeargs=0               (ai.Prompt.messages)
+        4     call 920 ntypeargs=0               (ai.Prompt.messages)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -26885,12 +26884,12 @@ function openai.internal.chat_lower_prompt(prompt: ai.Prompt, compat: openai.int
         39    store_var 7                        (role)
 
   677   40    load_var2 6 2                      
-        41    call 1120 ntypeargs=0              (openai.internal._chat_prompt_parts)
+        41    call 1121 ntypeargs=0              (openai.internal._chat_prompt_parts)
         42    store_var 9                        (parts)
 
   681   43    load_var2 9 6                      
         44    load_field 3                       (metadata)
-        45    call 1121 ntypeargs=0              (openai.internal._chat_apply_metadata)
+        45    call 1122 ntypeargs=0              (openai.internal._chat_apply_metadata)
         46    pop 1                              
 
   682   47    load_const 9                       (false)
@@ -26985,7 +26984,7 @@ function openai.internal.chat_lower_prompt(prompt: ai.Prompt, compat: openai.int
         123   load_field 1                       (parts)
         124   load_var 2                         (compat)
         125   load_field 6                       (collapse_text_content)
-        126   call 1123 ntypeargs=0              (openai.internal._chat_content)
+        126   call 1124 ntypeargs=0              (openai.internal._chat_content)
         127   store_var 21                       (_56)
 
   697   128   load_type 18                       
@@ -27158,7 +27157,7 @@ function openai.internal.chat_parse(response: openai.internal.CcResponse, provid
          128   pop_jump_if_false -49              (to 79)
          129   load_var 20                        (_56)
 
-  1207   130   call 1138 ntypeargs=0              (openai.internal._chat_media_block)
+  1207   130   call 1139 ntypeargs=0              (openai.internal._chat_media_block)
          131   store_var 21                       (_59)
          132   load_type 7                        
          133   load_var2 10 21                    
@@ -27225,7 +27224,7 @@ function openai.internal.chat_parse(response: openai.internal.CcResponse, provid
          188   pop_jump_if_false -32              (to 156)
          189   load_var 28                        (_86)
 
-  1225   190   call 1138 ntypeargs=0              (openai.internal._chat_media_block)
+  1225   190   call 1139 ntypeargs=0              (openai.internal._chat_media_block)
          191   store_var 29                       (_89)
          192   load_type 7                        
          193   load_var2 10 29                    
@@ -27280,7 +27279,7 @@ function openai.internal.chat_parse(response: openai.internal.CcResponse, provid
          234   load_field 0                       (id)
          235   load_const 0                       (<omitted>)
 
-  1239   236   call 913 ntypeargs=0               (ai.content.Media.new)
+  1239   236   call 914 ntypeargs=0               (ai.content.Media.new)
          237   store_var 36                       (_110)
 
   1238   238   load_type 7                        
@@ -27302,7 +27301,7 @@ function openai.internal.chat_parse(response: openai.internal.CcResponse, provid
 
   1248   253   load_var2 10 37                    
          254   load_var 2                         (provider)
-         255   call 1140 ntypeargs=0              (openai.internal._chat_push_tool_uses)
+         255   call 1141 ntypeargs=0              (openai.internal._chat_push_tool_uses)
          256   pop 1                              
 
   1249   257   load_var 8                         (message)
@@ -27352,7 +27351,7 @@ function openai.internal.chat_parse(response: openai.internal.CcResponse, provid
   1258   293   jump +12                           (to 305)
          294   load_var 42                        (_136)
 
-  1259   295   call 1137 ntypeargs=0              (openai.internal.chat_stop_reason)
+  1259   295   call 1138 ntypeargs=0              (openai.internal.chat_stop_reason)
          296   store_var 40                       (stop)
          297   jump +8                            (to 305)
 
@@ -27444,20 +27443,20 @@ function openai.internal.chat_parse(response: openai.internal.CcResponse, provid
 function openai.internal.chat_render(compat: openai.internal.ChatCompat, params: openai.internal.ChatParams, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
   1091   0    load_var2 1 2           
          1    load_var2 3 4           
-         2    call 1134 ntypeargs=0   (openai.internal.chat_build_request)
+         2    call 1135 ntypeargs=0   (openai.internal.chat_build_request)
          3    store_var 5             (request)
 
   1094   4    load_var2 1 2           
-         5    call 1131 ntypeargs=0   (openai.internal._chat_url)
+         5    call 1132 ntypeargs=0   (openai.internal._chat_url)
          6    store_var 6             (_6)
 
   1095   7    load_var2 1 2           
-         8    call 1132 ntypeargs=0   (openai.internal._chat_headers)
+         8    call 1133 ntypeargs=0   (openai.internal._chat_headers)
          9    store_var 7             (_7)
 
   1096   10   load_var2 1 2           
          11   load_var 5              (request)
-         12   call 1135 ntypeargs=0   (openai.internal.chat_render_body)
+         12   call 1136 ntypeargs=0   (openai.internal.chat_render_body)
          13   store_var 8             (_8)
 
   1092   14   load_const 0            ("POST")
@@ -27471,12 +27470,12 @@ function openai.internal.chat_render_body(compat: openai.internal.ChatCompat, pa
   1080   0   load_type 0             
          1   load_var 3              (request)
          2   call 363 ntypeargs=1    (baml.json.from)
-         3   call 1128 ntypeargs=0   (openai.internal._chat_prune_nulls)
-         4   call 1127 ntypeargs=0   (openai.internal._chat_apply_directives)
+         3   call 1129 ntypeargs=0   (openai.internal._chat_prune_nulls)
+         4   call 1128 ntypeargs=0   (openai.internal._chat_apply_directives)
 
   1081   5   load_var 2              (params)
          6   load_field 10           (request_body)
-         7   call 943 ntypeargs=0    (ai.wire.merge_request_body)
+         7   call 944 ntypeargs=0    (ai.wire.merge_request_body)
          8   call 358 ntypeargs=0    (baml.json.stringify)
          9   return                  
 }
@@ -27535,17 +27534,17 @@ function openai.internal.chat_stop_reason(reason: string) -> ai.content.StopReas
 
 function openai.internal.images_invoke(c: openai.ImageClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   404   0    load_var2 1 2           
-        1    call 1159 ntypeargs=0   (openai.internal.images_render)
+        1    call 1160 ntypeargs=0   (openai.internal.images_render)
         2    store_var 3             (req)
 
   405   3    load_type 0             
         4    load_var 3              (req)
         5    load_const 1            ("openai-images")
-        6    call 940 ntypeargs=1    (ai.wire.send_as)
+        6    call 941 ntypeargs=1    (ai.wire.send_as)
         7    store_var 4             (resp)
 
   406   8    load_var2 1 4           
-        9    call 1163 ntypeargs=0   (openai.internal.images_parse)
+        9    call 1164 ntypeargs=0   (openai.internal.images_parse)
         10   return                  
 }
 
@@ -27560,7 +27559,7 @@ function openai.internal.images_parse(c: openai.ImageClient, resp: openai.intern
         7     load_field 7                       (output_format)
         8     store_var 4                        (_5)
         9     load_var 4                         (_5)
-        10    call 1160 ntypeargs=0              (openai.internal._oai_images_mime)
+        10    call 1161 ntypeargs=0              (openai.internal._oai_images_mime)
         11    store_var 3                        (mime)
 
   368   12    load_var 2                         (resp)
@@ -27594,7 +27593,7 @@ function openai.internal.images_parse(c: openai.ImageClient, resp: openai.intern
         37    jump +12                           (to 49)
         38    load_var2 8 3                      
 
-  371   39    call 1162 ntypeargs=0              (openai.internal._oai_images_block)
+  371   39    call 1163 ntypeargs=0              (openai.internal._oai_images_block)
         40    store_var 9                        (_22)
         41    load_var 9                         (_22)
         42    narrow_bind 8 9                    
@@ -27673,7 +27672,7 @@ function openai.internal.images_parse(c: openai.ImageClient, resp: openai.intern
 function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTurnInput) -> baml.http.Request {
   259   0     load_var 2              (input)
         1     load_field 2            (toolbox)
-        2     call 933 ntypeargs=0    (ai.tools.Toolbox.is_empty)
+        2     call 934 ntypeargs=0    (ai.tools.Toolbox.is_empty)
         3     unary_op !              
         4     pop_jump_if_false +2    (to 6)
         5     jump +98                (to 103)
@@ -27682,10 +27681,10 @@ function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTur
         7     load_field 1            (journal)
         8     store_var 4             (_8)
         9     load_var 1              (c)
-        10    call 1150 ntypeargs=0   (openai.internal._oai_images_client_id)
+        10    call 1151 ntypeargs=0   (openai.internal._oai_images_client_id)
         11    store_var 5             (_9)
         12    load_var2 4 5           
-        13    call 944 ntypeargs=0    (ai.wire.sanitize_for_client)
+        13    call 945 ntypeargs=0    (ai.wire.sanitize_for_client)
         14    store_var 3             (journal)
 
   271   15    load_const 0            ("")
@@ -27693,7 +27692,7 @@ function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTur
         17    load_field 0            (prompt)
         18    call_indirect           
         19    load_var 3              (journal)
-        20    call 1153 ntypeargs=0   (openai.internal._oai_images_prompt_text)
+        20    call 1154 ntypeargs=0   (openai.internal._oai_images_prompt_text)
         21    store_var 6             (text)
 
   273   22    load_var 1              (c)
@@ -27740,7 +27739,7 @@ function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTur
         53    load_field 0            (model)
         54    load_var 1              (c)
         55    load_field 12           (response_format)
-        56    call 1154 ntypeargs=0   (openai.internal._oai_images_response_format)
+        56    call 1155 ntypeargs=0   (openai.internal._oai_images_response_format)
         57    store_var 17            (_26)
 
   286   58    load_type 1             
@@ -27755,15 +27754,15 @@ function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTur
         65    init_instance 0         (openai.internal.OaImagesRequest .model, .prompt, .n, .size, .quality, .background, .output_format, .output_compression, .moderation, .style, .user, .response_format)
 
   286   66    call 362 ntypeargs=1    (baml.json.to_json)
-        67    call 1151 ntypeargs=0   (openai.internal._oai_images_drop_nulls)
+        67    call 1152 ntypeargs=0   (openai.internal._oai_images_drop_nulls)
 
   287   68    load_var 1              (c)
         69    load_field 13           (request_body)
-        70    call 943 ntypeargs=0    (ai.wire.merge_request_body)
+        70    call 944 ntypeargs=0    (ai.wire.merge_request_body)
         71    store_var 18            (merged)
 
   289   72    load_var 1              (c)
-        73    call 1103 ntypeargs=0   (openai.ImageClient.resolved_base_url)
+        73    call 1104 ntypeargs=0   (openai.ImageClient.resolved_base_url)
         74    store_var_load_var 21   (_41)
         75    load_const 2            (null)
         76    cmp_op ==               
@@ -27771,7 +27770,7 @@ function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTur
         78    load_const 3            ("https://api.openai.com/v1")
         79    store_var 21            (_41)
         80    load_var 21             (_41)
-        81    call 1155 ntypeargs=0   (openai.internal._oai_images_trim_slash)
+        81    call 1156 ntypeargs=0   (openai.internal._oai_images_trim_slash)
         82    store_var 20            (_39)
         83    load_type 4             
         84    load_var 20             (_39)
@@ -27782,11 +27781,11 @@ function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTur
   290   88    load_var 1              (c)
         89    load_field 15           (query_params)
 
-  288   90    call 1157 ntypeargs=0   (openai.internal._oai_images_with_query)
+  288   90    call 1158 ntypeargs=0   (openai.internal._oai_images_with_query)
         91    store_var 19            (url)
 
   295   92    load_var 1              (c)
-        93    call 1158 ntypeargs=0   (openai.internal._oai_images_headers)
+        93    call 1159 ntypeargs=0   (openai.internal._oai_images_headers)
         94    store_var 22            (_47)
 
   296   95    load_var 18             (merged)
@@ -27810,15 +27809,15 @@ function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTur
 
 function openai.internal.invoke(c: openai.ResponsesClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   930   0   load_var2 1 2           
-        1   call 1045 ntypeargs=0   (openai.internal.openai_render)
+        1   call 1046 ntypeargs=0   (openai.internal.openai_render)
         2   store_var 3             (req)
 
   931   3   load_type 0             
         4   load_var 3              (req)
         5   load_const 1            ("openai")
-        6   call 940 ntypeargs=1    (ai.wire.send_as)
+        6   call 941 ntypeargs=1    (ai.wire.send_as)
 
-  932   7   call 1051 ntypeargs=0   (openai.internal.openai_parse)
+  932   7   call 1052 ntypeargs=0   (openai.internal.openai_parse)
         8   return                  
 }
 
@@ -27829,7 +27828,7 @@ function openai.internal.invoke_stream(c: openai.ResponsesClient, input: ai.Mode
 
   1151   3    load_var2 1 2           
          4    load_const 0            (true)
-         5    call 1046 ntypeargs=0   (openai.internal._openai_request)
+         5    call 1047 ntypeargs=0   (openai.internal._openai_request)
 
   1152   6    sys_op 259              (baml.http.fetch_sse)
          7    store_var 3             (sse)
@@ -27838,18 +27837,18 @@ function openai.internal.invoke_stream(c: openai.ResponsesClient, input: ai.Mode
          10   throw_if_panic          
 
   1153   11   load_var 4              (e)
-         12   call 1058 ntypeargs=0   (openai.internal._openai_sse_failure)
+         12   call 1059 ntypeargs=0   (openai.internal._openai_sse_failure)
          13   throw                   
 
-  1155   14   call 1053 ntypeargs=0   (openai.internal.OaStreamState.new)
+  1155   14   call 1054 ntypeargs=0   (openai.internal.OaStreamState.new)
          15   store_deref 5           
 
   1163   16   load_var2 3 5           
 
-  1164   17   make_closure 2730 1     
+  1164   17   make_closure 2731 1     
          18   load_const 1            ("openai")
 
-  1162   19   call 968 ntypeargs=0    (ai.stream.TurnStream.from_sse)
+  1162   19   call 969 ntypeargs=0    (ai.stream.TurnStream.from_sse)
          20   return                  
 }
 
@@ -27859,7 +27858,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> (openai.internal
         2     store_var 2                        (items)
 
   524   3     load_var 1                         (j)
-        4     call 914 ntypeargs=0               (ai.Journal.entries)
+        4     call 915 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -28062,7 +28061,7 @@ function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> (openai.inter
         2    store_var 2                        (items)
 
   439   3    load_var 1                         (prompt)
-        4    call 919 ntypeargs=0               (ai.Prompt.messages)
+        4    call 920 ntypeargs=0               (ai.Prompt.messages)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -28107,7 +28106,7 @@ function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> (openai.inter
   444   39   load_var 6                         (role)
         40   store_var 8                        (_15)
         41   load_var2 5 6                      
-        42   call 1032 ntypeargs=0              (openai.internal._openai_prompt_content)
+        42   call 1033 ntypeargs=0              (openai.internal._openai_prompt_content)
         43   store_var 9                        (_16)
         44   load_type 0                        
         45   load_var2 2 8                      
@@ -28210,7 +28209,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
 
   885   78    load_var 9                         (item)
         79    load_field 10                      (output_format)
-        80    call 1047 ntypeargs=0              (openai.internal._openai_image_mime)
+        80    call 1048 ntypeargs=0              (openai.internal._openai_image_mime)
         81    store_var 32                       (mime)
 
   888   82    load_var2 31 32                    
@@ -28222,7 +28221,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
   890   86    load_var 9                         (item)
         87    load_field 9                       (revised_prompt)
 
-  887   88    call 913 ntypeargs=0               (ai.content.Media.new)
+  887   88    call 914 ntypeargs=0               (ai.content.Media.new)
         89    store_var 33                       (_103)
 
   886   90    load_type 3                        
@@ -28558,7 +28557,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         374   return                             
 
   820   375   load_var 1                         (resp)
-        376   call 1050 ntypeargs=0              (openai.internal._openai_response_failure)
+        376   call 1051 ntypeargs=0              (openai.internal._openai_response_failure)
         377   throw                              
 }
 
@@ -28568,7 +28567,7 @@ function openai.internal.openai_prompt_metadata(prompt: ai.Prompt) -> map<string
         2    store_var 2                        (out)
 
   462   3    load_var 1                         (prompt)
-        4    call 919 ntypeargs=0               (ai.Prompt.messages)
+        4    call 920 ntypeargs=0               (ai.Prompt.messages)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -28599,7 +28598,7 @@ function openai.internal.openai_prompt_metadata(prompt: ai.Prompt) -> map<string
 function openai.internal.openai_render(c: openai.ResponsesClient, input: ai.ModelTurnInput) -> baml.http.Request {
   693   0   load_var2 1 2           
         1   load_const 0            (false)
-        2   call 1046 ntypeargs=0   (openai.internal._openai_request)
+        2   call 1047 ntypeargs=0   (openai.internal._openai_request)
         3   return                  
 }
 
@@ -28610,7 +28609,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  104   0   make_closure 2081 0   
+  104   0   make_closure 2082 0   
         1   return                
 }
 
@@ -28635,7 +28634,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   76   16   load_var 1             (threshold)
-       17   make_closure 2076 1    
+       17   make_closure 2077 1    
        18   return                 
 }
 
@@ -28674,7 +28673,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 2060 2    
+       29   make_closure 2061 2    
        30   return                 
 }
 
@@ -28693,12 +28692,12 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   42   10   load_var 1             (max_attempts)
-       11   make_closure 2070 1    
+       11   make_closure 2071 1    
        12   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  98   0   make_closure 2079 0   
+  98   0   make_closure 2080 0   
        1   return                
 }
 
@@ -28903,7 +28902,7 @@ function testing.TestCollector.register_test_at(self: testing.TestCollector, own
         5   load_var2 3 4          
         6   load_var 5             (runner)
 
-  107   7   call 849 ntypeargs=0   (testing.TestCollector.register_test)
+  107   7   call 850 ntypeargs=0   (testing.TestCollector.register_test)
         8   return                 
 }
 
@@ -29034,7 +29033,7 @@ function testing.TestCollector.register_test_set_at(self: testing.TestCollector,
         5   load_var2 3 4          
         6   load_var 5             (runner)
 
-  118   7   call 850 ntypeargs=0   (testing.TestCollector.register_test_set)
+  118   7   call 851 ntypeargs=0   (testing.TestCollector.register_test_set)
         8   return                 
 }
 
@@ -29064,11 +29063,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   290   22   load_var2 1 5                      
-        23   call 865 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 866 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   291   25   load_var 1                         (self)
-        26   call 857 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 858 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   295   28   load_type 5                        
@@ -29105,7 +29104,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   298   58   load_var2 9 2                      
-        59   call 864 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 865 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   301   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -29196,7 +29195,7 @@ function testing.TestRegistry.list_filtered(self: testing.TestRegistry, profile_
   281   0   load_var2 1 2          
         1   load_var2 3 4          
         2   load_var 5             (cli_exclude)
-        3   call 885 ntypeargs=0   (testing.select_names_layered)
+        3   call 886 ntypeargs=0   (testing.select_names_layered)
         4   return                 
 }
 
@@ -29212,9 +29211,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   237   0   load_var 1             (self)
-        1   call 866 ntypeargs=0   (testing.testset_children)
+        1   call 867 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 876 ntypeargs=0   (testing.run_testset)
+        3   call 877 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -29222,7 +29221,7 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
   259   0    load_var2 1 2          
         1    load_var2 3 4          
         2    load_var 5             (cli_exclude)
-        3    call 885 ntypeargs=0   (testing.select_names_layered)
+        3    call 886 ntypeargs=0   (testing.select_names_layered)
         4    store_var 6            (selected_names)
 
   261   5    load_var 2             (profile_include)
@@ -29265,22 +29264,22 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
         36   jump +4                (to 40)
 
   268   37   load_var2 1 6          
-        38   call 861 ntypeargs=0   (testing.TestRegistry.run_selected)
+        38   call 862 ntypeargs=0   (testing.TestRegistry.run_selected)
         39   jump +3                (to 42)
 
   266   40   load_var 1             (self)
-        41   call 860 ntypeargs=0   (testing.TestRegistry.run_all)
+        41   call 861 ntypeargs=0   (testing.TestRegistry.run_all)
 
   270   42   load_var 6             (selected_names)
-        43   call 891 ntypeargs=0   (testing.flatten_with_tolerated)
+        43   call 892 ntypeargs=0   (testing.flatten_with_tolerated)
         44   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   241   0   load_var2 1 2          
-        1   call 867 ntypeargs=0   (testing.testset_children_selected)
+        1   call 868 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 876 ntypeargs=0   (testing.run_testset)
+        3   call 877 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -29313,7 +29312,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 875 ntypeargs=0               (testing.run_test)
+        26   call 876 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   211   28   load_type 5                        
@@ -29350,7 +29349,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   215   58   load_var2 9 2                      
-        59   call 858 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 859 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   218   61   load_const 12                      ("Test not found: ")
@@ -29385,11 +29384,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   224   22   load_var2 1 5                      
-        23   call 865 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 866 ntypeargs=0               (testing.testset_children)
+        23   call 866 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 867 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 876 ntypeargs=0               (testing.run_testset)
+        27   call 877 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   227   29   load_type 5                        
@@ -29426,7 +29425,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   230   59   load_var2 9 2                      
-        60   call 859 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 860 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   233   62   load_const 12                      ("TestSet not found: ")
@@ -29520,7 +29519,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         71   store_var 10                       (_28)
 
   189   72   load_var 9                         (sub)
-        73   call 857 ntypeargs=0               (testing.TestRegistry.serialize)
+        73   call 858 ntypeargs=0               (testing.TestRegistry.serialize)
         74   store_var 11                       (_29)
 
   186   75   load_type 0                        
@@ -29819,7 +29818,7 @@ function testing.any_pattern_matches(pats: string[], canonical_id: string) -> bo
         13   jump +6                            (to 19)
 
   608   14   load_var2 2 4                      
-        15   call 878 ntypeargs=0               (testing.glob_match)
+        15   call 879 ntypeargs=0               (testing.glob_match)
         16   pop_jump_if_false -11              (to 5)
 
   609   17   load_const 5                       (true)
@@ -29857,7 +29856,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         23   store_var_load_var 7               (name)
 
   949   24   load_var 3                         (all_failed_names)
-        25   call 894 ntypeargs=0               (testing.failure_matches_selected)
+        25   call 895 ntypeargs=0               (testing.failure_matches_selected)
         26   pop_jump_if_false +2               (to 28)
         27   jump +8                            (to 35)
 
@@ -29870,7 +29869,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         34   jump -21                           (to 13)
 
   950   35   load_var2 7 2                      
-        36   call 894 ntypeargs=0               (testing.failure_matches_selected)
+        36   call 895 ntypeargs=0               (testing.failure_matches_selected)
         37   pop_jump_if_false +2               (to 39)
         38   jump +8                            (to 46)
 
@@ -29914,7 +29913,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          16   store_var_load_var 5               (name)
 
   1050   17   load_var 2                         (out)
-         18   call 893 ntypeargs=0               (testing.name_in)
+         18   call 894 ntypeargs=0               (testing.name_in)
          19   unary_op !                         
          20   pop_jump_if_false -14              (to 6)
 
@@ -29947,7 +29946,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          45   jump -13                           (to 32)
          46   load_var2 8 2                      
 
-  1057   47   call 896 ntypeargs=0               (testing.collect_all_failed_names)
+  1057   47   call 897 ntypeargs=0               (testing.collect_all_failed_names)
          48   pop 1                              
          49   jump -17                           (to 32)
 
@@ -30050,7 +30049,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
          79    store_var_load_var 17   (sentinel)
 
   1024   80    load_var 3              (selected_names)
-         81    call 893 ntypeargs=0    (testing.name_in)
+         81    call 894 ntypeargs=0    (testing.name_in)
          82    pop_jump_if_false +2    (to 84)
          83    jump +21                (to 104)
 
@@ -30106,7 +30105,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
 
   1018   124   load_var2 3 4           
 
-  1016   125   call 895 ntypeargs=0    (testing.collect_leaf_identities)
+  1016   125   call 896 ntypeargs=0    (testing.collect_leaf_identities)
          126   pop 1                   
          127   jump +30                (to 157)
 
@@ -30183,7 +30182,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
          23   load_field 5                       (results)
          24   load_var 2                         (out)
 
-  1077   25   call 897 ntypeargs=0               (testing.collect_leaf_messages)
+  1077   25   call 898 ntypeargs=0               (testing.collect_leaf_messages)
          26   pop 1                              
          27   jump -22                           (to 5)
 
@@ -30278,7 +30277,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         40   jump +21                           (to 61)
 
   749   41   load_var2 1 6                      
-        42   call 888 ntypeargs=0               (testing.collect_subtree_names)
+        42   call 889 ntypeargs=0               (testing.collect_subtree_names)
         43   load_type 10                       
         44   load_const 11                      ("iter")
         45   virtual_call nargs=1 ntypeargs=0   
@@ -30305,8 +30304,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   762   0    load_var2 1 2          
-        1    call 865 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 887 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 866 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 888 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +89               (to 92)
         4    load_var 3             (e)
         5    store_var 4            (_5)
@@ -30405,11 +30404,11 @@ function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testi
 
 function testing.collect_subtree_names_layered(registry: testing.TestRegistry, ts: testing.TestSetRegistration, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> string[] {
   778   0     load_var2 1 2           
-        1     call 865 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
+        1     call 866 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
 
   777   2     load_var2 3 4           
         3     load_var2 5 6           
-        4     call 885 ntypeargs=0    (testing.select_names_layered)
+        4     call 886 ntypeargs=0    (testing.select_names_layered)
         5     jump +109               (to 114)
         6     load_var 7              (e)
         7     store_var 8             (_9)
@@ -30493,7 +30492,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
   805   83    load_var2 3 4           
         84    load_var2 5 6           
 
-  804   85    call 881 ntypeargs=0    (testing.leaf_selected_layered)
+  804   85    call 882 ntypeargs=0    (testing.leaf_selected_layered)
 
   803   86    pop_jump_if_false +2    (to 88)
         87    jump +4                 (to 91)
@@ -30518,7 +30517,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
   789   100   load_var2 3 4           
         101   load_var2 5 6           
 
-  788   102   call 881 ntypeargs=0    (testing.leaf_selected_layered)
+  788   102   call 882 ntypeargs=0    (testing.leaf_selected_layered)
 
   787   103   pop_jump_if_false +2    (to 105)
         104   jump +4                 (to 108)
@@ -30634,7 +30633,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   856   74    load_var 12                        (tsr)
         75    load_field 5                       (results)
         76    load_var 13                        (ft)
-        77    call 890 ntypeargs=0               (testing.count_leaves)
+        77    call 891 ntypeargs=0               (testing.count_leaves)
         78    store_var 10                       (delta)
         79    jump +30                           (to 109)
 
@@ -30726,7 +30725,7 @@ function testing.expansion_error_report(name: string) -> testing.TestSetReport {
 
 function testing.failure_matches_selected(selected: string, failed_names: string[]) -> bool {
   972   0    load_var2 1 2                      
-        1    call 893 ntypeargs=0               (testing.name_in)
+        1    call 894 ntypeargs=0               (testing.name_in)
         2    pop_jump_if_false +2               (to 4)
         3    jump +40                           (to 43)
 
@@ -30836,7 +30835,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   889   37    load_var 1             (report)
         38    load_field 5           (results)
         39    load_var 3             (top_tolerated)
-        40    call 890 ntypeargs=0   (testing.count_leaves)
+        40    call 891 ntypeargs=0   (testing.count_leaves)
         41    store_var 4            (counts)
 
   905   42    load_type 2            
@@ -30846,7 +30845,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   906   45    load_var 1             (report)
         46    load_field 5           (results)
         47    load_var 6             (messages)
-        48    call 897 ntypeargs=0   (testing.collect_leaf_messages)
+        48    call 898 ntypeargs=0   (testing.collect_leaf_messages)
         49    pop 1                  
 
   907   50    load_type 2            
@@ -30854,7 +30853,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
         52    store_var 7            (all_failed_names)
 
   908   53    load_var2 1 7          
-        54    call 896 ntypeargs=0   (testing.collect_all_failed_names)
+        54    call 897 ntypeargs=0   (testing.collect_all_failed_names)
         55    pop 1                  
 
   909   56    load_type 2            
@@ -30868,7 +30867,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
 
   910   64    load_var2 1 3          
         65    load_var2 2 8          
-        66    call 895 ntypeargs=0   (testing.collect_leaf_identities)
+        66    call 896 ntypeargs=0   (testing.collect_leaf_identities)
         67    pop 1                  
 
   916   68    load_var 8             (executed)
@@ -30926,7 +30925,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   922   112   load_var2 2 1          
         113   load_field 4           (failed_names)
         114   load_var 7             (all_failed_names)
-        115   call 892 ntypeargs=0   (testing.classify_selected_names)
+        115   call 893 ntypeargs=0   (testing.classify_selected_names)
         116   store_var 9            (identities)
         117   jump +3                (to 120)
 
@@ -31093,7 +31092,7 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
 function testing.leaf_selected(name: string, include: string[], exclude: string[]) -> bool {
   618   0    load_var2 3 1          
-        1    call 879 ntypeargs=0   (testing.any_pattern_matches)
+        1    call 880 ntypeargs=0   (testing.any_pattern_matches)
         2    pop_jump_if_false +2   (to 4)
         3    jump +14               (to 17)
 
@@ -31107,7 +31106,7 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
         11   jump +4                (to 15)
 
   624   12   load_var2 2 1          
-        13   call 879 ntypeargs=0   (testing.any_pattern_matches)
+        13   call 880 ntypeargs=0   (testing.any_pattern_matches)
         14   jump +4                (to 18)
 
   622   15   load_const 1           (true)
@@ -31120,13 +31119,13 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
 function testing.leaf_selected_layered(name: string, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> bool {
   637   0   load_var2 1 2          
         1   load_var 3             (profile_exclude)
-        2   call 880 ntypeargs=0   (testing.leaf_selected)
+        2   call 881 ntypeargs=0   (testing.leaf_selected)
         3   jump_if_false +5       (to 8)
         4   pop 1                  
 
   638   5   load_var2 1 4          
         6   load_var 5             (cli_exclude)
-        7   call 880 ntypeargs=0   (testing.leaf_selected)
+        7   call 881 ntypeargs=0   (testing.leaf_selected)
         8   return                 
 }
 
@@ -31223,7 +31222,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   486   25   load_var 5                         (child)
-        26   make_closure 1960 1                
+        26   make_closure 1961 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   load_type 7                        
@@ -31242,7 +31241,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         41   call 508 ntypeargs=2               (baml.future.all_complete)
         42   await                              
 
-  491   43   call 873 ntypeargs=0               (testing.aggregate_reports)
+  491   43   call 874 ntypeargs=0               (testing.aggregate_reports)
         44   return                             
 }
 
@@ -31304,11 +31303,11 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         49   pop_jump_if_false -41              (to 8)
 
   119   50   load_var 3                         (named_results)
-        51   call 873 ntypeargs=0               (testing.aggregate_reports)
+        51   call 874 ntypeargs=0               (testing.aggregate_reports)
         52   jump +3                            (to 55)
 
   124   53   load_var 3                         (named_results)
-        54   call 873 ntypeargs=0               (testing.aggregate_reports)
+        54   call 874 ntypeargs=0               (testing.aggregate_reports)
         55   return                             
 }
 
@@ -31318,7 +31317,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   496   3    load_var 1             (body)
-        4    make_closure 1972 1    
+        4    make_closure 1973 1    
         5    store_var 3            (base_run)
 
   527   6    load_var 2             (runner)
@@ -31350,7 +31349,7 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         7    jump +3                (to 10)
 
   539   8    load_var 1             (children)
-        9    call 874 ntypeargs=0   (testing.run_children_parallel)
+        9    call 875 ntypeargs=0   (testing.run_children_parallel)
         10   return                 
 }
 
@@ -31361,7 +31360,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         3   load_type 0            
         4   alloc_array 0          
         5   load_var2 2 3          
-        6   call 885 ntypeargs=0   (testing.select_names_layered)
+        6   call 886 ntypeargs=0   (testing.select_names_layered)
         7   return                 
 }
 
@@ -31393,7 +31392,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
         22   load_var2 2 3                      
         23   load_var2 4 5                      
 
-  703   24   call 881 ntypeargs=0               (testing.leaf_selected_layered)
+  703   24   call 882 ntypeargs=0               (testing.leaf_selected_layered)
 
   702   25   pop_jump_if_false -15              (to 10)
 
@@ -31425,14 +31424,14 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   718   50   load_field 0                       (name)
         51   load_var2 2 3                      
-        52   call 884 ntypeargs=0               (testing.subtree_may_be_selected)
+        52   call 885 ntypeargs=0               (testing.subtree_may_be_selected)
         53   jump_if_false +6                   (to 59)
         54   pop 1                              
 
   719   55   load_var 12                        (ts)
         56   load_field 0                       (name)
         57   load_var2 4 5                      
-        58   call 884 ntypeargs=0               (testing.subtree_may_be_selected)
+        58   call 885 ntypeargs=0               (testing.subtree_may_be_selected)
 
   717   59   pop_jump_if_false -20              (to 39)
 
@@ -31441,7 +31440,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
   723   61   load_var2 2 3                      
         62   load_var2 4 5                      
 
-  721   63   call 889 ntypeargs=0               (testing.collect_subtree_names_layered)
+  721   63   call 890 ntypeargs=0               (testing.collect_subtree_names_layered)
 
   729   64   load_type 10                       
         65   load_const 11                      ("iter")
@@ -31511,7 +31510,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         37   jump_if_false +4                   (to 41)
         38   pop 1                              
         39   load_var2 3 6                      
-        40   call 878 ntypeargs=0               (testing.glob_match)
+        40   call 879 ntypeargs=0               (testing.glob_match)
         41   pop_jump_if_false -32              (to 9)
 
   655   42   load_const 9                       (true)
@@ -31526,7 +31525,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
 
 function testing.subtree_may_be_selected(prefix: string, include: string[], exclude: string[]) -> bool {
   677   0    load_var2 1 3                      
-        1    call 882 ntypeargs=0               (testing.subtree_excluded)
+        1    call 883 ntypeargs=0               (testing.subtree_excluded)
         2    pop_jump_if_false +2               (to 4)
         3    jump +32                           (to 35)
 
@@ -31555,7 +31554,7 @@ function testing.subtree_may_be_selected(prefix: string, include: string[], excl
         25   jump +6                            (to 31)
         26   load_var2 6 1                      
 
-  684   27   call 883 ntypeargs=0               (testing.pattern_may_match_descendant)
+  684   27   call 884 ntypeargs=0               (testing.pattern_may_match_descendant)
         28   pop_jump_if_false -11              (to 17)
 
   685   29   load_const 6                       (true)
@@ -31582,7 +31581,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   364   6    load_var2 1 2         
 
   366   7    load_var 3            (runner)
-        8    make_closure 1937 2   
+        8    make_closure 1938 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   return                
 }
@@ -31599,7 +31598,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   375   8    load_var2 1 2         
-        9    make_closure 1939 2   
+        9    make_closure 1940 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   return                
 }
@@ -31620,7 +31619,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   391   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1941 3   
+        13   make_closure 1942 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   return                
 }
@@ -31654,7 +31653,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 868 ntypeargs=0               (testing.test_child)
+        26   call 869 ntypeargs=0               (testing.test_child)
         27   store_var 6                        (_10)
         28   load_type 0                        
         29   load_var2 2 6                      
@@ -31680,7 +31679,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         48   jump +9                            (to 57)
 
   334   49   load_var2 1 8                      
-        50   call 869 ntypeargs=0               (testing.testset_child)
+        50   call 870 ntypeargs=0               (testing.testset_child)
         51   store_var 9                        (_22)
         52   load_type 0                        
         53   load_var2 2 9                      
@@ -31718,7 +31717,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   342   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 871 ntypeargs=0               (testing._name_selected)
+        23   call 872 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   343   25   load_var 6                         (t)
@@ -31727,7 +31726,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 6                         (t)
         30   load_field 2                       (runner)
-        31   call 868 ntypeargs=0               (testing.test_child)
+        31   call 869 ntypeargs=0               (testing.test_child)
         32   store_var 7                        (_13)
         33   load_type 0                        
         34   load_var2 3 7                      
@@ -31756,12 +31755,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   354   56   load_field 0                       (name)
         57   load_var 2                         (names)
-        58   call 872 ntypeargs=0               (testing._has_selected_descendant)
+        58   call 873 ntypeargs=0               (testing._has_selected_descendant)
         59   pop_jump_if_false -14              (to 45)
 
   355   60   load_var2 1 10                     
         61   load_var 2                         (names)
-        62   call 870 ntypeargs=0               (testing.testset_child_selected)
+        62   call 871 ntypeargs=0               (testing.testset_child_selected)
         63   store_var 11                       (_27)
         64   load_type 0                        
         65   load_var2 3 11                     
@@ -31782,7 +31781,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1           (age)
 
   10   6    load_var2 1 2           
-       7    call 1382 ntypeargs=0   (user.score)
+       7    call 1383 ntypeargs=0   (user.score)
        8    store_var 3             (base)
 
   11   9    load_var 3              (base)
@@ -31981,19 +31980,19 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
 
 function vercel.AiGatewayImageClient.ai.Client.id(self: vercel.AiGatewayImageClient) -> string {
   105   0   load_var 1              (self)
-        1   call 1344 ntypeargs=0   (vercel.internal._gw_images_client_id)
+        1   call 1345 ntypeargs=0   (vercel.internal._gw_images_client_id)
         2   return                  
 }
 
 function vercel.AiGatewayImageClient.ai.Client.invoke(self: vercel.AiGatewayImageClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   109   0   load_var2 1 2           
-        1   call 1359 ntypeargs=0   (vercel.internal.gateway_images_invoke)
+        1   call 1360 ntypeargs=0   (vercel.internal.gateway_images_invoke)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   110   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
@@ -32083,7 +32082,7 @@ function vercel.AiGatewayImageClient.resolved_api_key(self: vercel.AiGatewayImag
   87   0    load_var 1             (self)
        1    load_field 1           (api_key)
        2    load_const 0           ("AI_GATEWAY_API_KEY")
-       3    call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3    call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4    store_var 2            (_4)
        5    load_var 2             (_4)
        6    narrow_bind 1 2        
@@ -32093,7 +32092,7 @@ function vercel.AiGatewayImageClient.resolved_api_key(self: vercel.AiGatewayImag
   93   9    load_var 1             (self)
        10   load_field 1           (api_key)
        11   load_const 2           ("AI_GATEWAY_API_KEY")
-       12   call 939 ntypeargs=0   (ai.wire.credential_sources)
+       12   call 940 ntypeargs=0   (ai.wire.credential_sources)
        13   store_var 4            (_9)
        14   load_type 3            
        15   load_var 4             (_9)
@@ -32118,7 +32117,7 @@ function vercel.AiGatewayImageClient.resolved_base_url(self: vercel.AiGatewayIma
   100   0   load_var 1             (self)
         1   load_field 2           (base_url)
         2   load_const 0           (null)
-        3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4   return                 
 }
 
@@ -32173,7 +32172,7 @@ function vercel.internal._gw_images_drop_nulls(value: baml.json.json) -> baml.js
         30   jump +9                            (to 39)
         31   load_var 13                        (_29)
 
-  118   32   call 1345 ntypeargs=0              (vercel.internal._gw_images_drop_nulls)
+  118   32   call 1346 ntypeargs=0              (vercel.internal._gw_images_drop_nulls)
         33   store_var 14                       (_34)
         34   load_type 2                        
         35   load_var2 11 14                    
@@ -32225,7 +32224,7 @@ function vercel.internal._gw_images_drop_nulls(value: baml.json.json) -> baml.js
         75   jump -20                           (to 55)
 
   108   76   load_var 8                         (entry)
-        77   call 1345 ntypeargs=0              (vercel.internal._gw_images_drop_nulls)
+        77   call 1346 ntypeargs=0              (vercel.internal._gw_images_drop_nulls)
         78   store_var 9                        (_20)
         79   load_type 8                        
         80   load_type 2                        
@@ -32269,7 +32268,7 @@ function vercel.internal._gw_images_escape_query(raw: string) -> string {
 function vercel.internal._gw_images_file(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf) -> vercel.internal.GwImagesFile {
   141   0    load_var 1             (media)
         1    load_const 0           (false)
-        2    call 942 ntypeargs=0   (ai.wire.resolve_media)
+        2    call 943 ntypeargs=0   (ai.wire.resolve_media)
         3    store_var 2            (resolved)
 
   142   4    load_var 2             (resolved)
@@ -32369,7 +32368,7 @@ function vercel.internal._gw_images_find_output_format(value: baml.json.json | n
         46   jump +9                            (to 55)
 
   341   47   load_var 7                         (entry)
-        48   call 1354 ntypeargs=0              (vercel.internal._gw_images_find_output_format)
+        48   call 1355 ntypeargs=0              (vercel.internal._gw_images_find_output_format)
         49   store_var 9                        (_24)
         50   load_var 9                         (_24)
         51   narrow_bind 10 9                   
@@ -32453,7 +32452,7 @@ function vercel.internal._gw_images_headers(c: vercel.AiGatewayImageClient) -> m
         59   jump -30                           (to 29)
 
   277   60   load_var 1                         (c)
-        61   call 1340 ntypeargs=0              (vercel.AiGatewayImageClient.resolved_api_key)
+        61   call 1341 ntypeargs=0              (vercel.AiGatewayImageClient.resolved_api_key)
         62   store_var 11                       (_29)
         63   load_type 7                        
         64   load_var 11                        (_29)
@@ -32491,7 +32490,7 @@ function vercel.internal._gw_images_input(prompt: ai.Prompt, journal: ai.Journal
         5     store_var 4                        (files)
 
   173   6     load_var 1                         (prompt)
-        7     call 919 ntypeargs=0               (ai.Prompt.messages)
+        7     call 920 ntypeargs=0               (ai.Prompt.messages)
         8     load_type 2                        
         9     load_const 3                       ("iter")
         10    virtual_call nargs=1 ntypeargs=0   
@@ -32550,20 +32549,20 @@ function vercel.internal._gw_images_input(prompt: ai.Prompt, journal: ai.Journal
         61    jump +4                            (to 65)
 
   194   62    load_const 15                      ("pdf")
-        63    call 1346 ntypeargs=0              (vercel.internal._gw_images_media_rejected)
+        63    call 1347 ntypeargs=0              (vercel.internal._gw_images_media_rejected)
         64    throw                              
 
   191   65    load_const 16                      ("video")
-        66    call 1346 ntypeargs=0              (vercel.internal._gw_images_media_rejected)
+        66    call 1347 ntypeargs=0              (vercel.internal._gw_images_media_rejected)
         67    throw                              
 
   188   68    load_const 17                      ("audio")
-        69    call 1346 ntypeargs=0              (vercel.internal._gw_images_media_rejected)
+        69    call 1347 ntypeargs=0              (vercel.internal._gw_images_media_rejected)
         70    throw                              
 
   175   71    load_var 12                        (_25)
 
-  184   72    call 1347 ntypeargs=0              (vercel.internal._gw_images_file)
+  184   72    call 1348 ntypeargs=0              (vercel.internal._gw_images_file)
         73    store_var 13                       (_28)
         74    load_type 1                        
         75    load_var2 4 13                     
@@ -32588,7 +32587,7 @@ function vercel.internal._gw_images_input(prompt: ai.Prompt, journal: ai.Journal
         90    jump -63                           (to 27)
 
   199   91    load_var 2                         (journal)
-        92    call 914 ntypeargs=0               (ai.Journal.entries)
+        92    call 915 ntypeargs=0               (ai.Journal.entries)
         93    load_type 19                       
         94    load_const 20                      ("iter")
         95    virtual_call nargs=1 ntypeargs=0   
@@ -32854,7 +32853,7 @@ function vercel.internal._gw_images_with_query(url: string, params: map<string, 
         27    load_var 7                         (_10)
         28    store_var_load_var 8               (key)
 
-  247   29    call 1350 ntypeargs=0              (vercel.internal._gw_images_escape_query)
+  247   29    call 1351 ntypeargs=0              (vercel.internal._gw_images_escape_query)
         30    store_var 10                       (_18)
         31    load_type 0                        
         32    load_var 10                        (_18)
@@ -32871,7 +32870,7 @@ function vercel.internal._gw_images_with_query(url: string, params: map<string, 
         43    load_const 8                       ("")
         44    store_var 13                       (_24)
         45    load_var 13                        (_24)
-        46    call 1350 ntypeargs=0              (vercel.internal._gw_images_escape_query)
+        46    call 1351 ntypeargs=0              (vercel.internal._gw_images_escape_query)
         47    store_var 12                       (_22)
         48    load_type 0                        
         49    load_var 12                        (_22)
@@ -32942,17 +32941,17 @@ function vercel.internal._gw_images_with_query(url: string, params: map<string, 
 
 function vercel.internal.gateway_images_invoke(c: vercel.AiGatewayImageClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   457   0    load_var2 1 2           
-        1    call 1353 ntypeargs=0   (vercel.internal.gateway_images_render)
+        1    call 1354 ntypeargs=0   (vercel.internal.gateway_images_render)
         2    store_var 3             (req)
 
   458   3    load_type 0             
         4    load_var 3              (req)
         5    load_const 1            ("ai-gateway-images")
-        6    call 940 ntypeargs=1    (ai.wire.send_as)
+        6    call 941 ntypeargs=1    (ai.wire.send_as)
         7    store_var 4             (resp)
 
   459   8    load_var2 1 4           
-        9    call 1358 ntypeargs=0   (vercel.internal.gateway_images_parse)
+        9    call 1359 ntypeargs=0   (vercel.internal.gateway_images_parse)
         10   return                  
 }
 
@@ -32983,7 +32982,7 @@ function vercel.internal.gateway_images_parse(c: vercel.AiGatewayImageClient, re
         22    jump +15                           (to 37)
         23    load_var 5                         (_9)
 
-  414   24    call 1357 ntypeargs=0              (vercel.internal.gateway_images_warning_text)
+  414   24    call 1358 ntypeargs=0              (vercel.internal.gateway_images_warning_text)
         25    store_var 6                        (_13)
         26    load_const 7                       ("$baml_log")
         27    load_const 8                       ("warn")
@@ -32999,7 +32998,7 @@ function vercel.internal.gateway_images_parse(c: vercel.AiGatewayImageClient, re
 
   416   37    load_var 2                         (resp)
         38    load_field 2                       (providerMetadata)
-        39    call 1354 ntypeargs=0              (vercel.internal._gw_images_find_output_format)
+        39    call 1355 ntypeargs=0              (vercel.internal._gw_images_find_output_format)
         40    store_var_load_var 7               (_16)
         41    load_const 0                       (null)
         42    cmp_op ==                          
@@ -33007,11 +33006,11 @@ function vercel.internal.gateway_images_parse(c: vercel.AiGatewayImageClient, re
 
   417   44    load_var 1                         (c)
         45    load_field 7                       (request_body)
-        46    call 1354 ntypeargs=0              (vercel.internal._gw_images_find_output_format)
+        46    call 1355 ntypeargs=0              (vercel.internal._gw_images_find_output_format)
         47    store_var 7                        (_16)
         48    load_var 7                         (_16)
 
-  418   49    call 1355 ntypeargs=0              (vercel.internal._gw_images_mime)
+  418   49    call 1356 ntypeargs=0              (vercel.internal._gw_images_mime)
         50    store_var 8                        (fallback_mime)
 
   419   51    load_var 2                         (resp)
@@ -33053,10 +33052,10 @@ function vercel.internal.gateway_images_parse(c: vercel.AiGatewayImageClient, re
         83    pop_jump_if_false -15              (to 68)
 
   424   84    load_var2 13 8                     
-        85    call 1356 ntypeargs=0              (vercel.internal._gw_images_value)
+        85    call 1357 ntypeargs=0              (vercel.internal._gw_images_value)
         86    load_const 19                      (<omitted>)
         87    load_const 19                      (<omitted>)
-        88    call 913 ntypeargs=0               (ai.content.Media.new)
+        88    call 914 ntypeargs=0               (ai.content.Media.new)
         89    store_var 14                       (_37)
 
   423   90    load_type 13                       
@@ -33132,7 +33131,7 @@ function vercel.internal.gateway_images_parse(c: vercel.AiGatewayImageClient, re
 function vercel.internal.gateway_images_render(c: vercel.AiGatewayImageClient, input: ai.ModelTurnInput) -> baml.http.Request {
   287   0     load_var 2              (input)
         1     load_field 2            (toolbox)
-        2     call 933 ntypeargs=0    (ai.tools.Toolbox.is_empty)
+        2     call 934 ntypeargs=0    (ai.tools.Toolbox.is_empty)
         3     unary_op !              
         4     pop_jump_if_false +2    (to 6)
         5     jump +90                (to 95)
@@ -33141,10 +33140,10 @@ function vercel.internal.gateway_images_render(c: vercel.AiGatewayImageClient, i
         7     load_field 1            (journal)
         8     store_var 4             (_8)
         9     load_var 1              (c)
-        10    call 1344 ntypeargs=0   (vercel.internal._gw_images_client_id)
+        10    call 1345 ntypeargs=0   (vercel.internal._gw_images_client_id)
         11    store_var 5             (_9)
         12    load_var2 4 5           
-        13    call 944 ntypeargs=0    (ai.wire.sanitize_for_client)
+        13    call 945 ntypeargs=0    (ai.wire.sanitize_for_client)
         14    store_var 3             (journal)
 
   297   15    load_const 0            ("")
@@ -33152,7 +33151,7 @@ function vercel.internal.gateway_images_render(c: vercel.AiGatewayImageClient, i
         17    load_field 0            (prompt)
         18    call_indirect           
         19    load_var 3              (journal)
-        20    call 1348 ntypeargs=0   (vercel.internal._gw_images_input)
+        20    call 1349 ntypeargs=0   (vercel.internal._gw_images_input)
         21    store_var 6             (lowered)
 
   298   22    load_var 6              (lowered)
@@ -33204,15 +33203,15 @@ function vercel.internal.gateway_images_render(c: vercel.AiGatewayImageClient, i
         57    init_instance 0         (vercel.internal.GwImagesRequest .prompt, .n, .size, .aspectRatio, .seed, .files)
 
   311   58    call 362 ntypeargs=1    (baml.json.to_json)
-        59    call 1345 ntypeargs=0   (vercel.internal._gw_images_drop_nulls)
+        59    call 1346 ntypeargs=0   (vercel.internal._gw_images_drop_nulls)
 
   312   60    load_var 1              (c)
         61    load_field 7            (request_body)
-        62    call 943 ntypeargs=0    (ai.wire.merge_request_body)
+        62    call 944 ntypeargs=0    (ai.wire.merge_request_body)
         63    store_var 11            (merged)
 
   314   64    load_var 1              (c)
-        65    call 1341 ntypeargs=0   (vercel.AiGatewayImageClient.resolved_base_url)
+        65    call 1342 ntypeargs=0   (vercel.AiGatewayImageClient.resolved_base_url)
         66    store_var_load_var 14   (_40)
         67    load_const 2            (null)
         68    cmp_op ==               
@@ -33220,7 +33219,7 @@ function vercel.internal.gateway_images_render(c: vercel.AiGatewayImageClient, i
         70    load_const 5            ("https://ai-gateway.vercel.sh/v4/ai")
         71    store_var 14            (_40)
         72    load_var 14             (_40)
-        73    call 1349 ntypeargs=0   (vercel.internal._gw_images_trim_slash)
+        73    call 1350 ntypeargs=0   (vercel.internal._gw_images_trim_slash)
         74    store_var 13            (_38)
         75    load_type 6             
         76    load_var 13             (_38)
@@ -33231,11 +33230,11 @@ function vercel.internal.gateway_images_render(c: vercel.AiGatewayImageClient, i
   315   80    load_var 1              (c)
         81    load_field 9            (query_params)
 
-  313   82    call 1351 ntypeargs=0   (vercel.internal._gw_images_with_query)
+  313   82    call 1352 ntypeargs=0   (vercel.internal._gw_images_with_query)
         83    store_var 12            (url)
 
   320   84    load_var 1              (c)
-        85    call 1352 ntypeargs=0   (vercel.internal._gw_images_headers)
+        85    call 1353 ntypeargs=0   (vercel.internal._gw_images_headers)
         86    store_var 15            (_46)
 
   321   87    load_var 11             (merged)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded.snap
@@ -15828,11 +15828,11 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          60    cmp_op ==                          
          61    pop_jump_if_false +2               (to 63)
          62    jump +8                            (to 70)
-         63    load_const 12                      (0)
+         63    load_type 12                       
          64    load_var 8                         (resp)
          65    load_field 0                       (candidates)
-         66    make_bound_method 3                
-         67    call_indirect                      
+         66    load_const 13                      (0)
+         67    call 3 ntypeargs=1                 (baml.Array.at)
          68    store_var 15                       (cand)
          69    jump +3                            (to 72)
          70    load_const 6                       (null)
@@ -15863,18 +15863,18 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          94    load_const 6                       (null)
          95    cmp_op ==                          
          96    pop_jump_if_false +4               (to 100)
-         97    load_type 13                       
+         97    load_type 14                       
          98    alloc_array 0                      
          99    store_var 16                       (_43)
          100   load_var 16                        (_43)
-         101   load_type 14                       
-         102   load_const 15                      ("iter")
+         101   load_type 15                       
+         102   load_const 16                      ("iter")
          103   virtual_call nargs=1 ntypeargs=0   
          104   store_var 17                       (_56)
 
   994    105   load_var 17                        (_56)
-         106   load_type 16                       
-         107   load_const 17                      ("next")
+         106   load_type 17                       
+         107   load_const 18                      ("next")
          108   virtual_call nargs=1 ntypeargs=0   
          109   store_var 18                       (_57)
          110   load_var 18                        (_57)
@@ -15887,7 +15887,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
   995    116   load_field 0                       (text)
          117   store_var 20                       (_62)
          118   load_var 20                        (_62)
-         119   narrow_bind 18 20                  
+         119   narrow_bind 19 20                  
          120   pop_jump_if_false -15              (to 105)
          121   load_var 20                        (_62)
          122   store_var 21                       (t)
@@ -15898,7 +15898,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          126   load_const 6                       (null)
          127   cmp_op ==                          
          128   pop_jump_if_false +3               (to 131)
-         129   load_const 19                      (false)
+         129   load_const 20                      (false)
          130   store_var 22                       (_65)
          131   load_var 22                        (_65)
          132   pop_jump_if_false +2               (to 134)
@@ -15924,7 +15924,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          150   load_const 6                       (null)
          151   cmp_op ==                          
          152   pop_jump_if_false +3               (to 155)
-         153   load_const 20                      ("")
+         153   load_const 21                      ("")
          154   store_var 24                       (_73)
          155   load_var 24                        (_73)
          156   store_var 23                       (finish)
@@ -15945,7 +15945,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          170   store_var 25                       (_84)
 
   1008   171   load_var 23                        (finish)
-         172   load_const 21                      ("MAX_TOKENS")
+         172   load_const 22                      ("MAX_TOKENS")
          173   cmp_op ==                          
          174   pop_jump_if_false +2               (to 176)
          175   jump +26                           (to 201)
@@ -15962,7 +15962,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          184   jump +13                           (to 197)
 
   1012   185   load_var 23                        (finish)
-         186   load_const 22                      ("")
+         186   load_const 23                      ("")
          187   cmp_op !=                          
          188   pop_jump_if_false +2               (to 190)
          189   jump +4                            (to 193)
@@ -15972,19 +15972,19 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
 
   1012   192   jump +12                           (to 204)
 
-  1013   193   load_const 12                      (ai.content.StopReason.Complete)
+  1013   193   load_const 13                      (ai.content.StopReason.Complete)
          194   alloc_variant 774                  (ai.content.StopReason)
          195   store_var 26                       (stop)
 
   1012   196   jump +8                            (to 204)
 
-  1011   197   load_const 23                      (ai.content.StopReason.Refused)
+  1011   197   load_const 24                      (ai.content.StopReason.Refused)
          198   alloc_variant 774                  (ai.content.StopReason)
          199   store_var 26                       (stop)
 
   1010   200   jump +4                            (to 204)
 
-  1009   201   load_const 24                      (ai.content.StopReason.MaxTokens)
+  1009   201   load_const 25                      (ai.content.StopReason.MaxTokens)
          202   alloc_variant 774                  (ai.content.StopReason)
          203   store_var 26                       (stop)
 
@@ -16062,7 +16062,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          264   load_const 6                       (null)
          265   cmp_op ==                          
          266   pop_jump_if_false +3               (to 269)
-         267   load_const 12                      (0)
+         267   load_const 13                      (0)
          268   store_var 13                       (_30)
          269   load_var 13                        (_30)
          270   store_var 12                       (_29)
@@ -16076,7 +16076,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          278   store_var 14                       (_34)
          279   load_var2 2 12                     
          280   load_var 14                        (_34)
-         281   load_const 25                      (<omitted>)
+         281   load_const 26                      (<omitted>)
          282   call 987 ntypeargs=0               (ai.errors.classify_http)
          283   throw                              
 
@@ -17256,21 +17256,22 @@ function google.internal._vertex_key_in_query(c: google.VertexClient) -> bool {
        2    load_const 0           (null)
        3    cmp_op ==              
        4    pop_jump_if_false +2   (to 6)
-       5    jump +8                (to 13)
-       6    load_const 1           ("key")
-       7    load_var 1             (c)
-       8    load_field 9           (query_params)
-       9    make_bound_method 38   
-       10   call_indirect          
-       11   store_var 2            (_2)
-       12   jump +3                (to 15)
-       13   load_const 0           (null)
-       14   store_var 2            (_2)
-       15   load_var 2             (_2)
-       16   load_const 0           (null)
-       17   call 679 ntypeargs=0   (baml.ops.equals_equals)
-       18   unary_op !             
-       19   return                 
+       5    jump +9                (to 14)
+       6    load_type 1            
+       7    load_type 1            
+       8    load_var 1             (c)
+       9    load_field 9           (query_params)
+       10   load_const 2           ("key")
+       11   call 38 ntypeargs=2    (baml.Map.get)
+       12   store_var 2            (_2)
+       13   jump +3                (to 16)
+       14   load_const 0           (null)
+       15   store_var 2            (_2)
+       16   load_var 2             (_2)
+       17   load_const 0           (null)
+       18   call 679 ntypeargs=0   (baml.ops.equals_equals)
+       19   unary_op !             
+       20   return                 
 }
 
 function google.internal._vertex_method(c: google.VertexClient, stream: bool) -> string {
@@ -18317,11 +18318,11 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         23    cmp_op ==                          
         24    pop_jump_if_false +2               (to 26)
         25    jump +8                            (to 33)
-        26    load_const 5                       (0)
+        26    load_type 7                        
         27    load_var 1                         (resp)
         28    load_field 0                       (candidates)
-        29    make_bound_method 3                
-        30    call_indirect                      
+        29    load_const 5                       (0)
+        30    call 3 ntypeargs=1                 (baml.Array.at)
         31    store_var 12                       (cand)
         32    jump +3                            (to 35)
         33    load_const 6                       (null)
@@ -18340,7 +18341,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         45    load_const 6                       (null)
         46    cmp_op ==                          
         47    pop_jump_if_false +3               (to 50)
-        48    load_const 7                       ("")
+        48    load_const 8                       ("")
         49    store_var 14                       (_28)
         50    load_var 14                        (_28)
         51    store_var 13                       (finish)
@@ -18370,22 +18371,22 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         74    load_const 6                       (null)
         75    cmp_op ==                          
         76    pop_jump_if_false +4               (to 80)
-        77    load_type 8                        
+        77    load_type 9                        
         78    alloc_array 0                      
         79    store_var 15                       (_35)
         80    load_var 15                        (_35)
-        81    load_type 9                        
-        82    load_const 10                      ("iter")
+        81    load_type 10                       
+        82    load_const 11                      ("iter")
         83    virtual_call nargs=1 ntypeargs=0   
         84    store_var 16                       (_48)
 
   851   85    load_var 16                        (_48)
-        86    load_type 11                       
-        87    load_const 12                      ("next")
+        86    load_type 12                       
+        87    load_const 13                      ("next")
         88    virtual_call nargs=1 ntypeargs=0   
         89    store_var 17                       (_49)
         90    load_var 17                        (_49)
-        91    is_type 13                         
+        91    is_type 14                         
         92    pop_jump_if_false +2               (to 94)
         93    jump +122                          (to 215)
         94    load_var 17                        (_49)
@@ -18394,7 +18395,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
   852   96    load_field 3                       (functionCall)
         97    store_var 19                       (_54)
         98    load_var 19                        (_54)
-        99    narrow_bind 14 19                  
+        99    narrow_bind 15 19                  
         100   pop_jump_if_false +2               (to 102)
         101   jump +66                           (to 167)
 
@@ -18402,7 +18403,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         103   load_field 4                       (inlineData)
         104   store_var 26                       (_76)
         105   load_var 26                        (_76)
-        106   narrow_bind 15 26                  
+        106   narrow_bind 16 26                  
         107   pop_jump_if_false +2               (to 109)
         108   jump +32                           (to 140)
 
@@ -18410,7 +18411,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         110   load_field 0                       (text)
         111   store_var 32                       (_90)
         112   load_var 32                        (_90)
-        113   narrow_bind 16 32                  
+        113   narrow_bind 17 32                  
         114   pop_jump_if_false -29              (to 85)
         115   load_var 32                        (_90)
         116   store_var 33                       (t)
@@ -18449,7 +18450,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         144   load_const 6                       (null)
         145   cmp_op ==                          
         146   pop_jump_if_false +3               (to 149)
-        147   load_const 17                      ("image/png")
+        147   load_const 18                      ("image/png")
         148   store_var 30                       (_81)
         149   load_var 30                        (_81)
         150   store_var 29                       (_80)
@@ -18459,7 +18460,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         154   load_const 6                       (null)
         155   cmp_op ==                          
         156   pop_jump_if_false +3               (to 159)
-        157   load_const 18                      ("")
+        157   load_const 19                      ("")
         158   store_var 31                       (_85)
         159   load_var2 29 31                    
         160   call 1247 ntypeargs=0              (google.internal._gm_output_media)
@@ -18474,8 +18475,8 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
   852   167   load_var 19                        (_54)
         168   store_var 20                       (fc)
 
-  853   169   load_type 19                       
-        170   load_type 20                       
+  853   169   load_type 20                       
+        170   load_type 21                       
         171   alloc_map 0                        
         172   store_var 21                       (args)
 
@@ -18483,23 +18484,23 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         174   load_field 1                       (args)
         175   store_var 22                       (_58)
         176   load_var 22                        (_58)
-        177   narrow_bind 21 22                  
+        177   narrow_bind 22 22                  
         178   pop_jump_if_false +3               (to 181)
         179   load_var 22                        (_58)
         180   store_var 21                       (args)
 
-  859   181   load_type 22                       
+  859   181   load_type 23                       
         182   load_var 2                         (seq)
         183   call 145 ntypeargs=1               (baml.String.from)
         184   store_var 24                       (_66)
-        185   load_type 22                       
+        185   load_type 23                       
         186   load_var 11                        (call_index)
         187   call 145 ntypeargs=1               (baml.String.from)
         188   store_var 25                       (_68)
-        189   load_const 23                      ("call_")
+        189   load_const 24                      ("call_")
         190   load_var 24                        (_66)
         191   bin_op +                           
-        192   load_const 24                      ("_")
+        192   load_const 25                      ("_")
         193   bin_op +                           
         194   load_var 25                        (_68)
         195   bin_op +                           
@@ -18521,11 +18522,11 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         207   pop 1                              
 
   864   208   load_var 11                        (call_index)
-        209   load_const 16                      (1)
+        209   load_const 17                      (1)
         210   add_int                            
         211   store_var 11                       (call_index)
 
-  865   212   load_const 25                      (true)
+  865   212   load_const 26                      (true)
         213   store_var 10                       (has_call)
 
   852   214   jump -129                          (to 85)
@@ -18555,7 +18556,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         236   jump_if_false +5                   (to 241)
         237   pop 1                              
         238   load_var 13                        (finish)
-        239   load_const 26                      ("")
+        239   load_const 27                      ("")
         240   cmp_op ==                          
         241   jump_if_false +4                   (to 245)
         242   pop 1                              
@@ -18569,7 +18570,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         249   jump +23                           (to 272)
 
   901   250   load_var 13                        (finish)
-        251   load_const 27                      ("MAX_TOKENS")
+        251   load_const 28                      ("MAX_TOKENS")
         252   cmp_op ==                          
         253   pop_jump_if_false +2               (to 255)
         254   jump +15                           (to 269)
@@ -18588,17 +18589,17 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
 
   903   265   jump +9                            (to 274)
 
-  904   266   load_const 28                      (ai.content.StopReason.Refused)
+  904   266   load_const 29                      (ai.content.StopReason.Refused)
         267   alloc_variant 774                  (ai.content.StopReason)
 
   903   268   jump +6                            (to 274)
 
-  902   269   load_const 29                      (ai.content.StopReason.MaxTokens)
+  902   269   load_const 30                      (ai.content.StopReason.MaxTokens)
         270   alloc_variant 774                  (ai.content.StopReason)
 
   901   271   jump +3                            (to 274)
 
-  900   272   load_const 16                      (ai.content.StopReason.ToolUse)
+  900   272   load_const 17                      (ai.content.StopReason.ToolUse)
         273   alloc_variant 774                  (ai.content.StopReason)
 
   908   274   store_var 38                       (_128)
@@ -18611,7 +18612,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         281   init_instance 3                    (ai.ModelTurn .content, .stop_reason, .usage)
         282   return                             
 
-  896   283   load_type 30                       
+  896   283   load_type 31                       
         284   load_var 1                         (resp)
         285   call 362 ntypeargs=1               (baml.json.to_json)
         286   call 358 ntypeargs=0               (baml.json.stringify)
@@ -18640,7 +18641,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         305   load_const 6                       (null)
         306   cmp_op ==                          
         307   pop_jump_if_false +6               (to 313)
-        308   load_type 30                       
+        308   load_type 31                       
         309   load_var 1                         (resp)
         310   call 362 ntypeargs=1               (baml.json.to_json)
         311   call 358 ntypeargs=0               (baml.json.stringify)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -16243,11 +16243,11 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          61    cmp_op ==                          
          62    pop_jump_if_false +2               (to 64)
          63    jump +8                            (to 71)
-         64    load_const 12                      (0)
+         64    load_type 12                       
          65    load_var 10                        (resp)
          66    load_field 0                       (candidates)
-         67    make_bound_method 3                
-         68    call_indirect                      
+         67    load_const 13                      (0)
+         68    call 3 ntypeargs=1                 (baml.Array.at)
          69    store_var 17                       (cand)
          70    jump +3                            (to 73)
          71    load_const 6                       (null)
@@ -16278,19 +16278,19 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          95    load_const 6                       (null)
          96    cmp_op ==                          
          97    pop_jump_if_false +4               (to 101)
-         98    load_type 13                       
+         98    load_type 14                       
          99    alloc_array 0                      
          100   store_var 19                       (_43)
          101   load_var 19                        (_43)
          102   store_var_load_var 18              (parts)
 
-  994    103   load_type 14                       
-         104   load_const 15                      ("iter")
+  994    103   load_type 15                       
+         104   load_const 16                      ("iter")
          105   virtual_call nargs=1 ntypeargs=0   
          106   store_var 20                       (_56)
          107   load_var 20                        (_56)
-         108   load_type 16                       
-         109   load_const 17                      ("next")
+         108   load_type 17                       
+         109   load_const 18                      ("next")
          110   virtual_call nargs=1 ntypeargs=0   
          111   store_var 21                       (_57)
          112   load_var 21                        (_57)
@@ -16303,7 +16303,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
   995    118   load_field 0                       (text)
          119   store_var 23                       (_62)
          120   load_var 23                        (_62)
-         121   narrow_bind 18 23                  
+         121   narrow_bind 19 23                  
          122   pop_jump_if_false -15              (to 107)
          123   load_var 23                        (_62)
          124   store_var 24                       (t)
@@ -16314,7 +16314,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          128   load_const 6                       (null)
          129   cmp_op ==                          
          130   pop_jump_if_false +3               (to 133)
-         131   load_const 19                      (false)
+         131   load_const 20                      (false)
          132   store_var 25                       (_65)
          133   load_var 25                        (_65)
          134   pop_jump_if_false +2               (to 136)
@@ -16340,7 +16340,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          152   load_const 6                       (null)
          153   cmp_op ==                          
          154   pop_jump_if_false +3               (to 157)
-         155   load_const 20                      ("")
+         155   load_const 21                      ("")
          156   store_var 27                       (_73)
          157   load_var 27                        (_73)
          158   store_var 26                       (finish)
@@ -16362,7 +16362,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          173   store_var 28                       (blocked)
 
   1008   174   load_var 26                        (finish)
-         175   load_const 21                      ("MAX_TOKENS")
+         175   load_const 22                      ("MAX_TOKENS")
          176   cmp_op ==                          
          177   pop_jump_if_false +2               (to 179)
          178   jump +25                           (to 203)
@@ -16377,7 +16377,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          186   jump +13                           (to 199)
 
   1012   187   load_var 26                        (finish)
-         188   load_const 22                      ("")
+         188   load_const 23                      ("")
          189   cmp_op !=                          
          190   pop_jump_if_false +2               (to 192)
          191   jump +4                            (to 195)
@@ -16387,19 +16387,19 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
 
   1012   194   jump +12                           (to 206)
 
-  1013   195   load_const 12                      (ai.content.StopReason.Complete)
+  1013   195   load_const 13                      (ai.content.StopReason.Complete)
          196   alloc_variant 774                  (ai.content.StopReason)
          197   store_var 29                       (stop)
 
   1012   198   jump +8                            (to 206)
 
-  1011   199   load_const 23                      (ai.content.StopReason.Refused)
+  1011   199   load_const 24                      (ai.content.StopReason.Refused)
          200   alloc_variant 774                  (ai.content.StopReason)
          201   store_var 29                       (stop)
 
   1010   202   jump +4                            (to 206)
 
-  1009   203   load_const 24                      (ai.content.StopReason.MaxTokens)
+  1009   203   load_const 25                      (ai.content.StopReason.MaxTokens)
          204   alloc_variant 774                  (ai.content.StopReason)
          205   store_var 29                       (stop)
 
@@ -16477,7 +16477,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          266   load_const 6                       (null)
          267   cmp_op ==                          
          268   pop_jump_if_false +3               (to 271)
-         269   load_const 12                      (0)
+         269   load_const 13                      (0)
          270   store_var 15                       (_30)
          271   load_var 15                        (_30)
          272   store_var 14                       (_29)
@@ -16491,7 +16491,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          280   store_var 16                       (_34)
          281   load_var2 2 14                     
          282   load_var 16                        (_34)
-         283   load_const 25                      (<omitted>)
+         283   load_const 26                      (<omitted>)
          284   call 987 ntypeargs=0               (ai.errors.classify_http)
          285   throw                              
 
@@ -17714,23 +17714,24 @@ function google.internal._vertex_key_in_query(c: google.VertexClient) -> bool {
        2    load_const 0           (null)
        3    cmp_op ==              
        4    pop_jump_if_false +2   (to 6)
-       5    jump +8                (to 13)
-       6    load_const 1           ("key")
-       7    load_var 1             (c)
-       8    load_field 9           (query_params)
-       9    make_bound_method 38   
-       10   call_indirect          
-       11   store_var 3            (_2)
-       12   jump +3                (to 15)
-       13   load_const 0           (null)
-       14   store_var 3            (_2)
-       15   load_var 3             (_2)
-       16   load_const 0           (null)
-       17   call 679 ntypeargs=0   (baml.ops.equals_equals)
-       18   unary_op !             
-       19   store_var 2            (_0)
-       20   load_var 2             (_0)
-       21   return                 
+       5    jump +9                (to 14)
+       6    load_type 1            
+       7    load_type 1            
+       8    load_var 1             (c)
+       9    load_field 9           (query_params)
+       10   load_const 2           ("key")
+       11   call 38 ntypeargs=2    (baml.Map.get)
+       12   store_var 3            (_2)
+       13   jump +3                (to 16)
+       14   load_const 0           (null)
+       15   store_var 3            (_2)
+       16   load_var 3             (_2)
+       17   load_const 0           (null)
+       18   call 679 ntypeargs=0   (baml.ops.equals_equals)
+       19   unary_op !             
+       20   store_var 2            (_0)
+       21   load_var 2             (_0)
+       22   return                 
 }
 
 function google.internal._vertex_method(c: google.VertexClient, stream: bool) -> string {
@@ -18794,11 +18795,11 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         23    cmp_op ==                          
         24    pop_jump_if_false +2               (to 26)
         25    jump +8                            (to 33)
-        26    load_const 5                       (0)
+        26    load_type 7                        
         27    load_var 1                         (resp)
         28    load_field 0                       (candidates)
-        29    make_bound_method 3                
-        30    call_indirect                      
+        29    load_const 5                       (0)
+        30    call 3 ntypeargs=1                 (baml.Array.at)
         31    store_var 13                       (cand)
         32    jump +3                            (to 35)
         33    load_const 6                       (null)
@@ -18817,7 +18818,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         45    load_const 6                       (null)
         46    cmp_op ==                          
         47    pop_jump_if_false +3               (to 50)
-        48    load_const 7                       ("")
+        48    load_const 8                       ("")
         49    store_var 15                       (_28)
         50    load_var 15                        (_28)
         51    store_var 14                       (finish)
@@ -18847,23 +18848,23 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         74    load_const 6                       (null)
         75    cmp_op ==                          
         76    pop_jump_if_false +4               (to 80)
-        77    load_type 8                        
+        77    load_type 9                        
         78    alloc_array 0                      
         79    store_var 17                       (_35)
         80    load_var 17                        (_35)
         81    store_var_load_var 16              (parts)
 
-  851   82    load_type 9                        
-        83    load_const 10                      ("iter")
+  851   82    load_type 10                       
+        83    load_const 11                      ("iter")
         84    virtual_call nargs=1 ntypeargs=0   
         85    store_var 18                       (_48)
         86    load_var 18                        (_48)
-        87    load_type 11                       
-        88    load_const 12                      ("next")
+        87    load_type 12                       
+        88    load_const 13                      ("next")
         89    virtual_call nargs=1 ntypeargs=0   
         90    store_var 19                       (_49)
         91    load_var 19                        (_49)
-        92    is_type 13                         
+        92    is_type 14                         
         93    pop_jump_if_false +2               (to 95)
         94    jump +124                          (to 218)
         95    load_var 19                        (_49)
@@ -18872,7 +18873,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
   852   97    load_field 3                       (functionCall)
         98    store_var 21                       (_54)
         99    load_var 21                        (_54)
-        100   narrow_bind 14 21                  
+        100   narrow_bind 15 21                  
         101   pop_jump_if_false +2               (to 103)
         102   jump +66                           (to 168)
 
@@ -18880,7 +18881,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         104   load_field 4                       (inlineData)
         105   store_var 29                       (_76)
         106   load_var 29                        (_76)
-        107   narrow_bind 15 29                  
+        107   narrow_bind 16 29                  
         108   pop_jump_if_false +2               (to 110)
         109   jump +32                           (to 141)
 
@@ -18888,7 +18889,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         111   load_field 0                       (text)
         112   store_var 35                       (_90)
         113   load_var 35                        (_90)
-        114   narrow_bind 16 35                  
+        114   narrow_bind 17 35                  
         115   pop_jump_if_false -29              (to 86)
         116   load_var 35                        (_90)
         117   store_var 36                       (t)
@@ -18927,7 +18928,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         145   load_const 6                       (null)
         146   cmp_op ==                          
         147   pop_jump_if_false +3               (to 150)
-        148   load_const 17                      ("image/png")
+        148   load_const 18                      ("image/png")
         149   store_var 33                       (_81)
         150   load_var 33                        (_81)
         151   store_var 32                       (_80)
@@ -18937,7 +18938,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         155   load_const 6                       (null)
         156   cmp_op ==                          
         157   pop_jump_if_false +3               (to 160)
-        158   load_const 18                      ("")
+        158   load_const 19                      ("")
         159   store_var 34                       (_85)
         160   load_var2 32 34                    
         161   call 1247 ntypeargs=0              (google.internal._gm_output_media)
@@ -18952,8 +18953,8 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
   852   168   load_var 21                        (_54)
         169   store_var 22                       (fc)
 
-  853   170   load_type 19                       
-        171   load_type 20                       
+  853   170   load_type 20                       
+        171   load_type 21                       
         172   alloc_map 0                        
         173   store_var 23                       (args)
 
@@ -18961,7 +18962,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         175   load_field 1                       (args)
         176   store_var 24                       (_58)
         177   load_var 24                        (_58)
-        178   narrow_bind 21 24                  
+        178   narrow_bind 22 24                  
         179   pop_jump_if_false +5               (to 184)
         180   load_var 24                        (_58)
         181   store_var 25                       (a)
@@ -18969,18 +18970,18 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
   855   182   load_var 25                        (a)
         183   store_var 23                       (args)
 
-  859   184   load_type 22                       
+  859   184   load_type 23                       
         185   load_var 2                         (seq)
         186   call 145 ntypeargs=1               (baml.String.from)
         187   store_var 27                       (_66)
-        188   load_type 22                       
+        188   load_type 23                       
         189   load_var 12                        (call_index)
         190   call 145 ntypeargs=1               (baml.String.from)
         191   store_var 28                       (_68)
-        192   load_const 23                      ("call_")
+        192   load_const 24                      ("call_")
         193   load_var 27                        (_66)
         194   bin_op +                           
-        195   load_const 24                      ("_")
+        195   load_const 25                      ("_")
         196   bin_op +                           
         197   load_var 28                        (_68)
         198   bin_op +                           
@@ -19002,11 +19003,11 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         210   pop 1                              
 
   864   211   load_var 12                        (call_index)
-        212   load_const 16                      (1)
+        212   load_const 17                      (1)
         213   add_int                            
         214   store_var 12                       (call_index)
 
-  865   215   load_const 25                      (true)
+  865   215   load_const 26                      (true)
         216   store_var 11                       (has_call)
 
   852   217   jump -131                          (to 86)
@@ -19036,7 +19037,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         239   jump_if_false +5                   (to 244)
         240   pop 1                              
         241   load_var 14                        (finish)
-        242   load_const 26                      ("")
+        242   load_const 27                      ("")
         243   cmp_op ==                          
         244   jump_if_false +4                   (to 248)
         245   pop 1                              
@@ -19050,7 +19051,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         252   jump +23                           (to 275)
 
   901   253   load_var 14                        (finish)
-        254   load_const 27                      ("MAX_TOKENS")
+        254   load_const 28                      ("MAX_TOKENS")
         255   cmp_op ==                          
         256   pop_jump_if_false +2               (to 258)
         257   jump +15                           (to 272)
@@ -19069,17 +19070,17 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
 
   903   268   jump +9                            (to 277)
 
-  904   269   load_const 28                      (ai.content.StopReason.Refused)
+  904   269   load_const 29                      (ai.content.StopReason.Refused)
         270   alloc_variant 774                  (ai.content.StopReason)
 
   903   271   jump +6                            (to 277)
 
-  902   272   load_const 29                      (ai.content.StopReason.MaxTokens)
+  902   272   load_const 30                      (ai.content.StopReason.MaxTokens)
         273   alloc_variant 774                  (ai.content.StopReason)
 
   901   274   jump +3                            (to 277)
 
-  900   275   load_const 16                      (ai.content.StopReason.ToolUse)
+  900   275   load_const 17                      (ai.content.StopReason.ToolUse)
         276   alloc_variant 774                  (ai.content.StopReason)
 
   908   277   store_var 41                       (_128)
@@ -19094,7 +19095,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         286   load_var 4                         (_0)
         287   return                             
 
-  896   288   load_type 30                       
+  896   288   load_type 31                       
         289   load_var 1                         (resp)
         290   call 362 ntypeargs=1               (baml.json.to_json)
         291   call 358 ntypeargs=0               (baml.json.stringify)
@@ -19123,7 +19124,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         310   load_const 6                       (null)
         311   cmp_op ==                          
         312   pop_jump_if_false +6               (to 318)
-        313   load_type 30                       
+        313   load_type 31                       
         314   load_var 1                         (resp)
         315   call 362 ntypeargs=1               (baml.json.to_json)
         316   call 358 ntypeargs=0               (baml.json.stringify)

--- a/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
+++ b/baml_language/crates/baml_tests/tests/bytecode_format/snapshots/bytecode_format__bytecode_display_expanded_unoptimized.snap
@@ -29,14 +29,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
 
   292   23    load_type 1                                
         24    load_deref 2                               
-        25    call 915 ntypeargs=1                       (ai.Journal.new)
+        25    call 916 ntypeargs=1                       (ai.Journal.new)
         26    store_deref 5                              
 
   293   27    load_type 1                                
         28    load_deref 1                               
         29    load_deref 5                               
         30    load_const 2                               (0)
-        31    call 965 ntypeargs=1                       (ai.Agent._emit_from)
+        31    call 966 ntypeargs=1                       (ai.Agent._emit_from)
         32    store_var 6                                (seen)
 
   294   33    load_const 2                               (0)
@@ -72,7 +72,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         58    load_deref 5                               
         59    load_var 8                                 (total)
         60    load_const 5                               (2)
-        61    call 964 ntypeargs=1                       (ai.Agent._attempt_turn)
+        61    call 965 ntypeargs=1                       (ai.Agent._attempt_turn)
         62    store_var 10                               (turn)
 
   306   63    load_var 7                                 (steps)
@@ -84,11 +84,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         68    load_deref 1                               
         69    load_deref 5                               
         70    load_var 6                                 (seen)
-        71    call 965 ntypeargs=1                       (ai.Agent._emit_from)
+        71    call 966 ntypeargs=1                       (ai.Agent._emit_from)
         72    store_var 6                                (seen)
 
   308   73    load_var 10                                (turn)
-        74    call 936 ntypeargs=0                       (ai.ModelTurn.tool_uses)
+        74    call 937 ntypeargs=0                       (ai.ModelTurn.tool_uses)
         75    store_var 11                               (calls)
 
   309   76    load_var 11                                (calls)
@@ -101,7 +101,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         83    jump +78                                   (to 161)
 
   344   84    load_var 10                                (turn)
-        85    call 934 ntypeargs=0                       (ai.ModelTurn.terminal_text)
+        85    call 935 ntypeargs=0                       (ai.ModelTurn.terminal_text)
         86    store_var_load_var 33                      (_98)
         87    load_const 0                               (null)
         88    cmp_op ==                                  
@@ -114,7 +114,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
   352   94    load_type 1                                
         95    load_deref 1                               
         96    load_var 10                                (turn)
-        97    call 961 ntypeargs=1                       (ai.Agent._has_media_output)
+        97    call 962 ntypeargs=1                       (ai.Agent._has_media_output)
         98    pop_jump_if_false +2                       (to 100)
         99    jump +16                                   (to 115)
 
@@ -143,7 +143,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         120   load_type 1                                
         121   load_deref 1                               
         122   load_var2 10 35                            
-        123   call 962 ntypeargs=1                       (ai.Agent._media_value)
+        123   call 963 ntypeargs=1                       (ai.Agent._media_value)
         124   store_var 34                               (value)
 
   361   125   load_type 1                                
@@ -173,14 +173,14 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         145   load_type 12                               
         146   alloc_array 1                              
 
-  366   147   call 916 ntypeargs=0                       (ai.Journal.append_all)
+  366   147   call 917 ntypeargs=0                       (ai.Journal.append_all)
         148   pop 1                                      
 
   369   149   load_type 1                                
         150   load_deref 1                               
         151   load_deref 5                               
         152   load_var 6                                 (seen)
-        153   call 965 ntypeargs=1                       (ai.Agent._emit_from)
+        153   call 966 ntypeargs=1                       (ai.Agent._emit_from)
         154   store_var 6                                (seen)
 
   370   155   load_var 34                                (value)
@@ -191,7 +191,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         160   return                                     
 
   310   161   load_deref 5                               
-        162   call 914 ntypeargs=0                       (ai.Journal.entries)
+        162   call 915 ntypeargs=0                       (ai.Journal.entries)
         163   container_len                              
         164   store_var 13                               (before)
 
@@ -202,7 +202,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         169   load_type 1                                
         170   load_var2 1 2                              
         171   load_var 5                                 (j)
-        172   make_closure 2278 captures=3 ntypeargs=1   
+        172   make_closure 2279 captures=3 ntypeargs=1   
         173   call 16 ntypeargs=3                        (baml.Array.map)
         174   store_var 14                               (futures)
 
@@ -217,11 +217,11 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         182   load_deref 1                               
         183   load_deref 5                               
         184   load_var 6                                 (seen)
-        185   call 965 ntypeargs=1                       (ai.Agent._emit_from)
+        185   call 966 ntypeargs=1                       (ai.Agent._emit_from)
         186   store_var 6                                (seen)
 
   320   187   load_deref 5                               
-        188   call 914 ntypeargs=0                       (ai.Journal.entries)
+        188   call 915 ntypeargs=0                       (ai.Journal.entries)
         189   store_var 15                               (entries)
 
   321   190   load_var 13                                (before)
@@ -251,7 +251,7 @@ function ai.Agent.Runner<Out>.run(self: ai.Agent<#0>, spec: ai.FunctionSpec<#0>)
         211   load_var 11                                (calls)
         212   load_type 1                                
         213   load_var 20                                (f)
-        214   make_closure 2279 captures=1 ntypeargs=1   
+        214   make_closure 2280 captures=1 ntypeargs=1   
         215   call 19 ntypeargs=2                        (baml.Array.find)
 
   327   216   store_var 21                               (_59)
@@ -352,12 +352,12 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
   219   3     load_type 0                        
         4     load_var 3                         (spec)
-        5     call 926 ntypeargs=1               (ai.FunctionSpec.tools)
+        5     call 927 ntypeargs=1               (ai.FunctionSpec.tools)
         6     store_var 9                        (_10)
 
   220   7     load_type 0                        
         8     load_var 3                         (spec)
-        9     call 924 ntypeargs=1               (ai.FunctionSpec.output_type)
+        9     call 925 ntypeargs=1               (ai.FunctionSpec.output_type)
         10    store_var 10                       (_12)
 
   215   11    load_var2 2 8                      
@@ -454,7 +454,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         93    store_var 19                       (batch)
 
   235   94    load_var 7                         (turn)
-        95    call 936 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        95    call 937 ntypeargs=0               (ai.ModelTurn.tool_uses)
         96    load_type 8                        
         97    load_const 9                       ("iter")
         98    virtual_call nargs=1 ntypeargs=0   
@@ -498,7 +498,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         133   pop 1                              
 
   241   134   load_var 7                         (turn)
-        135   call 934 ntypeargs=0               (ai.ModelTurn.terminal_text)
+        135   call 935 ntypeargs=0               (ai.ModelTurn.terminal_text)
         136   store_var_load_var 28              (_58)
         137   load_const 5                       (null)
         138   cmp_op ==                          
@@ -509,7 +509,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         143   store_var 27                       (candidate)
 
   242   144   load_var 7                         (turn)
-        145   call 936 ntypeargs=0               (ai.ModelTurn.tool_uses)
+        145   call 937 ntypeargs=0               (ai.ModelTurn.tool_uses)
         146   container_len                      
         147   store_var 29                       (_65)
         148   load_var 29                        (_65)
@@ -542,7 +542,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
   245   170   load_type 0                        
         171   load_var2 1 7                      
         172   load_var 27                        (candidate)
-        173   call 963 ntypeargs=1               (ai.Agent._parses)
+        173   call 964 ntypeargs=1               (ai.Agent._parses)
 
   246   174   pop_jump_if_false +2               (to 176)
         175   jump +34                           (to 209)
@@ -554,7 +554,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         180   jump +12                           (to 192)
 
   268   181   load_var2 4 19                     
-        182   call 916 ntypeargs=0               (ai.Journal.append_all)
+        182   call 917 ntypeargs=0               (ai.Journal.append_all)
         183   pop 1                              
 
   269   184   load_var 2                         (c)
@@ -576,7 +576,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         197   pop 1                              
 
   265   198   load_var2 4 19                     
-        199   call 916 ntypeargs=0               (ai.Journal.append_all)
+        199   call 917 ntypeargs=0               (ai.Journal.append_all)
         200   pop 1                              
 
   266   201   load_type 0                        
@@ -585,11 +585,11 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
         204   load_var2 5 6                      
         205   load_const 16                      (1)
         206   sub_int                            
-        207   call 964 ntypeargs=1               (ai.Agent._attempt_turn)
+        207   call 965 ntypeargs=1               (ai.Agent._attempt_turn)
         208   jump +19                           (to 227)
 
   247   209   load_var2 4 19                     
-        210   call 916 ntypeargs=0               (ai.Journal.append_all)
+        210   call 917 ntypeargs=0               (ai.Journal.append_all)
         211   pop 1                              
 
   249   212   load_var 7                         (turn)
@@ -633,7 +633,7 @@ function ai.Agent._attempt_turn(self: ai.Agent<#0>, c: ai.Client, spec: ai.Funct
 
 function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> int {
   275   0    load_var 2             (j)
-        1    call 914 ntypeargs=0   (ai.Journal.entries)
+        1    call 915 ntypeargs=0   (ai.Journal.entries)
         2    store_var 4            (entries)
 
   276   3    load_var 3             (seen)
@@ -706,7 +706,7 @@ function ai.Agent._emit_from(self: ai.Agent<#0>, j: ai.Journal, seen: int) -> in
 
 function ai.Agent._has_media_output(self: ai.Agent<#0>, turn: ai.ModelTurn) -> bool {
   104   0    load_type 0            
-        1    call 994 ntypeargs=0   (ai.internal._media_shape)
+        1    call 995 ntypeargs=0   (ai.internal._media_shape)
         2    store_var 3            (shape)
 
   105   3    load_var 3             (shape)
@@ -758,7 +758,7 @@ function ai.Agent._has_media_output(self: ai.Agent<#0>, turn: ai.ModelTurn) -> b
         46   load_const 11          ("")
         47   store_var 9            (_22)
         48   load_var2 2 9          
-        49   call 996 ntypeargs=0   (ai.internal._media_of_kind)
+        49   call 997 ntypeargs=0   (ai.internal._media_of_kind)
         50   container_len          
         51   store_var 8            (_19)
         52   load_var 8             (_19)
@@ -767,7 +767,7 @@ function ai.Agent._has_media_output(self: ai.Agent<#0>, turn: ai.ModelTurn) -> b
         55   jump +10               (to 65)
 
   110   56   load_var 2             (turn)
-        57   call 997 ntypeargs=0   (ai.internal._media_mixed_parts)
+        57   call 998 ntypeargs=0   (ai.internal._media_mixed_parts)
         58   container_len          
         59   store_var 7            (_17)
         60   load_var 7             (_17)
@@ -784,7 +784,7 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
         1     store_var 4                        (t)
 
   120   2     load_var 4                         (t)
-        3     call 994 ntypeargs=0               (ai.internal._media_shape)
+        3     call 995 ntypeargs=0               (ai.internal._media_shape)
         4     store_var 5                        (shape)
 
   121   5     load_var 5                         (shape)
@@ -835,12 +835,12 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
         48    jump +118                          (to 166)
 
   152   49    load_var2 2 9                      
-        50    call 996 ntypeargs=0               (ai.internal._media_of_kind)
+        50    call 997 ntypeargs=0               (ai.internal._media_of_kind)
         51    store_var 23                       (parts)
 
   153   52    load_var2 2 9                      
         53    load_var 3                         (provider)
-        54    call 1000 ntypeargs=0              (ai.internal._media_reject_mixed)
+        54    call 1001 ntypeargs=0              (ai.internal._media_reject_mixed)
         55    pop 1                              
 
   154   56    load_var 23                        (parts)
@@ -967,18 +967,18 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
 
   147   166   load_var2 2 9                      
         167   load_var 3                         (provider)
-        168   call 1000 ntypeargs=0              (ai.internal._media_reject_mixed)
+        168   call 1001 ntypeargs=0              (ai.internal._media_reject_mixed)
         169   pop 1                              
 
   148   170   load_var2 2 9                      
-        171   call 996 ntypeargs=0               (ai.internal._media_of_kind)
+        171   call 997 ntypeargs=0               (ai.internal._media_of_kind)
 
   149   172   store_var 12                       (payload)
 
   123   173   jump +73                           (to 246)
 
   129   174   load_var 2                         (turn)
-        175   call 997 ntypeargs=0               (ai.internal._media_mixed_parts)
+        175   call 998 ntypeargs=0               (ai.internal._media_mixed_parts)
         176   store_var 13                       (items)
 
   130   177   load_var 13                        (items)
@@ -991,7 +991,7 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
         184   jump +35                           (to 219)
 
   136   185   load_var 13                        (items)
-        186   call 998 ntypeargs=0               (ai.internal._media_all_text)
+        186   call 999 ntypeargs=0               (ai.internal._media_all_text)
         187   pop_jump_if_false +2               (to 189)
         188   jump +27                           (to 215)
 
@@ -1025,7 +1025,7 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
         214   throw                              
 
   138   215   load_var 13                        (items)
-        216   call 999 ntypeargs=0               (ai.internal._media_join_text)
+        216   call 1000 ntypeargs=0              (ai.internal._media_join_text)
         217   store_var 12                       (payload)
         218   jump +28                           (to 246)
 
@@ -1060,7 +1060,7 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
   130   242   jump +4                            (to 246)
 
   125   243   load_var 2                         (turn)
-        244   call 997 ntypeargs=0               (ai.internal._media_mixed_parts)
+        244   call 998 ntypeargs=0               (ai.internal._media_mixed_parts)
 
   126   245   store_var 12                       (payload)
 
@@ -1112,7 +1112,7 @@ function ai.Agent._media_value(self: ai.Agent<#0>, turn: ai.ModelTurn, provider:
 function ai.Agent._parses(self: ai.Agent<#0>, turn: ai.ModelTurn, candidate: string) -> bool {
   190   0    load_type 0            
         1    load_var2 1 2          
-        2    call 961 ntypeargs=1   (ai.Agent._has_media_output)
+        2    call 962 ntypeargs=1   (ai.Agent._has_media_output)
         3    pop_jump_if_false +2   (to 5)
         4    jump +12               (to 16)
 
@@ -1137,7 +1137,7 @@ function ai.Agent._parses(self: ai.Agent<#0>, turn: ai.ModelTurn, candidate: str
 function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: ai.content.ToolUse, j: ai.Journal) -> void {
   56   0     load_var2 2 3           
        1     load_field 1            (name)
-       2     call 932 ntypeargs=0    (ai.tools.Toolbox.get)
+       2     call 933 ntypeargs=0    (ai.tools.Toolbox.get)
        3     store_var 5             (_7)
        4     load_var 5              (_7)
        5     narrow_bind 0 5         
@@ -1163,7 +1163,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        21    load_type 3             
        22    alloc_array 1           
 
-  86   23    call 916 ntypeargs=0    (ai.Journal.append_all)
+  86   23    call 917 ntypeargs=0    (ai.Journal.append_all)
        24    pop 1                   
 
   94   25    load_const 4            (null)
@@ -1174,7 +1174,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
 
   58   29    load_var2 6 3           
        30    load_field 2            (args)
-       31    call 927 ntypeargs=0    (ai.tools.Tool.call)
+       31    call 928 ntypeargs=0    (ai.tools.Tool.call)
        32    store_var 7             (outcome)
        33    jump +62                (to 95)
        34    load_var 8              (e)
@@ -1195,7 +1195,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        46    load_type 3             
        47    alloc_array 1           
 
-  60   48    call 916 ntypeargs=0    (ai.Journal.append_all)
+  60   48    call 917 ntypeargs=0    (ai.Journal.append_all)
        49    pop 1                   
 
   64   50    load_var 6              (t)
@@ -1269,7 +1269,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
        105   init_instance 3         (ai.events.ToolCompleted .id, .output)
        106   load_type 3             
        107   alloc_array 1           
-       108   call 916 ntypeargs=0    (ai.Journal.append_all)
+       108   call 917 ntypeargs=0    (ai.Journal.append_all)
        109   pop 1                   
 
   83   110   load_const 4            (null)
@@ -1314,7 +1314,7 @@ function ai.Agent.new(max_steps: int, client: ai.Client | null, tool_errors: ai.
        29   pop_jump_if_false +4                       (to 33)
 
   41   30   load_type 4                                
-       31   make_closure 2227 captures=0 ntypeargs=1   
+       31   make_closure 2228 captures=0 ntypeargs=1   
        32   store_var 5                                (_10)
 
   35   33   load_var2 1 2                              
@@ -1345,7 +1345,7 @@ function ai.FunctionSpec.output_type(self: ai.FunctionSpec<#0>) -> type {
         1   store_var 3             (output_type)
 
   113   2   load_var 3              (output_type)
-        3   call 1015 ntypeargs=0   (ai.internal.validate_output_type)
+        3   call 1016 ntypeargs=0   (ai.internal.validate_output_type)
         4   pop 1                   
 
   114   5   load_var 3              (output_type)
@@ -1416,11 +1416,11 @@ function ai.Journal.entries(self: ai.Journal) -> (ai.events.RunStarted | ai.even
 function ai.Journal.new(spec: ai.FunctionSpec<#0>) -> ai.Journal {
   21   0    load_type 0            
        1    load_var 1             (spec)
-       2    call 922 ntypeargs=1   (ai.FunctionSpec.name)
+       2    call 923 ntypeargs=1   (ai.FunctionSpec.name)
        3    store_var 3            (_4)
        4    load_type 0            
        5    load_var 1             (spec)
-       6    call 923 ntypeargs=1   (ai.FunctionSpec.arguments)
+       6    call 924 ntypeargs=1   (ai.FunctionSpec.arguments)
        7    store_var 4            (_6)
        8    load_var2 3 4          
        9    init_instance 0        (ai.events.RunStarted .spec_name, .arguments)
@@ -1561,7 +1561,7 @@ function ai.ModelTurn.tool_uses(self: ai.ModelTurn) -> ai.content.ToolUse[] {
 
 function ai.Prompt.baml.ToString.to_string(self: ai.Prompt) -> string {
   70   0   load_var 1             (self)
-       1   call 918 ntypeargs=0   (ai.Prompt.text)
+       1   call 919 ntypeargs=0   (ai.Prompt.text)
        2   return                 
 }
 
@@ -1739,7 +1739,7 @@ function ai.clients.Fallback._try(self: ai.clients.Fallback, input: ai.ModelTurn
         58   load_var 3                         (index)
         59   load_const 4                       (1)
         60   add_int                            
-        61   call 956 ntypeargs=0               (ai.clients.Fallback._try)
+        61   call 957 ntypeargs=0               (ai.clients.Fallback._try)
         62   return                             
 }
 
@@ -1774,13 +1774,13 @@ function ai.clients.Fallback.root.Client.id(self: ai.clients.Fallback) -> string
 function ai.clients.Fallback.root.Client.invoke(self: ai.clients.Fallback, input: ai.ModelTurnInput) -> ai.ModelTurn {
   229   0   load_var2 1 2          
         1   load_const 0           (0)
-        2   call 956 ntypeargs=0   (ai.clients.Fallback._try)
+        2   call 957 ntypeargs=0   (ai.clients.Fallback._try)
         3   jump +6                (to 9)
         4   load_var 3             (e)
         5   throw_if_panic         
 
   230   6   load_var 3             (e)
-        7   call 977 ntypeargs=0   (ai.errors.normalize)
+        7   call 978 ntypeargs=0   (ai.errors.normalize)
         8   throw                  
         9   return                 
 }
@@ -1848,7 +1848,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
   124   49   load_var 1                         (self)
         50   load_field 3                       (backoff)
         51   load_var2 8 6                      
-        52   call 948 ntypeargs=0               (ai.clients.Backoff.delay_ms)
+        52   call 949 ntypeargs=0               (ai.clients.Backoff.delay_ms)
         53   call 528 ntypeargs=0               (baml.time.Duration.from_milliseconds)
 
   123   54   sys_op 282                         (baml.sys.sleep)
@@ -1861,7 +1861,7 @@ function ai.clients.Retry._attempt(self: ai.clients.Retry, input: ai.ModelTurnIn
         60   load_var 3                         (remaining)
         61   load_const 3                       (1)
         62   sub_int                            
-        63   call 950 ntypeargs=0               (ai.clients.Retry._attempt)
+        63   call 951 ntypeargs=0               (ai.clients.Retry._attempt)
         64   return                             
 }
 
@@ -1906,7 +1906,7 @@ function ai.clients.Retry.new(inner: ai.Client, max_attempts: int, retry_if: ((a
         32   load_const 0           (<omitted>)
         33   load_const 0           (<omitted>)
         34   load_const 0           (<omitted>)
-        35   call 947 ntypeargs=0   (ai.clients.Backoff.new)
+        35   call 948 ntypeargs=0   (ai.clients.Backoff.new)
         36   store_var 7            (_12)
 
   105   37   load_var2 1 2          
@@ -1931,13 +1931,13 @@ function ai.clients.Retry.root.Client.invoke(self: ai.clients.Retry, input: ai.M
   143   0    load_var2 1 2          
         1    load_var 1             (self)
         2    load_field 1           (max_attempts)
-        3    call 950 ntypeargs=0   (ai.clients.Retry._attempt)
+        3    call 951 ntypeargs=0   (ai.clients.Retry._attempt)
         4    jump +6                (to 10)
         5    load_var 3             (e)
         6    throw_if_panic         
 
   144   7    load_var 3             (e)
-        8    call 977 ntypeargs=0   (ai.errors.normalize)
+        8    call 978 ntypeargs=0   (ai.errors.normalize)
         9    throw                  
         10   return                 
 }
@@ -2039,7 +2039,7 @@ function ai.clients.RoundRobin.root.Client.invoke(self: ai.clients.RoundRobin, i
         37   throw_if_panic                     
 
   185   38   load_var 4                         (e)
-        39   call 977 ntypeargs=0               (ai.errors.normalize)
+        39   call 978 ntypeargs=0               (ai.errors.normalize)
         40   throw                              
         41   load_var 3                         (_0)
         42   return                             
@@ -2116,7 +2116,7 @@ function ai.clients.resolve(selector: ai.Client | string | baml.env.Ref) -> ai.C
        27   load_field 0            (name)
        28   call 145 ntypeargs=1    (baml.String.from)
        29   store_var 8             (_18)
-       30   call 1010 ntypeargs=0   (ai.internal._shorthand_prefixes)
+       30   call 1011 ntypeargs=0   (ai.internal._shorthand_prefixes)
        31   store_var 10            (_22)
        32   load_type 2             
        33   load_var 10             (_22)
@@ -2151,13 +2151,13 @@ function ai.clients.resolve(selector: ai.Client | string | baml.env.Ref) -> ai.C
   33   59   load_var 6              (_8)
        60   store_var_load_var 7    (value)
 
-  34   61   call 1011 ntypeargs=0   (ai.internal._from_shorthand)
+  34   61   call 1012 ntypeargs=0   (ai.internal._from_shorthand)
        62   jump +4                 (to 66)
 
   30   63   load_var 2              (_2)
        64   store_var_load_var 3    (shorthand)
 
-  31   65   call 1011 ntypeargs=0   (ai.internal._from_shorthand)
+  31   65   call 1012 ntypeargs=0   (ai.internal._from_shorthand)
        66   return                  
 }
 
@@ -2386,7 +2386,7 @@ function ai.errors.classify_http(provider: string, status_code: int, body: strin
   141   43   jump +7                 (to 50)
 
   138   44   load_var 4              (headers)
-        45   call 1014 ntypeargs=0   (ai.internal._retry_after_ms)
+        45   call 1015 ntypeargs=0   (ai.internal._retry_after_ms)
         46   store_var 5             (_7)
 
   136   47   load_var2 1 5           
@@ -2506,7 +2506,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        9     load_var 1              (shorthand)
        10    call 145 ntypeargs=1    (baml.String.from)
        11    store_var 15            (_62)
-       12    call 1010 ntypeargs=0   (ai.internal._shorthand_prefixes)
+       12    call 1011 ntypeargs=0   (ai.internal._shorthand_prefixes)
        13    store_var 17            (_65)
        14    load_type 2             
        15    load_var 17             (_65)
@@ -2608,7 +2608,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        102   load_const 20           (<omitted>)
        103   load_const 20           (<omitted>)
        104   load_const 20           (<omitted>)
-       105   call 1360 ntypeargs=0   (claude_code.ClaudeCodeClient.new)
+       105   call 1361 ntypeargs=0   (claude_code.ClaudeCodeClient.new)
        106   jump +172               (to 278)
 
   49   107   load_var 5              (model)
@@ -2621,7 +2621,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        114   load_const 20           (<omitted>)
        115   load_const 20           (<omitted>)
        116   load_const 20           (<omitted>)
-       117   call 1339 ntypeargs=0   (vercel.AiGatewayImageClient.new)
+       117   call 1340 ntypeargs=0   (vercel.AiGatewayImageClient.new)
        118   jump +160               (to 278)
 
   48   119   load_var 5              (model)
@@ -2642,7 +2642,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        134   load_const 20           (<omitted>)
        135   load_const 20           (<omitted>)
        136   load_const 20           (<omitted>)
-       137   call 1280 ntypeargs=0   (aws.BedrockClient.new)
+       137   call 1281 ntypeargs=0   (aws.BedrockClient.new)
        138   jump +140               (to 278)
 
   47   139   load_var 5              (model)
@@ -2662,7 +2662,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        153   load_const 20           (<omitted>)
        154   load_const 20           (<omitted>)
        155   load_const 20           (<omitted>)
-       156   call 1216 ntypeargs=0   (google.VertexClient.new)
+       156   call 1217 ntypeargs=0   (google.VertexClient.new)
        157   jump +121               (to 278)
 
   46   158   load_var 5              (model)
@@ -2678,7 +2678,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        168   load_const 20           (<omitted>)
        169   load_const 20           (<omitted>)
        170   load_const 20           (<omitted>)
-       171   call 1210 ntypeargs=0   (google.GoogleClient.new)
+       171   call 1211 ntypeargs=0   (google.GoogleClient.new)
        172   jump +106               (to 278)
 
   45   173   load_var 5              (model)
@@ -2694,7 +2694,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        183   load_const 20           (<omitted>)
        184   load_const 20           (<omitted>)
        185   load_const 20           (<omitted>)
-       186   call 1171 ntypeargs=0   (anthropic.AnthropicClient.new)
+       186   call 1172 ntypeargs=0   (anthropic.AnthropicClient.new)
        187   jump +91                (to 278)
 
   44   188   load_var 5              (model)
@@ -2708,7 +2708,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        196   load_const 20           (<omitted>)
        197   load_const 20           (<omitted>)
        198   load_const 20           (<omitted>)
-       199   call 1093 ntypeargs=0   (openai.OpenRouterClient.new)
+       199   call 1094 ntypeargs=0   (openai.OpenRouterClient.new)
        200   jump +78                (to 278)
 
   43   201   load_var 5              (model)
@@ -2722,7 +2722,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        209   load_const 20           (<omitted>)
        210   load_const 20           (<omitted>)
        211   load_const 20           (<omitted>)
-       212   call 1085 ntypeargs=0   (openai.OllamaClient.new)
+       212   call 1086 ntypeargs=0   (openai.OllamaClient.new)
        213   jump +65                (to 278)
 
   42   214   load_var 5              (model)
@@ -2740,7 +2740,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        226   load_const 20           (<omitted>)
        227   load_const 20           (<omitted>)
        228   load_const 20           (<omitted>)
-       229   call 1076 ntypeargs=0   (openai.AzureClient.new)
+       229   call 1077 ntypeargs=0   (openai.AzureClient.new)
        230   jump +48                (to 278)
 
   41   231   load_var 5              (model)
@@ -2759,7 +2759,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        244   load_const 20           (<omitted>)
        245   load_const 20           (<omitted>)
        246   load_const 20           (<omitted>)
-       247   call 1101 ntypeargs=0   (openai.ImageClient.new)
+       247   call 1102 ntypeargs=0   (openai.ImageClient.new)
        248   jump +30                (to 278)
 
   40   249   load_var 5              (model)
@@ -2774,7 +2774,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        258   load_const 20           (<omitted>)
        259   load_const 20           (<omitted>)
        260   load_const 20           (<omitted>)
-       261   call 1060 ntypeargs=0   (openai.ChatClient.new)
+       261   call 1061 ntypeargs=0   (openai.ChatClient.new)
        262   jump +16                (to 278)
 
   39   263   load_var 5              (model)
@@ -2791,7 +2791,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        274   load_const 20           (<omitted>)
        275   load_const 20           (<omitted>)
        276   load_const 20           (<omitted>)
-       277   call 1020 ntypeargs=0   (openai.ResponsesClient.new)
+       277   call 1021 ntypeargs=0   (openai.ResponsesClient.new)
 
   53   278   store_var 8             (_36)
        279   load_var 8              (_36)
@@ -2807,7 +2807,7 @@ function ai.internal._from_shorthand(shorthand: string) -> ai.Client {
        288   load_var 1              (shorthand)
        289   call 145 ntypeargs=1    (baml.String.from)
        290   store_var 11            (_50)
-       291   call 1010 ntypeargs=0   (ai.internal._shorthand_prefixes)
+       291   call 1011 ntypeargs=0   (ai.internal._shorthand_prefixes)
        292   store_var 13            (_53)
        293   load_type 2             
        294   load_var 13             (_53)
@@ -2879,7 +2879,7 @@ function ai.internal._header(headers: map<string, string>, lower: string, canoni
 function ai.internal._int_header(headers: map<string, string>, lower: string, canonical: string) -> int | null {
   14   0    load_var2 1 2           
        1    load_var 3              (canonical)
-       2    call 1012 ntypeargs=0   (ai.internal._header)
+       2    call 1013 ntypeargs=0   (ai.internal._header)
        3    store_var 4             (_5)
        4    load_var 4              (_5)
        5    narrow_bind 0 4         
@@ -3293,13 +3293,13 @@ function ai.internal._media_mixed_parts(turn: ai.ModelTurn) -> baml.json.json[] 
        32   store_var 10                       (m)
 
   91   33   load_var 10                        (m)
-       34   call 912 ntypeargs=0               (ai.content.Media.kind)
+       34   call 913 ntypeargs=0               (ai.content.Media.kind)
        35   load_const 8                       ("image")
        36   cmp_op ==                          
        37   pop_jump_if_false -28              (to 9)
 
   92   38   load_var 10                        (m)
-       39   call 995 ntypeargs=0               (ai.internal._media_envelope)
+       39   call 996 ntypeargs=0               (ai.internal._media_envelope)
        40   store_var 11                       (_22)
        41   load_type 0                        
        42   load_var2 3 11                     
@@ -3361,13 +3361,13 @@ function ai.internal._media_of_kind(turn: ai.ModelTurn, kind: string) -> baml.js
        26   store_var 9                        (m)
 
   69   27   load_var 9                         (m)
-       28   call 912 ntypeargs=0               (ai.content.Media.kind)
+       28   call 913 ntypeargs=0               (ai.content.Media.kind)
        29   load_var 2                         (kind)
        30   cmp_op ==                          
        31   pop_jump_if_false -22              (to 9)
 
   70   32   load_var 9                         (m)
-       33   call 995 ntypeargs=0               (ai.internal._media_envelope)
+       33   call 996 ntypeargs=0               (ai.internal._media_envelope)
        34   store_var 10                       (_15)
        35   load_type 0                        
        36   load_var2 4 10                     
@@ -3434,7 +3434,7 @@ function ai.internal._media_reject_mixed(turn: ai.ModelTurn, kind: string, provi
         43   store_var 10                       (m)
 
   128   44   load_var 10                        (m)
-        45   call 912 ntypeargs=0               (ai.content.Media.kind)
+        45   call 913 ntypeargs=0               (ai.content.Media.kind)
         46   load_var 2                         (kind)
         47   cmp_op !=                          
         48   pop_jump_if_false -40              (to 8)
@@ -3707,7 +3707,7 @@ function ai.internal._merge_json(base: baml.json.json, patch: baml.json.json) ->
        83    load_var2 5 14                     
        84    call 38 ntypeargs=2                (baml.Map.get)
        85    load_var 15                        (value)
-       86    call 1006 ntypeargs=0              (ai.internal._merge_json)
+       86    call 1007 ntypeargs=0              (ai.internal._merge_json)
        87    store_var 16                       (_43)
        88    load_type 1                        
        89    load_type 2                        
@@ -3737,7 +3737,7 @@ function ai.internal._proxy(conn: ai.mcp.McpConnection, name: string) -> (map<st
        5    store_var 2           
 
   12   6    load_var2 1 2         
-       7    make_closure 4216 2   
+       7    make_closure 4217 2   
        8    store_var 3           (_0)
        9    load_var 3            (_0)
        10   return                
@@ -3804,7 +3804,7 @@ function ai.internal._redact_after(text: string, marker: string) -> string {
        46   store_var 10            (tail)
 
   26   47   load_var 10             (tail)
-       48   call 1005 ntypeargs=0   (ai.internal._redact_value_end)
+       48   call 1006 ntypeargs=0   (ai.internal._redact_value_end)
        49   store_var 12            (_16)
        50   load_var 10             (tail)
        51   call 146 ntypeargs=0    (baml.String.length)
@@ -4241,7 +4241,7 @@ function ai.internal._retry_after_ms(headers: map<string, string> | null) -> int
 
   34   7    load_const 1            ("retry-after-ms")
        8    load_const 2            ("Retry-After-Ms")
-       9    call 1013 ntypeargs=0   (ai.internal._int_header)
+       9    call 1014 ntypeargs=0   (ai.internal._int_header)
        10   store_var 4             (_6)
        11   load_var 4              (_6)
        12   narrow_bind 3 4         
@@ -4251,7 +4251,7 @@ function ai.internal._retry_after_ms(headers: map<string, string> | null) -> int
   37   15   load_var 3              (h)
        16   load_const 4            ("retry-after")
        17   load_const 5            ("Retry-After")
-       18   call 1013 ntypeargs=0   (ai.internal._int_header)
+       18   call 1014 ntypeargs=0   (ai.internal._int_header)
        19   store_var 6             (_10)
        20   load_var 6              (_10)
        21   narrow_bind 3 6         
@@ -4488,7 +4488,7 @@ function ai.internal.validate_output_type(return_type: type) -> void {
        13   store_var 3            (enum_type)
 
   13   14   load_var 3             (enum_type)
-       15   call 804 ntypeargs=0   (baml.reflect.enum.Type.values)
+       15   call 805 ntypeargs=0   (baml.reflect.enum.Type.values)
        16   container_len          
        17   store_var 4            (_7)
        18   load_var 4             (_7)
@@ -4534,10 +4534,10 @@ function ai.mcp.McpConnection._request(self: ai.mcp.McpConnection, method: strin
 
   88    9     load_var2 4 2                      
         10    load_var 3                         (params)
-        11    call 1373 ntypeargs=0              (ai.mcp.rpc_line)
+        11    call 1374 ntypeargs=0              (ai.mcp.rpc_line)
         12    store_var 5                        (_6)
         13    load_var2 1 5                      
-        14    call 1375 ntypeargs=0              (ai.mcp.McpConnection._send)
+        14    call 1376 ntypeargs=0              (ai.mcp.McpConnection._send)
         15    pop 1                              
 
   89    16    load_const 1                       (true)
@@ -4782,7 +4782,7 @@ function ai.mcp.McpConnection.call_tool(self: ai.mcp.McpConnection, name: string
   170   7    load_var 1                         (self)
         8    load_const 4                       ("tools/call")
         9    load_var 5                         (params)
-        10   call 1376 ntypeargs=0              (ai.mcp.McpConnection._request)
+        10   call 1377 ntypeargs=0              (ai.mcp.McpConnection._request)
         11   store_var 6                        (result)
 
   171   12   load_type 2                        
@@ -4960,16 +4960,16 @@ function ai.mcp.McpConnection.connect(name: string, command: string, args: strin
   62   61   load_var 11             (conn)
        62   load_const 18           ("initialize")
        63   load_var 12             (init)
-       64   call 1376 ntypeargs=0   (ai.mcp.McpConnection._request)
+       64   call 1377 ntypeargs=0   (ai.mcp.McpConnection._request)
        65   pop 1                   
 
   63   66   load_const 2            (null)
        67   load_const 19           ("notifications/initialized")
        68   load_const 2            (null)
-       69   call 1373 ntypeargs=0   (ai.mcp.rpc_line)
+       69   call 1374 ntypeargs=0   (ai.mcp.rpc_line)
        70   store_var 13            (_26)
        71   load_var2 11 13         
-       72   call 1375 ntypeargs=0   (ai.mcp.McpConnection._send)
+       72   call 1376 ntypeargs=0   (ai.mcp.McpConnection._send)
        73   pop 1                   
 
   64   74   load_var 11             (conn)
@@ -4984,7 +4984,7 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         2    load_type 1                        
         3    load_type 2                        
         4    alloc_map 0                        
-        5    call 1376 ntypeargs=0              (ai.mcp.McpConnection._request)
+        5    call 1377 ntypeargs=0              (ai.mcp.McpConnection._request)
         6    store_var 3                        (result)
 
   143   7    load_type 3                        
@@ -5056,14 +5056,14 @@ function ai.mcp.McpConnection.tools(self: ai.mcp.McpConnection) -> ai.tools.Tool
         65   store_var 15                       (_31)
 
   159   66   load_var2 1 8                      
-        67   call 1380 ntypeargs=0              (ai.internal._proxy)
+        67   call 1381 ntypeargs=0              (ai.internal._proxy)
         68   store_var 16                       (_32)
 
   156   69   load_var2 8 14                     
         70   load_var2 15 16                    
         71   load_const 18                      (<omitted>)
 
-  155   72   call 929 ntypeargs=0               (ai.tools.raw_tool)
+  155   72   call 930 ntypeargs=0               (ai.tools.raw_tool)
         73   store_var 13                       (_26)
 
   154   74   load_type 3                        
@@ -5133,7 +5133,7 @@ function ai.prompt(body: ((string) -> ai.Role throws never, ai.Context) -> baml.
        2   store_var 1           
 
   84   3   load_var 1            (body)
-       4   make_closure 2127 1   
+       4   make_closure 2128 1   
        5   store_var 3           (render)
 
   88   6   load_var 3            (render)
@@ -5336,14 +5336,14 @@ function ai.stream.TurnStream.final_turn(self: ai.stream.TurnStream) -> ai.Model
         1    pop_jump_if_false +7   (to 8)
 
   308   2    load_var 1             (self)
-        3    call 972 ntypeargs=0   (ai.stream.TurnStream.next)
+        3    call 973 ntypeargs=0   (ai.stream.TurnStream.next)
         4    store_var 2            (_3)
         5    load_var 2             (_3)
         6    narrow_bind 1 2        
         7    pop_jump_if_false -7   (to 0)
 
   318   8    load_var 1             (self)
-        9    call 971 ntypeargs=0   (ai.stream.TurnStream._check_terminal)
+        9    call 972 ntypeargs=0   (ai.stream.TurnStream._check_terminal)
         10   pop 1                  
 
   319   11   load_var 1             (self)
@@ -5514,7 +5514,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         38    jump +6                            (to 44)
 
   289   39    load_var 1                         (self)
-        40    call 970 ntypeargs=0               (ai.stream.TurnStream._finish)
+        40    call 971 ntypeargs=0               (ai.stream.TurnStream._finish)
         41    pop 1                              
 
   290   42    alloc_instance 411 ntypeargs=0     (ai.stream.Done)
@@ -5597,11 +5597,11 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         110   jump -17                           (to 93)
 
   262   111   load_var 1                         (self)
-        112   call 970 ntypeargs=0               (ai.stream.TurnStream._finish)
+        112   call 971 ntypeargs=0               (ai.stream.TurnStream._finish)
         113   pop 1                              
 
   263   114   load_var 1                         (self)
-        115   call 971 ntypeargs=0               (ai.stream.TurnStream._check_terminal)
+        115   call 972 ntypeargs=0               (ai.stream.TurnStream._check_terminal)
         116   pop 1                              
 
   264   117   alloc_instance 411 ntypeargs=0     (ai.stream.Done)
@@ -5645,7 +5645,7 @@ function ai.stream.TurnStream.next(self: ai.stream.TurnStream) -> string | ai.st
         151   store_field 12                     (_saw_terminal)
 
   248   152   load_var 1                         (self)
-        153   call 970 ntypeargs=0               (ai.stream.TurnStream._finish)
+        153   call 971 ntypeargs=0               (ai.stream.TurnStream._finish)
         154   pop 1                              
 
   249   155   alloc_instance 411 ntypeargs=0     (ai.stream.Done)
@@ -5738,8 +5738,8 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   402   9     load_type 2                                
         10    load_var 1                                 (spec)
-        11    call 926 ntypeargs=1                       (ai.FunctionSpec.tools)
-        12    call 933 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
+        11    call 927 ntypeargs=1                       (ai.FunctionSpec.tools)
+        12    call 934 ntypeargs=0                       (ai.tools.Toolbox.is_empty)
         13    unary_op !                                 
         14    pop_jump_if_false +2                       (to 16)
         15    jump +79                                   (to 94)
@@ -5799,17 +5799,17 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   427   57    load_type 2                                
         58    load_var 1                                 (spec)
-        59    call 915 ntypeargs=1                       (ai.Journal.new)
+        59    call 916 ntypeargs=1                       (ai.Journal.new)
         60    store_var 16                               (_29)
 
   428   61    load_type 2                                
         62    load_var 1                                 (spec)
-        63    call 926 ntypeargs=1                       (ai.FunctionSpec.tools)
+        63    call 927 ntypeargs=1                       (ai.FunctionSpec.tools)
         64    store_var 17                               (_31)
 
   429   65    load_type 2                                
         66    load_var 1                                 (spec)
-        67    call 924 ntypeargs=1                       (ai.FunctionSpec.output_type)
+        67    call 925 ntypeargs=1                       (ai.FunctionSpec.output_type)
         68    store_var 18                               (_33)
 
   424   69    load_var2 6 15                             
@@ -5830,7 +5830,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
   436   81    load_type 8                                
         82    load_type 2                                
         83    load_var 14                                (turns)
-        84    make_closure 2305 captures=1 ntypeargs=2   
+        84    make_closure 2306 captures=1 ntypeargs=2   
         85    load_var 19                                (_36)
         86    load_const 9                               ("")
         87    load_const 10                              (false)
@@ -5843,7 +5843,7 @@ function ai.stream.from_spec(spec: ai.FunctionSpec<#1>, client: ai.stream.Stream
 
   404   94    load_type 2                                
         95    load_var 1                                 (spec)
-        96    call 922 ntypeargs=1                       (ai.FunctionSpec.name)
+        96    call 923 ntypeargs=1                       (ai.FunctionSpec.name)
         97    store_var 5                                (_12)
         98    load_type 11                               
         99    load_var 5                                 (_12)
@@ -5955,7 +5955,7 @@ function ai.tools.Toolbox.get(self: ai.tools.Toolbox, name: string) -> ai.tools.
         5    load_var 1            (self)
         6    load_field 0          (entries)
         7    load_var 2            (name)
-        8    make_closure 2153 1   
+        8    make_closure 2154 1   
         9    call 19 ntypeargs=2   (baml.Array.find)
         10   return                
 }
@@ -6136,7 +6136,7 @@ function ai.tools.tool(handler: baml.AnyFunction<Returns = unknown, Throws = unk
        62   store_var 10            (_18)
 
   58   63   load_var 1              (handler)
-       64   call 987 ntypeargs=0    (ai.internal._schema_for_signature)
+       64   call 988 ntypeargs=0    (ai.internal._schema_for_signature)
        65   store_var 13            (_24)
 
   56   66   load_var2 9 10          
@@ -6210,7 +6210,7 @@ function ai.wire.merge_request_body(base: baml.json.json, overrides: baml.json.j
         4   jump +4                 (to 8)
 
   210   5   load_var2 1 2           
-        6   call 1006 ntypeargs=0   (ai.internal._merge_json)
+        6   call 1007 ntypeargs=0   (ai.internal._merge_json)
         7   jump +2                 (to 9)
 
   209   8   load_var 1              (base)
@@ -6220,23 +6220,23 @@ function ai.wire.merge_request_body(base: baml.json.json, overrides: baml.json.j
 function ai.wire.redact_url_secrets(text: string) -> string {
   51   0   load_var 1              (text)
        1   load_const 0            ("key=")
-       2   call 1004 ntypeargs=0   (ai.internal._redact_after)
+       2   call 1005 ntypeargs=0   (ai.internal._redact_after)
 
   52   3   load_const 1            ("token=")
-       4   call 1004 ntypeargs=0   (ai.internal._redact_after)
+       4   call 1005 ntypeargs=0   (ai.internal._redact_after)
 
   53   5   load_const 2            ("secret=")
-       6   call 1004 ntypeargs=0   (ai.internal._redact_after)
+       6   call 1005 ntypeargs=0   (ai.internal._redact_after)
        7   return                  
 }
 
 function ai.wire.render_output_format(t: type) -> string {
   115   0   load_var 1              (t)
-        1   call 1015 ntypeargs=0   (ai.internal.validate_output_type)
+        1   call 1016 ntypeargs=0   (ai.internal.validate_output_type)
         2   pop 1                   
 
   116   3   load_var 1              (t)
-        4   sys_op 1016             (ai.internal.render_output_format)
+        4   sys_op 1017             (ai.internal.render_output_format)
         5   return                  
 }
 
@@ -6269,13 +6269,13 @@ function ai.wire.resolve_credential(cred: string | baml.env.Ref | null, env_fall
        22   load_const 3            ("")
        23   store_var 7             (_10)
        24   load_var 7              (_10)
-       25   call 1003 ntypeargs=0   (ai.internal._configured)
+       25   call 1004 ntypeargs=0   (ai.internal._configured)
        26   jump +4                 (to 30)
 
   27   27   load_var 3              (_4)
        28   store_var_load_var 4    (literal)
 
-  28   29   call 1003 ntypeargs=0   (ai.internal._configured)
+  28   29   call 1004 ntypeargs=0   (ai.internal._configured)
 
   32   30   store_var 8             (_13)
        31   load_var 8              (_13)
@@ -6304,7 +6304,7 @@ function ai.wire.resolve_credential(cred: string | baml.env.Ref | null, env_fall
        50   load_const 4            ("")
        51   store_var 12            (_18)
        52   load_var 12             (_18)
-       53   call 1003 ntypeargs=0   (ai.internal._configured)
+       53   call 1004 ntypeargs=0   (ai.internal._configured)
        54   jump +4                 (to 58)
 
   32   55   load_var 8              (_13)
@@ -6371,13 +6371,13 @@ function ai.wire.resolve_media(media: baml.media.Image | baml.media.Audio | baml
         48    call 332 ntypeargs=0    (baml.media.Pdf.mime_type)
         49    load_var 31             (source)
         50    load_const 5            ("pdf")
-        51    call 1001 ntypeargs=0   (ai.internal._media_mime_type)
+        51    call 1002 ntypeargs=0   (ai.internal._media_mime_type)
         52    store_var 37            (_59)
 
   164   53    load_var2 34 35         
         54    load_var2 36 37         
         55    load_var 2              (fetch_url)
-        56    call 1002 ntypeargs=0   (ai.internal._resolve_media_content)
+        56    call 1003 ntypeargs=0   (ai.internal._resolve_media_content)
         57    jump +120               (to 177)
 
   131   58    load_var 21             (_33)
@@ -6418,13 +6418,13 @@ function ai.wire.resolve_media(media: baml.media.Image | baml.media.Audio | baml
         88    call 346 ntypeargs=0    (baml.media.Video.mime_type)
         89    load_var 23             (source)
         90    load_const 7            ("video")
-        91    call 1001 ntypeargs=0   (ai.internal._media_mime_type)
+        91    call 1002 ntypeargs=0   (ai.internal._media_mime_type)
         92    store_var 29            (_45)
 
   154   93    load_var2 26 27         
         94    load_var2 28 29         
         95    load_var 2              (fetch_url)
-        96    call 1002 ntypeargs=0   (ai.internal._resolve_media_content)
+        96    call 1003 ntypeargs=0   (ai.internal._resolve_media_content)
         97    jump +80                (to 177)
 
   131   98    load_var 12             (_18)
@@ -6465,13 +6465,13 @@ function ai.wire.resolve_media(media: baml.media.Image | baml.media.Audio | baml
         128   call 339 ntypeargs=0    (baml.media.Audio.mime_type)
         129   load_var 14             (source)
         130   load_const 9            ("audio")
-        131   call 1001 ntypeargs=0   (ai.internal._media_mime_type)
+        131   call 1002 ntypeargs=0   (ai.internal._media_mime_type)
         132   store_var 20            (_30)
 
   144   133   load_var2 17 18         
         134   load_var2 19 20         
         135   load_var 2              (fetch_url)
-        136   call 1002 ntypeargs=0   (ai.internal._resolve_media_content)
+        136   call 1003 ntypeargs=0   (ai.internal._resolve_media_content)
         137   jump +40                (to 177)
 
   131   138   load_var 3              (_3)
@@ -6512,13 +6512,13 @@ function ai.wire.resolve_media(media: baml.media.Image | baml.media.Audio | baml
         168   call 353 ntypeargs=0    (baml.media.Image.mime_type)
         169   load_var 5              (source)
         170   load_const 11           ("image")
-        171   call 1001 ntypeargs=0   (ai.internal._media_mime_type)
+        171   call 1002 ntypeargs=0   (ai.internal._media_mime_type)
         172   store_var 11            (_15)
 
   134   173   load_var2 8 9           
         174   load_var2 10 11         
         175   load_var 2              (fetch_url)
-        176   call 1002 ntypeargs=0   (ai.internal._resolve_media_content)
+        176   call 1003 ntypeargs=0   (ai.internal._resolve_media_content)
         177   return                  
 }
 
@@ -6532,7 +6532,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
         5     store_var 5                        (pending)
 
   271   6     load_var 1                         (j)
-        7     call 914 ntypeargs=0               (ai.Journal.entries)
+        7     call 915 ntypeargs=0               (ai.Journal.entries)
         8     load_type 2                        
         9     load_const 3                       ("iter")
         10    virtual_call nargs=1 ntypeargs=0   
@@ -6585,7 +6585,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
 
   305   54    load_var2 5 23                     
         55    load_field 0                       (id)
-        56    call 1009 ntypeargs=0              (ai.internal._resolve_pending_call)
+        56    call 1010 ntypeargs=0              (ai.internal._resolve_pending_call)
         57    pop 1                              
 
   306   58    load_type 0                        
@@ -6599,7 +6599,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
 
   300   65    load_var2 5 21                     
         66    load_field 0                       (id)
-        67    call 1009 ntypeargs=0              (ai.internal._resolve_pending_call)
+        67    call 1010 ntypeargs=0              (ai.internal._resolve_pending_call)
         68    pop 1                              
 
   301   69    load_type 0                        
@@ -6612,7 +6612,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
         75    store_var 19                       (user)
 
   295   76    load_var2 4 5                      
-        77    call 1008 ntypeargs=0              (ai.internal._flush_orphaned_calls)
+        77    call 1009 ntypeargs=0              (ai.internal._flush_orphaned_calls)
         78    pop 1                              
 
   296   79    load_type 0                        
@@ -6625,7 +6625,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
         85    store_var 10                       (assistant)
 
   274   86    load_var2 4 5                      
-        87    call 1008 ntypeargs=0              (ai.internal._flush_orphaned_calls)
+        87    call 1009 ntypeargs=0              (ai.internal._flush_orphaned_calls)
         88    pop 1                              
 
   275   89    load_var 10                        (assistant)
@@ -6634,7 +6634,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
         92    load_field 1                       (client_id)
         93    load_var 2                         (client_id)
         94    cmp_op ==                          
-        95    call 1007 ntypeargs=0              (ai.internal._wire_blocks)
+        95    call 1008 ntypeargs=0              (ai.internal._wire_blocks)
         96    store_var 11                       (blocks)
 
   276   97    load_var 11                        (blocks)
@@ -6688,7 +6688,7 @@ function ai.wire.sanitize_for_client(j: ai.Journal, client_id: string) -> ai.Jou
         139   jump -23                           (to 116)
 
   315   140   load_var2 4 5                      
-        141   call 1008 ntypeargs=0              (ai.internal._flush_orphaned_calls)
+        141   call 1009 ntypeargs=0              (ai.internal._flush_orphaned_calls)
         142   pop 1                              
 
   316   143   load_var 4                         (out)
@@ -6710,7 +6710,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
   89    7    load_type 1            
         8    load_var 4             (e)
         9    call 145 ntypeargs=1   (baml.String.from)
-        10   call 938 ntypeargs=0   (ai.wire.redact_url_secrets)
+        10   call 939 ntypeargs=0   (ai.wire.redact_url_secrets)
         11   store_var 6            (_8)
         12   load_type 2            
         13   load_var 6             (_8)
@@ -6761,7 +6761,7 @@ function ai.wire.send_as(req: baml.http.Request, provider: string) -> #0 {
         50   load_field 0           (status_code)
         51   load_var2 7 3          
         52   load_field 1           (headers)
-        53   call 986 ntypeargs=0   (ai.errors.classify_http)
+        53   call 987 ntypeargs=0   (ai.errors.classify_http)
         54   throw                  
 }
 
@@ -6781,26 +6781,26 @@ function anthropic.AnthropicClient.ai.Client.id(self: anthropic.AnthropicClient)
 
 function anthropic.AnthropicClient.ai.Client.invoke(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   162   0   load_var2 1 2           
-        1   call 1201 ntypeargs=0   (anthropic.internal.invoke)
+        1   call 1202 ntypeargs=0   (anthropic.internal.invoke)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   163   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
 
 function anthropic.AnthropicClient.ai.stream.StreamingClient.invoke_stream(self: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   170   0   load_var2 1 2           
-        1   call 1208 ntypeargs=0   (anthropic.internal.invoke_stream)
+        1   call 1209 ntypeargs=0   (anthropic.internal.invoke_stream)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   171   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
@@ -6913,7 +6913,7 @@ function anthropic.AnthropicClient.resolved_api_key(self: anthropic.AnthropicCli
   143   0    load_var 1              (self)
         1    load_field 1            (api_key)
         2    load_const 0            ("ANTHROPIC_API_KEY")
-        3    call 937 ntypeargs=0    (ai.wire.resolve_credential)
+        3    call 938 ntypeargs=0    (ai.wire.resolve_credential)
         4    store_var 2             (_4)
         5    load_var 2              (_4)
         6    narrow_bind 1 2         
@@ -6923,7 +6923,7 @@ function anthropic.AnthropicClient.resolved_api_key(self: anthropic.AnthropicCli
   147   9    load_var 1              (self)
         10   load_field 1            (api_key)
         11   load_const 2            ("ANTHROPIC_API_KEY")
-        12   call 939 ntypeargs=0    (ai.wire.credential_sources)
+        12   call 940 ntypeargs=0    (ai.wire.credential_sources)
         13   store_var 5             (_9)
         14   load_type 3             
         15   load_var 5              (_9)
@@ -6933,7 +6933,7 @@ function anthropic.AnthropicClient.resolved_api_key(self: anthropic.AnthropicCli
         19   load_var 4              (_8)
         20   bin_op +                
 
-  146   21   call 1177 ntypeargs=0   (anthropic.internal._reject)
+  146   21   call 1178 ntypeargs=0   (anthropic.internal._reject)
         22   throw                   
 
   143   23   load_var 2              (_4)
@@ -6947,7 +6947,7 @@ function anthropic.AnthropicClient.resolved_base_url(self: anthropic.AnthropicCl
   153   0   load_var 1             (self)
         1   load_field 2           (base_url)
         2   load_const 0           (null)
-        3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4   return                 
 }
 
@@ -7255,7 +7255,7 @@ function anthropic.internal._anth_drop_nulls(j: baml.json.json) -> baml.json.jso
         33   load_var 14                        (_32)
         34   store_var_load_var 15              (element)
 
-  237   35   call 1179 ntypeargs=0              (anthropic.internal._anth_drop_nulls)
+  237   35   call 1180 ntypeargs=0              (anthropic.internal._anth_drop_nulls)
         36   store_var 16                       (_37)
         37   load_type 2                        
         38   load_var2 12 16                    
@@ -7307,12 +7307,12 @@ function anthropic.internal._anth_drop_nulls(j: baml.json.json) -> baml.json.jso
         78   jump -20                           (to 58)
 
   222   79   load_var 7                         (key)
-        80   call 1178 ntypeargs=0              (anthropic.internal._anth_verbatim_subtree)
+        80   call 1179 ntypeargs=0              (anthropic.internal._anth_verbatim_subtree)
         81   pop_jump_if_false +2               (to 83)
         82   jump +5                            (to 87)
 
   225   83   load_var 8                         (value)
-        84   call 1179 ntypeargs=0              (anthropic.internal._anth_drop_nulls)
+        84   call 1180 ntypeargs=0              (anthropic.internal._anth_drop_nulls)
         85   store_var 9                        (kept)
         86   jump +3                            (to 89)
 
@@ -7772,7 +7772,7 @@ function anthropic.internal._anthropic_headers(c: anthropic.AnthropicClient) -> 
         54   jump -30                           (to 24)
 
   764   55   load_var 1                         (c)
-        56   call 1172 ntypeargs=0              (anthropic.AnthropicClient.resolved_api_key)
+        56   call 1173 ntypeargs=0              (anthropic.AnthropicClient.resolved_api_key)
         57   store_var 11                       (_26)
         58   load_type 4                        
         59   load_type 4                        
@@ -7794,7 +7794,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         2     store_var 3                        (msgs)
 
   480   3     load_var 1                         (j)
-        4     call 914 ntypeargs=0               (ai.Journal.entries)
+        4     call 915 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -7842,7 +7842,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         47    load_var 16                        (f)
         48    load_field 1                       (message)
         49    load_const 10                      (true)
-        50    call 1186 ntypeargs=0              (anthropic.internal._anthropic_push_tool_result)
+        50    call 1187 ntypeargs=0              (anthropic.internal._anthropic_push_tool_result)
         51    pop 1                              
         52    jump -43                           (to 9)
 
@@ -7854,7 +7854,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         57    load_var 14                        (c)
         58    load_field 1                       (output)
         59    load_const 11                      (false)
-        60    call 1186 ntypeargs=0              (anthropic.internal._anthropic_push_tool_result)
+        60    call 1187 ntypeargs=0              (anthropic.internal._anthropic_push_tool_result)
         61    pop 1                              
         62    jump -53                           (to 9)
 
@@ -7862,7 +7862,7 @@ function anthropic.internal._anthropic_lower_journal(j: ai.Journal) -> anthropic
         64    store_var_load_var 10              (m)
 
   495   65    load_field 0                       (content)
-        66    call 1185 ntypeargs=0              (anthropic.internal._anthropic_assistant_blocks)
+        66    call 1186 ntypeargs=0              (anthropic.internal._anthropic_assistant_blocks)
         67    store_var 11                       (blocks)
 
   500   68    load_var 11                        (blocks)
@@ -7924,7 +7924,7 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
         5     store_var 4                        (messages)
 
   381   6     load_var 1                         (prompt)
-        7     call 919 ntypeargs=0               (ai.Prompt.messages)
+        7     call 920 ntypeargs=0               (ai.Prompt.messages)
         8     load_type 2                        
         9     load_const 3                       ("iter")
         10    virtual_call nargs=1 ntypeargs=0   
@@ -7972,11 +7972,11 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
         46    store_var 13                       (role)
 
   396   47    load_var2 7 13                     
-        48    call 1183 ntypeargs=0              (anthropic.internal._anthropic_prompt_blocks)
+        48    call 1184 ntypeargs=0              (anthropic.internal._anthropic_prompt_blocks)
         49    store_var 14                       (blocks)
 
   397   50    load_var2 14 8                     
-        51    call 1180 ntypeargs=0              (anthropic.internal._anth_apply_cache_control)
+        51    call 1181 ntypeargs=0              (anthropic.internal._anth_apply_cache_control)
         52    pop 1                              
 
   400   53    load_var 14                        (blocks)
@@ -8000,11 +8000,11 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
 
   384   68    load_var 7                         (message)
         69    load_const 16                      ("system")
-        70    call 1183 ntypeargs=0              (anthropic.internal._anthropic_prompt_blocks)
+        70    call 1184 ntypeargs=0              (anthropic.internal._anthropic_prompt_blocks)
         71    store_var 9                        (blocks)
 
   385   72    load_var2 9 8                      
-        73    call 1180 ntypeargs=0              (anthropic.internal._anth_apply_cache_control)
+        73    call 1181 ntypeargs=0              (anthropic.internal._anth_apply_cache_control)
         74    pop 1                              
 
   386   75    load_var 9                         (blocks)
@@ -8040,7 +8040,7 @@ function anthropic.internal._anthropic_lower_prompt(prompt: ai.Prompt) -> anthro
 function anthropic.internal._anthropic_media_block(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf, block_type: string) -> anthropic.internal.AnthMediaBlock {
   308   0    load_var 1              (media)
         1    load_const 0            (false)
-        2    call 942 ntypeargs=0    (ai.wire.resolve_media)
+        2    call 943 ntypeargs=0    (ai.wire.resolve_media)
         3    store_var 3             (resolved)
 
   309   4    load_var 3              (resolved)
@@ -8058,7 +8058,7 @@ function anthropic.internal._anthropic_media_block(media: baml.media.Image | bam
         15   pop 1                   
         16   load_var 3              (resolved)
         17   load_field 2            (mime_type)
-        18   call 1181 ntypeargs=0   (anthropic.internal._anth_supported_image_mime)
+        18   call 1182 ntypeargs=0   (anthropic.internal._anth_supported_image_mime)
         19   unary_op !              
         20   pop_jump_if_false +2    (to 22)
         21   jump +18                (to 39)
@@ -8096,7 +8096,7 @@ function anthropic.internal._anthropic_media_block(media: baml.media.Image | bam
         47   load_const 8            (" images: the Messages API supports image/jpeg, image/png, image/gif and image/webp")
         48   bin_op +                
 
-  315   49   call 1177 ntypeargs=0   (anthropic.internal._reject)
+  315   49   call 1178 ntypeargs=0   (anthropic.internal._reject)
         50   throw                   
 
   309   51   load_var 5              (_6)
@@ -8164,7 +8164,7 @@ function anthropic.internal._anthropic_prompt_blocks(message: ai.PromptMessage, 
         43    jump +4                            (to 47)
 
   371   44    load_const 10                      ("Anthropic does not support video prompt input")
-        45    call 1177 ntypeargs=0              (anthropic.internal._reject)
+        45    call 1178 ntypeargs=0              (anthropic.internal._reject)
         46    throw                              
 
   332   47    load_var 15                        (_31)
@@ -8178,7 +8178,7 @@ function anthropic.internal._anthropic_prompt_blocks(message: ai.PromptMessage, 
 
   367   54    load_var 16                        (pdf)
         55    load_const 12                      ("document")
-        56    call 1182 ntypeargs=0              (anthropic.internal._anthropic_media_block)
+        56    call 1183 ntypeargs=0              (anthropic.internal._anthropic_media_block)
         57    store_var 18                       (_39)
         58    load_type 0                        
         59    load_var2 4 18                     
@@ -8194,11 +8194,11 @@ function anthropic.internal._anthropic_prompt_blocks(message: ai.PromptMessage, 
         68    load_var 17                        (_36)
         69    bin_op +                           
 
-  363   70    call 1177 ntypeargs=0              (anthropic.internal._reject)
+  363   70    call 1178 ntypeargs=0              (anthropic.internal._reject)
         71    throw                              
 
   357   72    load_const 15                      ("Anthropic does not support audio prompt input: the Messages API has no audio content block")
-        73    call 1177 ntypeargs=0              (anthropic.internal._reject)
+        73    call 1178 ntypeargs=0              (anthropic.internal._reject)
         74    throw                              
 
   332   75    load_var 10                        (_18)
@@ -8212,7 +8212,7 @@ function anthropic.internal._anthropic_prompt_blocks(message: ai.PromptMessage, 
 
   347   82    load_var 11                        (image)
         83    load_const 17                      ("image")
-        84    call 1182 ntypeargs=0              (anthropic.internal._anthropic_media_block)
+        84    call 1183 ntypeargs=0              (anthropic.internal._anthropic_media_block)
         85    store_var 13                       (_26)
         86    load_type 0                        
         87    load_var2 4 13                     
@@ -8228,7 +8228,7 @@ function anthropic.internal._anthropic_prompt_blocks(message: ai.PromptMessage, 
         96    load_var 12                        (_23)
         97    bin_op +                           
 
-  343   98    call 1177 ntypeargs=0              (anthropic.internal._reject)
+  343   98    call 1178 ntypeargs=0              (anthropic.internal._reject)
         99    throw                              
 
   332   100   load_var 8                         (_10)
@@ -8514,7 +8514,7 @@ function anthropic.internal._anthropic_render_messages(msgs: anthropic.internal.
 
 function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
   775   0    load_var 1              (c)
-        1    call 1173 ntypeargs=0   (anthropic.AnthropicClient.resolved_base_url)
+        1    call 1174 ntypeargs=0   (anthropic.AnthropicClient.resolved_base_url)
         2    store_var_load_var 6    (_5)
         3    load_const 0            (null)
         4    cmp_op ==               
@@ -8530,7 +8530,7 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         13   store_var 7             (_10)
         14   load_var 1              (c)
         15   load_field 12           (query_params)
-        16   call 1195 ntypeargs=0   (anthropic.internal._anthropic_query_suffix)
+        16   call 1196 ntypeargs=0   (anthropic.internal._anthropic_query_suffix)
         17   store_var 9             (_14)
         18   load_type 2             
         19   load_var 9              (_14)
@@ -8538,13 +8538,13 @@ function anthropic.internal._anthropic_request(c: anthropic.AnthropicClient, inp
         21   store_var 8             (_13)
 
   779   22   load_var 1              (c)
-        23   call 1196 ntypeargs=0   (anthropic.internal._anthropic_headers)
+        23   call 1197 ntypeargs=0   (anthropic.internal._anthropic_headers)
         24   store_var 10            (_17)
 
   780   25   load_var 1              (c)
-        26   call 1189 ntypeargs=0   (anthropic.internal._anthropic_body_params)
+        26   call 1190 ntypeargs=0   (anthropic.internal._anthropic_body_params)
         27   load_var2 2 3           
-        28   call 1194 ntypeargs=0   (anthropic.internal.anthropic_messages_body)
+        28   call 1195 ntypeargs=0   (anthropic.internal.anthropic_messages_body)
         29   store_var 11            (_18)
 
   776   30   load_const 3            ("POST")
@@ -8642,7 +8642,7 @@ function anthropic.internal._anthropic_sse_failure(message: string) -> ai.errors
   1202   65   load_const 8            ("anthropic")
          66   load_var2 10 11         
          67   load_const 9            (<omitted>)
-         68   call 986 ntypeargs=0    (ai.errors.classify_http)
+         68   call 987 ntypeargs=0    (ai.errors.classify_http)
          69   return                  
 }
 
@@ -8742,7 +8742,7 @@ function anthropic.internal._anthropic_tool_params(toolbox: ai.tools.Toolbox) ->
         2    store_var 3                        (out)
 
   587   3    load_var 1                         (toolbox)
-        4    call 931 ntypeargs=0               (ai.tools.Toolbox.list)
+        4    call 932 ntypeargs=0               (ai.tools.Toolbox.list)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -8807,7 +8807,7 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
          2     store_var 4                        (out)
 
   1033   3     load_var 1                         (batch)
-         4     call 967 ntypeargs=0               (ai.stream.decode_sse_batch)
+         4     call 968 ntypeargs=0               (ai.stream.decode_sse_batch)
          5     load_type 1                        
          6     load_const 2                       ("iter")
          7     virtual_call nargs=1 ntypeargs=0   
@@ -8978,7 +8978,7 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
          155   store_field 6                      (stop_reason_raw)
 
   1157   156   load_var 64                        (s)
-         157   call 1199 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
+         157   call 1200 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
          158   store_var 62                       (stop)
          159   jump +3                            (to 162)
 
@@ -9112,7 +9112,7 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
 
   1118   273   load_field 1                       (index)
 
-  1116   274   call 1204 ntypeargs=0              (anthropic.internal._anth_stream_call_at)
+  1116   274   call 1205 ntypeargs=0              (anthropic.internal._anth_stream_call_at)
          275   store_var 46                       (_136)
          276   load_var 46                        (_136)
          277   narrow_bind 27 46                  
@@ -9420,7 +9420,7 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
   1042   543   load_var 12                        (event)
          544   load_field 6                       (error)
          545   load_var 9                         (data)
-         546   call 1205 ntypeargs=0              (anthropic.internal._anth_stream_failure)
+         546   call 1206 ntypeargs=0              (anthropic.internal._anth_stream_failure)
          547   throw                              
 
   1185   548   load_var 4                         (out)
@@ -9432,17 +9432,17 @@ function anthropic.internal.anthropic_decode_batch(batch: string, state: anthrop
 function anthropic.internal.anthropic_messages_body(params: anthropic.internal.AnthropicBodyParams, input: ai.ModelTurnInput, stream: bool) -> string {
   723   0    load_var2 1 2           
         1    load_var 3              (stream)
-        2    call 1193 ntypeargs=0   (anthropic.internal.anthropic_messages_request)
+        2    call 1194 ntypeargs=0   (anthropic.internal.anthropic_messages_request)
         3    store_var 4             (request)
 
   724   4    load_type 0             
         5    load_var 4              (request)
         6    call 362 ntypeargs=1    (baml.json.to_json)
-        7    call 1179 ntypeargs=0   (anthropic.internal._anth_drop_nulls)
+        7    call 1180 ntypeargs=0   (anthropic.internal._anth_drop_nulls)
 
   725   8    load_var 1              (params)
         9    load_field 8            (request_body)
-        10   call 943 ntypeargs=0    (ai.wire.merge_request_body)
+        10   call 944 ntypeargs=0    (ai.wire.merge_request_body)
         11   call 358 ntypeargs=0    (baml.json.stringify)
         12   return                  
 }
@@ -9453,11 +9453,11 @@ function anthropic.internal.anthropic_messages_request(params: anthropic.interna
         2     store_var 4                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 941 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 942 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 4                         (_5)
         7     call_indirect                      
 
-  631   8     call 1184 ntypeargs=0              (anthropic.internal._anthropic_lower_prompt)
+  631   8     call 1185 ntypeargs=0              (anthropic.internal._anthropic_lower_prompt)
         9     store_var 5                        (lowered_prompt)
 
   632   10    load_var 5                         (lowered_prompt)
@@ -9472,9 +9472,9 @@ function anthropic.internal.anthropic_messages_request(params: anthropic.interna
         17    load_field 1                       (journal)
         18    load_var 1                         (params)
         19    load_field 9                       (client_id)
-        20    call 944 ntypeargs=0               (ai.wire.sanitize_for_client)
+        20    call 945 ntypeargs=0               (ai.wire.sanitize_for_client)
 
-  636   21    call 1187 ntypeargs=0              (anthropic.internal._anthropic_lower_journal)
+  636   21    call 1188 ntypeargs=0              (anthropic.internal._anthropic_lower_journal)
         22    load_type 0                        
         23    load_const 1                       ("iter")
         24    virtual_call nargs=1 ntypeargs=0   
@@ -9597,7 +9597,7 @@ function anthropic.internal.anthropic_messages_request(params: anthropic.interna
         127   load_var 7                         (lowered)
         128   call 7 ntypeargs=1                 (baml.Array.concat)
 
-  667   129   call 1188 ntypeargs=0              (anthropic.internal._anthropic_render_messages)
+  667   129   call 1189 ntypeargs=0              (anthropic.internal._anthropic_render_messages)
         130   store_var 17                       (messages)
 
   668   131   load_var 17                        (messages)
@@ -9632,7 +9632,7 @@ function anthropic.internal.anthropic_messages_request(params: anthropic.interna
 
   684   156   load_var 2                         (input)
         157   load_field 2                       (toolbox)
-        158   call 933 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        158   call 934 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         159   unary_op !                         
         160   store_var_load_var 21              (has_tools)
 
@@ -9646,7 +9646,7 @@ function anthropic.internal.anthropic_messages_request(params: anthropic.interna
 
   686   166   load_var 2                         (input)
         167   load_field 2                       (toolbox)
-        168   call 1190 ntypeargs=0              (anthropic.internal._anthropic_tool_params)
+        168   call 1191 ntypeargs=0              (anthropic.internal._anthropic_tool_params)
         169   store_var 22                       (tool_params)
 
   690   170   load_var 21                        (has_tools)
@@ -9660,7 +9660,7 @@ function anthropic.internal.anthropic_messages_request(params: anthropic.interna
 
   691   176   load_var 1                         (params)
         177   load_field 7                       (tool_choice)
-        178   call 1191 ntypeargs=0              (anthropic.internal._anthropic_tool_choice_param)
+        178   call 1192 ntypeargs=0              (anthropic.internal._anthropic_tool_choice_param)
         179   store_var 23                       (choice)
 
   695   180   load_var 3                         (stream)
@@ -9710,7 +9710,7 @@ function anthropic.internal.anthropic_messages_request(params: anthropic.interna
 
   711   212   load_var 1                         (params)
         213   load_field 6                       (thinking)
-        214   call 1192 ntypeargs=0              (anthropic.internal._anthropic_thinking_param)
+        214   call 1193 ntypeargs=0              (anthropic.internal._anthropic_thinking_param)
         215   store_var 34                       (_86)
 
   700   216   load_var2 25 26                    
@@ -9856,7 +9856,7 @@ function anthropic.internal.anthropic_parse(resp: anthropic.internal.AnthropicRe
         107   load_var 16                        (_44)
         108   store_var_load_var 17              (s)
 
-  838   109   call 1199 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
+  838   109   call 1200 ntypeargs=0              (anthropic.internal._anthropic_stop_reason)
         110   store_var 15                       (stop)
         111   jump +4                            (to 115)
 
@@ -9932,22 +9932,22 @@ function anthropic.internal.anthropic_parse(resp: anthropic.internal.AnthropicRe
 function anthropic.internal.anthropic_render(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> baml.http.Request {
   786   0   load_var2 1 2           
         1   load_const 0            (false)
-        2   call 1197 ntypeargs=0   (anthropic.internal._anthropic_request)
+        2   call 1198 ntypeargs=0   (anthropic.internal._anthropic_request)
         3   return                  
 }
 
 function anthropic.internal.invoke(c: anthropic.AnthropicClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   863   0   load_var2 1 2           
         1   load_const 0            (false)
-        2   call 1197 ntypeargs=0   (anthropic.internal._anthropic_request)
+        2   call 1198 ntypeargs=0   (anthropic.internal._anthropic_request)
         3   store_var 3             (req)
 
   864   4   load_type 1             
         5   load_var 3              (req)
         6   load_const 2            ("anthropic")
-        7   call 940 ntypeargs=1    (ai.wire.send_as)
+        7   call 941 ntypeargs=1    (ai.wire.send_as)
 
-  865   8   call 1200 ntypeargs=0   (anthropic.internal.anthropic_parse)
+  865   8   call 1201 ntypeargs=0   (anthropic.internal.anthropic_parse)
         9   return                  
 }
 
@@ -9958,7 +9958,7 @@ function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: a
 
   1220   3    load_var2 1 2           
          4    load_const 0            (true)
-         5    call 1197 ntypeargs=0   (anthropic.internal._anthropic_request)
+         5    call 1198 ntypeargs=0   (anthropic.internal._anthropic_request)
 
   1221   6    sys_op 259              (baml.http.fetch_sse)
          7    store_var 3             (sse)
@@ -9994,18 +9994,18 @@ function anthropic.internal.invoke_stream(c: anthropic.AnthropicClient, input: a
 
   1222   34   load_var 4              (e)
          35   load_field 0            (message)
-         36   call 1207 ntypeargs=0   (anthropic.internal._anthropic_sse_failure)
+         36   call 1208 ntypeargs=0   (anthropic.internal._anthropic_sse_failure)
          37   throw                   
 
-  1231   38   call 1202 ntypeargs=0   (anthropic.internal.AnthStreamState.new)
+  1231   38   call 1203 ntypeargs=0   (anthropic.internal.AnthStreamState.new)
          39   store_deref 7           
 
   1238   40   load_var2 3 7           
 
-  1239   41   make_closure 3291 1     
+  1239   41   make_closure 3292 1     
          42   load_const 8            ("anthropic")
 
-  1237   43   call 968 ntypeargs=0    (ai.stream.TurnStream.from_sse)
+  1237   43   call 969 ntypeargs=0    (ai.stream.TurnStream.from_sse)
          44   return                  
 }
 
@@ -10103,14 +10103,14 @@ function assert.equal(actual: unknown, expected: unknown) -> void {
        6    jump +23               (to 29)
 
   57   7    load_var 1             (actual)
-       8    call 907 ntypeargs=0   (assert.format_operand)
+       8    call 908 ntypeargs=0   (assert.format_operand)
        9    store_var 4            (_9)
        10   load_type 1            
        11   load_var 4             (_9)
        12   call 145 ntypeargs=1   (baml.String.from)
        13   store_var 3            (_8)
        14   load_var 2             (expected)
-       15   call 907 ntypeargs=0   (assert.format_operand)
+       15   call 908 ntypeargs=0   (assert.format_operand)
        16   store_var 6            (_12)
        17   load_type 1            
        18   load_var 6             (_12)
@@ -10232,13 +10232,13 @@ function aws.BedrockClient.ai.Client.id(self: aws.BedrockClient) -> string {
 
 function aws.BedrockClient.ai.Client.invoke(self: aws.BedrockClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   150   0   load_var2 1 2           
-        1   call 1336 ntypeargs=0   (aws.internal.invoke)
+        1   call 1337 ntypeargs=0   (aws.internal.invoke)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   151   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
@@ -10381,12 +10381,12 @@ function aws.BedrockClient.resolved_endpoint_url(self: aws.BedrockClient) -> str
   141   0   load_var 1             (self)
         1   load_field 6           (endpoint_url)
         2   load_const 0           (null)
-        3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4   return                 
 }
 
 function aws.internal.ContentBlock.of_audio(audio: aws.internal.AudioBlock) -> aws.internal.ContentBlock {
-  175   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  175   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 2                      (_2)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 2                       (_2)
@@ -10399,7 +10399,7 @@ function aws.internal.ContentBlock.of_audio(audio: aws.internal.AudioBlock) -> a
 }
 
 function aws.internal.ContentBlock.of_cache_point() -> aws.internal.ContentBlock {
-  187   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  187   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 1                      (_1)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 1                       (_1)
@@ -10411,7 +10411,7 @@ function aws.internal.ContentBlock.of_cache_point() -> aws.internal.ContentBlock
 }
 
 function aws.internal.ContentBlock.of_document(document: aws.internal.DocumentBlock) -> aws.internal.ContentBlock {
-  171   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  171   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 2                      (_2)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 2                       (_2)
@@ -10424,7 +10424,7 @@ function aws.internal.ContentBlock.of_document(document: aws.internal.DocumentBl
 }
 
 function aws.internal.ContentBlock.of_image(image: aws.internal.ImageBlock) -> aws.internal.ContentBlock {
-  163   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  163   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 2                      (_2)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 2                       (_2)
@@ -10437,7 +10437,7 @@ function aws.internal.ContentBlock.of_image(image: aws.internal.ImageBlock) -> a
 }
 
 function aws.internal.ContentBlock.of_text(text: string) -> aws.internal.ContentBlock {
-  159   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  159   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 2                      (_2)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 1                       (text)
@@ -10448,7 +10448,7 @@ function aws.internal.ContentBlock.of_text(text: string) -> aws.internal.Content
 }
 
 function aws.internal.ContentBlock.of_tool_result(tool_result: aws.internal.ToolResultBlock) -> aws.internal.ContentBlock {
-  183   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  183   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 2                      (_2)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 2                       (_2)
@@ -10461,7 +10461,7 @@ function aws.internal.ContentBlock.of_tool_result(tool_result: aws.internal.Tool
 }
 
 function aws.internal.ContentBlock.of_tool_use(tool_use: aws.internal.ToolUseBlock) -> aws.internal.ContentBlock {
-  179   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  179   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 2                      (_2)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 2                       (_2)
@@ -10474,7 +10474,7 @@ function aws.internal.ContentBlock.of_tool_use(tool_use: aws.internal.ToolUseBlo
 }
 
 function aws.internal.ContentBlock.of_video(video: aws.internal.VideoBlock) -> aws.internal.ContentBlock {
-  167   0   call 1295 ntypeargs=0            (aws.internal._empty_content_block)
+  167   0   call 1296 ntypeargs=0            (aws.internal._empty_content_block)
         1   store_var 2                      (_2)
         2   alloc_instance 730 ntypeargs=0   (aws.internal.ContentBlock)
         3   load_var 2                       (_2)
@@ -10578,7 +10578,7 @@ function aws.internal._apply_query(url: string, params: map<string, string> | nu
          27    load_var 6                         (_10)
          28    store_var_load_var 7               (name)
 
-  1082   29    call 1285 ntypeargs=0              (aws.internal.encode_path_label)
+  1082   29    call 1286 ntypeargs=0              (aws.internal.encode_path_label)
          30    store_var 9                        (_18)
          31    load_type 1                        
          32    load_var 9                         (_18)
@@ -10595,7 +10595,7 @@ function aws.internal._apply_query(url: string, params: map<string, string> | nu
          43    load_const 7                       ("")
          44    store_var 12                       (_24)
          45    load_var 12                        (_24)
-         46    call 1285 ntypeargs=0              (aws.internal.encode_path_label)
+         46    call 1286 ntypeargs=0              (aws.internal.encode_path_label)
          47    store_var 11                       (_22)
          48    load_type 1                        
          49    load_var 11                        (_22)
@@ -10729,7 +10729,7 @@ function aws.internal._assistant_content(content: (ai.content.Text | ai.content.
         43   load_field 2                       (args)
         44   init_instance 0                    (aws.internal.ToolUseBlock .toolUseId, .name, .input)
 
-  700   45   call 1292 ntypeargs=0              (aws.internal.ContentBlock.of_tool_use)
+  700   45   call 1293 ntypeargs=0              (aws.internal.ContentBlock.of_tool_use)
         46   store_var 13                       (_18)
 
   699   47   load_type 0                        
@@ -10742,7 +10742,7 @@ function aws.internal._assistant_content(content: (ai.content.Text | ai.content.
         53   store_var_load_var 8               (text)
 
   687   54   load_field 0                       (text)
-        55   call 1287 ntypeargs=0              (aws.internal.ContentBlock.of_text)
+        55   call 1288 ntypeargs=0              (aws.internal.ContentBlock.of_text)
         56   store_var 9                        (_11)
         57   load_type 0                        
         58   load_var2 3 9                      
@@ -10759,24 +10759,24 @@ function aws.internal._assistant_content(content: (ai.content.Text | ai.content.
 function aws.internal._audio_block(audio: baml.media.Audio) -> aws.internal.ContentBlock {
   518   0    load_var 1              (audio)
         1    call 336 ntypeargs=0    (baml.media.Audio.url)
-        2    call 1304 ntypeargs=0   (aws.internal._is_s3_url)
+        2    call 1305 ntypeargs=0   (aws.internal._is_s3_url)
         3    store_var 3             (_4)
         4    load_var2 1 3           
         5    unary_op !              
-        6    call 942 ntypeargs=0    (ai.wire.resolve_media)
+        6    call 943 ntypeargs=0    (ai.wire.resolve_media)
         7    store_var 2             (resolved)
 
   521   8    load_var 2              (resolved)
         9    load_field 2            (mime_type)
-        10   call 1307 ntypeargs=0   (aws.internal._audio_format)
+        10   call 1308 ntypeargs=0   (aws.internal._audio_format)
 
   522   11   load_var 2              (resolved)
         12   load_const 0            ("audio")
-        13   call 1308 ntypeargs=0   (aws.internal._media_source)
+        13   call 1309 ntypeargs=0   (aws.internal._media_source)
 
   520   14   init_instance 0         (aws.internal.AudioBlock .format, .source)
 
-  519   15   call 1291 ntypeargs=0   (aws.internal.ContentBlock.of_audio)
+  519   15   call 1292 ntypeargs=0   (aws.internal.ContentBlock.of_audio)
         16   return                  
 }
 
@@ -10869,7 +10869,7 @@ function aws.internal._audio_format(mime: string) -> string {
         84    load_const 21           ("unsupported audio format for Bedrock: ")
         85    load_var 2              (_24)
         86    bin_op +                
-        87    call 1303 ntypeargs=0   (aws.internal._reject)
+        87    call 1304 ntypeargs=0   (aws.internal._reject)
         88    throw                   
 
   456   89    load_const 22           ("webm")
@@ -10970,11 +10970,11 @@ function aws.internal._conversation_role(role: string) -> string {
 function aws.internal._document_block(pdf: baml.media.Pdf) -> aws.internal.ContentBlock {
   499   0    load_var 1              (pdf)
         1    call 329 ntypeargs=0    (baml.media.Pdf.url)
-        2    call 1304 ntypeargs=0   (aws.internal._is_s3_url)
+        2    call 1305 ntypeargs=0   (aws.internal._is_s3_url)
         3    store_var 3             (_4)
         4    load_var2 1 3           
         5    unary_op !              
-        6    call 942 ntypeargs=0    (ai.wire.resolve_media)
+        6    call 943 ntypeargs=0    (ai.wire.resolve_media)
         7    store_var 2             (resolved)
 
   500   8    load_var 2              (resolved)
@@ -10986,7 +10986,7 @@ function aws.internal._document_block(pdf: baml.media.Pdf) -> aws.internal.Conte
 
   509   14   load_var 2              (resolved)
         15   load_const 1            ("document")
-        16   call 1308 ntypeargs=0   (aws.internal._media_source)
+        16   call 1309 ntypeargs=0   (aws.internal._media_source)
         17   store_var 5             (_14)
 
   504   18   load_const 2            ("pdf")
@@ -10994,7 +10994,7 @@ function aws.internal._document_block(pdf: baml.media.Pdf) -> aws.internal.Conte
         20   load_var 5              (_14)
         21   init_instance 0         (aws.internal.DocumentBlock .format, .name, .source)
 
-  503   22   call 1290 ntypeargs=0   (aws.internal.ContentBlock.of_document)
+  503   22   call 1291 ntypeargs=0   (aws.internal.ContentBlock.of_document)
         23   return                  
 
   501   24   load_type 4             
@@ -11005,7 +11005,7 @@ function aws.internal._document_block(pdf: baml.media.Pdf) -> aws.internal.Conte
         29   load_const 5            ("unsupported document format for Bedrock: ")
         30   load_var 4              (_10)
         31   bin_op +                
-        32   call 1303 ntypeargs=0   (aws.internal._reject)
+        32   call 1304 ntypeargs=0   (aws.internal._reject)
         33   throw                   
 }
 
@@ -11027,24 +11027,24 @@ function aws.internal._empty_content_block() -> aws.internal.ContentBlock {
 function aws.internal._image_block(image: baml.media.Image) -> aws.internal.ContentBlock {
   477   0    load_var 1              (image)
         1    call 350 ntypeargs=0    (baml.media.Image.url)
-        2    call 1304 ntypeargs=0   (aws.internal._is_s3_url)
+        2    call 1305 ntypeargs=0   (aws.internal._is_s3_url)
         3    store_var 3             (_4)
         4    load_var2 1 3           
         5    unary_op !              
-        6    call 942 ntypeargs=0    (ai.wire.resolve_media)
+        6    call 943 ntypeargs=0    (ai.wire.resolve_media)
         7    store_var 2             (resolved)
 
   480   8    load_var 2              (resolved)
         9    load_field 2            (mime_type)
-        10   call 1305 ntypeargs=0   (aws.internal._image_format)
+        10   call 1306 ntypeargs=0   (aws.internal._image_format)
 
   481   11   load_var 2              (resolved)
         12   load_const 0            ("image")
-        13   call 1308 ntypeargs=0   (aws.internal._media_source)
+        13   call 1309 ntypeargs=0   (aws.internal._media_source)
 
   479   14   init_instance 0         (aws.internal.ImageBlock .format, .source)
 
-  478   15   call 1288 ntypeargs=0   (aws.internal.ContentBlock.of_image)
+  478   15   call 1289 ntypeargs=0   (aws.internal.ContentBlock.of_image)
         16   return                  
 }
 
@@ -11077,7 +11077,7 @@ function aws.internal._image_format(mime: string) -> string {
         24   load_const 6            ("unsupported image format for Bedrock: ")
         25   load_var 2              (_9)
         26   bin_op +                
-        27   call 1303 ntypeargs=0   (aws.internal._reject)
+        27   call 1304 ntypeargs=0   (aws.internal._reject)
         28   throw                   
 
   415   29   load_const 7            ("webp")
@@ -11209,7 +11209,7 @@ function aws.internal._inference_config(client: aws.BedrockClient) -> aws.intern
         84   load_const 5            (" is out of the supported range (0..=2147483647)")
         85   bin_op +                
 
-  871   86   call 1303 ntypeargs=0   (aws.internal._reject)
+  871   86   call 1304 ntypeargs=0   (aws.internal._reject)
         87   throw                   
 }
 
@@ -11334,7 +11334,7 @@ function aws.internal._lower_journal(journal: ai.Journal, with_status: bool) -> 
         2     store_var 4                        (pending)
 
   764   3     load_var 1                         (journal)
-        4     call 914 ntypeargs=0               (ai.Journal.entries)
+        4     call 915 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -11383,7 +11383,7 @@ function aws.internal._lower_journal(journal: ai.Journal, with_status: bool) -> 
         48    load_field 1                       (message)
         49    load_const 10                      (true)
         50    load_var 2                         (with_status)
-        51    call 1320 ntypeargs=0              (aws.internal._push_tool_result)
+        51    call 1321 ntypeargs=0              (aws.internal._push_tool_result)
         52    pop 1                              
         53    jump -44                           (to 9)
 
@@ -11396,7 +11396,7 @@ function aws.internal._lower_journal(journal: ai.Journal, with_status: bool) -> 
         59    load_field 1                       (output)
         60    load_const 11                      (false)
         61    load_var 2                         (with_status)
-        62    call 1320 ntypeargs=0              (aws.internal._push_tool_result)
+        62    call 1321 ntypeargs=0              (aws.internal._push_tool_result)
         63    pop 1                              
         64    jump -55                           (to 9)
 
@@ -11404,7 +11404,7 @@ function aws.internal._lower_journal(journal: ai.Journal, with_status: bool) -> 
         66    store_var_load_var 12              (assistant)
 
   779   67    load_field 0                       (content)
-        68    call 1318 ntypeargs=0              (aws.internal._assistant_content)
+        68    call 1319 ntypeargs=0              (aws.internal._assistant_content)
         69    store_var 13                       (content)
 
   787   70    load_var 13                        (content)
@@ -11432,7 +11432,7 @@ function aws.internal._lower_journal(journal: ai.Journal, with_status: bool) -> 
         88    store_var_load_var 9               (user)
 
   771   89    load_field 0                       (content)
-        90    call 1287 ntypeargs=0              (aws.internal.ContentBlock.of_text)
+        90    call 1288 ntypeargs=0              (aws.internal.ContentBlock.of_text)
         91    store_var 10                       (_16)
 
   767   92    load_type 0                        
@@ -11495,7 +11495,7 @@ function aws.internal._lower_prompt(prompt: ai.Prompt) -> aws.internal.BedrockPr
         5    store_var 4                        (messages)
 
   642   6    load_var 1                         (prompt)
-        7    call 919 ntypeargs=0               (ai.Prompt.messages)
+        7    call 920 ntypeargs=0               (ai.Prompt.messages)
         8    load_type 2                        
         9    load_const 3                       ("iter")
         10   virtual_call nargs=1 ntypeargs=0   
@@ -11519,7 +11519,7 @@ function aws.internal._lower_prompt(prompt: ai.Prompt) -> aws.internal.BedrockPr
         27   jump +31                           (to 58)
 
   652   28   load_var 7                         (message)
-        29   call 1313 ntypeargs=0              (aws.internal._prompt_content)
+        29   call 1314 ntypeargs=0              (aws.internal._prompt_content)
         30   store_var 12                       (content)
 
   656   31   load_var 12                        (content)
@@ -11531,10 +11531,10 @@ function aws.internal._lower_prompt(prompt: ai.Prompt) -> aws.internal.BedrockPr
         37   pop_jump_if_false -25              (to 12)
 
   657   38   load_var 7                         (message)
-        39   call 1315 ntypeargs=0              (aws.internal._wants_cache_point)
+        39   call 1316 ntypeargs=0              (aws.internal._wants_cache_point)
         40   pop_jump_if_false +7               (to 47)
 
-  658   41   call 1294 ntypeargs=0              (aws.internal.ContentBlock.of_cache_point)
+  658   41   call 1295 ntypeargs=0              (aws.internal.ContentBlock.of_cache_point)
         42   store_var 14                       (_34)
         43   load_type 9                        
         44   load_var2 12 14                    
@@ -11543,7 +11543,7 @@ function aws.internal._lower_prompt(prompt: ai.Prompt) -> aws.internal.BedrockPr
 
   660   47   load_var 7                         (message)
         48   load_field 0                       (role)
-        49   call 1316 ntypeargs=0              (aws.internal._conversation_role)
+        49   call 1317 ntypeargs=0              (aws.internal._conversation_role)
         50   store_var 15                       (_38)
         51   load_type 1                        
         52   load_var2 4 15                     
@@ -11554,7 +11554,7 @@ function aws.internal._lower_prompt(prompt: ai.Prompt) -> aws.internal.BedrockPr
         57   jump -45                           (to 12)
 
   644   58   load_var 7                         (message)
-        59   call 1314 ntypeargs=0              (aws.internal._prompt_system)
+        59   call 1315 ntypeargs=0              (aws.internal._prompt_system)
         60   load_type 10                       
         61   load_const 11                      ("iter")
         62   virtual_call nargs=1 ntypeargs=0   
@@ -11578,10 +11578,10 @@ function aws.internal._lower_prompt(prompt: ai.Prompt) -> aws.internal.BedrockPr
         79   jump -15                           (to 64)
 
   647   80   load_var 7                         (message)
-        81   call 1315 ntypeargs=0              (aws.internal._wants_cache_point)
+        81   call 1316 ntypeargs=0              (aws.internal._wants_cache_point)
         82   pop_jump_if_false -70              (to 12)
 
-  648   83   call 1297 ntypeargs=0              (aws.internal.SystemContentBlock.of_cache_point)
+  648   83   call 1298 ntypeargs=0              (aws.internal.SystemContentBlock.of_cache_point)
         84   store_var 11                       (_25)
         85   load_type 0                        
         86   load_var2 3 11                     
@@ -11622,7 +11622,7 @@ function aws.internal._media_source(resolved: ai.wire.ResolvedMedia, kind: strin
         20   bin_op +                
         21   load_const 3            (" content could not be resolved")
         22   bin_op +                
-        23   call 1303 ntypeargs=0   (aws.internal._reject)
+        23   call 1304 ntypeargs=0   (aws.internal._reject)
         24   throw                   
 
   467   25   load_var 5              (_8)
@@ -11649,7 +11649,7 @@ function aws.internal._media_source(resolved: ai.wire.ResolvedMedia, kind: strin
         44   bin_op +                
         45   load_var 8              (_19)
         46   bin_op +                
-        47   call 1303 ntypeargs=0   (aws.internal._reject)
+        47   call 1304 ntypeargs=0   (aws.internal._reject)
         48   throw                   
 
   469   49   load_const 7            (null)
@@ -11913,7 +11913,7 @@ function aws.internal._prompt_content(message: ai.PromptMessage) -> aws.internal
         44   load_var 6                         (part)
         45   store_var_load_var 19              (pdf)
 
-  566   46   call 1311 ntypeargs=0              (aws.internal._document_block)
+  566   46   call 1312 ntypeargs=0              (aws.internal._document_block)
         47   store_var 20                       (_37)
         48   load_type 0                        
         49   load_var2 3 20                     
@@ -11924,7 +11924,7 @@ function aws.internal._prompt_content(message: ai.PromptMessage) -> aws.internal
   542   53   load_var 16                        (_29)
         54   store_var_load_var 17              (video)
 
-  562   55   call 1310 ntypeargs=0              (aws.internal._video_block)
+  562   55   call 1311 ntypeargs=0              (aws.internal._video_block)
         56   store_var 18                       (_32)
         57   load_type 0                        
         58   load_var2 3 18                     
@@ -11935,7 +11935,7 @@ function aws.internal._prompt_content(message: ai.PromptMessage) -> aws.internal
   542   62   load_var 13                        (_23)
         63   store_var_load_var 14              (audio)
 
-  558   64   call 1312 ntypeargs=0              (aws.internal._audio_block)
+  558   64   call 1313 ntypeargs=0              (aws.internal._audio_block)
         65   store_var 15                       (_26)
         66   load_type 0                        
         67   load_var2 3 15                     
@@ -11946,7 +11946,7 @@ function aws.internal._prompt_content(message: ai.PromptMessage) -> aws.internal
   542   71   load_var 10                        (_17)
         72   store_var_load_var 11              (image)
 
-  554   73   call 1309 ntypeargs=0              (aws.internal._image_block)
+  554   73   call 1310 ntypeargs=0              (aws.internal._image_block)
         74   store_var 12                       (_20)
         75   load_type 0                        
         76   load_var2 3 12                     
@@ -11964,7 +11964,7 @@ function aws.internal._prompt_content(message: ai.PromptMessage) -> aws.internal
         86   pop_jump_if_false -77              (to 9)
 
   549   87   load_var 8                         (text)
-        88   call 1287 ntypeargs=0              (aws.internal.ContentBlock.of_text)
+        88   call 1288 ntypeargs=0              (aws.internal.ContentBlock.of_text)
         89   store_var 9                        (_14)
         90   load_type 0                        
         91   load_var2 3 9                      
@@ -12009,7 +12009,7 @@ function aws.internal._prompt_system(message: ai.PromptMessage) -> aws.internal.
         25   jump +4                            (to 29)
 
   589   26   load_const 7                       ("Bedrock system messages do not support media content")
-        27   call 1303 ntypeargs=0              (aws.internal._reject)
+        27   call 1304 ntypeargs=0              (aws.internal._reject)
         28   throw                              
 
   579   29   load_var 7                         (_9)
@@ -12022,7 +12022,7 @@ function aws.internal._prompt_system(message: ai.PromptMessage) -> aws.internal.
         35   pop_jump_if_false -26              (to 9)
 
   584   36   load_var 8                         (text)
-        37   call 1296 ntypeargs=0              (aws.internal.SystemContentBlock.of_text)
+        37   call 1297 ntypeargs=0              (aws.internal.SystemContentBlock.of_text)
         38   store_var 9                        (_14)
         39   load_type 0                        
         40   load_var2 3 9                      
@@ -12077,7 +12077,7 @@ function aws.internal._prune_nulls(value: baml.json.json) -> baml.json.json {
         33    load_var 14                        (_36)
         34    store_var_load_var 15              (item)
 
-  365   35    call 1302 ntypeargs=0              (aws.internal._prune_nulls)
+  365   35    call 1303 ntypeargs=0              (aws.internal._prune_nulls)
         36    store_var 16                       (_41)
         37    load_type 2                        
         38    load_var2 12 16                    
@@ -12129,12 +12129,12 @@ function aws.internal._prune_nulls(value: baml.json.json) -> baml.json.json {
         78    jump -20                           (to 58)
 
   350   79    load_var 7                         (key)
-        80    call 1301 ntypeargs=0              (aws.internal._is_opaque_key)
+        80    call 1302 ntypeargs=0              (aws.internal._is_opaque_key)
         81    pop_jump_if_false +2               (to 83)
         82    jump +11                           (to 93)
 
   354   83    load_var 8                         (member)
-        84    call 1302 ntypeargs=0              (aws.internal._prune_nulls)
+        84    call 1303 ntypeargs=0              (aws.internal._prune_nulls)
         85    store_var 9                        (_27)
         86    load_type 8                        
         87    load_type 2                        
@@ -12188,7 +12188,7 @@ function aws.internal._push_tool_result(pending: aws.internal.PendingMessage[], 
   745   19   load_var 7              (status)
         20   init_instance 1         (aws.internal.ToolResultBlock .toolUseId, .content, .status)
 
-  741   21   call 1293 ntypeargs=0   (aws.internal.ContentBlock.of_tool_result)
+  741   21   call 1294 ntypeargs=0   (aws.internal.ContentBlock.of_tool_result)
         22   store_var 8             (block)
 
   749   23   load_var 1              (pending)
@@ -12296,7 +12296,7 @@ function aws.internal._system_as_user(system: aws.internal.SystemContentBlock[])
         23   pop_jump_if_false +2               (to 25)
         24   jump +8                            (to 32)
 
-  911   25   call 1294 ntypeargs=0              (aws.internal.ContentBlock.of_cache_point)
+  911   25   call 1295 ntypeargs=0              (aws.internal.ContentBlock.of_cache_point)
         26   store_var 10                       (_16)
         27   load_type 0                        
         28   load_var2 3 10                     
@@ -12307,7 +12307,7 @@ function aws.internal._system_as_user(system: aws.internal.SystemContentBlock[])
   907   32   load_var 7                         (_9)
         33   store_var_load_var 8               (text)
 
-  908   34   call 1287 ntypeargs=0              (aws.internal.ContentBlock.of_text)
+  908   34   call 1288 ntypeargs=0              (aws.internal.ContentBlock.of_text)
         35   store_var 9                        (_12)
         36   load_type 0                        
         37   load_var2 3 9                      
@@ -12373,7 +12373,7 @@ function aws.internal._tool_choice(choice: string) -> aws.internal.ToolChoice {
 
 function aws.internal._tool_config(toolbox: ai.tools.Toolbox, tool_choice: string | null, cache_tools: bool) -> aws.internal.ToolConfig | null {
   833   0    load_var 1                         (toolbox)
-        1    call 933 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        1    call 934 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         2    pop_jump_if_false +2               (to 4)
         3    jump +66                           (to 69)
 
@@ -12382,7 +12382,7 @@ function aws.internal._tool_config(toolbox: ai.tools.Toolbox, tool_choice: strin
         6    store_var 4                        (entries)
 
   837   7    load_var 1                         (toolbox)
-        8    call 931 ntypeargs=0               (ai.tools.Toolbox.list)
+        8    call 932 ntypeargs=0               (ai.tools.Toolbox.list)
         9    load_type 1                        
         10   load_const 2                       ("iter")
         11   virtual_call nargs=1 ntypeargs=0   
@@ -12419,7 +12419,7 @@ function aws.internal._tool_config(toolbox: ai.tools.Toolbox, tool_choice: strin
         37   init_instance 0                    (aws.internal.ToolInputSchema .json_schema)
         38   init_instance 1                    (aws.internal.ToolSpec .name, .description, .inputSchema)
 
-  839   39   call 1299 ntypeargs=0              (aws.internal.ToolEntry.of_spec)
+  839   39   call 1300 ntypeargs=0              (aws.internal.ToolEntry.of_spec)
         40   store_var 8                        (_13)
 
   838   41   load_type 0                        
@@ -12431,7 +12431,7 @@ function aws.internal._tool_config(toolbox: ai.tools.Toolbox, tool_choice: strin
   848   46   load_var 3                         (cache_tools)
         47   pop_jump_if_false +7               (to 54)
 
-  849   48   call 1300 ntypeargs=0              (aws.internal.ToolEntry.of_cache_point)
+  849   48   call 1301 ntypeargs=0              (aws.internal.ToolEntry.of_cache_point)
         49   store_var 12                       (_23)
         50   load_type 0                        
         51   load_var2 4 12                     
@@ -12446,7 +12446,7 @@ function aws.internal._tool_config(toolbox: ai.tools.Toolbox, tool_choice: strin
         59   load_var 2                         (tool_choice)
         60   store_var_load_var 14              (choice)
 
-  856   61   call 1322 ntypeargs=0              (aws.internal._tool_choice)
+  856   61   call 1323 ntypeargs=0              (aws.internal._tool_choice)
         62   store_var 13                       (selection)
         63   jump +3                            (to 66)
 
@@ -12464,20 +12464,20 @@ function aws.internal._tool_config(toolbox: ai.tools.Toolbox, tool_choice: strin
 function aws.internal._video_block(video: baml.media.Video) -> aws.internal.ContentBlock {
   489   0    load_var 1              (video)
         1    load_const 0            (false)
-        2    call 942 ntypeargs=0    (ai.wire.resolve_media)
+        2    call 943 ntypeargs=0    (ai.wire.resolve_media)
         3    store_var 2             (resolved)
 
   492   4    load_var 2              (resolved)
         5    load_field 2            (mime_type)
-        6    call 1306 ntypeargs=0   (aws.internal._video_format)
+        6    call 1307 ntypeargs=0   (aws.internal._video_format)
 
   493   7    load_var 2              (resolved)
         8    load_const 1            ("video")
-        9    call 1308 ntypeargs=0   (aws.internal._media_source)
+        9    call 1309 ntypeargs=0   (aws.internal._media_source)
 
   491   10   init_instance 0         (aws.internal.VideoBlock .format, .source)
 
-  490   11   call 1289 ntypeargs=0   (aws.internal.ContentBlock.of_video)
+  490   11   call 1290 ntypeargs=0   (aws.internal.ContentBlock.of_video)
         12   return                  
 }
 
@@ -12534,7 +12534,7 @@ function aws.internal._video_format(mime: string) -> string {
         48   load_const 12           ("unsupported video format for Bedrock: ")
         49   load_var 2              (_15)
         50   bin_op +                
-        51   call 1303 ntypeargs=0   (aws.internal._reject)
+        51   call 1304 ntypeargs=0   (aws.internal._reject)
         52   throw                   
 
   433   53   load_const 13           ("three_gp")
@@ -12603,23 +12603,23 @@ function aws.internal._wants_cache_point(message: ai.PromptMessage) -> bool {
 
 function aws.internal.build_request(client: aws.BedrockClient, input: ai.ModelTurnInput) -> baml.http.Request {
   1101   0    load_var2 1 2           
-         1    call 1327 ntypeargs=0   (aws.internal.converse_request)
+         1    call 1328 ntypeargs=0   (aws.internal.converse_request)
          2    store_var 4             (_5)
          3    load_type 0             
          4    load_var 4              (_5)
          5    call 362 ntypeargs=1    (baml.json.to_json)
-         6    call 1302 ntypeargs=0   (aws.internal._prune_nulls)
+         6    call 1303 ntypeargs=0   (aws.internal._prune_nulls)
 
   1102   7    load_var 1              (client)
          8    load_field 15           (request_body)
-         9    call 943 ntypeargs=0    (ai.wire.merge_request_body)
+         9    call 944 ntypeargs=0    (ai.wire.merge_request_body)
          10   store_var 5             (merged)
 
   1105   11   load_var 1              (client)
-         12   call 1328 ntypeargs=0   (aws.internal.converse_url)
+         12   call 1329 ntypeargs=0   (aws.internal.converse_url)
          13   load_var 1              (client)
          14   load_field 17           (query_params)
-         15   call 1330 ntypeargs=0   (aws.internal._apply_query)
+         15   call 1331 ntypeargs=0   (aws.internal._apply_query)
          16   store_var 6             (_10)
 
   1107   17   load_const 1            ("application/json")
@@ -12633,7 +12633,7 @@ function aws.internal.build_request(client: aws.BedrockClient, input: ai.ModelTu
   1108   24   load_var 1              (client)
          25   load_field 16           (headers)
 
-  1106   26   call 1329 ntypeargs=0   (aws.internal._merge_headers)
+  1106   26   call 1330 ntypeargs=0   (aws.internal._merge_headers)
          27   store_var 7             (_13)
 
   1110   28   load_var 5              (merged)
@@ -12651,7 +12651,7 @@ function aws.internal.build_request(client: aws.BedrockClient, input: ai.ModelTu
 
 function aws.internal.converse_model_path(model_id: string) -> string {
   72   0    load_var 1              (model_id)
-       1    call 1285 ntypeargs=0   (aws.internal.encode_path_label)
+       1    call 1286 ntypeargs=0   (aws.internal.encode_path_label)
        2    store_var 4             (_4)
        3    load_type 0             
        4    load_var 4              (_4)
@@ -12673,10 +12673,10 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
          2     store_var 5                        (_5)
          3     load_var 2                         (input)
          4     load_field 3                       (output_type)
-         5     call 941 ntypeargs=0               (ai.wire.render_output_format)
+         5     call 942 ntypeargs=0               (ai.wire.render_output_format)
          6     load_var 5                         (_5)
          7     call_indirect                      
-         8     call 1317 ntypeargs=0              (aws.internal._lower_prompt)
+         8     call 1318 ntypeargs=0              (aws.internal._lower_prompt)
          9     store_var 4                        (prompt)
 
   952    10    load_var 4                         (prompt)
@@ -12695,7 +12695,7 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
          22    cmp_int_op >                       
          23    pop_jump_if_false +7               (to 30)
 
-  954    24    call 1297 ntypeargs=0              (aws.internal.SystemContentBlock.of_cache_point)
+  954    24    call 1298 ntypeargs=0              (aws.internal.SystemContentBlock.of_cache_point)
          25    store_var 8                        (_13)
          26    load_type 1                        
          27    load_var2 6 8                      
@@ -12715,16 +12715,16 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
          39    virtual_call nargs=1 ntypeargs=0   
          40    store_var 12                       (_19)
          41    load_var2 11 12                    
-         42    call 944 ntypeargs=0               (ai.wire.sanitize_for_client)
+         42    call 945 ntypeargs=0               (ai.wire.sanitize_for_client)
          43    store_var 10                       (_17)
 
   959    44    load_var 1                         (client)
          45    load_field 0                       (model)
-         46    call 1319 ntypeargs=0              (aws.internal._supports_tool_result_status)
+         46    call 1320 ntypeargs=0              (aws.internal._supports_tool_result_status)
          47    store_var 13                       (_20)
 
   957    48    load_var2 10 13                    
-         49    call 1321 ntypeargs=0              (aws.internal._lower_journal)
+         49    call 1322 ntypeargs=0              (aws.internal._lower_journal)
 
   961    50    load_type 4                        
          51    load_const 5                       ("iter")
@@ -12819,7 +12819,7 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
   980    132   jump +24                           (to 156)
 
   981    133   load_const 14                      ("(continue)")
-         134   call 1287 ntypeargs=0              (aws.internal.ContentBlock.of_text)
+         134   call 1288 ntypeargs=0              (aws.internal.ContentBlock.of_text)
          135   store_var 25                       (_62)
          136   load_type 9                        
          137   load_const 15                      ("user")
@@ -12836,7 +12836,7 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
          146   jump +10                           (to 156)
 
   979    147   load_var 6                         (system)
-         148   call 1325 ntypeargs=0              (aws.internal._system_as_user)
+         148   call 1326 ntypeargs=0              (aws.internal._system_as_user)
          149   store_var 24                       (_54)
          150   load_type 9                        
          151   load_var 24                        (_54)
@@ -12845,7 +12845,7 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
          154   load_var 9                         (messages)
          155   call 7 ntypeargs=1                 (baml.Array.concat)
 
-  977    156   call 1326 ntypeargs=0              (aws.internal._merge_adjacent_roles)
+  977    156   call 1327 ntypeargs=0              (aws.internal._merge_adjacent_roles)
          157   store_var 23                       (wire_messages)
 
   988    158   load_var 23                        (wire_messages)
@@ -12879,7 +12879,7 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
   999    181   store_var 28                       (_73)
 
   1000   182   load_var 1                         (client)
-         183   call 1324 ntypeargs=0              (aws.internal._inference_config)
+         183   call 1325 ntypeargs=0              (aws.internal._inference_config)
          184   store_var 29                       (_74)
 
   1001   185   load_var 2                         (input)
@@ -12888,7 +12888,7 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
          188   load_field 11                      (tool_choice)
          189   load_var 1                         (client)
          190   load_field 13                      (cache_tools)
-         191   call 1323 ntypeargs=0              (aws.internal._tool_config)
+         191   call 1324 ntypeargs=0              (aws.internal._tool_config)
          192   store_var 30                       (_75)
 
   998    193   load_var2 23 28                    
@@ -12902,18 +12902,18 @@ function aws.internal.converse_request(client: aws.BedrockClient, input: ai.Mode
          200   return                             
 
   989    201   load_const 17                      ("the rendered prompt and journal produced no message content")
-         202   call 1303 ntypeargs=0              (aws.internal._reject)
+         202   call 1304 ntypeargs=0              (aws.internal._reject)
          203   throw                              
 }
 
 function aws.internal.converse_url(client: aws.BedrockClient) -> string {
   1010   0     load_var 1              (client)
          1     load_field 0            (model)
-         2     call 1286 ntypeargs=0   (aws.internal.converse_model_path)
+         2     call 1287 ntypeargs=0   (aws.internal.converse_model_path)
          3     store_var 2             (path)
 
   1011   4     load_var 1              (client)
-         5     call 1281 ntypeargs=0   (aws.BedrockClient.resolved_endpoint_url)
+         5     call 1282 ntypeargs=0   (aws.BedrockClient.resolved_endpoint_url)
          6     store_var 3             (_5)
          7     load_var 3              (_5)
          8     narrow_bind 0 3         
@@ -12931,7 +12931,7 @@ function aws.internal.converse_url(client: aws.BedrockClient) -> string {
   1029   18    load_const 1            (null)
          19    load_var 1              (client)
          20    load_field 2            (profile)
-         21    call 1338 ntypeargs=0   (aws.internal.resolve_region)
+         21    call 1339 ntypeargs=0   (aws.internal.resolve_region)
          22    jump +19                (to 41)
          23    load_var 13             (e)
          24    throw_if_panic          
@@ -13073,7 +13073,7 @@ function aws.internal.encode_path_label(value: string) -> string {
        21   load_var 5                         (_7)
        22   store_var_load_var 6               (byte)
 
-  60   23   call 1284 ntypeargs=0              (aws.internal._is_unreserved_byte)
+  60   23   call 1285 ntypeargs=0              (aws.internal._is_unreserved_byte)
        24   pop_jump_if_false +2               (to 26)
        25   jump +39                           (to 64)
 
@@ -13136,17 +13136,17 @@ function aws.internal.encode_path_label(value: string) -> string {
 
 function aws.internal.invoke(client: aws.BedrockClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   1328   0    load_var2 1 2           
-         1    call 1331 ntypeargs=0   (aws.internal.build_request)
+         1    call 1332 ntypeargs=0   (aws.internal.build_request)
          2    store_var 4             (_4)
          3    load_var2 1 4           
-         4    call 1332 ntypeargs=0   (aws.internal.sign)
+         4    call 1333 ntypeargs=0   (aws.internal.sign)
          5    store_var 3             (request)
 
   1329   6    load_type 0             
          7    load_var 3              (request)
          8    load_const 1            ("aws-bedrock")
-         9    call 940 ntypeargs=1    (ai.wire.send_as)
-         10   call 1335 ntypeargs=0   (aws.internal.parse_response)
+         9    call 941 ntypeargs=1    (ai.wire.send_as)
+         10   call 1336 ntypeargs=0   (aws.internal.parse_response)
          11   return                  
 }
 
@@ -13160,7 +13160,7 @@ function aws.internal.parse_response(response: aws.internal.ConverseResponse) ->
          6     load_var 2                         (_3)
          7     store_var_load_var 3               (raw)
 
-  1258   8     call 1333 ntypeargs=0              (aws.internal._is_malformed_stop)
+  1258   8     call 1334 ntypeargs=0              (aws.internal._is_malformed_stop)
          9     pop_jump_if_false +2               (to 11)
          10    jump +203                          (to 213)
 
@@ -13334,7 +13334,7 @@ function aws.internal.parse_response(response: aws.internal.ConverseResponse) ->
          157   load_var 28                        (_72)
          158   store_var_load_var 29              (raw)
 
-  1303   159   call 1334 ntypeargs=0              (aws.internal.stop_reason)
+  1303   159   call 1335 ntypeargs=0              (aws.internal.stop_reason)
          160   store_var 27                       (stop)
          161   jump +4                            (to 165)
 
@@ -13414,7 +13414,7 @@ function aws.internal.parse_response(response: aws.internal.ConverseResponse) ->
 
 function aws.internal.resolve_region(region: string | null, profile: string | null) -> string | null {
   61   0   load_var2 1 2   
-       1   sys_op 993      (ai.internal._aws_resolve_region)
+       1   sys_op 994      (ai.internal._aws_resolve_region)
        2   return          
 }
 
@@ -13437,7 +13437,7 @@ function aws.internal.sign(client: aws.BedrockClient, request: baml.http.Request
          10   load_const 0            ("bedrock")
          11   init_instance 0         (aws.internal.AwsSignOptions .region, .profile, .access_key_id, .secret_access_key, .session_token, .service)
 
-  1117   12   call 1337 ntypeargs=0   (aws.internal.sign_request)
+  1117   12   call 1338 ntypeargs=0   (aws.internal.sign_request)
          13   jump +19                (to 32)
          14   load_var 3              (e)
          15   throw_if_panic          
@@ -13482,7 +13482,7 @@ function aws.internal.sign_request(req: baml.http.Request, opts: aws.internal.Aw
 
   52   10   load_var 2      (opts)
        11   load_field 4    (session_token)
-       12   sys_op 992      (ai.internal._aws_sign_request)
+       12   sys_op 993      (ai.internal._aws_sign_request)
        13   return          
 }
 
@@ -13510,7 +13510,7 @@ function aws.internal.stop_reason(raw: string) -> ai.content.StopReason {
          20   load_var 1              (raw)
          21   store_var_load_var 2    (r)
 
-  1240   22   call 1333 ntypeargs=0   (aws.internal._is_malformed_stop)
+  1240   22   call 1334 ntypeargs=0   (aws.internal._is_malformed_stop)
 
   1230   23   pop_jump_if_false +2    (to 25)
          24   jump +4                 (to 28)
@@ -13575,13 +13575,13 @@ function claude_code.ClaudeCodeClient.ai.Client.id(self: claude_code.ClaudeCodeC
 
 function claude_code.ClaudeCodeClient.ai.Client.invoke(self: claude_code.ClaudeCodeClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   44   0   load_var2 1 2           
-       1   call 1372 ntypeargs=0   (claude_code.internal.invoke)
+       1   call 1373 ntypeargs=0   (claude_code.internal.invoke)
        2   jump +6                 (to 8)
        3   load_var 3              (e)
        4   throw_if_panic          
 
   45   5   load_var 3              (e)
-       6   call 977 ntypeargs=0    (ai.errors.normalize)
+       6   call 978 ntypeargs=0    (ai.errors.normalize)
        7   throw                   
        8   return                  
 }
@@ -13791,7 +13791,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> void {
         116   load_const 31                      (".thinking")
         117   load_const 32                      ("")
         118   call 371 ntypeargs=1               (baml.json.path_or)
-        119   call 1368 ntypeargs=0              (claude_code.internal._preview)
+        119   call 1369 ntypeargs=0              (claude_code.internal._preview)
         120   store_var 32                       (_110)
         121   load_type 0                        
         122   load_var 32                        (_110)
@@ -13814,7 +13814,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> void {
         135   load_const 34                      (".text")
         136   load_const 35                      ("")
         137   call 371 ntypeargs=1               (baml.json.path_or)
-        138   call 1368 ntypeargs=0              (claude_code.internal._preview)
+        138   call 1369 ntypeargs=0              (claude_code.internal._preview)
         139   store_var 30                       (_101)
         140   load_type 0                        
         141   load_var 30                        (_101)
@@ -13950,7 +13950,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> void {
         261   load_const 55                      (".thinking")
         262   load_const 56                      ("")
         263   call 371 ntypeargs=1               (baml.json.path_or)
-        264   call 1368 ntypeargs=0              (claude_code.internal._preview)
+        264   call 1369 ntypeargs=0              (claude_code.internal._preview)
         265   store_var 18                       (_54)
         266   load_type 0                        
         267   load_var 18                        (_54)
@@ -13973,7 +13973,7 @@ function claude_code.internal._log_cc_event(raw: baml.json.json) -> void {
         280   load_const 58                      (".text")
         281   load_const 59                      ("")
         282   call 371 ntypeargs=1               (baml.json.path_or)
-        283   call 1368 ntypeargs=0              (claude_code.internal._preview)
+        283   call 1369 ntypeargs=0              (claude_code.internal._preview)
         284   store_var 16                       (_45)
         285   load_type 0                        
         286   load_var 16                        (_45)
@@ -14169,7 +14169,7 @@ function claude_code.internal._read_result(p: baml.sys.Process) -> baml.json.jso
         36   throw                              
 
   136   37   load_var 7                         (raw)
-        38   call 1369 ntypeargs=0              (claude_code.internal._log_cc_event)
+        38   call 1370 ntypeargs=0              (claude_code.internal._log_cc_event)
         39   pop 1                              
 
   137   40   load_type 8                        
@@ -14233,7 +14233,7 @@ function claude_code.internal.allowed_mcp_tools(c: claude_code.ClaudeCodeClient)
         8    load_type 2           
         9    load_var 3            (_3)
 
-  224   10   make_closure 4086 0   
+  224   10   make_closure 4087 0   
 
   223   11   call 16 ntypeargs=3   (baml.Array.map)
         12   store_var 2           (_2)
@@ -14266,7 +14266,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        16    store_var 6             (call_props)
 
   55   17    load_const 4            ("string")
-       18    call 1365 ntypeargs=0   (claude_code.internal._type_schema)
+       18    call 1366 ntypeargs=0   (claude_code.internal._type_schema)
        19    store_var 7             (_10)
        20    load_type 1             
        21    load_type 2             
@@ -14277,7 +14277,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        26    pop 1                   
 
   56   27    load_const 6            ("string")
-       28    call 1365 ntypeargs=0   (claude_code.internal._type_schema)
+       28    call 1366 ntypeargs=0   (claude_code.internal._type_schema)
        29    store_var 8             (_14)
        30    load_type 1             
        31    load_type 2             
@@ -14288,7 +14288,7 @@ function claude_code.internal.envelope_schema(output_type: type) -> map<string, 
        36    pop 1                   
 
   57   37    load_const 8            ("object")
-       38    call 1365 ntypeargs=0   (claude_code.internal._type_schema)
+       38    call 1366 ntypeargs=0   (claude_code.internal._type_schema)
        39    store_var 9             (_18)
        40    load_type 1             
        41    load_type 2             
@@ -14512,12 +14512,12 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         1     load_var 2                         (input)
         2     load_field 0                       (prompt)
         3     call_indirect                      
-        4     call 918 ntypeargs=0               (ai.Prompt.text)
+        4     call 919 ntypeargs=0               (ai.Prompt.text)
         5     store_var 4                        (instructions)
 
   238   6     load_var 2                         (input)
         7     load_field 2                       (toolbox)
-        8     call 933 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        8     call 934 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         9     unary_op !                         
         10    store_var_load_var 5               (has_tools)
 
@@ -14532,7 +14532,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 
   240   18    load_var 2                         (input)
         19    load_field 3                       (output_type)
-        20    call 1364 ntypeargs=0              (claude_code.internal.envelope_schema)
+        20    call 1365 ntypeargs=0              (claude_code.internal.envelope_schema)
         21    store_var 7                        (_11)
         22    load_type 1                        
         23    load_var 7                         (_11)
@@ -14549,7 +14549,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         32    store_var 14                       (_29)
         33    load_var 2                         (input)
         34    load_field 1                       (journal)
-        35    call 1363 ntypeargs=0              (claude_code.internal.transcript_text)
+        35    call 1364 ntypeargs=0              (claude_code.internal.transcript_text)
         36    store_var 16                       (_33)
         37    load_type 2                        
         38    load_var 16                        (_33)
@@ -14567,7 +14567,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         48    store_var 9                        (_18)
         49    load_var 2                         (input)
         50    load_field 1                       (journal)
-        51    call 1363 ntypeargs=0              (claude_code.internal.transcript_text)
+        51    call 1364 ntypeargs=0              (claude_code.internal.transcript_text)
         52    store_var 11                       (_22)
         53    load_type 2                        
         54    load_var 11                        (_22)
@@ -14575,7 +14575,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         56    store_var 10                       (_21)
         57    load_var 2                         (input)
         58    load_field 2                       (toolbox)
-        59    call 1366 ntypeargs=0              (claude_code.internal.tool_protocol)
+        59    call 1367 ntypeargs=0              (claude_code.internal.tool_protocol)
         60    store_var 13                       (_26)
         61    load_type 2                        
         62    load_var 13                        (_26)
@@ -14601,7 +14601,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         81    store_var 18                       (_44)
         82    load_var 2                         (input)
         83    load_field 2                       (toolbox)
-        84    call 931 ntypeargs=0               (ai.tools.Toolbox.list)
+        84    call 932 ntypeargs=0               (ai.tools.Toolbox.list)
         85    container_len                      
         86    store_var 21                       (_48)
         87    load_type 3                        
@@ -14708,7 +14708,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         173   pop 1                              
 
   271   174   load_var 1                         (c)
-        175   call 1370 ntypeargs=0              (claude_code.internal.mcp_config_json)
+        175   call 1371 ntypeargs=0              (claude_code.internal.mcp_config_json)
         176   store_var 24                       (_81)
         177   load_var 24                        (_81)
         178   narrow_bind 21 24                  
@@ -14734,7 +14734,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         195   pop 1                              
 
   275   196   load_var 1                         (c)
-        197   call 1371 ntypeargs=0              (claude_code.internal.allowed_mcp_tools)
+        197   call 1372 ntypeargs=0              (claude_code.internal.allowed_mcp_tools)
         198   store_var 27                       (_93)
         199   load_type 2                        
         200   load_var 27                        (_93)
@@ -14812,7 +14812,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
         261   throw_if_panic                     
 
   303   262   load_var 29                        (p)
-        263   call 1367 ntypeargs=0              (claude_code.internal._read_result)
+        263   call 1368 ntypeargs=0              (claude_code.internal._read_result)
         264   store_var 36                       (result)
 
   304   265   load_var 29                        (p)
@@ -15040,7 +15040,7 @@ function claude_code.internal.invoke(c: claude_code.ClaudeCodeClient, input: ai.
 
   363   459   load_var 2                         (input)
         460   load_field 1                       (journal)
-        461   call 914 ntypeargs=0               (ai.Journal.entries)
+        461   call 915 ntypeargs=0               (ai.Journal.entries)
         462   container_len                      
         463   store_var 69                       (_214)
         464   load_type 3                        
@@ -15211,7 +15211,7 @@ function claude_code.internal.tool_protocol(tb: ai.tools.Toolbox) -> string {
         2    store_var 3                        (catalog)
 
   100   3    load_var 1                         (tb)
-        4    call 931 ntypeargs=0               (ai.tools.Toolbox.list)
+        4    call 932 ntypeargs=0               (ai.tools.Toolbox.list)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -15296,7 +15296,7 @@ function claude_code.internal.transcript_text(j: ai.Journal) -> string {
        2     store_var 2                        (lines)
 
   8    3     load_var 1                         (j)
-       4     call 914 ntypeargs=0               (ai.Journal.entries)
+       4     call 915 ntypeargs=0               (ai.Journal.entries)
        5     load_type 1                        
        6     load_const 2                       ("iter")
        7     virtual_call nargs=1 ntypeargs=0   
@@ -15542,26 +15542,26 @@ function google.GoogleClient.ai.Client.id(self: google.GoogleClient) -> string {
 
 function google.GoogleClient.ai.Client.invoke(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   129   0   load_var2 1 2           
-        1   call 1255 ntypeargs=0   (google.internal.gemini_invoke)
+        1   call 1256 ntypeargs=0   (google.internal.gemini_invoke)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   130   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
 
 function google.GoogleClient.ai.stream.StreamingClient.invoke_stream(self: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   137   0   load_var2 1 2           
-        1   call 1257 ntypeargs=0   (google.internal.gemini_invoke_stream)
+        1   call 1258 ntypeargs=0   (google.internal.gemini_invoke_stream)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   138   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
@@ -15674,7 +15674,7 @@ function google.GoogleClient.resolved_api_key(self: google.GoogleClient) -> stri
   107   0    load_var 1             (self)
         1    load_field 1           (api_key)
         2    load_const 0           ("GOOGLE_API_KEY")
-        3    call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3    call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4    store_var 2            (_4)
         5    load_var 2             (_4)
         6    narrow_bind 1 2        
@@ -15684,7 +15684,7 @@ function google.GoogleClient.resolved_api_key(self: google.GoogleClient) -> stri
   113   9    load_var 1             (self)
         10   load_field 1           (api_key)
         11   load_const 2           ("GOOGLE_API_KEY")
-        12   call 939 ntypeargs=0   (ai.wire.credential_sources)
+        12   call 940 ntypeargs=0   (ai.wire.credential_sources)
         13   store_var 5            (_9)
         14   load_type 3            
         15   load_var 5             (_9)
@@ -15712,7 +15712,7 @@ function google.GoogleClient.resolved_base_url(self: google.GoogleClient) -> str
   120   0   load_var 1             (self)
         1   load_field 2           (base_url)
         2   load_const 0           (null)
-        3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4   return                 
 }
 
@@ -15740,26 +15740,26 @@ function google.VertexClient.ai.Client.id(self: google.VertexClient) -> string {
 
 function google.VertexClient.ai.Client.invoke(self: google.VertexClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   113   0   load_var2 1 2           
-        1   call 1274 ntypeargs=0   (google.internal.vertex_invoke)
+        1   call 1275 ntypeargs=0   (google.internal.vertex_invoke)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   114   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
 
 function google.VertexClient.ai.stream.StreamingClient.invoke_stream(self: google.VertexClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   121   0   load_var2 1 2           
-        1   call 1276 ntypeargs=0   (google.internal.vertex_invoke_stream)
+        1   call 1277 ntypeargs=0   (google.internal.vertex_invoke_stream)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   122   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
@@ -15902,7 +15902,7 @@ function google.VertexClient.resolved_api_key(self: google.VertexClient) -> stri
   99   0   load_var 1             (self)
        1   load_field 5           (api_key)
        2   load_const 0           (null)
-       3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4   return                 
 }
 
@@ -15910,7 +15910,7 @@ function google.VertexClient.resolved_base_url(self: google.VertexClient) -> str
   104   0   load_var 1             (self)
         1   load_field 6           (base_url)
         2   load_const 0           (null)
-        3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4   return                 
 }
 
@@ -16098,7 +16098,7 @@ function google.internal._gm_apply_query(url: string, params: map<string, string
         47   call 145 ntypeargs=1               (baml.String.from)
         48   store_var 11                       (_22)
         49   load_var 8                         (name)
-        50   call 1229 ntypeargs=0              (google.internal._gm_encode_query)
+        50   call 1230 ntypeargs=0              (google.internal._gm_encode_query)
         51   store_var 13                       (_26)
         52   load_type 1                        
         53   load_var 13                        (_26)
@@ -16115,7 +16115,7 @@ function google.internal._gm_apply_query(url: string, params: map<string, string
         64   load_const 11                      ("")
         65   store_var 16                       (_32)
         66   load_var 16                        (_32)
-        67   call 1229 ntypeargs=0              (google.internal._gm_encode_query)
+        67   call 1230 ntypeargs=0              (google.internal._gm_encode_query)
         68   store_var 15                       (_30)
         69   load_type 1                        
         70   load_var 15                        (_30)
@@ -16138,7 +16138,7 @@ function google.internal._gm_apply_query(url: string, params: map<string, string
 }
 
 function google.internal._gm_call_id_signature(id: string) -> string | null {
-  549   0    call 1239 ntypeargs=0   (google.internal._gm_sig_marker)
+  549   0    call 1240 ntypeargs=0   (google.internal._gm_sig_marker)
         1    store_var 2             (marker)
 
   550   2    load_var2 1 2           
@@ -16177,7 +16177,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          2     store_var 4                        (out)
 
   974    3     load_var 1                         (batch)
-         4     call 967 ntypeargs=0               (ai.stream.decode_sse_batch)
+         4     call 968 ntypeargs=0               (ai.stream.decode_sse_batch)
          5     load_type 1                        
          6     load_const 2                       ("iter")
          7     virtual_call nargs=1 ntypeargs=0   
@@ -16243,11 +16243,11 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          61    cmp_op ==                          
          62    pop_jump_if_false +2               (to 64)
          63    jump +8                            (to 71)
-         64    load_type 12                       
+         64    load_const 12                      (0)
          65    load_var 10                        (resp)
          66    load_field 0                       (candidates)
-         67    load_const 13                      (0)
-         68    call 3 ntypeargs=1                 (baml.Array.at)
+         67    make_bound_method 3                
+         68    call_indirect                      
          69    store_var 17                       (cand)
          70    jump +3                            (to 73)
          71    load_const 6                       (null)
@@ -16278,19 +16278,19 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          95    load_const 6                       (null)
          96    cmp_op ==                          
          97    pop_jump_if_false +4               (to 101)
-         98    load_type 14                       
+         98    load_type 13                       
          99    alloc_array 0                      
          100   store_var 19                       (_43)
          101   load_var 19                        (_43)
          102   store_var_load_var 18              (parts)
 
-  994    103   load_type 15                       
-         104   load_const 16                      ("iter")
+  994    103   load_type 14                       
+         104   load_const 15                      ("iter")
          105   virtual_call nargs=1 ntypeargs=0   
          106   store_var 20                       (_56)
          107   load_var 20                        (_56)
-         108   load_type 17                       
-         109   load_const 18                      ("next")
+         108   load_type 16                       
+         109   load_const 17                      ("next")
          110   virtual_call nargs=1 ntypeargs=0   
          111   store_var 21                       (_57)
          112   load_var 21                        (_57)
@@ -16303,7 +16303,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
   995    118   load_field 0                       (text)
          119   store_var 23                       (_62)
          120   load_var 23                        (_62)
-         121   narrow_bind 19 23                  
+         121   narrow_bind 18 23                  
          122   pop_jump_if_false -15              (to 107)
          123   load_var 23                        (_62)
          124   store_var 24                       (t)
@@ -16314,7 +16314,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          128   load_const 6                       (null)
          129   cmp_op ==                          
          130   pop_jump_if_false +3               (to 133)
-         131   load_const 20                      (false)
+         131   load_const 19                      (false)
          132   store_var 25                       (_65)
          133   load_var 25                        (_65)
          134   pop_jump_if_false +2               (to 136)
@@ -16340,7 +16340,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          152   load_const 6                       (null)
          153   cmp_op ==                          
          154   pop_jump_if_false +3               (to 157)
-         155   load_const 21                      ("")
+         155   load_const 20                      ("")
          156   store_var 27                       (_73)
          157   load_var 27                        (_73)
          158   store_var 26                       (finish)
@@ -16362,7 +16362,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          173   store_var 28                       (blocked)
 
   1008   174   load_var 26                        (finish)
-         175   load_const 22                      ("MAX_TOKENS")
+         175   load_const 21                      ("MAX_TOKENS")
          176   cmp_op ==                          
          177   pop_jump_if_false +2               (to 179)
          178   jump +25                           (to 203)
@@ -16372,12 +16372,12 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          181   jump +4                            (to 185)
          182   pop 1                              
          183   load_var 26                        (finish)
-         184   call 1247 ntypeargs=0              (google.internal._gm_is_blocked)
+         184   call 1248 ntypeargs=0              (google.internal._gm_is_blocked)
          185   pop_jump_if_false +2               (to 187)
          186   jump +13                           (to 199)
 
   1012   187   load_var 26                        (finish)
-         188   load_const 23                      ("")
+         188   load_const 22                      ("")
          189   cmp_op !=                          
          190   pop_jump_if_false +2               (to 192)
          191   jump +4                            (to 195)
@@ -16387,19 +16387,19 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
 
   1012   194   jump +12                           (to 206)
 
-  1013   195   load_const 13                      (ai.content.StopReason.Complete)
+  1013   195   load_const 12                      (ai.content.StopReason.Complete)
          196   alloc_variant 774                  (ai.content.StopReason)
          197   store_var 29                       (stop)
 
   1012   198   jump +8                            (to 206)
 
-  1011   199   load_const 24                      (ai.content.StopReason.Refused)
+  1011   199   load_const 23                      (ai.content.StopReason.Refused)
          200   alloc_variant 774                  (ai.content.StopReason)
          201   store_var 29                       (stop)
 
   1010   202   jump +4                            (to 206)
 
-  1009   203   load_const 25                      (ai.content.StopReason.MaxTokens)
+  1009   203   load_const 24                      (ai.content.StopReason.MaxTokens)
          204   alloc_variant 774                  (ai.content.StopReason)
          205   store_var 29                       (stop)
 
@@ -16477,7 +16477,7 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          266   load_const 6                       (null)
          267   cmp_op ==                          
          268   pop_jump_if_false +3               (to 271)
-         269   load_const 13                      (0)
+         269   load_const 12                      (0)
          270   store_var 15                       (_30)
          271   load_var 15                        (_30)
          272   store_var 14                       (_29)
@@ -16491,8 +16491,8 @@ function google.internal._gm_decode_batch(batch: string, provider: string) -> (a
          280   store_var 16                       (_34)
          281   load_var2 2 14                     
          282   load_var 16                        (_34)
-         283   load_const 26                      (<omitted>)
-         284   call 986 ntypeargs=0               (ai.errors.classify_http)
+         283   load_const 25                      (<omitted>)
+         284   call 987 ntypeargs=0               (ai.errors.classify_http)
          285   throw                              
 
   1042   286   load_var 4                         (out)
@@ -16519,7 +16519,7 @@ function google.internal._gm_encode_call_id(id: string, signature: string | null
         11   load_var 1              (id)
         12   call 145 ntypeargs=1    (baml.String.from)
         13   store_var 5             (_6)
-        14   call 1239 ntypeargs=0   (google.internal._gm_sig_marker)
+        14   call 1240 ntypeargs=0   (google.internal._gm_sig_marker)
         15   store_var 7             (_9)
         16   load_type 1             
         17   load_var 7              (_9)
@@ -16740,7 +16740,7 @@ function google.internal._gm_is_provider_uri(url: string) -> bool {
 
 function google.internal._gm_media_part(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf, fetch_url: bool) -> google.internal.GmPart {
   431   0    load_var 1              (media)
-        1    call 1233 ntypeargs=0   (google.internal._gm_media_url)
+        1    call 1234 ntypeargs=0   (google.internal._gm_media_url)
 
   432   2    store_var 4             (_5)
         3    load_var 4              (_5)
@@ -16755,7 +16755,7 @@ function google.internal._gm_media_part(media: baml.media.Image | baml.media.Aud
         10   load_var 4              (_5)
         11   store_var_load_var 5    (url)
 
-  433   12   call 1234 ntypeargs=0   (google.internal._gm_is_provider_uri)
+  433   12   call 1235 ntypeargs=0   (google.internal._gm_is_provider_uri)
         13   store_var 3             (passthrough)
 
   437   14   load_var 2              (fetch_url)
@@ -16768,7 +16768,7 @@ function google.internal._gm_media_part(media: baml.media.Image | baml.media.Aud
         21   unary_op !              
         22   store_var 7             (_9)
         23   load_var2 1 7           
-        24   call 942 ntypeargs=0    (ai.wire.resolve_media)
+        24   call 943 ntypeargs=0    (ai.wire.resolve_media)
         25   store_var 6             (resolved)
 
   438   26   load_var 6              (resolved)
@@ -16793,7 +16793,7 @@ function google.internal._gm_media_part(media: baml.media.Image | baml.media.Aud
         44   load_var2 10 11         
         45   init_instance 0         (google.internal.GmInlineData .mimeType, .data)
 
-  443   46   call 1223 ntypeargs=0   (google.internal.GmPart.of_inline_data)
+  443   46   call 1224 ntypeargs=0   (google.internal.GmPart.of_inline_data)
         47   jump +9                 (to 56)
 
   438   48   load_var 8              (_12)
@@ -16801,11 +16801,11 @@ function google.internal._gm_media_part(media: baml.media.Image | baml.media.Aud
 
   440   50   load_var 6              (resolved)
         51   load_field 2            (mime_type)
-        52   call 1235 ntypeargs=0   (google.internal._gm_mime_for_uri)
+        52   call 1236 ntypeargs=0   (google.internal._gm_mime_for_uri)
         53   load_var 9              (url)
         54   init_instance 1         (google.internal.GmFileData .mimeType, .fileUri)
 
-  439   55   call 1224 ntypeargs=0   (google.internal.GmPart.of_file_data)
+  439   55   call 1225 ntypeargs=0   (google.internal.GmPart.of_file_data)
         56   return                  
 }
 
@@ -16890,7 +16890,7 @@ function google.internal._gm_open_sse(req: baml.http.Request, provider: string) 
         4   throw_if_panic          
 
   953   5   load_var2 2 3           
-        6   call 1250 ntypeargs=0   (google.internal._gm_sse_failure)
+        6   call 1251 ntypeargs=0   (google.internal._gm_sse_failure)
         7   throw                   
         8   return                  
 }
@@ -16931,7 +16931,7 @@ function google.internal._gm_output_media(mime: string, data: string) -> ai.cont
 
   794   26   load_const 3           (<omitted>)
         27   load_const 3           (<omitted>)
-        28   call 913 ntypeargs=0   (ai.content.Media.new)
+        28   call 914 ntypeargs=0   (ai.content.Media.new)
         29   return                 
 }
 
@@ -16986,7 +16986,7 @@ function google.internal._gm_prompt_parts(message: ai.PromptMessage, fetch_url: 
         45   store_var_load_var 20              (pdf)
 
   470   46   load_var 2                         (fetch_url)
-        47   call 1236 ntypeargs=0              (google.internal._gm_media_part)
+        47   call 1237 ntypeargs=0              (google.internal._gm_media_part)
         48   store_var 21                       (_36)
         49   load_type 0                        
         50   load_var2 4 21                     
@@ -16998,7 +16998,7 @@ function google.internal._gm_prompt_parts(message: ai.PromptMessage, fetch_url: 
         55   store_var_load_var 18              (video)
 
   466   56   load_var 2                         (fetch_url)
-        57   call 1236 ntypeargs=0              (google.internal._gm_media_part)
+        57   call 1237 ntypeargs=0              (google.internal._gm_media_part)
         58   store_var 19                       (_31)
         59   load_type 0                        
         60   load_var2 4 19                     
@@ -17010,7 +17010,7 @@ function google.internal._gm_prompt_parts(message: ai.PromptMessage, fetch_url: 
         65   store_var_load_var 15              (audio)
 
   462   66   load_var 2                         (fetch_url)
-        67   call 1236 ntypeargs=0              (google.internal._gm_media_part)
+        67   call 1237 ntypeargs=0              (google.internal._gm_media_part)
         68   store_var 16                       (_25)
         69   load_type 0                        
         70   load_var2 4 16                     
@@ -17022,7 +17022,7 @@ function google.internal._gm_prompt_parts(message: ai.PromptMessage, fetch_url: 
         75   store_var_load_var 12              (image)
 
   458   76   load_var 2                         (fetch_url)
-        77   call 1236 ntypeargs=0              (google.internal._gm_media_part)
+        77   call 1237 ntypeargs=0              (google.internal._gm_media_part)
         78   store_var 13                       (_19)
         79   load_type 0                        
         80   load_var2 4 13                     
@@ -17033,7 +17033,7 @@ function google.internal._gm_prompt_parts(message: ai.PromptMessage, fetch_url: 
   452   84   load_var 8                         (_10)
         85   store_var_load_var 9               (text)
 
-  454   86   call 1222 ntypeargs=0              (google.internal.GmPart.of_text)
+  454   86   call 1223 ntypeargs=0              (google.internal.GmPart.of_text)
         87   store_var 10                       (_13)
         88   load_type 0                        
         89   load_var2 4 10                     
@@ -17076,7 +17076,7 @@ function google.internal._gm_sse_failure(provider: string, error: unknown) -> ai
         15    store_var 4             (_4)
 
   923   16    load_var 4              (_4)
-        17    call 938 ntypeargs=0    (ai.wire.redact_url_secrets)
+        17    call 939 ntypeargs=0    (ai.wire.redact_url_secrets)
         18    store_var 3             (text)
 
   927   19    load_const 2            ("failed with status ")
@@ -17185,7 +17185,7 @@ function google.internal._gm_sse_failure(provider: string, error: unknown) -> ai
   940   108   load_var2 1 17          
         109   load_var 19             (body)
         110   load_const 12           (<omitted>)
-        111   call 986 ntypeargs=0    (ai.errors.classify_http)
+        111   call 987 ntypeargs=0    (ai.errors.classify_http)
         112   return                  
 }
 
@@ -17217,7 +17217,7 @@ function google.internal._gm_strip_nulls(value: baml.json.json, opaque: bool) ->
         20   load_type 2                        
         21   load_type 3                        
         22   load_var 13                        (items)
-        23   make_closure 3326 0                
+        23   make_closure 3327 0                
         24   call 16 ntypeargs=3                (baml.Array.map)
         25   jump +52                           (to 77)
 
@@ -17262,10 +17262,10 @@ function google.internal._gm_strip_nulls(value: baml.json.json, opaque: bool) ->
         60   jump -20                           (to 40)
 
   282   61   load_var 8                         (key)
-        62   call 1227 ntypeargs=0              (google.internal._gm_is_opaque_key)
+        62   call 1228 ntypeargs=0              (google.internal._gm_is_opaque_key)
         63   store_var 11                       (_23)
         64   load_var2 9 11                     
-        65   call 1228 ntypeargs=0              (google.internal._gm_strip_nulls)
+        65   call 1229 ntypeargs=0              (google.internal._gm_strip_nulls)
         66   store_var 10                       (_21)
         67   load_type 4                        
         68   load_type 2                        
@@ -17288,7 +17288,7 @@ function google.internal._gm_tool_name_for(j: ai.Journal, id: string) -> string 
         1    store_var 3                        (name)
 
   561   2    load_var 1                         (j)
-        3    call 914 ntypeargs=0               (ai.Journal.entries)
+        3    call 915 ntypeargs=0               (ai.Journal.entries)
         4    load_type 1                        
         5    load_const 2                       ("iter")
         6    virtual_call nargs=1 ntypeargs=0   
@@ -17400,7 +17400,7 @@ function google.internal._gm_usage(usage: google.internal.GmUsageMetadata | null
 function google.internal._google_decode_batch(batch: string) -> (ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone)[] {
   1097   0   load_var 1              (batch)
          1   load_const 0            ("google")
-         2   call 1252 ntypeargs=0   (google.internal._gm_decode_batch)
+         2   call 1253 ntypeargs=0   (google.internal._gm_decode_batch)
          3   return                  
 }
 
@@ -17429,7 +17429,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
   1069   15   load_var 1                         (c)
          16   load_field 11                      (response_modalities)
 
-  1063   17   call 1232 ntypeargs=0              (google.internal._gm_generation_config)
+  1063   17   call 1233 ntypeargs=0              (google.internal._gm_generation_config)
          18   store_var 7                        (_6)
 
   1060   19   load_var2 2 6                      
@@ -17441,11 +17441,11 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
          23   load_field 3                       (request_body)
          24   load_const 2                       (<omitted>)
 
-  1060   25   call 1244 ntypeargs=0              (google.internal.gemini_build_body)
+  1060   25   call 1245 ntypeargs=0              (google.internal.gemini_build_body)
          26   store_var 5                        (body)
 
   1074   27   load_var 1                         (c)
-         28   call 1212 ntypeargs=0              (google.GoogleClient.resolved_base_url)
+         28   call 1213 ntypeargs=0              (google.GoogleClient.resolved_base_url)
          29   store_var_load_var 9               (_16)
          30   load_const 3                       (null)
          31   cmp_op ==                          
@@ -17465,7 +17465,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
          44   call 145 ntypeargs=1               (baml.String.from)
          45   store_var 12                       (_26)
          46   load_var 3                         (stream)
-         47   call 1245 ntypeargs=0              (google.internal.gemini_method)
+         47   call 1246 ntypeargs=0              (google.internal.gemini_method)
          48   store_var 14                       (_30)
          49   load_type 5                        
          50   load_var 14                        (_30)
@@ -17482,7 +17482,7 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
   1077   60   load_var 1                         (c)
          61   load_field 5                       (query_params)
 
-  1075   62   call 1230 ntypeargs=0              (google.internal._gm_apply_query)
+  1075   62   call 1231 ntypeargs=0              (google.internal._gm_apply_query)
          63   store_var 10                       (url)
 
   1079   64   load_const 7                       ("application/json")
@@ -17494,11 +17494,11 @@ function google.internal._google_request(c: google.GoogleClient, input: ai.Model
 
   1080   70   load_var 1                         (c)
          71   load_field 4                       (headers)
-         72   call 1231 ntypeargs=0              (google.internal._gm_apply_headers)
+         72   call 1232 ntypeargs=0              (google.internal._gm_apply_headers)
          73   store_var 16                       (with_user)
 
   1081   74   load_var 1                         (c)
-         75   call 1211 ntypeargs=0              (google.GoogleClient.resolved_api_key)
+         75   call 1212 ntypeargs=0              (google.GoogleClient.resolved_api_key)
          76   store_var 17                       (_38)
          77   load_type 5                        
          78   load_type 5                        
@@ -17560,7 +17560,7 @@ function google.internal._vertex_anthropic_body(c: google.VertexClient, input: a
 
   256   33   load_var2 4 1                      
         34   load_field 7                       (request_body)
-        35   call 943 ntypeargs=0               (ai.wire.merge_request_body)
+        35   call 944 ntypeargs=0               (ai.wire.merge_request_body)
         36   store_var 13                       (_15)
 
   257   37   load_var 1                         (c)
@@ -17579,7 +17579,7 @@ function google.internal._vertex_anthropic_body(c: google.VertexClient, input: a
         49   store_var_load_var 5               (params)
 
   259   50   load_var2 2 3                      
-        51   call 1194 ntypeargs=0              (anthropic.internal.anthropic_messages_body)
+        51   call 1195 ntypeargs=0              (anthropic.internal.anthropic_messages_body)
         52   return                             
 }
 
@@ -17620,7 +17620,7 @@ function google.internal._vertex_credentials(c: google.VertexClient) -> string |
        29   jump +39                (to 68)
 
   67   30   load_var 11             (from_env)
-       31   call 1259 ntypeargs=0   (google.internal._vertex_unwrap_json)
+       31   call 1260 ntypeargs=0   (google.internal._vertex_unwrap_json)
        32   jump +36                (to 68)
 
   52   33   load_var 4              (_7)
@@ -17658,32 +17658,32 @@ function google.internal._vertex_credentials(c: google.VertexClient) -> string |
        61   init_instance 0         (ai.errors.InvalidRequest .provider, .status_code, .detail, .raw_body)
        62   throw                   
 
-  63   63   call 1259 ntypeargs=0   (google.internal._vertex_unwrap_json)
+  63   63   call 1260 ntypeargs=0   (google.internal._vertex_unwrap_json)
        64   jump +4                 (to 68)
 
   49   65   load_var 2              (_3)
        66   store_var_load_var 3    (inline)
 
-  50   67   call 1259 ntypeargs=0   (google.internal._vertex_unwrap_json)
+  50   67   call 1260 ntypeargs=0   (google.internal._vertex_unwrap_json)
        68   return                  
 }
 
 function google.internal._vertex_decode_batch(batch: string) -> (ai.stream.TextDelta | ai.stream.TurnMeta | ai.stream.TurnDone)[] {
   342   0   load_var 1              (batch)
         1   load_const 0            ("vertex")
-        2   call 1252 ntypeargs=0   (google.internal._gm_decode_batch)
+        2   call 1253 ntypeargs=0   (google.internal._gm_decode_batch)
         3   return                  
 }
 
 function google.internal._vertex_express_key(c: google.VertexClient) -> string | null {
   77   0   load_var 1              (c)
-       1   call 1217 ntypeargs=0   (google.VertexClient.resolved_api_key)
+       1   call 1218 ntypeargs=0   (google.VertexClient.resolved_api_key)
        2   return                  
 }
 
 function google.internal._vertex_is_express(c: google.VertexClient) -> bool {
   87   0    load_var 1              (c)
-       1    call 1261 ntypeargs=0   (google.internal._vertex_express_key)
+       1    call 1262 ntypeargs=0   (google.internal._vertex_express_key)
        2    load_const 0            (null)
        3    call 679 ntypeargs=0    (baml.ops.equals_equals)
        4    unary_op !              
@@ -17691,7 +17691,7 @@ function google.internal._vertex_is_express(c: google.VertexClient) -> bool {
        6    jump +4                 (to 10)
        7    pop 1                   
        8    load_var 1              (c)
-       9    call 1262 ntypeargs=0   (google.internal._vertex_key_in_query)
+       9    call 1263 ntypeargs=0   (google.internal._vertex_key_in_query)
        10   return                  
 }
 
@@ -17714,36 +17714,35 @@ function google.internal._vertex_key_in_query(c: google.VertexClient) -> bool {
        2    load_const 0           (null)
        3    cmp_op ==              
        4    pop_jump_if_false +2   (to 6)
-       5    jump +9                (to 14)
-       6    load_type 1            
-       7    load_type 1            
-       8    load_var 1             (c)
-       9    load_field 9           (query_params)
-       10   load_const 2           ("key")
-       11   call 38 ntypeargs=2    (baml.Map.get)
-       12   store_var 3            (_2)
-       13   jump +3                (to 16)
-       14   load_const 0           (null)
-       15   store_var 3            (_2)
-       16   load_var 3             (_2)
-       17   load_const 0           (null)
-       18   call 679 ntypeargs=0   (baml.ops.equals_equals)
-       19   unary_op !             
-       20   store_var 2            (_0)
-       21   load_var 2             (_0)
-       22   return                 
+       5    jump +8                (to 13)
+       6    load_const 1           ("key")
+       7    load_var 1             (c)
+       8    load_field 9           (query_params)
+       9    make_bound_method 38   
+       10   call_indirect          
+       11   store_var 3            (_2)
+       12   jump +3                (to 15)
+       13   load_const 0           (null)
+       14   store_var 3            (_2)
+       15   load_var 3             (_2)
+       16   load_const 0           (null)
+       17   call 679 ntypeargs=0   (baml.ops.equals_equals)
+       18   unary_op !             
+       19   store_var 2            (_0)
+       20   load_var 2             (_0)
+       21   return                 
 }
 
 function google.internal._vertex_method(c: google.VertexClient, stream: bool) -> string {
   202   0    load_var 1              (c)
-        1    call 1266 ntypeargs=0   (google.internal._vertex_publisher)
+        1    call 1267 ntypeargs=0   (google.internal._vertex_publisher)
         2    load_const 0            ("anthropic")
         3    cmp_op ==               
         4    pop_jump_if_false +2    (to 6)
         5    jump +4                 (to 9)
 
   209   6    load_var 2              (stream)
-        7    call 1245 ntypeargs=0   (google.internal.gemini_method)
+        7    call 1246 ntypeargs=0   (google.internal.gemini_method)
         8    jump +7                 (to 15)
 
   203   9    load_var 2              (stream)
@@ -17760,7 +17759,7 @@ function google.internal._vertex_method(c: google.VertexClient, stream: bool) ->
 
 function google.internal._vertex_models_base(c: google.VertexClient) -> string {
   168   0     load_var 1              (c)
-        1     call 1218 ntypeargs=0   (google.VertexClient.resolved_base_url)
+        1     call 1219 ntypeargs=0   (google.VertexClient.resolved_base_url)
         2     store_var 2             (_3)
         3     load_var 2              (_3)
         4     narrow_bind 0 2         
@@ -17768,11 +17767,11 @@ function google.internal._vertex_models_base(c: google.VertexClient) -> string {
         6     jump +99                (to 105)
 
   171   7     load_var 1              (c)
-        8     call 1266 ntypeargs=0   (google.internal._vertex_publisher)
+        8     call 1267 ntypeargs=0   (google.internal._vertex_publisher)
         9     store_var 4             (publisher)
 
   172   10    load_var 1              (c)
-        11    call 1264 ntypeargs=0   (google.internal.vertex_location)
+        11    call 1265 ntypeargs=0   (google.internal.vertex_location)
         12    store_var 5             (location)
 
   173   13    load_var 5              (location)
@@ -17782,7 +17781,7 @@ function google.internal._vertex_models_base(c: google.VertexClient) -> string {
         17    jump +23                (to 40)
 
   175   18    load_var 5              (location)
-        19    call 1267 ntypeargs=0   (google.internal._vertex_is_multi_region)
+        19    call 1268 ntypeargs=0   (google.internal._vertex_is_multi_region)
         20    pop_jump_if_false +2    (to 22)
         21    jump +8                 (to 29)
 
@@ -17812,7 +17811,7 @@ function google.internal._vertex_models_base(c: google.VertexClient) -> string {
         41    store_var 6             (host)
 
   182   42    load_var 1              (c)
-        43    call 1265 ntypeargs=0   (google.internal.vertex_project_id)
+        43    call 1266 ntypeargs=0   (google.internal.vertex_project_id)
 
   183   44    store_var 8             (_20)
         45    load_var 8              (_20)
@@ -17821,7 +17820,7 @@ function google.internal._vertex_models_base(c: google.VertexClient) -> string {
         48    jump +21                (to 69)
 
   185   49    load_var 1              (c)
-        50    call 1263 ntypeargs=0   (google.internal._vertex_is_express)
+        50    call 1264 ntypeargs=0   (google.internal._vertex_is_express)
         51    pop_jump_if_false +2    (to 53)
         52    jump +7                 (to 59)
 
@@ -17908,7 +17907,7 @@ function google.internal._vertex_publisher(c: google.VertexClient) -> string {
 
 function google.internal._vertex_request(c: google.VertexClient, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
   274   0     load_var 1                         (c)
-        1     call 1266 ntypeargs=0              (google.internal._vertex_publisher)
+        1     call 1267 ntypeargs=0              (google.internal._vertex_publisher)
         2     load_const 0                       ("anthropic")
         3     cmp_op ==                          
         4     pop_jump_if_false +2               (to 6)
@@ -17938,7 +17937,7 @@ function google.internal._vertex_request(c: google.VertexClient, input: ai.Model
   286   21    load_var 1                         (c)
         22    load_field 15                      (response_modalities)
 
-  280   23    call 1232 ntypeargs=0              (google.internal._gm_generation_config)
+  280   23    call 1233 ntypeargs=0              (google.internal._gm_generation_config)
         24    store_var 6                        (_8)
 
   277   25    load_var2 2 5                      
@@ -17950,17 +17949,17 @@ function google.internal._vertex_request(c: google.VertexClient, input: ai.Model
         29    load_field 7                       (request_body)
         30    load_const 3                       (false)
 
-  277   31    call 1244 ntypeargs=0              (google.internal.gemini_build_body)
+  277   31    call 1245 ntypeargs=0              (google.internal.gemini_build_body)
         32    store_var 4                        (body)
         33    jump +5                            (to 38)
 
   275   34    load_var2 1 2                      
         35    load_var 3                         (stream)
-        36    call 1271 ntypeargs=0              (google.internal._vertex_anthropic_body)
+        36    call 1272 ntypeargs=0              (google.internal._vertex_anthropic_body)
         37    store_var 4                        (body)
 
   297   38    load_var2 1 3                      
-        39    call 1270 ntypeargs=0              (google.internal.vertex_url)
+        39    call 1271 ntypeargs=0              (google.internal.vertex_url)
         40    store_var 7                        (url)
 
   298   41    load_const 4                       ("application/json")
@@ -17972,22 +17971,22 @@ function google.internal._vertex_request(c: google.VertexClient, input: ai.Model
 
   299   47    load_var 1                         (c)
         48    load_field 8                       (headers)
-        49    call 1231 ntypeargs=0              (google.internal._gm_apply_headers)
+        49    call 1232 ntypeargs=0              (google.internal._gm_apply_headers)
         50    store_var 9                        (with_user)
 
   300   51    load_var 1                         (c)
-        52    call 1263 ntypeargs=0              (google.internal._vertex_is_express)
+        52    call 1264 ntypeargs=0              (google.internal._vertex_is_express)
         53    pop_jump_if_false +2               (to 55)
         54    jump +64                           (to 118)
 
   304   55    load_var 1                         (c)
-        56    call 1260 ntypeargs=0              (google.internal._vertex_credentials)
+        56    call 1261 ntypeargs=0              (google.internal._vertex_credentials)
         57    store_var 10                       (credentials)
 
-  305   58    call 1258 ntypeargs=0              (google.internal._vertex_scope)
+  305   58    call 1259 ntypeargs=0              (google.internal._vertex_scope)
         59    store_var 13                       (_27)
         60    load_var2 10 13                    
-        61    call 1277 ntypeargs=0              (google.internal.gcp_access_token)
+        61    call 1278 ntypeargs=0              (google.internal.gcp_access_token)
         62    store_var 11                       (token)
         63    jump +19                           (to 82)
         64    load_var 12                        (e)
@@ -18036,7 +18035,7 @@ function google.internal._vertex_request(c: google.VertexClient, input: ai.Model
         102   pop_jump_if_false +16              (to 118)
 
   319   103   load_var 10                        (credentials)
-        104   call 1279 ntypeargs=0              (google.internal.gcp_quota_project_id)
+        104   call 1280 ntypeargs=0              (google.internal.gcp_quota_project_id)
         105   store_var 17                       (_47)
         106   load_var 17                        (_47)
         107   narrow_bind 14 17                  
@@ -18094,19 +18093,19 @@ function google.internal._vertex_unwrap_json(document: string) -> string {
 
 function google.internal.gcp_access_token(credentials_json: string | null, scope: string) -> string {
   25   0   load_var2 1 2   
-       1   sys_op 989      (ai.internal._gcp_access_token)
+       1   sys_op 990      (ai.internal._gcp_access_token)
        2   return          
 }
 
 function google.internal.gcp_project_id(credentials_json: string | null) -> string | null {
   33   0   load_var 1   (credentials_json)
-       1   sys_op 990   (ai.internal._gcp_project_id)
+       1   sys_op 991   (ai.internal._gcp_project_id)
        2   return       
 }
 
 function google.internal.gcp_quota_project_id(credentials_json: string | null) -> string | null {
   40   0   load_var 1   (credentials_json)
-       1   sys_op 991   (ai.internal._gcp_quota_project_id)
+       1   sys_op 992   (ai.internal._gcp_quota_project_id)
        2   return       
 }
 
@@ -18124,12 +18123,12 @@ function google.internal.gemini_build_body(input: ai.ModelTurnInput, client_id: 
         8     store_var 7                        (_9)
         9     load_var 1                         (input)
         10    load_field 3                       (output_type)
-        11    call 941 ntypeargs=0               (ai.wire.render_output_format)
+        11    call 942 ntypeargs=0               (ai.wire.render_output_format)
         12    load_var 7                         (_9)
         13    call_indirect                      
 
   699   14    load_var 6                         (fetch_url)
-        15    call 1238 ntypeargs=0              (google.internal.google_lower_prompt)
+        15    call 1239 ntypeargs=0              (google.internal.google_lower_prompt)
         16    store_var 8                        (lowered)
 
   700   17    load_var 8                         (lowered)
@@ -18139,9 +18138,9 @@ function google.internal.gemini_build_body(input: ai.ModelTurnInput, client_id: 
   701   20    load_var 1                         (input)
         21    load_field 1                       (journal)
         22    load_var 2                         (client_id)
-        23    call 944 ntypeargs=0               (ai.wire.sanitize_for_client)
+        23    call 945 ntypeargs=0               (ai.wire.sanitize_for_client)
 
-  702   24    call 1243 ntypeargs=0              (google.internal.google_lower_journal)
+  702   24    call 1244 ntypeargs=0              (google.internal.google_lower_journal)
         25    load_type 2                        
         26    load_const 3                       ("iter")
         27    virtual_call nargs=1 ntypeargs=0   
@@ -18250,7 +18249,7 @@ function google.internal.gemini_build_body(input: ai.ModelTurnInput, client_id: 
 
   736   119   load_var 1                         (input)
         120   load_field 2                       (toolbox)
-        121   call 933 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        121   call 934 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         122   unary_op !                         
         123   pop_jump_if_false +42              (to 165)
 
@@ -18260,7 +18259,7 @@ function google.internal.gemini_build_body(input: ai.ModelTurnInput, client_id: 
 
   738   127   load_var 1                         (input)
         128   load_field 2                       (toolbox)
-        129   call 931 ntypeargs=0               (ai.tools.Toolbox.list)
+        129   call 932 ntypeargs=0               (ai.tools.Toolbox.list)
         130   load_type 14                       
         131   load_const 15                      ("iter")
         132   virtual_call nargs=1 ntypeargs=0   
@@ -18316,10 +18315,10 @@ function google.internal.gemini_build_body(input: ai.ModelTurnInput, client_id: 
         171   load_var 25                        (request)
         172   call 362 ntypeargs=1               (baml.json.to_json)
         173   load_const 21                      (false)
-        174   call 1228 ntypeargs=0              (google.internal._gm_strip_nulls)
+        174   call 1229 ntypeargs=0              (google.internal._gm_strip_nulls)
 
   765   175   load_var 5                         (request_body)
-        176   call 943 ntypeargs=0               (ai.wire.merge_request_body)
+        176   call 944 ntypeargs=0               (ai.wire.merge_request_body)
         177   call 358 ntypeargs=0               (baml.json.stringify)
         178   return                             
 
@@ -18334,36 +18333,36 @@ function google.internal.gemini_build_body(input: ai.ModelTurnInput, client_id: 
 function google.internal.gemini_invoke(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   1090   0    load_var 2              (input)
          1    load_field 1            (journal)
-         2    call 914 ntypeargs=0    (ai.Journal.entries)
+         2    call 915 ntypeargs=0    (ai.Journal.entries)
          3    container_len           
          4    store_var 3             (seq)
 
   1091   5    load_var2 1 2           
-         6    call 1253 ntypeargs=0   (google.internal.google_render)
+         6    call 1254 ntypeargs=0   (google.internal.google_render)
          7    store_var 4             (req)
 
   1092   8    load_type 0             
          9    load_var 4              (req)
          10   load_const 1            ("google")
-         11   call 940 ntypeargs=1    (ai.wire.send_as)
+         11   call 941 ntypeargs=1    (ai.wire.send_as)
 
   1093   12   load_var 3              (seq)
          13   load_const 2            (<omitted>)
-         14   call 1249 ntypeargs=0   (google.internal.google_parse)
+         14   call 1250 ntypeargs=0   (google.internal.google_parse)
          15   return                  
 }
 
 function google.internal.gemini_invoke_stream(c: google.GoogleClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   1106   0   load_var2 1 2           
          1   load_const 0            (true)
-         2   call 1254 ntypeargs=0   (google.internal._google_request)
+         2   call 1255 ntypeargs=0   (google.internal._google_request)
 
   1110   3   load_const 1            ("google")
-         4   call 1251 ntypeargs=0   (google.internal._gm_open_sse)
+         4   call 1252 ntypeargs=0   (google.internal._gm_open_sse)
 
   1109   5   load_const 2            (google.internal._google_decode_batch)
          6   load_const 3            ("google")
-         7   call 968 ntypeargs=0    (ai.stream.TurnStream.from_sse)
+         7   call 969 ntypeargs=0    (ai.stream.TurnStream.from_sse)
          8   return                  
 }
 
@@ -18390,7 +18389,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> google.internal.
         5     store_var 4                        (pending)
 
   592   6     load_var 1                         (j)
-        7     call 914 ntypeargs=0               (ai.Journal.entries)
+        7     call 915 ntypeargs=0               (ai.Journal.entries)
         8     load_type 2                        
         9     load_const 3                       ("iter")
         10    virtual_call nargs=1 ntypeargs=0   
@@ -18449,11 +18448,11 @@ function google.internal.google_lower_journal(j: ai.Journal) -> google.internal.
 
   662   60    load_var2 1 33                     
         61    load_field 0                       (id)
-        62    call 1242 ntypeargs=0              (google.internal._gm_tool_name_for)
+        62    call 1243 ntypeargs=0              (google.internal._gm_tool_name_for)
         63    load_var 34                        (response)
         64    init_instance 0                    (google.internal.GmFunctionResponse .name, .response)
 
-  661   65    call 1226 ntypeargs=0              (google.internal.GmPart.of_function_response)
+  661   65    call 1227 ntypeargs=0              (google.internal.GmPart.of_function_response)
         66    store_var 35                       (_83)
 
   660   67    load_type 1                        
@@ -18481,11 +18480,11 @@ function google.internal.google_lower_journal(j: ai.Journal) -> google.internal.
 
   652   86    load_var2 1 29                     
         87    load_field 0                       (id)
-        88    call 1242 ntypeargs=0              (google.internal._gm_tool_name_for)
+        88    call 1243 ntypeargs=0              (google.internal._gm_tool_name_for)
         89    load_var 30                        (response)
         90    init_instance 1                    (google.internal.GmFunctionResponse .name, .response)
 
-  651   91    call 1226 ntypeargs=0              (google.internal.GmPart.of_function_response)
+  651   91    call 1227 ntypeargs=0              (google.internal.GmPart.of_function_response)
         92    store_var 31                       (_69)
 
   650   93    load_type 1                        
@@ -18561,11 +18560,11 @@ function google.internal.google_lower_journal(j: ai.Journal) -> google.internal.
 
   627   155   load_var 23                        (use)
         156   load_field 0                       (id)
-        157   call 1241 ntypeargs=0              (google.internal._gm_call_id_signature)
+        157   call 1242 ntypeargs=0              (google.internal._gm_call_id_signature)
         158   store_var 26                       (_52)
 
   625   159   load_var2 25 26                    
-        160   call 1225 ntypeargs=0              (google.internal.GmPart.of_function_call)
+        160   call 1226 ntypeargs=0              (google.internal.GmPart.of_function_call)
         161   store_var 24                       (_48)
 
   624   162   load_type 1                        
@@ -18578,7 +18577,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> google.internal.
         168   store_var_load_var 20              (t)
 
   617   169   load_field 0                       (text)
-        170   call 1222 ntypeargs=0              (google.internal.GmPart.of_text)
+        170   call 1223 ntypeargs=0              (google.internal.GmPart.of_text)
         171   store_var 21                       (_42)
         172   load_type 1                        
         173   load_var2 15 21                    
@@ -18628,7 +18627,7 @@ function google.internal.google_lower_journal(j: ai.Journal) -> google.internal.
 
   602   211   load_var 9                         (u)
         212   load_field 0                       (content)
-        213   call 1222 ntypeargs=0              (google.internal.GmPart.of_text)
+        213   call 1223 ntypeargs=0              (google.internal.GmPart.of_text)
         214   store_var 11                       (_21)
         215   load_type 0                        
         216   load_var 3                         (contents)
@@ -18681,7 +18680,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt, fetch_url: bool)
         11   store_var 5                        (contents)
 
   492   12   load_var 1                         (prompt)
-        13   call 919 ntypeargs=0               (ai.Prompt.messages)
+        13   call 920 ntypeargs=0               (ai.Prompt.messages)
         14   load_type 4                        
         15   load_const 5                       ("iter")
         16   virtual_call nargs=1 ntypeargs=0   
@@ -18699,7 +18698,7 @@ function google.internal.google_lower_prompt(prompt: ai.Prompt, fetch_url: bool)
         28   store_var_load_var 8               (message)
 
   493   29   load_var 2                         (fetch_url)
-        30   call 1237 ntypeargs=0              (google.internal._gm_prompt_parts)
+        30   call 1238 ntypeargs=0              (google.internal._gm_prompt_parts)
         31   store_var 9                        (parts)
 
   494   32   load_var 8                         (message)
@@ -18795,11 +18794,11 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         23    cmp_op ==                          
         24    pop_jump_if_false +2               (to 26)
         25    jump +8                            (to 33)
-        26    load_type 7                        
+        26    load_const 5                       (0)
         27    load_var 1                         (resp)
         28    load_field 0                       (candidates)
-        29    load_const 5                       (0)
-        30    call 3 ntypeargs=1                 (baml.Array.at)
+        29    make_bound_method 3                
+        30    call_indirect                      
         31    store_var 13                       (cand)
         32    jump +3                            (to 35)
         33    load_const 6                       (null)
@@ -18818,7 +18817,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         45    load_const 6                       (null)
         46    cmp_op ==                          
         47    pop_jump_if_false +3               (to 50)
-        48    load_const 8                       ("")
+        48    load_const 7                       ("")
         49    store_var 15                       (_28)
         50    load_var 15                        (_28)
         51    store_var 14                       (finish)
@@ -18848,23 +18847,23 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         74    load_const 6                       (null)
         75    cmp_op ==                          
         76    pop_jump_if_false +4               (to 80)
-        77    load_type 9                        
+        77    load_type 8                        
         78    alloc_array 0                      
         79    store_var 17                       (_35)
         80    load_var 17                        (_35)
         81    store_var_load_var 16              (parts)
 
-  851   82    load_type 10                       
-        83    load_const 11                      ("iter")
+  851   82    load_type 9                        
+        83    load_const 10                      ("iter")
         84    virtual_call nargs=1 ntypeargs=0   
         85    store_var 18                       (_48)
         86    load_var 18                        (_48)
-        87    load_type 12                       
-        88    load_const 13                      ("next")
+        87    load_type 11                       
+        88    load_const 12                      ("next")
         89    virtual_call nargs=1 ntypeargs=0   
         90    store_var 19                       (_49)
         91    load_var 19                        (_49)
-        92    is_type 14                         
+        92    is_type 13                         
         93    pop_jump_if_false +2               (to 95)
         94    jump +124                          (to 218)
         95    load_var 19                        (_49)
@@ -18873,7 +18872,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
   852   97    load_field 3                       (functionCall)
         98    store_var 21                       (_54)
         99    load_var 21                        (_54)
-        100   narrow_bind 15 21                  
+        100   narrow_bind 14 21                  
         101   pop_jump_if_false +2               (to 103)
         102   jump +66                           (to 168)
 
@@ -18881,7 +18880,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         104   load_field 4                       (inlineData)
         105   store_var 29                       (_76)
         106   load_var 29                        (_76)
-        107   narrow_bind 16 29                  
+        107   narrow_bind 15 29                  
         108   pop_jump_if_false +2               (to 110)
         109   jump +32                           (to 141)
 
@@ -18889,7 +18888,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         111   load_field 0                       (text)
         112   store_var 35                       (_90)
         113   load_var 35                        (_90)
-        114   narrow_bind 17 35                  
+        114   narrow_bind 16 35                  
         115   pop_jump_if_false -29              (to 86)
         116   load_var 35                        (_90)
         117   store_var 36                       (t)
@@ -18928,7 +18927,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         145   load_const 6                       (null)
         146   cmp_op ==                          
         147   pop_jump_if_false +3               (to 150)
-        148   load_const 18                      ("image/png")
+        148   load_const 17                      ("image/png")
         149   store_var 33                       (_81)
         150   load_var 33                        (_81)
         151   store_var 32                       (_80)
@@ -18938,10 +18937,10 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         155   load_const 6                       (null)
         156   cmp_op ==                          
         157   pop_jump_if_false +3               (to 160)
-        158   load_const 19                      ("")
+        158   load_const 18                      ("")
         159   store_var 34                       (_85)
         160   load_var2 32 34                    
-        161   call 1246 ntypeargs=0              (google.internal._gm_output_media)
+        161   call 1247 ntypeargs=0              (google.internal._gm_output_media)
         162   store_var 31                       (_79)
 
   869   163   load_type 3                        
@@ -18953,8 +18952,8 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
   852   168   load_var 21                        (_54)
         169   store_var 22                       (fc)
 
-  853   170   load_type 20                       
-        171   load_type 21                       
+  853   170   load_type 19                       
+        171   load_type 20                       
         172   alloc_map 0                        
         173   store_var 23                       (args)
 
@@ -18962,7 +18961,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         175   load_field 1                       (args)
         176   store_var 24                       (_58)
         177   load_var 24                        (_58)
-        178   narrow_bind 22 24                  
+        178   narrow_bind 21 24                  
         179   pop_jump_if_false +5               (to 184)
         180   load_var 24                        (_58)
         181   store_var 25                       (a)
@@ -18970,24 +18969,24 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
   855   182   load_var 25                        (a)
         183   store_var 23                       (args)
 
-  859   184   load_type 23                       
+  859   184   load_type 22                       
         185   load_var 2                         (seq)
         186   call 145 ntypeargs=1               (baml.String.from)
         187   store_var 27                       (_66)
-        188   load_type 23                       
+        188   load_type 22                       
         189   load_var 12                        (call_index)
         190   call 145 ntypeargs=1               (baml.String.from)
         191   store_var 28                       (_68)
-        192   load_const 24                      ("call_")
+        192   load_const 23                      ("call_")
         193   load_var 27                        (_66)
         194   bin_op +                           
-        195   load_const 25                      ("_")
+        195   load_const 24                      ("_")
         196   bin_op +                           
         197   load_var 28                        (_68)
         198   bin_op +                           
         199   load_var 20                        (p)
         200   load_field 2                       (thoughtSignature)
-        201   call 1240 ntypeargs=0              (google.internal._gm_encode_call_id)
+        201   call 1241 ntypeargs=0              (google.internal._gm_encode_call_id)
         202   store_var 26                       (_62)
 
   857   203   load_type 3                        
@@ -19003,11 +19002,11 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         210   pop 1                              
 
   864   211   load_var 12                        (call_index)
-        212   load_const 17                      (1)
+        212   load_const 16                      (1)
         213   add_int                            
         214   store_var 12                       (call_index)
 
-  865   215   load_const 26                      (true)
+  865   215   load_const 25                      (true)
         216   store_var 11                       (has_call)
 
   852   217   jump -131                          (to 86)
@@ -19037,7 +19036,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         239   jump_if_false +5                   (to 244)
         240   pop 1                              
         241   load_var 14                        (finish)
-        242   load_const 27                      ("")
+        242   load_const 26                      ("")
         243   cmp_op ==                          
         244   jump_if_false +4                   (to 248)
         245   pop 1                              
@@ -19051,7 +19050,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         252   jump +23                           (to 275)
 
   901   253   load_var 14                        (finish)
-        254   load_const 28                      ("MAX_TOKENS")
+        254   load_const 27                      ("MAX_TOKENS")
         255   cmp_op ==                          
         256   pop_jump_if_false +2               (to 258)
         257   jump +15                           (to 272)
@@ -19061,7 +19060,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         260   jump +4                            (to 264)
         261   pop 1                              
         262   load_var 14                        (finish)
-        263   call 1247 ntypeargs=0              (google.internal._gm_is_blocked)
+        263   call 1248 ntypeargs=0              (google.internal._gm_is_blocked)
         264   pop_jump_if_false +2               (to 266)
         265   jump +4                            (to 269)
 
@@ -19070,23 +19069,23 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
 
   903   268   jump +9                            (to 277)
 
-  904   269   load_const 29                      (ai.content.StopReason.Refused)
+  904   269   load_const 28                      (ai.content.StopReason.Refused)
         270   alloc_variant 774                  (ai.content.StopReason)
 
   903   271   jump +6                            (to 277)
 
-  902   272   load_const 30                      (ai.content.StopReason.MaxTokens)
+  902   272   load_const 29                      (ai.content.StopReason.MaxTokens)
         273   alloc_variant 774                  (ai.content.StopReason)
 
   901   274   jump +3                            (to 277)
 
-  900   275   load_const 17                      (ai.content.StopReason.ToolUse)
+  900   275   load_const 16                      (ai.content.StopReason.ToolUse)
         276   alloc_variant 774                  (ai.content.StopReason)
 
   908   277   store_var 41                       (_128)
         278   load_var 1                         (resp)
         279   load_field 1                       (usageMetadata)
-        280   call 1248 ntypeargs=0              (google.internal._gm_usage)
+        280   call 1249 ntypeargs=0              (google.internal._gm_usage)
         281   store_var 42                       (_129)
         282   load_var2 10 41                    
         283   load_var 42                        (_129)
@@ -19095,7 +19094,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         286   load_var 4                         (_0)
         287   return                             
 
-  896   288   load_type 31                       
+  896   288   load_type 30                       
         289   load_var 1                         (resp)
         290   call 362 ntypeargs=1               (baml.json.to_json)
         291   call 358 ntypeargs=0               (baml.json.stringify)
@@ -19124,7 +19123,7 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
         310   load_const 6                       (null)
         311   cmp_op ==                          
         312   pop_jump_if_false +6               (to 318)
-        313   load_type 31                       
+        313   load_type 30                       
         314   load_var 1                         (resp)
         315   call 362 ntypeargs=1               (baml.json.to_json)
         316   call 358 ntypeargs=0               (baml.json.stringify)
@@ -19135,24 +19134,24 @@ function google.internal.google_parse(resp: google.internal.GmResponse, seq: int
   842   319   load_var 9                         (_14)
         320   load_const 0                       (<omitted>)
 
-  839   321   call 986 ntypeargs=0               (ai.errors.classify_http)
+  839   321   call 987 ntypeargs=0               (ai.errors.classify_http)
         322   throw                              
 }
 
 function google.internal.google_render(c: google.GoogleClient, input: ai.ModelTurnInput) -> baml.http.Request {
   1050   0   load_var2 1 2           
          1   load_const 0            (false)
-         2   call 1254 ntypeargs=0   (google.internal._google_request)
+         2   call 1255 ntypeargs=0   (google.internal._google_request)
          3   return                  
 }
 
 function google.internal.vertex_invoke(c: google.VertexClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   331   0    load_var2 1 2           
-        1    call 1272 ntypeargs=0   (google.internal.vertex_render)
+        1    call 1273 ntypeargs=0   (google.internal.vertex_render)
         2    store_var 3             (req)
 
   332   3    load_var 1              (c)
-        4    call 1266 ntypeargs=0   (google.internal._vertex_publisher)
+        4    call 1267 ntypeargs=0   (google.internal._vertex_publisher)
         5    load_const 0            ("anthropic")
         6    cmp_op ==               
         7    pop_jump_if_false +2    (to 9)
@@ -19160,26 +19159,26 @@ function google.internal.vertex_invoke(c: google.VertexClient, input: ai.ModelTu
 
   336   9    load_var 2              (input)
         10   load_field 1            (journal)
-        11   call 914 ntypeargs=0    (ai.Journal.entries)
+        11   call 915 ntypeargs=0    (ai.Journal.entries)
         12   container_len           
         13   store_var 4             (seq)
 
   337   14   load_type 1             
         15   load_var 3              (req)
         16   load_const 2            ("vertex")
-        17   call 940 ntypeargs=1    (ai.wire.send_as)
+        17   call 941 ntypeargs=1    (ai.wire.send_as)
 
   338   18   load_var 4              (seq)
         19   load_const 3            ("vertex")
-        20   call 1249 ntypeargs=0   (google.internal.google_parse)
+        20   call 1250 ntypeargs=0   (google.internal.google_parse)
         21   jump +6                 (to 27)
 
   333   22   load_type 4             
         23   load_var 3              (req)
         24   load_const 5            ("vertex")
-        25   call 940 ntypeargs=1    (ai.wire.send_as)
+        25   call 941 ntypeargs=1    (ai.wire.send_as)
 
-  334   26   call 1200 ntypeargs=0   (anthropic.internal.anthropic_parse)
+  334   26   call 1201 ntypeargs=0   (anthropic.internal.anthropic_parse)
         27   return                  
 }
 
@@ -19190,14 +19189,14 @@ function google.internal.vertex_invoke_stream(c: google.VertexClient, input: ai.
 
   353   3    load_var2 1 2           
         4    load_const 0            (true)
-        5    call 1273 ntypeargs=0   (google.internal._vertex_request)
+        5    call 1274 ntypeargs=0   (google.internal._vertex_request)
 
   354   6    load_const 1            ("vertex")
-        7    call 1251 ntypeargs=0   (google.internal._gm_open_sse)
+        7    call 1252 ntypeargs=0   (google.internal._gm_open_sse)
         8    store_var 3             (sse)
 
   359   9    load_var 1              (c)
-        10   call 1266 ntypeargs=0   (google.internal._vertex_publisher)
+        10   call 1267 ntypeargs=0   (google.internal._vertex_publisher)
         11   load_const 2            ("anthropic")
         12   cmp_op ==               
         13   pop_jump_if_false +2    (to 15)
@@ -19206,18 +19205,18 @@ function google.internal.vertex_invoke_stream(c: google.VertexClient, input: ai.
   369   15   load_var 3              (sse)
         16   load_const 3            (google.internal._vertex_decode_batch)
         17   load_const 4            ("vertex")
-        18   call 968 ntypeargs=0    (ai.stream.TurnStream.from_sse)
+        18   call 969 ntypeargs=0    (ai.stream.TurnStream.from_sse)
         19   jump +7                 (to 26)
 
-  360   20   call 1202 ntypeargs=0   (anthropic.internal.AnthStreamState.new)
+  360   20   call 1203 ntypeargs=0   (anthropic.internal.AnthStreamState.new)
         21   store_deref 4           
 
   362   22   load_var2 3 4           
 
-  363   23   make_closure 3565 1     
+  363   23   make_closure 3566 1     
         24   load_const 5            ("vertex")
 
-  361   25   call 968 ntypeargs=0    (ai.stream.TurnStream.from_sse)
+  361   25   call 969 ntypeargs=0    (ai.stream.TurnStream.from_sse)
         26   return                  
 }
 
@@ -19290,7 +19289,7 @@ function google.internal.vertex_project_id(c: google.VertexClient) -> string | n
         6    jump +45                (to 51)
 
   130   7    load_var 1              (c)
-        8    call 1263 ntypeargs=0   (google.internal._vertex_is_express)
+        8    call 1264 ntypeargs=0   (google.internal._vertex_is_express)
         9    pop_jump_if_false +2    (to 11)
         10   jump +39                (to 49)
 
@@ -19327,8 +19326,8 @@ function google.internal.vertex_project_id(c: google.VertexClient) -> string | n
         38   jump +5                 (to 43)
 
   143   39   load_var 1              (c)
-        40   call 1260 ntypeargs=0   (google.internal._vertex_credentials)
-        41   call 1278 ntypeargs=0   (google.internal.gcp_project_id)
+        40   call 1261 ntypeargs=0   (google.internal._vertex_credentials)
+        41   call 1279 ntypeargs=0   (google.internal.gcp_project_id)
         42   jump +12                (to 54)
 
   140   43   load_var 7              (legacy)
@@ -19352,13 +19351,13 @@ function google.internal.vertex_project_id(c: google.VertexClient) -> string | n
 function google.internal.vertex_render(c: google.VertexClient, input: ai.ModelTurnInput) -> baml.http.Request {
   264   0   load_var2 1 2           
         1   load_const 0            (false)
-        2   call 1273 ntypeargs=0   (google.internal._vertex_request)
+        2   call 1274 ntypeargs=0   (google.internal._vertex_request)
         3   return                  
 }
 
 function google.internal.vertex_url(c: google.VertexClient, stream: bool) -> string {
   216   0    load_var 1              (c)
-        1    call 1268 ntypeargs=0   (google.internal._vertex_models_base)
+        1    call 1269 ntypeargs=0   (google.internal._vertex_models_base)
         2    store_var 5             (_8)
         3    load_type 0             
         4    load_var 5              (_8)
@@ -19370,7 +19369,7 @@ function google.internal.vertex_url(c: google.VertexClient, stream: bool) -> str
         10   call 145 ntypeargs=1    (baml.String.from)
         11   store_var 6             (_10)
         12   load_var2 1 2           
-        13   call 1269 ntypeargs=0   (google.internal._vertex_method)
+        13   call 1270 ntypeargs=0   (google.internal._vertex_method)
         14   store_var 8             (_14)
         15   load_type 0             
         16   load_var 8              (_14)
@@ -19387,11 +19386,11 @@ function google.internal.vertex_url(c: google.VertexClient, stream: bool) -> str
   217   26   load_var 1              (c)
         27   load_field 9            (query_params)
 
-  215   28   call 1230 ntypeargs=0   (google.internal._gm_apply_query)
+  215   28   call 1231 ntypeargs=0   (google.internal._gm_apply_query)
         29   store_var 3             (with_params)
 
   219   30   load_var 1              (c)
-        31   call 1261 ntypeargs=0   (google.internal._vertex_express_key)
+        31   call 1262 ntypeargs=0   (google.internal._vertex_express_key)
         32   store_var 9             (_18)
         33   load_var 9              (_18)
         34   narrow_bind 2 9         
@@ -19411,7 +19410,7 @@ function google.internal.vertex_url(c: google.VertexClient, stream: bool) -> str
         45   store_var 11            (params)
 
   221   46   load_var2 3 11          
-        47   call 1230 ntypeargs=0   (google.internal._gm_apply_query)
+        47   call 1231 ntypeargs=0   (google.internal._gm_apply_query)
         48   return                  
 }
 
@@ -19431,40 +19430,40 @@ function openai.AzureClient.ai.Client.id(self: openai.AzureClient) -> string {
 
 function openai.AzureClient.ai.Client.invoke(self: openai.AzureClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   191   0    load_var 1              (self)
-        1    call 1080 ntypeargs=0   (openai.AzureClient.compat)
+        1    call 1081 ntypeargs=0   (openai.AzureClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1081 ntypeargs=0   (openai.AzureClient.params)
+        4    call 1082 ntypeargs=0   (openai.AzureClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1143 ntypeargs=0   (openai.internal.chat_invoke)
+        8    call 1144 ntypeargs=0   (openai.internal.chat_invoke)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   192   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
 
 function openai.AzureClient.ai.stream.StreamingClient.invoke_stream(self: openai.AzureClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   199   0    load_var 1              (self)
-        1    call 1080 ntypeargs=0   (openai.AzureClient.compat)
+        1    call 1081 ntypeargs=0   (openai.AzureClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1081 ntypeargs=0   (openai.AzureClient.params)
+        4    call 1082 ntypeargs=0   (openai.AzureClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1149 ntypeargs=0   (openai.internal.chat_invoke_stream)
+        8    call 1150 ntypeargs=0   (openai.internal.chat_invoke_stream)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   200   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
@@ -19493,7 +19492,7 @@ function openai.AzureClient.compat(self: openai.AzureClient) -> openai.internal.
         18   pop 1                   
 
   160   19   load_var 1              (self)
-        20   call 1079 ntypeargs=0   (openai.AzureClient.resolved_base_url)
+        20   call 1080 ntypeargs=0   (openai.AzureClient.resolved_base_url)
         21   store_var 5             (_10)
 
   158   22   load_const 3            ("azure")
@@ -19512,7 +19511,7 @@ function openai.AzureClient.compat(self: openai.AzureClient) -> openai.internal.
 
   165   35   load_var 2              (query)
 
-  158   36   call 1108 ntypeargs=0   (openai.internal.ChatCompat.new)
+  158   36   call 1109 ntypeargs=0   (openai.internal.ChatCompat.new)
         37   return                  
 }
 
@@ -19634,7 +19633,7 @@ function openai.AzureClient.params(self: openai.AzureClient) -> openai.internal.
         2    store_var 2             (_2)
 
   172   3    load_var 1              (self)
-        4    call 1077 ntypeargs=0   (openai.AzureClient.resolved_api_key)
+        4    call 1078 ntypeargs=0   (openai.AzureClient.resolved_api_key)
         5    store_var 3             (_3)
 
   170   6    load_var2 2 3           
@@ -19666,7 +19665,7 @@ function openai.AzureClient.params(self: openai.AzureClient) -> openai.internal.
   181   23   load_var 1              (self)
         24   load_field 6            (request_body)
 
-  170   25   call 1109 ntypeargs=0   (openai.internal.ChatParams.new)
+  170   25   call 1110 ntypeargs=0   (openai.internal.ChatParams.new)
         26   return                  
 }
 
@@ -19674,7 +19673,7 @@ function openai.AzureClient.resolved_api_key(self: openai.AzureClient) -> string
   95   0   load_var 1             (self)
        1   load_field 5           (api_key)
        2   load_const 0           ("AZURE_OPENAI_API_KEY")
-       3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4   return                 
 }
 
@@ -19682,7 +19681,7 @@ function openai.AzureClient.resolved_base_url(self: openai.AzureClient) -> strin
   126   0     load_var 1              (self)
         1     load_field 4            (base_url)
         2     load_const 0            (null)
-        3     call 937 ntypeargs=0    (ai.wire.resolve_credential)
+        3     call 938 ntypeargs=0    (ai.wire.resolve_credential)
         4     store_var 2             (_4)
         5     load_var 2              (_4)
         6     narrow_bind 1 2         
@@ -19690,7 +19689,7 @@ function openai.AzureClient.resolved_base_url(self: openai.AzureClient) -> strin
         8     jump +74                (to 82)
 
   134   9     load_var 1              (self)
-        10    call 1078 ntypeargs=0   (openai.AzureClient.resolved_deployment_id)
+        10    call 1079 ntypeargs=0   (openai.AzureClient.resolved_deployment_id)
         11    store_var 4             (deployment)
 
   135   12    load_var 1              (self)
@@ -19703,7 +19702,7 @@ function openai.AzureClient.resolved_base_url(self: openai.AzureClient) -> strin
 
   140   19    load_const 0            (null)
         20    load_const 2            ("AZURE_OPENAI_ENDPOINT")
-        21    call 937 ntypeargs=0    (ai.wire.resolve_credential)
+        21    call 938 ntypeargs=0    (ai.wire.resolve_credential)
         22    store_var 9             (_26)
         23    load_var 9              (_26)
         24    narrow_bind 1 9         
@@ -19711,7 +19710,7 @@ function openai.AzureClient.resolved_base_url(self: openai.AzureClient) -> strin
         26    jump +4                 (to 30)
 
   148   27    load_const 3            ("openai.AzureClient needs a deployment endpoint: set base_url, or resource_name, or the AZURE_OPENAI_ENDPOINT environment variable")
-        28    call 1107 ntypeargs=0   (openai.internal._azure_reject)
+        28    call 1108 ntypeargs=0   (openai.internal._azure_reject)
         29    throw                   
 
   140   30    load_var 9              (_26)
@@ -19797,7 +19796,7 @@ function openai.AzureClient.resolved_base_url(self: openai.AzureClient) -> strin
         100   return                  
 
   128   101   load_const 10           ("openai.AzureClient takes base_url OR resource_name/deployment_id, not both")
-        102   call 1107 ntypeargs=0   (openai.internal._azure_reject)
+        102   call 1108 ntypeargs=0   (openai.internal._azure_reject)
         103   throw                   
 }
 
@@ -19831,47 +19830,47 @@ function openai.ChatClient.ai.Client.id(self: openai.ChatClient) -> string {
 
 function openai.ChatClient.ai.Client.invoke(self: openai.ChatClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   115   0    load_var 1              (self)
-        1    call 1063 ntypeargs=0   (openai.ChatClient.compat)
+        1    call 1064 ntypeargs=0   (openai.ChatClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1064 ntypeargs=0   (openai.ChatClient.params)
+        4    call 1065 ntypeargs=0   (openai.ChatClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1143 ntypeargs=0   (openai.internal.chat_invoke)
+        8    call 1144 ntypeargs=0   (openai.internal.chat_invoke)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   116   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
 
 function openai.ChatClient.ai.stream.StreamingClient.invoke_stream(self: openai.ChatClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   123   0    load_var 1              (self)
-        1    call 1063 ntypeargs=0   (openai.ChatClient.compat)
+        1    call 1064 ntypeargs=0   (openai.ChatClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1064 ntypeargs=0   (openai.ChatClient.params)
+        4    call 1065 ntypeargs=0   (openai.ChatClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1149 ntypeargs=0   (openai.internal.chat_invoke_stream)
+        8    call 1150 ntypeargs=0   (openai.internal.chat_invoke_stream)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   124   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
 
 function openai.ChatClient.compat(self: openai.ChatClient) -> openai.internal.ChatCompat {
   86   0    load_var 1              (self)
-       1    call 1062 ntypeargs=0   (openai.ChatClient.resolved_base_url)
+       1    call 1063 ntypeargs=0   (openai.ChatClient.resolved_base_url)
        2    store_var 2             (_2)
 
   84   3    load_const 0            ("openai-chat")
@@ -19887,7 +19886,7 @@ function openai.ChatClient.compat(self: openai.ChatClient) -> openai.internal.Ch
        13   load_const 1            (<omitted>)
        14   load_const 1            (<omitted>)
        15   load_const 1            (<omitted>)
-       16   call 1108 ntypeargs=0   (openai.internal.ChatCompat.new)
+       16   call 1109 ntypeargs=0   (openai.internal.ChatCompat.new)
        17   return                  
 }
 
@@ -19993,7 +19992,7 @@ function openai.ChatClient.params(self: openai.ChatClient) -> openai.internal.Ch
         2    store_var 2             (_2)
 
   96    3    load_var 1              (self)
-        4    call 1061 ntypeargs=0   (openai.ChatClient.resolved_api_key)
+        4    call 1062 ntypeargs=0   (openai.ChatClient.resolved_api_key)
         5    store_var 3             (_3)
 
   94    6    load_var2 2 3           
@@ -20025,7 +20024,7 @@ function openai.ChatClient.params(self: openai.ChatClient) -> openai.internal.Ch
   105   23   load_var 1              (self)
         24   load_field 3            (request_body)
 
-  94    25   call 1109 ntypeargs=0   (openai.internal.ChatParams.new)
+  94    25   call 1110 ntypeargs=0   (openai.internal.ChatParams.new)
         26   return                  
 }
 
@@ -20033,7 +20032,7 @@ function openai.ChatClient.resolved_api_key(self: openai.ChatClient) -> string |
   72   0   load_var 1             (self)
        1   load_field 1           (api_key)
        2   load_const 0           ("OPENAI_API_KEY")
-       3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4   return                 
 }
 
@@ -20041,7 +20040,7 @@ function openai.ChatClient.resolved_base_url(self: openai.ChatClient) -> string 
   77   0    load_var 1             (self)
        1    load_field 2           (base_url)
        2    load_const 0           (null)
-       3    call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3    call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4    store_var_load_var 2   (_2)
        5    load_const 0           (null)
        6    cmp_op ==              
@@ -20068,47 +20067,47 @@ function openai.GenericClient.ai.Client.id(self: openai.GenericClient) -> string
 
 function openai.GenericClient.ai.Client.invoke(self: openai.GenericClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   114   0    load_var 1              (self)
-        1    call 1071 ntypeargs=0   (openai.GenericClient.compat)
+        1    call 1072 ntypeargs=0   (openai.GenericClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1072 ntypeargs=0   (openai.GenericClient.params)
+        4    call 1073 ntypeargs=0   (openai.GenericClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1143 ntypeargs=0   (openai.internal.chat_invoke)
+        8    call 1144 ntypeargs=0   (openai.internal.chat_invoke)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   115   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
 
 function openai.GenericClient.ai.stream.StreamingClient.invoke_stream(self: openai.GenericClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   122   0    load_var 1              (self)
-        1    call 1071 ntypeargs=0   (openai.GenericClient.compat)
+        1    call 1072 ntypeargs=0   (openai.GenericClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1072 ntypeargs=0   (openai.GenericClient.params)
+        4    call 1073 ntypeargs=0   (openai.GenericClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1149 ntypeargs=0   (openai.internal.chat_invoke_stream)
+        8    call 1150 ntypeargs=0   (openai.internal.chat_invoke_stream)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   123   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
 
 function openai.GenericClient.compat(self: openai.GenericClient) -> openai.internal.ChatCompat {
   88   0    load_var 1              (self)
-       1    call 1070 ntypeargs=0   (openai.GenericClient.resolved_base_url)
+       1    call 1071 ntypeargs=0   (openai.GenericClient.resolved_base_url)
        2    store_var 2             (_2)
 
   86   3    load_const 0            ("openai-generic")
@@ -20124,7 +20123,7 @@ function openai.GenericClient.compat(self: openai.GenericClient) -> openai.inter
        13   load_const 1            (<omitted>)
        14   load_const 1            (<omitted>)
        15   load_const 1            (<omitted>)
-       16   call 1108 ntypeargs=0   (openai.internal.ChatCompat.new)
+       16   call 1109 ntypeargs=0   (openai.internal.ChatCompat.new)
        17   return                  
 }
 
@@ -20216,7 +20215,7 @@ function openai.GenericClient.params(self: openai.GenericClient) -> openai.inter
         2    store_var 2             (_2)
 
   96    3    load_var 1              (self)
-        4    call 1069 ntypeargs=0   (openai.GenericClient.resolved_api_key)
+        4    call 1070 ntypeargs=0   (openai.GenericClient.resolved_api_key)
         5    store_var 3             (_3)
 
   94    6    load_var2 2 3           
@@ -20246,7 +20245,7 @@ function openai.GenericClient.params(self: openai.GenericClient) -> openai.inter
   104   22   load_var 1              (self)
         23   load_field 3            (request_body)
 
-  94    24   call 1109 ntypeargs=0   (openai.internal.ChatParams.new)
+  94    24   call 1110 ntypeargs=0   (openai.internal.ChatParams.new)
         25   return                  
 }
 
@@ -20254,7 +20253,7 @@ function openai.GenericClient.resolved_api_key(self: openai.GenericClient) -> st
   64   0   load_var 1             (self)
        1   load_field 2           (api_key)
        2   load_const 0           (null)
-       3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4   return                 
 }
 
@@ -20262,7 +20261,7 @@ function openai.GenericClient.resolved_base_url(self: openai.GenericClient) -> s
   72   0    load_var 1              (self)
        1    load_field 1            (base_url)
        2    load_const 0            (null)
-       3    call 937 ntypeargs=0    (ai.wire.resolve_credential)
+       3    call 938 ntypeargs=0    (ai.wire.resolve_credential)
        4    store_var 2             (_4)
        5    load_var 2              (_4)
        6    narrow_bind 1 2         
@@ -20272,7 +20271,7 @@ function openai.GenericClient.resolved_base_url(self: openai.GenericClient) -> s
   81   9    load_var 1              (self)
        10   load_field 1            (base_url)
        11   load_const 0            (null)
-       12   call 939 ntypeargs=0    (ai.wire.credential_sources)
+       12   call 940 ntypeargs=0    (ai.wire.credential_sources)
        13   store_var 5             (_9)
        14   load_type 2             
        15   load_var 5              (_9)
@@ -20285,7 +20284,7 @@ function openai.GenericClient.resolved_base_url(self: openai.GenericClient) -> s
        20   load_var 4              (_8)
        21   bin_op +                
 
-  79   22   call 1106 ntypeargs=0   (openai.internal._reject)
+  79   22   call 1107 ntypeargs=0   (openai.internal._reject)
        23   throw                   
 
   72   24   load_var 2              (_4)
@@ -20297,19 +20296,19 @@ function openai.GenericClient.resolved_base_url(self: openai.GenericClient) -> s
 
 function openai.ImageClient.ai.Client.id(self: openai.ImageClient) -> string {
   133   0   load_var 1              (self)
-        1   call 1150 ntypeargs=0   (openai.internal._oai_images_client_id)
+        1   call 1151 ntypeargs=0   (openai.internal._oai_images_client_id)
         2   return                  
 }
 
 function openai.ImageClient.ai.Client.invoke(self: openai.ImageClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   137   0   load_var2 1 2           
-        1   call 1164 ntypeargs=0   (openai.internal.images_invoke)
+        1   call 1165 ntypeargs=0   (openai.internal.images_invoke)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   138   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
@@ -20444,7 +20443,7 @@ function openai.ImageClient.resolved_api_key(self: openai.ImageClient) -> string
   115   0    load_var 1             (self)
         1    load_field 1           (api_key)
         2    load_const 0           ("OPENAI_API_KEY")
-        3    call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3    call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4    store_var 2            (_4)
         5    load_var 2             (_4)
         6    narrow_bind 1 2        
@@ -20454,7 +20453,7 @@ function openai.ImageClient.resolved_api_key(self: openai.ImageClient) -> string
   121   9    load_var 1             (self)
         10   load_field 1           (api_key)
         11   load_const 2           ("OPENAI_API_KEY")
-        12   call 939 ntypeargs=0   (ai.wire.credential_sources)
+        12   call 940 ntypeargs=0   (ai.wire.credential_sources)
         13   store_var 5            (_9)
         14   load_type 3            
         15   load_var 5             (_9)
@@ -20482,7 +20481,7 @@ function openai.ImageClient.resolved_base_url(self: openai.ImageClient) -> strin
   128   0   load_var 1             (self)
         1   load_field 2           (base_url)
         2   load_const 0           (null)
-        3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4   return                 
 }
 
@@ -20502,47 +20501,47 @@ function openai.OllamaClient.ai.Client.id(self: openai.OllamaClient) -> string {
 
 function openai.OllamaClient.ai.Client.invoke(self: openai.OllamaClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   97   0    load_var 1              (self)
-       1    call 1088 ntypeargs=0   (openai.OllamaClient.compat)
+       1    call 1089 ntypeargs=0   (openai.OllamaClient.compat)
        2    store_var 4             (_4)
        3    load_var 1              (self)
-       4    call 1089 ntypeargs=0   (openai.OllamaClient.params)
+       4    call 1090 ntypeargs=0   (openai.OllamaClient.params)
        5    store_var 5             (_5)
        6    load_var2 4 5           
        7    load_var 2              (input)
-       8    call 1143 ntypeargs=0   (openai.internal.chat_invoke)
+       8    call 1144 ntypeargs=0   (openai.internal.chat_invoke)
        9    jump +6                 (to 15)
        10   load_var 3              (e)
        11   throw_if_panic          
 
   98   12   load_var 3              (e)
-       13   call 977 ntypeargs=0    (ai.errors.normalize)
+       13   call 978 ntypeargs=0    (ai.errors.normalize)
        14   throw                   
        15   return                  
 }
 
 function openai.OllamaClient.ai.stream.StreamingClient.invoke_stream(self: openai.OllamaClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   105   0    load_var 1              (self)
-        1    call 1088 ntypeargs=0   (openai.OllamaClient.compat)
+        1    call 1089 ntypeargs=0   (openai.OllamaClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1089 ntypeargs=0   (openai.OllamaClient.params)
+        4    call 1090 ntypeargs=0   (openai.OllamaClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1149 ntypeargs=0   (openai.internal.chat_invoke_stream)
+        8    call 1150 ntypeargs=0   (openai.internal.chat_invoke_stream)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   106   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
 
 function openai.OllamaClient.compat(self: openai.OllamaClient) -> openai.internal.ChatCompat {
   70   0    load_var 1              (self)
-       1    call 1087 ntypeargs=0   (openai.OllamaClient.resolved_base_url)
+       1    call 1088 ntypeargs=0   (openai.OllamaClient.resolved_base_url)
        2    store_var 2             (_2)
 
   68   3    load_const 0            ("ollama")
@@ -20558,7 +20557,7 @@ function openai.OllamaClient.compat(self: openai.OllamaClient) -> openai.interna
        13   load_const 1            (<omitted>)
        14   load_const 1            (<omitted>)
        15   load_const 1            (<omitted>)
-       16   call 1108 ntypeargs=0   (openai.internal.ChatCompat.new)
+       16   call 1109 ntypeargs=0   (openai.internal.ChatCompat.new)
        17   return                  
 }
 
@@ -20650,7 +20649,7 @@ function openai.OllamaClient.params(self: openai.OllamaClient) -> openai.interna
        2    store_var 2             (_2)
 
   79   3    load_var 1              (self)
-       4    call 1086 ntypeargs=0   (openai.OllamaClient.resolved_api_key)
+       4    call 1087 ntypeargs=0   (openai.OllamaClient.resolved_api_key)
        5    store_var 3             (_3)
 
   77   6    load_var2 2 3           
@@ -20680,7 +20679,7 @@ function openai.OllamaClient.params(self: openai.OllamaClient) -> openai.interna
   87   22   load_var 1              (self)
        23   load_field 3            (request_body)
 
-  77   24   call 1109 ntypeargs=0   (openai.internal.ChatParams.new)
+  77   24   call 1110 ntypeargs=0   (openai.internal.ChatParams.new)
        25   return                  
 }
 
@@ -20688,7 +20687,7 @@ function openai.OllamaClient.resolved_api_key(self: openai.OllamaClient) -> stri
   60   0   load_var 1             (self)
        1   load_field 2           (api_key)
        2   load_const 0           (null)
-       3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4   return                 
 }
 
@@ -20696,7 +20695,7 @@ function openai.OllamaClient.resolved_base_url(self: openai.OllamaClient) -> str
   64   0    load_var 1             (self)
        1    load_field 1           (base_url)
        2    load_const 0           (null)
-       3    call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3    call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4    store_var_load_var 2   (_2)
        5    load_const 0           (null)
        6    cmp_op ==              
@@ -20723,47 +20722,47 @@ function openai.OpenRouterClient.ai.Client.id(self: openai.OpenRouterClient) -> 
 
 function openai.OpenRouterClient.ai.Client.invoke(self: openai.OpenRouterClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   95   0    load_var 1              (self)
-       1    call 1096 ntypeargs=0   (openai.OpenRouterClient.compat)
+       1    call 1097 ntypeargs=0   (openai.OpenRouterClient.compat)
        2    store_var 4             (_4)
        3    load_var 1              (self)
-       4    call 1097 ntypeargs=0   (openai.OpenRouterClient.params)
+       4    call 1098 ntypeargs=0   (openai.OpenRouterClient.params)
        5    store_var 5             (_5)
        6    load_var2 4 5           
        7    load_var 2              (input)
-       8    call 1143 ntypeargs=0   (openai.internal.chat_invoke)
+       8    call 1144 ntypeargs=0   (openai.internal.chat_invoke)
        9    jump +6                 (to 15)
        10   load_var 3              (e)
        11   throw_if_panic          
 
   96   12   load_var 3              (e)
-       13   call 977 ntypeargs=0    (ai.errors.normalize)
+       13   call 978 ntypeargs=0    (ai.errors.normalize)
        14   throw                   
        15   return                  
 }
 
 function openai.OpenRouterClient.ai.stream.StreamingClient.invoke_stream(self: openai.OpenRouterClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   103   0    load_var 1              (self)
-        1    call 1096 ntypeargs=0   (openai.OpenRouterClient.compat)
+        1    call 1097 ntypeargs=0   (openai.OpenRouterClient.compat)
         2    store_var 4             (_4)
         3    load_var 1              (self)
-        4    call 1097 ntypeargs=0   (openai.OpenRouterClient.params)
+        4    call 1098 ntypeargs=0   (openai.OpenRouterClient.params)
         5    store_var 5             (_5)
         6    load_var2 4 5           
         7    load_var 2              (input)
-        8    call 1149 ntypeargs=0   (openai.internal.chat_invoke_stream)
+        8    call 1150 ntypeargs=0   (openai.internal.chat_invoke_stream)
         9    jump +6                 (to 15)
         10   load_var 3              (e)
         11   throw_if_panic          
 
   104   12   load_var 3              (e)
-        13   call 977 ntypeargs=0    (ai.errors.normalize)
+        13   call 978 ntypeargs=0    (ai.errors.normalize)
         14   throw                   
         15   return                  
 }
 
 function openai.OpenRouterClient.compat(self: openai.OpenRouterClient) -> openai.internal.ChatCompat {
   68   0    load_var 1              (self)
-       1    call 1095 ntypeargs=0   (openai.OpenRouterClient.resolved_base_url)
+       1    call 1096 ntypeargs=0   (openai.OpenRouterClient.resolved_base_url)
        2    store_var 2             (_2)
 
   66   3    load_const 0            ("openrouter")
@@ -20779,7 +20778,7 @@ function openai.OpenRouterClient.compat(self: openai.OpenRouterClient) -> openai
        13   load_const 1            (<omitted>)
        14   load_const 1            (<omitted>)
        15   load_const 1            (<omitted>)
-       16   call 1108 ntypeargs=0   (openai.internal.ChatCompat.new)
+       16   call 1109 ntypeargs=0   (openai.internal.ChatCompat.new)
        17   return                  
 }
 
@@ -20871,7 +20870,7 @@ function openai.OpenRouterClient.params(self: openai.OpenRouterClient) -> openai
        2    store_var 2             (_2)
 
   77   3    load_var 1              (self)
-       4    call 1094 ntypeargs=0   (openai.OpenRouterClient.resolved_api_key)
+       4    call 1095 ntypeargs=0   (openai.OpenRouterClient.resolved_api_key)
        5    store_var 3             (_3)
 
   75   6    load_var2 2 3           
@@ -20901,7 +20900,7 @@ function openai.OpenRouterClient.params(self: openai.OpenRouterClient) -> openai
   85   22   load_var 1              (self)
        23   load_field 3            (request_body)
 
-  75   24   call 1109 ntypeargs=0   (openai.internal.ChatParams.new)
+  75   24   call 1110 ntypeargs=0   (openai.internal.ChatParams.new)
        25   return                  
 }
 
@@ -20909,7 +20908,7 @@ function openai.OpenRouterClient.resolved_api_key(self: openai.OpenRouterClient)
   58   0   load_var 1             (self)
        1   load_field 1           (api_key)
        2   load_const 0           ("OPENROUTER_API_KEY")
-       3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4   return                 
 }
 
@@ -20917,7 +20916,7 @@ function openai.OpenRouterClient.resolved_base_url(self: openai.OpenRouterClient
   62   0    load_var 1             (self)
        1    load_field 2           (base_url)
        2    load_const 0           (null)
-       3    call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3    call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4    store_var_load_var 2   (_2)
        5    load_const 0           (null)
        6    cmp_op ==              
@@ -20944,26 +20943,26 @@ function openai.ResponsesClient.ai.Client.id(self: openai.ResponsesClient) -> st
 
 function openai.ResponsesClient.ai.Client.invoke(self: openai.ResponsesClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   127   0   load_var2 1 2           
-        1   call 1052 ntypeargs=0   (openai.internal.invoke)
+        1   call 1053 ntypeargs=0   (openai.internal.invoke)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   128   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
 
 function openai.ResponsesClient.ai.stream.StreamingClient.invoke_stream(self: openai.ResponsesClient, input: ai.ModelTurnInput) -> ai.stream.TurnStream {
   135   0   load_var2 1 2           
-        1   call 1059 ntypeargs=0   (openai.internal.invoke_stream)
+        1   call 1060 ntypeargs=0   (openai.internal.invoke_stream)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   136   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
@@ -21083,7 +21082,7 @@ function openai.ResponsesClient.resolved_api_key(self: openai.ResponsesClient) -
   105   0    load_var 1             (self)
         1    load_field 1           (api_key)
         2    load_const 0           ("OPENAI_API_KEY")
-        3    call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3    call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4    store_var 2            (_4)
         5    load_var 2             (_4)
         6    narrow_bind 1 2        
@@ -21093,7 +21092,7 @@ function openai.ResponsesClient.resolved_api_key(self: openai.ResponsesClient) -
   111   9    load_var 1             (self)
         10   load_field 1           (api_key)
         11   load_const 2           ("OPENAI_API_KEY")
-        12   call 939 ntypeargs=0   (ai.wire.credential_sources)
+        12   call 940 ntypeargs=0   (ai.wire.credential_sources)
         13   store_var 5            (_9)
         14   load_type 3            
         15   load_var 5             (_9)
@@ -21121,7 +21120,7 @@ function openai.ResponsesClient.resolved_base_url(self: openai.ResponsesClient) 
   118   0   load_var 1             (self)
         1   load_field 2           (base_url)
         2   load_const 0           (null)
-        3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4   return                 
 }
 
@@ -21339,7 +21338,7 @@ function openai.internal.ChatExtraPart.baml.ToJson.to_json(self: openai.internal
         59   cmp_int_op >                       
         60   pop_jump_if_false +14              (to 74)
 
-  271   61   call 1112 ntypeargs=0              (openai.internal._chat_directives_key)
+  271   61   call 1113 ntypeargs=0              (openai.internal._chat_directives_key)
         62   store_var 11                       (_31)
         63   load_type 1                        
         64   load_var 1                         (self)
@@ -21461,7 +21460,7 @@ function openai.internal.ChatStreamDecoder._absorb_call(self: openai.internal.Ch
          16    load_field 1            (calls)
 
   1398   17    load_var 4              (index)
-         18    make_closure 2984 1     
+         18    make_closure 2985 1     
 
   1397   19    call 19 ntypeargs=2     (baml.Array.find)
 
@@ -21584,7 +21583,7 @@ function openai.internal.ChatStreamDecoder.decode(self: openai.internal.ChatStre
          2     store_var 4                        (out)
 
   1424   3     load_var 2                         (batch)
-         4     call 967 ntypeargs=0               (ai.stream.decode_sse_batch)
+         4     call 968 ntypeargs=0               (ai.stream.decode_sse_batch)
          5     load_type 1                        
          6     load_const 2                       ("iter")
          7     virtual_call nargs=1 ntypeargs=0   
@@ -21771,7 +21770,7 @@ function openai.internal.ChatStreamDecoder.decode(self: openai.internal.ChatStre
 
   1458   170   load_var2 1 28                     
          171   load_var 25                        (position)
-         172   call 1145 ntypeargs=0              (openai.internal.ChatStreamDecoder._absorb_call)
+         172   call 1146 ntypeargs=0              (openai.internal.ChatStreamDecoder._absorb_call)
          173   pop 1                              
 
   1459   174   load_var 25                        (position)
@@ -21790,7 +21789,7 @@ function openai.internal.ChatStreamDecoder.decode(self: openai.internal.ChatStre
          185   load_var 29                        (_82)
          186   store_var_load_var 30              (reason)
 
-  1464   187   call 1137 ntypeargs=0              (openai.internal.chat_stop_reason)
+  1464   187   call 1138 ntypeargs=0              (openai.internal.chat_stop_reason)
          188   store_var 31                       (_86)
 
   1462   189   load_type 0                        
@@ -21897,7 +21896,7 @@ function openai.internal.ChatStreamDecoder.tool_uses(self: openai.internal.ChatS
          32   load_field 3                       (arguments)
          33   load_var 1                         (self)
          34   load_field 0                       (provider)
-         35   call 1139 ntypeargs=0              (openai.internal._chat_tool_args)
+         35   call 1140 ntypeargs=0              (openai.internal._chat_tool_args)
          36   store_var 8                        (args)
          37   jump +3                            (to 40)
 
@@ -22020,7 +22019,7 @@ function openai.internal.OaStreamState.new() -> openai.internal.OaStreamState {
 function openai.internal._azure_reject(detail: string) -> ai.errors.InvalidRequest {
   49   0   load_const 0            ("azure")
        1   load_var 1              (detail)
-       2   call 1106 ntypeargs=0   (openai.internal._reject)
+       2   call 1107 ntypeargs=0   (openai.internal._reject)
        3   return                  
 }
 
@@ -22085,7 +22084,7 @@ function openai.internal._chat_apply_directives(j: baml.json.json) -> baml.json.
         17    load_type 2                        
         18    load_type 3                        
         19    load_var 18                        (items)
-        20    make_closure 2899 0                
+        20    make_closure 2900 0                
         21    call 16 ntypeargs=3                (baml.Array.map)
         22    jump +88                           (to 110)
 
@@ -22117,7 +22116,7 @@ function openai.internal._chat_apply_directives(j: baml.json.json) -> baml.json.
         46    load_var 6                         (_9)
         47    store_var 7                        (key)
 
-  839   48    call 1112 ntypeargs=0              (openai.internal._chat_directives_key)
+  839   48    call 1113 ntypeargs=0              (openai.internal._chat_directives_key)
         49    store_var 8                        (_15)
         50    load_var2 7 8                      
         51    cmp_op !=                          
@@ -22127,7 +22126,7 @@ function openai.internal._chat_apply_directives(j: baml.json.json) -> baml.json.
         54    load_type 2                        
         55    load_var2 3 7                      
         56    call 38 ntypeargs=2                (baml.Map.get)
-        57    call 1127 ntypeargs=0              (openai.internal._chat_apply_directives)
+        57    call 1128 ntypeargs=0              (openai.internal._chat_apply_directives)
         58    store_var 9                        (_18)
         59    load_type 4                        
         60    load_type 2                        
@@ -22137,7 +22136,7 @@ function openai.internal._chat_apply_directives(j: baml.json.json) -> baml.json.
         64    pop 1                              
         65    jump -28                           (to 37)
 
-  843   66    call 1112 ntypeargs=0              (openai.internal._chat_directives_key)
+  843   66    call 1113 ntypeargs=0              (openai.internal._chat_directives_key)
         67    store_var 10                       (_26)
         68    load_type 4                        
         69    load_type 2                        
@@ -22351,7 +22350,7 @@ function openai.internal._chat_content(parts: (openai.internal.ChatTextPart | op
         1    jump_if_false +4                   (to 5)
         2    pop 1                              
         3    load_var 1                         (parts)
-        4    call 1122 ntypeargs=0              (openai.internal._chat_all_text)
+        4    call 1123 ntypeargs=0              (openai.internal._chat_all_text)
         5    pop_jump_if_false +2               (to 7)
         6    jump +3                            (to 9)
 
@@ -22564,7 +22563,7 @@ function openai.internal._chat_headers(compat: openai.internal.ChatCompat, param
         134   load_var 15                        (_37)
         135   bin_op +                           
 
-  955   136   call 1106 ntypeargs=0              (openai.internal._reject)
+  955   136   call 1107 ntypeargs=0              (openai.internal._reject)
         137   throw                              
 }
 
@@ -22575,7 +22574,7 @@ function openai.internal._chat_is_opaque_key(key: string) -> bool {
         3    jump_if_false +2        (to 5)
         4    jump +6                 (to 10)
         5    pop 1                   
-        6    call 1112 ntypeargs=0   (openai.internal._chat_directives_key)
+        6    call 1113 ntypeargs=0   (openai.internal._chat_directives_key)
         7    store_var 2             (_3)
         8    load_var2 1 2           
         9    cmp_op ==               
@@ -22602,7 +22601,7 @@ function openai.internal._chat_media_block(url: string) -> ai.content.Media {
          14   call 354 ntypeargs=0   (baml.media.Image.from_url)
          15   load_const 4           (<omitted>)
          16   load_const 4           (<omitted>)
-         17   call 913 ntypeargs=0   (ai.content.Media.new)
+         17   call 914 ntypeargs=0   (ai.content.Media.new)
          18   jump +23               (to 41)
 
   1117   19   load_var 2             (_4)
@@ -22630,7 +22629,7 @@ function openai.internal._chat_media_block(url: string) -> ai.content.Media {
 
   1118   38   load_const 4           (<omitted>)
          39   load_const 4           (<omitted>)
-         40   call 913 ntypeargs=0   (ai.content.Media.new)
+         40   call 914 ntypeargs=0   (ai.content.Media.new)
          41   return                 
 }
 
@@ -22658,14 +22657,14 @@ function openai.internal._chat_media_part(media: baml.media.Image | baml.media.A
         19    load_field 0            (provider)
         20    load_const 3            ("OpenAI Chat Completions has no video input part; extract frames as images, or use the Realtime API")
 
-  576   21    call 1106 ntypeargs=0   (openai.internal._reject)
+  576   21    call 1107 ntypeargs=0   (openai.internal._reject)
         22    throw                   
 
   524   23    load_var 12             (_22)
         24    store_var_load_var 13   (pdf)
 
   552   25    load_const 4            (true)
-        26    call 942 ntypeargs=0    (ai.wire.resolve_media)
+        26    call 943 ntypeargs=0    (ai.wire.resolve_media)
         27    store_var 14            (resolved)
 
   556   28    load_var 14             (resolved)
@@ -22701,7 +22700,7 @@ function openai.internal._chat_media_part(media: baml.media.Image | baml.media.A
         54    load_const 10           (" is not a URL this client can fetch (gs:// and other non-HTTP schemes are not supported here). Pass the PDF as base64 or a local file.")
         55    bin_op +                
 
-  558   56    call 1106 ntypeargs=0   (openai.internal._reject)
+  558   56    call 1107 ntypeargs=0   (openai.internal._reject)
         57    throw                   
 
   556   58    load_var 16             (_28)
@@ -22720,7 +22719,7 @@ function openai.internal._chat_media_part(media: baml.media.Image | baml.media.A
         69    call 329 ntypeargs=0    (baml.media.Pdf.url)
         70    store_var 22            (_43)
         71    load_var 22             (_43)
-        72    call 1029 ntypeargs=0   (openai.internal._openai_file_name)
+        72    call 1030 ntypeargs=0   (openai.internal._openai_file_name)
         73    store_var 21            (_41)
 
   571   74    load_type 8             
@@ -22752,7 +22751,7 @@ function openai.internal._chat_media_part(media: baml.media.Image | baml.media.A
         96    store_var_load_var 7    (audio)
 
   535   97    load_const 4            (true)
-        98    call 942 ntypeargs=0    (ai.wire.resolve_media)
+        98    call 943 ntypeargs=0    (ai.wire.resolve_media)
         99    store_var 8             (resolved)
 
   539   100   load_var 8              (resolved)
@@ -22768,7 +22767,7 @@ function openai.internal._chat_media_part(media: baml.media.Image | baml.media.A
 
   540   110   load_var 8              (resolved)
         111   load_field 2            (mime_type)
-        112   call 1117 ntypeargs=0   (openai.internal._chat_audio_format)
+        112   call 1118 ntypeargs=0   (openai.internal._chat_audio_format)
         113   store_var 11            (_20)
 
   536   114   load_const 15           ("input_audio")
@@ -22783,9 +22782,9 @@ function openai.internal._chat_media_part(media: baml.media.Image | baml.media.A
 
   526   121   load_var 2              (compat)
         122   load_field 7            (inline_image_urls)
-        123   call 942 ntypeargs=0    (ai.wire.resolve_media)
+        123   call 943 ntypeargs=0    (ai.wire.resolve_media)
 
-  529   124   call 1116 ntypeargs=0   (openai.internal._chat_media_url)
+  529   124   call 1117 ntypeargs=0   (openai.internal._chat_media_url)
         125   store_var 5             (_9)
 
   527   126   load_const 16           ("image_url")
@@ -22983,7 +22982,7 @@ function openai.internal._chat_prompt_parts(message: ai.PromptMessage, compat: o
         45   store_var_load_var 19              (video)
 
   605   46   load_var 2                         (compat)
-        47   call 1119 ntypeargs=0              (openai.internal._chat_media_part)
+        47   call 1120 ntypeargs=0              (openai.internal._chat_media_part)
         48   store_var 20                       (_36)
         49   load_type 0                        
         50   load_var2 4 20                     
@@ -22995,7 +22994,7 @@ function openai.internal._chat_prompt_parts(message: ai.PromptMessage, compat: o
         55   store_var_load_var 17              (pdf)
 
   601   56   load_var 2                         (compat)
-        57   call 1119 ntypeargs=0              (openai.internal._chat_media_part)
+        57   call 1120 ntypeargs=0              (openai.internal._chat_media_part)
         58   store_var 18                       (_31)
         59   load_type 0                        
         60   load_var2 4 18                     
@@ -23007,7 +23006,7 @@ function openai.internal._chat_prompt_parts(message: ai.PromptMessage, compat: o
         65   store_var_load_var 14              (audio)
 
   597   66   load_var 2                         (compat)
-        67   call 1119 ntypeargs=0              (openai.internal._chat_media_part)
+        67   call 1120 ntypeargs=0              (openai.internal._chat_media_part)
         68   store_var 15                       (_25)
         69   load_type 0                        
         70   load_var2 4 15                     
@@ -23019,7 +23018,7 @@ function openai.internal._chat_prompt_parts(message: ai.PromptMessage, compat: o
         75   store_var_load_var 11              (image)
 
   593   76   load_var 2                         (compat)
-        77   call 1119 ntypeargs=0              (openai.internal._chat_media_part)
+        77   call 1120 ntypeargs=0              (openai.internal._chat_media_part)
         78   store_var 12                       (_19)
         79   load_type 0                        
         80   load_var2 4 12                     
@@ -23069,7 +23068,7 @@ function openai.internal._chat_prune_nulls(j: baml.json.json) -> baml.json.json 
         17   load_type 2                        
         18   load_type 3                        
         19   load_var 11                        (items)
-        20   make_closure 2905 0                
+        20   make_closure 2906 0                
         21   call 16 ntypeargs=3                (baml.Array.map)
         22   jump +58                           (to 80)
 
@@ -23114,12 +23113,12 @@ function openai.internal._chat_prune_nulls(j: baml.json.json) -> baml.json.json 
         57   jump -20                           (to 37)
 
   873   58   load_var 7                         (key)
-        59   call 1126 ntypeargs=0              (openai.internal._chat_is_opaque_key)
+        59   call 1127 ntypeargs=0              (openai.internal._chat_is_opaque_key)
         60   pop_jump_if_false +2               (to 62)
         61   jump +11                           (to 72)
 
   877   62   load_var 8                         (value)
-        63   call 1128 ntypeargs=0              (openai.internal._chat_prune_nulls)
+        63   call 1129 ntypeargs=0              (openai.internal._chat_prune_nulls)
         64   store_var 9                        (_27)
         65   load_type 4                        
         66   load_type 2                        
@@ -23196,7 +23195,7 @@ function openai.internal._chat_push_tool_uses(content: (ai.content.Text | ai.con
          46   jump +5                            (to 51)
 
   1155   47   load_var2 11 3                     
-         48   call 1139 ntypeargs=0              (openai.internal._chat_tool_args)
+         48   call 1140 ntypeargs=0              (openai.internal._chat_tool_args)
          49   store_var 9                        (args)
          50   jump +3                            (to 53)
 
@@ -23317,7 +23316,7 @@ function openai.internal._chat_send(request: baml.http.Request, provider: string
 
   1319   56   load_var2 2 8           
          57   load_var 3              (audio_mime)
-         58   call 1141 ntypeargs=0   (openai.internal.chat_parse)
+         58   call 1142 ntypeargs=0   (openai.internal.chat_parse)
          59   return                  
 
   1309   60   load_var2 2 4           
@@ -23328,7 +23327,7 @@ function openai.internal._chat_send(request: baml.http.Request, provider: string
 
   1313   63   load_field 1            (headers)
 
-  1309   64   call 986 ntypeargs=0    (ai.errors.classify_http)
+  1309   64   call 987 ntypeargs=0    (ai.errors.classify_http)
          65   throw                   
 }
 
@@ -23422,7 +23421,7 @@ function openai.internal._chat_stream_failure(provider: string, detail: string) 
   1517   74   load_var2 1 14          
          75   load_var 15             (_23)
          76   load_const 7            (<omitted>)
-         77   call 986 ntypeargs=0    (ai.errors.classify_http)
+         77   call 987 ntypeargs=0    (ai.errors.classify_http)
          78   return                  
 }
 
@@ -23442,7 +23441,7 @@ function openai.internal._chat_tool_args(raw: string, provider: string) -> map<s
 
 function openai.internal._chat_tools(toolbox: ai.tools.Toolbox) -> openai.internal.ChatTool[] | null {
   978   0    load_var 1                         (toolbox)
-        1    call 933 ntypeargs=0               (ai.tools.Toolbox.is_empty)
+        1    call 934 ntypeargs=0               (ai.tools.Toolbox.is_empty)
         2    pop_jump_if_false +2               (to 4)
         3    jump +44                           (to 47)
 
@@ -23451,7 +23450,7 @@ function openai.internal._chat_tools(toolbox: ai.tools.Toolbox) -> openai.intern
         6    store_var 2                        (tools)
 
   982   7    load_var 1                         (toolbox)
-        8    call 931 ntypeargs=0               (ai.tools.Toolbox.list)
+        8    call 932 ntypeargs=0               (ai.tools.Toolbox.list)
         9    load_type 1                        
         10   load_const 2                       ("iter")
         11   virtual_call nargs=1 ntypeargs=0   
@@ -23647,7 +23646,7 @@ function openai.internal._chat_url(compat: openai.internal.ChatCompat, params: o
         131   load_var 20                        (_64)
         132   store_var_load_var 21              (key)
 
-  939   133   call 1130 ntypeargs=0              (openai.internal._chat_percent_encode)
+  939   133   call 1131 ntypeargs=0              (openai.internal._chat_percent_encode)
         134   store_var 23                       (_72)
         135   load_type 0                        
         136   load_var 23                        (_72)
@@ -23664,7 +23663,7 @@ function openai.internal._chat_url(compat: openai.internal.ChatCompat, params: o
         147   load_const 15                      ("")
         148   store_var 26                       (_78)
         149   load_var 26                        (_78)
-        150   call 1130 ntypeargs=0              (openai.internal._chat_percent_encode)
+        150   call 1131 ntypeargs=0              (openai.internal._chat_percent_encode)
         151   store_var 25                       (_76)
         152   load_type 0                        
         153   load_var 25                        (_76)
@@ -23728,14 +23727,14 @@ function openai.internal._oai_images_block(datum: openai.internal.OaImageDatum, 
         17   store_var_load_var 6    (location)
 
   356   18   load_var 2              (mime)
-        19   call 1161 ntypeargs=0   (openai.internal._oai_images_fetch_inline)
+        19   call 1162 ntypeargs=0   (openai.internal._oai_images_fetch_inline)
 
   355   20   load_const 2            (<omitted>)
 
   357   21   load_var 1              (datum)
         22   load_field 2            (revised_prompt)
 
-  355   23   call 913 ntypeargs=0    (ai.content.Media.new)
+  355   23   call 914 ntypeargs=0    (ai.content.Media.new)
         24   jump +9                 (to 33)
 
   348   25   load_var 3              (_4)
@@ -23749,7 +23748,7 @@ function openai.internal._oai_images_block(datum: openai.internal.OaImageDatum, 
   351   30   load_var 1              (datum)
         31   load_field 2            (revised_prompt)
 
-  349   32   call 913 ntypeargs=0    (ai.content.Media.new)
+  349   32   call 914 ntypeargs=0    (ai.content.Media.new)
         33   return                  
 }
 
@@ -23811,7 +23810,7 @@ function openai.internal._oai_images_drop_nulls(value: baml.json.json) -> baml.j
         33   load_var 14                        (_29)
         34   store_var_load_var 15              (item)
 
-  115   35   call 1151 ntypeargs=0              (openai.internal._oai_images_drop_nulls)
+  115   35   call 1152 ntypeargs=0              (openai.internal._oai_images_drop_nulls)
         36   store_var 16                       (_34)
         37   load_type 2                        
         38   load_var2 12 16                    
@@ -23863,7 +23862,7 @@ function openai.internal._oai_images_drop_nulls(value: baml.json.json) -> baml.j
         78   jump -20                           (to 58)
 
   105   79   load_var 8                         (entry)
-        80   call 1151 ntypeargs=0              (openai.internal._oai_images_drop_nulls)
+        80   call 1152 ntypeargs=0              (openai.internal._oai_images_drop_nulls)
         81   store_var 9                        (_20)
         82   load_type 8                        
         83   load_type 2                        
@@ -24078,7 +24077,7 @@ function openai.internal._oai_images_headers(c: openai.ImageClient) -> map<strin
         52   jump -30                           (to 22)
 
   253   53   load_var 1                         (c)
-        54   call 1102 ntypeargs=0              (openai.ImageClient.resolved_api_key)
+        54   call 1103 ntypeargs=0              (openai.ImageClient.resolved_api_key)
         55   store_var 12                       (_28)
         56   load_type 2                        
         57   load_var 12                        (_28)
@@ -24178,7 +24177,7 @@ function openai.internal._oai_images_prompt_text(prompt: ai.Prompt, journal: ai.
         2     store_var 4                        (parts)
 
   143   3     load_var 1                         (prompt)
-        4     call 919 ntypeargs=0               (ai.Prompt.messages)
+        4     call 920 ntypeargs=0               (ai.Prompt.messages)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -24238,19 +24237,19 @@ function openai.internal._oai_images_prompt_text(prompt: ai.Prompt, journal: ai.
         59    jump +4                            (to 63)
 
   163   60    load_const 14                      ("pdf")
-        61    call 1152 ntypeargs=0              (openai.internal._oai_images_media_rejected)
+        61    call 1153 ntypeargs=0              (openai.internal._oai_images_media_rejected)
         62    throw                              
 
   160   63    load_const 15                      ("video")
-        64    call 1152 ntypeargs=0              (openai.internal._oai_images_media_rejected)
+        64    call 1153 ntypeargs=0              (openai.internal._oai_images_media_rejected)
         65    throw                              
 
   157   66    load_const 16                      ("audio")
-        67    call 1152 ntypeargs=0              (openai.internal._oai_images_media_rejected)
+        67    call 1153 ntypeargs=0              (openai.internal._oai_images_media_rejected)
         68    throw                              
 
   154   69    load_const 17                      ("image")
-        70    call 1152 ntypeargs=0              (openai.internal._oai_images_media_rejected)
+        70    call 1153 ntypeargs=0              (openai.internal._oai_images_media_rejected)
         71    throw                              
 
   145   72    load_var 11                        (_16)
@@ -24272,7 +24271,7 @@ function openai.internal._oai_images_prompt_text(prompt: ai.Prompt, journal: ai.
         85    jump -60                           (to 25)
 
   168   86    load_var 2                         (journal)
-        87    call 914 ntypeargs=0               (ai.Journal.entries)
+        87    call 915 ntypeargs=0               (ai.Journal.entries)
         88    load_type 19                       
         89    load_const 20                      ("iter")
         90    virtual_call nargs=1 ntypeargs=0   
@@ -24419,7 +24418,7 @@ function openai.internal._oai_images_with_query(url: string, params: map<string,
         27    load_var 7                         (_10)
         28    store_var_load_var 8               (key)
 
-  228   29    call 1156 ntypeargs=0              (openai.internal._oai_images_escape_query)
+  228   29    call 1157 ntypeargs=0              (openai.internal._oai_images_escape_query)
         30    store_var 10                       (_18)
         31    load_type 0                        
         32    load_var 10                        (_18)
@@ -24436,7 +24435,7 @@ function openai.internal._oai_images_with_query(url: string, params: map<string,
         43    load_const 8                       ("")
         44    store_var 13                       (_24)
         45    load_var 13                        (_24)
-        46    call 1156 ntypeargs=0              (openai.internal._oai_images_escape_query)
+        46    call 1157 ntypeargs=0              (openai.internal._oai_images_escape_query)
         47    store_var 12                       (_22)
         48    load_type 0                        
         49    load_var 12                        (_22)
@@ -24561,7 +24560,7 @@ function openai.internal._openai_apply_message_metadata(body: baml.json.json, me
         47   load_var2 7 8                      
         48   call 3 ntypeargs=1                 (baml.Array.at)
         49   load_var 11                        (directives)
-        50   call 1035 ntypeargs=0              (openai.internal._openai_merge_onto_last_part)
+        50   call 1036 ntypeargs=0              (openai.internal._openai_merge_onto_last_part)
         51   pop 1                              
 
   506   52   load_var 8                         (index)
@@ -24653,7 +24652,7 @@ function openai.internal._openai_decode_batch(batch: string, state: openai.inter
          2    store_var 4                        (out)
 
   1099   3    load_var 1                         (batch)
-         4    call 967 ntypeargs=0               (ai.stream.decode_sse_batch)
+         4    call 968 ntypeargs=0               (ai.stream.decode_sse_batch)
          5    load_type 1                        
          6    load_const 2                       ("iter")
          7    virtual_call nargs=1 ntypeargs=0   
@@ -24697,7 +24696,7 @@ function openai.internal._openai_decode_batch(batch: string, state: openai.inter
   1105   40   load_var 7                         (raw)
          41   load_field 0                       (event)
          42   load_var 2                         (state)
-         43   call 1056 ntypeargs=0              (openai.internal._openai_stream_events)
+         43   call 1057 ntypeargs=0              (openai.internal._openai_stream_events)
          44   load_type 10                       
          45   load_const 11                      ("iter")
          46   virtual_call nargs=1 ntypeargs=0   
@@ -24806,7 +24805,7 @@ function openai.internal._openai_error_failure(err: openai.internal.OaErrorBody)
         72   jump +14                (to 86)
 
   792   73   load_var 2              (code)
-        74   call 1048 ntypeargs=0   (openai.internal._openai_transient_code)
+        74   call 1049 ntypeargs=0   (openai.internal._openai_transient_code)
         75   pop_jump_if_false +2    (to 77)
         76   jump +6                 (to 82)
 
@@ -25031,7 +25030,7 @@ function openai.internal._openai_headers(c: openai.ResponsesClient) -> map<strin
         52   jump -30                           (to 22)
 
   665   53   load_var 1                         (c)
-        54   call 1021 ntypeargs=0              (openai.ResponsesClient.resolved_api_key)
+        54   call 1022 ntypeargs=0              (openai.ResponsesClient.resolved_api_key)
         55   store_var 12                       (_28)
         56   load_type 2                        
         57   load_var 12                        (_28)
@@ -25399,7 +25398,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
 
   394   57    load_var 25                        (pdf)
         58    load_const 14                      (false)
-        59    call 942 ntypeargs=0               (ai.wire.resolve_media)
+        59    call 943 ntypeargs=0               (ai.wire.resolve_media)
         60    store_var 26                       (resolved)
 
   395   61    load_var 25                        (pdf)
@@ -25412,7 +25411,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
         68    call 329 ntypeargs=0               (baml.media.Pdf.url)
         69    store_var 28                       (_70)
         70    load_var 28                        (_70)
-        71    call 1029 ntypeargs=0              (openai.internal._openai_file_name)
+        71    call 1030 ntypeargs=0              (openai.internal._openai_file_name)
         72    store_var 27                       (name)
 
   396   73    load_var 26                        (resolved)
@@ -25484,7 +25483,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
 
   392   127   load_const 21                      ("PDF")
         128   load_var 2                         (role)
-        129   call 1031 ntypeargs=0              (openai.internal._openai_media_role_error)
+        129   call 1032 ntypeargs=0              (openai.internal._openai_media_role_error)
         130   throw                              
 
   346   131   load_var 18                        (_46)
@@ -25498,7 +25497,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
 
   378   138   load_var 19                        (audio)
         139   load_const 23                      (true)
-        140   call 942 ntypeargs=0               (ai.wire.resolve_media)
+        140   call 943 ntypeargs=0               (ai.wire.resolve_media)
         141   store_var 20                       (resolved)
 
   383   142   load_var 20                        (resolved)
@@ -25514,7 +25513,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
 
   384   152   load_var 20                        (resolved)
         153   load_field 2                       (mime_type)
-        154   call 1030 ntypeargs=0              (openai.internal._openai_audio_format)
+        154   call 1031 ntypeargs=0              (openai.internal._openai_audio_format)
         155   store_var 23                       (_59)
 
   379   156   load_type 0                        
@@ -25532,7 +25531,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
 
   375   165   load_const 26                      ("audio")
         166   load_var 2                         (role)
-        167   call 1031 ntypeargs=0              (openai.internal._openai_media_role_error)
+        167   call 1032 ntypeargs=0              (openai.internal._openai_media_role_error)
         168   throw                              
 
   346   169   load_var 10                        (_21)
@@ -25546,7 +25545,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
 
   361   176   load_var 11                        (image)
         177   load_const 14                      (false)
-        178   call 942 ntypeargs=0               (ai.wire.resolve_media)
+        178   call 943 ntypeargs=0               (ai.wire.resolve_media)
         179   store_var 12                       (resolved)
 
   362   180   load_var 12                        (resolved)
@@ -25599,7 +25598,7 @@ function openai.internal._openai_prompt_content(message: ai.PromptMessage, role:
 
   359   223   load_const 33                      ("image")
         224   load_var 2                         (role)
-        225   call 1031 ntypeargs=0              (openai.internal._openai_media_role_error)
+        225   call 1032 ntypeargs=0              (openai.internal._openai_media_role_error)
         226   throw                              
 
   346   227   load_var 8                         (_10)
@@ -25676,7 +25675,7 @@ function openai.internal._openai_prune_nulls(value: baml.json.json) -> baml.json
         33   load_var 14                        (_29)
         34   store_var_load_var 15              (item)
 
-  237   35   call 1026 ntypeargs=0              (openai.internal._openai_prune_nulls)
+  237   35   call 1027 ntypeargs=0              (openai.internal._openai_prune_nulls)
         36   store_var 16                       (_34)
         37   load_type 2                        
         38   load_var2 12 16                    
@@ -25728,7 +25727,7 @@ function openai.internal._openai_prune_nulls(value: baml.json.json) -> baml.json
         78   jump -20                           (to 58)
 
   227   79   load_var 8                         (entry)
-        80   call 1026 ntypeargs=0              (openai.internal._openai_prune_nulls)
+        80   call 1027 ntypeargs=0              (openai.internal._openai_prune_nulls)
         81   store_var 9                        (_20)
         82   load_type 8                        
         83   load_type 2                        
@@ -25774,13 +25773,13 @@ function openai.internal._openai_request(c: openai.ResponsesClient, input: ai.Mo
         2     store_var 6                        (_5)
         3     load_var 2                         (input)
         4     load_field 3                       (output_type)
-        5     call 941 ntypeargs=0               (ai.wire.render_output_format)
+        5     call 942 ntypeargs=0               (ai.wire.render_output_format)
         6     load_var 6                         (_5)
         7     call_indirect                      
         8     store_var 5                        (prompt)
 
   704   9     load_var 5                         (prompt)
-        10    call 1033 ntypeargs=0              (openai.internal.openai_lower_prompt)
+        10    call 1034 ntypeargs=0              (openai.internal.openai_lower_prompt)
         11    store_var 7                        (items)
 
   707   12    load_var 2                         (input)
@@ -25792,9 +25791,9 @@ function openai.internal._openai_request(c: openai.ResponsesClient, input: ai.Mo
         18    virtual_call nargs=1 ntypeargs=0   
         19    store_var 9                        (_12)
         20    load_var2 8 9                      
-        21    call 944 ntypeargs=0               (ai.wire.sanitize_for_client)
+        21    call 945 ntypeargs=0               (ai.wire.sanitize_for_client)
 
-  708   22    call 1037 ntypeargs=0              (openai.internal.openai_lower_journal)
+  708   22    call 1038 ntypeargs=0              (openai.internal.openai_lower_journal)
         23    load_type 2                        
         24    load_const 3                       ("iter")
         25    virtual_call nargs=1 ntypeargs=0   
@@ -25819,13 +25818,13 @@ function openai.internal._openai_request(c: openai.ResponsesClient, input: ai.Mo
 
   711   43    load_var 2                         (input)
         44    load_field 3                       (output_type)
-        45    call 1038 ntypeargs=0              (openai.internal._openai_wants_image)
+        45    call 1039 ntypeargs=0              (openai.internal._openai_wants_image)
         46    store_var 13                       (wants_image)
 
   712   47    load_var 2                         (input)
         48    load_field 2                       (toolbox)
         49    load_var 13                        (wants_image)
-        50    call 1039 ntypeargs=0              (openai.internal._openai_tools)
+        50    call 1040 ntypeargs=0              (openai.internal._openai_tools)
         51    store_var 14                       (tools)
 
   714   52    load_var 1                         (c)
@@ -25861,11 +25860,11 @@ function openai.internal._openai_request(c: openai.ResponsesClient, input: ai.Mo
         74    store_var 21                       (_35)
 
   725   75    load_var 1                         (c)
-        76    call 1041 ntypeargs=0              (openai.internal._openai_reasoning)
+        76    call 1042 ntypeargs=0              (openai.internal._openai_reasoning)
         77    store_var 22                       (_36)
 
   726   78    load_var 1                         (c)
-        79    call 1042 ntypeargs=0              (openai.internal._openai_text)
+        79    call 1043 ntypeargs=0              (openai.internal._openai_text)
         80    store_var 23                       (_37)
 
   727   81    load_var 1                         (c)
@@ -25873,7 +25872,7 @@ function openai.internal._openai_request(c: openai.ResponsesClient, input: ai.Mo
         83    store_var 24                       (_38)
 
   729   84    load_var2 14 13                    
-        85    call 1040 ntypeargs=0              (openai.internal._openai_tool_choice)
+        85    call 1041 ntypeargs=0              (openai.internal._openai_tool_choice)
         86    store_var 25                       (_40)
 
   713   87    load_var2 16 7                     
@@ -25890,31 +25889,31 @@ function openai.internal._openai_request(c: openai.ResponsesClient, input: ai.Mo
   735   95    load_type 10                       
         96    load_var 15                        (request)
         97    call 362 ntypeargs=1               (baml.json.to_json)
-        98    call 1026 ntypeargs=0              (openai.internal._openai_prune_nulls)
+        98    call 1027 ntypeargs=0              (openai.internal._openai_prune_nulls)
 
   736   99    load_var 14                        (tools)
 
-  734   100   call 1027 ntypeargs=0              (openai.internal._openai_restore_tool_schemas)
+  734   100   call 1028 ntypeargs=0              (openai.internal._openai_restore_tool_schemas)
         101   store_var 26                       (pruned)
 
   739   102   load_var 5                         (prompt)
-        103   call 1034 ntypeargs=0              (openai.internal.openai_prompt_metadata)
+        103   call 1035 ntypeargs=0              (openai.internal.openai_prompt_metadata)
         104   store_var 28                       (_52)
         105   load_var2 26 28                    
-        106   call 1036 ntypeargs=0              (openai.internal._openai_apply_message_metadata)
+        106   call 1037 ntypeargs=0              (openai.internal._openai_apply_message_metadata)
 
   740   107   load_var 1                         (c)
         108   load_field 11                      (request_body)
 
-  738   109   call 943 ntypeargs=0               (ai.wire.merge_request_body)
+  738   109   call 944 ntypeargs=0               (ai.wire.merge_request_body)
         110   store_var 27                       (body)
 
   744   111   load_var 1                         (c)
-        112   call 1044 ntypeargs=0              (openai.internal._openai_url)
+        112   call 1045 ntypeargs=0              (openai.internal._openai_url)
         113   store_var 29                       (_55)
 
   745   114   load_var 1                         (c)
-        115   call 1043 ntypeargs=0              (openai.internal._openai_headers)
+        115   call 1044 ntypeargs=0              (openai.internal._openai_headers)
         116   store_var 30                       (_56)
 
   746   117   load_var 27                        (body)
@@ -25958,13 +25957,13 @@ function openai.internal._openai_response_failure(resp: openai.internal.OaRespon
         23   load_const 1            (null)
         24   init_instance 0         (openai.internal.OaErrorBody .code, .message, .type)
 
-  808   25   call 1049 ntypeargs=0   (openai.internal._openai_error_failure)
+  808   25   call 1050 ntypeargs=0   (openai.internal._openai_error_failure)
         26   jump +4                 (to 30)
 
   805   27   load_var 2              (_3)
         28   store_var_load_var 3    (err)
 
-  806   29   call 1049 ntypeargs=0   (openai.internal._openai_error_failure)
+  806   29   call 1050 ntypeargs=0   (openai.internal._openai_error_failure)
         30   return                  
 }
 
@@ -26181,7 +26180,7 @@ function openai.internal._openai_sse_failure(error: unknown) -> ai.errors.Failur
   1133   91   load_const 10           ("openai")
          92   load_var2 16 17         
          93   load_const 11           (<omitted>)
-         94   call 986 ntypeargs=0    (ai.errors.classify_http)
+         94   call 987 ntypeargs=0    (ai.errors.classify_http)
          95   return                  
 }
 
@@ -26274,7 +26273,7 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          80    load_var 38                      (_122)
          81    store_var_load_var 39            (final_response)
 
-  1079   82    call 1051 ntypeargs=0            (openai.internal.openai_parse)
+  1079   82    call 1052 ntypeargs=0            (openai.internal.openai_parse)
          83    store_var 40                     (turn)
 
   1082   84    load_var 40                      (turn)
@@ -26334,7 +26333,7 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          131   load_var 32                      (_101)
          132   store_var_load_var 33            (final_response)
 
-  1079   133   call 1051 ntypeargs=0            (openai.internal.openai_parse)
+  1079   133   call 1052 ntypeargs=0            (openai.internal.openai_parse)
          134   store_var 34                     (turn)
 
   1082   135   load_var 34                      (turn)
@@ -26386,10 +26385,10 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          175   jump +151                        (to 326)
 
   1076   176   load_var 1                       (event)
-         177   call 1055 ntypeargs=0            (openai.internal._openai_stream_failure)
+         177   call 1056 ntypeargs=0            (openai.internal._openai_stream_failure)
          178   throw                            
          179   load_var 1                       (event)
-         180   call 1055 ntypeargs=0            (openai.internal._openai_stream_failure)
+         180   call 1056 ntypeargs=0            (openai.internal._openai_stream_failure)
          181   throw                            
 
   1071   182   load_var 1                       (event)
@@ -26405,7 +26404,7 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          191   load_field 2                     (call_arguments)
          192   store_var 30                     (_90)
          193   load_var 1                       (event)
-         194   call 1054 ntypeargs=0            (openai.internal._openai_event_key)
+         194   call 1055 ntypeargs=0            (openai.internal._openai_event_key)
          195   store_var 31                     (_91)
          196   load_type 18                     
          197   load_type 18                     
@@ -26425,7 +26424,7 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          210   store_var 24                     (delta)
 
   1062   211   load_var 1                       (event)
-         212   call 1054 ntypeargs=0            (openai.internal._openai_event_key)
+         212   call 1055 ntypeargs=0            (openai.internal._openai_event_key)
          213   store_var 25                     (key)
 
   1063   214   load_var 3                       (state)
@@ -26457,7 +26456,7 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          236   jump +90                         (to 326)
 
   1045   237   load_var 1                       (event)
-         238   call 1054 ntypeargs=0            (openai.internal._openai_event_key)
+         238   call 1055 ntypeargs=0            (openai.internal._openai_event_key)
          239   store_var 19                     (key)
 
   1046   240   load_type 18                     
@@ -26514,7 +26513,7 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
          286   load_field 1                     (text_started)
          287   store_var 17                     (_34)
          288   load_var 1                       (event)
-         289   call 1054 ntypeargs=0            (openai.internal._openai_event_key)
+         289   call 1055 ntypeargs=0            (openai.internal._openai_event_key)
          290   store_var 18                     (_35)
          291   load_type 18                     
          292   load_type 20                     
@@ -26565,7 +26564,7 @@ function openai.internal._openai_stream_events(event: openai.internal.OaStreamEv
   1022   330   load_var 9                       (_17)
          331   store_var_load_var 10            (nested)
 
-  1023   332   call 1049 ntypeargs=0            (openai.internal._openai_error_failure)
+  1023   332   call 1050 ntypeargs=0            (openai.internal._openai_error_failure)
          333   throw                            
 }
 
@@ -26592,19 +26591,19 @@ function openai.internal._openai_stream_failure(event: openai.internal.OaStreamE
          17   load_field 10           (message)
          18   load_const 2            (null)
          19   init_instance 0         (openai.internal.OaErrorBody .code, .message, .type)
-         20   call 1049 ntypeargs=0   (openai.internal._openai_error_failure)
+         20   call 1050 ntypeargs=0   (openai.internal._openai_error_failure)
          21   jump +8                 (to 29)
 
   1005   22   load_var 4              (_7)
          23   store_var_load_var 5    (nested)
 
-  1006   24   call 1049 ntypeargs=0   (openai.internal._openai_error_failure)
+  1006   24   call 1050 ntypeargs=0   (openai.internal._openai_error_failure)
          25   jump +4                 (to 29)
 
   1002   26   load_var 2              (_3)
          27   store_var_load_var 3    (response)
 
-  1003   28   call 1050 ntypeargs=0   (openai.internal._openai_response_failure)
+  1003   28   call 1051 ntypeargs=0   (openai.internal._openai_response_failure)
          29   return                  
 }
 
@@ -26656,7 +26655,7 @@ function openai.internal._openai_tools(toolbox: ai.tools.Toolbox, wants_image: b
         2    store_var 3                        (tools)
 
   609   3    load_var 1                         (toolbox)
-        4    call 931 ntypeargs=0               (ai.tools.Toolbox.list)
+        4    call 932 ntypeargs=0               (ai.tools.Toolbox.list)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -26775,7 +26774,7 @@ function openai.internal._openai_transient_code(code: string) -> bool {
 
 function openai.internal._openai_url(c: openai.ResponsesClient) -> string {
   670   0     load_var 1                         (c)
-        1     call 1022 ntypeargs=0              (openai.ResponsesClient.resolved_base_url)
+        1     call 1023 ntypeargs=0              (openai.ResponsesClient.resolved_base_url)
         2     store_var_load_var 3               (_3)
         3     load_const 0                       (null)
         4     cmp_op ==                          
@@ -26847,7 +26846,7 @@ function openai.internal._openai_url(c: openai.ResponsesClient) -> string {
         62    load_var 11                        (_22)
         63    store_var_load_var 12              (key)
 
-  681   64    call 1028 ntypeargs=0              (openai.internal._openai_percent_encode)
+  681   64    call 1029 ntypeargs=0              (openai.internal._openai_percent_encode)
         65    store_var 14                       (_30)
         66    load_type 5                        
         67    load_var 14                        (_30)
@@ -26864,7 +26863,7 @@ function openai.internal._openai_url(c: openai.ResponsesClient) -> string {
         78    load_const 13                      ("")
         79    store_var 17                       (_36)
         80    load_var 17                        (_36)
-        81    call 1028 ntypeargs=0              (openai.internal._openai_percent_encode)
+        81    call 1029 ntypeargs=0              (openai.internal._openai_percent_encode)
         82    store_var 16                       (_34)
         83    load_type 5                        
         84    load_var 16                        (_34)
@@ -26918,7 +26917,7 @@ function openai.internal._openai_url(c: openai.ResponsesClient) -> string {
 
 function openai.internal._openai_wants_image(output_type: type) -> bool {
   604   0   load_var 1             (output_type)
-        1   call 994 ntypeargs=0   (ai.internal._media_shape)
+        1   call 995 ntypeargs=0   (ai.internal._media_shape)
         2   load_const 0           (":image")
         3   call 156 ntypeargs=0   (baml.String.ends_with)
         4   return                 
@@ -26941,24 +26940,24 @@ function openai.internal.chat_build_request(compat: openai.internal.ChatCompat, 
          2     store_var 5                        (_6)
          3     load_var 3                         (input)
          4     load_field 3                       (output_type)
-         5     call 941 ntypeargs=0               (ai.wire.render_output_format)
+         5     call 942 ntypeargs=0               (ai.wire.render_output_format)
          6     load_var 5                         (_6)
          7     call_indirect                      
 
   1006   8     load_var 1                         (compat)
-         9     call 1124 ntypeargs=0              (openai.internal.chat_lower_prompt)
+         9     call 1125 ntypeargs=0              (openai.internal.chat_lower_prompt)
          10    store_var 6                        (messages)
 
   1007   11    load_var 3                         (input)
          12    load_field 1                       (journal)
          13    store_var 7                        (_12)
          14    load_var2 1 2                      
-         15    call 1110 ntypeargs=0              (openai.internal.chat_client_id)
+         15    call 1111 ntypeargs=0              (openai.internal.chat_client_id)
          16    store_var 8                        (_13)
          17    load_var2 7 8                      
-         18    call 944 ntypeargs=0               (ai.wire.sanitize_for_client)
+         18    call 945 ntypeargs=0               (ai.wire.sanitize_for_client)
 
-  1008   19    call 1125 ntypeargs=0              (openai.internal.chat_lower_journal)
+  1008   19    call 1126 ntypeargs=0              (openai.internal.chat_lower_journal)
          20    load_type 0                        
          21    load_const 1                       ("iter")
          22    virtual_call nargs=1 ntypeargs=0   
@@ -27038,7 +27037,7 @@ function openai.internal.chat_build_request(compat: openai.internal.ChatCompat, 
   1032   83    load_var 2                         (params)
          84    load_field 10                      (request_body)
          85    load_const 9                       ("max_tokens")
-         86    call 1129 ntypeargs=0              (openai.internal._chat_body_mentions)
+         86    call 1130 ntypeargs=0              (openai.internal._chat_body_mentions)
          87    unary_op !                         
 
   1030   88    jump_if_false +7                   (to 95)
@@ -27047,7 +27046,7 @@ function openai.internal.chat_build_request(compat: openai.internal.ChatCompat, 
   1033   90    load_var 2                         (params)
          91    load_field 10                      (request_body)
          92    load_const 10                      ("max_completion_tokens")
-         93    call 1129 ntypeargs=0              (openai.internal._chat_body_mentions)
+         93    call 1130 ntypeargs=0              (openai.internal._chat_body_mentions)
          94    unary_op !                         
 
   1029   95    pop_jump_if_false +20              (to 115)
@@ -27078,7 +27077,7 @@ function openai.internal.chat_build_request(compat: openai.internal.ChatCompat, 
 
   1044   115   load_var 3                         (input)
          116   load_field 2                       (toolbox)
-         117   call 1133 ntypeargs=0              (openai.internal._chat_tools)
+         117   call 1134 ntypeargs=0              (openai.internal._chat_tools)
          118   store_var 17                       (tools)
 
   1045   119   load_var 17                        (tools)
@@ -27175,7 +27174,7 @@ function openai.internal.chat_invoke(compat: openai.internal.ChatCompat, params:
   1328   0    load_var2 1 2           
          1    load_var 3              (input)
          2    load_const 0            (false)
-         3    call 1136 ntypeargs=0   (openai.internal.chat_render)
+         3    call 1137 ntypeargs=0   (openai.internal.chat_render)
          4    store_var 4             (request)
 
   1331   5    load_var 1              (compat)
@@ -27184,13 +27183,13 @@ function openai.internal.chat_invoke(compat: openai.internal.ChatCompat, params:
 
   1332   8    load_var 2              (params)
          9    load_field 10           (request_body)
-         10   call 1118 ntypeargs=0   (openai.internal._chat_audio_output_mime)
+         10   call 1119 ntypeargs=0   (openai.internal._chat_audio_output_mime)
          11   store_var 6             (_7)
 
   1330   12   load_var2 4 5           
          13   load_var 6              (_7)
 
-  1329   14   call 1142 ntypeargs=0   (openai.internal._chat_send)
+  1329   14   call 1143 ntypeargs=0   (openai.internal._chat_send)
          15   return                  
 }
 
@@ -27202,12 +27201,12 @@ function openai.internal.chat_invoke_stream(compat: openai.internal.ChatCompat, 
   1539   3    load_var2 1 2           
          4    load_var 3              (input)
          5    load_const 0            (true)
-         6    call 1136 ntypeargs=0   (openai.internal.chat_render)
+         6    call 1137 ntypeargs=0   (openai.internal.chat_render)
          7    store_var 4             (request)
 
   1540   8    load_var 1              (compat)
          9    load_field 0            (provider)
-         10   call 1144 ntypeargs=0   (openai.internal.ChatStreamDecoder.new)
+         10   call 1145 ntypeargs=0   (openai.internal.ChatStreamDecoder.new)
          11   store_deref 5           
 
   1541   12   load_var 4              (request)
@@ -27224,16 +27223,16 @@ function openai.internal.chat_invoke_stream(compat: openai.internal.ChatCompat, 
          22   call 145 ntypeargs=1    (baml.String.from)
          23   store_var 8             (_12)
          24   load_var2 7 8           
-         25   call 1148 ntypeargs=0   (openai.internal._chat_stream_failure)
+         25   call 1149 ntypeargs=0   (openai.internal._chat_stream_failure)
          26   throw                   
 
   1551   27   load_var 5              (decoder)
-         28   make_closure 3006 1     
+         28   make_closure 3007 1     
 
   1552   29   load_var 1              (compat)
          30   load_field 0            (provider)
 
-  1549   31   call 968 ntypeargs=0    (ai.stream.TurnStream.from_sse)
+  1549   31   call 969 ntypeargs=0    (ai.stream.TurnStream.from_sse)
          32   return                  
 }
 
@@ -27243,7 +27242,7 @@ function openai.internal.chat_lower_journal(j: ai.Journal) -> openai.internal.Ch
         2     store_var 3                        (out)
 
   722   3     load_var 1                         (j)
-        4     call 914 ntypeargs=0               (ai.Journal.entries)
+        4     call 915 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -27510,7 +27509,7 @@ function openai.internal.chat_lower_prompt(prompt: ai.Prompt, compat: openai.int
         2     store_var 4                        (lowered)
 
   671   3     load_var 1                         (prompt)
-        4     call 919 ntypeargs=0               (ai.Prompt.messages)
+        4     call 920 ntypeargs=0               (ai.Prompt.messages)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -27554,12 +27553,12 @@ function openai.internal.chat_lower_prompt(prompt: ai.Prompt, compat: openai.int
         39    store_var 8                        (role)
 
   677   40    load_var2 7 2                      
-        41    call 1120 ntypeargs=0              (openai.internal._chat_prompt_parts)
+        41    call 1121 ntypeargs=0              (openai.internal._chat_prompt_parts)
         42    store_var 10                       (parts)
 
   681   43    load_var2 10 7                     
         44    load_field 3                       (metadata)
-        45    call 1121 ntypeargs=0              (openai.internal._chat_apply_metadata)
+        45    call 1122 ntypeargs=0              (openai.internal._chat_apply_metadata)
         46    pop 1                              
 
   682   47    load_const 9                       (false)
@@ -27654,7 +27653,7 @@ function openai.internal.chat_lower_prompt(prompt: ai.Prompt, compat: openai.int
         125   load_field 1                       (parts)
         126   load_var 2                         (compat)
         127   load_field 6                       (collapse_text_content)
-        128   call 1123 ntypeargs=0              (openai.internal._chat_content)
+        128   call 1124 ntypeargs=0              (openai.internal._chat_content)
         129   store_var 23                       (_56)
 
   697   130   load_type 18                       
@@ -27839,7 +27838,7 @@ function openai.internal.chat_parse(response: openai.internal.CcResponse, provid
          139   load_var 26                        (_56)
          140   store_var_load_var 27              (url)
 
-  1207   141   call 1138 ntypeargs=0              (openai.internal._chat_media_block)
+  1207   141   call 1139 ntypeargs=0              (openai.internal._chat_media_block)
          142   store_var 28                       (_59)
          143   load_type 7                        
          144   load_var2 13 28                    
@@ -27909,7 +27908,7 @@ function openai.internal.chat_parse(response: openai.internal.CcResponse, provid
          203   load_var 37                        (_86)
          204   store_var_load_var 38              (url)
 
-  1225   205   call 1138 ntypeargs=0              (openai.internal._chat_media_block)
+  1225   205   call 1139 ntypeargs=0              (openai.internal._chat_media_block)
          206   store_var 39                       (_89)
          207   load_type 7                        
          208   load_var2 13 39                    
@@ -27964,7 +27963,7 @@ function openai.internal.chat_parse(response: openai.internal.CcResponse, provid
          249   load_field 0                       (id)
          250   load_const 0                       (<omitted>)
 
-  1239   251   call 913 ntypeargs=0               (ai.content.Media.new)
+  1239   251   call 914 ntypeargs=0               (ai.content.Media.new)
          252   store_var 46                       (_110)
 
   1238   253   load_type 7                        
@@ -27986,7 +27985,7 @@ function openai.internal.chat_parse(response: openai.internal.CcResponse, provid
 
   1248   268   load_var2 13 47                    
          269   load_var 2                         (provider)
-         270   call 1140 ntypeargs=0              (openai.internal._chat_push_tool_uses)
+         270   call 1141 ntypeargs=0              (openai.internal._chat_push_tool_uses)
          271   pop 1                              
 
   1249   272   load_var 10                        (message)
@@ -28037,7 +28036,7 @@ function openai.internal.chat_parse(response: openai.internal.CcResponse, provid
          311   load_var 53                        (_136)
          312   store_var_load_var 54              (reason)
 
-  1259   313   call 1137 ntypeargs=0              (openai.internal.chat_stop_reason)
+  1259   313   call 1138 ntypeargs=0              (openai.internal.chat_stop_reason)
          314   store_var 51                       (stop)
          315   jump +8                            (to 323)
 
@@ -28129,20 +28128,20 @@ function openai.internal.chat_parse(response: openai.internal.CcResponse, provid
 function openai.internal.chat_render(compat: openai.internal.ChatCompat, params: openai.internal.ChatParams, input: ai.ModelTurnInput, stream: bool) -> baml.http.Request {
   1091   0    load_var2 1 2           
          1    load_var2 3 4           
-         2    call 1134 ntypeargs=0   (openai.internal.chat_build_request)
+         2    call 1135 ntypeargs=0   (openai.internal.chat_build_request)
          3    store_var 6             (request)
 
   1094   4    load_var2 1 2           
-         5    call 1131 ntypeargs=0   (openai.internal._chat_url)
+         5    call 1132 ntypeargs=0   (openai.internal._chat_url)
          6    store_var 7             (_6)
 
   1095   7    load_var2 1 2           
-         8    call 1132 ntypeargs=0   (openai.internal._chat_headers)
+         8    call 1133 ntypeargs=0   (openai.internal._chat_headers)
          9    store_var 8             (_7)
 
   1096   10   load_var2 1 2           
          11   load_var 6              (request)
-         12   call 1135 ntypeargs=0   (openai.internal.chat_render_body)
+         12   call 1136 ntypeargs=0   (openai.internal.chat_render_body)
          13   store_var 9             (_8)
 
   1092   14   load_const 0            ("POST")
@@ -28158,12 +28157,12 @@ function openai.internal.chat_render_body(compat: openai.internal.ChatCompat, pa
   1080   0   load_type 0             
          1   load_var 3              (request)
          2   call 363 ntypeargs=1    (baml.json.from)
-         3   call 1128 ntypeargs=0   (openai.internal._chat_prune_nulls)
-         4   call 1127 ntypeargs=0   (openai.internal._chat_apply_directives)
+         3   call 1129 ntypeargs=0   (openai.internal._chat_prune_nulls)
+         4   call 1128 ntypeargs=0   (openai.internal._chat_apply_directives)
 
   1081   5   load_var 2              (params)
          6   load_field 10           (request_body)
-         7   call 943 ntypeargs=0    (ai.wire.merge_request_body)
+         7   call 944 ntypeargs=0    (ai.wire.merge_request_body)
          8   call 358 ntypeargs=0    (baml.json.stringify)
          9   return                  
 }
@@ -28222,17 +28221,17 @@ function openai.internal.chat_stop_reason(reason: string) -> ai.content.StopReas
 
 function openai.internal.images_invoke(c: openai.ImageClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   404   0    load_var2 1 2           
-        1    call 1159 ntypeargs=0   (openai.internal.images_render)
+        1    call 1160 ntypeargs=0   (openai.internal.images_render)
         2    store_var 3             (req)
 
   405   3    load_type 0             
         4    load_var 3              (req)
         5    load_const 1            ("openai-images")
-        6    call 940 ntypeargs=1    (ai.wire.send_as)
+        6    call 941 ntypeargs=1    (ai.wire.send_as)
         7    store_var 4             (resp)
 
   406   8    load_var2 1 4           
-        9    call 1163 ntypeargs=0   (openai.internal.images_parse)
+        9    call 1164 ntypeargs=0   (openai.internal.images_parse)
         10   return                  
 }
 
@@ -28247,7 +28246,7 @@ function openai.internal.images_parse(c: openai.ImageClient, resp: openai.intern
         7     load_field 7                       (output_format)
         8     store_var 4                        (_5)
         9     load_var 4                         (_5)
-        10    call 1160 ntypeargs=0              (openai.internal._oai_images_mime)
+        10    call 1161 ntypeargs=0              (openai.internal._oai_images_mime)
         11    store_var 3                        (mime)
 
   368   12    load_var 2                         (resp)
@@ -28284,7 +28283,7 @@ function openai.internal.images_parse(c: openai.ImageClient, resp: openai.intern
         41    store_var_load_var 10              (datum)
 
   371   42    load_var 3                         (mime)
-        43    call 1162 ntypeargs=0              (openai.internal._oai_images_block)
+        43    call 1163 ntypeargs=0              (openai.internal._oai_images_block)
         44    store_var 11                       (_22)
         45    load_var 11                        (_22)
         46    narrow_bind 8 11                   
@@ -28365,7 +28364,7 @@ function openai.internal.images_parse(c: openai.ImageClient, resp: openai.intern
 function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTurnInput) -> baml.http.Request {
   259   0     load_var 2              (input)
         1     load_field 2            (toolbox)
-        2     call 933 ntypeargs=0    (ai.tools.Toolbox.is_empty)
+        2     call 934 ntypeargs=0    (ai.tools.Toolbox.is_empty)
         3     unary_op !              
         4     pop_jump_if_false +2    (to 6)
         5     jump +102               (to 107)
@@ -28374,10 +28373,10 @@ function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTur
         7     load_field 1            (journal)
         8     store_var 5             (_8)
         9     load_var 1              (c)
-        10    call 1150 ntypeargs=0   (openai.internal._oai_images_client_id)
+        10    call 1151 ntypeargs=0   (openai.internal._oai_images_client_id)
         11    store_var 6             (_9)
         12    load_var2 5 6           
-        13    call 944 ntypeargs=0    (ai.wire.sanitize_for_client)
+        13    call 945 ntypeargs=0    (ai.wire.sanitize_for_client)
         14    store_var 4             (journal)
 
   271   15    load_const 0            ("")
@@ -28385,7 +28384,7 @@ function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTur
         17    load_field 0            (prompt)
         18    call_indirect           
         19    load_var 4              (journal)
-        20    call 1153 ntypeargs=0   (openai.internal._oai_images_prompt_text)
+        20    call 1154 ntypeargs=0   (openai.internal._oai_images_prompt_text)
         21    store_var 7             (text)
 
   273   22    load_var 1              (c)
@@ -28432,7 +28431,7 @@ function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTur
         53    load_field 0            (model)
         54    load_var 1              (c)
         55    load_field 12           (response_format)
-        56    call 1154 ntypeargs=0   (openai.internal._oai_images_response_format)
+        56    call 1155 ntypeargs=0   (openai.internal._oai_images_response_format)
         57    store_var 19            (_26)
 
   272   58    load_var2 9 7           
@@ -28448,15 +28447,15 @@ function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTur
   286   66    load_type 1             
         67    load_var 8              (request)
         68    call 362 ntypeargs=1    (baml.json.to_json)
-        69    call 1151 ntypeargs=0   (openai.internal._oai_images_drop_nulls)
+        69    call 1152 ntypeargs=0   (openai.internal._oai_images_drop_nulls)
 
   287   70    load_var 1              (c)
         71    load_field 13           (request_body)
-        72    call 943 ntypeargs=0    (ai.wire.merge_request_body)
+        72    call 944 ntypeargs=0    (ai.wire.merge_request_body)
         73    store_var 20            (merged)
 
   289   74    load_var 1              (c)
-        75    call 1103 ntypeargs=0   (openai.ImageClient.resolved_base_url)
+        75    call 1104 ntypeargs=0   (openai.ImageClient.resolved_base_url)
         76    store_var_load_var 23   (_41)
         77    load_const 2            (null)
         78    cmp_op ==               
@@ -28464,7 +28463,7 @@ function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTur
         80    load_const 3            ("https://api.openai.com/v1")
         81    store_var 23            (_41)
         82    load_var 23             (_41)
-        83    call 1155 ntypeargs=0   (openai.internal._oai_images_trim_slash)
+        83    call 1156 ntypeargs=0   (openai.internal._oai_images_trim_slash)
         84    store_var 22            (_39)
         85    load_type 4             
         86    load_var 22             (_39)
@@ -28475,11 +28474,11 @@ function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTur
   290   90    load_var 1              (c)
         91    load_field 15           (query_params)
 
-  288   92    call 1157 ntypeargs=0   (openai.internal._oai_images_with_query)
+  288   92    call 1158 ntypeargs=0   (openai.internal._oai_images_with_query)
         93    store_var 21            (url)
 
   295   94    load_var 1              (c)
-        95    call 1158 ntypeargs=0   (openai.internal._oai_images_headers)
+        95    call 1159 ntypeargs=0   (openai.internal._oai_images_headers)
         96    store_var 24            (_47)
 
   296   97    load_var 20             (merged)
@@ -28505,15 +28504,15 @@ function openai.internal.images_render(c: openai.ImageClient, input: ai.ModelTur
 
 function openai.internal.invoke(c: openai.ResponsesClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   930   0   load_var2 1 2           
-        1   call 1045 ntypeargs=0   (openai.internal.openai_render)
+        1   call 1046 ntypeargs=0   (openai.internal.openai_render)
         2   store_var 3             (req)
 
   931   3   load_type 0             
         4   load_var 3              (req)
         5   load_const 1            ("openai")
-        6   call 940 ntypeargs=1    (ai.wire.send_as)
+        6   call 941 ntypeargs=1    (ai.wire.send_as)
 
-  932   7   call 1051 ntypeargs=0   (openai.internal.openai_parse)
+  932   7   call 1052 ntypeargs=0   (openai.internal.openai_parse)
         8   return                  
 }
 
@@ -28524,7 +28523,7 @@ function openai.internal.invoke_stream(c: openai.ResponsesClient, input: ai.Mode
 
   1151   3    load_var2 1 2           
          4    load_const 0            (true)
-         5    call 1046 ntypeargs=0   (openai.internal._openai_request)
+         5    call 1047 ntypeargs=0   (openai.internal._openai_request)
 
   1152   6    sys_op 259              (baml.http.fetch_sse)
          7    store_var 3             (sse)
@@ -28533,18 +28532,18 @@ function openai.internal.invoke_stream(c: openai.ResponsesClient, input: ai.Mode
          10   throw_if_panic          
 
   1153   11   load_var 4              (e)
-         12   call 1058 ntypeargs=0   (openai.internal._openai_sse_failure)
+         12   call 1059 ntypeargs=0   (openai.internal._openai_sse_failure)
          13   throw                   
 
-  1155   14   call 1053 ntypeargs=0   (openai.internal.OaStreamState.new)
+  1155   14   call 1054 ntypeargs=0   (openai.internal.OaStreamState.new)
          15   store_deref 5           
 
   1163   16   load_var2 3 5           
 
-  1164   17   make_closure 2726 1     
+  1164   17   make_closure 2727 1     
          18   load_const 1            ("openai")
 
-  1162   19   call 968 ntypeargs=0    (ai.stream.TurnStream.from_sse)
+  1162   19   call 969 ntypeargs=0    (ai.stream.TurnStream.from_sse)
          20   return                  
 }
 
@@ -28554,7 +28553,7 @@ function openai.internal.openai_lower_journal(j: ai.Journal) -> (openai.internal
         2     store_var 3                        (items)
 
   524   3     load_var 1                         (j)
-        4     call 914 ntypeargs=0               (ai.Journal.entries)
+        4     call 915 ntypeargs=0               (ai.Journal.entries)
         5     load_type 1                        
         6     load_const 2                       ("iter")
         7     virtual_call nargs=1 ntypeargs=0   
@@ -28764,7 +28763,7 @@ function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> (openai.inter
         2    store_var 3                        (items)
 
   439   3    load_var 1                         (prompt)
-        4    call 919 ntypeargs=0               (ai.Prompt.messages)
+        4    call 920 ntypeargs=0               (ai.Prompt.messages)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -28809,7 +28808,7 @@ function openai.internal.openai_lower_prompt(prompt: ai.Prompt) -> (openai.inter
   444   39   load_var 7                         (role)
         40   store_var 9                        (_15)
         41   load_var2 6 7                      
-        42   call 1032 ntypeargs=0              (openai.internal._openai_prompt_content)
+        42   call 1033 ntypeargs=0              (openai.internal._openai_prompt_content)
         43   store_var 10                       (_16)
         44   load_type 0                        
         45   load_var2 3 9                      
@@ -28915,7 +28914,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
 
   885   79    load_var 10                        (item)
         80    load_field 10                      (output_format)
-        81    call 1047 ntypeargs=0              (openai.internal._openai_image_mime)
+        81    call 1048 ntypeargs=0              (openai.internal._openai_image_mime)
         82    store_var 37                       (mime)
 
   888   83    load_var2 36 37                    
@@ -28927,7 +28926,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
   890   87    load_var 10                        (item)
         88    load_field 9                       (revised_prompt)
 
-  887   89    call 913 ntypeargs=0               (ai.content.Media.new)
+  887   89    call 914 ntypeargs=0               (ai.content.Media.new)
         90    store_var 38                       (_103)
 
   886   91    load_type 3                        
@@ -29266,7 +29265,7 @@ function openai.internal.openai_parse(resp: openai.internal.OaResponse) -> ai.Mo
         380   return                             
 
   820   381   load_var 1                         (resp)
-        382   call 1050 ntypeargs=0              (openai.internal._openai_response_failure)
+        382   call 1051 ntypeargs=0              (openai.internal._openai_response_failure)
         383   throw                              
 }
 
@@ -29276,7 +29275,7 @@ function openai.internal.openai_prompt_metadata(prompt: ai.Prompt) -> map<string
         2    store_var 3                        (out)
 
   462   3    load_var 1                         (prompt)
-        4    call 919 ntypeargs=0               (ai.Prompt.messages)
+        4    call 920 ntypeargs=0               (ai.Prompt.messages)
         5    load_type 1                        
         6    load_const 2                       ("iter")
         7    virtual_call nargs=1 ntypeargs=0   
@@ -29309,7 +29308,7 @@ function openai.internal.openai_prompt_metadata(prompt: ai.Prompt) -> map<string
 function openai.internal.openai_render(c: openai.ResponsesClient, input: ai.ModelTurnInput) -> baml.http.Request {
   693   0   load_var2 1 2           
         1   load_const 0            (false)
-        2   call 1046 ntypeargs=0   (openai.internal._openai_request)
+        2   call 1047 ntypeargs=0   (openai.internal._openai_request)
         3   return                  
 }
 
@@ -29320,7 +29319,7 @@ function testing.$invoke_collector(collector: (testing.TestCollector) -> void th
 }
 
 function testing.FailFast() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  104   0   make_closure 2078 0   
+  104   0   make_closure 2079 0   
         1   store_var 1           (_0)
         2   load_var 1            (_0)
         3   return                
@@ -29347,7 +29346,7 @@ function testing.PassRate(threshold: float) -> (testing.TestSetChild[]) -> testi
        15   pop 1                  
 
   76   16   load_var 1             (threshold)
-       17   make_closure 2073 1    
+       17   make_closure 2074 1    
        18   store_var 2            (_0)
        19   load_var 2             (_0)
        20   return                 
@@ -29388,7 +29387,7 @@ function testing.Quorum(n: int, m: int) -> (() -> testing.TestReport throws neve
        27   pop 1                  
 
   10   28   load_var2 1 2          
-       29   make_closure 2057 2    
+       29   make_closure 2058 2    
        30   store_var 3            (_0)
        31   load_var 3             (_0)
        32   return                 
@@ -29409,14 +29408,14 @@ function testing.Retry(max_attempts: int) -> (() -> testing.TestReport throws ne
        9    pop 1                  
 
   42   10   load_var 1             (max_attempts)
-       11   make_closure 2067 1    
+       11   make_closure 2068 1    
        12   store_var 2            (_0)
        13   load_var 2             (_0)
        14   return                 
 }
 
 function testing.Sequential() -> (testing.TestSetChild[]) -> testing.TestSetReport throws never {
-  98   0   make_closure 2076 0   
+  98   0   make_closure 2077 0   
        1   store_var 1           (_0)
        2   load_var 1            (_0)
        3   return                
@@ -29632,7 +29631,7 @@ function testing.TestCollector.register_test_at(self: testing.TestCollector, own
 
   107   6   load_var2 6 3          
         7   load_var2 4 5          
-        8   call 849 ntypeargs=0   (testing.TestCollector.register_test)
+        8   call 850 ntypeargs=0   (testing.TestCollector.register_test)
         9   return                 
 }
 
@@ -29766,7 +29765,7 @@ function testing.TestCollector.register_test_set_at(self: testing.TestCollector,
 
   118   6   load_var2 6 3          
         7   load_var2 4 5          
-        8   call 850 ntypeargs=0   (testing.TestCollector.register_test_set)
+        8   call 851 ntypeargs=0   (testing.TestCollector.register_test_set)
         9   return                 
 }
 
@@ -29796,11 +29795,11 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         21   pop_jump_if_false -14              (to 7)
 
   290   22   load_var2 1 5                      
-        23   call 865 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        23   call 866 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
         24   pop 1                              
 
   291   25   load_var 1                         (self)
-        26   call 857 ntypeargs=0               (testing.TestRegistry.serialize)
+        26   call 858 ntypeargs=0               (testing.TestRegistry.serialize)
         27   jump +33                           (to 60)
 
   295   28   load_type 5                        
@@ -29837,7 +29836,7 @@ function testing.TestRegistry.expand_set(self: testing.TestRegistry, name: strin
         57   pop_jump_if_false -20              (to 37)
 
   298   58   load_var2 9 2                      
-        59   call 864 ntypeargs=0               (testing.TestRegistry.expand_set)
+        59   call 865 ntypeargs=0               (testing.TestRegistry.expand_set)
         60   return                             
 
   301   61   load_const 12                      ("TestSet not found for expansion: ")
@@ -29931,7 +29930,7 @@ function testing.TestRegistry.list_filtered(self: testing.TestRegistry, profile_
   281   0   load_var2 1 2          
         1   load_var2 3 4          
         2   load_var 5             (cli_exclude)
-        3   call 885 ntypeargs=0   (testing.select_names_layered)
+        3   call 886 ntypeargs=0   (testing.select_names_layered)
         4   return                 
 }
 
@@ -29949,9 +29948,9 @@ function testing.TestRegistry.new(collector: testing.TestCollector) -> testing.T
 
 function testing.TestRegistry.run_all(self: testing.TestRegistry) -> testing.TestSetReport {
   237   0   load_var 1             (self)
-        1   call 866 ntypeargs=0   (testing.testset_children)
+        1   call 867 ntypeargs=0   (testing.testset_children)
         2   load_const 0           (null)
-        3   call 876 ntypeargs=0   (testing.run_testset)
+        3   call 877 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -29959,7 +29958,7 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
   259   0    load_var2 1 2          
         1    load_var2 3 4          
         2    load_var 5             (cli_exclude)
-        3    call 885 ntypeargs=0   (testing.select_names_layered)
+        3    call 886 ntypeargs=0   (testing.select_names_layered)
         4    store_var 6            (selected_names)
 
   261   5    load_var 2             (profile_include)
@@ -30002,22 +30001,22 @@ function testing.TestRegistry.run_filtered(self: testing.TestRegistry, profile_i
         36   jump +4                (to 40)
 
   268   37   load_var2 1 6          
-        38   call 861 ntypeargs=0   (testing.TestRegistry.run_selected)
+        38   call 862 ntypeargs=0   (testing.TestRegistry.run_selected)
         39   jump +3                (to 42)
 
   266   40   load_var 1             (self)
-        41   call 860 ntypeargs=0   (testing.TestRegistry.run_all)
+        41   call 861 ntypeargs=0   (testing.TestRegistry.run_all)
 
   270   42   load_var 6             (selected_names)
-        43   call 891 ntypeargs=0   (testing.flatten_with_tolerated)
+        43   call 892 ntypeargs=0   (testing.flatten_with_tolerated)
         44   return                 
 }
 
 function testing.TestRegistry.run_selected(self: testing.TestRegistry, names: string[]) -> testing.TestSetReport {
   241   0   load_var2 1 2          
-        1   call 867 ntypeargs=0   (testing.testset_children_selected)
+        1   call 868 ntypeargs=0   (testing.testset_children_selected)
         2   load_const 0           (null)
-        3   call 876 ntypeargs=0   (testing.run_testset)
+        3   call 877 ntypeargs=0   (testing.run_testset)
         4   return                 
 }
 
@@ -30050,7 +30049,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         23   load_field 1                       (body)
         24   load_var 5                         (t)
         25   load_field 2                       (runner)
-        26   call 875 ntypeargs=0               (testing.run_test)
+        26   call 876 ntypeargs=0               (testing.run_test)
         27   jump +33                           (to 60)
 
   211   28   load_type 5                        
@@ -30087,7 +30086,7 @@ function testing.TestRegistry.run_test(self: testing.TestRegistry, name: string)
         57   pop_jump_if_false -20              (to 37)
 
   215   58   load_var2 9 2                      
-        59   call 858 ntypeargs=0               (testing.TestRegistry.run_test)
+        59   call 859 ntypeargs=0               (testing.TestRegistry.run_test)
         60   return                             
 
   218   61   load_const 12                      ("Test not found: ")
@@ -30122,11 +30121,11 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         21   pop_jump_if_false -14              (to 7)
 
   224   22   load_var2 1 5                      
-        23   call 865 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
-        24   call 866 ntypeargs=0               (testing.testset_children)
+        23   call 866 ntypeargs=0               (testing.TestRegistry.expand_testset_registry)
+        24   call 867 ntypeargs=0               (testing.testset_children)
         25   load_var 5                         (ts)
         26   load_field 2                       (runner)
-        27   call 876 ntypeargs=0               (testing.run_testset)
+        27   call 877 ntypeargs=0               (testing.run_testset)
         28   jump +33                           (to 61)
 
   227   29   load_type 5                        
@@ -30163,7 +30162,7 @@ function testing.TestRegistry.run_testset(self: testing.TestRegistry, name: stri
         58   pop_jump_if_false -20              (to 38)
 
   230   59   load_var2 9 2                      
-        60   call 859 ntypeargs=0               (testing.TestRegistry.run_testset)
+        60   call 860 ntypeargs=0               (testing.TestRegistry.run_testset)
         61   return                             
 
   233   62   load_const 12                      ("TestSet not found: ")
@@ -30257,7 +30256,7 @@ function testing.TestRegistry.serialize(self: testing.TestRegistry) -> (testing.
         73   store_var 12                       (_28)
 
   189   74   load_var 11                        (sub)
-        75   call 857 ntypeargs=0               (testing.TestRegistry.serialize)
+        75   call 858 ntypeargs=0               (testing.TestRegistry.serialize)
         76   store_var 13                       (_29)
 
   186   77   load_type 0                        
@@ -30578,7 +30577,7 @@ function testing.any_pattern_matches(pats: string[], canonical_id: string) -> bo
         15   store_var 5                        (p)
 
   608   16   load_var2 2 5                      
-        17   call 878 ntypeargs=0               (testing.glob_match)
+        17   call 879 ntypeargs=0               (testing.glob_match)
         18   pop_jump_if_false -13              (to 5)
 
   609   19   load_const 5                       (true)
@@ -30616,7 +30615,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         23   store_var_load_var 8               (name)
 
   949   24   load_var 3                         (all_failed_names)
-        25   call 894 ntypeargs=0               (testing.failure_matches_selected)
+        25   call 895 ntypeargs=0               (testing.failure_matches_selected)
         26   pop_jump_if_false +2               (to 28)
         27   jump +8                            (to 35)
 
@@ -30629,7 +30628,7 @@ function testing.classify_selected_names(selected_names: string[], hard_failed_n
         34   jump -21                           (to 13)
 
   950   35   load_var2 8 2                      
-        36   call 894 ntypeargs=0               (testing.failure_matches_selected)
+        36   call 895 ntypeargs=0               (testing.failure_matches_selected)
         37   pop_jump_if_false +2               (to 39)
         38   jump +8                            (to 46)
 
@@ -30675,7 +30674,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          16   store_var_load_var 6               (name)
 
   1050   17   load_var 2                         (out)
-         18   call 893 ntypeargs=0               (testing.name_in)
+         18   call 894 ntypeargs=0               (testing.name_in)
          19   unary_op !                         
          20   pop_jump_if_false -14              (to 6)
 
@@ -30710,7 +30709,7 @@ function testing.collect_all_failed_names(report: testing.TestSetReport, out: st
          47   store_var_load_var 10              (nested)
 
   1057   48   load_var 2                         (out)
-         49   call 896 ntypeargs=0               (testing.collect_all_failed_names)
+         49   call 897 ntypeargs=0               (testing.collect_all_failed_names)
          50   pop 1                              
          51   jump -19                           (to 32)
 
@@ -30815,7 +30814,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
          79    store_var_load_var 18   (sentinel)
 
   1024   80    load_var 3              (selected_names)
-         81    call 893 ntypeargs=0    (testing.name_in)
+         81    call 894 ntypeargs=0    (testing.name_in)
          82    pop_jump_if_false +2    (to 84)
          83    jump +21                (to 104)
 
@@ -30871,7 +30870,7 @@ function testing.collect_leaf_identities(report: testing.TestSetReport, tolerate
 
   1018   124   load_var2 3 4           
 
-  1016   125   call 895 ntypeargs=0    (testing.collect_leaf_identities)
+  1016   125   call 896 ntypeargs=0    (testing.collect_leaf_identities)
          126   pop 1                   
          127   jump +31                (to 158)
 
@@ -30950,7 +30949,7 @@ function testing.collect_leaf_messages(results: (testing.TestReport | testing.Te
 
   1077   24   load_field 5                       (results)
          25   load_var 2                         (out)
-         26   call 897 ntypeargs=0               (testing.collect_leaf_messages)
+         26   call 898 ntypeargs=0               (testing.collect_leaf_messages)
          27   pop 1                              
          28   jump -23                           (to 5)
 
@@ -31052,7 +31051,7 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
         44   store_var 9                        (ts)
 
   749   45   load_var2 1 9                      
-        46   call 888 ntypeargs=0               (testing.collect_subtree_names)
+        46   call 889 ntypeargs=0               (testing.collect_subtree_names)
         47   load_type 10                       
         48   load_const 11                      ("iter")
         49   virtual_call nargs=1 ntypeargs=0   
@@ -31083,8 +31082,8 @@ function testing.collect_leaf_names(registry: testing.TestRegistry) -> string[] 
 
 function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testing.TestSetRegistration) -> string[] {
   762   0    load_var2 1 2          
-        1    call 865 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
-        2    call 887 ntypeargs=0   (testing.collect_leaf_names)
+        1    call 866 ntypeargs=0   (testing.TestRegistry.expand_testset_registry)
+        2    call 888 ntypeargs=0   (testing.collect_leaf_names)
         3    jump +91               (to 94)
         4    load_var 3             (e)
         5    store_var 4            (_5)
@@ -31186,11 +31185,11 @@ function testing.collect_subtree_names(registry: testing.TestRegistry, ts: testi
 
 function testing.collect_subtree_names_layered(registry: testing.TestRegistry, ts: testing.TestSetRegistration, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> string[] {
   778   0     load_var2 1 2           
-        1     call 865 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
+        1     call 866 ntypeargs=0    (testing.TestRegistry.expand_testset_registry)
 
   777   2     load_var2 3 4           
         3     load_var2 5 6           
-        4     call 885 ntypeargs=0    (testing.select_names_layered)
+        4     call 886 ntypeargs=0    (testing.select_names_layered)
         5     jump +111               (to 116)
         6     load_var 7              (e)
         7     store_var 8             (_9)
@@ -31274,7 +31273,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
   805   83    load_var2 3 4           
         84    load_var2 5 6           
 
-  804   85    call 881 ntypeargs=0    (testing.leaf_selected_layered)
+  804   85    call 882 ntypeargs=0    (testing.leaf_selected_layered)
 
   803   86    pop_jump_if_false +2    (to 88)
         87    jump +4                 (to 91)
@@ -31299,7 +31298,7 @@ function testing.collect_subtree_names_layered(registry: testing.TestRegistry, t
   789   100   load_var2 3 4           
         101   load_var2 5 6           
 
-  788   102   call 881 ntypeargs=0    (testing.leaf_selected_layered)
+  788   102   call 882 ntypeargs=0    (testing.leaf_selected_layered)
 
   787   103   pop_jump_if_false +2    (to 105)
         104   jump +4                 (to 108)
@@ -31418,7 +31417,7 @@ function testing.count_leaves(results: (testing.TestReport | testing.TestSetRepo
   856   74    load_var 13                        (tsr)
         75    load_field 5                       (results)
         76    load_var 14                        (ft)
-        77    call 890 ntypeargs=0               (testing.count_leaves)
+        77    call 891 ntypeargs=0               (testing.count_leaves)
         78    store_var 10                       (delta)
         79    jump +31                           (to 110)
 
@@ -31513,7 +31512,7 @@ function testing.expansion_error_report(name: string) -> testing.TestSetReport {
 
 function testing.failure_matches_selected(selected: string, failed_names: string[]) -> bool {
   972   0    load_var2 1 2                      
-        1    call 893 ntypeargs=0               (testing.name_in)
+        1    call 894 ntypeargs=0               (testing.name_in)
         2    pop_jump_if_false +2               (to 4)
         3    jump +43                           (to 46)
 
@@ -31622,7 +31621,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   889   37    load_var 1             (report)
         38    load_field 5           (results)
         39    load_var 3             (top_tolerated)
-        40    call 890 ntypeargs=0   (testing.count_leaves)
+        40    call 891 ntypeargs=0   (testing.count_leaves)
         41    store_var 4            (counts)
 
   905   42    load_type 2            
@@ -31632,7 +31631,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   906   45    load_var 1             (report)
         46    load_field 5           (results)
         47    load_var 6             (messages)
-        48    call 897 ntypeargs=0   (testing.collect_leaf_messages)
+        48    call 898 ntypeargs=0   (testing.collect_leaf_messages)
         49    pop 1                  
 
   907   50    load_type 2            
@@ -31640,7 +31639,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
         52    store_var 7            (all_failed_names)
 
   908   53    load_var2 1 7          
-        54    call 896 ntypeargs=0   (testing.collect_all_failed_names)
+        54    call 897 ntypeargs=0   (testing.collect_all_failed_names)
         55    pop 1                  
 
   909   56    load_type 2            
@@ -31654,7 +31653,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
 
   910   64    load_var2 1 3          
         65    load_var2 2 8          
-        66    call 895 ntypeargs=0   (testing.collect_leaf_identities)
+        66    call 896 ntypeargs=0   (testing.collect_leaf_identities)
         67    pop 1                  
 
   916   68    load_var 8             (executed)
@@ -31712,7 +31711,7 @@ function testing.flatten_with_tolerated(report: testing.TestSetReport, selected_
   922   112   load_var2 2 1          
         113   load_field 4           (failed_names)
         114   load_var 7             (all_failed_names)
-        115   call 892 ntypeargs=0   (testing.classify_selected_names)
+        115   call 893 ntypeargs=0   (testing.classify_selected_names)
         116   store_var 9            (identities)
         117   jump +3                (to 120)
 
@@ -31880,7 +31879,7 @@ function testing.glob_match(subject: string, pattern: string) -> bool {
 
 function testing.leaf_selected(name: string, include: string[], exclude: string[]) -> bool {
   618   0    load_var2 3 1          
-        1    call 879 ntypeargs=0   (testing.any_pattern_matches)
+        1    call 880 ntypeargs=0   (testing.any_pattern_matches)
         2    pop_jump_if_false +2   (to 4)
         3    jump +14               (to 17)
 
@@ -31894,7 +31893,7 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
         11   jump +4                (to 15)
 
   624   12   load_var2 2 1          
-        13   call 879 ntypeargs=0   (testing.any_pattern_matches)
+        13   call 880 ntypeargs=0   (testing.any_pattern_matches)
         14   jump +4                (to 18)
 
   622   15   load_const 1           (true)
@@ -31907,13 +31906,13 @@ function testing.leaf_selected(name: string, include: string[], exclude: string[
 function testing.leaf_selected_layered(name: string, profile_include: string[], profile_exclude: string[], cli_include: string[], cli_exclude: string[]) -> bool {
   637   0   load_var2 1 2          
         1   load_var 3             (profile_exclude)
-        2   call 880 ntypeargs=0   (testing.leaf_selected)
+        2   call 881 ntypeargs=0   (testing.leaf_selected)
         3   jump_if_false +5       (to 8)
         4   pop 1                  
 
   638   5   load_var2 1 4          
         6   load_var 5             (cli_exclude)
-        7   call 880 ntypeargs=0   (testing.leaf_selected)
+        7   call 881 ntypeargs=0   (testing.leaf_selected)
         8   return                 
 }
 
@@ -32013,7 +32012,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         24   store_deref 5                      
 
   486   25   load_var 5                         (child)
-        26   make_closure 1958 1                
+        26   make_closure 1959 1                
         27   load_const 6                       (null)
         28   load_const 6                       (null)
         29   load_type 7                        
@@ -32032,7 +32031,7 @@ function testing.run_children_parallel(children: testing.TestSetChild[]) -> test
         41   call 508 ntypeargs=2               (baml.future.all_complete)
         42   await                              
 
-  491   43   call 873 ntypeargs=0               (testing.aggregate_reports)
+  491   43   call 874 ntypeargs=0               (testing.aggregate_reports)
         44   return                             
 }
 
@@ -32101,11 +32100,11 @@ function testing.run_children_sequential(children: testing.TestSetChild[], fail_
         53   pop_jump_if_false -45              (to 8)
 
   119   54   load_var 3                         (named_results)
-        55   call 873 ntypeargs=0               (testing.aggregate_reports)
+        55   call 874 ntypeargs=0               (testing.aggregate_reports)
         56   jump +3                            (to 59)
 
   124   57   load_var 3                         (named_results)
-        58   call 873 ntypeargs=0               (testing.aggregate_reports)
+        58   call 874 ntypeargs=0               (testing.aggregate_reports)
         59   return                             
 }
 
@@ -32115,7 +32114,7 @@ function testing.run_test(body: () -> void throws unknown, runner: ((() -> testi
         2    store_var 1            
 
   496   3    load_var 1             (body)
-        4    make_closure 1970 1    
+        4    make_closure 1971 1    
         5    store_var 3            (base_run)
 
   527   6    load_var 2             (runner)
@@ -32151,7 +32150,7 @@ function testing.run_testset(children: testing.TestSetChild[], runner: ((testing
         9    jump +3                (to 12)
 
   539   10   load_var 1             (children)
-        11   call 874 ntypeargs=0   (testing.run_children_parallel)
+        11   call 875 ntypeargs=0   (testing.run_children_parallel)
         12   return                 
 }
 
@@ -32162,7 +32161,7 @@ function testing.select_names(registry: testing.TestRegistry, include: string[],
         3   load_type 0            
         4   alloc_array 0          
         5   load_var2 2 3          
-        6   call 885 ntypeargs=0   (testing.select_names_layered)
+        6   call 886 ntypeargs=0   (testing.select_names_layered)
         7   return                 
 }
 
@@ -32194,7 +32193,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
         22   load_var2 2 3                      
         23   load_var2 4 5                      
 
-  703   24   call 881 ntypeargs=0               (testing.leaf_selected_layered)
+  703   24   call 882 ntypeargs=0               (testing.leaf_selected_layered)
 
   702   25   pop_jump_if_false -15              (to 10)
 
@@ -32226,14 +32225,14 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
 
   718   50   load_field 0                       (name)
         51   load_var2 2 3                      
-        52   call 884 ntypeargs=0               (testing.subtree_may_be_selected)
+        52   call 885 ntypeargs=0               (testing.subtree_may_be_selected)
         53   jump_if_false +6                   (to 59)
         54   pop 1                              
 
   719   55   load_var 13                        (ts)
         56   load_field 0                       (name)
         57   load_var2 4 5                      
-        58   call 884 ntypeargs=0               (testing.subtree_may_be_selected)
+        58   call 885 ntypeargs=0               (testing.subtree_may_be_selected)
 
   717   59   pop_jump_if_false -20              (to 39)
 
@@ -32242,7 +32241,7 @@ function testing.select_names_layered(registry: testing.TestRegistry, profile_in
   723   61   load_var2 2 3                      
         62   load_var2 4 5                      
 
-  721   63   call 889 ntypeargs=0               (testing.collect_subtree_names_layered)
+  721   63   call 890 ntypeargs=0               (testing.collect_subtree_names_layered)
 
   729   64   load_type 10                       
         65   load_const 11                      ("iter")
@@ -32316,7 +32315,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
         37   jump_if_false +4                   (to 41)
         38   pop 1                              
         39   load_var2 3 6                      
-        40   call 878 ntypeargs=0               (testing.glob_match)
+        40   call 879 ntypeargs=0               (testing.glob_match)
         41   pop_jump_if_false -32              (to 9)
 
   655   42   load_const 9                       (true)
@@ -32331,7 +32330,7 @@ function testing.subtree_excluded(prefix: string, excludes: string[]) -> bool {
 
 function testing.subtree_may_be_selected(prefix: string, include: string[], exclude: string[]) -> bool {
   677   0    load_var2 1 3                      
-        1    call 882 ntypeargs=0               (testing.subtree_excluded)
+        1    call 883 ntypeargs=0               (testing.subtree_excluded)
         2    pop_jump_if_false +2               (to 4)
         3    jump +34                           (to 37)
 
@@ -32362,7 +32361,7 @@ function testing.subtree_may_be_selected(prefix: string, include: string[], excl
         27   store_var_load_var 7               (pattern)
 
   684   28   load_var 1                         (prefix)
-        29   call 883 ntypeargs=0               (testing.pattern_may_match_descendant)
+        29   call 884 ntypeargs=0               (testing.pattern_may_match_descendant)
         30   pop_jump_if_false -13              (to 17)
 
   685   31   load_const 6                       (true)
@@ -32389,7 +32388,7 @@ function testing.test_child(name: string, body: () -> void throws unknown, runne
   364   6    load_var2 1 2         
 
   366   7    load_var 3            (runner)
-        8    make_closure 1935 2   
+        8    make_closure 1936 2   
         9    init_instance 0       (testing.TestSetChild .name, .run)
         10   store_var 4           (_0)
         11   load_var 4            (_0)
@@ -32408,7 +32407,7 @@ function testing.testset_child(registry: testing.TestRegistry, ts: testing.TestS
         7    load_field 0          (name)
 
   375   8    load_var2 1 2         
-        9    make_closure 1937 2   
+        9    make_closure 1938 2   
         10   init_instance 0       (testing.TestSetChild .name, .run)
         11   store_var 3           (_0)
         12   load_var 3            (_0)
@@ -32431,7 +32430,7 @@ function testing.testset_child_selected(registry: testing.TestRegistry, ts: test
 
   391   11   load_var2 1 2         
         12   load_var 3            (names)
-        13   make_closure 1939 3   
+        13   make_closure 1940 3   
         14   init_instance 0       (testing.TestSetChild .name, .run)
         15   store_var 4           (_0)
         16   load_var 4            (_0)
@@ -32467,7 +32466,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         23   load_field 1                       (body)
         24   load_var 6                         (t)
         25   load_field 2                       (runner)
-        26   call 868 ntypeargs=0               (testing.test_child)
+        26   call 869 ntypeargs=0               (testing.test_child)
         27   store_var 7                        (_10)
         28   load_type 0                        
         29   load_var2 3 7                      
@@ -32495,7 +32494,7 @@ function testing.testset_children(registry: testing.TestRegistry) -> testing.Tes
         50   store_var 10                       (ts)
 
   334   51   load_var2 1 10                     
-        52   call 869 ntypeargs=0               (testing.testset_child)
+        52   call 870 ntypeargs=0               (testing.testset_child)
         53   store_var 11                       (_22)
         54   load_type 0                        
         55   load_var2 3 11                     
@@ -32535,7 +32534,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   342   21   load_field 0                       (name)
         22   load_var 2                         (names)
-        23   call 871 ntypeargs=0               (testing._name_selected)
+        23   call 872 ntypeargs=0               (testing._name_selected)
         24   pop_jump_if_false -14              (to 10)
 
   343   25   load_var 7                         (t)
@@ -32544,7 +32543,7 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
         28   load_field 1                       (body)
         29   load_var 7                         (t)
         30   load_field 2                       (runner)
-        31   call 868 ntypeargs=0               (testing.test_child)
+        31   call 869 ntypeargs=0               (testing.test_child)
         32   store_var 8                        (_13)
         33   load_type 0                        
         34   load_var2 4 8                      
@@ -32573,12 +32572,12 @@ function testing.testset_children_selected(registry: testing.TestRegistry, names
 
   354   56   load_field 0                       (name)
         57   load_var 2                         (names)
-        58   call 872 ntypeargs=0               (testing._has_selected_descendant)
+        58   call 873 ntypeargs=0               (testing._has_selected_descendant)
         59   pop_jump_if_false -14              (to 45)
 
   355   60   load_var2 1 11                     
         61   load_var 2                         (names)
-        62   call 870 ntypeargs=0               (testing.testset_child_selected)
+        62   call 871 ntypeargs=0               (testing.testset_child_selected)
         63   store_var 12                       (_27)
         64   load_type 0                        
         65   load_var2 4 12                     
@@ -32601,7 +32600,7 @@ function user.User.promote(self: User, bonus: int) -> Report {
        5    store_field 1           (age)
 
   10   6    load_var2 1 2           
-       7    call 1382 ntypeargs=0   (user.score)
+       7    call 1383 ntypeargs=0   (user.score)
        8    store_var 4             (base)
 
   11   9    load_var 4              (base)
@@ -32822,19 +32821,19 @@ function user.score(input: User | ErrorInfo, threshold: int) -> Report {
 
 function vercel.AiGatewayImageClient.ai.Client.id(self: vercel.AiGatewayImageClient) -> string {
   105   0   load_var 1              (self)
-        1   call 1344 ntypeargs=0   (vercel.internal._gw_images_client_id)
+        1   call 1345 ntypeargs=0   (vercel.internal._gw_images_client_id)
         2   return                  
 }
 
 function vercel.AiGatewayImageClient.ai.Client.invoke(self: vercel.AiGatewayImageClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   109   0   load_var2 1 2           
-        1   call 1359 ntypeargs=0   (vercel.internal.gateway_images_invoke)
+        1   call 1360 ntypeargs=0   (vercel.internal.gateway_images_invoke)
         2   jump +6                 (to 8)
         3   load_var 3              (e)
         4   throw_if_panic          
 
   110   5   load_var 3              (e)
-        6   call 977 ntypeargs=0    (ai.errors.normalize)
+        6   call 978 ntypeargs=0    (ai.errors.normalize)
         7   throw                   
         8   return                  
 }
@@ -32924,7 +32923,7 @@ function vercel.AiGatewayImageClient.resolved_api_key(self: vercel.AiGatewayImag
   87   0    load_var 1             (self)
        1    load_field 1           (api_key)
        2    load_const 0           ("AI_GATEWAY_API_KEY")
-       3    call 937 ntypeargs=0   (ai.wire.resolve_credential)
+       3    call 938 ntypeargs=0   (ai.wire.resolve_credential)
        4    store_var 2            (_4)
        5    load_var 2             (_4)
        6    narrow_bind 1 2        
@@ -32934,7 +32933,7 @@ function vercel.AiGatewayImageClient.resolved_api_key(self: vercel.AiGatewayImag
   93   9    load_var 1             (self)
        10   load_field 1           (api_key)
        11   load_const 2           ("AI_GATEWAY_API_KEY")
-       12   call 939 ntypeargs=0   (ai.wire.credential_sources)
+       12   call 940 ntypeargs=0   (ai.wire.credential_sources)
        13   store_var 5            (_9)
        14   load_type 3            
        15   load_var 5             (_9)
@@ -32962,7 +32961,7 @@ function vercel.AiGatewayImageClient.resolved_base_url(self: vercel.AiGatewayIma
   100   0   load_var 1             (self)
         1   load_field 2           (base_url)
         2   load_const 0           (null)
-        3   call 937 ntypeargs=0   (ai.wire.resolve_credential)
+        3   call 938 ntypeargs=0   (ai.wire.resolve_credential)
         4   return                 
 }
 
@@ -33024,7 +33023,7 @@ function vercel.internal._gw_images_drop_nulls(value: baml.json.json) -> baml.js
         33   load_var 14                        (_29)
         34   store_var_load_var 15              (item)
 
-  118   35   call 1345 ntypeargs=0              (vercel.internal._gw_images_drop_nulls)
+  118   35   call 1346 ntypeargs=0              (vercel.internal._gw_images_drop_nulls)
         36   store_var 16                       (_34)
         37   load_type 2                        
         38   load_var2 12 16                    
@@ -33076,7 +33075,7 @@ function vercel.internal._gw_images_drop_nulls(value: baml.json.json) -> baml.js
         78   jump -20                           (to 58)
 
   108   79   load_var 8                         (entry)
-        80   call 1345 ntypeargs=0              (vercel.internal._gw_images_drop_nulls)
+        80   call 1346 ntypeargs=0              (vercel.internal._gw_images_drop_nulls)
         81   store_var 9                        (_20)
         82   load_type 8                        
         83   load_type 2                        
@@ -33122,7 +33121,7 @@ function vercel.internal._gw_images_escape_query(raw: string) -> string {
 function vercel.internal._gw_images_file(media: baml.media.Image | baml.media.Audio | baml.media.Video | baml.media.Pdf) -> vercel.internal.GwImagesFile {
   141   0    load_var 1             (media)
         1    load_const 0           (false)
-        2    call 942 ntypeargs=0   (ai.wire.resolve_media)
+        2    call 943 ntypeargs=0   (ai.wire.resolve_media)
         3    store_var 2            (resolved)
 
   142   4    load_var 2             (resolved)
@@ -33226,7 +33225,7 @@ function vercel.internal._gw_images_find_output_format(value: baml.json.json | n
         46   jump +11                           (to 57)
 
   341   47   load_var 7                         (entry)
-        48   call 1354 ntypeargs=0              (vercel.internal._gw_images_find_output_format)
+        48   call 1355 ntypeargs=0              (vercel.internal._gw_images_find_output_format)
         49   store_var 10                       (_24)
         50   load_var 10                        (_24)
         51   narrow_bind 10 10                  
@@ -33314,7 +33313,7 @@ function vercel.internal._gw_images_headers(c: vercel.AiGatewayImageClient) -> m
         59   jump -30                           (to 29)
 
   277   60   load_var 1                         (c)
-        61   call 1340 ntypeargs=0              (vercel.AiGatewayImageClient.resolved_api_key)
+        61   call 1341 ntypeargs=0              (vercel.AiGatewayImageClient.resolved_api_key)
         62   store_var 12                       (_29)
         63   load_type 7                        
         64   load_var 12                        (_29)
@@ -33354,7 +33353,7 @@ function vercel.internal._gw_images_input(prompt: ai.Prompt, journal: ai.Journal
         5     store_var 5                        (files)
 
   173   6     load_var 1                         (prompt)
-        7     call 919 ntypeargs=0               (ai.Prompt.messages)
+        7     call 920 ntypeargs=0               (ai.Prompt.messages)
         8     load_type 2                        
         9     load_const 3                       ("iter")
         10    virtual_call nargs=1 ntypeargs=0   
@@ -33414,21 +33413,21 @@ function vercel.internal._gw_images_input(prompt: ai.Prompt, journal: ai.Journal
         62    jump +4                            (to 66)
 
   194   63    load_const 15                      ("pdf")
-        64    call 1346 ntypeargs=0              (vercel.internal._gw_images_media_rejected)
+        64    call 1347 ntypeargs=0              (vercel.internal._gw_images_media_rejected)
         65    throw                              
 
   191   66    load_const 16                      ("video")
-        67    call 1346 ntypeargs=0              (vercel.internal._gw_images_media_rejected)
+        67    call 1347 ntypeargs=0              (vercel.internal._gw_images_media_rejected)
         68    throw                              
 
   188   69    load_const 17                      ("audio")
-        70    call 1346 ntypeargs=0              (vercel.internal._gw_images_media_rejected)
+        70    call 1347 ntypeargs=0              (vercel.internal._gw_images_media_rejected)
         71    throw                              
 
   175   72    load_var 15                        (_25)
         73    store_var_load_var 16              (image)
 
-  184   74    call 1347 ntypeargs=0              (vercel.internal._gw_images_file)
+  184   74    call 1348 ntypeargs=0              (vercel.internal._gw_images_file)
         75    store_var 17                       (_28)
         76    load_type 1                        
         77    load_var2 5 17                     
@@ -33455,7 +33454,7 @@ function vercel.internal._gw_images_input(prompt: ai.Prompt, journal: ai.Journal
         94    jump -66                           (to 28)
 
   199   95    load_var 2                         (journal)
-        96    call 914 ntypeargs=0               (ai.Journal.entries)
+        96    call 915 ntypeargs=0               (ai.Journal.entries)
         97    load_type 19                       
         98    load_const 20                      ("iter")
         99    virtual_call nargs=1 ntypeargs=0   
@@ -33730,7 +33729,7 @@ function vercel.internal._gw_images_with_query(url: string, params: map<string, 
         27    load_var 7                         (_10)
         28    store_var_load_var 8               (key)
 
-  247   29    call 1350 ntypeargs=0              (vercel.internal._gw_images_escape_query)
+  247   29    call 1351 ntypeargs=0              (vercel.internal._gw_images_escape_query)
         30    store_var 10                       (_18)
         31    load_type 0                        
         32    load_var 10                        (_18)
@@ -33747,7 +33746,7 @@ function vercel.internal._gw_images_with_query(url: string, params: map<string, 
         43    load_const 8                       ("")
         44    store_var 13                       (_24)
         45    load_var 13                        (_24)
-        46    call 1350 ntypeargs=0              (vercel.internal._gw_images_escape_query)
+        46    call 1351 ntypeargs=0              (vercel.internal._gw_images_escape_query)
         47    store_var 12                       (_22)
         48    load_type 0                        
         49    load_var 12                        (_22)
@@ -33818,17 +33817,17 @@ function vercel.internal._gw_images_with_query(url: string, params: map<string, 
 
 function vercel.internal.gateway_images_invoke(c: vercel.AiGatewayImageClient, input: ai.ModelTurnInput) -> ai.ModelTurn {
   457   0    load_var2 1 2           
-        1    call 1353 ntypeargs=0   (vercel.internal.gateway_images_render)
+        1    call 1354 ntypeargs=0   (vercel.internal.gateway_images_render)
         2    store_var 3             (req)
 
   458   3    load_type 0             
         4    load_var 3              (req)
         5    load_const 1            ("ai-gateway-images")
-        6    call 940 ntypeargs=1    (ai.wire.send_as)
+        6    call 941 ntypeargs=1    (ai.wire.send_as)
         7    store_var 4             (resp)
 
   459   8    load_var2 1 4           
-        9    call 1358 ntypeargs=0   (vercel.internal.gateway_images_parse)
+        9    call 1359 ntypeargs=0   (vercel.internal.gateway_images_parse)
         10   return                  
 }
 
@@ -33861,7 +33860,7 @@ function vercel.internal.gateway_images_parse(c: vercel.AiGatewayImageClient, re
         24    load_var 6                         (_9)
         25    store_var_load_var 7               (warning)
 
-  414   26    call 1357 ntypeargs=0              (vercel.internal.gateway_images_warning_text)
+  414   26    call 1358 ntypeargs=0              (vercel.internal.gateway_images_warning_text)
         27    store_var 8                        (_13)
         28    load_const 7                       ("$baml_log")
         29    load_const 8                       ("warn")
@@ -33877,7 +33876,7 @@ function vercel.internal.gateway_images_parse(c: vercel.AiGatewayImageClient, re
 
   416   39    load_var 2                         (resp)
         40    load_field 2                       (providerMetadata)
-        41    call 1354 ntypeargs=0              (vercel.internal._gw_images_find_output_format)
+        41    call 1355 ntypeargs=0              (vercel.internal._gw_images_find_output_format)
         42    store_var_load_var 10              (_16)
         43    load_const 0                       (null)
         44    cmp_op ==                          
@@ -33885,13 +33884,13 @@ function vercel.internal.gateway_images_parse(c: vercel.AiGatewayImageClient, re
 
   417   46    load_var 1                         (c)
         47    load_field 7                       (request_body)
-        48    call 1354 ntypeargs=0              (vercel.internal._gw_images_find_output_format)
+        48    call 1355 ntypeargs=0              (vercel.internal._gw_images_find_output_format)
         49    store_var 10                       (_16)
 
   416   50    load_var 10                        (_16)
         51    store_var_load_var 9               (requested)
 
-  418   52    call 1355 ntypeargs=0              (vercel.internal._gw_images_mime)
+  418   52    call 1356 ntypeargs=0              (vercel.internal._gw_images_mime)
         53    store_var 11                       (fallback_mime)
 
   419   54    load_var 2                         (resp)
@@ -33934,10 +33933,10 @@ function vercel.internal.gateway_images_parse(c: vercel.AiGatewayImageClient, re
         88    pop_jump_if_false -15              (to 73)
 
   424   89    load_var2 17 11                    
-        90    call 1356 ntypeargs=0              (vercel.internal._gw_images_value)
+        90    call 1357 ntypeargs=0              (vercel.internal._gw_images_value)
         91    load_const 19                      (<omitted>)
         92    load_const 19                      (<omitted>)
-        93    call 913 ntypeargs=0               (ai.content.Media.new)
+        93    call 914 ntypeargs=0               (ai.content.Media.new)
         94    store_var 18                       (_37)
 
   423   95    load_type 13                       
@@ -34013,7 +34012,7 @@ function vercel.internal.gateway_images_parse(c: vercel.AiGatewayImageClient, re
 function vercel.internal.gateway_images_render(c: vercel.AiGatewayImageClient, input: ai.ModelTurnInput) -> baml.http.Request {
   287   0     load_var 2              (input)
         1     load_field 2            (toolbox)
-        2     call 933 ntypeargs=0    (ai.tools.Toolbox.is_empty)
+        2     call 934 ntypeargs=0    (ai.tools.Toolbox.is_empty)
         3     unary_op !              
         4     pop_jump_if_false +2    (to 6)
         5     jump +94                (to 99)
@@ -34022,10 +34021,10 @@ function vercel.internal.gateway_images_render(c: vercel.AiGatewayImageClient, i
         7     load_field 1            (journal)
         8     store_var 5             (_8)
         9     load_var 1              (c)
-        10    call 1344 ntypeargs=0   (vercel.internal._gw_images_client_id)
+        10    call 1345 ntypeargs=0   (vercel.internal._gw_images_client_id)
         11    store_var 6             (_9)
         12    load_var2 5 6           
-        13    call 944 ntypeargs=0    (ai.wire.sanitize_for_client)
+        13    call 945 ntypeargs=0    (ai.wire.sanitize_for_client)
         14    store_var 4             (journal)
 
   297   15    load_const 0            ("")
@@ -34033,7 +34032,7 @@ function vercel.internal.gateway_images_render(c: vercel.AiGatewayImageClient, i
         17    load_field 0            (prompt)
         18    call_indirect           
         19    load_var 4              (journal)
-        20    call 1348 ntypeargs=0   (vercel.internal._gw_images_input)
+        20    call 1349 ntypeargs=0   (vercel.internal._gw_images_input)
         21    store_var 7             (lowered)
 
   298   22    load_var 7              (lowered)
@@ -34086,15 +34085,15 @@ function vercel.internal.gateway_images_render(c: vercel.AiGatewayImageClient, i
   311   58    load_type 4             
         59    load_var 10             (request)
         60    call 362 ntypeargs=1    (baml.json.to_json)
-        61    call 1345 ntypeargs=0   (vercel.internal._gw_images_drop_nulls)
+        61    call 1346 ntypeargs=0   (vercel.internal._gw_images_drop_nulls)
 
   312   62    load_var 1              (c)
         63    load_field 7            (request_body)
-        64    call 943 ntypeargs=0    (ai.wire.merge_request_body)
+        64    call 944 ntypeargs=0    (ai.wire.merge_request_body)
         65    store_var 13            (merged)
 
   314   66    load_var 1              (c)
-        67    call 1341 ntypeargs=0   (vercel.AiGatewayImageClient.resolved_base_url)
+        67    call 1342 ntypeargs=0   (vercel.AiGatewayImageClient.resolved_base_url)
         68    store_var_load_var 16   (_40)
         69    load_const 2            (null)
         70    cmp_op ==               
@@ -34102,7 +34101,7 @@ function vercel.internal.gateway_images_render(c: vercel.AiGatewayImageClient, i
         72    load_const 5            ("https://ai-gateway.vercel.sh/v4/ai")
         73    store_var 16            (_40)
         74    load_var 16             (_40)
-        75    call 1349 ntypeargs=0   (vercel.internal._gw_images_trim_slash)
+        75    call 1350 ntypeargs=0   (vercel.internal._gw_images_trim_slash)
         76    store_var 15            (_38)
         77    load_type 6             
         78    load_var 15             (_38)
@@ -34113,11 +34112,11 @@ function vercel.internal.gateway_images_render(c: vercel.AiGatewayImageClient, i
   315   82    load_var 1              (c)
         83    load_field 9            (query_params)
 
-  313   84    call 1351 ntypeargs=0   (vercel.internal._gw_images_with_query)
+  313   84    call 1352 ntypeargs=0   (vercel.internal._gw_images_with_query)
         85    store_var 14            (url)
 
   320   86    load_var 1              (c)
-        87    call 1352 ntypeargs=0   (vercel.internal._gw_images_headers)
+        87    call 1353 ntypeargs=0   (vercel.internal._gw_images_headers)
         88    store_var 17            (_46)
 
   321   89    load_var 13             (merged)

--- a/baml_language/crates/baml_tests/tests/output_format_non_data.rs
+++ b/baml_language/crates/baml_tests/tests/output_format_non_data.rs
@@ -309,3 +309,39 @@ async fn generic_class_output_fails_before_provider_io() {
         "E0164|non-data type `Wrapper<Item>` cannot be rendered as an LLM output schema"
     );
 }
+
+/// B-1582 item 4, verification: `never[]` reached through a generic companion is
+/// the ticket's exact shape. #4470 already rejects it with a catchable E0164
+/// rather than panicking in `output_format`; this pins the nested-in-a-container
+/// case, which is the one that could have escaped `first_non_data_type`'s walk.
+#[tokio::test]
+async fn never_nested_in_a_runtime_class_field_is_rejected_not_panicked() {
+    let source = format!(
+        r#"
+            {GENERIC_VALUE}
+
+            function main() -> string throws never {{
+                let outer = reflect.class.new("RuntimeOuter", {{
+                    "items": type.of<never>().array().as_type(),
+                }}) catch (e) {{
+                    _ => return "class.new threw",
+                }}
+                let rendered = GenericValue$render_prompt<unreflect(outer.as_type())>("runtime")
+                    catch (e) {{
+                        baml.reflect.errors.CompilationError => e.diagnostics[0].code + "|" + e.diagnostics[0].message,
+                        _ => "wrong error",
+                    }}
+                if rendered is string {{
+                    return rendered
+                }}
+                "render did not throw"
+            }}
+            "#
+    );
+    let output = baml_test!(&source);
+
+    assert_eq!(
+        result_string(output),
+        "E0164|field `RuntimeOuter.items` has non-data type `never`, which cannot be rendered as an LLM output schema"
+    );
+}

--- a/baml_language/crates/baml_tests/tests/reflect_call_any.rs
+++ b/baml_language/crates/baml_tests/tests/reflect_call_any.rs
@@ -780,3 +780,94 @@ fn runtime_type_arguments_are_rejected_on_streaming_companions() {
         "missing streaming firewall diagnostic: {diagnostics:#?}"
     );
 }
+
+/// B-1582 item 3: a generic LLM function's `$render_prompt` companion has a
+/// signature free of `T` (it takes the parent's value arguments and returns an
+/// `ai.Prompt`), so it reconstructs and `Package.get_function` hands it out.
+/// Its *body* still materializes `T` for the output-format schema, and entering
+/// it with an empty frame died as a VM internal error
+/// ("template references frame type-arg slot 0 but the frame has 0 type args").
+/// Until reflection can supply type arguments, that is a normal E0165.
+#[tokio::test]
+async fn call_any_rejects_an_unspecialized_generic_companion() {
+    let output = baml_test!(
+        r#"
+        client TestClient = openai.ResponsesClient.new(
+            model = "gpt-4o-mini",
+            api_key = "test-key",
+            base_url = "http://localhost:1234",
+        );
+
+        type AnyCallable = baml.AnyFunction<Returns = unknown, Throws = unknown>;
+
+        function GenericList<T>(topic: string) -> T[] {
+            client: TestClient
+            prompt: `
+                Return an empty list of ${topic}.
+                ${ctx.output_format}
+            `
+        }
+
+        function main() -> string throws never {
+            let package = reflect.Package.current()
+            let callable: AnyCallable = package.get_function<AnyCallable>(
+                "GenericList$render_prompt",
+            ) catch (e) {
+                _ => return "get_function threw",
+            } else {
+                return "get_function returned null"
+            }
+            reflect.call_any<unknown, unknown>(callable, { "topic": "items" }) catch (e) {
+                baml.reflect.errors.CompilationError => {
+                    return e.diagnostics[0].code + "|" + e.diagnostics[0].message
+                },
+                _ => return "wrong error",
+            }
+            "call_any did not throw"
+        }
+        "#
+    );
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String(
+            "E0165|generic function `GenericList$render_prompt` cannot be invoked through \
+             reflection until it is specialized: its body needs type arguments and reflection \
+             cannot supply them yet"
+                .into()
+        ))
+    );
+}
+
+/// The floor is gated on the callable actually being an under-supplied generic:
+/// a non-generic companion of an ordinary LLM function still invokes.
+#[tokio::test]
+async fn call_any_still_invokes_a_non_generic_companion() {
+    let output = baml_test!(
+        r#"
+        client TestClient = openai.ResponsesClient.new(
+            model = "gpt-4o-mini",
+            api_key = "test-key",
+            base_url = "http://localhost:1234",
+        );
+
+        type AnyCallable = baml.AnyFunction<Returns = unknown, Throws = unknown>;
+
+        function Plain(topic: string) -> string {
+            client: TestClient
+            prompt: `
+                Say ${topic}.
+                ${ctx.output_format}
+            `
+        }
+
+        function main() -> bool throws unknown {
+            let package = reflect.Package.current()
+            let callable = package.get_function<AnyCallable>("Plain$render_prompt")
+                ?? throw "expected the companion"
+            let rendered = reflect.call_any<unknown, unknown>(callable, { "topic": "hello" })
+            rendered is ai.Prompt
+        }
+        "#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}

--- a/baml_language/crates/baml_tests/tests/reflect_call_any.rs
+++ b/baml_language/crates/baml_tests/tests/reflect_call_any.rs
@@ -783,13 +783,14 @@ fn runtime_type_arguments_are_rejected_on_streaming_companions() {
 
 /// B-1582 item 3: a generic LLM function's `$render_prompt` companion has a
 /// signature free of `T` (it takes the parent's value arguments and returns an
-/// `ai.Prompt`), so it reconstructs and `Package.get_function` hands it out.
-/// Its *body* still materializes `T` for the output-format schema, and entering
-/// it with an empty frame died as a VM internal error
-/// ("template references frame type-arg slot 0 but the frame has 0 type args").
-/// Until reflection can supply type arguments, that is a normal E0165.
+/// `ai.Prompt`), so it reconstructs and `Package.get_function` used to hand it
+/// out. Its *body* still materializes `T` for the output-format schema, and
+/// entering it with an empty frame died as a VM internal error ("template
+/// references frame type-arg slot 0 but the frame has 0 type args"). Until
+/// reflection can supply type arguments, that is a normal E0165 — refused at
+/// extraction, through the `AnyFunction` contract as well as a concrete one.
 #[tokio::test]
-async fn call_any_rejects_an_unspecialized_generic_companion() {
+async fn get_function_refuses_an_unspecialized_generic_through_any_function() {
     let output = baml_test!(
         r#"
         client TestClient = openai.ResponsesClient.new(
@@ -813,17 +814,19 @@ async fn call_any_rejects_an_unspecialized_generic_companion() {
             let callable: AnyCallable = package.get_function<AnyCallable>(
                 "GenericList$render_prompt",
             ) catch (e) {
-                _ => return "get_function threw",
-            } else {
-                return "get_function returned null"
-            }
-            reflect.call_any<unknown, unknown>(callable, { "topic": "items" }) catch (e) {
                 baml.reflect.errors.CompilationError => {
                     return e.diagnostics[0].code + "|" + e.diagnostics[0].message
                 },
                 _ => return "wrong error",
+            } else {
+                return "get_function returned null"
             }
-            "call_any did not throw"
+            // Unreachable: extraction throws above. `reflect.call_any` keeps the
+            // same check for any callable that reaches it by another door.
+            reflect.call_any<unknown, unknown>(callable, { "topic": "items" }) catch_all (e) {
+                _ => return "call_any threw",
+            }
+            "get_function did not throw"
         }
         "#
     );
@@ -866,6 +869,98 @@ async fn call_any_still_invokes_a_non_generic_companion() {
                 ?? throw "expected the companion"
             let rendered = reflect.call_any<unknown, unknown>(callable, { "topic": "hello" })
             rendered is ai.Prompt
+        }
+        "#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+/// The floor has to sit at *extraction*, not only at `reflect.call_any`: a
+/// caller can ask for the companion through an ordinary function-type contract
+/// and then call the value directly, which enters the body with an empty frame
+/// and fails as a VM internal error no `catch` can see. `Package.get_function`
+/// refuses it while the caller still has a diagnostic channel.
+#[tokio::test]
+async fn get_function_refuses_an_unspecialized_generic_companion() {
+    let output = baml_test!(
+        r#"
+        client TestClient = openai.ResponsesClient.new(
+            model = "gpt-4o-mini",
+            api_key = "test-key",
+            base_url = "http://localhost:1234",
+        );
+
+        type PromptFn = (topic: string) -> ai.Prompt throws unknown;
+
+        function GenericList<T>(topic: string) -> T[] {
+            client: TestClient
+            prompt: `
+                Return an empty list of ${topic}.
+                ${ctx.output_format}
+            `
+        }
+
+        function main() -> string throws never {
+            let package = reflect.Package.current()
+            let callable: PromptFn = package.get_function<PromptFn>(
+                "GenericList$render_prompt",
+            ) catch (e) {
+                baml.reflect.errors.CompilationError => {
+                    return e.diagnostics[0].code + "|" + e.diagnostics[0].message
+                },
+                _ => return "wrong error",
+            } else {
+                return "get_function returned null"
+            }
+            // Unreachable: the extraction above throws. Calling it directly is
+            // what used to die inside the body as an uncatchable internal error.
+            callable("items") catch_all (e) {
+                _ => return "direct call threw",
+            }
+            "get_function did not throw"
+        }
+        "#
+    );
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String(
+            "E0165|generic function `GenericList$render_prompt` cannot be invoked through \
+             reflection until it is specialized: its body needs type arguments and reflection \
+             cannot supply them yet"
+                .into()
+        ))
+    );
+}
+
+/// Extraction of an ordinary non-generic companion through the same contract
+/// still works — the refusal is gated on the callable being an under-supplied
+/// generic whose body needs the missing arguments.
+#[tokio::test]
+async fn get_function_still_extracts_a_non_generic_companion() {
+    let output = baml_test!(
+        r#"
+        client TestClient = openai.ResponsesClient.new(
+            model = "gpt-4o-mini",
+            api_key = "test-key",
+            base_url = "http://localhost:1234",
+        );
+
+        type PromptFn = (topic: string) -> ai.Prompt throws unknown;
+
+        function Plain(topic: string) -> string {
+            client: TestClient
+            prompt: `
+                Say ${topic}.
+                ${ctx.output_format}
+            `
+        }
+
+        function main() -> bool throws unknown {
+            let package = reflect.Package.current()
+            let callable = package.get_function<PromptFn>("Plain$render_prompt")
+                ?? throw "expected the companion"
+            let rendered = callable("hello")
+            rendered.text().length() > 0
         }
         "#
     );

--- a/baml_language/crates/baml_tests/tests/runtime_builders_and_pending_types.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_builders_and_pending_types.rs
@@ -206,3 +206,110 @@ async fn unreflect_runtime_escape_does_not_accept_ordinary_values() {
         "#
     );
 }
+
+/// B-1582 item 5: a recursive field could be built and an ordinary field could
+/// carry metadata, but not both — `PendingType` had no `meta`, so a recursive
+/// reference could not be aliased or described.
+#[tokio::test]
+async fn recursive_pending_fields_carry_metadata() {
+    let output = baml_test!(
+        r#"
+        function main() -> string throws unknown {
+            let node = reflect.class.builder("Node")
+            let next = node.type().optional()
+            node.field("label", type.of<string>())
+            node.field(
+                "next",
+                next.meta(alias = "child", description = "Recursive child"),
+            )
+
+            let built = node.build().as_type().as_class() ?? throw "expected class"
+            let fields = built.fields()
+            let label = fields.at(0) ?? throw "expected label field"
+            let child = fields.at(1) ?? throw "expected next field"
+
+            let label_alias = label.meta.alias ?? "none"
+            let child_alias = child.meta.alias ?? "none"
+            let child_description = child.meta.description ?? "none"
+            `${label.name}|${label_alias}|${child.name}|${child_alias}|${child_description}`
+        }
+        "#
+    );
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String(
+            "label|none|next|child|Recursive child".into()
+        ))
+    );
+}
+
+/// The alias a recursive field carries is the key the LLM schema serializes it
+/// under, so it has to survive the atomic group build all the way to render.
+#[tokio::test]
+async fn recursive_pending_field_metadata_reaches_the_rendered_schema() {
+    let output = baml_test!(
+        r##"
+        client TestClient = openai.ResponsesClient.new(
+            model = "gpt-4o-mini",
+            api_key = "test-key",
+            base_url = "http://localhost:1234",
+        );
+
+        function Extract<T>() -> T {
+            client: TestClient
+            prompt: `${ctx.output_format}`
+        }
+
+        function main() -> string throws unknown {
+            let node = reflect.class.builder("Node")
+            let next = node.type().optional()
+            node.field("label", type.of<string>())
+            node.field(
+                "next",
+                next.meta(alias = "child", description = "Recursive child"),
+            )
+            let built = node.build().as_type()
+            Extract$render_prompt<unreflect(built)>().text()
+        }
+        "##
+    );
+    let BexExternalValue::String(rendered) = output.result.expect("render should succeed") else {
+        panic!("expected a string")
+    };
+    let rendered = rendered.to_string();
+    assert!(rendered.contains("child"), "missing alias: {rendered}");
+    assert!(
+        rendered.contains("Recursive child"),
+        "missing description: {rendered}"
+    );
+    assert!(
+        !rendered.contains("next"),
+        "aliased field leaked its source name: {rendered}"
+    );
+}
+
+/// A metadata-wrapped pending reference whose group is already frozen resolves
+/// to an ordinary type; the metadata must not be dropped on that path.
+#[tokio::test]
+async fn metadata_survives_an_already_resolved_pending_reference() {
+    let output = baml_test!(
+        r#"
+        function main() -> string throws unknown {
+            let inner = reflect.class.builder("Inner")
+            inner.field("value", type.of<string>())
+            let pending = inner.type()
+            inner.build()
+
+            let outer = reflect.class.builder("Outer")
+            outer.field("nested", pending.meta(alias = "kid", description = "Frozen child"))
+            let built = outer.build().as_type().as_class() ?? throw "expected class"
+            let field = built.fields().at(0) ?? throw "expected field"
+            `${field.name}|${field.meta.alias ?? "none"}|${field.meta.description ?? "none"}`
+        }
+        "#
+    );
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String("nested|kid|Frozen child".into()))
+    );
+}

--- a/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_package_compile.rs
@@ -218,7 +218,7 @@ function Present(value: string) -> string { value }
   functions.get("root.identity") == null && functions.get("root.Present") != null
 }
 
-function generic_function_companion_is_extractable() -> bool throws unknown {
+function generic_function_companion_extraction_is_refused() -> string throws unknown {
   let pkg = reflect.Package.compile({
     "main.baml": #"
 client Dummy = openai.ResponsesClient.new(
@@ -232,7 +232,16 @@ function Extract<T>(document: string) -> T {
 }
 "#
   })
-  pkg.get_function<(string) -> ai.Prompt>("root.Extract$render_prompt") != null
+  let extracted = pkg.get_function<(string) -> ai.Prompt>("root.Extract$render_prompt") catch (e) {
+    baml.reflect.errors.CompilationError => {
+      return e.diagnostics[0].code
+    },
+    _ => return "wrong error",
+  } else {
+    return "returned null"
+  }
+  let _ = extracted
+  "did not throw"
 }
 
 function generic_function_companion_is_listed() -> bool throws unknown {
@@ -552,13 +561,19 @@ async fn function_listing_omits_unspecialized_generics() {
     assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
 }
 
+/// #4473 let a generic function's companion through `get_function` because its
+/// declared surface mentions no `T`. B-1582 showed what that value is worth: its
+/// body still materializes `T`, so calling it dies inside `LoadType` as an
+/// internal error no `catch` can see. The companion is still *listed* — see the
+/// test below — but extracting it now reports the same reflection limit its
+/// parent does.
 #[tokio::test]
-async fn generic_function_companion_remains_extractable() {
+async fn generic_function_companion_extraction_reports_reflection_limit() {
     let output = baml_test!(
         baml: SCENARIO_6_SOURCE,
-        entry: "generic_function_companion_is_extractable"
+        entry: "generic_function_companion_extraction_is_refused"
     );
-    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+    assert_eq!(output.result, Ok(BexExternalValue::String("E0165".into())));
 }
 
 #[tokio::test]

--- a/baml_language/crates/baml_tests/tests/runtime_type_bindings.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_type_bindings.rs
@@ -238,3 +238,119 @@ function main() -> string throws unknown {
     );
     assert_eq!(output.result, Ok(BexExternalValue::String("E0010".into())));
 }
+
+/// A scripted `ai.Client` that answers with a fixed payload, so the Agent loop
+/// runs end to end without a network or an API key.
+const PROBE_CLIENT: &str = r##"
+client DefaultClient = openai.ResponsesClient.new(
+    model = "gpt-4o-mini",
+    api_key = "test-key",
+    base_url = "http://localhost:1234",
+);
+
+class ProbeClient {
+    reply: string,
+
+    implements ai.Client {
+        function id(self) -> string {
+            "probe"
+        }
+
+        function invoke(self, input: ai.ModelTurnInput) -> ai.ModelTurn {
+            let _ = input;
+            ai.ModelTurn {
+                content: [ai.content.Text { text: self.reply }],
+                stop_reason: ai.content.StopReason.Complete,
+                usage: null,
+            }
+        }
+    }
+}
+"##;
+
+/// B-1582 item 1: an interface-impl method reads its owner's type argument out
+/// of the resolved impl frame, which carries realized types but no runtime
+/// definition overlay. Anything that needs the *definition* — SAP, rendering,
+/// reflection — used to fail on a type the caller could use fine.
+#[tokio::test]
+async fn interface_impl_methods_keep_runtime_type_definitions() {
+    let output = baml_test!(
+        r##"
+        interface Parser<Out> {
+            function parse_it(self, text: string) -> Out throws unknown
+            function describe(self) -> string throws never
+        }
+
+        class Holder<T> {
+            function new() -> Holder<T> throws never {
+                Holder {}
+            }
+
+            implements Parser<T> {
+                function parse_it(self, text: string) -> T throws unknown {
+                    baml.sap.parse<T>(text)
+                }
+
+                function describe(self) -> string throws never {
+                    type.of<T>().to_string()
+                }
+            }
+        }
+
+        function main() -> string throws unknown {
+            let output_type = reflect.class.new("RuntimeOutput", {
+                "name": type.of<string>(),
+            }).as_type()
+            type Out = unreflect(output_type)
+
+            let holder = Holder<Out>.new()
+            let parsed = holder.parse_it(#"{"name":"Pixel"}"#)
+            `${holder.describe()}|${reflect.class.get_field<string>(parsed, "name")}`
+        }
+        "##
+    );
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String("RuntimeOutput|Pixel".into()))
+    );
+}
+
+/// The ticket's Agent repro: `ai.Agent<Out>.run` is `implements Runner<Out>`, so
+/// it took the same hole — a payload `baml.sap.parse<unreflect(t)>` handled fine
+/// came back as `ai.errors.ParseFailed` through the runner.
+#[tokio::test]
+async fn agent_run_parses_a_reflected_output_type() {
+    let source = format!(
+        r##"
+        {PROBE_CLIENT}
+
+        function DynamicOutput<T>() -> T {{
+            client: DefaultClient
+            prompt: `${{ctx.output_format}}`
+        }}
+
+        function main() -> string throws unknown {{
+            let output_type = reflect.class.new("RuntimeOutput", {{
+                "name": type.of<string>(),
+            }}).as_type()
+            type Out = unreflect(output_type)
+
+            // Control: the direct SAP call has always worked.
+            let direct = baml.sap.parse<Out>(#"{{"name":"Pixel"}}"#)
+
+            let run = ai.Agent<Out>.new(
+                client = ProbeClient {{ reply: #"{{"name":"Pixel"}}"# }},
+            ).run(DynamicOutput@spec<Out>())
+
+            let direct_name = reflect.class.get_field<string>(direct, "name")
+            let agent_name = reflect.class.get_field<string>(run.value, "name")
+            `${{direct_name}}|${{agent_name}}`
+        }}
+        "##
+    );
+    let output = baml_test!(&source);
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String("Pixel|Pixel".into()))
+    );
+}

--- a/baml_language/crates/baml_tests/tests/type_kinds.rs
+++ b/baml_language/crates/baml_tests/tests/type_kinds.rs
@@ -323,3 +323,26 @@ async fn map_key_and_function_views_keep_runtime_definitions() {
     );
     assert_eq!(output.result, Ok(BexExternalValue::String("SECOND".into())));
 }
+
+/// A class nested inside a runtime-*package* type is reached the same way, and
+/// its definition lives in the owning package rather than in a per-value
+/// overlay. Reading it back must not fall through to the static type table.
+#[tokio::test]
+async fn nested_class_of_a_runtime_package_type_reads_back() {
+    let output = baml_test!(
+        r#"
+        function main() -> string throws unknown {
+            let pkg = reflect.Package.compile({
+                "schema.baml": "class Leaf { name string } class Root { leaf Leaf }",
+            })
+            let root = pkg.get_class("root.Root") ?? throw "missing Root"
+            let field = root.fields().at(0) ?? throw "missing field"
+            let field_type = field.type ?? throw "missing field type"
+            let leaf = field_type.as_class() ?? throw "expected a class view"
+            let leaf_field = leaf.fields().at(0) ?? throw "expected a leaf field"
+            leaf_field.name
+        }
+        "#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::String("name".into())));
+}

--- a/baml_language/crates/baml_tests/tests/type_kinds.rs
+++ b/baml_language/crates/baml_tests/tests/type_kinds.rs
@@ -305,11 +305,10 @@ async fn nested_views_of_a_runtime_type_keep_its_definitions() {
     );
 }
 
-/// The map *key* and the function views decompose through the same helper, so
-/// pin them too — a runtime enum used as a map key or a parameter type stays
-/// introspectable.
+/// The map *key* decomposes through the same helper as the value, so pin it too
+/// — a runtime enum used as a map key stays introspectable.
 #[tokio::test]
-async fn map_key_and_function_views_keep_runtime_definitions() {
+async fn map_key_type_view_keeps_runtime_definitions() {
     let output = baml_test!(
         r#"
         function main() -> string throws unknown {
@@ -345,4 +344,53 @@ async fn nested_class_of_a_runtime_package_type_reads_back() {
         "#
     );
     assert_eq!(output.result, Ok(BexExternalValue::String("name".into())));
+}
+
+/// A function view's own types are *produced* by reflection rather than
+/// decomposed out of a value the caller already holds, so carrying the overlay
+/// forward on the consumer side does not reach them: `package.functions()` and
+/// `reflect.signature` built their `type` values with no definitions attached,
+/// and reading a runtime package's enum back out of a parameter or a return
+/// type hit `unreachable!("reflected enum … must be loaded")`. Both producers
+/// now attach the owning package's declarations.
+#[tokio::test]
+async fn function_views_of_a_runtime_package_keep_its_definitions() {
+    let output = baml_test!(
+        r#"
+        function main() -> string throws unknown {
+            let pkg = reflect.Package.compile({
+                "schema.baml": "enum Choice { FIRST SECOND } function pick(c: Choice) -> Choice { c }",
+            })
+
+            let view = pkg.functions().get("root.pick") ?? throw "missing pick"
+            let returned = view.return_type().as_enum() ?? throw "expected a return enum"
+            let returned_row = returned.values().at(0) ?? throw "no return rows"
+            let param = view.params().at(0) ?? throw "expected a param"
+            let param_enum = param.type.as_enum() ?? throw "expected a param enum"
+            let param_row = param_enum.values().at(1) ?? throw "no param rows"
+
+            let callable = pkg.get_function<baml.AnyFunction<Returns = unknown, Throws = unknown>>(
+                "root.pick",
+            ) ?? throw "missing callable"
+            let sig = reflect.signature(callable)
+            let sig_returns = sig.returns.as_enum() ?? throw "expected a signature return enum"
+            let sig_return_row = sig_returns.values().at(0) ?? throw "no signature return rows"
+            let arg = sig.args.at(0) ?? throw "expected a signature arg"
+            let sig_arg = arg.type.as_enum() ?? throw "expected a signature arg enum"
+            let sig_arg_row = sig_arg.values().at(1) ?? throw "no signature arg rows"
+
+            let parts = [
+                returned_row.name,
+                param_row.name,
+                sig_return_row.name,
+                sig_arg_row.name,
+            ]
+            parts.join("|")
+        }
+        "#
+    );
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String("FIRST|SECOND|FIRST|SECOND".into()))
+    );
 }

--- a/baml_language/crates/baml_tests/tests/type_kinds.rs
+++ b/baml_language/crates/baml_tests/tests/type_kinds.rs
@@ -259,3 +259,67 @@ async fn nested_type_walker_and_kind_specific_readback_work_end_to_end() {
     );
     assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
 }
+
+/// B-1582 item 2: decomposing a runtime type's view must keep the definition
+/// overlay the enclosing value carries. Reading the nested enum's rows used to
+/// hit `unreachable!("reflected enum … must be loaded")` in the VM.
+#[tokio::test]
+async fn nested_views_of_a_runtime_type_keep_its_definitions() {
+    let output = baml_test!(
+        r#"
+        function main() -> string throws unknown {
+            let choice = reflect.enum.new("Choice", ["FIRST", "SECOND"]).as_type();
+
+            // Through a class field's array element.
+            let root = reflect.class.new("Root", {
+                "choices": choice.array().as_type(),
+            }).as_type();
+            let root_class = root.as_class() ?? throw "expected class";
+            let field = root_class.fields().at(0) ?? throw "expected field";
+            let field_type = field.type ?? throw "expected field type";
+            let array = field_type.as_array() ?? throw "expected array";
+            let from_array = array.element_type().as_enum() ?? throw "expected array enum";
+
+            // Through a map value.
+            let map_view = reflect.map.new(type.of<string>(), choice).as_type().as_map()
+                ?? throw "expected map";
+            let from_map_value = map_view.value_type().as_enum() ?? throw "expected map enum";
+
+            // Through a union member.
+            let union_view = reflect.union.new([choice, type.of<int>()]).as_type().as_union()
+                ?? throw "expected union";
+            let member = union_view.member_types().at(0) ?? throw "expected member";
+            let from_union = member.as_enum() ?? throw "expected union enum";
+
+            [
+                (from_array.values().at(0) ?? throw "array rows").name,
+                (from_map_value.values().at(1) ?? throw "map rows").name,
+                (from_union.values().at(0) ?? throw "union rows").name,
+            ].join("|")
+        }
+        "#
+    );
+    assert_eq!(
+        output.result,
+        Ok(BexExternalValue::String("FIRST|SECOND|FIRST".into()))
+    );
+}
+
+/// The map *key* and the function views decompose through the same helper, so
+/// pin them too — a runtime enum used as a map key or a parameter type stays
+/// introspectable.
+#[tokio::test]
+async fn map_key_and_function_views_keep_runtime_definitions() {
+    let output = baml_test!(
+        r#"
+        function main() -> string throws unknown {
+            let choice = reflect.enum.new("Choice", ["FIRST", "SECOND"]).as_type();
+            let map_view = reflect.map.new(choice, type.of<int>()).as_type().as_map()
+                ?? throw "expected map";
+            let key_enum = map_view.key_type().as_enum() ?? throw "expected key enum";
+            (key_enum.values().at(1) ?? throw "key rows").name
+        }
+        "#
+    );
+    assert_eq!(output.result, Ok(BexExternalValue::String("SECOND".into())));
+}

--- a/baml_language/crates/bex_vm/src/package_baml/reflect.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/reflect.rs
@@ -2145,6 +2145,17 @@ fn call_any_impl(
         }
         return non_callable_error("reflect.call_any").into();
     };
+    // A generic whose signature happens to be free of its own type parameters
+    // reconstructs above and would otherwise be entered with an empty frame,
+    // failing inside its body as a VM internal error.
+    if let Some(name) = vm.underspecialized_generic_callable_name(f_val) {
+        let diagnostic = runtime_type::unspecialized_reflected_generic_call(&name);
+        return VmRustFnError::Thrown(super::type_kinds::alloc_compilation_error(
+            vm,
+            &[diagnostic],
+        ))
+        .into();
+    }
 
     // Walk the parameters in declaration order, resolving each from the map
     // by its addressable name and assembling the callee's frame as we go.

--- a/baml_language/crates/bex_vm/src/package_baml/reflect.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/reflect.rs
@@ -281,14 +281,19 @@ fn package_interface_type(
     Value::object(vm.alloc_static_type(ty))
 }
 
-fn allocate_runtime_declaration_types(
-    vm: &mut BexVm,
-    package_ptr: HeapPtr,
+/// The definition overlay a package's own declarations form.
+///
+/// A statically compiled package needs none: its declarations live in the
+/// engine image and resolve by name. A runtime package's do not, so every
+/// `type` value reflection hands out of one has to carry this overlay or the
+/// name it mentions is unresolvable — the BEP-066 rule that a minted type and
+/// its definitions travel together.
+fn declaration_defs(
+    vm: &BexVm,
     classes: &IndexMap<LocalName, HeapPtr>,
     enums: &IndexMap<LocalName, HeapPtr>,
-    interfaces: &IndexMap<LocalName, HeapPtr>,
-) -> IndexMap<String, HeapPtr> {
-    let source_defs = DynTypeDefs {
+) -> DynTypeDefs {
+    DynTypeDefs {
         classes: classes
             .values()
             .filter_map(|ptr| match vm.get_object(*ptr) {
@@ -306,7 +311,38 @@ fn allocate_runtime_declaration_types(
             })
             .collect(),
         witnesses: Vec::new(),
+    }
+}
+
+/// [`declaration_defs`] for an already-populated package object. Empty for a
+/// null pointer, which is what a statically compiled callable reports.
+fn package_defs(vm: &BexVm, package_ptr: HeapPtr) -> DynTypeDefs {
+    if package_ptr.is_null() {
+        return DynTypeDefs::default();
+    }
+    let Object::Package(package) = vm.get_object(package_ptr) else {
+        return DynTypeDefs::default();
     };
+    declaration_defs(vm, &package.classes, &package.enums)
+}
+
+/// Allocate a `type` value inside a definition overlay, keeping the memoized
+/// static path when there is nothing to carry.
+fn alloc_type_in(vm: &mut BexVm, ty: RealizedTy, defs: &DynTypeDefs) -> Value {
+    if defs.is_empty() {
+        return Value::object(vm.alloc_static_type(ty));
+    }
+    Value::object(vm.alloc_static_type_with_defs(ty, defs.clone()))
+}
+
+fn allocate_runtime_declaration_types(
+    vm: &mut BexVm,
+    package_ptr: HeapPtr,
+    classes: &IndexMap<LocalName, HeapPtr>,
+    enums: &IndexMap<LocalName, HeapPtr>,
+    interfaces: &IndexMap<LocalName, HeapPtr>,
+) -> IndexMap<String, HeapPtr> {
+    let source_defs = declaration_defs(vm, classes, enums);
     let class_rows = classes
         .iter()
         .filter_map(|(name, &class_ptr)| match vm.get_object(class_ptr) {
@@ -436,7 +472,8 @@ fn function_type(vm: &mut BexVm, package: HeapPtr, name: &LocalName) -> Option<V
     let callable = package_function_value(vm, package, name)?;
     let signature = vm.callable_signature(callable)?;
     let ty = callee_fn_ty(&signature);
-    Some(Value::object(vm.alloc_static_type(ty)))
+    let defs = package_defs(vm, package);
+    Some(alloc_type_in(vm, ty, &defs))
 }
 
 fn dependency_object(vm: &BexVm, package: HeapPtr, local: &str) -> Option<HeapPtr> {
@@ -1108,6 +1145,17 @@ impl BamlClassReflectPackage for PackageBamlImpl {
             }
             return Ok(None);
         };
+        // Signature reconstruction only sees the declared surface. A companion
+        // whose surface is free of its parent's `T` gets this far and would be
+        // handed out as an ordinary function value — and calling one directly
+        // fails inside its body as a VM internal error no `catch` can see. Refuse
+        // it here, where the caller still has a diagnostic channel.
+        if let Some(name) = vm.generic_callable_body_needs_type_args(function_value) {
+            let diagnostic = runtime_type::unspecialized_reflected_generic_call(&name);
+            return Err(VmRustFnError::Thrown(
+                super::type_kinds::alloc_compilation_error(vm, &[diagnostic]),
+            ));
+        }
         let actual = callee_fn_ty(&signature);
         let expected = vm
             .current_call_type_args()
@@ -1963,12 +2011,13 @@ fn alloc_arg(
     name: Option<&baml_type::Name>,
     position: usize,
     ty: RealizedTy,
+    defs: &DynTypeDefs,
 ) -> Value {
     let name = match name {
         Some(n) => Value::object(vm.alloc_string(n.as_str())),
         None => Value::object(vm.alloc_string(format!("$arg{position}"))),
     };
-    let ty = Value::object(vm.alloc_static_type(ty));
+    let ty = alloc_type_in(vm, ty, defs);
     copy::reflect::Arg { name, r#type: ty }.to_value(vm)
 }
 
@@ -1986,13 +2035,17 @@ fn signature_impl(vm: &mut BexVm, f_val: Value) -> Result<Value, VmRustFnError> 
     let Some(sig) = vm.callable_signature(f_val) else {
         return Err(non_callable_error("reflect.signature"));
     };
+    // A signature reconstructed off a runtime package's function names that
+    // package's classes and enums; the reported types have to carry its
+    // declarations or nothing downstream can resolve them.
+    let defs = package_defs(vm, vm.callable_runtime_package(f_val));
     let mut positional = Vec::new();
     let mut opts: IndexMap<bex_str::BexStr, Value> = IndexMap::new();
     for param in &sig.params {
         match param.mode {
             FunctionParamMode::Required => {
                 let position = positional.len();
-                let arg = alloc_arg(vm, param.name.as_ref(), position, param.ty.clone());
+                let arg = alloc_arg(vm, param.name.as_ref(), position, param.ty.clone(), &defs);
                 positional.push(arg);
             }
             FunctionParamMode::Optional => {
@@ -2001,7 +2054,7 @@ fn signature_impl(vm: &mut BexVm, f_val: Value) -> Result<Value, VmRustFnError> 
                 // it by), so it is simply absent from `opts`. Placeholders
                 // are for positionals only and never enter by-name matching.
                 if let Some(name) = &param.name {
-                    let arg = alloc_arg(vm, Some(name), positional.len(), param.ty.clone());
+                    let arg = alloc_arg(vm, Some(name), positional.len(), param.ty.clone(), &defs);
                     opts.insert(bex_str::BexStr::from(name.as_str()), arg);
                 }
             }
@@ -2009,8 +2062,8 @@ fn signature_impl(vm: &mut BexVm, f_val: Value) -> Result<Value, VmRustFnError> 
     }
     let args = Value::object(vm.tlab.alloc_array(ty_arg(), positional));
     let opts = Value::object(vm.tlab.alloc_map(RealizedTy::string(), ty_arg(), opts));
-    let returns = Value::object(vm.alloc_static_type(sig.ret.clone()));
-    let errors = Value::object(vm.alloc_static_type(sig.throws));
+    let returns = alloc_type_in(vm, sig.ret.clone(), &defs);
+    let errors = alloc_type_in(vm, sig.throws, &defs);
     let docstring = opt_string(vm, sig.docstring.as_ref());
     let name = opt_string(vm, sig.name.as_ref());
     Ok(copy::reflect::Signature {
@@ -2148,7 +2201,7 @@ fn call_any_impl(
     // A generic whose signature happens to be free of its own type parameters
     // reconstructs above and would otherwise be entered with an empty frame,
     // failing inside its body as a VM internal error.
-    if let Some(name) = vm.underspecialized_generic_callable_name(f_val) {
+    if let Some(name) = vm.generic_callable_body_needs_type_args(f_val) {
         let diagnostic = runtime_type::unspecialized_reflected_generic_call(&name);
         return VmRustFnError::Thrown(super::type_kinds::alloc_compilation_error(
             vm,

--- a/baml_language/crates/bex_vm/src/package_baml/runtime_class_builder.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/runtime_class_builder.rs
@@ -29,8 +29,9 @@ use indexmap::IndexMap;
 use super::{
     BamlClassReflectClassBuilder, BamlClassReflectClassPendingType, PackageBamlImpl,
     type_kinds::{
-        ReflectedTypeRow, WitnessField, alloc_compilation_error, compiler_diagnostic,
-        is_baml_identifier, reflected_type_row, register_class_witnesses, validate_class_witnesses,
+        ReflectedTypeRow, WitnessField, alloc_compilation_error, alloc_with_meta,
+        compiler_diagnostic, is_baml_identifier, reflected_type_row, register_class_witnesses,
+        string_map_rows, validate_class_witnesses, with_meta_row,
     },
 };
 use crate::{BexVm, errors::VmRustFnError};
@@ -69,6 +70,23 @@ enum PendingOp {
 #[derive(Clone, Copy)]
 struct PendingHandle {
     op: PendingOp,
+}
+
+/// The schema metadata a field root carries, independent of how its type is
+/// spelled. Empty for a bare `type` or a bare `PendingType`.
+#[derive(Clone, Default)]
+struct FieldMeta {
+    alias: Option<String>,
+    description: Option<String>,
+    docstring: Option<String>,
+    other: IndexMap<String, String>,
+}
+
+/// A field root that names a not-yet-frozen builder, bare or wrapped in
+/// `reflect.WithMeta`.
+struct PendingFieldRoot {
+    pending: Value,
+    meta: Option<FieldMeta>,
 }
 
 struct BuilderNode {
@@ -157,6 +175,35 @@ fn pending_parts(vm: &BexVm, value: Value) -> Result<(HeapPtr, PendingHandle), S
         .as_rust_data::<PendingHandle>(&instance.load_field(0))
         .map_err(|_| "pending type has invalid native state".to_string())?;
     Ok((ptr, handle))
+}
+
+/// Split a field root into the pending reference it names and the metadata
+/// attached to it. `None` when the root is not a pending reference at all —
+/// a `type` value or a `reflect.WithMeta<type>` row, which the ordinary
+/// resolved-field path reads.
+fn pending_field_root(vm: &BexVm, root: Value) -> Option<Result<PendingFieldRoot, String>> {
+    if class_name(vm, root).as_deref() == Some(PENDING_FQN) {
+        return Some(Ok(PendingFieldRoot {
+            pending: root,
+            meta: None,
+        }));
+    }
+    let row = match with_meta_row(vm, root)? {
+        Ok(row) => row,
+        Err(message) => return Some(Err(message)),
+    };
+    if class_name(vm, row.payload).as_deref() != Some(PENDING_FQN) {
+        return None;
+    }
+    Some(Ok(PendingFieldRoot {
+        pending: row.payload,
+        meta: Some(FieldMeta {
+            alias: row.alias,
+            description: row.description,
+            docstring: row.docstring,
+            other: row.other,
+        }),
+    }))
 }
 
 fn instance_array_field(vm: &BexVm, value: Value, index: usize) -> Result<Vec<Value>, String> {
@@ -286,19 +333,41 @@ impl BamlClassReflectClassBuilder for PackageBamlImpl {
             }
         }
 
-        let (stored_type, pending_builders) = if class_name(vm, *ty).as_deref() == Some(PENDING_FQN)
-        {
-            match resolve_pending_if_ready(vm, *ty)
+        let pending_root =
+            match pending_field_root(vm, *ty) {
+                Some(root) => Some(root.map_err(|message| {
+                    compilation_error(vm, DiagnosticId::TypeMismatch, message)
+                })?),
+                None => None,
+            };
+        let (stored_type, pending_builders) = if let Some(root) = pending_root {
+            match resolve_pending_if_ready(vm, root.pending)
                 .map_err(|message| compilation_error(vm, DiagnosticId::TypeMismatch, message))?
             {
+                // The group this reference names is already frozen, so the
+                // field stores an ordinary type — re-wrapped so metadata the
+                // caller attached to the pending reference is not dropped.
                 Some(resolved) => {
                     reflected_type_row(vm, resolved).map_err(|message| {
                         compilation_error(vm, DiagnosticId::TypeMismatch, message)
                     })?;
-                    (resolved, Vec::new())
+                    let stored = match &root.meta {
+                        Some(meta) => alloc_with_meta(
+                            vm,
+                            resolved,
+                            meta.alias.as_deref(),
+                            meta.description.as_deref(),
+                            meta.docstring.as_deref(),
+                            &meta.other,
+                        ),
+                        None => resolved,
+                    };
+                    (stored, Vec::new())
                 }
+                // Still pending: store the root exactly as written (wrapper
+                // included) and wire the builders into one recursive group.
                 None => {
-                    let builders = direct_builders(vm, *ty).map_err(|message| {
+                    let builders = direct_builders(vm, root.pending).map_err(|message| {
                         compilation_error(vm, DiagnosticId::TypeMismatch, message)
                     })?;
                     let mut unfrozen = Vec::with_capacity(builders.len());
@@ -371,6 +440,25 @@ impl BamlClassReflectClassPendingType for PackageBamlImpl {
 
     fn resolved(vm: &mut BexVm, pendingtype: &Value) -> Option<Value> {
         resolve_pending_if_ready(vm, *pendingtype).ok().flatten()
+    }
+
+    fn meta(
+        vm: &mut BexVm,
+        pendingtype: &Value,
+        alias: Option<&bex_str::BexStr>,
+        description: Option<&bex_str::BexStr>,
+        docstring: Option<&bex_str::BexStr>,
+        other: Option<&IndexMap<bex_str::BexStr, Value>>,
+    ) -> Value {
+        let other = string_map_rows(vm, other);
+        alloc_with_meta(
+            vm,
+            *pendingtype,
+            alias.map(bex_str::BexStr::as_str),
+            description.map(bex_str::BexStr::as_str),
+            docstring.map(bex_str::BexStr::as_str),
+            &other,
+        )
     }
 }
 
@@ -490,16 +578,27 @@ fn prepare_group(
                 continue;
             };
 
-            let row = if class_name(vm, root).as_deref() == Some(PENDING_FQN) {
-                match validate_pending(vm, root, group) {
-                    Ok(()) => PreparedField {
-                        name: field.name.clone(),
-                        field_type: PreparedFieldType::Pending(root),
-                        alias: None,
-                        description: None,
-                        docstring: None,
-                        other: IndexMap::new(),
-                    },
+            let pending_root = match pending_field_root(vm, root) {
+                Some(Ok(root)) => Some(root),
+                Some(Err(message)) => {
+                    diagnostics.push(compiler_diagnostic(DiagnosticId::TypeMismatch, message));
+                    continue;
+                }
+                None => None,
+            };
+            let row = if let Some(pending_root) = pending_root {
+                match validate_pending(vm, pending_root.pending, group) {
+                    Ok(()) => {
+                        let meta = pending_root.meta.unwrap_or_default();
+                        PreparedField {
+                            name: field.name.clone(),
+                            field_type: PreparedFieldType::Pending(pending_root.pending),
+                            alias: meta.alias,
+                            description: meta.description,
+                            docstring: meta.docstring,
+                            other: meta.other,
+                        }
+                    }
                     Err(message) => {
                         diagnostics.push(compiler_diagnostic(DiagnosticId::TypeMismatch, message));
                         continue;

--- a/baml_language/crates/bex_vm/src/package_baml/type_class.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/type_class.rs
@@ -1,8 +1,7 @@
-use bex_heap::TlabHolder;
 use bex_vm_types::types::{DynTypeDefs, DynWitnessDef, Object, TypeValue, Value};
 use indexmap::IndexMap;
 
-use super::{BamlClassTypeValue, BamlNamespaceType, PackageBamlImpl, copy, resolve};
+use super::{BamlClassTypeValue, BamlNamespaceType, PackageBamlImpl, resolve};
 use crate::{BexVm, errors::VmRustFnError};
 
 impl BamlNamespaceType for PackageBamlImpl {
@@ -111,37 +110,15 @@ impl BamlClassTypeValue for PackageBamlImpl {
         docstring: Option<&bex_str::BexStr>,
         other: Option<&IndexMap<bex_str::BexStr, Value>>,
     ) -> Value {
-        fn opt_string(vm: &mut BexVm, value: Option<&bex_str::BexStr>) -> Value {
-            value.map_or(Value::NULL, |s| Value::object(vm.alloc_string(s.clone())))
-        }
-
-        let entries = other
-            .into_iter()
-            .flatten()
-            .map(|(key, value)| {
-                let value = vm
-                    .as_string(value)
-                    .expect("map<string, string> value checked by native glue")
-                    .clone();
-                (key.clone(), Value::object(vm.alloc_string(value)))
-            })
-            .collect();
-        let other = Value::object(vm.alloc_map(
-            baml_type::RealizedTy::string(),
-            baml_type::RealizedTy::string(),
-            entries,
-        ));
-        let alias = opt_string(vm, alias);
-        let description = opt_string(vm, description);
-        let docstring = opt_string(vm, docstring);
-        copy::reflect::WithMeta {
-            ty: *self_value,
-            alias,
-            description,
-            docstring,
-            other,
-        }
-        .to_value(vm)
+        let other = super::type_kinds::string_map_rows(vm, other);
+        super::type_kinds::alloc_with_meta(
+            vm,
+            *self_value,
+            alias.map(bex_str::BexStr::as_str),
+            description.map(bex_str::BexStr::as_str),
+            docstring.map(bex_str::BexStr::as_str),
+            &other,
+        )
     }
 
     fn kind(_vm: &BexVm, self_value: &Value) -> Value {

--- a/baml_language/crates/bex_vm/src/package_baml/type_kinds.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/type_kinds.rs
@@ -7,12 +7,14 @@ use baml_compiler_diagnostics::{
     runtime_type::{self, DuplicateMemberKind, InvalidIdentifierKind, SerializedKeyContainer},
 };
 use bex_heap::TlabHolder;
-use bex_vm_types::HeapPtr;
-use bex_vm_types::types::{
-    Class, ClassField, DynTypeDefs, DynWitnessDef, Enum, EnumVariant, InterfaceDef, MethodImpl,
-    MintId, Object, PortableClassDef, PortableClassFieldDef, PortableEnumDef,
-    PortableEnumVariantDef, PortableMetadata, PortableTypeDef, RuntimeImplRule,
-    RuntimeTypeProvenance, TypeValue, Value,
+use bex_vm_types::{
+    HeapPtr,
+    types::{
+        Class, ClassField, DynTypeDefs, DynWitnessDef, Enum, EnumVariant, InterfaceDef, MethodImpl,
+        MintId, Object, PortableClassDef, PortableClassFieldDef, PortableEnumDef,
+        PortableEnumVariantDef, PortableMetadata, PortableTypeDef, RuntimeImplRule,
+        RuntimeTypeProvenance, TypeValue, Value,
+    },
 };
 use indexmap::IndexMap;
 

--- a/baml_language/crates/bex_vm/src/package_baml/type_kinds.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/type_kinds.rs
@@ -1232,63 +1232,89 @@ pub(super) struct ReflectedTypeRow {
     pub(super) other: IndexMap<String, String>,
 }
 
-pub(super) fn reflected_type_row(vm: &BexVm, value: Value) -> Result<ReflectedTypeRow, String> {
-    let Some(ptr) = value.as_object_ptr() else {
-        return Err("class fields must be type values or reflect.WithMeta<type> rows".into());
+/// A `reflect.WithMeta<T>` row read without interpreting its payload.
+///
+/// `T` is `type` for an ordinary field and `reflect.class.PendingType` for a
+/// recursive one, so the payload stays a raw `Value` and each caller decides
+/// what it accepts.
+pub(super) struct WithMetaRow {
+    pub(super) payload: Value,
+    pub(super) alias: Option<String>,
+    pub(super) description: Option<String>,
+    pub(super) docstring: Option<String>,
+    pub(super) other: IndexMap<String, String>,
+}
+
+/// Read `value` as a `reflect.WithMeta` wrapper. `None` when it is not one.
+pub(super) fn with_meta_row(vm: &BexVm, value: Value) -> Option<Result<WithMetaRow, String>> {
+    let Object::Instance(instance) = vm.get_object(value.as_object_ptr()?) else {
+        return None;
     };
-    match vm.get_object(ptr) {
-        Object::Type(type_value) => Ok(ReflectedTypeRow {
+    let Object::Class(class) = vm.get_object(instance.class) else {
+        unreachable!("Instance.class must point to Object::Class")
+    };
+    if class.name.to_string() != "baml.reflect.WithMeta" {
+        return None;
+    }
+    let optional_string = |index| {
+        let value = instance.load_field(index);
+        if value.is_null() {
+            Ok(None)
+        } else {
+            vm.as_string(&value)
+                .map(|value| Some(value.to_string()))
+                .map_err(|_| "reflect.WithMeta string field has an invalid value".to_string())
+        }
+    };
+    let read = || {
+        let other = vm
+            .as_map(&instance.load_field(4))
+            .map_err(|_| "reflect.WithMeta.other must be map<string, string>".to_string())?
+            .to_index_map()
+            .iter()
+            .map(|(key, value)| {
+                vm.as_string(value)
+                    .map(|value| (key.to_string(), value.to_string()))
+                    .map_err(|_| "reflect.WithMeta.other must be map<string, string>".to_string())
+            })
+            .collect::<Result<IndexMap<_, _>, _>>()?;
+        Ok(WithMetaRow {
+            payload: instance.load_field(0),
+            alias: optional_string(1)?,
+            description: optional_string(2)?,
+            docstring: optional_string(3)?,
+            other,
+        })
+    };
+    Some(read())
+}
+
+pub(super) fn reflected_type_row(vm: &BexVm, value: Value) -> Result<ReflectedTypeRow, String> {
+    const EXPECTED: &str = "class fields must be type values or reflect.WithMeta<type> rows";
+    let Some(ptr) = value.as_object_ptr() else {
+        return Err(EXPECTED.into());
+    };
+    if let Object::Type(type_value) = vm.get_object(ptr) {
+        return Ok(ReflectedTypeRow {
             type_value: (**type_value).clone(),
             alias: None,
             description: None,
             docstring: None,
             other: IndexMap::new(),
-        }),
-        Object::Instance(instance) => {
-            let Object::Class(class) = vm.get_object(instance.class) else {
-                unreachable!("Instance.class must point to Object::Class")
-            };
-            if class.name.to_string() != "baml.reflect.WithMeta" {
-                return Err(
-                    "class fields must be type values or reflect.WithMeta<type> rows".into(),
-                );
-            }
-            let type_value = reflected_type_value(vm, instance.load_field(0));
-            let optional_string = |index| {
-                let value = instance.load_field(index);
-                if value.is_null() {
-                    Ok(None)
-                } else {
-                    vm.as_string(&value)
-                        .map(|value| Some(value.to_string()))
-                        .map_err(|_| {
-                            "reflect.WithMeta string field has an invalid value".to_string()
-                        })
-                }
-            };
-            let other = vm
-                .as_map(&instance.load_field(4))
-                .map_err(|_| "reflect.WithMeta.other must be map<string, string>".to_string())?
-                .to_index_map()
-                .iter()
-                .map(|(key, value)| {
-                    vm.as_string(value)
-                        .map(|value| (key.to_string(), value.to_string()))
-                        .map_err(|_| {
-                            "reflect.WithMeta.other must be map<string, string>".to_string()
-                        })
-                })
-                .collect::<Result<IndexMap<_, _>, _>>()?;
-            Ok(ReflectedTypeRow {
-                type_value,
-                alias: optional_string(1)?,
-                description: optional_string(2)?,
-                docstring: optional_string(3)?,
-                other,
-            })
-        }
-        _ => Err("class fields must be type values or reflect.WithMeta<type> rows".into()),
+        });
     }
+    let row = with_meta_row(vm, value).ok_or_else(|| EXPECTED.to_string())??;
+    let Some(Object::Type(type_value)) = row.payload.as_object_ptr().map(|ptr| vm.get_object(ptr))
+    else {
+        return Err(EXPECTED.into());
+    };
+    Ok(ReflectedTypeRow {
+        type_value: (**type_value).clone(),
+        alias: row.alias,
+        description: row.description,
+        docstring: row.docstring,
+        other: row.other,
+    })
 }
 
 fn reflected_class(vm: &BexVm, value: Value) -> (bex_vm_types::Class, Vec<baml_type::RealizedTy>) {
@@ -1351,6 +1377,59 @@ fn reflected_enum(vm: &BexVm, value: Value) -> bex_vm_types::Enum {
 
 fn opt_string(vm: &mut BexVm, value: Option<&str>) -> Value {
     value.map_or(Value::NULL, |s| Value::object(vm.alloc_string(s)))
+}
+
+/// Read a native `map<string, string>` argument into owned rows.
+pub(super) fn string_map_rows(
+    vm: &BexVm,
+    other: Option<&IndexMap<bex_str::BexStr, Value>>,
+) -> IndexMap<String, String> {
+    other
+        .into_iter()
+        .flatten()
+        .map(|(key, value)| {
+            let value = vm
+                .as_string(value)
+                .expect("map<string, string> value checked by native glue");
+            (key.to_string(), value.to_string())
+        })
+        .collect()
+}
+
+/// Pair `payload` with schema metadata as a `reflect.WithMeta` row. `payload`
+/// is a `type` value for `type.meta` and a pending reference for
+/// `reflect.class.PendingType.meta`.
+pub(super) fn alloc_with_meta(
+    vm: &mut BexVm,
+    payload: Value,
+    alias: Option<&str>,
+    description: Option<&str>,
+    docstring: Option<&str>,
+    other: &IndexMap<String, String>,
+) -> Value {
+    let mut entries = IndexMap::with_capacity(other.len());
+    for (key, value) in other {
+        entries.insert(
+            bex_str::BexStr::from(key.as_str()),
+            Value::object(vm.alloc_string(value.as_str())),
+        );
+    }
+    let other = Value::object(vm.alloc_map(
+        baml_type::RealizedTy::string(),
+        baml_type::RealizedTy::string(),
+        entries,
+    ));
+    let alias = opt_string(vm, alias);
+    let description = opt_string(vm, description);
+    let docstring = opt_string(vm, docstring);
+    copy::reflect::WithMeta {
+        ty: payload,
+        alias,
+        description,
+        docstring,
+        other,
+    }
+    .to_value(vm)
 }
 
 fn alloc_meta(

--- a/baml_language/crates/bex_vm/src/package_baml/type_kinds.rs
+++ b/baml_language/crates/bex_vm/src/package_baml/type_kinds.rs
@@ -7,6 +7,7 @@ use baml_compiler_diagnostics::{
     runtime_type::{self, DuplicateMemberKind, InvalidIdentifierKind, SerializedKeyContainer},
 };
 use bex_heap::TlabHolder;
+use bex_vm_types::HeapPtr;
 use bex_vm_types::types::{
     Class, ClassField, DynTypeDefs, DynWitnessDef, Enum, EnumVariant, InterfaceDef, MethodImpl,
     MintId, Object, PortableClassDef, PortableClassFieldDef, PortableEnumDef,
@@ -1017,9 +1018,23 @@ impl BamlNamespaceReflectUnion for PackageBamlImpl {
     }
 }
 
-fn reflected_ty(vm: &BexVm, value: Value) -> baml_type::RealizedTy {
-    super::type_class::type_value_ty(vm, value)
-        .unwrap_or_else(|| unreachable!("kind method receiver must be Object::Type"))
+/// Hand back a type nested inside `parent`, keeping `parent`'s runtime
+/// definition overlay.
+///
+/// A minted `type` value gives its nominal names meaning through the
+/// [`DynTypeDefs`] it carries (BEP-066): `user.$dyn.2.Choice` is only a name
+/// until the overlay maps it to a definition. Every decomposing view accessor
+/// (`element_type`, `key_type`, `value_type`, `member_types`, `params`,
+/// `return_type`, and a class field's type) hands back a type that was written
+/// *inside* that overlay, so allocating it as a plain static value strands the
+/// definitions it names and the next `values()`/`fields()` call cannot find
+/// them. Carrying the overlay forward is the same thing `LoadType` does for a
+/// type materialized inside a frame that has one.
+fn nested_type_value(vm: &mut BexVm, inner: baml_type::RealizedTy, parent: &TypeValue) -> HeapPtr {
+    if parent.defs().is_empty() {
+        return vm.alloc_static_type(inner);
+    }
+    vm.alloc_static_type_with_defs(inner, parent.defs().clone())
 }
 
 /// Realize an interface field declaration against the exact interface
@@ -1534,6 +1549,7 @@ impl BamlClassReflectClassType for PackageBamlImpl {
     impl_as_type!(BamlClassReflectClassType);
 
     fn fields(vm: &mut BexVm, r#type: &Value) -> Vec<Value> {
+        let parent = reflected_type_value(vm, *r#type);
         let (class, args) = reflected_class(vm, *r#type);
         class
             .fields
@@ -1549,7 +1565,7 @@ impl BamlClassReflectClassType for PackageBamlImpl {
                         .unwrap_or_else(|err| {
                             unreachable!("emitted class field template must realize: {err}")
                         });
-                    Value::object(vm.alloc_static_type(ty))
+                    Value::object(nested_type_value(vm, ty, &parent))
                 };
                 let meta = alloc_meta(
                     vm,
@@ -1618,12 +1634,13 @@ impl BamlClassReflectUnionType for PackageBamlImpl {
     impl_as_type!(BamlClassReflectUnionType);
 
     fn member_types(vm: &mut BexVm, r#type: &Value) -> Vec<Value> {
-        let baml_type::RealizedTy::Union(members, _) = reflected_ty(vm, *r#type) else {
+        let parent = reflected_type_value(vm, *r#type);
+        let baml_type::RealizedTy::Union(members, _) = parent.ty.clone() else {
             unreachable!("union.Type receiver must wrap a union type")
         };
         members
             .into_iter()
-            .map(|ty| Value::object(vm.alloc_static_type(ty)))
+            .map(|ty| Value::object(nested_type_value(vm, ty, &parent)))
             .collect()
     }
 }
@@ -1632,10 +1649,11 @@ impl BamlClassReflectArrayType for PackageBamlImpl {
     impl_as_type!(BamlClassReflectArrayType);
 
     fn element_type(vm: &mut BexVm, r#type: &Value) -> Value {
-        let baml_type::RealizedTy::List(element, _) = reflected_ty(vm, *r#type) else {
+        let parent = reflected_type_value(vm, *r#type);
+        let baml_type::RealizedTy::List(element, _) = parent.ty.clone() else {
             unreachable!("array.Type receiver must wrap an array type")
         };
-        Value::object(vm.alloc_static_type(*element))
+        Value::object(nested_type_value(vm, *element, &parent))
     }
 }
 
@@ -1643,17 +1661,19 @@ impl BamlClassReflectMapType for PackageBamlImpl {
     impl_as_type!(BamlClassReflectMapType);
 
     fn key_type(vm: &mut BexVm, r#type: &Value) -> Value {
-        let baml_type::RealizedTy::Map { key, .. } = reflected_ty(vm, *r#type) else {
+        let parent = reflected_type_value(vm, *r#type);
+        let baml_type::RealizedTy::Map { key, .. } = parent.ty.clone() else {
             unreachable!("map.Type receiver must wrap a map type")
         };
-        Value::object(vm.alloc_static_type(*key))
+        Value::object(nested_type_value(vm, *key, &parent))
     }
 
     fn value_type(vm: &mut BexVm, r#type: &Value) -> Value {
-        let baml_type::RealizedTy::Map { value, .. } = reflected_ty(vm, *r#type) else {
+        let parent = reflected_type_value(vm, *r#type);
+        let baml_type::RealizedTy::Map { value, .. } = parent.ty.clone() else {
             unreachable!("map.Type receiver must wrap a map type")
         };
-        Value::object(vm.alloc_static_type(*value))
+        Value::object(nested_type_value(vm, *value, &parent))
     }
 }
 
@@ -1661,7 +1681,8 @@ impl BamlClassReflectFunctionType for PackageBamlImpl {
     impl_as_type!(BamlClassReflectFunctionType);
 
     fn params(vm: &mut BexVm, r#type: &Value) -> Vec<Value> {
-        let baml_type::RealizedTy::Function { params, .. } = reflected_ty(vm, *r#type) else {
+        let parent = reflected_type_value(vm, *r#type);
+        let baml_type::RealizedTy::Function { params, .. } = parent.ty.clone() else {
             unreachable!("function.Type receiver must wrap a function type")
         };
         params
@@ -1669,7 +1690,7 @@ impl BamlClassReflectFunctionType for PackageBamlImpl {
             .map(|param| {
                 let name = opt_string(vm, param.name.as_ref().map(baml_type::Name::as_str));
                 let optional = param.is_optional();
-                let r#type = Value::object(vm.alloc_static_type(param.ty));
+                let r#type = Value::object(nested_type_value(vm, param.ty, &parent));
                 copy::reflect::function::Parameter {
                     name,
                     r#type,
@@ -1681,10 +1702,11 @@ impl BamlClassReflectFunctionType for PackageBamlImpl {
     }
 
     fn return_type(vm: &mut BexVm, r#type: &Value) -> Value {
-        let baml_type::RealizedTy::Function { ret, .. } = reflected_ty(vm, *r#type) else {
+        let parent = reflected_type_value(vm, *r#type);
+        let baml_type::RealizedTy::Function { ret, .. } = parent.ty.clone() else {
             unreachable!("function.Type receiver must wrap a function type")
         };
-        Value::object(vm.alloc_static_type(*ret))
+        Value::object(nested_type_value(vm, *ret, &parent))
     }
 }
 

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -2576,46 +2576,11 @@ impl BexVm {
         Some(self.value_concrete_ty(value)?.into())
     }
 
-    /// Name an otherwise callable value whose generic frame is incomplete.
-    /// Reflection uses this to distinguish an unspecialized generic from a
-    /// genuinely non-callable value when signature reconstruction fails.
-    pub(crate) fn unspecialized_generic_callable_name(&self, value: Value) -> Option<String> {
-        fn incomplete(function: &Function, supplied: usize) -> Option<String> {
-            (supplied < function.generic_param_bounds.len()).then(|| {
-                function
-                    .declared_name
-                    .clone()
-                    .unwrap_or_else(|| function.name.clone())
-            })
-        }
-
-        match self.get_object(value.as_object_ptr()?) {
-            Object::Closure(closure) => match unsafe { closure.function.get() } {
-                Object::Function(function) => {
-                    incomplete(function, closure.captured_type_args.len())
-                }
-                _ => None,
-            },
-            Object::GenericFunction(generic) => {
-                let inner = self.load_global_in(generic.runtime_package, generic.function);
-                match inner.as_object_ptr().map(|ptr| self.get_object(ptr)) {
-                    Some(Object::Function(function)) => {
-                        incomplete(function, generic.type_args.len())
-                    }
-                    _ => None,
-                }
-            }
-            Object::BoundMethod(method) => match unsafe { method.function.get() } {
-                Object::Function(function) => incomplete(function, method.type_args.len()),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
-    /// The callable's own `Function` plus the type arguments it already
-    /// carries. Mirrors the value shapes
-    /// [`Self::unspecialized_generic_callable_name`] recognizes.
+    /// The callable's own `Function` plus the type arguments it already carries.
+    ///
+    /// A callable value is one of three shapes, each currying its arguments in
+    /// its own field; the two questions below both need the same pair, so they
+    /// ask it here rather than each re-matching the three.
     fn callable_function_and_type_args(
         &self,
         value: Value,
@@ -2640,22 +2605,54 @@ impl BexVm {
         }
     }
 
+    /// The runtime package whose declarations give a callable's types meaning.
+    ///
+    /// Null for a statically compiled callable: its declarations live in the
+    /// engine image and resolve by name, so reflection needs no overlay for it.
+    pub(crate) fn callable_runtime_package(&self, value: Value) -> HeapPtr {
+        if let Some(ptr) = value.as_object_ptr()
+            && let Object::GenericFunction(generic) = self.get_object(ptr)
+            && !generic.runtime_package.is_null()
+        {
+            return generic.runtime_package;
+        }
+        self.callable_function_and_type_args(value)
+            .map_or_else(HeapPtr::null, |(function, _)| function.runtime_package)
+    }
+
+    /// The declared name of a callable, for a diagnostic.
+    fn callable_display_name(function: &Function) -> String {
+        function
+            .declared_name
+            .clone()
+            .unwrap_or_else(|| function.name.clone())
+    }
+
+    /// Name an otherwise callable value whose generic frame is incomplete.
+    /// Reflection uses this to distinguish an unspecialized generic from a
+    /// genuinely non-callable value when signature reconstruction fails.
+    pub(crate) fn unspecialized_generic_callable_name(&self, value: Value) -> Option<String> {
+        let (function, type_args) = self.callable_function_and_type_args(value)?;
+        (type_args.len() < function.generic_param_bounds.len())
+            .then(|| Self::callable_display_name(function))
+    }
+
     /// Name a callable whose *body* cannot be realized against the type-argument
     /// frame it carries.
     ///
     /// A generic function's declared signature can be free of its own type
-    /// parameters — a companion like `GenericList$build_request` takes the
-    /// parent's value arguments and returns a fixed type — so signature
+    /// parameters — a companion like `GenericList$render_prompt` takes the
+    /// parent's value arguments and returns an `ai.Prompt` — so signature
     /// reconstruction succeeds and the value looks ordinary. Its body still
     /// materializes `T` (the output-format schema, for one), and entering it
-    /// with an empty frame would fail deep inside `LoadType` as a VM internal
-    /// error. Reflection asks this question before dispatching so the caller
-    /// gets a diagnostic instead.
+    /// with an empty frame fails deep inside `LoadType` as a VM internal error
+    /// that no `catch` can see. Reflection asks this question before handing
+    /// such a value out or dispatching it, so the caller gets a diagnostic.
     ///
     /// The check runs the very substitution the body would run, so detection and
     /// failure cannot drift apart; it is gated on the callable being a generic
     /// missing arguments, which keeps it off every ordinary call.
-    pub(crate) fn underspecialized_generic_callable_name(&self, value: Value) -> Option<String> {
+    pub(crate) fn generic_callable_body_needs_type_args(&self, value: Value) -> Option<String> {
         let (function, type_args) = self.callable_function_and_type_args(value)?;
         if type_args.len() >= function.generic_param_bounds.len() {
             return None;
@@ -2672,12 +2669,7 @@ impl BexVm {
             || function.bytecode.constants.iter().any(
                 |constant| matches!(constant, ConstValue::Type(template) if unrealizable(template)),
             );
-        needs_arguments.then(|| {
-            function
-                .declared_name
-                .clone()
-                .unwrap_or_else(|| function.name.clone())
-        })
+        needs_arguments.then(|| Self::callable_display_name(function))
     }
 
     /// The value's concrete type as a [`ConcreteRealizedTy`] — the invariant every
@@ -6009,7 +6001,13 @@ impl BexVm {
         );
         self.pending_call_type_args = previous_type_args;
         self.pending_call_type_values = previous_type_values;
-        if !options.type_args.is_empty()
+        // A definition overlay can arrive without any type-argument slots of its
+        // own — interface dispatch hands one down for a method that declares no
+        // generics — so the metadata lane is written whenever any of the three
+        // has something to say, not only when the frame widens.
+        if (!options.type_args.is_empty()
+            || !options.type_defs.is_empty()
+            || !options.type_values.is_empty())
             && self.frames.len() == frames_before + 1
             && *frame_idx == frames_before
             && let Some(Frame::Bytecode(frame)) = self.frames.get_mut(frames_before)

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -2613,6 +2613,73 @@ impl BexVm {
         }
     }
 
+    /// The callable's own `Function` plus the type arguments it already
+    /// carries. Mirrors the value shapes
+    /// [`Self::unspecialized_generic_callable_name`] recognizes.
+    fn callable_function_and_type_args(
+        &self,
+        value: Value,
+    ) -> Option<(&Function, &[baml_type::RealizedTy])> {
+        match self.get_object(value.as_object_ptr()?) {
+            Object::Closure(closure) => match unsafe { closure.function.get() } {
+                Object::Function(function) => Some((function, &closure.captured_type_args)),
+                _ => None,
+            },
+            Object::GenericFunction(generic) => {
+                let inner = self.load_global_in(generic.runtime_package, generic.function);
+                match inner.as_object_ptr().map(|ptr| self.get_object(ptr)) {
+                    Some(Object::Function(function)) => Some((function, &generic.type_args)),
+                    _ => None,
+                }
+            }
+            Object::BoundMethod(method) => match unsafe { method.function.get() } {
+                Object::Function(function) => Some((function, &method.type_args)),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Name a callable whose *body* cannot be realized against the type-argument
+    /// frame it carries.
+    ///
+    /// A generic function's declared signature can be free of its own type
+    /// parameters — a companion like `GenericList$build_request` takes the
+    /// parent's value arguments and returns a fixed type — so signature
+    /// reconstruction succeeds and the value looks ordinary. Its body still
+    /// materializes `T` (the output-format schema, for one), and entering it
+    /// with an empty frame would fail deep inside `LoadType` as a VM internal
+    /// error. Reflection asks this question before dispatching so the caller
+    /// gets a diagnostic instead.
+    ///
+    /// The check runs the very substitution the body would run, so detection and
+    /// failure cannot drift apart; it is gated on the callable being a generic
+    /// missing arguments, which keeps it off every ordinary call.
+    pub(crate) fn underspecialized_generic_callable_name(&self, value: Value) -> Option<String> {
+        let (function, type_args) = self.callable_function_and_type_args(value)?;
+        if type_args.len() >= function.generic_param_bounds.len() {
+            return None;
+        }
+        let unrealizable = |template: &baml_type::TyTemplate| {
+            matches!(
+                template.substitute(type_args, self),
+                Err(baml_type::SubstituteError::TypeArgRefOutOfRange { .. })
+            )
+        };
+        let needs_arguments = function.param_types.iter().any(&unrealizable)
+            || unrealizable(&function.return_type)
+            || unrealizable(&function.throws_type)
+            || function.bytecode.constants.iter().any(
+                |constant| matches!(constant, ConstValue::Type(template) if unrealizable(template)),
+            );
+        needs_arguments.then(|| {
+            function
+                .declared_name
+                .clone()
+                .unwrap_or_else(|| function.name.clone())
+        })
+    }
+
     /// The value's concrete type as a [`ConcreteRealizedTy`] — the invariant every
     /// runtime value's type satisfies (a concrete top with realized arguments, no
     /// type variables) made explicit in the type. `None` for a value kind that

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -7358,6 +7358,23 @@ impl BexVm {
                     let method_value = self.stack.ensure_pop();
                     let iface_value = self.stack.ensure_pop();
 
+                    // A parameterized interface operand carries the runtime
+                    // definitions of its arguments (BEP-066). Resolution reads
+                    // only the realized `ty` off it, so without carrying the
+                    // overlay into the callee the impl body would see
+                    // `user.$dyn.N.Out` as a name nothing defines — reflection,
+                    // rendering and SAP inside an interface method would fail on
+                    // a type the caller can use fine.
+                    let iface_defs =
+                        iface_value
+                            .as_object_ptr()
+                            .and_then(|ptr| match self.get_object(ptr) {
+                                Object::Type(type_value) if !type_value.defs().is_empty() => {
+                                    Some(type_value.defs().clone())
+                                }
+                                _ => None,
+                            });
+
                     let method_type_args = if ntypeargs == 0 {
                         None
                     } else {
@@ -7492,6 +7509,7 @@ impl BexVm {
 
                     let result = if type_args.is_empty()
                         && method_type_args.is_none()
+                        && iface_defs.is_none()
                         && self.pending_call_type_args.is_empty()
                         && self.pending_call_type_values.is_empty()
                     {
@@ -7505,10 +7523,11 @@ impl BexVm {
                             function,
                         )
                     } else {
-                        let empty_defs = DynTypeDefs::default();
-                        let type_defs = method_type_args
-                            .as_ref()
-                            .map_or(&empty_defs, |args| &args.defs);
+                        let mut type_defs = iface_defs.unwrap_or_default();
+                        if let Some(method) = method_type_args.as_ref() {
+                            type_defs.merge_from(&method.defs);
+                        }
+                        let type_defs = &type_defs;
                         self.execute_call_from_locals_offset_with_type_args(
                             callee_ptr,
                             locals_offset,


### PR DESCRIPTION
Closes the reproducible half of [B-1582](https://linear.app/boundaryml2/issue/B-1582)
(Aaron's VetRec umbrella). The ticket is pinned at `b992706`; every repro was
re-verified at current canary head first, because three of the five had moved.

## Status

| # | Ticket item | Outcome |
|---|---|---|
| 1 | `ai.Agent<runtime type>.run(spec)` returns `ParseFailed` | **fixed here** — runtime definitions now survive interface dispatch. One sub-case deferred, see below. |
| 2 | `array.element_type().as_enum()` panics | **fixed here**, plus the sibling accessors |
| 3 | reflected generic companion dies with a VM internal error | **fixed here** — diagnostic floor only; the specialization API stays a design item |
| 4 | `never` in a generic LLM output panics `output_format` | **already fixed by #4470** — regression added, no product change |
| 5 | recursive reflected fields cannot carry metadata | **fixed here** |

Surface drift the ticket's snippets predate: `ai.Client` has no `render` (just
`id` + `invoke`), `ai.Agent.new` has no `schema_attempts`, and the compiler emits
`$spec` / `$render_prompt` / `$parse` / `$stream` companions — there is no
`$build_request`. The repros were adapted accordingly.

## 1 + 2 — runtime definitions have to travel with the type

A minted `type` value only means something together with the `DynTypeDefs`
overlay it carries: `user.$dyn.2.Choice` is a name until the overlay maps it to a
definition. Two places dropped the overlay.

**Interface dispatch.** `VirtualCall` resolves the impl from the receiver's
realized `Self` type and seeds the callee frame from the resolver's realized
frame. The interface operand is itself a minted type value carrying the
definitions of its arguments, but only its `ty` was read — so an impl body saw a
name nothing defined. `ai.Agent<Out>.run` is `implements Runner<Out>`, which is
exactly why the ticket's payload parsed through `baml.sap.parse<unreflect(t)>`
and failed through the Agent. The overlay now flows into the callee frame
alongside any method-level type arguments.

**Nested type views.** `array.element_type`, `map.key_type` / `value_type`,
`union.member_types`, `function.params` / `return_type` and a class field's
substituted type all allocated a plain static type value, stranding every
definition the inner type named. The next `values()` call then hit
`unreachable!("reflected enum … must be loaded")` — a user program reaching an
internal panic (B-1512). They now hand the inner type back inside the enclosing
overlay, which is what `LoadType` already does for a type materialized inside a
frame that has one.

**Function views and signatures.** Carrying the overlay forward on the *consumer*
side does not reach a type reflection **produces** rather than decomposes.
`package.functions()`' function view (`function_type`) and `reflect.signature`
(`alloc_arg`, plus `returns` / `errors`) built their `type` values with nothing
attached, so `return_type().as_enum()`, `params().at(0).type.as_enum()`,
`signature(f).returns.as_enum()` and `signature(f).args.at(0).type.as_enum()` all
still hit the same `unreachable!` for a runtime package's enum. All three
producers now attach the owning package's declarations — the same overlay
`allocate_runtime_declaration_types` already built, factored into
`declaration_defs` / `package_defs` so there is one construction of it. Four
regressions, one per shape.

The remaining accessors were audited: `class.fields`' `runtime_type` branch
already carried the overlay, and `enum.values`, `interface.implemented_by`,
`literal` and `primitive` produce no nested type.

## 3 — an unspecialized generic companion is a diagnostic, not a crash

Post-#4473, a generic function whose signature still mentions `T` is refused at
extraction with E0165. A companion like `GenericList$render_prompt` slips through
that edge: it takes the parent's value arguments and returns an `ai.Prompt`, so
its signature reconstructs and `Package.get_function` hands it out. Its *body*
still materializes `T` for the output-format schema, and `reflect.call_any`
entered it with an empty frame and died as
`could not realize type template: template references frame type-arg slot 0 but
the frame has 0 type args`.

The check asks whether the callable is a generic missing type arguments *whose
emitted templates cannot realize against the frame it carries* — running the very
substitution the body would run, so detection and failure cannot drift apart —
and throws a new E0165 saying the function needs specialization. The gate is the
missing-arguments check, so ordinary calls and non-generic companions pay nothing
and keep working.

It runs at **extraction**, in `Package.get_function`, not only in
`reflect.call_any`. Guarding the call alone left the hole open: a caller can ask
for the companion through an ordinary function-type contract and then call the
value directly, which enters the body with an empty frame and fails as an
internal error `catch` cannot see. `call_any` keeps the same check for any
callable that reaches it by another door.

**This narrows a contract #4473 asserted.** `generic_function_companion_remains_extractable`
pinned that a generic function's companion *is* extractable, because its declared
surface mentions no `T`. B-1582 shows what that value is worth — it can never be
invoked, and invoking it is an uncatchable crash — so extraction now reports the
same reflection limit the parent does. That test is updated in place and renamed.
The companion is still **listed** by `package.functions()`, which is deliberate:
discovery is what a future specialization API will build on. The asymmetry
between "listed" and "extractable" is worth a ruling; the stdlib doc for
`functions()` currently says unspecialized generics are omitted, which was
already inaccurate for companions before this PR.

**The specialization API itself is deliberately not designed here** and remains
Antonio's item; this PR only removes the internal error underneath it.

## 4 — verification

`GenericList$render_prompt<never>(…)` and a direct `GenericList<never>(…)` were
already covered by #4470's suite and still return a catchable E0164. The one
shape that could plausibly have escaped `first_non_data_type`'s walk — `never`
inside a container, inside a *runtime-minted* class — is now pinned too, and it
reports the field path correctly. No product change.

## 5 — metadata on recursive pending fields

`reflect.class.PendingType` gains `meta(alias =, description =, docstring =,
other =) -> reflect.WithMeta<PendingType>`, mirroring `type.meta`, and
`Builder.field` accepts `type | WithMeta<type> | PendingType |
WithMeta<PendingType>`. The wrapper is stored as the field root so the rows
survive the atomic recursive-group build, and when the referenced group is
already frozen the metadata is re-attached to the resolved type. `type.meta` and
the new method now share one allocator.

Regressions cover read-back through `fields()`, the rendered LLM schema (the
alias is the serialized key, so it has to reach render), and the
already-resolved-reference path.

## Deferred

Inline `unreflect(expr)` written directly in a **class** type-argument position —
`ai.Agent<unreflect(t)>` rather than `type Out = unreflect(t)` — is call-scoped by
design: `infer.rs` publishes the parameter's `occurrence_ty` (its first bound, or
`unknown`) as the expression's static type. So the constructed `Agent` is
statically `Agent<unknown>` while the instance carries the real runtime class, and
the two disagree. That inconsistency surfaces as
`UnresolvedVirtualCall { method: "run" }`, and the struct-literal spelling
`Holder<unreflect(t)> { … }` reaches MIR with an error-recovery type and panics in
`runtime_ty.rs`. Both are B-1512 violations, but fixing them means ruling on
whether a runtime type parameter may escape its call — a BEP-066 scoping
question, not a propagation bug. Written up separately with the three options.

## Two properties this does *not* claim

**Identity does not cross dispatch, only definitions do.** `type.of<T>()` inside
an interface-impl method re-mints: the impl frame carries realized types plus the
overlay, not the caller's exact `TypeValue`s, so the type value the method sees
is `==`-distinct from the one the caller passed even though it names the same
definition and renders and parses identically. That is pre-existing (the direct
call path threads exact values through `LoadType(TypeArgRef)`; the resolver path
never did) and it is the BEP-066 I-1 surface worth knowing about. Nothing here
depends on mint equality; making identity survive dispatch means carrying exact
values through `realize_frame`, which is a separate change.

**The overlay is cloned per virtual dispatch.** Merging the interface operand's
definitions into the callee frame is `O(defs)` allocations on every interface
call that carries any — cheap in absolute terms (an `IndexMap` of pointers, only
for calls whose interface argument is a runtime type; a static interface operand
short-circuits on `is_empty`), but it is a clone where the type value already
owns one. `Arc<DynTypeDefs>` is the lever if this ever shows up in an
interface-heavy profile; it would make both this merge and the frame-metadata
lane refcount bumps.

## Verification

Focused: `type_kinds`, `runtime_type_bindings`, `reflect_call_any`,
`runtime_builders_and_pending_types`, `output_format_non_data`,
`runtime_package_compile`. Full pinned gate below. #4459's behavior (concrete
`AnyFunction` `Returns`/`Throws` inference, generic render identity) is untouched
and its tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added metadata support for recursive pending fields, including aliases, descriptions, docstrings, and custom properties.
  - Preserved runtime type information across nested fields, collections, unions, interfaces, and reflected outputs.
  - Improved reflective calls involving parameterized types and dynamic interfaces.

- **Bug Fixes**
  - Missing generic type arguments now produce clear, catchable compilation diagnostics.
  - Invalid runtime-generated schemas report diagnostics instead of causing a panic.
  - Improved parsing and introspection of reflected agent outputs and interface methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->