### PR TITLE
fix(sdkgen_rust): re-export baml_bridge

### DIFF
--- a/baml_language/sdks/rust/sdkgen_rust/src/analyze.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/analyze.rs
@@ -8,7 +8,9 @@ use baml_codegen_types::{Name, Symbol, SymbolPool, Ty};
 
 use crate::{SkipWarning, routing};
 
-const RESERVED_ROOT_TYPE_NAMES: &[&str] = &["baml_bridge"];
+pub(crate) const RESERVED_ROOT_TYPE_NAMES: &[&str] =
+    &["_inlinedbaml", "_runtime", "baml", "baml_bridge"];
+pub(crate) const RESERVED_ROOT_MODULE_NAMES: &[&str] = &["_inlinedbaml", "_runtime", "baml_bridge"];
 
 /// Results of [`analyze`]. Emitters treat this as read-only context.
 pub(crate) struct Analysis {
@@ -616,7 +618,7 @@ fn compute_renames(
         }
     }
     types_in.entry(Vec::new()).or_default().extend(
-        RESERVED_ROOT_TYPE_NAMES
+        RESERVED_ROOT_MODULE_NAMES
             .iter()
             .map(|name| (*name).to_string()),
     );

--- a/baml_language/sdks/rust/sdkgen_rust/src/analyze.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/analyze.rs
@@ -8,6 +8,8 @@ use baml_codegen_types::{Name, Symbol, SymbolPool, Ty};
 
 use crate::{SkipWarning, routing};
 
+const RESERVED_ROOT_TYPE_NAMES: &[&str] = &["baml_bridge"];
+
 /// Results of [`analyze`]. Emitters treat this as read-only context.
 pub(crate) struct Analysis {
     /// Nominal types (classes and enums) that will be emitted. A
@@ -23,6 +25,9 @@ pub(crate) struct Analysis {
     /// (Rust puts `mod` and type names in one namespace). Keyed by the
     /// original routed path; values are the fully renamed path.
     renames: HashMap<Vec<String>, Vec<String>>,
+    /// Emitted nominal types renamed away from generator-owned crate-root
+    /// items. Keys absent from this map retain their BAML name.
+    type_renames: HashMap<Name, String>,
     /// Emitted type names per (renamed) leaf — the namespace synthesized
     /// union enums must not collide with.
     type_names_by_leaf: HashMap<Vec<String>, HashSet<String>>,
@@ -49,6 +54,13 @@ impl Analysis {
             Some(renamed) => renamed,
             None => path,
         }
+    }
+
+    /// The Rust item name for an emitted nominal type.
+    pub(crate) fn rust_type_name<'a>(&'a self, name: &'a Name) -> &'a str {
+        self.type_renames
+            .get(name)
+            .map_or_else(|| name.name().as_str(), String::as_str)
     }
 
     /// Emitted type names in a (renamed) leaf.
@@ -237,7 +249,8 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
         .collect();
     let scc = compute_sccs(&class_edges);
 
-    let renames = compute_renames(pool, &emitted);
+    let type_renames = compute_type_renames(pool, &emitted);
+    let renames = compute_renames(pool, &emitted, &type_renames);
 
     // Emitted type names per renamed leaf, for synthesized-name
     // de-collision.
@@ -250,10 +263,12 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
         {
             let routed = routing::route(name).segments;
             let leaf = renames.get(&routed).cloned().unwrap_or(routed);
-            type_names_by_leaf
-                .entry(leaf)
-                .or_default()
-                .insert(name.name().as_str().to_string());
+            type_names_by_leaf.entry(leaf).or_default().insert(
+                type_renames
+                    .get(name)
+                    .cloned()
+                    .unwrap_or_else(|| name.name().as_str().to_string()),
+            );
         }
     }
 
@@ -262,6 +277,7 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
             emitted,
             scc,
             renames,
+            type_renames,
             type_names_by_leaf,
         },
         warnings,
@@ -521,12 +537,62 @@ fn compute_sccs(edges: &BTreeMap<&Name, Vec<&Name>>) -> HashMap<Name, usize> {
     sccs
 }
 
