### PR TITLE
feat(wrapper): expose machine-readable active toolchain resolution

### DIFF
--- a/baml_language/crates/baml/src/main.rs
+++ b/baml_language/crates/baml/src/main.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
+#[cfg(windows)]
+use std::io::{Read, Seek, SeekFrom};
 use std::{
     collections::{BTreeMap, hash_map::DefaultHasher},
     env, fs,
@@ -106,6 +108,15 @@ struct ResolvedSelector {
     source: SelectorSource,
 }
 
+#[derive(Debug, Serialize)]
+struct ToolchainResolution {
+    selector: String,
+    version: String,
+    wrapper_path: PathBuf,
+    toolchain_path: PathBuf,
+    installed: bool,
+}
+
 #[derive(Clone, Copy)]
 enum FetchPolicy {
     CacheAllowed,
@@ -121,6 +132,7 @@ Commands:
   use <canary|nightly|version|path>  Install if needed and select as default
   pin <canary|nightly|version|path>  Select in the nearest baml.toml
   install <canary|nightly|version>   Download without selecting
+  resolve [--install] [--json]       Resolve the active managed toolchain
   update                             Advance the active channel
   status                             Check latest remote version without installing
   list                               Show installed toolchains, local only
@@ -378,6 +390,7 @@ fn toolchain(args: Vec<String>) -> Result<()> {
             }
             pin_toolchain(selector, manifest_base_url.as_deref())
         }
+        Some("resolve") => resolve_toolchain(&args[1..], manifest_base_url.as_deref()),
         Some("update") => update_toolchain(manifest_base_url.as_deref()),
         Some("status") => status_toolchain(manifest_base_url.as_deref()),
         Some("list") => {
@@ -394,6 +407,87 @@ fn toolchain(args: Vec<String>) -> Result<()> {
             "unknown toolchain command {other:?}\n\n{TOOLCHAIN_HELP}"
         )),
     }
+}
+
+fn resolve_toolchain(args: &[String], override_url: Option<&str>) -> Result<()> {
+    if args.iter().any(|arg| is_help_arg(arg)) {
+        println!(
+            "Resolve the active managed BAML toolchain\n\nUsage:\n  baml toolchain resolve [--install] [--json]\n\nOptions:\n  --install  Install the resolved toolchain if needed\n  --json     Emit stable machine-readable JSON"
+        );
+        return Ok(());
+    }
+    let install = args.iter().any(|arg| arg == "--install");
+    let json = args.iter().any(|arg| arg == "--json");
+    let unexpected: Vec<_> = args
+        .iter()
+        .filter(|arg| arg.as_str() != "--install" && arg.as_str() != "--json")
+        .collect();
+    if !unexpected.is_empty() {
+        return Err(anyhow!(
+            "usage: baml toolchain resolve [--install] [--json]\nunexpected arguments: {}",
+            unexpected
+                .into_iter()
+                .map(String::as_str)
+                .collect::<Vec<_>>()
+                .join(" ")
+        ));
+    }
+
+    let selector = active_selector()?;
+    if is_path_selector(&selector.selector) {
+        return Err(anyhow!(
+            "active selector {} is a local path and cannot be resolved as a managed toolchain.{}\nSelect canary, nightly, or an exact version for automated setup.",
+            selector.selector,
+            path_selector_origin(&selector.source)
+        ));
+    }
+
+    let unresolved_channel =
+        is_channel(&selector.selector) && !read_state().channels.contains_key(&selector.selector);
+    let version = if install && unresolved_channel {
+        install_toolchain_with_policy(
+            &selector.selector,
+            true,
+            override_url,
+            false,
+            FetchPolicy::CacheAllowed,
+        )?
+    } else {
+        concrete_version_for_selector_with_base(&selector, &manifest_base_url(override_url))?
+    };
+
+    let toolchain_path = toolchain_cli_path(&version);
+    if install && verify_managed_toolchain(&version).is_err() {
+        install_toolchain_with_policy(
+            &version,
+            false,
+            override_url,
+            true,
+            FetchPolicy::CacheAllowed,
+        )?;
+    }
+    let installed = verify_managed_toolchain(&version).is_ok();
+    if install {
+        verify_managed_toolchain(&version)?;
+    }
+    let resolution = ToolchainResolution {
+        selector: selector.selector,
+        version,
+        wrapper_path: env::current_exe().context("failed to resolve the baml wrapper path")?,
+        toolchain_path,
+        installed,
+    };
+
+    if json {
+        println!("{}", serde_json::to_string(&resolution)?);
+    } else {
+        println!("active selector: {}", resolution.selector);
+        println!("resolved version: {}", resolution.version);
+        println!("wrapper path: {}", resolution.wrapper_path.display());
+        println!("toolchain path: {}", resolution.toolchain_path.display());
+        println!("installed: {}", resolution.installed);
+    }
+    Ok(())
 }
 
 fn is_help_arg(arg: &str) -> bool {
@@ -689,6 +783,15 @@ fn verify_toolchain_version_file(version: &str) -> Result<()> {
     Ok(())
 }
 
+fn verify_managed_toolchain(version: &str) -> Result<()> {
+    verify_path_toolchain(&toolchain_cli_path(version), "").with_context(|| {
+        format!(
+            "BAML toolchain {version} is not usable.\nRun: baml toolchain install {version} --force"
+        )
+    })?;
+    verify_toolchain_version_file(version)
+}
+
 fn is_channel(selector: &str) -> bool {
     selector == "canary" || selector == "nightly"
 }
@@ -943,6 +1046,33 @@ fn verify_path_toolchain(cli: &Path, origin: &str) -> Result<()> {
             ));
         }
     }
