### PR TITLE
fix: generate baml_sdk in next to `baml.toml` by default

### DIFF
--- a/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
+++ b/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
@@ -272,7 +272,7 @@ generator:
     output_dir = "."
     naming_convention = "preserve-case"
   details: |
-    Generators are declared in `baml.toml` as `[generator.<name>]` tables, where `<name>` is an arbitrary identifier. `output_type` and `naming_convention` are required. `output_dir` is optional and defaults to `..`; BAML creates a `baml_sdk` directory inside it for every generator.
+    Generators are declared in `baml.toml` as `[generator.<name>]` tables, where `<name>` is an arbitrary identifier. `output_type` and `naming_convention` are required. `output_dir` is optional and defaults to `.`; BAML creates a `baml_sdk` directory inside it for every generator.
 
     Accepted `output_type` values:
 

--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -697,8 +697,8 @@ fn discover_generators(root: &Path) -> (Vec<GeneratorDef>, Vec<Diagnostic>) {
             sdkgen_go::DEFAULT_MAX_TYPED_UNION_ARITY
         };
         // `output_dir` is resolved relative to the project root and defaults
-        // to "..", with the target-owned generated directory appended.
-        let raw_output_dir = generator.output_dir.as_deref().unwrap_or("..");
+        // to the project root, with the target-owned generated directory appended.
+        let raw_output_dir = generator.output_dir.as_deref().unwrap_or(".");
         let generated_directory = output_type.map_or("baml_sdk", OutputType::generated_directory);
         let output_dir = root.join(raw_output_dir).join(generated_directory);
 
@@ -925,16 +925,13 @@ mod tests {
         };
         assert_eq!(
             output_for("csharp_default"),
-            &directory.path().join("..").join("baml_sdk")
+            &directory.path().join("baml_sdk")
         );
         assert_eq!(
             output_for("csharp_explicit"),
             &directory.path().join("generated").join("baml_sdk")
         );
-        assert_eq!(
-            output_for("python"),
-            &directory.path().join("..").join("baml_sdk")
-        );
+        assert_eq!(output_for("python"), &directory.path().join("baml_sdk"));
     }
 
     #[test]
@@ -1055,6 +1052,22 @@ mod tests {
                 .get_ref(),
             "typescript/node"
         );
+    }
+
+    #[test]
+    fn generator_output_defaults_to_project_root() {
+        let directory = tempfile::tempdir().unwrap();
+        fs::write(
+            directory.path().join("baml.toml"),
+            "[package]\nname = \"test\"\n\n[generator.rust]\noutput_type = \"rust\"\nnaming_convention = \"preserve-case\"\n",
+        )
+        .unwrap();
+
+        let (generators, diagnostics) = discover_generators(directory.path());
+
+        assert!(diagnostics.is_empty());
+        assert_eq!(generators.len(), 1);
+        assert_eq!(generators[0].output_dir, directory.path().join("baml_sdk"));
     }
 
     #[test]

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_generator.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_generator.snap
@@ -11,7 +11,7 @@ Syntax:
   output_dir = "."
   naming_convention = "preserve-case"
 
-Generators are declared in `baml.toml` as `[generator.<name>]` tables, where `<name>` is an arbitrary identifier. `output_type` and `naming_convention` are required. `output_dir` is optional and defaults to `..`; BAML creates a `baml_sdk` directory inside it for every generator.
+Generators are declared in `baml.toml` as `[generator.<name>]` tables, where `<name>` is an arbitrary identifier. `output_type` and `naming_convention` are required. `output_dir` is optional and defaults to `.`; BAML creates a `baml_sdk` directory inside it for every generator.
 
 Accepted `output_type` values:
 

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -332,6 +332,44 @@ fn generate_rust_language_naming_convention_returns_diagnostic() {
 }
 
 #[test]
+fn generate_rust_default_output_stays_inside_project() {
+    let built = &common::baml_cli();
+    let tmp = tempfile::tempdir().unwrap();
+    let project = tmp.path().join("project");
+    std::fs::create_dir(&project).unwrap();
+    create_project(
+        &project,
+        "function echo(value: string) -> string { value }\n",
+    );
+    std::fs::write(
+        project.join("baml.toml"),
+        "[package]\nname = \"test-project\"\n\n\
+         [generator.rust]\n\
+         output_type = \"rust\"\n\
+         naming_convention = \"preserve-case\"\n",
+    )
+    .unwrap();
+
+    let output = run_baml_cli(built, &project, &["generate", "--from", "."]);
+
+    assert!(
+        output.status.success(),
+        "Rust generation failed: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    assert!(
+        project.join("baml_sdk/Cargo.toml").is_file(),
+        "the default Rust SDK should be generated inside the project"
+    );
+    assert!(
+        !tmp.path().join("baml_sdk").exists(),
+        "generation must not create a sibling directory outside the project"
+    );
+}
+
+#[test]
 fn generate_go_writes_sdk_through_cli() {
     if !gofmt_is_available() {
         return;

--- a/baml_language/sdks/agent-docs/bridge-ref/ref-java-packaging.md
+++ b/baml_language/sdks/agent-docs/bridge-ref/ref-java-packaging.md
@@ -65,7 +65,7 @@ homebrew/AUR). npm uses OIDC trusted publishing with channel→dist-tag
 ## Where generated code goes in a Java project
 
 `baml generate` config lives in `baml.toml` `[generator.<name>]`
-(`output_type`, `naming_convention`, `output_dir` — default `".."`,
+(`output_type`, `naming_convention`, `output_dir` — default `"."`,
 with `baml_sdk` always appended). Generated files declare
 `package baml_sdk.*`, so **the registered source root must be the
 parent of the `baml_sdk/` directory** — which composes exactly with


### PR DESCRIPTION
[sheep council user ](https://github.com/BoundaryML/baml/issues/4376)pointed out that if you have baml.toml in the root of your repo, baml generate defaulting to ../baml_sdk means that the generated baml_sdk is outside of our repo, which seems strictly wrong

i agree with this conclusion and i'm going to flip the default for output_dir to ./baml_sdk

for comparison, the way Cargo.toml handles this is that Cargo.toml is a sibling of src/, whereas our baml.toml pattern is to have baml_src/baml.toml - whereas instead we should have baml.toml and baml_src/ as siblings

## Summary

- default an omitted `output_dir` to the BAML project root so the generated `baml_sdk` stays inside the project
- preserve explicit `output_dir` behavior
- add resolver-level and real CLI filesystem regressions, and update the generator documentation

## Root cause

Generator configuration moved from source files, where paths were relative to `baml_src`, to `baml.toml`, where paths resolve relative to the project root. The former `..` default was retained during that migration, changing its effective destination to the parent of the project.

## Validation

- `cargo test -p baml_cli generator_output_defaults_to_project_root`
- `cargo test -p baml_cli render_keyword_generator`
- `cargo test -p baml_cli --test exit_code_e2e generate_rust_default_output_stays_inside_project`
- `cargo test -p baml_bridge --lib`
- `cargo clippy -p baml_cli --all-targets -- -D warnings`
- `cargo fmt --check -- --config imports_granularity=Crate --config group_imports=StdExternalCrate`

Fixes #4376


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generator output now defaults to the project directory instead of its parent.
  * Rust SDK files are created in the project’s `baml_sdk` folder by default.
  * Generator naming conventions are now validated consistently across targets, with clearer target-specific guidance.
  * Verified that default Rust SDK generation succeeds without creating files outside the project.

* **Documentation**
  * Clarified required naming conventions and Go’s additional SDK import path setting.
  * Updated Java generation documentation to reflect the revised default output location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->