### PR TITLE
fix: diagnose reserved test names and clarify env loading

### DIFF
--- a/baml_language/crates/baml_cli/src/check_command.rs
+++ b/baml_language/crates/baml_cli/src/check_command.rs
@@ -13,6 +13,9 @@ use crate::reporter::Reporter;
 /// source file in that project, and prints compiler errors and warnings.
 #[derive(Args, Debug)]
 #[command(after_long_help = "\
+Environment:
+  BAML does not load .env files. Export variables in the invoking process or use an environment-loading tool.
+
 Examples:
   Check the nearest project:
     baml check

--- a/baml_language/crates/baml_cli/src/run_command.rs
+++ b/baml_language/crates/baml_cli/src/run_command.rs
@@ -144,6 +144,9 @@ fn parse_script_body(tokens: &[String]) -> Result<ScriptExpansion> {
 #[command(after_long_help = "\
 Use `baml run <target> -- --help` to display the target's generated arguments.
 
+Environment:
+  BAML does not load .env files. Export variables in the invoking process or use an environment-loading tool.
+
 Examples:
   Run a function:
     baml run main -- --name Ada

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__run_detailed_help.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__run_detailed_help.snap
@@ -112,3 +112,7 @@ Global options:
           Display concise help for this command
 
 Use `baml run <target> -- --help` to display the target's generated arguments.
+
+Environment:
+  BAML does not load .env files. Export variables in the invoking process or use an
+  environment-loading tool.

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__test_detailed_help.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__help_command__tests__test_detailed_help.snap
@@ -103,3 +103,7 @@ PROFILES:
   profile scalar options. Profile args cannot contain --profile, --no-profile,
   --project, --directory, --from, --features, or --help. With no default profile,
   all tests are selected.
+
+ENVIRONMENT:
+  BAML does not load .env files. Export variables in the invoking process or use an
+  environment-loading tool.

--- a/baml_language/crates/baml_cli/src/test_command.rs
+++ b/baml_language/crates/baml_cli/src/test_command.rs
@@ -54,6 +54,9 @@ PROFILES:
   --project, --directory, --from, --features, or --help. With no default profile,
   all tests are selected.
 
+ENVIRONMENT:
+  BAML does not load .env files. Export variables in the invoking process or use an environment-loading tool.
+
 Examples:
   List available tests:
     baml test --list

--- a/baml_language/crates/baml_cli/tests/test_profiles_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/test_profiles_e2e.rs
@@ -281,6 +281,15 @@ fn double_colon_is_reserved_inside_declared_test_names() {
     )
     .unwrap();
 
+    let checked = run(tmp.path(), &["check"]);
+    assert!(!checked.status.success());
+    let check_error = String::from_utf8_lossy(&checked.stderr);
+    assert!(
+        check_error.contains("reserved separator `::`"),
+        "{check_error}"
+    );
+    assert!(check_error.contains("testset"), "{check_error}");
+
     let output = run(tmp.path(), &["test", "--list", "--no-profile"]);
     assert!(!output.status.success());
     let error = String::from_utf8_lossy(&output.stderr);
@@ -300,6 +309,14 @@ testset "outer" {
 "#,
     )
     .unwrap();
+
+    let checked = run(tmp.path(), &["check"]);
+    assert!(!checked.status.success());
+    let check_error = String::from_utf8_lossy(&checked.stderr);
+    assert!(
+        check_error.contains("reserved separator `::`"),
+        "{check_error}"
+    );
 
     let output = run(tmp.path(), &["test", "--list", "--no-profile"]);
     assert!(!output.status.success());

--- a/baml_language/crates/baml_cli/tests/test_profiles_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/test_profiles_e2e.rs
@@ -297,6 +297,29 @@ fn double_colon_is_reserved_inside_declared_test_names() {
 }
 
 #[test]
+fn double_colon_is_reserved_inside_top_level_testset_names() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_project(tmp.path());
+    std::fs::write(
+        tmp.path().join("baml_src/ns_orders/tests.baml"),
+        r#"
+testset "bad::name" {
+  test "works" { assert.is_true(true) }
+}
+"#,
+    )
+    .unwrap();
+
+    let checked = run(tmp.path(), &["check"]);
+    assert!(!checked.status.success());
+    let check_error = String::from_utf8_lossy(&checked.stderr);
+    assert!(
+        check_error.contains("testset name may not contain reserved separator `::`"),
+        "{check_error}"
+    );
+}
+
+#[test]
 fn nested_reserved_names_are_discovery_errors_not_sentinel_tests() {
     let tmp = tempfile::tempdir().unwrap();
     create_project(tmp.path());
@@ -334,6 +357,31 @@ testset "outer" {
     let combined = format!("{}{}", stdout(&execution), execution_error);
     assert!(!combined.contains("(testset error)"), "{combined}");
     assert!(!combined.contains("(failed to expand)"), "{combined}");
+}
+
+#[test]
+fn double_colon_is_reserved_inside_nested_testset_names() {
+    let tmp = tempfile::tempdir().unwrap();
+    create_project(tmp.path());
+    std::fs::write(
+        tmp.path().join("baml_src/ns_orders/tests.baml"),
+        r#"
+testset "outer" {
+  testset "bad::name" {
+    test "works" { assert.is_true(true) }
+  }
+}
+"#,
+    )
+    .unwrap();
+
+    let checked = run(tmp.path(), &["check"]);
+    assert!(!checked.status.success());
+    let check_error = String::from_utf8_lossy(&checked.stderr);
+    assert!(
+        check_error.contains("testset name may not contain reserved separator `::`"),
+        "{check_error}"
+    );
 }
 
 #[test]

--- a/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_cst.rs
@@ -2098,7 +2098,7 @@ fn synthesize_register_call(
             );
 
             // Args: (name_expr, lambda, runner_or_null)
-            let name_arg = lower_expr_body::lower_runner_element(ctx, name_element);
+            let name_arg = ctx.lower_test_name_element(name_element, "test");
             let owner_arg = ctx.alloc_expr(
                 Expr::Literal(crate::ast::Literal::String(test_owner.to_string())),
                 span,
@@ -2173,7 +2173,7 @@ fn synthesize_register_call(
             );
 
             // Args: (name_expr, collector_lambda, runner_or_null)
-            let name_arg = lower_expr_body::lower_runner_element(ctx, name_element);
+            let name_arg = ctx.lower_test_name_element(name_element, "testset");
             let owner_arg = ctx.alloc_expr(
                 Expr::Literal(crate::ast::Literal::String(test_owner.to_string())),
                 span,

--- a/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lower_expr_body.rs
@@ -266,6 +266,19 @@ impl InitTestContext {
         self.inner.alloc_stmt(stmt, span)
     }
 
+    /// Lower a top-level test/testset name and diagnose a literal `::` before
+    /// runtime discovery. Computed names keep the runtime registry check.
+    pub(crate) fn lower_test_name_element(
+        &mut self,
+        element: &baml_compiler_syntax::SyntaxElement,
+        item_kind: &'static str,
+    ) -> ExprId {
+        let expr = lower_runner_element(self, element);
+        self.inner
+            .validate_literal_test_name(expr, item_kind, element.text_range());
+        expr
+    }
+
     /// Lower a top-level `test`'s body into the `$init_test` arena, as the body
     /// of the lambda that gets registered.
     ///
@@ -5836,14 +5849,37 @@ impl LoweringContext {
                     | SyntaxKind::LINE_COMMENT
             )
         });
+        let name_span = name_element
+            .as_ref()
+            .map_or(span, baml_compiler_syntax::SyntaxElement::text_range);
 
-        match name_element {
+        let expr = match name_element {
             Some(rowan::NodeOrToken::Node(ref name_node)) => self.lower_expr(name_node),
             Some(rowan::NodeOrToken::Token(ref token)) => {
                 let expr = lower_bare_token_expr(self, token);
                 self.alloc_expr(expr, token.text_range())
             }
             None => self.alloc_expr(Expr::Literal(Literal::String(String::new())), span),
+        };
+        let item_kind = if node.kind() == SyntaxKind::TESTSET_DEF {
+            "testset"
+        } else {
+            "test"
+        };
+        self.validate_literal_test_name(expr, item_kind, name_span);
+        expr
+    }
+
+    fn validate_literal_test_name(
+        &mut self,
+        expr: ExprId,
+        item_kind: &'static str,
+        span: TextRange,
+    ) {
+        if matches!(&self.exprs[expr], Expr::Literal(Literal::String(name)) if name.contains("::"))
+        {
+            self.diags
+                .push(LoweringDiagnostic::InvalidTestName { item_kind, span });
         }
     }
 

--- a/baml_language/crates/baml_compiler2_ast/src/lowering_diagnostic.rs
+++ b/baml_language/crates/baml_compiler2_ast/src/lowering_diagnostic.rs
@@ -99,6 +99,12 @@ pub enum LoweringDiagnostic {
     /// A byte string literal contains an invalid escape sequence.
     InvalidByteStringEscape { message: String, span: TextRange },
 
+    /// A statically known test or testset name contains the canonical-ID separator.
+    InvalidTestName {
+        item_kind: &'static str,
+        span: TextRange,
+    },
+
     /// The `instanceof` operator was used; it has been removed. Use `match` instead.
     InstanceofRemoved { span: TextRange },
 
@@ -433,6 +439,15 @@ impl LoweringDiagnostic {
                 format!("invalid byte string literal: {message}"),
                 *span,
                 "invalid escape",
+            ),
+            LoweringDiagnostic::InvalidTestName { item_kind, span } => (
+                DiagnosticId::InvalidTestName,
+                Severity::Error,
+                format!(
+                    "{item_kind} name may not contain reserved separator `::`; use nested `testset` blocks to group tests"
+                ),
+                *span,
+                "`::` is reserved for canonical test IDs",
             ),
             LoweringDiagnostic::InstanceofRemoved { span } => (
                 DiagnosticId::RemovedFeature,

--- a/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
+++ b/baml_language/crates/baml_compiler_diagnostics/src/diagnostic.rs
@@ -382,6 +382,11 @@ pub enum DiagnosticId {
     /// A condition whose static type decides the branch (always truthy /
     /// always falsy) - B-1563 truthiness.
     ConditionAlwaysConstant,
+
+    // Test registration names (E0168)
+    /// A statically known test or testset name contains `::`, which is reserved
+    /// for separating components in canonical test IDs.
+    InvalidTestName,
 }
 
 impl DiagnosticId {
@@ -588,6 +593,7 @@ impl DiagnosticId {
             // E0164 is owned by the non-data output-format diagnostic in #4470.
             DiagnosticId::UnspecializedReflectedGeneric => "E0165",
             DiagnosticId::CannotConstructBuiltinCompanion => "E0166",
+            DiagnosticId::InvalidTestName => "E0168",
         }
     }
 }


### PR DESCRIPTION
## Summary

- Reject literal `test` and `testset` names containing `::` during compilation with E0168, while preserving the runtime check for computed names.
- Point users toward nested `testset` blocks and cover both top-level and nested declarations with CLI regression tests.
- Clarify in the new `baml run`, `baml test`, and `baml check` detailed help that BAML does not auto-load `.env` files. The legacy `baml-cli` dotenv behavior and documentation remain unchanged.

## Issue audit

The other concrete reports in #4422 are already resolved on current `canary`: the removed `client<llm>` form has been replaced by provider clients, plain `==` performs structural comparison (and the current skill documents it), fresh literal widening allows the reported `reduce` seed, and credential-source diagnostics now report both configured and canonical environment variables. The unstable command-list report has no current reproduction.

## Testing

- `cargo test -p baml_cli --test test_profiles_e2e double_colon_is_reserved_inside_declared_test_names`
- `cargo test -p baml_cli --test test_profiles_e2e nested_reserved_names_are_discovery_errors_not_sentinel_tests`
- `cargo test -p baml_compiler2_ast --lib`
- `cargo test -p baml_cli --lib`
- `cargo build -p bridge_cffi && cargo test -p baml_bridge --lib`
- `cargo check --target wasm32-unknown-unknown -p bridge_wasm`
- `mise run clippy-wasm`

Fixes #4422