### PR TITLE
fix: materialize reassigned short-circuit locals

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -1208,12 +1208,25 @@ fn is_short_circuit_phi(local: Local, du: &LocalDefUse, body: &MirFunctionBody) 
         return false;
     }
 
-    // One of the defs must be a ShortCircuit terminator targeting this local.
-    du.all_defs.iter().any(|&(block_id, ref stmt_ref)| {
-        *stmt_ref == StatementRef::Terminator
+    let use_block = du.uses[0].block;
+
+    // `_0` is the return place; all other named locals are source variables
+    // and may be reassigned. Keep them in slots rather than stack-carrying a
+    // value across control-flow edges. This mirrors MIR copy propagation,
+    // which only optimizes unnamed compiler temporaries for the same reason.
+    if local != Local(0) && body.local(local).name.is_some() {
+        return false;
+    }
+
+    du.all_defs.iter().any(|&(block_id, statement_ref)| {
+        statement_ref == StatementRef::Terminator
             && matches!(
                 &body.block(block_id).terminator,
-                Some(Terminator::ShortCircuit { destination: Place::Local(l), .. }) if *l == local
+                Some(Terminator::ShortCircuit {
+                    destination: Place::Local(destination),
+                    join,
+                    ..
+                }) if *destination == local && *join == use_block
             )
     })
 }
@@ -2359,6 +2372,131 @@ mod tests {
             scope_span: None,
             is_captured: false,
         }
+    }
+
+    fn nested_short_circuit_body(
+        name: Option<&str>,
+        with_prior_definition: bool,
+    ) -> MirFunctionBody {
+        let destination = Local(1);
+        let prior_definition = with_prior_definition.then_some(Statement {
+            kind: StatementKind::Assign {
+                destination: Place::Local(destination),
+                value: Rvalue::Use(Operand::Constant(Constant::Bool(false))),
+            },
+            span: None,
+        });
+
+        MirFunctionBody {
+            blocks: vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    statements: prior_definition.into_iter().collect(),
+                    terminator: Some(Terminator::ShortCircuit {
+                        operand: Operand::Constant(Constant::Bool(true)),
+                        is_and: true,
+                        destination: Place::Local(destination),
+                        eval_rhs: BlockId(1),
+                        join: BlockId(4),
+                    }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    statements: vec![],
+                    terminator: Some(Terminator::ShortCircuit {
+                        operand: Operand::Constant(Constant::Bool(true)),
+                        is_and: true,
+                        destination: Place::Local(destination),
+                        eval_rhs: BlockId(2),
+                        join: BlockId(3),
+                    }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(2),
+                    statements: vec![Statement {
+                        kind: StatementKind::Assign {
+                            destination: Place::Local(destination),
+                            value: Rvalue::Use(Operand::Constant(Constant::Bool(true))),
+                        },
+                        span: None,
+                    }],
+                    terminator: Some(Terminator::Goto { target: BlockId(3) }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(3),
+                    statements: vec![],
+                    terminator: Some(Terminator::Goto { target: BlockId(4) }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(4),
+                    statements: vec![Statement {
+                        kind: StatementKind::Assign {
+                            destination: Place::Local(Local(0)),
+                            value: Rvalue::Use(Operand::copy_local(destination)),
+                        },
+                        span: None,
+                    }],
+                    terminator: Some(Terminator::Return),
+                    span: None,
+                    terminator_span: None,
+                },
+            ],
+            entry: BlockId(0),
+            locals: vec![
+                LocalDecl {
+                    name: None,
+                    ty: RuntimeTy::Bool {
+                        attr: TyAttr::default(),
+                    },
+                    span: None,
+                    scope_span: None,
+                    is_captured: false,
+                },
+                LocalDecl {
+                    name: name.map(baml_base::Name::new),
+                    ty: RuntimeTy::Bool {
+                        attr: TyAttr::default(),
+                    },
+                    span: None,
+                    scope_span: None,
+                    is_captured: false,
+                },
+            ],
+            catch_regions: vec![],
+            viz_nodes: vec![],
+        }
+    }
+
+    #[test]
+    fn nested_short_circuit_definitions_are_stack_carried() {
+        let body = nested_short_circuit_body(None, false);
+        let def_use = collect_def_use(&body);
+
+        assert!(is_short_circuit_phi(Local(1), &def_use[&Local(1)], &body));
+    }
+
+    #[test]
+    fn named_short_circuit_local_is_materialized() {
+        let body = nested_short_circuit_body(Some("result"), false);
+        let def_use = collect_def_use(&body);
+
+        assert!(!is_short_circuit_phi(Local(1), &def_use[&Local(1)], &body));
+    }
+
+    #[test]
+    fn reassigned_named_short_circuit_local_is_materialized() {
+        let body = nested_short_circuit_body(Some("result"), true);
+        let def_use = collect_def_use(&body);
+
+        assert!(!is_short_circuit_phi(Local(1), &def_use[&Local(1)], &body));
     }
 
     /// A single static use in a CFG cycle represents repeated dynamic uses.

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_errorcontext/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_errorcontext/bytecode.snap
@@ -198,35 +198,53 @@ function errorcontext.ec_deferthrow_check() -> bool {
   L3:
     jump_if_false L4
     pop 1
+    jump L5
+
+  L4:
+    store_var all_present
+    jump L6
+
+  L5:
     load_var cleanup_at
     load_const 0
     cmp_int_op >=
+    store_var all_present
 
-  L4:
+  L6:
     load_var2 2 4
     cmp_int_op <
-    jump_if_false L5
+    jump_if_false L7
     pop 1
+    jump L8
+
+  L7:
+    store_var ordered
+    jump L9
+
+  L8:
     load_var2 4 6
     cmp_int_op <
+    store_var ordered
 
-  L5:
+  L9:
     load_var rendered
     load_const "During handling of the above error, another error occurred"
     call baml.String.split
     container_len
     store_var pieces
-    jump_if_false L6
+    load_var all_present
+    jump_if_false L10
     pop 1
+    load_var ordered
 
-  L6:
-    jump_if_false L7
+  L10:
+    jump_if_false L11
     pop 1
     load_var pieces
     load_const 3
     cmp_int_op ==
 
-  L7:
+  L11:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_expressions/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_expressions/bytecode.snap
@@ -37,15 +37,25 @@ function fixtures.parser_expressions.IndexAccess(users: fixtures.parser_expressi
 function fixtures.parser_expressions.TestPrecedence() -> bool {
     load_const true
     jump_if_false L0
-    jump L1
+    store_var d
+    jump L3
 
   L0:
     pop 1
     load_const false
     jump_if_false L1
     pop 1
-    load_const false
+    jump L2
 
   L1:
+    store_var d
+    jump L3
+
+  L2:
+    load_const false
+    store_var d
+
+  L3:
+    load_var d
     return
 }

--- a/baml_language/crates/baml_tests/tests/loop_reassignment.rs
+++ b/baml_language/crates/baml_tests/tests/loop_reassignment.rs
@@ -1,0 +1,82 @@
+//! Regression tests for outer-variable reassignment across loop branches.
+
+use baml_tests::{baml_test, baml_test_optimized};
+use bex_engine::BexExternalValue;
+
+const SOURCE: &str = r###"
+        class Fact {
+            subject_id string
+            section string
+            text string
+        }
+
+        function parse_subject_file(content: string, subject_id: string) -> Fact[] {
+            let facts: Fact[] = []
+            let current_section = ""
+            let in_scope = false
+            for (let raw_line in content.lines()) {
+                let line = raw_line.trim()
+                if (line.starts_with("## ")) {
+                    let heading = line.slice(3, line.length())
+                    in_scope = heading != "One-Sentence Takeaway" && heading != "References & Rabbit Holes"
+                    current_section = heading
+                } else if (in_scope && line.starts_with("- ")) {
+                    facts.push(Fact {
+                        subject_id: subject_id,
+                        section: current_section,
+                        text: line.slice(2, line.length()),
+                    })
+                }
+            }
+            facts
+        }
+
+        function main() -> string {
+            let content = #"# Created Pipeline (Marketing)
+
+---
+
+## 1. First Idea
+
+- Bullet one here.
+
+## One-Sentence Takeaway
+
+- This bullet should be ignored.
+
+## 2. Second Idea
+
+- Bullet two here.
+"#
+            let facts = parse_subject_file(content, "x")
+            facts[0].section + ":" + facts[0].text + "|" + facts[1].section + ":" + facts[1].text
+        }
+        "###;
+
+fn expected_result() -> Result<BexExternalValue, String> {
+    Ok(BexExternalValue::String(
+        "1. First Idea:Bullet one here.|2. Second Idea:Bullet two here."
+            .to_string()
+            .into(),
+    ))
+}
+
+#[tokio::test]
+async fn multiple_outer_reassignments_with_array_push() {
+    let output = baml_test!(SOURCE);
+
+    assert_eq!(
+        output.result.map_err(|error| format!("{error:?}")),
+        expected_result()
+    );
+}
+
+#[tokio::test]
+async fn multiple_outer_reassignments_with_array_push_optimized() {
+    let output = baml_test_optimized!(SOURCE);
+
+    assert_eq!(
+        output.result.map_err(|error| format!("{error:?}")),
+        expected_result()
+    );
+}


### PR DESCRIPTION
## Issue Reference

- [x] Fixes #4421

## Changes

- Restrict short-circuit phi stack-carrying to the return place and unnamed compiler temporaries, matching the existing conservative treatment of named source locals in MIR copy propagation.
- Materialize named locals assigned from short-circuit expressions so reassignment cannot leave earlier values stranded on the VM stack, while preserving the optimization for nested compiler-generated temporaries.
- Add the reported multi-variable loop and array-push scenario as O1 and O2 regression coverage, including both evaluated and direct short-circuit paths.
- Regenerate the affected bytecode corpus snapshots in the current per-namespace layout.

## Testing

- [x] `cargo fmt -p baml_compiler2_emit -p baml_tests --check -- --config imports_granularity="Crate" --config group_imports="StdExternalCrate"`
- [x] `cargo clippy -p baml_compiler2_emit --all-targets -- -D warnings`
- [x] `cargo test -p baml_compiler2_emit` (46 passed)
- [x] `cargo test -p baml_tests --test loop_reassignment` (2 passed)
- [x] `cargo test -p baml_tests --test baml_src` (3 Rust tests and 3,163 BAML tests passed)
- [x] `cargo test --lib` passed through the affected compiler and BAML suites (including 1,413 `baml_tests` tests); the local macOS run then encountered an environment-only `/install/lib/libpython3.13.dylib` loader path, and `bridge_python --lib` passes when pointed at the installed Python 3.13 library
- [x] GitHub Actions language and runtime workflows, including Rust unit, snapshot, lint, SDK, platform, size, and benchmark instrumentation jobs

## PR Checklist

- [x] I have read and followed the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented the non-obvious optimization constraint
- [x] My changes generate no new warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed incorrect handling of variables reassigned across loop branches, preventing hangs and inaccurate type errors.
  - Improved nested short-circuit expression handling, including values carried across loop iterations and reassigned variables.

- **Tests**
  - Added regression coverage for loop-branch reassignment scenarios.
  - Added standard and optimized execution tests for nested short-circuit behavior and variable materialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
