### PR TITLE
fix(rust): reject partial generated clients

### DIFF
--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -435,6 +435,19 @@ impl GenerateArgs {
                     for warning in &generated.warnings {
                         reporter.warning(format!("skipped `{}`: {}", warning.fqn, warning.reason));
                     }
+                    let blocking_skips = generated
+                        .warnings
+                        .iter()
+                        .filter(|warning| warning.blocks_generation())
+                        .count();
+                    if blocking_skips > 0 {
+                        reporter.abandon();
+                        crate::reporter::print_error(format_args!(
+                            "Rust generator `{}` skipped {blocking_skips} required symbol(s); refusing to write a partial client",
+                            generator.name
+                        ));
+                        return Ok(crate::ExitCode::Other);
+                    }
                     generated
                         .files
                         .into_iter()

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -100,6 +100,19 @@ fn create_project_with_go_generator(dir: &Path, source: &str) {
     .unwrap();
 }
 
+fn create_project_with_rust_generator(dir: &Path, source: &str) {
+    create_project(dir, source);
+    std::fs::write(
+        dir.join("baml.toml"),
+        "[package]\nname = \"test-project\"\n\n\
+         [generator.rust_client]\n\
+         output_type = \"rust\"\n\
+         output_dir = \".\"\n\
+         naming_convention = \"preserve-case\"\n",
+    )
+    .unwrap();
+}
+
 // ============================================================================
 // Tests for `baml check` exit codes
 // ============================================================================
@@ -286,6 +299,49 @@ fn generate_valid_project_returns_zero_exit_code() {
     assert!(
         stderr.contains("Compiling 1 file(s)"),
         "`baml generate` should keep compile progress, got: {stderr}",
+    );
+}
+
+#[test]
+fn generate_rust_skipped_user_symbol_returns_nonzero_without_overwriting_output() {
+    let built = &common::baml_cli();
+    let tmp = tempfile::tempdir().unwrap();
+    create_project_with_rust_generator(
+        tmp.path(),
+        "function inspect(image: image) -> string { \"ok\" }\n",
+    );
+    let generated_dir = tmp.path().join("baml_sdk");
+    std::fs::create_dir(&generated_dir).unwrap();
+    std::fs::write(generated_dir.join("keep.txt"), "pre-existing output").unwrap();
+
+    let output = run_baml_cli(built, tmp.path(), &["generate", "--project", "."]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "Rust generation unexpectedly succeeded\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr
+            .contains("skipped `user.inspect`: argument `image`: unsupported type: media (image)"),
+        "missing per-symbol diagnostic: {stderr}",
+    );
+    assert!(
+        stderr.contains(
+            "Rust generator `rust_client` skipped 1 required symbol(s); refusing to write a partial client"
+        ),
+        "missing fatal summary: {stderr}",
+    );
+    assert_eq!(
+        std::fs::read_to_string(generated_dir.join("keep.txt")).unwrap(),
+        "pre-existing output"
+    );
+    assert!(
+        !generated_dir.join("Cargo.toml").exists(),
+        "partial Rust client was written despite the blocking skip"
     );
 }
 

--- a/baml_language/sdks/rust/sdkgen_rust/src/analyze.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/analyze.rs
@@ -74,10 +74,10 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
             Symbol::Class(class) => classes.push((name, class)),
             Symbol::Enum(_) => {
                 if name.name().as_str().contains('$') {
-                    warnings.push(SkipWarning {
-                        fqn: name.to_string(),
-                        reason: "companion types ($stream, …) are not emitted yet".to_string(),
-                    });
+                    warnings.push(SkipWarning::companion(
+                        name.to_string(),
+                        "companion types ($stream, …) are not emitted yet",
+                    ));
                 } else {
                     enums.insert(name.clone());
                 }
@@ -99,10 +99,10 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
         // representable as Rust identifiers and are not emitted yet —
         // same filter the function emitter applies.
         if name.name().as_str().contains('$') {
-            warnings.push(SkipWarning {
-                fqn: name.to_string(),
-                reason: "companion types ($stream, …) are not emitted yet".to_string(),
-            });
+            warnings.push(SkipWarning::companion(
+                name.to_string(),
+                "companion types ($stream, …) are not emitted yet",
+            ));
             continue;
         }
         // A generic class emits as a `<T: BamlValue>` struct: its own type
@@ -120,10 +120,10 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
                 .map(|reason| (prop.name.as_str(), reason))
         });
         match unsupported {
-            Some((field, reason)) => warnings.push(SkipWarning {
-                fqn: name.to_string(),
-                reason: format!("field `{field}`: {reason}"),
-            }),
+            Some((field, reason)) => warnings.push(SkipWarning::for_symbol(
+                name,
+                format!("field `{field}`: {reason}"),
+            )),
             None => {
                 // Every type parameter must appear in some field in a
                 // *non-recursive* position. An entirely unused param is an
@@ -138,13 +138,13 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
                     collect_non_recursive_type_vars(&prop.ty, name, &mut used);
                 }
                 if let Some(unused) = class_params.iter().find(|param| !used.contains(**param)) {
-                    warnings.push(SkipWarning {
-                        fqn: name.to_string(),
-                        reason: format!(
+                    warnings.push(SkipWarning::for_symbol(
+                        name,
+                        format!(
                             "generic type parameter `{unused}` is not used in a non-recursive \
                              field position (not representable as a Rust struct)"
                         ),
-                    });
+                    ));
                     continue;
                 }
                 deps.insert(name, class_deps);
@@ -160,28 +160,24 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
     // `type`) and structurally unsupported right-hand sides skip.
     for (name, alias) in &aliases {
         if name.name().as_str().contains('$') {
-            warnings.push(SkipWarning {
-                fqn: name.to_string(),
-                reason: "companion types ($stream, …) are not emitted yet".to_string(),
-            });
+            warnings.push(SkipWarning::companion(
+                name.to_string(),
+                "companion types ($stream, …) are not emitted yet",
+            ));
             continue;
         }
         if alias.recursive {
-            warnings.push(SkipWarning {
-                fqn: name.to_string(),
-                reason: "recursive type aliases are not representable as a plain Rust `type` yet"
-                    .to_string(),
-            });
+            warnings.push(SkipWarning::for_symbol(
+                name,
+                "recursive type aliases are not representable as a plain Rust `type` yet",
+            ));
             continue;
         }
         let mut alias_deps = Vec::new();
         // Aliases carry no type parameters of their own in the current
         // scope, so no TypeVar is ever in scope for their right-hand side.
         match field_deps(&alias.resolves_to, &[], &mut alias_deps) {
-            Err(reason) => warnings.push(SkipWarning {
-                fqn: name.to_string(),
-                reason,
-            }),
+            Err(reason) => warnings.push(SkipWarning::for_symbol(name, reason)),
             Ok(()) => {
                 deps.insert(name, alias_deps);
                 alive.insert((*name).clone());
@@ -202,10 +198,10 @@ pub(crate) fn analyze(pool: &SymbolPool) -> (Analysis, Vec<SkipWarning>) {
                 .iter()
                 .find(|dep| !alive.contains(dep) && !enums.contains(dep))
             {
-                warnings.push(SkipWarning {
-                    fqn: name.to_string(),
-                    reason: format!("references skipped or unknown type `{dead}`"),
-                });
+                warnings.push(SkipWarning::for_symbol(
+                    name,
+                    format!("references skipped or unknown type `{dead}`"),
+                ));
                 removed.push((*name).clone());
             }
         }

--- a/baml_language/sdks/rust/sdkgen_rust/src/emit/class.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/emit/class.rs
@@ -89,12 +89,14 @@ pub(crate) fn emit(
     for prop in &class.properties {
         let field_name = prop.name.as_str();
         let field_ident = idents::ident(field_name);
-        let field_ty = translate_ty::translate(&prop.ty, &field_ctx).map_err(|u| SkipWarning {
-            fqn: fqn.clone(),
-            reason: format!(
-                "generator bug: analysis accepted field `{field_name}` but translation failed: {}",
-                u.reason
-            ),
+        let field_ty = translate_ty::translate(&prop.ty, &field_ctx).map_err(|u| {
+            SkipWarning::generator_bug(
+                fqn.clone(),
+                format!(
+                    "generator bug: analysis accepted field `{field_name}` but translation failed: {}",
+                    u.reason
+                ),
+            )
         })?;
         let field_docs = doc_attrs(prop.docstring.as_deref());
         field_defs.push(quote! {

--- a/baml_language/sdks/rust/sdkgen_rust/src/emit/function.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/emit/function.rs
@@ -31,11 +31,10 @@ pub(crate) fn emit(
 ) -> Result<TokenStream, SkipWarning> {
     let fqn = name.to_string();
     if name.name().as_str().contains('$') {
-        return Err(SkipWarning {
+        return Err(SkipWarning::companion(
             fqn,
-            reason: "companion functions ($stream, $build_request, …) are not emitted yet"
-                .to_string(),
-        });
+            "companion functions ($stream, $build_request, …) are not emitted yet",
+        ));
     }
     // Generic free functions ARE emitted: their `<...>` params become Rust
     // generics bound by `BamlValue`. TypeVars that appear in positions the
@@ -47,6 +46,7 @@ pub(crate) fn emit(
         function,
         Receiver::None,
         &[],
+        name.is_local(),
         ctx,
     )
 }
@@ -73,13 +73,20 @@ pub(crate) fn emit_method(
     let method_name = method.name.as_str();
     let fqn = format!("{class_name}.{method_name}");
     if method_name.contains('$') {
-        return Err(SkipWarning {
+        return Err(SkipWarning::companion(
             fqn,
-            reason: "companion methods ($stream, $build_request, …) are not emitted yet"
-                .to_string(),
-        });
+            "companion methods ($stream, $build_request, …) are not emitted yet",
+        ));
     }
-    emit_binding(&fqn, method_name, method, receiver, class_params, ctx)
+    emit_binding(
+        &fqn,
+        method_name,
+        method,
+        receiver,
+        class_params,
+        class_name.is_local(),
+        ctx,
+    )
 }
 
 /// Shared body of [`emit`] / [`emit_method`]: translate the signature and
@@ -90,12 +97,11 @@ fn emit_binding(
     function: &Function,
     receiver: Receiver,
     class_params: &[String],
+    blocks_generation: bool,
     ctx: &TyCtx<'_>,
 ) -> Result<TokenStream, SkipWarning> {
-    let skip = |reason: String| SkipWarning {
-        fqn: fqn.to_string(),
-        reason,
-    };
+    let skip =
+        |reason: String| SkipWarning::for_callable(fqn.to_string(), reason, blocks_generation);
 
     // The class's params (for instance methods) and the callee's own
     // `<...>` params come into scope for translating this binding's

--- a/baml_language/sdks/rust/sdkgen_rust/src/emit/type_alias.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/emit/type_alias.rs
@@ -25,12 +25,14 @@ pub(crate) fn emit(
     ctx: &TyCtx<'_>,
 ) -> Result<TokenStream, SkipWarning> {
     let ident = idents::ident(name.name().as_str());
-    let rhs = translate_ty::translate(&alias.resolves_to, ctx).map_err(|u| SkipWarning {
-        fqn: name.to_string(),
-        reason: format!(
-            "generator bug: analysis accepted this alias but translation failed: {}",
-            u.reason
-        ),
+    let rhs = translate_ty::translate(&alias.resolves_to, ctx).map_err(|u| {
+        SkipWarning::generator_bug(
+            name.to_string(),
+            format!(
+                "generator bug: analysis accepted this alias but translation failed: {}",
+                u.reason
+            ),
+        )
     })?;
     Ok(quote! {
         pub type #ident = #rhs;

--- a/baml_language/sdks/rust/sdkgen_rust/src/emit/union.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/emit/union.rs
@@ -56,12 +56,14 @@ pub(crate) fn emit(union_enum: &UnionEnum, ctx: &TyCtx<'_>) -> Result<TokenStrea
         let variant = idents::ident(&arm.variant);
         match &arm.kind {
             UnionArmKind::Payload(ty) => {
-                let payload = translate_ty::translate(ty, ctx).map_err(|u| SkipWarning {
-                    fqn: union_enum.rust_name.clone(),
-                    reason: format!(
-                        "generator bug: registered union arm failed to translate: {}",
-                        u.reason
-                    ),
+                let payload = translate_ty::translate(ty, ctx).map_err(|u| {
+                    SkipWarning::generator_bug(
+                        union_enum.rust_name.clone(),
+                        format!(
+                            "generator bug: registered union arm failed to translate: {}",
+                            u.reason
+                        ),
+                    )
                 })?;
                 baml_ty_options.push(quote! {
                     <#payload as ::baml_bridge::baml_value::internal::__BamlValuePrivate>::baml_ty()

--- a/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
@@ -20,9 +20,12 @@
 //! are never flattened into a parent.
 //!
 //! Symbols that reference BAML types the Rust SDK cannot represent yet are
-//! skipped rather than failing codegen: each skip is reported through
-//! [`Generated::warnings`] so callers can surface them, and the rest of the
-//! SDK still compiles.
+//! skipped rather than failing this low-level codegen API: each skip is
+//! reported through [`Generated::warnings`] so callers can choose their
+//! policy. [`SkipWarning::blocks_generation`] distinguishes skipped local
+//! symbols and generator invariant failures from advisory dependency and
+//! companion skips. The CLI refuses to install a partial SDK when a blocking
+//! warning is present.
 
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -74,6 +77,47 @@ pub struct SkipWarning {
     pub fqn: String,
     /// Human-readable reason, e.g. `unsupported type: media`.
     pub reason: String,
+    blocks_generation: bool,
+}
+
+impl SkipWarning {
+    /// Whether installing the generated files would silently omit part of the
+    /// user's requested SDK surface or conceal a generator invariant failure.
+    pub fn blocks_generation(&self) -> bool {
+        self.blocks_generation
+    }
+
+    fn for_symbol(name: &baml_codegen_types::Name, reason: impl Into<String>) -> Self {
+        Self {
+            fqn: name.to_string(),
+            reason: reason.into(),
+            blocks_generation: name.is_local(),
+        }
+    }
+
+    fn companion(fqn: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            fqn: fqn.into(),
+            reason: reason.into(),
+            blocks_generation: false,
+        }
+    }
+
+    fn for_callable(fqn: impl Into<String>, reason: impl Into<String>, is_local: bool) -> Self {
+        Self {
+            fqn: fqn.into(),
+            reason: reason.into(),
+            blocks_generation: is_local,
+        }
+    }
+
+    fn generator_bug(fqn: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self {
+            fqn: fqn.into(),
+            reason: reason.into(),
+            blocks_generation: true,
+        }
+    }
 }
 
 /// Contents of one generated file. Nearly everything is text; the
@@ -1624,6 +1668,48 @@ mod tests {
         assert_eq!(generated.warnings.len(), 1);
         assert_eq!(generated.warnings[0].fqn, "user.needs_media");
         assert!(generated.warnings[0].reason.contains("media"));
+        assert!(generated.warnings[0].blocks_generation());
+    }
+
+    #[test]
+    fn unknown_throws_arm_blocks_installing_a_partial_user_client() {
+        let n = name("user", &[], "extract");
+        let mut f = nullary_string_fn(&n);
+        f.throws = Some(Ty::Union(
+            vec![
+                Ty::String {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
+                Ty::BuiltinUnknown {
+                    attr: baml_base::TyAttr::EMPTY,
+                },
+            ],
+            baml_base::TyAttr::EMPTY,
+        ));
+        let pool = SymbolPool::from([(n, Symbol::Function(f))]);
+
+        let generated = to_source_code_with_bytecode(&pool, &[], &options());
+
+        assert_eq!(generated.warnings.len(), 1, "{:?}", generated.warnings);
+        assert_eq!(generated.warnings[0].fqn, "user.extract");
+        assert_eq!(
+            generated.warnings[0].reason,
+            "throws contract: unsupported union arm: unknown"
+        );
+        assert!(generated.warnings[0].blocks_generation());
+    }
+
+    #[test]
+    fn unsupported_dependency_symbols_remain_advisory() {
+        let n = name("baml", &["internal"], "needs_media");
+        let mut f = nullary_string_fn(&n);
+        f.return_type = Ty::Media(baml_base::MediaKind::Image, baml_base::TyAttr::EMPTY);
+        let pool = SymbolPool::from([(n, Symbol::Function(f))]);
+
+        let generated = to_source_code_with_bytecode(&pool, &[], &options());
+
+        assert_eq!(generated.warnings.len(), 1, "{:?}", generated.warnings);
+        assert!(!generated.warnings[0].blocks_generation());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Classify skipped local Rust SDK symbols and generator invariant failures as blocking while keeping dependency and generated-companion skips advisory.
- Refuse to replace generated output when a blocking skip would produce an empty or partial client, returning a nonzero exit with a clear summary.
- Add regression coverage for the reported `throws contract: unsupported union arm: unknown` path and an end-to-end CLI test that verifies existing output is preserved.

## Root cause

The low-level Rust generator intentionally returns usable files alongside skip warnings, but the CLI treated every warning as advisory, wrote the partial tree, and exited successfully. An intermittent unknown throws arm could therefore silently install a client with its user functions omitted. The classification preserves permissive low-level generation for dependency coverage while making the user-facing install boundary fail closed.

## Testing

- `cargo test -p sdkgen_rust`
- `cargo test -p baml_cli --test exit_code_e2e generate_rust_skipped_user_symbol_returns_nonzero_without_overwriting_output -- --exact --nocapture`
- `cargo clippy -p sdkgen_rust --all-targets -- -D warnings`
- `cargo clippy -p baml_cli --tests -- -D warnings`
- `cargo fmt --check -- --config imports_granularity=Crate --config group_imports=StdExternalCrate`
- GitHub Actions: all 53 reported checks passed, including native, musl, Windows, and wasm cargo tests plus Rust SDK tests

Fixes #4475