+    #[cfg(windows)]
+    verify_windows_executable(cli, origin)?;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn verify_windows_executable(cli: &Path, origin: &str) -> Result<()> {
+    let mut file = fs::File::open(cli)
+        .with_context(|| format!("failed to read toolchain binary: {}{origin}", cli.display()))?;
+    let mut dos_header = [0_u8; 64];
+    if file.read_exact(&mut dos_header).is_err() || &dos_header[..2] != b"MZ" {
+        return Err(anyhow!(
+            "toolchain binary is not a valid Windows executable: {}{origin}",
+            cli.display()
+        ));
+    }
+
+    let pe_offset = u32::from_le_bytes(dos_header[60..64].try_into().expect("four-byte slice"));
+    file.seek(SeekFrom::Start(u64::from(pe_offset)))
+        .with_context(|| format!("failed to read toolchain binary: {}{origin}", cli.display()))?;
+    let mut pe_signature = [0_u8; 4];
+    if file.read_exact(&mut pe_signature).is_err() || pe_signature != *b"PE\0\0" {
+        return Err(anyhow!(
+            "toolchain binary is not a valid Windows executable: {}{origin}",
+            cli.display()
+        ));
+    }
     Ok(())
 }
 
@@ -1178,13 +1308,15 @@ fn install_toolchain(
             "{selector} is a local path; there is nothing to install.\nRun: baml toolchain use {selector}"
         ));
     }
-    install_toolchain_with_policy(
+    let version = install_toolchain_with_policy(
         selector,
         activate_channel,
         override_url,
         force,
         FetchPolicy::CacheAllowed,
-    )
+    )?;
+    println!("installed BAML toolchain {version}");
+    Ok(())
 }
 
 fn install_toolchain_with_policy(
@@ -1193,7 +1325,7 @@ fn install_toolchain_with_policy(
     override_url: Option<&str>,
     force: bool,
     policy: FetchPolicy,
-) -> Result<()> {
+) -> Result<String> {
     let manifest = fetch_manifest(selector, override_url, policy)?;
     let target = baml_release::release_host_target_triple()?;
     let artifact = manifest.artifact_for_target(target)?.clone();
@@ -1215,8 +1347,7 @@ fn install_toolchain_with_policy(
         );
         write_state(&state)?;
     }
-    println!("installed BAML toolchain {}", manifest.version);
-    Ok(())
+    Ok(manifest.version)
 }
 
 fn install_manifest_artifact(
@@ -1362,7 +1493,7 @@ fn update_toolchain(override_url: Option<&str>) -> Result<()> {
         );
         return Ok(());
     }
-    install_toolchain_with_policy(
+    let version = install_toolchain_with_policy(
         &config.default.selector,
         true,
         override_url,
@@ -1375,6 +1506,7 @@ fn update_toolchain(override_url: Option<&str>) -> Result<()> {
             config.default.selector
         )
     })?;
+    println!("installed BAML toolchain {version}");
     Ok(())
 }
 