+/// Rename emitted root types away from generator-owned public items.
+fn compute_type_renames(pool: &SymbolPool, emitted: &HashSet<Name>) -> HashMap<Name, String> {
+    let original_root_names: HashSet<String> = pool
+        .iter()
+        .filter(|(name, symbol)| {
+            routing::route(name).segments.is_empty()
+                && matches!(
+                    symbol,
+                    Symbol::Class(_) | Symbol::Enum(_) | Symbol::TypeAlias(_)
+                )
+                && emitted.contains(*name)
+        })
+        .map(|(name, _)| name.name().as_str().to_string())
+        .collect();
+    let mut renames = HashMap::new();
+    let mut reserved: HashSet<String> = RESERVED_ROOT_TYPE_NAMES
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect();
+    let mut names: Vec<&Name> = pool
+        .iter()
+        .filter_map(|(name, symbol)| {
+            (routing::route(name).segments.is_empty()
+                && matches!(
+                    symbol,
+                    Symbol::Class(_) | Symbol::Enum(_) | Symbol::TypeAlias(_)
+                )
+                && emitted.contains(name))
+            .then_some(name)
+        })
+        .collect();
+    names.sort();
+    for name in names {
+        let original = name.name().as_str();
+        if !reserved.contains(original) {
+            reserved.insert(original.to_string());
+            continue;
+        }
+        let mut renamed = format!("{original}_");
+        while reserved.contains(&renamed) || original_root_names.contains(&renamed) {
+            renamed.push('_');
+        }
+        reserved.insert(renamed.clone());
+        renames.insert(name.clone(), renamed);
+    }
+    renames
+}
+
 /// Rust puts modules and types in one namespace: a namespace segment
-/// whose name equals a type emitted in its parent module is renamed with
-/// a trailing underscore (deterministic, and cascading to descendants).
+/// whose name equals a type emitted in its parent module or a reserved
+/// root item is renamed with trailing underscores (deterministic, and
+/// cascading to descendants).
 fn compute_renames(
     pool: &SymbolPool,
     emitted: &HashSet<Name>,
+    type_renames: &HashMap<Name, String>,
 ) -> HashMap<Vec<String>, Vec<String>> {
     // Types per module path (original routed segments).
     let mut types_in: HashMap<Vec<String>, HashSet<String>> = HashMap::new();
@@ -541,12 +607,19 @@ fn compute_renames(
             Symbol::Class(_) | Symbol::Enum(_) | Symbol::TypeAlias(_)
         ) && emitted.contains(name)
         {
-            types_in
-                .entry(path.clone())
-                .or_default()
-                .insert(name.name().as_str().to_string());
+            types_in.entry(path.clone()).or_default().insert(
+                type_renames
+                    .get(name)
+                    .cloned()
+                    .unwrap_or_else(|| name.name().as_str().to_string()),
+            );
         }
     }
+    types_in.entry(Vec::new()).or_default().extend(
+        RESERVED_ROOT_TYPE_NAMES
+            .iter()
+            .map(|name| (*name).to_string()),
+    );
 
     // Rename each colliding segment, deepest paths inheriting their
     // ancestors' renames.
