### PR TITLE
fix(rust): generate LLM functions with interface error contracts

### DIFF
--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -333,6 +333,7 @@ impl GenerateArgs {
 
         // Build the codegen SymbolPool from the compiler database.
         let pool = baml_project::build_symbol_pool(&db);
+        let interface_implementors = baml_project::build_interface_implementors(&db);
 
         reporter.spin("Compiling", format!("{} file(s)", source_files.len()));
         let program = db
@@ -418,8 +419,9 @@ impl GenerateArgs {
                     .collect()
                 }
                 OutputType::Rust => {
-                    let generated = sdkgen_rust::to_source_code_with_bytecode_and_metadata(
+                    let generated = sdkgen_rust::to_source_code_with_bytecode_and_metadata_and_interface_implementors(
                         &pool,
+                        &interface_implementors,
                         &baml_bytecode,
                         &embedded_baml_toml,
                         &sdkgen_rust::RustGenOptions {
@@ -434,6 +436,22 @@ impl GenerateArgs {
                     );
                     for warning in &generated.warnings {
                         reporter.warning(format!("skipped `{}`: {}", warning.fqn, warning.reason));
+                    }
+                    let skipped_user_callables = generated
+                        .warnings
+                        .iter()
+                        .filter(|warning| {
+                            warning.kind == sdkgen_rust::SkipKind::Callable
+                                && warning.fqn.starts_with("user.")
+                                && !warning.fqn.contains('$')
+                        })
+                        .count();
+                    if skipped_user_callables > 0 {
+                        reporter.abandon();
+                        crate::reporter::print_error(format!(
+                            "Rust SDK generation skipped {skipped_user_callables} user callable(s); no partial client was written"
+                        ));
+                        return Ok(crate::ExitCode::Other);
                     }
                     generated
                         .files

--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -449,7 +449,9 @@ impl GenerateArgs {
                     if skipped_user_callables > 0 {
                         reporter.abandon();
                         crate::reporter::print_error(format!(
-                            "Rust SDK generation skipped {skipped_user_callables} user callable(s); no partial client was written"
+                            "Rust SDK generator `{}` skipped {skipped_user_callables} user callable(s); output `{}` was not written",
+                            generator.name,
+                            output_dir.display(),
                         ));
                         return Ok(crate::ExitCode::Other);
                     }

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -358,8 +358,17 @@ fn generate_rust_fails_before_writing_a_partial_client() {
         String::from_utf8_lossy(&output.stderr)
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let expected_output = tmp
+        .path()
+        .canonicalize()
+        .unwrap()
+        .join("generated/baml_sdk");
     assert!(
-        stderr.contains("Rust SDK generation skipped 1 user callable(s)"),
+        stderr.contains("Rust SDK generator `rust_client` skipped 1 user callable(s)")
+            && stderr.contains(&format!(
+                "output `{}` was not written",
+                expected_output.display()
+            )),
         "stderr: {stderr}"
     );
     assert!(
@@ -393,9 +402,18 @@ class Unsupported {
         String::from_utf8_lossy(&output.stderr)
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
+    let expected_output = tmp
+        .path()
+        .canonicalize()
+        .unwrap()
+        .join("generated/baml_sdk");
     assert!(
         stderr.contains("skipped `user.Unsupported.ping`")
-            && stderr.contains("Rust SDK generation skipped 1 user callable(s)"),
+            && stderr.contains("Rust SDK generator `rust_client` skipped 1 user callable(s)")
+            && stderr.contains(&format!(
+                "output `{}` was not written",
+                expected_output.display()
+            )),
         "stderr: {stderr}"
     );
     assert!(

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -100,6 +100,19 @@ fn create_project_with_go_generator(dir: &Path, source: &str) {
     .unwrap();
 }
 
+fn create_project_with_rust_generator(dir: &Path, source: &str) {
+    create_project(dir, source);
+    std::fs::write(
+        dir.join("baml.toml"),
+        "[package]\nname = \"test-project\"\n\n\
+         [generator.rust_client]\n\
+         output_type = \"rust\"\n\
+         output_dir = \"generated\"\n\
+         naming_convention = \"preserve-case\"\n",
+    )
+    .unwrap();
+}
+
 // ============================================================================
 // Tests for `baml check` exit codes
 // ============================================================================
@@ -286,6 +299,72 @@ fn generate_valid_project_returns_zero_exit_code() {
     assert!(
         stderr.contains("Compiling 1 file(s)"),
         "`baml generate` should keep compile progress, got: {stderr}",
+    );
+}
+
+#[test]
+fn generate_rust_keeps_llm_functions_with_implicit_failure_contract() {
+    let built = &common::baml_cli();
+    let tmp = tempfile::tempdir().unwrap();
+    create_project_with_rust_generator(
+        tmp.path(),
+        r#"
+class Thing {
+  name string
+}
+
+function ProbeFn(text: string) -> Thing {
+  client: "openai/gpt-4o-mini"
+  prompt: `Return a Thing for ${text}. ${ctx.output_format}`
+}
+"#,
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["generate", "--from", "."]);
+    assert!(
+        output.status.success(),
+        "Rust generation failed: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let generated = std::fs::read_to_string(tmp.path().join("generated/baml_sdk/src/lib.rs"))
+        .expect("Rust SDK root should be generated");
+    assert!(
+        generated.contains("pub fn ProbeFn("),
+        "generated SDK:\n{generated}"
+    );
+    assert!(
+        generated.contains("NetworkFailure") && generated.contains("ToolFailedError"),
+        "the implicit Failure contract should remain typed:\n{generated}"
+    );
+}
+
+#[test]
+fn generate_rust_fails_before_writing_a_partial_client() {
+    let built = &common::baml_cli();
+    let tmp = tempfile::tempdir().unwrap();
+    create_project_with_rust_generator(
+        tmp.path(),
+        "function unsupported(value: image) -> image { value }\n",
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["generate", "--from", "."]);
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Rust SDK generation skipped 1 user callable(s)"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !tmp.path().join("generated").exists(),
+        "a failed generation must not write a partial SDK"
     );
 }
 

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -369,6 +369,42 @@ fn generate_rust_fails_before_writing_a_partial_client() {
 }
 
 #[test]
+fn generate_rust_fails_when_a_skipped_class_hides_user_methods() {
+    let built = &common::baml_cli();
+    let tmp = tempfile::tempdir().unwrap();
+    create_project_with_rust_generator(
+        tmp.path(),
+        r#"
+class Unsupported {
+  picture image
+
+  function ping(self) -> string {
+    "pong"
+  }
+}
+"#,
+    );
+
+    let output = run_baml_cli(built, tmp.path(), &["generate", "--from", "."]);
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("skipped `user.Unsupported.ping`")
+            && stderr.contains("Rust SDK generation skipped 1 user callable(s)"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        !tmp.path().join("generated").exists(),
+        "a failed generation must not write a partial SDK"
+    );
+}
+
+#[test]
 fn generate_go_writes_sdk_through_cli() {
     if !gofmt_is_available() {
         return;

--- a/baml_language/crates/baml_project/src/client_codegen.rs
+++ b/baml_language/crates/baml_project/src/client_codegen.rs
@@ -574,6 +574,57 @@ pub fn build_symbol_pool(db: &ProjectDatabase) -> SymbolPool {
     pool
 }
 
+/// Collect the concrete, non-generic implementors of each non-generic interface.
+///
+/// Interface declarations are intentionally absent from [`SymbolPool`]: most
+/// generators erase them or project them in language-specific ways. Generators
+/// that need a closed-world representation (notably Rust's typed `throws`
+/// surface) consume this side table and choose their own projection.
+pub fn build_interface_implementors(db: &ProjectDatabase) -> HashMap<cg::Name, Vec<cg::Ty>> {
+    let mut package_names = std::collections::HashSet::new();
+    for source_file in compiler2_all_files(db) {
+        package_names.insert(file_package::file_package(db, source_file).package.clone());
+    }
+
+    let mut implementors: HashMap<cg::Name, Vec<cg::Ty>> = HashMap::new();
+    for package_name in package_names {
+        let package = baml_compiler2_hir_ty::package_interface::package_interface(
+            db,
+            PackageId::new(db, package_name),
+        );
+        for implementation in &package.impls {
+            // A generic implementation denotes an open family rather than a
+            // finite host-language union. Likewise, a parameterized interface
+            // needs realization-specific matching that this side table does
+            // not attempt. Leave both forms untouched so generators continue
+            // to fail closed on them.
+            if !implementation.generic_params.is_empty()
+                || !implementation.interface.generics.is_empty()
+                || !implementation.interface.associated_types.is_empty()
+            {
+                continue;
+            }
+
+            let interface_name = name_from_qtn(&implementation.interface.name);
+            let concrete = convert_tir_to_codegen_ty(
+                &implementation.for_ty_pattern,
+                &HashMap::new(),
+                &std::collections::HashSet::new(),
+            );
+            implementors
+                .entry(interface_name)
+                .or_default()
+                .push(concrete);
+        }
+    }
+
+    for concrete_types in implementors.values_mut() {
+        concrete_types.sort_by_key(std::string::ToString::to_string);
+        concrete_types.dedup();
+    }
+    implementors
+}
+
 // ---------------------------------------------------------------------------
 // Type resolution
 // ---------------------------------------------------------------------------
@@ -1451,6 +1502,80 @@ function passthrough(x: Marker) -> Marker { x }
                         && generics.is_empty()
                         && associated.is_empty()),
                 "interface identity should survive in shared codegen IR: {ty:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_interface_implementors_are_available_to_language_specific_codegen() {
+        let root = Path::new("/tmp/interface_implementors_for_codegen");
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(root);
+        db.add_or_update_file(
+            root.join("main.baml").as_path(),
+            r#"
+interface Failure {}
+
+class FirstFailure {
+  message string
+  implements Failure {}
+}
+
+class SecondFailure {
+  code int
+  implements Failure {}
+}
+"#,
+        );
+
+        let diagnostics = crate::collect_compiler2_diagnostics(&db);
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:#?}");
+
+        let implementors = build_interface_implementors(&db);
+        let failure = cg::Name::new(Name::new("user"), vec![], Name::new("Failure"));
+        let concrete = implementors
+            .get(&failure)
+            .expect("Failure implementors must be collected");
+        let class_names: Vec<_> = concrete
+            .iter()
+            .map(|ty| match ty {
+                cg::Ty::Class(name, arguments, _attr) if arguments.is_empty() => {
+                    name.bare_name().to_string()
+                }
+                other => panic!("expected a concrete class implementor, got {other:?}"),
+            })
+            .collect();
+        assert_eq!(class_names, ["FirstFailure", "SecondFailure"]);
+    }
+
+    #[test]
+    fn test_ai_failure_implementors_are_available_to_codegen() {
+        let root = Path::new("/tmp/ai_failure_implementors_for_codegen");
+        let mut db = ProjectDatabase::new();
+        db.set_project_root(root);
+        db.add_or_update_file(
+            root.join("main.baml").as_path(),
+            "function noop() -> string { \"ok\" }\n",
+        );
+
+        let implementors = build_interface_implementors(&db);
+        let (_failure, concrete) = implementors
+            .iter()
+            .find(|(name, _)| name.bare_name() == "Failure")
+            .expect("ai.errors.Failure implementors must be collected");
+        assert_eq!(concrete.len(), 8);
+        let pool = build_symbol_pool(&db);
+        for ty in concrete {
+            let cg::Ty::Class(name, arguments, _attr) = ty else {
+                panic!("expected concrete Failure class, got {ty:?}");
+            };
+            assert!(arguments.is_empty());
+            assert!(
+                pool.contains_key(name),
+                "Failure implementor {name:?} is not keyed the same way in the symbol pool; matching keys: {:#?}",
+                pool.keys()
+                    .filter(|key| key.bare_name() == name.bare_name())
+                    .collect::<Vec<_>>()
             );
         }
     }

--- a/baml_language/crates/baml_project/src/lib.rs
+++ b/baml_language/crates/baml_project/src/lib.rs
@@ -36,7 +36,7 @@ pub use check::{
     collect_compiler2_diagnostics_narrowed, collect_diagnostics, collect_package_level_diagnostics,
     prime_file_indexes_parallel,
 };
-pub use client_codegen::build_symbol_pool;
+pub use client_codegen::{build_interface_implementors, build_symbol_pool};
 pub use db::{CursorContext, EventCallback, ProjectDatabase};
 pub use param_schema::{FieldSchema, FieldSchemaField, ParamSchema, TypeSchema};
 pub use symbols::{

--- a/baml_language/sdk_tests/harness_setup/src/lib.rs
+++ b/baml_language/sdk_tests/harness_setup/src/lib.rs
@@ -142,6 +142,8 @@ pub type UserBamlFile = (PathBuf, String);
 pub struct LoadedFixture {
     pub baml_src: PathBuf,
     pub pool: SymbolPool,
+    pub interface_implementors:
+        std::collections::HashMap<baml_codegen_types::Name, Vec<baml_codegen_types::Ty>>,
     pub user_baml_files: Vec<UserBamlFile>,
     pub baml_bytecode: Vec<u8>,
 }
@@ -229,6 +231,7 @@ pub fn load_fixture(fixtures_root: &Path, fixture: &str) -> LoadedFixture {
     }
 
     let pool = baml_project::build_symbol_pool(&db);
+    let interface_implementors = baml_project::build_interface_implementors(&db);
     let program = db
         .get_bytecode()
         .unwrap_or_else(|e| panic!("fixture `{fixture}`: bytecode compilation failed: {e:?}"));
@@ -246,6 +249,7 @@ pub fn load_fixture(fixtures_root: &Path, fixture: &str) -> LoadedFixture {
     LoadedFixture {
         baml_src: canonical,
         pool,
+        interface_implementors,
         user_baml_files,
         baml_bytecode,
     }

--- a/baml_language/sdk_tests/harness_setup/src/rust.rs
+++ b/baml_language/sdk_tests/harness_setup/src/rust.rs
@@ -273,9 +273,15 @@ fn codegen_fixture(
         edition: GENERATED_EDITION.to_string(),
     };
     let pool = loaded.pool;
+    let interface_implementors = loaded.interface_implementors;
     let baml_bytecode = loaded.baml_bytecode;
     let codegen_result = panic::catch_unwind(panic::AssertUnwindSafe(|| {
-        sdkgen_rust::to_source_code_with_bytecode(&pool, &baml_bytecode, &options)
+        sdkgen_rust::to_source_code_with_bytecode_and_interface_implementors(
+            &pool,
+            &interface_implementors,
+            &baml_bytecode,
+            &options,
+        )
     }));
     match codegen_result {
         Ok(output) => {

--- a/baml_language/sdks/rust/sdkgen_rust/src/analyze.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/analyze.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use baml_codegen_types::{Name, Symbol, SymbolPool, Ty};
 
-use crate::{SkipWarning, routing};
+use crate::{SkipKind, SkipWarning, routing};
 
 /// Results of [`analyze`]. Emitters treat this as read-only context.
 pub(crate) struct Analysis {
@@ -75,6 +75,7 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
             Symbol::Enum(_) => {
                 if name.name().as_str().contains('$') {
                     warnings.push(SkipWarning {
+                        kind: SkipKind::Type,
                         fqn: name.to_string(),
                         reason: "companion types ($stream, …) are not emitted yet".to_string(),
                     });
@@ -100,6 +101,7 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
         // same filter the function emitter applies.
         if name.name().as_str().contains('$') {
             warnings.push(SkipWarning {
+                kind: SkipKind::Type,
                 fqn: name.to_string(),
                 reason: "companion types ($stream, …) are not emitted yet".to_string(),
             });
@@ -121,6 +123,7 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
         });
         match unsupported {
             Some((field, reason)) => warnings.push(SkipWarning {
+                kind: SkipKind::Type,
                 fqn: name.to_string(),
                 reason: format!("field `{field}`: {reason}"),
             }),
@@ -139,6 +142,7 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
                 }
                 if let Some(unused) = class_params.iter().find(|param| !used.contains(**param)) {
                     warnings.push(SkipWarning {
+                        kind: SkipKind::Type,
                         fqn: name.to_string(),
                         reason: format!(
                             "generic type parameter `{unused}` is not used in a non-recursive \
@@ -161,6 +165,7 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
     for (name, alias) in &aliases {
         if name.name().as_str().contains('$') {
             warnings.push(SkipWarning {
+                kind: SkipKind::Type,
                 fqn: name.to_string(),
                 reason: "companion types ($stream, …) are not emitted yet".to_string(),
             });
@@ -168,6 +173,7 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
         }
         if alias.recursive {
             warnings.push(SkipWarning {
+                kind: SkipKind::Type,
                 fqn: name.to_string(),
                 reason: "recursive type aliases are not representable as a plain Rust `type` yet"
                     .to_string(),
@@ -179,6 +185,7 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
         // scope, so no TypeVar is ever in scope for their right-hand side.
         match field_deps(&alias.resolves_to, &[], &mut alias_deps) {
             Err(reason) => warnings.push(SkipWarning {
+                kind: SkipKind::Type,
                 fqn: name.to_string(),
                 reason,
             }),
@@ -203,6 +210,7 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
                 .find(|dep| !alive.contains(dep) && !enums.contains(dep))
             {
                 warnings.push(SkipWarning {
+                    kind: SkipKind::Type,
                     fqn: name.to_string(),
                     reason: format!("references skipped or unknown type `{dead}`"),
                 });

--- a/baml_language/sdks/rust/sdkgen_rust/src/analyze.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/analyze.rs
@@ -61,7 +61,8 @@ impl Analysis {
 }
 
 /// Analyze the pool. Returns the analysis plus one warning per skipped
-/// class or type alias (functions warn separately at emission time).
+/// class or type alias. Methods on a skipped class also receive callable
+/// warnings because they never reach the function emitter.
 pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
     let mut warnings = Vec::new();
 
@@ -227,6 +228,23 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
 
     let mut emitted = alive;
     emitted.extend(enums.iter().cloned());
+
+    // A skipped class never reaches `emit::class`, so none of its methods
+    // reaches the function emitter that normally produces per-callable
+    // warnings. Preserve that lost-callable information explicitly: CLI
+    // callers use it to reject partial SDKs that silently omit user methods.
+    for (name, class) in &classes {
+        if emitted.contains(*name) {
+            continue;
+        }
+        for method in class.static_methods.iter().chain(&class.instance_methods) {
+            warnings.push(SkipWarning {
+                kind: SkipKind::Callable,
+                fqn: format!("{name}.{}", method.name.as_str()),
+                reason: format!("owning class `{name}` was skipped"),
+            });
+        }
+    }
 
     // Containment graph over emitted classes: an edge per class reference
     // reachable without crossing a heap-indirected container (`Vec`,

--- a/baml_language/sdks/rust/sdkgen_rust/src/emit/class.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/emit/class.rs
@@ -11,7 +11,7 @@ use quote::quote;
 
 use super::function::{Receiver, doc_attrs, emit_method};
 use crate::{
-    SkipWarning, idents,
+    SkipKind, SkipWarning, idents,
     translate_ty::{self, TyCtx},
 };
 
@@ -90,6 +90,7 @@ pub(crate) fn emit(
         let field_name = prop.name.as_str();
         let field_ident = idents::ident(field_name);
         let field_ty = translate_ty::translate(&prop.ty, &field_ctx).map_err(|u| SkipWarning {
+            kind: SkipKind::Type,
             fqn: fqn.clone(),
             reason: format!(
                 "generator bug: analysis accepted field `{field_name}` but translation failed: {}",

--- a/baml_language/sdks/rust/sdkgen_rust/src/emit/function.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/emit/function.rs
@@ -7,7 +7,7 @@ use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 
 use crate::{
-    SkipWarning, idents,
+    SkipKind, SkipWarning, idents,
     translate_ty::{self, TyCtx},
 };
 
@@ -32,6 +32,7 @@ pub(crate) fn emit(
     let fqn = name.to_string();
     if name.name().as_str().contains('$') {
         return Err(SkipWarning {
+            kind: SkipKind::Callable,
             fqn,
             reason: "companion functions ($stream, $build_request, …) are not emitted yet"
                 .to_string(),
@@ -74,6 +75,7 @@ pub(crate) fn emit_method(
     let fqn = format!("{class_name}.{method_name}");
     if method_name.contains('$') {
         return Err(SkipWarning {
+            kind: SkipKind::Callable,
             fqn,
             reason: "companion methods ($stream, $build_request, …) are not emitted yet"
                 .to_string(),
@@ -93,6 +95,7 @@ fn emit_binding(
     ctx: &TyCtx<'_>,
 ) -> Result<TokenStream, SkipWarning> {
     let skip = |reason: String| SkipWarning {
+        kind: SkipKind::Callable,
         fqn: fqn.to_string(),
         reason,
     };

--- a/baml_language/sdks/rust/sdkgen_rust/src/emit/type_alias.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/emit/type_alias.rs
@@ -10,7 +10,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::{
-    SkipWarning, idents,
+    SkipKind, SkipWarning, idents,
     translate_ty::{self, TyCtx},
 };
 
@@ -26,6 +26,7 @@ pub(crate) fn emit(
 ) -> Result<TokenStream, SkipWarning> {
     let ident = idents::ident(name.name().as_str());
     let rhs = translate_ty::translate(&alias.resolves_to, ctx).map_err(|u| SkipWarning {
+        kind: SkipKind::Type,
         fqn: name.to_string(),
         reason: format!(
             "generator bug: analysis accepted this alias but translation failed: {}",

--- a/baml_language/sdks/rust/sdkgen_rust/src/emit/union.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/emit/union.rs
@@ -16,7 +16,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use crate::{
-    SkipWarning, idents,
+    SkipKind, SkipWarning, idents,
     translate_ty::{self, TyCtx},
     unions::{UnionArmKind, UnionEnum},
 };
@@ -57,6 +57,7 @@ pub(crate) fn emit(union_enum: &UnionEnum, ctx: &TyCtx<'_>) -> Result<TokenStrea
         match &arm.kind {
             UnionArmKind::Payload(ty) => {
                 let payload = translate_ty::translate(ty, ctx).map_err(|u| SkipWarning {
+                    kind: SkipKind::Type,
                     fqn: union_enum.rust_name.clone(),
                     reason: format!(
                         "generator bug: registered union arm failed to translate: {}",

--- a/baml_language/sdks/rust/sdkgen_rust/src/interface_lowering.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/interface_lowering.rs
@@ -7,7 +7,7 @@
 //! Open/generic interfaces remain untouched and fail closed in the normal type
 //! translator.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use baml_codegen_types::{CallableParam, Class, Function, Name, Symbol, SymbolPool, Ty};
 
@@ -65,18 +65,29 @@ fn lower_function(function: &Function, implementors: &HashMap<Name, Vec<Ty>>) ->
 }
 
 fn lower_ty(ty: &Ty, implementors: &HashMap<Name, Vec<Ty>>) -> Ty {
+    lower_ty_on_path(ty, implementors, &mut HashSet::new())
+}
+
+fn lower_ty_on_path(
+    ty: &Ty,
+    implementors: &HashMap<Name, Vec<Ty>>,
+    active_interfaces: &mut HashSet<Name>,
+) -> Ty {
     let lowered = match ty {
         Ty::Interface(name, generics, associated, attr)
             if generics.is_empty() && associated.is_empty() =>
         {
             match implementors.get(name) {
-                Some(concrete) if !concrete.is_empty() => Ty::Union(
-                    concrete
+                Some(concrete)
+                    if !concrete.is_empty() && active_interfaces.insert(name.clone()) =>
+                {
+                    let members = concrete
                         .iter()
-                        .map(|ty| lower_ty(ty, implementors))
-                        .collect(),
-                    attr.clone(),
-                ),
+                        .map(|ty| lower_ty_on_path(ty, implementors, active_interfaces))
+                        .collect();
+                    active_interfaces.remove(name);
+                    Ty::Union(members, attr.clone())
+                }
                 _ => ty.clone(),
             }
         }
@@ -84,7 +95,7 @@ fn lower_ty(ty: &Ty, implementors: &HashMap<Name, Vec<Ty>>) -> Ty {
             name.clone(),
             arguments
                 .iter()
-                .map(|ty| lower_ty(ty, implementors))
+                .map(|ty| lower_ty_on_path(ty, implementors, active_interfaces))
                 .collect(),
             attr.clone(),
         ),
@@ -92,24 +103,32 @@ fn lower_ty(ty: &Ty, implementors: &HashMap<Name, Vec<Ty>>) -> Ty {
             name.clone(),
             generics
                 .iter()
-                .map(|ty| lower_ty(ty, implementors))
+                .map(|ty| lower_ty_on_path(ty, implementors, active_interfaces))
                 .collect(),
             associated
                 .iter()
-                .map(|(name, ty)| (name.clone(), lower_ty(ty, implementors)))
+                .map(|(name, ty)| {
+                    (
+                        name.clone(),
+                        lower_ty_on_path(ty, implementors, active_interfaces),
+                    )
+                })
                 .collect(),
             attr.clone(),
         ),
-        Ty::List(inner, attr) => Ty::List(Box::new(lower_ty(inner, implementors)), attr.clone()),
+        Ty::List(inner, attr) => Ty::List(
+            Box::new(lower_ty_on_path(inner, implementors, active_interfaces)),
+            attr.clone(),
+        ),
         Ty::Map { key, value, attr } => Ty::Map {
-            key: Box::new(lower_ty(key, implementors)),
-            value: Box::new(lower_ty(value, implementors)),
+            key: Box::new(lower_ty_on_path(key, implementors, active_interfaces)),
+            value: Box::new(lower_ty_on_path(value, implementors, active_interfaces)),
             attr: attr.clone(),
         },
         Ty::Union(members, attr) => Ty::Union(
             members
                 .iter()
-                .map(|ty| lower_ty(ty, implementors))
+                .map(|ty| lower_ty_on_path(ty, implementors, active_interfaces))
                 .collect(),
             attr.clone(),
         ),
@@ -123,20 +142,59 @@ fn lower_ty(ty: &Ty, implementors: &HashMap<Name, Vec<Ty>>) -> Ty {
                 .iter()
                 .map(|param| CallableParam {
                     name: param.name.clone(),
-                    ty: lower_ty(&param.ty, implementors),
+                    ty: lower_ty_on_path(&param.ty, implementors, active_interfaces),
                     mode: param.mode,
                 })
                 .collect(),
-            ret: Box::new(lower_ty(ret, implementors)),
-            throws: Box::new(lower_ty(throws, implementors)),
+            ret: Box::new(lower_ty_on_path(ret, implementors, active_interfaces)),
+            throws: Box::new(lower_ty_on_path(throws, implementors, active_interfaces)),
             attr: attr.clone(),
         },
         Ty::Future(value, error, attr) => Ty::Future(
-            Box::new(lower_ty(value, implementors)),
-            Box::new(lower_ty(error, implementors)),
+            Box::new(lower_ty_on_path(value, implementors, active_interfaces)),
+            Box::new(lower_ty_on_path(error, implementors, active_interfaces)),
             attr.clone(),
         ),
         _ => ty.clone(),
     };
     lowered.canonicalize()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recursive_implementor_arguments_do_not_reexpand_an_active_interface() {
+        let failure = Name::new(
+            baml_base::Name::new("ai"),
+            vec![baml_base::Name::new("errors")],
+            baml_base::Name::new("Failure"),
+        );
+        let wrapper = Name::new(
+            baml_base::Name::new("user"),
+            Vec::new(),
+            baml_base::Name::new("Wrapper"),
+        );
+        let interface = Ty::Interface(
+            failure.clone(),
+            Vec::new(),
+            Vec::new(),
+            baml_base::TyAttr::EMPTY,
+        );
+        let implementors = HashMap::from([(
+            failure,
+            vec![Ty::Class(
+                wrapper,
+                vec![interface.clone()],
+                baml_base::TyAttr::EMPTY,
+            )],
+        )]);
+
+        let lowered = lower_ty(&interface, &implementors);
+        let Ty::Class(_, arguments, _) = lowered else {
+            panic!("expected the outer interface to expand to its sole implementor")
+        };
+        assert_eq!(arguments, &[interface]);
+    }
 }

--- a/baml_language/sdks/rust/sdkgen_rust/src/interface_lowering.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/interface_lowering.rs
@@ -1,0 +1,142 @@
+//! Rust projection for closed, non-generic BAML interfaces.
+//!
+//! Rust needs a concrete `BamlValue` in every generated signature. The
+//! compiler-facing symbol pool deliberately retains interfaces as interfaces,
+//! so this Rust-only pass replaces interfaces whose complete concrete
+//! implementor set is known with an anonymous union of those implementors.
+//! Open/generic interfaces remain untouched and fail closed in the normal type
+//! translator.
+
+use std::collections::HashMap;
+
+use baml_codegen_types::{CallableParam, Class, Function, Name, Symbol, SymbolPool, Ty};
+
+pub(crate) fn lower(pool: &SymbolPool, implementors: &HashMap<Name, Vec<Ty>>) -> SymbolPool {
+    pool.iter()
+        .map(|(name, symbol)| (name.clone(), lower_symbol(symbol, implementors)))
+        .collect()
+}
+
+fn lower_symbol(symbol: &Symbol, implementors: &HashMap<Name, Vec<Ty>>) -> Symbol {
+    match symbol {
+        Symbol::Function(function) => Symbol::Function(lower_function(function, implementors)),
+        Symbol::Class(class) => Symbol::Class(lower_class(class, implementors)),
+        Symbol::Enum(_) => symbol.clone(),
+        Symbol::TypeAlias(alias) => {
+            let mut alias = alias.clone();
+            alias.resolves_to = lower_ty(&alias.resolves_to, implementors);
+            Symbol::TypeAlias(alias)
+        }
+    }
+}
+
+fn lower_class(class: &Class, implementors: &HashMap<Name, Vec<Ty>>) -> Class {
+    let mut class = class.clone();
+    for property in &mut class.properties {
+        property.ty = lower_ty(&property.ty, implementors);
+    }
+    class.static_methods = class
+        .static_methods
+        .iter()
+        .map(|function| lower_function(function, implementors))
+        .collect();
+    class.instance_methods = class
+        .instance_methods
+        .iter()
+        .map(|function| lower_function(function, implementors))
+        .collect();
+    class
+}
+
+fn lower_function(function: &Function, implementors: &HashMap<Name, Vec<Ty>>) -> Function {
+    let mut function = function.clone();
+    for argument in &mut function.arguments {
+        argument.ty = lower_ty(&argument.ty, implementors);
+    }
+    function.return_type = lower_ty(&function.return_type, implementors);
+    function.throws = function
+        .throws
+        .as_ref()
+        .map(|ty| lower_ty(ty, implementors));
+    for (_, watcher) in &mut function.watchers {
+        *watcher = lower_ty(watcher, implementors);
+    }
+    function
+}
+
+fn lower_ty(ty: &Ty, implementors: &HashMap<Name, Vec<Ty>>) -> Ty {
+    let lowered = match ty {
+        Ty::Interface(name, generics, associated, attr)
+            if generics.is_empty() && associated.is_empty() =>
+        {
+            match implementors.get(name) {
+                Some(concrete) if !concrete.is_empty() => Ty::Union(
+                    concrete
+                        .iter()
+                        .map(|ty| lower_ty(ty, implementors))
+                        .collect(),
+                    attr.clone(),
+                ),
+                _ => ty.clone(),
+            }
+        }
+        Ty::Class(name, arguments, attr) => Ty::Class(
+            name.clone(),
+            arguments
+                .iter()
+                .map(|ty| lower_ty(ty, implementors))
+                .collect(),
+            attr.clone(),
+        ),
+        Ty::Interface(name, generics, associated, attr) => Ty::Interface(
+            name.clone(),
+            generics
+                .iter()
+                .map(|ty| lower_ty(ty, implementors))
+                .collect(),
+            associated
+                .iter()
+                .map(|(name, ty)| (name.clone(), lower_ty(ty, implementors)))
+                .collect(),
+            attr.clone(),
+        ),
+        Ty::List(inner, attr) => Ty::List(Box::new(lower_ty(inner, implementors)), attr.clone()),
+        Ty::Map { key, value, attr } => Ty::Map {
+            key: Box::new(lower_ty(key, implementors)),
+            value: Box::new(lower_ty(value, implementors)),
+            attr: attr.clone(),
+        },
+        Ty::Union(members, attr) => Ty::Union(
+            members
+                .iter()
+                .map(|ty| lower_ty(ty, implementors))
+                .collect(),
+            attr.clone(),
+        ),
+        Ty::Function {
+            params,
+            ret,
+            throws,
+            attr,
+        } => Ty::Function {
+            params: params
+                .iter()
+                .map(|param| CallableParam {
+                    name: param.name.clone(),
+                    ty: lower_ty(&param.ty, implementors),
+                    mode: param.mode,
+                })
+                .collect(),
+            ret: Box::new(lower_ty(ret, implementors)),
+            throws: Box::new(lower_ty(throws, implementors)),
+            attr: attr.clone(),
+        },
+        Ty::Future(value, error, attr) => Ty::Future(
+            Box::new(lower_ty(value, implementors)),
+            Box::new(lower_ty(error, implementors)),
+            attr.clone(),
+        ),
+        _ => ty.clone(),
+    };
+    lowered.canonicalize()
+}

--- a/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
@@ -1064,6 +1064,28 @@ mod tests {
     }
 
     #[test]
+    fn unclosed_non_union_interface_throws_remains_a_callable_skip() {
+        let failure = name("vendor", &["errors"], "OpenFailure");
+        let call = name("user", &[], "call");
+        let mut function = nullary_string_fn(&call);
+        function.throws = Some(Ty::Interface(
+            failure,
+            Vec::new(),
+            Vec::new(),
+            baml_base::TyAttr::EMPTY,
+        ));
+        let pool = SymbolPool::from([(call, Symbol::Function(function))]);
+
+        let generated = to_source_code_with_bytecode(&pool, &[], &options());
+        assert!(generated.warnings.iter().any(|warning| {
+            warning.kind == SkipKind::Callable
+                && warning.fqn == "user.call"
+                && warning.reason.contains("interface")
+        }));
+        assert!(!text(&generated, "src/lib.rs").contains("pub fn call("));
+    }
+
+    #[test]
     fn unrepresentable_nominal_throws_arms_use_runtime_fallback() {
         let typed = name("user", &[], "TypedError");
         let opaque = name("baml", &["errors"], "UnknownError");

--- a/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
@@ -39,7 +39,9 @@ mod effect_rename;
 mod emit;
 mod host_types;
 mod idents;
+mod interface_lowering;
 mod routing;
+mod throws_lowering;
 mod translate_ty;
 mod unions;
 
@@ -70,10 +72,20 @@ pub struct RustGenOptions {
 /// SDK cannot represent yet (media, non-null unions, generics, …).
 #[derive(Debug)]
 pub struct SkipWarning {
+    /// Whether the skipped symbol is callable. The CLI treats skipped user
+    /// callables as generation failures while retaining soft skips for types
+    /// and compiler-generated companions.
+    pub kind: SkipKind,
     /// Fully qualified BAML name of the skipped symbol.
     pub fqn: String,
     /// Human-readable reason, e.g. `unsupported type: media`.
     pub reason: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkipKind {
+    Callable,
+    Type,
 }
 
 /// Contents of one generated file. Nearly everything is text; the
@@ -146,7 +158,27 @@ pub fn to_source_code_with_bytecode(
     baml_bytecode: &[u8],
     options: &RustGenOptions,
 ) -> Generated {
-    to_source_code_with_optional_metadata(pool, baml_bytecode, None, options)
+    to_source_code_with_optional_metadata(pool, &HashMap::new(), baml_bytecode, None, options)
+}
+
+/// Generate a Rust SDK with closed-world interface implementor information.
+///
+/// The compiler supplies this side table so Rust can project a non-generic
+/// interface to an enum of its concrete implementors without changing the
+/// shared codegen IR seen by languages that erase interfaces.
+pub fn to_source_code_with_bytecode_and_interface_implementors(
+    pool: &SymbolPool,
+    interface_implementors: &HashMap<baml_codegen_types::Name, Vec<baml_codegen_types::Ty>>,
+    baml_bytecode: &[u8],
+    options: &RustGenOptions,
+) -> Generated {
+    to_source_code_with_optional_metadata(
+        pool,
+        interface_implementors,
+        baml_bytecode,
+        None,
+        options,
+    )
 }
 
 pub fn to_source_code_with_bytecode_and_metadata(
@@ -155,11 +187,34 @@ pub fn to_source_code_with_bytecode_and_metadata(
     embedded_baml_toml: &str,
     options: &RustGenOptions,
 ) -> Generated {
-    to_source_code_with_optional_metadata(pool, baml_bytecode, Some(embedded_baml_toml), options)
+    to_source_code_with_optional_metadata(
+        pool,
+        &HashMap::new(),
+        baml_bytecode,
+        Some(embedded_baml_toml),
+        options,
+    )
+}
+
+pub fn to_source_code_with_bytecode_and_metadata_and_interface_implementors(
+    pool: &SymbolPool,
+    interface_implementors: &HashMap<baml_codegen_types::Name, Vec<baml_codegen_types::Ty>>,
+    baml_bytecode: &[u8],
+    embedded_baml_toml: &str,
+    options: &RustGenOptions,
+) -> Generated {
+    to_source_code_with_optional_metadata(
+        pool,
+        interface_implementors,
+        baml_bytecode,
+        Some(embedded_baml_toml),
+        options,
+    )
 }
 
 fn to_source_code_with_optional_metadata(
     pool: &SymbolPool,
+    interface_implementors: &HashMap<baml_codegen_types::Name, Vec<baml_codegen_types::Ty>>,
     baml_bytecode: &[u8],
     embedded_baml_toml: Option<&str>,
     options: &RustGenOptions,
@@ -174,6 +229,14 @@ fn to_source_code_with_optional_metadata(
     // that union's variant all read `CbError` rather than `__effect_param_0`.
     let pool = effect_rename::rename_effect_params(pool);
     let pool = &host_types::lower_unrepresentable_literals(&pool);
+    let pool = &interface_lowering::lower(pool, interface_implementors);
+
+    // Error::Runtime preserves thrown values outside the generated typed
+    // contract. Narrow only nominal throws arms whose class/type could not be
+    // emitted, so one opaque stdlib error does not suppress an otherwise
+    // representable function (or its typed ai.errors.Failure variants).
+    let (preliminary_analysis, _) = analyze::analyze(pool);
+    let pool = &throws_lowering::lower(pool, &preliminary_analysis);
 
     let (analysis, mut warnings) = analyze::analyze(pool);
     let union_registry = unions::collect(pool, &analysis);
@@ -915,6 +978,139 @@ mod tests {
         assert!(
             lib.contains("/// are never written back to the caller's values.\n///\n/// # Errors"),
             "{lib}"
+        );
+    }
+
+    #[test]
+    fn closed_interface_throws_lower_to_concrete_error_union() {
+        let failure = name("ai", &["errors"], "Failure");
+        let network = name("ai", &["errors"], "NetworkFailure");
+        let tool = name("ai", &["errors"], "ToolFailedError");
+        let probe = name("user", &[], "ProbeFn");
+        let interface_ty = Ty::Interface(
+            failure.clone(),
+            Vec::new(),
+            Vec::new(),
+            baml_base::TyAttr::EMPTY,
+        );
+        let nullable_failure = Ty::Union(
+            vec![
+                interface_ty.clone(),
+                Ty::Null {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
+            ],
+            baml_base::TyAttr::EMPTY,
+        );
+        let mut function = nullary_string_fn(&probe);
+        function.throws = Some(interface_ty);
+        let pool = SymbolPool::from([
+            (
+                network.clone(),
+                class_symbol(&network, Vec::new(), Vec::new(), Vec::new()),
+            ),
+            (
+                tool.clone(),
+                class_symbol(
+                    &tool,
+                    vec![baml_codegen_types::ClassProperty {
+                        name: baml_base::Name::new("cause"),
+                        docstring: None,
+                        ty: nullable_failure,
+                    }],
+                    Vec::new(),
+                    Vec::new(),
+                ),
+            ),
+            (probe, Symbol::Function(function)),
+        ]);
+        let implementors = HashMap::from([(
+            failure,
+            vec![
+                Ty::Class(network, Vec::new(), baml_base::TyAttr::EMPTY),
+                Ty::Class(tool, Vec::new(), baml_base::TyAttr::EMPTY),
+            ],
+        )]);
+
+        let generated = to_source_code_with_bytecode_and_interface_implementors(
+            &pool,
+            &implementors,
+            &[],
+            &options(),
+        );
+        assert!(generated.warnings.is_empty(), "{:?}", generated.warnings);
+        let lib = text(&generated, "src/lib.rs");
+        let flat_lib = flat(lib);
+        assert!(
+            flat_lib.contains("pubenumNetworkFailureOrToolFailedError"),
+            "{lib}"
+        );
+        assert!(
+            flat_lib.contains("Error<crate::NetworkFailureOrToolFailedError>"),
+            "{lib}"
+        );
+        let errors = text(&generated, "src/vendor/ai/errors/mod.rs");
+        let flat_errors = flat(errors);
+        assert!(
+            flat_errors.contains("pubcause:::std::option::Option<"),
+            "{errors}"
+        );
+        assert!(
+            flat_errors.contains(
+                "::std::boxed::Box<crate::vendor::ai::errors::NetworkFailureOrToolFailedError>"
+            ),
+            "{errors}"
+        );
+    }
+
+    #[test]
+    fn unrepresentable_nominal_throws_arms_use_runtime_fallback() {
+        let typed = name("user", &[], "TypedError");
+        let opaque = name("baml", &["errors"], "UnknownError");
+        let call = name("user", &[], "call");
+        let mut function = nullary_string_fn(&call);
+        function.throws = Some(Ty::Union(
+            vec![
+                Ty::Class(typed.clone(), Vec::new(), baml_base::TyAttr::EMPTY),
+                Ty::Class(opaque.clone(), Vec::new(), baml_base::TyAttr::EMPTY),
+            ],
+            baml_base::TyAttr::EMPTY,
+        ));
+        let pool = SymbolPool::from([
+            (
+                typed.clone(),
+                class_symbol(&typed, Vec::new(), Vec::new(), Vec::new()),
+            ),
+            (
+                opaque.clone(),
+                class_symbol(
+                    &opaque,
+                    vec![baml_codegen_types::ClassProperty {
+                        name: baml_base::Name::new("data"),
+                        docstring: None,
+                        ty: Ty::BuiltinUnknown {
+                            attr: baml_base::TyAttr::EMPTY,
+                        },
+                    }],
+                    Vec::new(),
+                    Vec::new(),
+                ),
+            ),
+            (call, Symbol::Function(function)),
+        ]);
+
+        let generated = to_source_code_with_bytecode(&pool, &[], &options());
+        assert_eq!(generated.warnings.len(), 1, "{:?}", generated.warnings);
+        assert_eq!(generated.warnings[0].fqn, "baml.errors.UnknownError");
+        assert_eq!(generated.warnings[0].kind, SkipKind::Type);
+        let lib = text(&generated, "src/lib.rs");
+        assert!(
+            flat(lib).contains("Error<crate::TypedError>"),
+            "typed representable errors should remain in the contract:\n{lib}"
+        );
+        assert!(
+            !lib.contains("UnknownError"),
+            "opaque errors are preserved by Error::Runtime, not a generated type:\n{lib}"
         );
     }
 

--- a/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
@@ -1723,6 +1723,39 @@ mod tests {
     }
 
     #[test]
+    fn skipped_classes_report_their_methods_as_skipped_callables() {
+        let widget = name("user", &[], "Widget");
+        let ping = nullary_string_fn(&name("user", &[], "ping"));
+        let pool = SymbolPool::from([(
+            widget.clone(),
+            class_symbol(
+                &widget,
+                vec![baml_codegen_types::ClassProperty {
+                    name: baml_base::Name::new("picture"),
+                    docstring: None,
+                    ty: Ty::Media(baml_base::MediaKind::Image, baml_base::TyAttr::EMPTY),
+                }],
+                Vec::new(),
+                vec![ping],
+            ),
+        )]);
+
+        let generated = to_source_code_with_bytecode(&pool, &[], &options());
+        assert!(
+            generated
+                .warnings
+                .iter()
+                .any(|warning| { warning.kind == SkipKind::Type && warning.fqn == "user.Widget" })
+        );
+        assert!(generated.warnings.iter().any(|warning| {
+            warning.kind == SkipKind::Callable
+                && warning.fqn == "user.Widget.ping"
+                && warning.reason.contains("owning class")
+        }));
+        assert!(!text(&generated, "src/lib.rs").contains("pub struct Widget"));
+    }
+
+    #[test]
     fn method_signatures_do_not_box_recursive_class_references() {
         let node = name("user", &[], "Node");
         let next_field = Ty::Union(

--- a/baml_language/sdks/rust/sdkgen_rust/src/throws_lowering.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/throws_lowering.rs
@@ -61,8 +61,12 @@ fn lower_contract(ty: &Ty, analysis: &Analysis) -> Option<Ty> {
                 _ => Some(Ty::Union(retained, attr.clone()).canonicalize()),
             }
         }
-        nominal if nominal_is_emitted(nominal, analysis) => Some(nominal.clone()),
-        _ => None,
+        nominal @ (Ty::Class(..) | Ty::Enum(..) | Ty::EnumVariant(..) | Ty::TypeAlias(..))
+            if !nominal_is_emitted(nominal, analysis) =>
+        {
+            None
+        }
+        _ => Some(ty.clone()),
     }
 }
 

--- a/baml_language/sdks/rust/sdkgen_rust/src/throws_lowering.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/throws_lowering.rs
@@ -1,0 +1,77 @@
+//! Rust projection for error-contract arms whose nominal type is not emitted.
+//!
+//! The bridge already preserves an error-arm value that does not decode as the
+//! generated throws type as `Error::Runtime`. Remove only references to nominal
+//! types that the pool analysis proved cannot be emitted; all structurally
+//! unsupported types remain in place and make the callable fail closed.
+
+use baml_codegen_types::{Class, Function, Symbol, SymbolPool, Ty};
+
+use crate::analyze::Analysis;
+
+pub(crate) fn lower(pool: &SymbolPool, analysis: &Analysis) -> SymbolPool {
+    pool.iter()
+        .map(|(name, symbol)| (name.clone(), lower_symbol(symbol, analysis)))
+        .collect()
+}
+
+fn lower_symbol(symbol: &Symbol, analysis: &Analysis) -> Symbol {
+    match symbol {
+        Symbol::Function(function) => Symbol::Function(lower_function(function, analysis)),
+        Symbol::Class(class) => Symbol::Class(lower_class(class, analysis)),
+        Symbol::Enum(_) | Symbol::TypeAlias(_) => symbol.clone(),
+    }
+}
+
+fn lower_class(class: &Class, analysis: &Analysis) -> Class {
+    let mut class = class.clone();
+    class.static_methods = class
+        .static_methods
+        .iter()
+        .map(|function| lower_function(function, analysis))
+        .collect();
+    class.instance_methods = class
+        .instance_methods
+        .iter()
+        .map(|function| lower_function(function, analysis))
+        .collect();
+    class
+}
+
+fn lower_function(function: &Function, analysis: &Analysis) -> Function {
+    let mut function = function.clone();
+    function.throws = function
+        .throws
+        .as_ref()
+        .and_then(|throws| lower_contract(throws, analysis));
+    function
+}
+
+fn lower_contract(ty: &Ty, analysis: &Analysis) -> Option<Ty> {
+    match ty {
+        Ty::Union(items, attr) => {
+            let retained: Vec<_> = items
+                .iter()
+                .filter(|item| nominal_is_emitted(item, analysis))
+                .cloned()
+                .collect();
+            match retained.as_slice() {
+                [] => None,
+                [only] => Some(only.clone()),
+                _ => Some(Ty::Union(retained, attr.clone()).canonicalize()),
+            }
+        }
+        nominal if nominal_is_emitted(nominal, analysis) => Some(nominal.clone()),
+        _ => None,
+    }
+}
+
+fn nominal_is_emitted(ty: &Ty, analysis: &Analysis) -> bool {
+    match ty {
+        Ty::Class(name, _, _)
+        | Ty::Enum(name, _)
+        | Ty::EnumVariant(name, _, _)
+        | Ty::TypeAlias(name, _) => analysis.is_emitted(name),
+        _ => true,
+    }
+}

--- a/baml_language/sdks/rust/sdkgen_rust/src/translate_ty.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/translate_ty.rs
@@ -114,7 +114,13 @@ fn translate_inner(ty: &Ty, ctx: &TyCtx<'_>, under_heap: bool) -> Result<TokenSt
                     let Some(union_enum) = ctx.unions.lookup(ctx.leaf, arms) else {
                         return Err(Unsupported {
                             reason: unions::shape_error(arms).unwrap_or_else(|| {
-                                "union references a skipped or unknown type".to_string()
+                                format!(
+                                    "union references a skipped or unknown type: {}",
+                                    arms.iter()
+                                        .map(std::string::ToString::to_string)
+                                        .collect::<Vec<_>>()
+                                        .join(" | ")
+                                )
                             }),
                         });
                     };


### PR DESCRIPTION
## Issue Reference

- [x] Fixes #4370

## Changes

- Project closed, non-generic BAML interfaces such as `ai.errors.Failure` to concrete Rust union enums while keeping the shared codegen IR unchanged.
- Preserve representable typed error arms and route unrepresentable nominal arms through the existing `Error::Runtime` fallback.
- Treat a skipped user callable as a generation failure and stop before writing a partial Rust client.
- Pass interface implementation metadata through CLI and SDK-test generation.

## Testing

- [x] Added unit coverage for interface implementor collection, recursive interface lowering, and opaque error fallback.
- [x] Added CLI regressions for the exact implicit LLM failure contract and fail-before-write behavior.
- [x] Ran `cargo test -p sdkgen_rust --lib` (53 passed).
- [x] Ran `cargo test -p baml_project --lib` (86 passed, 2 ignored).
- [x] Ran the two Rust CLI generation regressions.
- [x] Ran `cargo test -p sdk_test_rust --no-run` and compiled the generated `llm_functions` crate.
- [x] Ran formatting and Clippy with warnings denied for affected crates.

## Screenshots

Not applicable.

## PR Checklist

- [x] I have read and followed the contributing guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented the non-obvious lowering behavior.
- [x] Documentation is not required for this internal codegen correction.
- [x] My changes generate no new warnings.

## Additional Notes

Unrepresentable error-contract classes remain observable as `baml_bridge::Error::Runtime` with their class name, rendered message, and trace preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rust SDK generation now supports lowering closed interfaces into concrete implementor unions.
  * Throws contracts better preserve supported failure types and runtime fallbacks.
  * Generation diagnostics now distinguish skipped callables from skipped types.

* **Bug Fixes**
  * Rust generation stops before writing partial output when unsupported user callables are skipped.
  * Error messages now identify problematic union types more clearly.

* **Tests**
  * Added coverage for interface-based failures, throws behavior, skipped symbols, and generation exit codes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->