--- a/baml_language/crates/baml/tests/resolve_e2e.rs
+++ b/baml_language/crates/baml/tests/resolve_e2e.rs
@@ -1,0 +1,254 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, Output},
+};
+
+use serde_json::Value;
+
+struct TestHome {
+    _dir: tempfile::TempDir,
+    root: PathBuf,
+}
+
+impl TestHome {
+    fn new(default_selector: &str) -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path().to_path_buf();
+        fs::write(
+            root.join("config.toml"),
+            format!("[default]\nselector = {default_selector:?}\n"),
+        )
+        .unwrap();
+        Self { _dir: dir, root }
+    }
+
+    fn install(&self, version: &str) -> PathBuf {
+        let bin = self.root.join("toolchains").join(version).join("bin");
+        fs::create_dir_all(&bin).unwrap();
+        fs::write(
+            self.root.join("toolchains").join(version).join("VERSION"),
+            format!("{version}\n"),
+        )
+        .unwrap();
+        let cli = bin.join(if cfg!(windows) {
+            "baml-cli.exe"
+        } else {
+            "baml-cli"
+        });
+        fs::copy(env!("CARGO_BIN_EXE_baml"), &cli).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&cli, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        cli
+    }
+
+    fn activate_channel(&self, channel: &str, version: &str) {
+        fs::write(
+            self.root.join("state.toml"),
+            format!(
+                "[channels.{channel}]\nactive_version = {version:?}\nresolved_at = \"test\"\nmanifest_path = \"test\"\n"
+            ),
+        )
+        .unwrap();
+    }
+
+    fn cache_channel_manifest(&self, channel: &str, version: &str) {
+        let artifacts = baml_release::SUPPORTED_RELEASE_TARGETS
+            .iter()
+            .map(|target| {
+                (
+                    (*target).to_string(),
+                    serde_json::json!({
+                        "url": format!("https://example.test/{target}.tar.gz"),
+                        "sha256": "0".repeat(64),
+                    }),
+                )
+            })
+            .collect::<serde_json::Map<_, _>>();
+        let cache = self.root.join("manifest-cache/prod");
+        fs::create_dir_all(&cache).unwrap();
+        fs::write(
+            cache.join(format!("{channel}.json")),
+            serde_json::to_vec(&serde_json::json!({
+                "schema": 1,
+                "version": version,
+                "channel": channel,
+                "released_at": "2026-08-18T00:00:00Z",
+                "artifacts": artifacts,
+            }))
+            .unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn run(&self, cwd: &Path, args: &[&str]) -> Output {
+        Command::new(env!("CARGO_BIN_EXE_baml"))
+            .args(args)
+            .current_dir(cwd)
+            .env("BAML_HOME", &self.root)
+            .env("HOME", cwd.parent().unwrap_or(cwd))
+            .env_remove("BAML_VERSION")
+            .output()
+            .unwrap()
+    }
+}
+
+fn json(output: &Output) -> Value {
+    assert!(
+        output.status.success(),
+        "wrapper failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|err| {
+        panic!(
+            "stdout was not JSON: {err}: {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    })
+}
+
+#[test]
+fn resolves_active_channel_as_json() {
+    let home = TestHome::new("canary");
+    let cli = home.install("0.11.0");
+    home.activate_channel("canary", "0.11.0");
+    let cwd = tempfile::tempdir().unwrap();
+
+    let resolution = json(&home.run(cwd.path(), &["toolchain", "resolve", "--json"]));
+
+    assert_eq!(resolution["selector"], "canary");
+    assert_eq!(resolution["version"], "0.11.0");
+    assert_eq!(resolution["toolchain_path"], cli.display().to_string());
+    assert_eq!(resolution["installed"], true);
+    let reported_wrapper = Path::new(resolution["wrapper_path"].as_str().unwrap());
+    assert_eq!(
+        fs::canonicalize(reported_wrapper).unwrap(),
+        fs::canonicalize(env!("CARGO_BIN_EXE_baml")).unwrap()
+    );
+}
+
+#[test]
+fn install_flag_keeps_stdout_machine_readable_for_installed_exact_version() {
+    let home = TestHome::new("0.11.0");
+    home.install("0.11.0");
+    let cwd = tempfile::tempdir().unwrap();
+
+    let resolution = json(&home.run(cwd.path(), &["toolchain", "resolve", "--install", "--json"]));
+
+    assert_eq!(resolution["selector"], "0.11.0");
+    assert_eq!(resolution["version"], "0.11.0");
+    assert_eq!(resolution["installed"], true);
+}
+
+#[test]
+#[cfg(unix)]
+fn non_executable_managed_binary_is_not_reported_as_installed() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let home = TestHome::new("0.11.0");
+    let cli = home.install("0.11.0");
+    fs::set_permissions(&cli, fs::Permissions::from_mode(0o644)).unwrap();
+    let cwd = tempfile::tempdir().unwrap();
+
+    let resolution = json(&home.run(cwd.path(), &["toolchain", "resolve", "--json"]));
+
+    assert_eq!(resolution["version"], "0.11.0");
+    assert_eq!(resolution["installed"], false);
+}
+
+#[test]
+#[cfg(windows)]
+fn invalid_windows_managed_binary_is_not_reported_as_installed() {
+    let home = TestHome::new("0.11.0");
+    let cli = home.install("0.11.0");
+    fs::write(cli, "").unwrap();
+    let cwd = tempfile::tempdir().unwrap();
+
+    let resolution = json(&home.run(cwd.path(), &["toolchain", "resolve", "--json"]));
+
+    assert_eq!(resolution["version"], "0.11.0");
+    assert_eq!(resolution["installed"], false);
+}
+
+#[test]
+fn install_flag_resolves_and_activates_channel_without_prior_state() {
+    let home = TestHome::new("canary");
+    home.install("0.12.0");
+    home.cache_channel_manifest("canary", "0.12.0");
+    let cwd = tempfile::tempdir().unwrap();
+
+    let output = home.run(cwd.path(), &["toolchain", "resolve", "--install", "--json"]);
+    let resolution = json(&output);
+
+    assert_eq!(resolution["selector"], "canary");
+    assert_eq!(resolution["version"], "0.12.0");
+    assert_eq!(resolution["installed"], true);
+    assert!(Path::new(resolution["toolchain_path"].as_str().unwrap()).exists());
+    let state = fs::read_to_string(home.root.join("state.toml")).unwrap();
+    assert!(state.contains("active_version = \"0.12.0\""), "{state}");
+}
+
+#[test]
+fn install_flag_preserves_recorded_channel_version() {
+    let home = TestHome::new("canary");
+    home.install("0.11.0");
+    home.activate_channel("canary", "0.11.0");
+    home.cache_channel_manifest("canary", "0.12.0");
+    let cwd = tempfile::tempdir().unwrap();
+
+    let output = home.run(cwd.path(), &["toolchain", "resolve", "--install", "--json"]);
+    let resolution = json(&output);
+
+    assert_eq!(resolution["selector"], "canary");
+    assert_eq!(resolution["version"], "0.11.0");
+    assert_eq!(resolution["installed"], true);
+    let state = fs::read_to_string(home.root.join("state.toml")).unwrap();
+    assert!(state.contains("active_version = \"0.11.0\""), "{state}");
+    assert!(!state.contains("active_version = \"0.12.0\""), "{state}");
+}
+
+#[test]
+fn environment_override_wins_over_project_and_global_selectors() {
+    let home = TestHome::new("0.10.0");
+    let project = tempfile::tempdir().unwrap();
+    fs::write(
+        project.path().join("baml.toml"),
+        "[toolchain]\nversion = \"0.11.0\"\n",
+    )
+    .unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_baml"))
+        .args(["toolchain", "resolve", "--json"])
+        .current_dir(project.path())
+        .env("BAML_HOME", &home.root)
+        .env("HOME", project.path().parent().unwrap())
+        .env("BAML_VERSION", "0.12.0")
+        .output()
+        .unwrap();
+
+    let resolution = json(&output);
+    assert_eq!(resolution["selector"], "0.12.0");
+    assert_eq!(resolution["version"], "0.12.0");
+    assert_eq!(resolution["installed"], false);
+}
+
+#[test]
+fn project_path_selector_is_rejected_with_source_attribution() {
+    let home = TestHome::new("canary");
+    let project = tempfile::tempdir().unwrap();
+    let manifest = project.path().join("baml.toml");
+    fs::write(
+        &manifest,
+        "[toolchain]\npath = \"./target/debug/baml-cli\"\n",
+    )
+    .unwrap();
+
+    let output = home.run(project.path(), &["toolchain", "resolve", "--json"]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("local path"), "{stderr}");
+    assert!(stderr.contains(&manifest.display().to_string()), "{stderr}");
+}


### PR DESCRIPTION
## Summary

- add `baml toolchain resolve [--install] [--json]` using the wrapper's existing `BAML_VERSION`, project traversal, global config, and fallback precedence
- report the active selector, concrete version, wrapper path, managed toolchain binary path, and verified installation state without contaminating JSON stdout
- reject unmanaged path selectors with source attribution and reuse the existing verified installer for managed selectors
- cover channel resolution, channel activation without prior state, exact versions, selector precedence, JSON-only install output, and project path rejection end to end

## Why

Setup actions currently have to parse `baml toolchain list` and `baml --version` or duplicate wrapper resolution behavior. This gives automation a single stable, non-interactive interface while keeping manifest resolution, checksum validation, extraction safety, and project traversal inside the wrapper.

## Validation

- `cargo fmt --check -- --config imports_granularity="Crate" --config group_imports="StdExternalCrate"`
- `cargo test -p baml --tests`
- `cargo test -p baml --no-default-features --features no-self-update`
- `cargo clippy -p baml --tests -- -D warnings`

Fixes #4417


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `toolchain resolve` for resolving configured toolchain versions.
  * Supports optional installation and structured JSON output.
  * Reports resolved versions, wrapper paths, installation state, and active channels.
  * Validates selectors and clearly rejects unsupported project-local path selectors.
  * Installation and update operations now report the installed version.

* **Tests**
  * Added end-to-end coverage for resolution, installation, selector precedence, channel handling, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->