@@ -561,14 +634,12 @@ fn compute_renames(
             .get(parent)
             .cloned()
             .unwrap_or_else(|| parent.to_vec());
-        let collides = types_in
-            .get(parent)
-            .is_some_and(|types| types.contains(child));
-        let renamed_child = if collides {
-            format!("{child}_")
-        } else {
-            child.clone()
-        };
+        let types = types_in.get(parent);
+        let mut renamed_child = child.clone();
+        while types.is_some_and(|types| types.contains(&renamed_child)) {
+            renamed_child.push('_');
+        }
+        let collides = renamed_child != *child;
         if collides || renames.contains_key(parent) {
             let mut renamed = renamed_parent;
             renamed.push(renamed_child);

--- a/baml_language/sdks/rust/sdkgen_rust/src/emit/class.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/emit/class.rs
@@ -80,7 +80,7 @@ pub(crate) fn emit(
         }
     }
 
-    let ident = idents::ident(name.name().as_str());
+    let ident = idents::ident(ctx.analysis.rust_type_name(name));
     let docs = doc_attrs(class.docstring.as_deref());
 
     let mut field_defs = Vec::new();

--- a/baml_language/sdks/rust/sdkgen_rust/src/emit/enum_.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/emit/enum_.rs
@@ -11,11 +11,11 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use super::function::doc_attrs;
-use crate::idents;
+use crate::{analyze::Analysis, idents};
 
-pub(crate) fn emit(name: &Name, enum_: &Enum) -> TokenStream {
+pub(crate) fn emit(name: &Name, enum_: &Enum, analysis: &Analysis) -> TokenStream {
     let fqn = name.to_string();
-    let ident = idents::ident(name.name().as_str());
+    let ident = idents::ident(analysis.rust_type_name(name));
     let docs = doc_attrs(enum_.docstring.as_deref());
 
     let mut variant_defs = Vec::new();

--- a/baml_language/sdks/rust/sdkgen_rust/src/emit/type_alias.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/emit/type_alias.rs
@@ -24,7 +24,7 @@ pub(crate) fn emit(
     alias: &TypeAlias,
     ctx: &TyCtx<'_>,
 ) -> Result<TokenStream, SkipWarning> {
-    let ident = idents::ident(name.name().as_str());
+    let ident = idents::ident(ctx.analysis.rust_type_name(name));
     let rhs = translate_ty::translate(&alias.resolves_to, ctx).map_err(|u| SkipWarning {
         fqn: name.to_string(),
         reason: format!(

--- a/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
@@ -390,6 +390,8 @@ fn to_source_code_with_optional_metadata(
                     mod _inlinedbaml;
                     mod _runtime;
 
+                    /// The runtime crate version matched to this generated SDK.
+                    pub use baml_bridge;
                     pub use _runtime::init;
 
                     #(#mod_decls)*
@@ -780,7 +782,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_pool_emits_crate_skeleton_with_stdlib_module() {
+    fn empty_pool_emits_crate_skeleton_with_runtime_reexports_and_stdlib_module() {
         let generated = to_source_code_with_bytecode(&SymbolPool::default(), &[], &options());
         assert!(generated.warnings.is_empty());
         let mut paths: Vec<_> = generated
@@ -802,6 +804,7 @@ mod tests {
         );
         let lib = text(&generated, "src/lib.rs");
         assert!(lib.contains("pub mod baml;"));
+        assert!(lib.contains("pub use baml_bridge;"));
         assert!(lib.contains("pub use _runtime::init;"));
     }
 

--- a/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
@@ -262,7 +262,7 @@ fn to_source_code_with_optional_metadata(
                         rank: 0,
                         source_file_path: enum_.origin.source_file_path.clone(),
                         span_start: enum_.origin.span_start,
-                        tokens: emit::enum_::emit(name, enum_),
+                        tokens: emit::enum_::emit(name, enum_, &analysis),
                     });
             }
             Symbol::TypeAlias(alias) => {
@@ -614,6 +614,36 @@ mod tests {
         })
     }
 
+    fn enum_symbol(n: &Name) -> Symbol {
+        Symbol::Enum(baml_codegen_types::Enum {
+            name: n.clone(),
+            docstring: None,
+            variants: vec![baml_codegen_types::EnumVariant {
+                name: baml_base::Name::new("Value"),
+                docstring: None,
+                value: "value".to_string(),
+            }],
+            origin: Origin {
+                source_file_path: "main.baml".to_string(),
+                span_start: 0,
+            },
+        })
+    }
+
+    fn alias_symbol(n: &Name) -> Symbol {
+        Symbol::TypeAlias(baml_codegen_types::TypeAlias {
+            name: n.clone(),
+            resolves_to: Ty::String {
+                attr: baml_base::TyAttr::EMPTY,
+            },
+            recursive: false,
+            origin: Origin {
+                source_file_path: "main.baml".to_string(),
+                span_start: 0,
+            },
+        })
+    }
+
     /// A generic class with the given `<...>` params and properties (no
     /// methods).
     fn generic_class(n: &Name, params: &[&str], properties: Vec<(&str, Ty)>) -> Symbol {
@@ -806,6 +836,70 @@ mod tests {
         assert!(lib.contains("pub mod baml;"));
         assert!(lib.contains("pub use baml_bridge;"));
         assert!(lib.contains("pub use _runtime::init;"));
+    }
+
+    #[test]
+    fn baml_bridge_reexport_reserves_the_root_nominal_name() {
+        let n = name("user", &[], "baml_bridge");
+        for (symbol, expected) in [
+            (
+                class_symbol(&n, Vec::new(), Vec::new(), Vec::new()),
+                "pub struct baml_bridge_",
+            ),
+            (enum_symbol(&n), "pub enum baml_bridge_"),
+            (alias_symbol(&n), "pub type baml_bridge_"),
+        ] {
+            let generated = to_source_code_with_bytecode(
+                &SymbolPool::from([(n.clone(), symbol)]),
+                &[],
+                &options(),
+            );
+            assert!(generated.warnings.is_empty());
+            let lib = text(&generated, "src/lib.rs");
+            assert!(lib.contains("pub use baml_bridge;"), "{lib}");
+            assert!(lib.contains(expected), "expected `{expected}` in:\n{lib}");
+        }
+    }
+
+    #[test]
+    fn baml_bridge_reexport_reserves_the_root_namespace() {
+        let runtime_named_type = name("user", &[], "baml_bridge");
+        let in_runtime_named_namespace = name("user", &["baml_bridge"], "call");
+        let function_using_runtime_named_type = name("user", &[], "use_bridge_type");
+        let runtime_named_ty = Ty::Class(
+            runtime_named_type.clone(),
+            Vec::new(),
+            baml_base::TyAttr::EMPTY,
+        );
+        let pool = SymbolPool::from([
+            (
+                runtime_named_type.clone(),
+                class_symbol(&runtime_named_type, Vec::new(), Vec::new(), Vec::new()),
+            ),
+            (
+                in_runtime_named_namespace.clone(),
+                Symbol::Function(nullary_string_fn(&in_runtime_named_namespace)),
+            ),
+            (
+                function_using_runtime_named_type.clone(),
+                Symbol::Function(unary_fn(
+                    &function_using_runtime_named_type,
+                    runtime_named_ty.clone(),
+                    runtime_named_ty,
+                )),
+            ),
+        ]);
+        let generated = to_source_code_with_bytecode(&pool, &[], &options());
+        assert!(generated.warnings.is_empty());
+        let lib = text(&generated, "src/lib.rs");
+        assert!(lib.contains("pub use baml_bridge;"), "{lib}");
+        assert!(lib.contains("pub struct baml_bridge_"), "{lib}");
+        assert!(lib.contains("pub mod baml_bridge__;"), "{lib}");
+        assert!(
+            flat(lib).contains("pubfnuse_bridge_type(u:crate::baml_bridge_,)->"),
+            "{lib}"
+        );
+        assert!(text(&generated, "src/baml_bridge__/mod.rs").contains("pub fn call()"));
     }
 
     #[test]

--- a/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
@@ -839,25 +839,48 @@ mod tests {
     }
 
     #[test]
-    fn baml_bridge_reexport_reserves_the_root_nominal_name() {
-        let n = name("user", &[], "baml_bridge");
-        for (symbol, expected) in [
-            (
-                class_symbol(&n, Vec::new(), Vec::new(), Vec::new()),
-                "pub struct baml_bridge_",
-            ),
-            (enum_symbol(&n), "pub enum baml_bridge_"),
-            (alias_symbol(&n), "pub type baml_bridge_"),
-        ] {
+    fn generated_root_items_reserve_root_nominal_names() {
+        for reserved in analyze::RESERVED_ROOT_TYPE_NAMES {
+            let n = name("user", &[], reserved);
+            for (symbol, item_kind) in [
+                (
+                    class_symbol(&n, Vec::new(), Vec::new(), Vec::new()),
+                    "struct",
+                ),
+                (enum_symbol(&n), "enum"),
+                (alias_symbol(&n), "type"),
+            ] {
+                let generated = to_source_code_with_bytecode(
+                    &SymbolPool::from([(n.clone(), symbol)]),
+                    &[],
+                    &options(),
+                );
+                assert!(generated.warnings.is_empty());
+                let lib = text(&generated, "src/lib.rs");
+                let expected = format!("pub {item_kind} {reserved}_");
+                assert!(lib.contains("pub use baml_bridge;"), "{lib}");
+                assert!(lib.contains(&expected), "expected `{expected}` in:\n{lib}");
+            }
+        }
+    }
+
+    #[test]
+    fn generated_internal_modules_reserve_root_namespace_names() {
+        for reserved in analyze::RESERVED_ROOT_MODULE_NAMES {
+            let in_reserved_namespace = name("user", &[*reserved], "call");
             let generated = to_source_code_with_bytecode(
-                &SymbolPool::from([(n.clone(), symbol)]),
+                &SymbolPool::from([(
+                    in_reserved_namespace.clone(),
+                    Symbol::Function(nullary_string_fn(&in_reserved_namespace)),
+                )]),
                 &[],
                 &options(),
             );
             assert!(generated.warnings.is_empty());
+            let renamed = format!("{reserved}_");
             let lib = text(&generated, "src/lib.rs");
-            assert!(lib.contains("pub use baml_bridge;"), "{lib}");
-            assert!(lib.contains(expected), "expected `{expected}` in:\n{lib}");
+            assert!(lib.contains(&format!("pub mod {renamed};")), "{lib}");
+            assert!(text(&generated, &format!("src/{renamed}/mod.rs")).contains("pub fn call()"));
         }
     }
 

--- a/baml_language/sdks/rust/sdkgen_rust/src/translate_ty.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/translate_ty.rs
@@ -62,7 +62,7 @@ pub(crate) fn type_path(name: &Name, analysis: &Analysis) -> TokenStream {
     let routed = routing::route(name).segments;
     let segments = analysis.renamed(&routed);
     let mods = segments.iter().map(|seg| idents::ident(seg));
-    let type_ident = idents::ident(name.name().as_str());
+    let type_ident = idents::ident(analysis.rust_type_name(name));
     quote! { crate::#(#mods::)*#type_ident }
 }
 

--- a/baml_language/sdks/rust/verify/consumer_main.rs
+++ b/baml_language/sdks/rust/verify/consumer_main.rs
@@ -9,6 +9,12 @@
 //! are not implemented yet; the verifier grows to cover them as they land.
 
 fn main() {
+    // Public bridge types must come from the SDK's exact runtime dependency;
+    // consumers should not need a second, manually synchronized version pin.
+    let unset: baml_sdk::baml_bridge::OptionalArg<String> =
+        baml_sdk::baml_bridge::OptionalArg::Unset;
+    assert!(matches!(unset, baml_sdk::baml_bridge::OptionalArg::Unset));
+
     let sync = baml_sdk::rt_int(7).expect("sync rt_int call");
     assert_eq!(sync, 7, "sync roundtrip");
 


### PR DESCRIPTION
## Issue Reference

Fixes #4374

## Changes

- Re-export the generated SDK's exact `baml_bridge` dependency from `baml_sdk::baml_bridge`.
- Keep the re-export collision-free by reserving generator-owned crate-root names for BAML classes, enums, type aliases, and namespaces, including deterministic chained underscore renames.
- Document the re-export in generated `lib.rs`.
- Extend the packaged Rust SDK consumer verifier to name `OptionalArg::Unset` through the generated SDK without a direct dependency pin.

## Testing

- `cargo test -p sdkgen_rust`
- `cargo fmt -p sdkgen_rust -- --check --config imports_granularity="Crate" --config group_imports="StdExternalCrate"`
- `rustfmt --check --edition 2024 --config imports_granularity=Crate --config group_imports=StdExternalCrate sdks/rust/verify/consumer_main.rs`
- `cargo clippy -p sdkgen_rust --all-targets -- -D warnings`
- `cargo check -p sdk_test_rust`
- `cargo check --manifest-path sdk_tests/crates/rust/type_shapes/generated/Cargo.toml --tests`

## PR Checklist

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding test changes
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Rust SDK runtime integration by making the bridge runtime available through generated SDKs.
  * Resolved naming conflicts in generated Rust types and namespaces, including conflicts with reserved names.
  * Ensured generated classes, enums, aliases, and referenced types use consistent conflict-free names.
* **Tests**
  * Added coverage for optional unset arguments and verified synchronous and asynchronous calls continue to work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->