### PR TITLE
fix(rust): generate functions with media parameters

### DIFF
--- a/baml_language/sdk_tests/crates/rust/type_shapes/customizable/roundtrip_tests/test_media.rs
+++ b/baml_language/sdk_tests/crates/rust/type_shapes/customizable/roundtrip_tests/test_media.rs
@@ -1,11 +1,8 @@
 //! Roundtrip coverage for `baml_sdk::media`.
 //!
-//! Values exercise both outbound descriptors returned by BAML and Rust-side
-//! media constructors encoded through the bridge's native handle ABI.
-use baml_bridge::{
-    DecodeError, Error,
-    media::{Audio, Image},
-};
+//! Values exercise both outbound media returned by BAML and Rust-side opaque
+//! handles encoded through the bridge's native handle ABI.
+use baml_bridge::media::{Audio, Image};
 use baml_sdk::media::{
     ImageOrAudio, Media, return_audio, return_image, return_pdf, return_video, round_trip_audio,
     round_trip_image, round_trip_image_or_audio, round_trip_media, round_trip_pdf,
@@ -21,7 +18,11 @@ fn test_media_return_image() {
     // DIVERGENCE(rust): python asserts `is not None`; the successful unwrap
     // of the non-optional media result is that assertion here (and in every
     // test below).
-    return_image(URL.to_string(), None).unwrap();
+    let image = return_image(URL.to_string(), Some("image/png".to_string())).unwrap();
+    assert_eq!(image.url().unwrap().as_deref(), Some(URL));
+    assert_eq!(image.file().unwrap(), None);
+    assert_eq!(image.base64().unwrap(), "");
+    assert_eq!(image.mime_type().unwrap().as_deref(), Some("image/png"));
 }
 
 #[test]
@@ -46,9 +47,24 @@ fn test_media_round_trip_image() {
     let path = std::env::temp_dir().join("baml-rust-sdk-media-example.png");
     let path = path.to_string_lossy().into_owned();
     let img = Image::from_file(path.clone(), Some("image/png".to_string())).unwrap();
-    let returned = round_trip_image(img).unwrap();
-    assert_eq!(returned.file(), Some(path.as_str()));
-    assert_eq!(returned.mime_type(), Some("image/png"));
+    let returned = round_trip_image(img.clone()).unwrap();
+    assert_eq!(returned.file().unwrap().as_deref(), Some(path.as_str()));
+    assert_eq!(returned.mime_type().unwrap().as_deref(), Some("image/png"));
+
+    // Encoding clones the engine handle for wire ownership. The original
+    // opaque value remains live and may be inspected or sent again.
+    assert_eq!(img.file().unwrap().as_deref(), Some(path.as_str()));
+    round_trip_image(img).unwrap();
+}
+
+// SDK_PARITY_LINT(skip): validates the Python-compatible Rust media accessor surface
+#[test]
+fn test_media_base64_introspection() {
+    let image = Image::from_base64("aGk=", Some("image/png".to_string())).unwrap();
+    assert_eq!(image.url().unwrap(), None);
+    assert_eq!(image.file().unwrap(), None);
+    assert_eq!(image.base64().unwrap(), "aGk=");
+    assert_eq!(image.mime_type().unwrap().as_deref(), Some("image/png"));
 }
 
 #[test]
@@ -92,12 +108,9 @@ fn test_media_round_trip_union() {
     assert!(matches!(returned, ImageOrAudio::Audio(_)));
 }
 
-// SDK_PARITY_LINT(skip): validates Rust bridge rejection of C-incompatible media descriptors
+// SDK_PARITY_LINT(skip): validates that opaque returned handles do not re-encode descriptor strings
 #[test]
-fn test_media_return_rejects_interior_nul() {
-    let error = return_image("bad\0url".to_string(), None).unwrap_err();
-    assert!(matches!(
-        error,
-        Error::Decode(DecodeError::InvalidMedia { field: "source" })
-    ));
+fn test_media_return_preserves_interior_nul() {
+    let image = return_image("bad\0url".to_string(), None).unwrap();
+    assert_eq!(image.url().unwrap().as_deref(), Some("bad\0url"));
 }

--- a/baml_language/sdk_tests/crates/rust/type_shapes/customizable/roundtrip_tests/test_media.rs
+++ b/baml_language/sdk_tests/crates/rust/type_shapes/customizable/roundtrip_tests/test_media.rs
@@ -1,17 +1,15 @@
 //! Roundtrip coverage for `baml_sdk::media`.
 //!
-//! Media values can't be hand-built as plain structs, so each value is
-//! sourced from the matching `return_*` function (which builds it
-//! engine-side via `image.from_url(...)` etc.). The *decode* path yields a
-//! handle-backed media value; the *encode* path passes that value back into
-//! a `round_trip_*` function.
-
-// PROVISIONAL: media types have no Rust SDK design yet. This port assumes
-// opaque handle-backed values that decode from `return_*` and encode back
-// through `round_trip_*` with no host-side construction.
+//! Values exercise both outbound descriptors returned by BAML and Rust-side
+//! media constructors encoded through the bridge's native handle ABI.
+use baml_bridge::{
+    DecodeError, Error,
+    media::{Audio, Image},
+};
 use baml_sdk::media::{
-    Media, return_audio, return_image, return_pdf, return_video, round_trip_audio,
-    round_trip_image, round_trip_media, round_trip_pdf, round_trip_video,
+    ImageOrAudio, Media, return_audio, return_image, return_pdf, return_video, round_trip_audio,
+    round_trip_image, round_trip_image_or_audio, round_trip_media, round_trip_pdf,
+    round_trip_video,
 };
 
 const URL: &str = "https://example.com/asset";
@@ -45,8 +43,12 @@ fn test_media_return_pdf() {
 
 #[test]
 fn test_media_round_trip_image() {
-    let img = return_image(URL.to_string(), None).unwrap();
-    round_trip_image(img).unwrap();
+    let path = std::env::temp_dir().join("baml-rust-sdk-media-example.png");
+    let path = path.to_string_lossy().into_owned();
+    let img = Image::from_file(path.clone(), Some("image/png".to_string())).unwrap();
+    let returned = round_trip_image(img).unwrap();
+    assert_eq!(returned.file(), Some(path.as_str()));
+    assert_eq!(returned.mime_type(), Some("image/png"));
 }
 
 #[test]
@@ -76,4 +78,26 @@ fn test_media_round_trip_media() {
         pdf_field: return_pdf(URL.to_string(), None).unwrap(),
     };
     round_trip_media(m).unwrap();
+}
+
+// SDK_PARITY_LINT(skip): validates Rust-specific generated media-union encode/decode
+#[test]
+fn test_media_round_trip_union() {
+    let img = Image::from_url(URL, Some("image/png".to_string())).unwrap();
+    let returned = round_trip_image_or_audio(ImageOrAudio::Image(img)).unwrap();
+    assert!(matches!(returned, ImageOrAudio::Image(_)));
+
+    let audio = Audio::from_url(URL, Some("audio/mpeg".to_string())).unwrap();
+    let returned = round_trip_image_or_audio(ImageOrAudio::Audio(audio)).unwrap();
+    assert!(matches!(returned, ImageOrAudio::Audio(_)));
+}
+
+// SDK_PARITY_LINT(skip): validates Rust bridge rejection of C-incompatible media descriptors
+#[test]
+fn test_media_return_rejects_interior_nul() {
+    let error = return_image("bad\0url".to_string(), None).unwrap_err();
+    assert!(matches!(
+        error,
+        Error::Decode(DecodeError::InvalidMedia { field: "source" })
+    ));
 }

--- a/baml_language/sdk_tests/harness_setup/src/rust.rs
+++ b/baml_language/sdk_tests/harness_setup/src/rust.rs
@@ -174,11 +174,7 @@ const TEST_MODS: &[(&str, &str, Gate)] = &[
         Gate::Later("needs literal types"),
     ),
     ("type_shapes", "roundtrip_tests/test_maps.rs", Gate::Now),
-    (
-        "type_shapes",
-        "roundtrip_tests/test_media.rs",
-        Gate::Later("needs media types"),
-    ),
+    ("type_shapes", "roundtrip_tests/test_media.rs", Gate::Now),
     ("type_shapes", "roundtrip_tests/test_optional.rs", Gate::Now),
     (
         "type_shapes",

--- a/baml_language/sdks/rust/bridge_rust/README.md
+++ b/baml_language/sdks/rust/bridge_rust/README.md
@@ -1,12 +1,7 @@
 # baml_bridge
 
-The BAML runtime bridge for Rust. Generated BAML SDKs (`baml-cli generate`
-with `output_type = "rust"`) depend on this crate: it boots the BAML engine,
-converts values across the boundary via the `BamlValue` trait, and surfaces
-BAML's typed `throws` contracts as `Result<T, baml_bridge::Error<E>>`.
+The BAML runtime bridge for Rust. Generated BAML SDKs (`baml-cli generate` with `output_type = "rust"`) depend on this crate: it boots the BAML engine, converts values across the boundary via the `BamlValue` trait, and surfaces BAML's typed `throws` contracts as `Result<T, baml_bridge::Error<E>>`.
 
-You normally don't add this crate by hand — the generated `baml_sdk` crate
-pins the matching version. See the BAML documentation for getting started:
-<https://docs.boundaryml.com>.
+You normally don't add this crate by hand — the generated `baml_sdk` crate pins the matching version. See the BAML documentation for getting started: <https://docs.boundaryml.com>.
 
-Generated functions with `image`, `audio`, `video`, or `pdf` parameters use `baml_bridge::media::{Image, Audio, Video, Pdf}`. Each type provides `from_url`, `from_file`, and `from_base64` constructors and can be passed directly to generated functions. A generic `media` parameter uses `baml_bridge::media::Media`, an enum over those concrete kinds plus `GenericMedia`.
+Generated functions with `image`, `audio`, `video`, or `pdf` parameters use `baml_bridge::media::{Image, Audio, Video, Pdf}`. These are opaque engine handles with `from_url`, `from_file`, and `from_base64` constructors, plus the same limited `url`, `file`, `base64`, and `mime_type` introspection surface as Python media values. Cloning a Rust media value shares its owned handle, and passing it to a generated function clones the engine key so other Rust owners remain usable. A generic `media` parameter uses `baml_bridge::media::Media`, an enum over those concrete kinds plus `GenericMedia`.

--- a/baml_language/sdks/rust/bridge_rust/README.md
+++ b/baml_language/sdks/rust/bridge_rust/README.md
@@ -8,3 +8,5 @@ BAML's typed `throws` contracts as `Result<T, baml_bridge::Error<E>>`.
 You normally don't add this crate by hand — the generated `baml_sdk` crate
 pins the matching version. See the BAML documentation for getting started:
 <https://docs.boundaryml.com>.
+
+Generated functions with `image`, `audio`, `video`, or `pdf` parameters use `baml_bridge::media::{Image, Audio, Video, Pdf}`. Each type provides `from_url`, `from_file`, and `from_base64` constructors and can be passed directly to generated functions. A generic `media` parameter uses `baml_bridge::media::Media`, an enum over those concrete kinds plus `GenericMedia`.

--- a/baml_language/sdks/rust/bridge_rust/src/capi.rs
+++ b/baml_language/sdks/rust/bridge_rust/src/capi.rs
@@ -53,6 +53,16 @@ pub(crate) struct Api {
     pub(crate) call_function: unsafe extern "C" fn(*const u8, usize, u32),
     pub(crate) handle_clone: unsafe extern "C" fn(u64, *mut u64) -> u32,
     pub(crate) handle_release: unsafe extern "C" fn(u64) -> u32,
+    pub(crate) media_from_url:
+        unsafe extern "C" fn(i32, *const c_char, *const c_char, *mut u64, *mut i32) -> u32,
+    pub(crate) media_from_file:
+        unsafe extern "C" fn(i32, *const c_char, *const c_char, *mut u64, *mut i32) -> u32,
+    pub(crate) media_from_base64:
+        unsafe extern "C" fn(i32, *const c_char, *const c_char, *mut u64, *mut i32) -> u32,
+    pub(crate) media_url: unsafe extern "C" fn(u64, i32, *mut Buffer) -> u32,
+    pub(crate) media_file: unsafe extern "C" fn(u64, i32, *mut Buffer) -> u32,
+    pub(crate) media_base64: unsafe extern "C" fn(u64, i32, *mut Buffer) -> u32,
+    pub(crate) media_mime_type: unsafe extern "C" fn(u64, i32, *mut Buffer) -> u32,
     pub(crate) free_buffer: unsafe extern "C" fn(Buffer),
     pub(crate) register_host_dispatch_callback: unsafe extern "C" fn(HostDispatchFn),
     pub(crate) register_host_release_callback: unsafe extern "C" fn(HostReleaseFn),
@@ -88,6 +98,18 @@ impl Api {
             };
             (self.free_buffer)(buffer);
             bytes
+        }
+    }
+
+    pub(crate) fn take_optional_string(&self, buffer: Buffer) -> Result<Option<String>, SdkError> {
+        let is_none = buffer.ptr.is_null();
+        let bytes = self.copy_and_free(buffer);
+        if is_none {
+            Ok(None)
+        } else {
+            String::from_utf8(bytes)
+                .map(Some)
+                .map_err(|_| SdkError::new("media accessor returned invalid UTF-8"))
         }
     }
 }
@@ -269,13 +291,13 @@ fn load_inner(env: &loader::LoaderEnv) -> Result<Api, LoaderError> {
     let complete_host_call = required_slot(table.complete_host_call, "complete_host_call", &path)?;
     let handle_clone = required_slot(table.handle_clone, "handle_clone", &path)?;
     let handle_release = required_slot(table.handle_release, "handle_release", &path)?;
-    required_slot(table.media_from_url, "media_from_url", &path)?;
-    required_slot(table.media_from_file, "media_from_file", &path)?;
-    required_slot(table.media_from_base64, "media_from_base64", &path)?;
-    required_slot(table.media_url, "media_url", &path)?;
-    required_slot(table.media_file, "media_file", &path)?;
-    required_slot(table.media_base64, "media_base64", &path)?;
-    required_slot(table.media_mime_type, "media_mime_type", &path)?;
+    let media_from_url = required_slot(table.media_from_url, "media_from_url", &path)?;
+    let media_from_file = required_slot(table.media_from_file, "media_from_file", &path)?;
+    let media_from_base64 = required_slot(table.media_from_base64, "media_from_base64", &path)?;
+    let media_url = required_slot(table.media_url, "media_url", &path)?;
+    let media_file = required_slot(table.media_file, "media_file", &path)?;
+    let media_base64 = required_slot(table.media_base64, "media_base64", &path)?;
+    let media_mime_type = required_slot(table.media_mime_type, "media_mime_type", &path)?;
     let register_bridge = required_slot(table.register_bridge, "register_bridge", &path)?;
     required_slot(
         table.register_unhandled_spawn_error_callback,
@@ -294,6 +316,13 @@ fn load_inner(env: &loader::LoaderEnv) -> Result<Api, LoaderError> {
         call_function,
         handle_clone,
         handle_release,
+        media_from_url,
+        media_from_file,
+        media_from_base64,
+        media_url,
+        media_file,
+        media_base64,
+        media_mime_type,
         free_buffer,
         register_host_dispatch_callback,
         register_host_release_callback,

--- a/baml_language/sdks/rust/bridge_rust/src/error.rs
+++ b/baml_language/sdks/rust/bridge_rust/src/error.rs
@@ -165,7 +165,7 @@ pub enum DecodeError {
         /// Length of the offending wire string.
         len: usize,
     },
-    /// A decoded media descriptor cannot be safely passed back through the C ABI.
+    /// A legacy inline media descriptor cannot be safely converted to an opaque handle.
     InvalidMedia {
         /// The invalid descriptor field (`source` or `MIME type`).
         field: &'static str,

--- a/baml_language/sdks/rust/bridge_rust/src/error.rs
+++ b/baml_language/sdks/rust/bridge_rust/src/error.rs
@@ -165,6 +165,11 @@ pub enum DecodeError {
         /// Length of the offending wire string.
         len: usize,
     },
+    /// A decoded media descriptor cannot be safely passed back through the C ABI.
+    InvalidMedia {
+        /// The invalid descriptor field (`source` or `MIME type`).
+        field: &'static str,
+    },
     /// A union envelope selected an arm outside the generated union's range.
     InvalidUnionOptionIndex {
         /// Generated union type being decoded.
@@ -193,6 +198,9 @@ impl fmt::Display for DecodeError {
             }
             DecodeError::InvalidBigint { len } => {
                 write!(f, "invalid bigint wire string ({len} bytes)")
+            }
+            DecodeError::InvalidMedia { field } => {
+                write!(f, "media {field} contains an interior NUL byte")
             }
             DecodeError::InvalidUnionOptionIndex {
                 union,

--- a/baml_language/sdks/rust/bridge_rust/src/error.rs
+++ b/baml_language/sdks/rust/bridge_rust/src/error.rs
@@ -170,6 +170,13 @@ pub enum DecodeError {
         /// The invalid descriptor field (`source` or `MIME type`).
         field: &'static str,
     },
+    /// The runtime rejected a legacy inline media descriptor while converting it to an opaque handle.
+    MediaHandleCreation {
+        /// The media kind being decoded.
+        expected: &'static str,
+        /// Native constructor context and status.
+        detail: String,
+    },
     /// A union envelope selected an arm outside the generated union's range.
     InvalidUnionOptionIndex {
         /// Generated union type being decoded.
@@ -201,6 +208,9 @@ impl fmt::Display for DecodeError {
             }
             DecodeError::InvalidMedia { field } => {
                 write!(f, "media {field} contains an interior NUL byte")
+            }
+            DecodeError::MediaHandleCreation { expected, detail } => {
+                write!(f, "failed to create {expected} handle: {detail}")
             }
             DecodeError::InvalidUnionOptionIndex {
                 union,

--- a/baml_language/sdks/rust/bridge_rust/src/lib.rs
+++ b/baml_language/sdks/rust/bridge_rust/src/lib.rs
@@ -20,6 +20,7 @@ pub mod error;
 mod function;
 pub mod host_value;
 pub mod loader;
+pub mod media;
 pub mod runtime;
 #[cfg(test)]
 pub(crate) mod test_support;

--- a/baml_language/sdks/rust/bridge_rust/src/media.rs
+++ b/baml_language/sdks/rust/bridge_rust/src/media.rs
@@ -1,76 +1,78 @@
-//! Typed BAML media values used by generated Rust SDK signatures.
+//! Opaque, handle-backed BAML media values used by generated Rust SDK signatures.
 //!
-//! Media stays descriptor-backed on the Rust side. Immediately before a call,
-//! encoding turns the descriptor into an owned engine handle through the
-//! existing media C ABI; the engine takes ownership of that wire handle.
+//! Constructors allocate an engine handle immediately. Introspection goes through
+//! the media C ABI, encoding clones the handle for wire ownership, and the final
+//! Rust owner releases the original handle.
 
-use std::ffi::CString;
+use std::{ffi::CString, sync::Arc};
 
 use crate::{DecodeError, SdkError, baml_value::internal::__BamlValuePrivate, wire};
 
-#[derive(Clone, PartialEq, Eq)]
-enum Source {
-    Url(String),
-    File(String),
-    Base64(String),
+#[derive(Clone, Copy)]
+enum SourceKind {
+    Url,
+    File,
+    Base64,
 }
 
-#[derive(Clone, PartialEq, Eq)]
+struct MediaHandle {
+    key: u64,
+    handle_type: i32,
+    #[cfg(test)]
+    release: Option<Arc<dyn Fn(u64) + Send + Sync>>,
+}
+
+impl Drop for MediaHandle {
+    fn drop(&mut self) {
+        if self.key == 0 {
+            return;
+        }
+        #[cfg(test)]
+        if let Some(release) = &self.release {
+            release(self.key);
+            return;
+        }
+        if let Ok(api) = crate::capi::api() {
+            // SAFETY: this is the one owned handle key retained by this value.
+            #[expect(unsafe_code)]
+            unsafe {
+                (api.handle_release)(self.key);
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
 struct MediaValue {
-    source: Source,
-    mime_type: Option<String>,
+    handle: Arc<MediaHandle>,
 }
 
 impl MediaValue {
-    fn new(source: Source, mime_type: Option<String>) -> Result<Self, SdkError> {
-        Self::validate(&source, mime_type.as_deref()).map_err(|field| {
-            SdkError::new(format!("media {field} contains an interior NUL byte"))
-        })?;
-        Ok(Self { source, mime_type })
-    }
-
-    fn decoded(source: Source, mime_type: Option<String>) -> Result<Self, DecodeError> {
-        Self::validate(&source, mime_type.as_deref())
-            .map_err(|field| DecodeError::InvalidMedia { field })?;
-        Ok(Self { source, mime_type })
-    }
-
-    fn validate(source: &Source, mime_type: Option<&str>) -> Result<(), &'static str> {
-        let source_value = match source {
-            Source::Url(value) | Source::File(value) | Source::Base64(value) => value,
-        };
-        CString::new(source_value.as_str()).map_err(|_| "source")?;
-        if let Some(mime_type) = mime_type {
-            CString::new(mime_type).map_err(|_| "MIME type")?;
-        }
-        Ok(())
-    }
-
-    fn to_baml(&self, kind: Kind) -> wire::InboundValue {
-        let source = match &self.source {
-            Source::Url(value) | Source::File(value) | Source::Base64(value) => {
-                CString::new(value.as_str()).expect("validated media source")
-            }
-        };
-        let mime_type = self
-            .mime_type
-            .as_deref()
+    fn create(
+        kind: Kind,
+        source_kind: SourceKind,
+        source: String,
+        mime_type: Option<String>,
+    ) -> Result<Self, SdkError> {
+        let source = CString::new(source)
+            .map_err(|_| SdkError::new("media source contains an interior NUL byte"))?;
+        let mime_type = mime_type
             .map(CString::new)
             .transpose()
-            .expect("validated media MIME type");
-        let mime_type_ptr = mime_type
-            .as_ref()
-            .map_or(std::ptr::null(), |value| value.as_ptr());
-        let api = crate::capi::api().expect("BAML runtime must be loaded before encoding media");
-        let constructor = match self.source {
-            Source::Url(_) => api.media_from_url,
-            Source::File(_) => api.media_from_file,
-            Source::Base64(_) => api.media_from_base64,
+            .map_err(|_| SdkError::new("media MIME type contains an interior NUL byte"))?;
+        let api = crate::capi::api()?;
+        let constructor = match source_kind {
+            SourceKind::Url => api.media_from_url,
+            SourceKind::File => api.media_from_file,
+            SourceKind::Base64 => api.media_from_base64,
         };
         let mut key = 0_u64;
         let mut handle_type = 0_i32;
-        // SAFETY: both strings are NUL-terminated and live for the duration of
-        // the call; both output pointers refer to initialized stack storage.
+        let mime_type_ptr = mime_type
+            .as_ref()
+            .map_or(std::ptr::null(), |value| value.as_ptr());
+        // SAFETY: both strings are NUL-terminated and live for the call, and
+        // both output pointers refer to initialized stack storage.
         #[expect(unsafe_code)]
         let status = unsafe {
             constructor(
@@ -81,23 +83,50 @@ impl MediaValue {
                 &raw mut handle_type,
             )
         };
-        // The safe constructors already enforce the engine's only descriptor
-        // rejection (interior NUL), the kind is a fixed protocol value, and
-        // `insert_entry` guarantees a matching type tag and nonzero key. A
-        // failure here therefore means the exact-version C ABI violated its
-        // contract, not a recoverable input error.
-        assert_eq!(status, 0, "failed to construct a BAML media handle");
-        assert_ne!(key, 0, "media constructor returned a zero handle");
-        assert_eq!(
-            handle_type,
-            kind.handle_type() as i32,
-            "media constructor returned the wrong handle type"
-        );
+        if status != 0 {
+            return Err(status_error(source_kind.constructor_name(), status));
+        }
+        if key == 0 || handle_type != kind.handle_type() as i32 {
+            if key != 0 {
+                // SAFETY: a successful constructor transferred this key to us.
+                #[expect(unsafe_code)]
+                unsafe {
+                    (api.handle_release)(key);
+                }
+            }
+            return Err(SdkError::new(format!(
+                "{} returned an invalid media handle",
+                source_kind.constructor_name()
+            )));
+        }
+        Ok(Self::adopt(key, handle_type))
+    }
+
+    fn adopt(key: u64, handle_type: i32) -> Self {
+        Self {
+            handle: Arc::new(MediaHandle {
+                key,
+                handle_type,
+                #[cfg(test)]
+                release: None,
+            }),
+        }
+    }
+
+    fn to_baml(&self) -> wire::InboundValue {
+        let api = crate::capi::api().expect("BAML runtime must be loaded before encoding media");
+        let mut cloned = 0_u64;
+        // SAFETY: `cloned` is valid stack storage and the retained key remains
+        // live for the duration of this call.
+        #[expect(unsafe_code)]
+        let status = unsafe { (api.handle_clone)(self.handle.key, &raw mut cloned) };
+        assert_eq!(status, 0, "failed to clone a BAML media handle");
+        assert_ne!(cloned, 0, "media handle clone returned a zero handle");
         wire::InboundValue {
             value_type: None,
             value: Some(wire::inbound_value::Value::Handle(wire::BamlHandle {
-                key,
-                handle_type,
+                key: cloned,
+                handle_type: self.handle.handle_type,
             })),
         }
     }
@@ -108,46 +137,27 @@ impl MediaValue {
     ) -> Result<(Kind, Self), DecodeError> {
         let value = crate::decode::unwrap(value);
         let got = crate::baml_value::wire_variant_kind(&value);
-        let media = match value.value {
-            Some(wire::baml_outbound_value::Value::MediaValue(media)) => media,
+        match value.value {
+            Some(wire::baml_outbound_value::Value::MediaValue(media)) => {
+                Self::from_descriptor(media, expected)
+            }
             Some(wire::baml_outbound_value::Value::HandleValue(handle)) => {
-                return Self::from_handle(handle.key, handle.handle_type, expected);
+                Self::from_handle(handle.key, handle.handle_type, expected)
             }
             Some(wire::baml_outbound_value::Value::ClassValue(class)) => {
-                let class_kind =
-                    Kind::from_wrapper_class(&class.name).ok_or(DecodeError::WrongType {
-                        expected: expected.map_or("media", Kind::name),
-                        got: "class",
-                    })?;
-                let handle = class
-                    .fields
-                    .into_iter()
-                    .find(|field| field.key == "_data")
-                    .and_then(|field| field.value)
-                    .and_then(|value| match crate::decode::unwrap(value).value {
-                        Some(wire::baml_outbound_value::Value::HandleValue(handle)) => Some(handle),
-                        _ => None,
-                    })
-                    .ok_or(DecodeError::WrongType {
-                        expected: expected.map_or("media", Kind::name),
-                        got: "media class without a handle",
-                    })?;
-                if expected.is_some_and(|expected| expected != class_kind) {
-                    return Err(DecodeError::WrongType {
-                        expected: expected.map_or("media", Kind::name),
-                        got: class_kind.name(),
-                    });
-                }
-                let decoded = Self::from_handle(handle.key, handle.handle_type, Some(class_kind))?;
-                return Ok(decoded);
+                Self::from_wrapper_class(class, expected)
             }
-            _ => {
-                return Err(DecodeError::WrongType {
-                    expected: expected.map_or("media", Kind::name),
-                    got,
-                });
-            }
-        };
+            _ => Err(DecodeError::WrongType {
+                expected: expected.map_or("media", Kind::name),
+                got,
+            }),
+        }
+    }
+
+    fn from_descriptor(
+        media: wire::BamlValueMedia,
+        expected: Option<Kind>,
+    ) -> Result<(Kind, Self), DecodeError> {
         let Some(kind) = Kind::from_media_type(media.media) else {
             return Err(DecodeError::WrongType {
                 expected: expected.map_or("media", Kind::name),
@@ -160,10 +170,10 @@ impl MediaValue {
                 got: kind.name(),
             });
         }
-        let source = match media.value {
-            Some(wire::baml_value_media::Value::Url(value)) => Source::Url(value),
-            Some(wire::baml_value_media::Value::File(value)) => Source::File(value),
-            Some(wire::baml_value_media::Value::Base64(value)) => Source::Base64(value),
+        let (source_kind, source) = match media.value {
+            Some(wire::baml_value_media::Value::Url(value)) => (SourceKind::Url, value),
+            Some(wire::baml_value_media::Value::File(value)) => (SourceKind::File, value),
+            Some(wire::baml_value_media::Value::Base64(value)) => (SourceKind::Base64, value),
             None => {
                 return Err(DecodeError::WrongType {
                     expected: expected.map_or("media", Kind::name),
@@ -171,7 +181,44 @@ impl MediaValue {
                 });
             }
         };
-        Ok((kind, Self::decoded(source, media.mime_type)?))
+        validate_descriptor(&source, media.mime_type.as_deref())?;
+        let value = Self::create(kind, source_kind, source, media.mime_type).map_err(|_| {
+            DecodeError::WrongType {
+                expected: expected.map_or("media", Kind::name),
+                got: "media descriptor rejected by the runtime",
+            }
+        })?;
+        Ok((kind, value))
+    }
+
+    fn from_wrapper_class(
+        class: wire::BamlValueClass,
+        expected: Option<Kind>,
+    ) -> Result<(Kind, Self), DecodeError> {
+        let class_kind = Kind::from_wrapper_class(&class.name).ok_or(DecodeError::WrongType {
+            expected: expected.map_or("media", Kind::name),
+            got: "class",
+        })?;
+        if expected.is_some_and(|expected| expected != class_kind) {
+            return Err(DecodeError::WrongType {
+                expected: expected.map_or("media", Kind::name),
+                got: class_kind.name(),
+            });
+        }
+        let handle = class
+            .fields
+            .into_iter()
+            .find(|field| field.key == "_data")
+            .and_then(|field| field.value)
+            .and_then(|value| match crate::decode::unwrap(value).value {
+                Some(wire::baml_outbound_value::Value::HandleValue(handle)) => Some(handle),
+                _ => None,
+            })
+            .ok_or(DecodeError::WrongType {
+                expected: expected.map_or("media", Kind::name),
+                got: "media class without a handle",
+            })?;
+        Self::from_handle(handle.key, handle.handle_type, Some(class_kind))
     }
 
     fn from_handle(
@@ -199,113 +246,91 @@ impl MediaValue {
                 got: kind.name(),
             });
         }
-        let api = crate::capi::api().map_err(|_| DecodeError::WrongType {
-            expected: expected.map_or("media", Kind::name),
-            got: "media handle without a loaded runtime",
-        })?;
-        let guard = HandleGuard { api, key };
-        let url = read_optional(api, api.media_url, key, handle_type)?;
-        let file = read_optional(api, api.media_file, key, handle_type)?;
-        let mime_type = read_optional(api, api.media_mime_type, key, handle_type)?;
-        let source = if let Some(url) = url {
-            Source::Url(url)
-        } else if let Some(file) = file {
-            Source::File(file)
-        } else {
-            let base64 = read_optional(api, api.media_base64, key, handle_type)?.ok_or(
-                DecodeError::WrongType {
-                    expected: expected.map_or("media", Kind::name),
-                    got: "media handle without a source",
-                },
-            )?;
-            Source::Base64(base64)
+        Ok((kind, Self::adopt(key, handle_type)))
+    }
+
+    fn optional_string(
+        &self,
+        api: &crate::capi::Api,
+        accessor: MediaAccessor,
+        context: &str,
+    ) -> Result<Option<String>, SdkError> {
+        let mut output = crate::capi::Buffer {
+            ptr: std::ptr::null(),
+            len: 0,
         };
-        let value = Self::decoded(source, mime_type)?;
-        drop(guard);
-        Ok((kind, value))
-    }
-
-    fn url(&self) -> Option<&str> {
-        match &self.source {
-            Source::Url(value) => Some(value),
-            Source::File(_) | Source::Base64(_) => None,
-        }
-    }
-
-    fn file(&self) -> Option<&str> {
-        match &self.source {
-            Source::File(value) => Some(value),
-            Source::Url(_) | Source::Base64(_) => None,
-        }
-    }
-
-    fn base64(&self) -> Option<&str> {
-        match &self.source {
-            Source::Base64(value) => Some(value),
-            Source::Url(_) | Source::File(_) => None,
-        }
-    }
-}
-
-impl std::fmt::Debug for MediaValue {
-    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let source = match self.source {
-            Source::Url(_) => "url",
-            Source::File(_) => "file",
-            Source::Base64(_) => "base64",
-        };
-        formatter
-            .debug_struct("MediaValue")
-            .field("source", &source)
-            .field("mime_type", &self.mime_type)
-            .finish()
-    }
-}
-
-struct HandleGuard<'a> {
-    api: &'a crate::capi::Api,
-    key: u64,
-}
-
-impl Drop for HandleGuard<'_> {
-    fn drop(&mut self) {
-        // SAFETY: the outbound handle key is owned by this decoder and must be
-        // released exactly once after its descriptor has been copied out.
+        // SAFETY: `output` is valid stack storage and this value retains the
+        // matching live handle for the duration of the call.
         #[expect(unsafe_code)]
-        unsafe {
-            (self.api.handle_release)(self.key);
+        let status = unsafe { accessor(self.handle.key, self.handle.handle_type, &raw mut output) };
+        if status != 0 {
+            return Err(status_error(context, status));
+        }
+        api.take_optional_string(output)
+    }
+
+    fn url(&self) -> Result<Option<String>, SdkError> {
+        let api = crate::capi::api()?;
+        self.optional_string(api, api.media_url, "media.url")
+    }
+
+    fn file(&self) -> Result<Option<String>, SdkError> {
+        let api = crate::capi::api()?;
+        self.optional_string(api, api.media_file, "media.file")
+    }
+
+    fn base64(&self) -> Result<String, SdkError> {
+        let api = crate::capi::api()?;
+        Ok(self
+            .optional_string(api, api.media_base64, "media.base64")?
+            .unwrap_or_default())
+    }
+
+    fn mime_type(&self) -> Result<Option<String>, SdkError> {
+        let api = crate::capi::api()?;
+        self.optional_string(api, api.media_mime_type, "media.mime_type")
+    }
+}
+
+impl PartialEq for MediaValue {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.handle, &other.handle)
+    }
+}
+
+impl Eq for MediaValue {}
+
+impl SourceKind {
+    fn constructor_name(self) -> &'static str {
+        match self {
+            Self::Url => "media.from_url",
+            Self::File => "media.from_file",
+            Self::Base64 => "media.from_base64",
         }
     }
+}
+
+fn validate_descriptor(source: &str, mime_type: Option<&str>) -> Result<(), DecodeError> {
+    CString::new(source).map_err(|_| DecodeError::InvalidMedia { field: "source" })?;
+    if let Some(mime_type) = mime_type {
+        CString::new(mime_type).map_err(|_| DecodeError::InvalidMedia { field: "MIME type" })?;
+    }
+    Ok(())
+}
+
+fn status_error(context: &str, status: u32) -> SdkError {
+    let detail = match status {
+        1 => "invalid handle",
+        2 => "handle type mismatch",
+        3 => "unsupported handle type",
+        4 => "internal error",
+        5 => "unexpected null pointer",
+        _ => "unknown error",
+    };
+    SdkError::new(format!("{context}: {detail} (status {status})"))
 }
 
 type MediaAccessor = unsafe extern "C" fn(u64, i32, *mut crate::capi::Buffer) -> u32;
-
-fn read_optional(
-    api: &crate::capi::Api,
-    accessor: MediaAccessor,
-    key: u64,
-    handle_type: i32,
-) -> Result<Option<String>, DecodeError> {
-    let mut output = crate::capi::Buffer {
-        ptr: std::ptr::null(),
-        len: 0,
-    };
-    // SAFETY: `output` is valid stack storage, and the handle key and type
-    // came from the engine's outbound value.
-    #[expect(unsafe_code)]
-    let status = unsafe { accessor(key, handle_type, &raw mut output) };
-    if status != 0 {
-        return Err(DecodeError::WrongType {
-            expected: "media",
-            got: "invalid media handle",
-        });
-    }
-    api.take_optional_string(output)
-        .map_err(|_| DecodeError::WrongType {
-            expected: "media",
-            got: "invalid media descriptor",
-        })
-}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Kind {
@@ -400,59 +425,67 @@ fn media_ty(kind: wire::BamlTyMediaKind) -> wire::BamlTy {
 
 macro_rules! define_media {
     ($name:ident, $kind:expr) => {
-        #[doc = concat!("A BAML `", stringify!($name), "` media value.")]
-        #[derive(Clone, Debug, PartialEq, Eq)]
+        #[doc = concat!("An opaque, handle-backed BAML `", stringify!($name), "` value.")]
+        #[derive(Clone, PartialEq, Eq)]
         pub struct $name(MediaValue);
 
         impl $name {
-            /// Create a URL-backed media value.
+            /// Create a URL-backed media handle.
             pub fn from_url(
                 url: impl Into<String>,
                 mime_type: Option<String>,
             ) -> Result<Self, SdkError> {
-                MediaValue::new(Source::Url(url.into()), mime_type).map(Self)
+                MediaValue::create($kind, SourceKind::Url, url.into(), mime_type).map(Self)
             }
 
-            /// Create a file-backed media value. The engine reads the file when the value is used.
+            /// Create a file-backed media handle. The engine reads the file when the value is used.
             pub fn from_file(
                 file: impl Into<String>,
                 mime_type: Option<String>,
             ) -> Result<Self, SdkError> {
-                MediaValue::new(Source::File(file.into()), mime_type).map(Self)
+                MediaValue::create($kind, SourceKind::File, file.into(), mime_type).map(Self)
             }
 
-            /// Create a base64-backed media value.
+            /// Create a base64-backed media handle.
             pub fn from_base64(
                 base64: impl Into<String>,
                 mime_type: Option<String>,
             ) -> Result<Self, SdkError> {
-                MediaValue::new(Source::Base64(base64.into()), mime_type).map(Self)
+                MediaValue::create($kind, SourceKind::Base64, base64.into(), mime_type).map(Self)
             }
 
-            /// Return the URL descriptor, when this value is URL-backed.
-            pub fn url(&self) -> Option<&str> {
+            /// Return the URL for a URL-backed value.
+            pub fn url(&self) -> Result<Option<String>, SdkError> {
                 self.0.url()
             }
 
-            /// Return the file descriptor, when this value is file-backed.
-            pub fn file(&self) -> Option<&str> {
+            /// Return the file path for a file-backed value.
+            pub fn file(&self) -> Result<Option<String>, SdkError> {
                 self.0.file()
             }
 
-            /// Return the base64 descriptor, when this value is base64-backed.
-            pub fn base64(&self) -> Option<&str> {
+            /// Return the base64 payload, or an empty string when this value is not base64-backed.
+            pub fn base64(&self) -> Result<String, SdkError> {
                 self.0.base64()
             }
 
-            /// Return the optional MIME type supplied with this value.
-            pub fn mime_type(&self) -> Option<&str> {
-                self.0.mime_type.as_deref()
+            /// Return the media value's MIME type.
+            pub fn mime_type(&self) -> Result<Option<String>, SdkError> {
+                self.0.mime_type()
+            }
+        }
+
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter
+                    .debug_struct(stringify!($name))
+                    .finish_non_exhaustive()
             }
         }
 
         impl __BamlValuePrivate for $name {
             fn to_baml(&self) -> wire::InboundValue {
-                self.0.to_baml($kind)
+                self.0.to_baml()
             }
 
             fn from_baml(value: wire::BamlOutboundValue) -> Result<Self, DecodeError> {
@@ -472,7 +505,7 @@ define_media!(Video, Kind::Video);
 define_media!(Pdf, Kind::Pdf);
 define_media!(GenericMedia, Kind::Generic);
 
-/// A media value whose concrete kind is selected at runtime.
+/// An opaque media handle whose concrete kind is selected at runtime.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Media {
     /// An image value.
@@ -533,6 +566,8 @@ impl_media_from!(GenericMedia, Generic);
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
     use super::*;
 
     fn outbound(
@@ -548,73 +583,6 @@ mod tests {
                 },
             )),
         }
-    }
-
-    #[test]
-    fn image_decodes_without_loading_the_runtime() {
-        let image = Image::from_baml(outbound(
-            wire::MediaTypeEnum::Image,
-            wire::baml_value_media::Value::Url("https://example.com/image.png".to_string()),
-        ))
-        .unwrap();
-        assert_eq!(image.url(), Some("https://example.com/image.png"));
-        assert_eq!(image.mime_type(), Some("image/png"));
-    }
-
-    #[test]
-    fn image_decodes_file_and_base64_sources() {
-        let file = Image::from_baml(outbound(
-            wire::MediaTypeEnum::Image,
-            wire::baml_value_media::Value::File("/tmp/image.png".to_string()),
-        ))
-        .unwrap();
-        assert_eq!(file.file(), Some("/tmp/image.png"));
-        assert_eq!(file.url(), None);
-        assert_eq!(file.base64(), None);
-
-        let base64 = Image::from_baml(outbound(
-            wire::MediaTypeEnum::Image,
-            wire::baml_value_media::Value::Base64("aGk=".to_string()),
-        ))
-        .unwrap();
-        assert_eq!(base64.base64(), Some("aGk="));
-        assert_eq!(base64.url(), None);
-        assert_eq!(base64.file(), None);
-    }
-
-    #[test]
-    fn concrete_media_rejects_a_different_kind() {
-        let error = Image::from_baml(outbound(
-            wire::MediaTypeEnum::Audio,
-            wire::baml_value_media::Value::Url("https://example.com/audio.mp3".to_string()),
-        ))
-        .unwrap_err();
-        assert_eq!(error.to_string(), "expected image, got wire variant audio");
-    }
-
-    #[test]
-    fn dynamic_media_selects_the_variant_for_each_kind() {
-        let url = || wire::baml_value_media::Value::Url("https://example.com/asset".to_string());
-        assert!(matches!(
-            Media::from_baml(outbound(wire::MediaTypeEnum::Image, url())).unwrap(),
-            Media::Image(_)
-        ));
-        assert!(matches!(
-            Media::from_baml(outbound(wire::MediaTypeEnum::Audio, url())).unwrap(),
-            Media::Audio(_)
-        ));
-        assert!(matches!(
-            Media::from_baml(outbound(wire::MediaTypeEnum::Video, url())).unwrap(),
-            Media::Video(_)
-        ));
-        assert!(matches!(
-            Media::from_baml(outbound(wire::MediaTypeEnum::Pdf, url())).unwrap(),
-            Media::Pdf(_)
-        ));
-        assert!(matches!(
-            Media::from_baml(outbound(wire::MediaTypeEnum::Other, url())).unwrap(),
-            Media::Generic(_)
-        ));
     }
 
     fn outbound_handle(kind: wire::BamlHandleType) -> wire::BamlOutboundValue {
@@ -645,6 +613,16 @@ mod tests {
     }
 
     #[test]
+    fn concrete_media_rejects_a_different_descriptor_kind_before_allocating() {
+        let error = Image::from_baml(outbound(
+            wire::MediaTypeEnum::Audio,
+            wire::baml_value_media::Value::Url("https://example.com/audio.mp3".to_string()),
+        ))
+        .unwrap_err();
+        assert_eq!(error.to_string(), "expected image, got wire variant audio");
+    }
+
+    #[test]
     fn mismatched_handle_kind_fails_before_loading_the_runtime() {
         let error =
             Image::from_baml(outbound_handle(wire::BamlHandleType::AdtMediaAudio)).unwrap_err();
@@ -662,7 +640,7 @@ mod tests {
     }
 
     #[test]
-    fn decoded_media_rejects_interior_nul_bytes() {
+    fn decoded_media_rejects_interior_nul_bytes_before_allocating() {
         let source_error = Image::from_baml(outbound(
             wire::MediaTypeEnum::Image,
             wire::baml_value_media::Value::Url("bad\0url".to_string()),
@@ -685,7 +663,7 @@ mod tests {
     }
 
     #[test]
-    fn constructors_reject_interior_nul_bytes() {
+    fn constructors_reject_interior_nul_bytes_before_loading_the_runtime() {
         assert_eq!(
             Image::from_file("bad\0path", None).unwrap_err().to_string(),
             "media source contains an interior NUL byte"
@@ -696,6 +674,39 @@ mod tests {
                 .to_string(),
             "media MIME type contains an interior NUL byte"
         );
+    }
+
+    #[test]
+    fn cloned_media_share_one_owned_handle() {
+        let image = Image(MediaValue::adopt(
+            0,
+            wire::BamlHandleType::AdtMediaImage as i32,
+        ));
+        let cloned = image.clone();
+        assert!(Arc::ptr_eq(&image.0.handle, &cloned.0.handle));
+    }
+
+    #[test]
+    fn media_handle_drop_releases_exactly_its_key() {
+        let released = Arc::new(AtomicU64::new(0));
+        let capture = Arc::clone(&released);
+        drop(MediaHandle {
+            key: 73,
+            handle_type: wire::BamlHandleType::AdtMediaImage as i32,
+            release: Some(Arc::new(move |key| {
+                capture.store(key, Ordering::SeqCst);
+            })),
+        });
+        assert_eq!(released.load(Ordering::SeqCst), 73);
+    }
+
+    #[test]
+    fn media_debug_output_is_opaque() {
+        let image = Image(MediaValue::adopt(
+            0,
+            wire::BamlHandleType::AdtMediaImage as i32,
+        ));
+        assert_eq!(format!("{image:?}"), "Image { .. }");
     }
 
     #[test]

--- a/baml_language/sdks/rust/bridge_rust/src/media.rs
+++ b/baml_language/sdks/rust/bridge_rust/src/media.rs
@@ -1,0 +1,718 @@
+//! Typed BAML media values used by generated Rust SDK signatures.
+//!
+//! Media stays descriptor-backed on the Rust side. Immediately before a call,
+//! encoding turns the descriptor into an owned engine handle through the
+//! existing media C ABI; the engine takes ownership of that wire handle.
+
+use std::ffi::CString;
+
+use crate::{DecodeError, SdkError, baml_value::internal::__BamlValuePrivate, wire};
+
+#[derive(Clone, PartialEq, Eq)]
+enum Source {
+    Url(String),
+    File(String),
+    Base64(String),
+}
+
+#[derive(Clone, PartialEq, Eq)]
+struct MediaValue {
+    source: Source,
+    mime_type: Option<String>,
+}
+
+impl MediaValue {
+    fn new(source: Source, mime_type: Option<String>) -> Result<Self, SdkError> {
+        Self::validate(&source, mime_type.as_deref()).map_err(|field| {
+            SdkError::new(format!("media {field} contains an interior NUL byte"))
+        })?;
+        Ok(Self { source, mime_type })
+    }
+
+    fn decoded(source: Source, mime_type: Option<String>) -> Result<Self, DecodeError> {
+        Self::validate(&source, mime_type.as_deref())
+            .map_err(|field| DecodeError::InvalidMedia { field })?;
+        Ok(Self { source, mime_type })
+    }
+
+    fn validate(source: &Source, mime_type: Option<&str>) -> Result<(), &'static str> {
+        let source_value = match source {
+            Source::Url(value) | Source::File(value) | Source::Base64(value) => value,
+        };
+        CString::new(source_value.as_str()).map_err(|_| "source")?;
+        if let Some(mime_type) = mime_type {
+            CString::new(mime_type).map_err(|_| "MIME type")?;
+        }
+        Ok(())
+    }
+
+    fn to_baml(&self, kind: Kind) -> wire::InboundValue {
+        let source = match &self.source {
+            Source::Url(value) | Source::File(value) | Source::Base64(value) => {
+                CString::new(value.as_str()).expect("validated media source")
+            }
+        };
+        let mime_type = self
+            .mime_type
+            .as_deref()
+            .map(CString::new)
+            .transpose()
+            .expect("validated media MIME type");
+        let mime_type_ptr = mime_type
+            .as_ref()
+            .map_or(std::ptr::null(), |value| value.as_ptr());
+        let api = crate::capi::api().expect("BAML runtime must be loaded before encoding media");
+        let constructor = match self.source {
+            Source::Url(_) => api.media_from_url,
+            Source::File(_) => api.media_from_file,
+            Source::Base64(_) => api.media_from_base64,
+        };
+        let mut key = 0_u64;
+        let mut handle_type = 0_i32;
+        // SAFETY: both strings are NUL-terminated and live for the duration of
+        // the call; both output pointers refer to initialized stack storage.
+        #[expect(unsafe_code)]
+        let status = unsafe {
+            constructor(
+                kind.media_type() as i32,
+                source.as_ptr(),
+                mime_type_ptr,
+                &raw mut key,
+                &raw mut handle_type,
+            )
+        };
+        // The safe constructors already enforce the engine's only descriptor
+        // rejection (interior NUL), the kind is a fixed protocol value, and
+        // `insert_entry` guarantees a matching type tag and nonzero key. A
+        // failure here therefore means the exact-version C ABI violated its
+        // contract, not a recoverable input error.
+        assert_eq!(status, 0, "failed to construct a BAML media handle");
+        assert_ne!(key, 0, "media constructor returned a zero handle");
+        assert_eq!(
+            handle_type,
+            kind.handle_type() as i32,
+            "media constructor returned the wrong handle type"
+        );
+        wire::InboundValue {
+            value_type: None,
+            value: Some(wire::inbound_value::Value::Handle(wire::BamlHandle {
+                key,
+                handle_type,
+            })),
+        }
+    }
+
+    fn from_baml(
+        value: wire::BamlOutboundValue,
+        expected: Option<Kind>,
+    ) -> Result<(Kind, Self), DecodeError> {
+        let value = crate::decode::unwrap(value);
+        let got = crate::baml_value::wire_variant_kind(&value);
+        let media = match value.value {
+            Some(wire::baml_outbound_value::Value::MediaValue(media)) => media,
+            Some(wire::baml_outbound_value::Value::HandleValue(handle)) => {
+                return Self::from_handle(handle.key, handle.handle_type, expected);
+            }
+            Some(wire::baml_outbound_value::Value::ClassValue(class)) => {
+                let class_kind =
+                    Kind::from_wrapper_class(&class.name).ok_or(DecodeError::WrongType {
+                        expected: expected.map_or("media", Kind::name),
+                        got: "class",
+                    })?;
+                let handle = class
+                    .fields
+                    .into_iter()
+                    .find(|field| field.key == "_data")
+                    .and_then(|field| field.value)
+                    .and_then(|value| match crate::decode::unwrap(value).value {
+                        Some(wire::baml_outbound_value::Value::HandleValue(handle)) => Some(handle),
+                        _ => None,
+                    })
+                    .ok_or(DecodeError::WrongType {
+                        expected: expected.map_or("media", Kind::name),
+                        got: "media class without a handle",
+                    })?;
+                if expected.is_some_and(|expected| expected != class_kind) {
+                    return Err(DecodeError::WrongType {
+                        expected: expected.map_or("media", Kind::name),
+                        got: class_kind.name(),
+                    });
+                }
+                let decoded = Self::from_handle(handle.key, handle.handle_type, Some(class_kind))?;
+                return Ok(decoded);
+            }
+            _ => {
+                return Err(DecodeError::WrongType {
+                    expected: expected.map_or("media", Kind::name),
+                    got,
+                });
+            }
+        };
+        let Some(kind) = Kind::from_media_type(media.media) else {
+            return Err(DecodeError::WrongType {
+                expected: expected.map_or("media", Kind::name),
+                got: "media with unknown kind",
+            });
+        };
+        if expected.is_some_and(|expected| expected != kind) {
+            return Err(DecodeError::WrongType {
+                expected: expected.map_or("media", Kind::name),
+                got: kind.name(),
+            });
+        }
+        let source = match media.value {
+            Some(wire::baml_value_media::Value::Url(value)) => Source::Url(value),
+            Some(wire::baml_value_media::Value::File(value)) => Source::File(value),
+            Some(wire::baml_value_media::Value::Base64(value)) => Source::Base64(value),
+            None => {
+                return Err(DecodeError::WrongType {
+                    expected: expected.map_or("media", Kind::name),
+                    got: "media without a source",
+                });
+            }
+        };
+        Ok((kind, Self::decoded(source, media.mime_type)?))
+    }
+
+    fn from_handle(
+        key: u64,
+        handle_type: i32,
+        expected: Option<Kind>,
+    ) -> Result<(Kind, Self), DecodeError> {
+        if key == 0 {
+            return Err(DecodeError::WrongType {
+                expected: expected.map_or("media", Kind::name),
+                got: "zero media handle",
+            });
+        }
+        // Union decoders may try multiple concrete arms against the same
+        // outbound handle. Take ownership only after this arm matches.
+        let Some(kind) = Kind::from_handle_type(handle_type) else {
+            return Err(DecodeError::WrongType {
+                expected: expected.map_or("media", Kind::name),
+                got: "non-media handle",
+            });
+        };
+        if expected.is_some_and(|expected| expected != kind) {
+            return Err(DecodeError::WrongType {
+                expected: expected.map_or("media", Kind::name),
+                got: kind.name(),
+            });
+        }
+        let api = crate::capi::api().map_err(|_| DecodeError::WrongType {
+            expected: expected.map_or("media", Kind::name),
+            got: "media handle without a loaded runtime",
+        })?;
+        let guard = HandleGuard { api, key };
+        let url = read_optional(api, api.media_url, key, handle_type)?;
+        let file = read_optional(api, api.media_file, key, handle_type)?;
+        let mime_type = read_optional(api, api.media_mime_type, key, handle_type)?;
+        let source = if let Some(url) = url {
+            Source::Url(url)
+        } else if let Some(file) = file {
+            Source::File(file)
+        } else {
+            let base64 = read_optional(api, api.media_base64, key, handle_type)?.ok_or(
+                DecodeError::WrongType {
+                    expected: expected.map_or("media", Kind::name),
+                    got: "media handle without a source",
+                },
+            )?;
+            Source::Base64(base64)
+        };
+        let value = Self::decoded(source, mime_type)?;
+        drop(guard);
+        Ok((kind, value))
+    }
+
+    fn url(&self) -> Option<&str> {
+        match &self.source {
+            Source::Url(value) => Some(value),
+            Source::File(_) | Source::Base64(_) => None,
+        }
+    }
+
+    fn file(&self) -> Option<&str> {
+        match &self.source {
+            Source::File(value) => Some(value),
+            Source::Url(_) | Source::Base64(_) => None,
+        }
+    }
+
+    fn base64(&self) -> Option<&str> {
+        match &self.source {
+            Source::Base64(value) => Some(value),
+            Source::Url(_) | Source::File(_) => None,
+        }
+    }
+}
+
+impl std::fmt::Debug for MediaValue {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let source = match self.source {
+            Source::Url(_) => "url",
+            Source::File(_) => "file",
+            Source::Base64(_) => "base64",
+        };
+        formatter
+            .debug_struct("MediaValue")
+            .field("source", &source)
+            .field("mime_type", &self.mime_type)
+            .finish()
+    }
+}
+
+struct HandleGuard<'a> {
+    api: &'a crate::capi::Api,
+    key: u64,
+}
+
+impl Drop for HandleGuard<'_> {
+    fn drop(&mut self) {
+        // SAFETY: the outbound handle key is owned by this decoder and must be
+        // released exactly once after its descriptor has been copied out.
+        #[expect(unsafe_code)]
+        unsafe {
+            (self.api.handle_release)(self.key);
+        }
+    }
+}
+
+type MediaAccessor = unsafe extern "C" fn(u64, i32, *mut crate::capi::Buffer) -> u32;
+
+fn read_optional(
+    api: &crate::capi::Api,
+    accessor: MediaAccessor,
+    key: u64,
+    handle_type: i32,
+) -> Result<Option<String>, DecodeError> {
+    let mut output = crate::capi::Buffer {
+        ptr: std::ptr::null(),
+        len: 0,
+    };
+    // SAFETY: `output` is valid stack storage, and the handle key and type
+    // came from the engine's outbound value.
+    #[expect(unsafe_code)]
+    let status = unsafe { accessor(key, handle_type, &raw mut output) };
+    if status != 0 {
+        return Err(DecodeError::WrongType {
+            expected: "media",
+            got: "invalid media handle",
+        });
+    }
+    api.take_optional_string(output)
+        .map_err(|_| DecodeError::WrongType {
+            expected: "media",
+            got: "invalid media descriptor",
+        })
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Kind {
+    Image,
+    Audio,
+    Video,
+    Pdf,
+    Generic,
+}
+
+impl Kind {
+    fn name(self) -> &'static str {
+        match self {
+            Self::Image => "image",
+            Self::Audio => "audio",
+            Self::Video => "video",
+            Self::Pdf => "pdf",
+            Self::Generic => "media",
+        }
+    }
+
+    fn media_type(self) -> wire::MediaTypeEnum {
+        match self {
+            Self::Image => wire::MediaTypeEnum::Image,
+            Self::Audio => wire::MediaTypeEnum::Audio,
+            Self::Video => wire::MediaTypeEnum::Video,
+            Self::Pdf => wire::MediaTypeEnum::Pdf,
+            Self::Generic => wire::MediaTypeEnum::Other,
+        }
+    }
+
+    fn type_kind(self) -> wire::BamlTyMediaKind {
+        match self {
+            Self::Image => wire::BamlTyMediaKind::Image,
+            Self::Audio => wire::BamlTyMediaKind::Audio,
+            Self::Video => wire::BamlTyMediaKind::Video,
+            Self::Pdf => wire::BamlTyMediaKind::Pdf,
+            Self::Generic => wire::BamlTyMediaKind::Generic,
+        }
+    }
+
+    fn handle_type(self) -> wire::BamlHandleType {
+        match self {
+            Self::Image => wire::BamlHandleType::AdtMediaImage,
+            Self::Audio => wire::BamlHandleType::AdtMediaAudio,
+            Self::Video => wire::BamlHandleType::AdtMediaVideo,
+            Self::Pdf => wire::BamlHandleType::AdtMediaPdf,
+            Self::Generic => wire::BamlHandleType::AdtMediaGeneric,
+        }
+    }
+
+    fn from_media_type(value: i32) -> Option<Self> {
+        match wire::MediaTypeEnum::try_from(value).ok()? {
+            wire::MediaTypeEnum::Image => Some(Self::Image),
+            wire::MediaTypeEnum::Audio => Some(Self::Audio),
+            wire::MediaTypeEnum::Video => Some(Self::Video),
+            wire::MediaTypeEnum::Pdf => Some(Self::Pdf),
+            wire::MediaTypeEnum::Other => Some(Self::Generic),
+            wire::MediaTypeEnum::MediaTypeUnspecified => None,
+        }
+    }
+
+    fn from_handle_type(value: i32) -> Option<Self> {
+        match wire::BamlHandleType::try_from(value).ok()? {
+            wire::BamlHandleType::AdtMediaImage => Some(Self::Image),
+            wire::BamlHandleType::AdtMediaAudio => Some(Self::Audio),
+            wire::BamlHandleType::AdtMediaVideo => Some(Self::Video),
+            wire::BamlHandleType::AdtMediaPdf => Some(Self::Pdf),
+            wire::BamlHandleType::AdtMediaGeneric => Some(Self::Generic),
+            _ => None,
+        }
+    }
+
+    fn from_wrapper_class(value: &str) -> Option<Self> {
+        match value {
+            "baml.media.Image" => Some(Self::Image),
+            "baml.media.Audio" => Some(Self::Audio),
+            "baml.media.Video" => Some(Self::Video),
+            "baml.media.Pdf" => Some(Self::Pdf),
+            _ => None,
+        }
+    }
+}
+
+fn media_ty(kind: wire::BamlTyMediaKind) -> wire::BamlTy {
+    wire::BamlTy {
+        ty: Some(wire::baml_ty::Ty::Media(wire::BamlTyMedia {
+            kind: kind as i32,
+        })),
+    }
+}
+
+macro_rules! define_media {
+    ($name:ident, $kind:expr) => {
+        #[doc = concat!("A BAML `", stringify!($name), "` media value.")]
+        #[derive(Clone, Debug, PartialEq, Eq)]
+        pub struct $name(MediaValue);
+
+        impl $name {
+            /// Create a URL-backed media value.
+            pub fn from_url(
+                url: impl Into<String>,
+                mime_type: Option<String>,
+            ) -> Result<Self, SdkError> {
+                MediaValue::new(Source::Url(url.into()), mime_type).map(Self)
+            }
+
+            /// Create a file-backed media value. The engine reads the file when the value is used.
+            pub fn from_file(
+                file: impl Into<String>,
+                mime_type: Option<String>,
+            ) -> Result<Self, SdkError> {
+                MediaValue::new(Source::File(file.into()), mime_type).map(Self)
+            }
+
+            /// Create a base64-backed media value.
+            pub fn from_base64(
+                base64: impl Into<String>,
+                mime_type: Option<String>,
+            ) -> Result<Self, SdkError> {
+                MediaValue::new(Source::Base64(base64.into()), mime_type).map(Self)
+            }
+
+            /// Return the URL descriptor, when this value is URL-backed.
+            pub fn url(&self) -> Option<&str> {
+                self.0.url()
+            }
+
+            /// Return the file descriptor, when this value is file-backed.
+            pub fn file(&self) -> Option<&str> {
+                self.0.file()
+            }
+
+            /// Return the base64 descriptor, when this value is base64-backed.
+            pub fn base64(&self) -> Option<&str> {
+                self.0.base64()
+            }
+
+            /// Return the optional MIME type supplied with this value.
+            pub fn mime_type(&self) -> Option<&str> {
+                self.0.mime_type.as_deref()
+            }
+        }
+
+        impl __BamlValuePrivate for $name {
+            fn to_baml(&self) -> wire::InboundValue {
+                self.0.to_baml($kind)
+            }
+
+            fn from_baml(value: wire::BamlOutboundValue) -> Result<Self, DecodeError> {
+                MediaValue::from_baml(value, Some($kind)).map(|(_, value)| Self(value))
+            }
+
+            fn baml_ty() -> wire::BamlTy {
+                media_ty($kind.type_kind())
+            }
+        }
+    };
+}
+
+define_media!(Image, Kind::Image);
+define_media!(Audio, Kind::Audio);
+define_media!(Video, Kind::Video);
+define_media!(Pdf, Kind::Pdf);
+define_media!(GenericMedia, Kind::Generic);
+
+/// A media value whose concrete kind is selected at runtime.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Media {
+    /// An image value.
+    Image(Image),
+    /// An audio value.
+    Audio(Audio),
+    /// A video value.
+    Video(Video),
+    /// A PDF value.
+    Pdf(Pdf),
+    /// A media value without a more specific kind.
+    Generic(GenericMedia),
+}
+
+impl __BamlValuePrivate for Media {
+    fn to_baml(&self) -> wire::InboundValue {
+        match self {
+            Self::Image(value) => value.to_baml(),
+            Self::Audio(value) => value.to_baml(),
+            Self::Video(value) => value.to_baml(),
+            Self::Pdf(value) => value.to_baml(),
+            Self::Generic(value) => value.to_baml(),
+        }
+    }
+
+    fn from_baml(value: wire::BamlOutboundValue) -> Result<Self, DecodeError> {
+        let (kind, value) = MediaValue::from_baml(value, None)?;
+        Ok(match kind {
+            Kind::Image => Self::Image(Image(value)),
+            Kind::Audio => Self::Audio(Audio(value)),
+            Kind::Video => Self::Video(Video(value)),
+            Kind::Pdf => Self::Pdf(Pdf(value)),
+            Kind::Generic => Self::Generic(GenericMedia(value)),
+        })
+    }
+
+    fn baml_ty() -> wire::BamlTy {
+        media_ty(wire::BamlTyMediaKind::Generic)
+    }
+}
+
+macro_rules! impl_media_from {
+    ($name:ident, $variant:ident) => {
+        impl From<$name> for Media {
+            #[doc = concat!("Wrap a [`", stringify!($name), "`] as dynamic [`Media`].")]
+            fn from(value: $name) -> Self {
+                Self::$variant(value)
+            }
+        }
+    };
+}
+
+impl_media_from!(Image, Image);
+impl_media_from!(Audio, Audio);
+impl_media_from!(Video, Video);
+impl_media_from!(Pdf, Pdf);
+impl_media_from!(GenericMedia, Generic);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn outbound(
+        kind: wire::MediaTypeEnum,
+        value: wire::baml_value_media::Value,
+    ) -> wire::BamlOutboundValue {
+        wire::BamlOutboundValue {
+            value: Some(wire::baml_outbound_value::Value::MediaValue(
+                wire::BamlValueMedia {
+                    media: kind as i32,
+                    mime_type: Some("image/png".to_string()),
+                    value: Some(value),
+                },
+            )),
+        }
+    }
+
+    #[test]
+    fn image_decodes_without_loading_the_runtime() {
+        let image = Image::from_baml(outbound(
+            wire::MediaTypeEnum::Image,
+            wire::baml_value_media::Value::Url("https://example.com/image.png".to_string()),
+        ))
+        .unwrap();
+        assert_eq!(image.url(), Some("https://example.com/image.png"));
+        assert_eq!(image.mime_type(), Some("image/png"));
+    }
+
+    #[test]
+    fn image_decodes_file_and_base64_sources() {
+        let file = Image::from_baml(outbound(
+            wire::MediaTypeEnum::Image,
+            wire::baml_value_media::Value::File("/tmp/image.png".to_string()),
+        ))
+        .unwrap();
+        assert_eq!(file.file(), Some("/tmp/image.png"));
+        assert_eq!(file.url(), None);
+        assert_eq!(file.base64(), None);
+
+        let base64 = Image::from_baml(outbound(
+            wire::MediaTypeEnum::Image,
+            wire::baml_value_media::Value::Base64("aGk=".to_string()),
+        ))
+        .unwrap();
+        assert_eq!(base64.base64(), Some("aGk="));
+        assert_eq!(base64.url(), None);
+        assert_eq!(base64.file(), None);
+    }
+
+    #[test]
+    fn concrete_media_rejects_a_different_kind() {
+        let error = Image::from_baml(outbound(
+            wire::MediaTypeEnum::Audio,
+            wire::baml_value_media::Value::Url("https://example.com/audio.mp3".to_string()),
+        ))
+        .unwrap_err();
+        assert_eq!(error.to_string(), "expected image, got wire variant audio");
+    }
+
+    #[test]
+    fn dynamic_media_selects_the_variant_for_each_kind() {
+        let url = || wire::baml_value_media::Value::Url("https://example.com/asset".to_string());
+        assert!(matches!(
+            Media::from_baml(outbound(wire::MediaTypeEnum::Image, url())).unwrap(),
+            Media::Image(_)
+        ));
+        assert!(matches!(
+            Media::from_baml(outbound(wire::MediaTypeEnum::Audio, url())).unwrap(),
+            Media::Audio(_)
+        ));
+        assert!(matches!(
+            Media::from_baml(outbound(wire::MediaTypeEnum::Video, url())).unwrap(),
+            Media::Video(_)
+        ));
+        assert!(matches!(
+            Media::from_baml(outbound(wire::MediaTypeEnum::Pdf, url())).unwrap(),
+            Media::Pdf(_)
+        ));
+        assert!(matches!(
+            Media::from_baml(outbound(wire::MediaTypeEnum::Other, url())).unwrap(),
+            Media::Generic(_)
+        ));
+    }
+
+    fn outbound_handle(kind: wire::BamlHandleType) -> wire::BamlOutboundValue {
+        wire::BamlOutboundValue {
+            value: Some(wire::baml_outbound_value::Value::HandleValue(
+                wire::BamlOutboundHandle {
+                    key: 1,
+                    handle_type: kind as i32,
+                    ty: None,
+                },
+            )),
+        }
+    }
+
+    fn outbound_wrapper(class: &str, kind: wire::BamlHandleType) -> wire::BamlOutboundValue {
+        wire::BamlOutboundValue {
+            value: Some(wire::baml_outbound_value::Value::ClassValue(
+                wire::BamlValueClass {
+                    name: class.to_string(),
+                    fields: vec![wire::BamlOutboundMapEntry {
+                        key: "_data".to_string(),
+                        value: Some(outbound_handle(kind)),
+                    }],
+                    type_args: Vec::new(),
+                },
+            )),
+        }
+    }
+
+    #[test]
+    fn mismatched_handle_kind_fails_before_loading_the_runtime() {
+        let error =
+            Image::from_baml(outbound_handle(wire::BamlHandleType::AdtMediaAudio)).unwrap_err();
+        assert_eq!(error.to_string(), "expected image, got wire variant audio");
+    }
+
+    #[test]
+    fn mismatched_wrapper_class_fails_before_decoding_its_handle() {
+        let error = Image::from_baml(outbound_wrapper(
+            "baml.media.Audio",
+            wire::BamlHandleType::AdtMediaAudio,
+        ))
+        .unwrap_err();
+        assert_eq!(error.to_string(), "expected image, got wire variant audio");
+    }
+
+    #[test]
+    fn decoded_media_rejects_interior_nul_bytes() {
+        let source_error = Image::from_baml(outbound(
+            wire::MediaTypeEnum::Image,
+            wire::baml_value_media::Value::Url("bad\0url".to_string()),
+        ))
+        .unwrap_err();
+        assert_eq!(source_error, DecodeError::InvalidMedia { field: "source" });
+
+        let mut value = outbound(
+            wire::MediaTypeEnum::Image,
+            wire::baml_value_media::Value::Url("https://example.com/image.png".to_string()),
+        );
+        let Some(wire::baml_outbound_value::Value::MediaValue(media)) = &mut value.value else {
+            panic!("expected media value");
+        };
+        media.mime_type = Some("bad\0mime".to_string());
+        assert_eq!(
+            Image::from_baml(value).unwrap_err(),
+            DecodeError::InvalidMedia { field: "MIME type" }
+        );
+    }
+
+    #[test]
+    fn constructors_reject_interior_nul_bytes() {
+        assert_eq!(
+            Image::from_file("bad\0path", None).unwrap_err().to_string(),
+            "media source contains an interior NUL byte"
+        );
+        assert_eq!(
+            Image::from_url("https://example.com", Some("bad\0mime".to_string()))
+                .unwrap_err()
+                .to_string(),
+            "media MIME type contains an interior NUL byte"
+        );
+    }
+
+    #[test]
+    fn media_types_preserve_the_protocol_kind_ordering() {
+        let image = <Image as __BamlValuePrivate>::baml_ty();
+        let audio = <Audio as __BamlValuePrivate>::baml_ty();
+        let video = <Video as __BamlValuePrivate>::baml_ty();
+        let pdf = <Pdf as __BamlValuePrivate>::baml_ty();
+        let generic = <GenericMedia as __BamlValuePrivate>::baml_ty();
+        let kind = |ty: wire::BamlTy| match ty.ty.unwrap() {
+            wire::baml_ty::Ty::Media(media) => media.kind,
+            _ => panic!("expected media type"),
+        };
+        assert_eq!(kind(image), wire::BamlTyMediaKind::Image as i32);
+        assert_eq!(kind(audio), wire::BamlTyMediaKind::Audio as i32);
+        assert_eq!(kind(video), wire::BamlTyMediaKind::Video as i32);
+        assert_eq!(kind(pdf), wire::BamlTyMediaKind::Pdf as i32);
+        assert_eq!(kind(generic), wire::BamlTyMediaKind::Generic as i32);
+    }
+}

--- a/baml_language/sdks/rust/bridge_rust/src/media.rs
+++ b/baml_language/sdks/rust/bridge_rust/src/media.rs
@@ -182,10 +182,10 @@ impl MediaValue {
             }
         };
         validate_descriptor(&source, media.mime_type.as_deref())?;
-        let value = Self::create(kind, source_kind, source, media.mime_type).map_err(|_| {
-            DecodeError::WrongType {
-                expected: expected.map_or("media", Kind::name),
-                got: "media descriptor rejected by the runtime",
+        let value = Self::create(kind, source_kind, source, media.mime_type).map_err(|error| {
+            DecodeError::MediaHandleCreation {
+                expected: expected.map_or_else(|| kind.name(), Kind::name),
+                detail: error.to_string(),
             }
         })?;
         Ok((kind, value))

--- a/baml_language/sdks/rust/sdkgen_rust/src/analyze.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/analyze.rs
@@ -347,7 +347,7 @@ fn field_deps(ty: &Ty, generic_params: &[&str], deps: &mut Vec<Name>) -> Result<
                 ))
             }
         }
-        Ty::Media(kind, _) => Err(format!("unsupported type: media ({kind})")),
+        Ty::Media(..) => Ok(()),
         Ty::BuiltinUnknown { .. } => Err("unsupported type: unknown".to_string()),
         Ty::Function { .. } => Err("unsupported type: function".to_string()),
         Ty::Future(..) => Err("unsupported type: future handle".to_string()),

--- a/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
@@ -67,12 +67,12 @@ pub struct RustGenOptions {
 }
 
 /// A symbol the emitter skipped because it references a BAML type the Rust
-/// SDK cannot represent yet (media, non-null unions, generics, …).
+/// SDK cannot represent yet (prompt ASTs, resource handles, …).
 #[derive(Debug)]
 pub struct SkipWarning {
     /// Fully qualified BAML name of the skipped symbol.
     pub fqn: String,
-    /// Human-readable reason, e.g. `unsupported type: media`.
+    /// Human-readable reason, e.g. `unsupported type: prompt AST`.
     pub reason: String,
 }
 
@@ -1497,7 +1497,9 @@ mod tests {
         let w = name("user", &[], "Widget");
         let ok = nullary_string_fn(&name("user", &[], "ok"));
         let mut snap = nullary_string_fn(&name("user", &[], "snap"));
-        snap.return_type = Ty::Media(baml_base::MediaKind::Image, baml_base::TyAttr::EMPTY);
+        snap.return_type = Ty::PromptAst {
+            attr: baml_base::TyAttr::EMPTY,
+        };
         // A generic method on a non-generic class emits (its own `<T>`),
         // proving `snap`'s skip is per-method, not per-vec.
         let mut pick = nullary_string_fn(&name("user", &[], "pick"));
@@ -1520,7 +1522,7 @@ mod tests {
         assert_eq!(generated.warnings.len(), 1, "{:?}", generated.warnings);
         assert_eq!(generated.warnings[0].fqn, "user.Widget.snap");
         assert!(
-            generated.warnings[0].reason.contains("media"),
+            generated.warnings[0].reason.contains("prompt AST"),
             "{}",
             generated.warnings[0].reason
         );
@@ -1616,14 +1618,101 @@ mod tests {
 
     #[test]
     fn unsupported_symbols_skip_with_a_warning() {
-        let n = name("user", &[], "needs_media");
+        let n = name("user", &[], "needs_prompt_ast");
         let mut f = nullary_string_fn(&n);
-        f.return_type = Ty::Media(baml_base::MediaKind::Image, baml_base::TyAttr::EMPTY);
+        f.return_type = Ty::PromptAst {
+            attr: baml_base::TyAttr::EMPTY,
+        };
         let pool = SymbolPool::from([(n, Symbol::Function(f))]);
         let generated = to_source_code_with_bytecode(&pool, &[], &options());
         assert_eq!(generated.warnings.len(), 1);
-        assert_eq!(generated.warnings[0].fqn, "user.needs_media");
-        assert!(generated.warnings[0].reason.contains("media"));
+        assert_eq!(generated.warnings[0].fqn, "user.needs_prompt_ast");
+        assert!(generated.warnings[0].reason.contains("prompt AST"));
+    }
+
+    #[test]
+    fn media_functions_and_containing_classes_are_emitted() {
+        let media = name("user", &[], "MediaInput");
+        let classify = name("user", &[], "classify");
+        let image = Ty::Media(baml_base::MediaKind::Image, baml_base::TyAttr::EMPTY);
+        let pool = SymbolPool::from([
+            (
+                media.clone(),
+                class_symbol(
+                    &media,
+                    vec![baml_codegen_types::ClassProperty {
+                        name: baml_base::Name::new("page_image"),
+                        docstring: None,
+                        ty: image.clone(),
+                    }],
+                    Vec::new(),
+                    Vec::new(),
+                ),
+            ),
+            (
+                classify.clone(),
+                Symbol::Function(Function {
+                    name: classify.name().clone(),
+                    generic_params: Vec::new(),
+                    arguments: vec![baml_codegen_types::FunctionArgument {
+                        name: baml_base::Name::new("page_image"),
+                        docstring: None,
+                        ty: image,
+                        default: None,
+                    }],
+                    return_type: Ty::String {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
+                    throws: None,
+                    watchers: Vec::new(),
+                    docstring: None,
+                    origin: Origin {
+                        source_file_path: "main.baml".to_string(),
+                        span_start: 0,
+                    },
+                }),
+            ),
+        ]);
+
+        let generated = to_source_code_with_bytecode(&pool, &[], &options());
+        assert!(generated.warnings.is_empty(), "{:?}", generated.warnings);
+        let lib = text(&generated, "src/lib.rs");
+        assert!(
+            lib.contains("pub page_image: ::baml_bridge::media::Image"),
+            "{lib}"
+        );
+        assert!(
+            flat(lib).contains("pubfnclassify(page_image:::baml_bridge::media::Image"),
+            "{lib}"
+        );
+    }
+
+    #[test]
+    fn every_media_kind_maps_to_its_bridge_type() {
+        for (kind, expected) in [
+            (baml_base::MediaKind::Image, "::baml_bridge::media::Image"),
+            (baml_base::MediaKind::Audio, "::baml_bridge::media::Audio"),
+            (baml_base::MediaKind::Video, "::baml_bridge::media::Video"),
+            (baml_base::MediaKind::Pdf, "::baml_bridge::media::Pdf"),
+            (baml_base::MediaKind::Generic, "::baml_bridge::media::Media"),
+        ] {
+            let function_name = name("user", &[], "take");
+            let function = unary_fn(
+                &function_name,
+                Ty::Media(kind, baml_base::TyAttr::EMPTY),
+                Ty::String {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
+            );
+            let pool = SymbolPool::from([(function_name, Symbol::Function(function))]);
+            let generated = to_source_code_with_bytecode(&pool, &[], &options());
+            assert!(generated.warnings.is_empty(), "{:?}", generated.warnings);
+            let lib = flat(text(&generated, "src/lib.rs"));
+            assert!(
+                lib.contains(&format!("pubfntake(u:{expected},)")),
+                "{kind:?} did not map to {expected}\n{lib}"
+            );
+        }
     }
 
     #[test]

--- a/baml_language/sdks/rust/sdkgen_rust/src/translate_ty.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/translate_ty.rs
@@ -208,7 +208,13 @@ fn translate_inner(ty: &Ty, ctx: &TyCtx<'_>, under_heap: bool) -> Result<TokenSt
             }
             Ok(type_path(name, ctx.analysis))
         }
-        Ty::Media(kind, _) => Err(unsupported(&format!("media ({kind})"))),
+        Ty::Media(kind, _) => Ok(match kind {
+            baml_base::MediaKind::Image => quote! { ::baml_bridge::media::Image },
+            baml_base::MediaKind::Audio => quote! { ::baml_bridge::media::Audio },
+            baml_base::MediaKind::Video => quote! { ::baml_bridge::media::Video },
+            baml_base::MediaKind::Pdf => quote! { ::baml_bridge::media::Pdf },
+            baml_base::MediaKind::Generic => quote! { ::baml_bridge::media::Media },
+        }),
         // Opaque alias references (in-package non-recursive aliases are
         // inlined upstream, so these are recursive or cross-package ones).
         // A Rust `type` alias is transparent, so the reference resolves to
@@ -556,7 +562,7 @@ mod tests {
 
     #[test]
     fn references_to_skipped_types_fail_closed() {
-        // `Bad` has a media field, so it is skipped; a reference to it
+        // `Bad` has a prompt-AST field, so it is skipped; a reference to it
         // must not translate.
         let bad = name("user", &[], "Bad");
         let pool = SymbolPool::from([(
@@ -565,7 +571,9 @@ mod tests {
                 &bad,
                 vec![(
                     "m",
-                    Ty::Media(baml_base::MediaKind::Image, baml_base::TyAttr::EMPTY),
+                    Ty::PromptAst {
+                        attr: baml_base::TyAttr::EMPTY,
+                    },
                 )],
             ),
         )]);
@@ -698,7 +706,7 @@ mod tests {
 
     #[test]
     fn transitively_poisoned_classes_skip_with_a_warning() {
-        // Bad (media field) poisons Holder, which references it.
+        // Bad (prompt-AST field) poisons Holder, which references it.
         let bad = name("user", &[], "Bad");
         let holder = name("user", &[], "Holder");
         let pool = SymbolPool::from([
@@ -708,7 +716,9 @@ mod tests {
                     &bad,
                     vec![(
                         "m",
-                        Ty::Media(baml_base::MediaKind::Image, baml_base::TyAttr::EMPTY),
+                        Ty::PromptAst {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
                     )],
                 ),
             ),

--- a/baml_language/sdks/rust/sdkgen_rust/src/unions.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/unions.rs
@@ -12,9 +12,10 @@
 //! Decode is a trial of the arms in declared order, which is sound only
 //! when the arms are pairwise discriminable on the wire (distinct wire
 //! kinds, FQN-verified nominals, distinct literal values). Shapes that
-//! are not — a `string` arm alongside a string-literal arm — and arms the
-//! SDK cannot represent (non-string literals) make the whole shape
-//! unsupported, fail-closed.
+//! are not — a `string` arm alongside a string-literal arm, or generic
+//! `media` alongside a concrete media kind — and arms the SDK cannot
+//! represent (non-string literals) make the whole shape unsupported,
+//! fail-closed.
 
 use std::collections::{BTreeMap, HashSet};
 
@@ -200,6 +201,8 @@ fn register_unions_in(ty: &Ty, leaf: &[String], analysis: &Analysis, registry: &
 pub(crate) fn shape_error(arms: &[Ty]) -> Option<String> {
     let mut has_bare_string_arm = false;
     let mut has_string_literal_arm = false;
+    let mut has_generic_media_arm = false;
+    let mut has_concrete_media_arm = false;
     let mut seen = HashSet::new();
     for arm in arms {
         match arm {
@@ -211,6 +214,8 @@ pub(crate) fn shape_error(arms: &[Ty]) -> Option<String> {
                 ));
             }
             Ty::String { .. } => has_bare_string_arm = true,
+            Ty::Media(baml_base::MediaKind::Generic, _) => has_generic_media_arm = true,
+            Ty::Media(..) => has_concrete_media_arm = true,
             _ => {}
         }
         let Some(variant) = variant_name(arm) else {
@@ -229,6 +234,15 @@ pub(crate) fn shape_error(arms: &[Ty]) -> Option<String> {
     if has_bare_string_arm && has_string_literal_arm {
         return Some(
             "union mixes a `string` arm with string-literal arms, which are \
+             indistinguishable on the wire"
+                .to_string(),
+        );
+    }
+    // Generic media accepts every concrete media kind, so trial decoding
+    // would always select whichever overlapping arm appeared first.
+    if has_generic_media_arm && has_concrete_media_arm {
+        return Some(
+            "union mixes a generic `media` arm with concrete media arms, which are \
              indistinguishable on the wire"
                 .to_string(),
         );
@@ -315,7 +329,8 @@ fn arm_is_representable(ty: &Ty, analysis: &Analysis) -> bool {
         | Ty::Float { .. }
         | Ty::String { .. }
         | Ty::Bool { .. }
-        | Ty::Uint8Array { .. } => true,
+        | Ty::Uint8Array { .. }
+        | Ty::Media(..) => true,
         // A `TypeVar` arm makes the enum generic over that param: the
         // variant holds a bare `T`. Whether `T` is actually in scope at the
         // use site is enforced when the reference is translated.
@@ -338,7 +353,6 @@ fn arm_is_representable(ty: &Ty, analysis: &Analysis) -> bool {
         Ty::Null { .. }
         | Ty::Void { .. }
         | Ty::Literal(..)
-        | Ty::Media(..)
         | Ty::BuiltinUnknown { .. }
         | Ty::Function { .. }
         | Ty::Future(..)
@@ -361,6 +375,16 @@ fn variant_name(arm: &Ty) -> Option<String> {
         Ty::String { .. } => Some("String".to_string()),
         Ty::Bool { .. } => Some("Bool".to_string()),
         Ty::Uint8Array { .. } => Some("Uint8Array".to_string()),
+        Ty::Media(kind, _) => Some(
+            match kind {
+                baml_base::MediaKind::Image => "Image",
+                baml_base::MediaKind::Audio => "Audio",
+                baml_base::MediaKind::Video => "Video",
+                baml_base::MediaKind::Pdf => "Pdf",
+                baml_base::MediaKind::Generic => "Media",
+            }
+            .to_string(),
+        ),
         Ty::Class(name, _, _)
         | Ty::Enum(name, _)
         | Ty::EnumVariant(name, _, _)
@@ -393,7 +417,6 @@ fn variant_name(arm: &Ty) -> Option<String> {
         Ty::Null { .. }
         | Ty::Void { .. }
         | Ty::Literal(..)
-        | Ty::Media(..)
         | Ty::BuiltinUnknown { .. }
         | Ty::Function { .. }
         | Ty::Future(..)
@@ -403,5 +426,30 @@ fn variant_name(arm: &Ty) -> Option<String> {
         | Ty::PromptAst { .. }
         | Ty::Never { .. }
         | Ty::RustType { .. } => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use baml_base::{MediaKind, TyAttr};
+
+    use super::*;
+
+    fn media(kind: MediaKind) -> Ty {
+        Ty::Media(kind, TyAttr::EMPTY)
+    }
+
+    #[test]
+    fn generic_media_cannot_overlap_concrete_media_in_a_union() {
+        for kind in [
+            MediaKind::Image,
+            MediaKind::Audio,
+            MediaKind::Video,
+            MediaKind::Pdf,
+        ] {
+            let error = shape_error(&[media(MediaKind::Generic), media(kind)]).unwrap();
+            assert!(error.contains("generic `media`"));
+        }
+        assert!(shape_error(&[media(MediaKind::Image), media(MediaKind::Audio)]).is_none());
     }
 }


### PR DESCRIPTION
## Summary

- generate typed Rust SDK signatures for `image`, `audio`, `video`, `pdf`, and generic media values
- expose opaque, handle-backed Rust media types with Python-compatible `from_url`, `from_file`, `from_base64`, `url`, `file`, `base64`, and `mime_type` APIs
- allocate media handles at construction, clone engine keys for each send, and release the retained key when the final Rust owner drops
- decode outbound media handles without materializing descriptors, including media fields, containing classes, and media unions

## Tests

- `cargo test --manifest-path baml_language/sdks/rust/bridge_rust/Cargo.toml --lib`
- `cargo clippy --manifest-path baml_language/sdks/rust/bridge_rust/Cargo.toml --all-targets -- -D warnings`
- `cargo test --manifest-path baml_language/sdks/rust/sdkgen_rust/Cargo.toml`
- generated Rust type-shape suite: 95 tests, including 12 media-specific tests with handle reuse and introspection coverage

Fixes #4372

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Rust SDK support for image, audio, video, PDF, and generic media values.
  * Create media from URLs, files, or Base64 data with optional MIME types.
  * Added support for media fields, function parameters, and media variants in unions.
  * Added metadata accessors, handle cloning, and media round-trip support.

* **Bug Fixes**
  * Invalid media values, including interior-NUL URLs, now return clear errors.
  * Added validation for invalid handles and mismatched media types.

* **Documentation**
  * Documented Rust media types, constructors, accessors, and parameter support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->