### PR TITLE
fix(rust): support non-identifier string literal union arms

### DIFF
--- a/baml_language/sdk_tests/crates/rust/type_shapes/customizable/test_complex_models.rs
+++ b/baml_language/sdk_tests/crates/rust/type_shapes/customizable/test_complex_models.rs
@@ -8,10 +8,34 @@
 use baml_bridge::Map;
 use baml_sdk::complex_models::{
     AccountTier, AuditEvent, CardPayment, CardPaymentOrWirePayment, ComplexProfile, ContactMethod,
-    CreatedOrUpdatedOrApproved, DraftOrSentOrPaid, GeoPoint, IntOrStringOrBool, Invoice,
-    InvoiceOrPostalAddressOrString, LineItem, PostalAddress, ProfileOwner, WirePayment,
-    round_trip_complex_profile,
+    CreatedOrUpdatedOrApproved, DraftOrSentOrPaid, GeoPoint, GraphQueryOrGraphDiff,
+    IntOrStringOrBool, Invoice, InvoiceOrPostalAddressOrString, LineItem,
+    LiteralUnionIdentifierEdges, PostalAddress, ProfileOwner, Utf8LossyOrUtf8Strict, WirePayment,
+    round_trip_complex_profile, round_trip_literal_union_identifier_edges,
 };
+
+// SDK_PARITY_LINT(skip): exercises Rust identifier synthesis for string-literal union arms
+#[test]
+fn test_complex_models_round_trip_non_identifier_string_literal_union_arms() {
+    for command in [
+        GraphQueryOrGraphDiff::GraphQuery,
+        GraphQueryOrGraphDiff::GraphDiff,
+    ] {
+        for encoding in [
+            Utf8LossyOrUtf8Strict::Utf8Lossy,
+            Utf8LossyOrUtf8Strict::Utf8Strict,
+        ] {
+            let value = LiteralUnionIdentifierEdges {
+                command: command.clone(),
+                encoding,
+            };
+            assert_eq!(
+                round_trip_literal_union_identifier_edges(value.clone()).unwrap(),
+                value
+            );
+        }
+    }
+}
 
 #[test]
 fn test_complex_models_round_trip_complex_profile_preserves_deeply_nested_mixed_shape_class() {

--- a/baml_language/sdk_tests/crates/rust/type_shapes/customizable/test_complex_models.rs
+++ b/baml_language/sdk_tests/crates/rust/type_shapes/customizable/test_complex_models.rs
@@ -5,7 +5,9 @@
 // arms as unit variants from their value, class/primitive arms wrapping
 // their payload — and a trailing `| null` lowering to `Option<...>`
 // around the enum.
-use baml_bridge::Map;
+use baml_bridge::{
+    Map, baml_value::internal::__BamlValuePrivate, wire::inbound_value::Value as WireValue,
+};
 use baml_sdk::complex_models::{
     AccountTier, AuditEvent, CardPayment, CardPaymentOrWirePayment, ComplexProfile, ContactMethod,
     CreatedOrUpdatedOrApproved, DraftOrSentOrPaid, GeoPoint, GraphQueryOrGraphDiff,
@@ -17,14 +19,16 @@ use baml_sdk::complex_models::{
 // SDK_PARITY_LINT(skip): exercises Rust identifier synthesis for string-literal union arms
 #[test]
 fn test_complex_models_round_trip_non_identifier_string_literal_union_arms() {
-    for command in [
-        GraphQueryOrGraphDiff::GraphQuery,
-        GraphQueryOrGraphDiff::GraphDiff,
+    for (command, command_wire_value) in [
+        (GraphQueryOrGraphDiff::GraphQuery, "graph.query"),
+        (GraphQueryOrGraphDiff::GraphDiff, "graph.diff"),
     ] {
-        for encoding in [
-            Utf8LossyOrUtf8Strict::Utf8Lossy,
-            Utf8LossyOrUtf8Strict::Utf8Strict,
+        assert_string_wire_value(&command, command_wire_value);
+        for (encoding, encoding_wire_value) in [
+            (Utf8LossyOrUtf8Strict::Utf8Lossy, "utf8-lossy"),
+            (Utf8LossyOrUtf8Strict::Utf8Strict, "utf8-strict"),
         ] {
+            assert_string_wire_value(&encoding, encoding_wire_value);
             let value = LiteralUnionIdentifierEdges {
                 command: command.clone(),
                 encoding,
@@ -34,6 +38,13 @@ fn test_complex_models_round_trip_non_identifier_string_literal_union_arms() {
                 value
             );
         }
+    }
+}
+
+fn assert_string_wire_value<T: __BamlValuePrivate>(value: &T, expected: &str) {
+    match value.to_baml().value {
+        Some(WireValue::StringValue(actual)) => assert_eq!(actual, expected),
+        other => panic!("expected string wire value {expected:?}, got {other:?}"),
     }
 }
 

--- a/baml_language/sdk_tests/fixtures/type_shapes/baml_src/ns_complex_models/types.baml
+++ b/baml_language/sdk_tests/fixtures/type_shapes/baml_src/ns_complex_models/types.baml
@@ -71,6 +71,14 @@ class AuditEvent {
   context map<string, string>
 }
 
+// String-literal union arms need valid host-language identifiers without
+// changing their exact wire values. These cover punctuation from real SDK
+// surfaces such as commands and text-decoding modes.
+class LiteralUnionIdentifierEdges {
+  command "graph.query" | "graph.diff"
+  encoding "utf8-lossy" | "utf8-strict"
+}
+
 class ComplexProfile {
   id string
   tier AccountTier
@@ -85,4 +93,8 @@ class ComplexProfile {
 
 function round_trip_complex_profile(profile: ComplexProfile) -> ComplexProfile {
   profile
+}
+
+function round_trip_literal_union_identifier_edges(value: LiteralUnionIdentifierEdges) -> LiteralUnionIdentifierEdges {
+  value
 }

--- a/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
@@ -709,7 +709,7 @@ mod tests {
         let route = name("user", &[], "Route");
         let pick = name("user", &[], "pick");
         let command = Ty::Union(
-            ["graph.query", "graph.diff", "utf8-lossy"]
+            ["graph.query", "graph.diff", "utf8-lossy", "self"]
                 .into_iter()
                 .map(|value| {
                     Ty::Literal(
@@ -746,13 +746,13 @@ mod tests {
         let flat = flat(lib);
         assert!(
             flat.contains(
-                "pubenumGraphQueryOrGraphDiffOrUtf8Lossy{GraphQuery,GraphDiff,Utf8Lossy,}"
+                "pubenumGraphQueryOrGraphDiffOrUtf8LossyOrSelf_{GraphQuery,GraphDiff,Utf8Lossy,Self_,}"
             ),
             "{lib}"
         );
         assert!(flat.contains("pubstructRoute{"), "{lib}");
         assert!(flat.contains("pubfnpick()"), "{lib}");
-        for wire_value in ["graph.query", "graph.diff", "utf8-lossy"] {
+        for wire_value in ["graph.query", "graph.diff", "utf8-lossy", "self"] {
             assert!(
                 lib.contains(wire_value),
                 "missing wire value {wire_value}:\n{lib}"

--- a/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
@@ -705,6 +705,62 @@ mod tests {
     }
 
     #[test]
+    fn non_identifier_string_literal_union_arms_keep_classes_and_functions() {
+        let route = name("user", &[], "Route");
+        let pick = name("user", &[], "pick");
+        let command = Ty::Union(
+            ["graph.query", "graph.diff", "utf8-lossy"]
+                .into_iter()
+                .map(|value| {
+                    Ty::Literal(
+                        baml_base::Literal::String(value.to_string()),
+                        baml_codegen_types::Freshness::Regular,
+                        baml_base::TyAttr::EMPTY,
+                    )
+                })
+                .collect(),
+            baml_base::TyAttr::EMPTY,
+        );
+        let mut pick_fn = nullary_string_fn(&pick);
+        pick_fn.return_type = Ty::Class(route.clone(), Vec::new(), baml_base::TyAttr::EMPTY);
+        let pool = SymbolPool::from([
+            (
+                route.clone(),
+                class_symbol(
+                    &route,
+                    vec![baml_codegen_types::ClassProperty {
+                        name: baml_base::Name::new("command"),
+                        docstring: None,
+                        ty: command,
+                    }],
+                    Vec::new(),
+                    Vec::new(),
+                ),
+            ),
+            (pick, Symbol::Function(pick_fn)),
+        ]);
+
+        let generated = to_source_code_with_bytecode(&pool, &[], &options());
+        assert!(generated.warnings.is_empty(), "{:?}", generated.warnings);
+        let lib = text(&generated, "src/lib.rs");
+        let flat = flat(lib);
+        assert!(
+            flat.contains(
+                "pubenumGraphQueryOrGraphDiffOrUtf8Lossy{GraphQuery,GraphDiff,Utf8Lossy,}"
+            ),
+            "{lib}"
+        );
+        assert!(flat.contains("pubstructRoute{"), "{lib}");
+        assert!(flat.contains("pubfnpick()"), "{lib}");
+        for wire_value in ["graph.query", "graph.diff", "utf8-lossy"] {
+            assert!(
+                lib.contains(wire_value),
+                "missing wire value {wire_value}:\n{lib}"
+            );
+        }
+    }
+
+    #[test]
     fn string_arm_with_string_literal_arm_skips_fail_closed() {
         let n = name("user", &[], "f");
         let union = Ty::Union(

--- a/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/lib.rs
@@ -752,10 +752,25 @@ mod tests {
         );
         assert!(flat.contains("pubstructRoute{"), "{lib}");
         assert!(flat.contains("pubfnpick()"), "{lib}");
-        for wire_value in ["graph.query", "graph.diff", "utf8-lossy", "self"] {
+        for (variant, wire_value) in [
+            ("GraphQuery", "graph.query"),
+            ("GraphDiff", "graph.diff"),
+            ("Utf8Lossy", "utf8-lossy"),
+            ("Self_", "self"),
+        ] {
             assert!(
                 lib.contains(wire_value),
                 "missing wire value {wire_value}:\n{lib}"
+            );
+            let marker = format!("Self::{variant}=>");
+            let tail = flat
+                .split_once(&marker)
+                .unwrap_or_else(|| panic!("missing encode arm {marker}:\n{lib}"))
+                .1;
+            let arm = tail.split_once("Self::").map_or(tail, |(arm, _)| arm);
+            assert!(
+                arm.contains(&format!("from({wire_value:?})")),
+                "encode arm {variant} is not associated with {wire_value:?}:\n{lib}"
             );
         }
     }

--- a/baml_language/sdks/rust/sdkgen_rust/src/unions.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/unions.rs
@@ -194,13 +194,12 @@ fn register_unions_in(ty: &Ty, leaf: &[String], analysis: &Analysis, registry: &
 
 /// The pure (emitted-set-independent) reasons a null-stripped arm list
 /// cannot become a Rust enum: undecodable arm kinds, wire-ambiguous arm
-/// combinations, or underivable/duplicate variant names. Shared by the
+/// combinations, or underivable variant names. Shared by the
 /// class-fixpoint checks in `analyze` and [`collect`] so the two can
 /// never disagree.
 pub(crate) fn shape_error(arms: &[Ty]) -> Option<String> {
     let mut has_bare_string_arm = false;
     let mut has_string_literal_arm = false;
-    let mut seen = HashSet::new();
     for arm in arms {
         match arm {
             Ty::Literal(baml_base::Literal::String(_), ..) => has_string_literal_arm = true,
@@ -213,15 +212,8 @@ pub(crate) fn shape_error(arms: &[Ty]) -> Option<String> {
             Ty::String { .. } => has_bare_string_arm = true,
             _ => {}
         }
-        let Some(variant) = variant_name(arm) else {
+        if variant_name(arm).is_none() {
             return Some(format!("unsupported union arm: {arm}"));
-        };
-        // Duplicate variant names (two `Bar` classes from different
-        // namespaces) would not compile — fail closed.
-        if !seen.insert(variant.clone()) {
-            return Some(format!(
-                "union arms produce a duplicate variant name `{variant}`"
-            ));
         }
     }
     // A bare `string` arm makes string-literal arms indistinguishable on
@@ -244,8 +236,9 @@ fn synthesize(arms: &[Ty], analysis: &Analysis) -> Option<UnionEnum> {
     if shape_error(arms).is_some() {
         return None;
     }
+    let variants = unique_variant_names(arms)?;
     let mut built = Vec::new();
-    for arm in arms {
+    for (arm, variant) in arms.iter().zip(variants) {
         let kind = match arm {
             Ty::Literal(baml_base::Literal::String(value), ..) => {
                 UnionArmKind::StringLiteral(value.clone())
@@ -255,10 +248,7 @@ fn synthesize(arms: &[Ty], analysis: &Analysis) -> Option<UnionEnum> {
             }
             _ => return None,
         };
-        built.push(UnionArm {
-            variant: variant_name(arm)?,
-            kind,
-        });
+        built.push(UnionArm { variant, kind });
     }
     let rust_name = built
         .iter()
@@ -270,6 +260,24 @@ fn synthesize(arms: &[Ty], analysis: &Analysis) -> Option<UnionEnum> {
         arms: built,
         generic_params: union_generic_params(arms),
     })
+}
+
+/// Derive one distinct Rust variant name per arm. Different wire values can
+/// normalize to the same identifier (`"graph.query"` and `"graph-query"`),
+/// and nominal arms from different namespaces can share a leaf name. Trailing
+/// underscores keep all of those shapes representable without changing their
+/// wire identities.
+fn unique_variant_names(arms: &[Ty]) -> Option<Vec<String>> {
+    let mut names = Vec::with_capacity(arms.len());
+    let mut seen = HashSet::new();
+    for arm in arms {
+        let mut variant = variant_name(arm)?;
+        while !seen.insert(variant.clone()) {
+            variant.push('_');
+        }
+        names.push(variant);
+    }
+    Some(names)
 }
 
 /// The `TypeVar` names appearing anywhere in the arms, in first-appearance
@@ -351,8 +359,8 @@ fn arm_is_representable(ty: &Ty, analysis: &Analysis) -> bool {
     }
 }
 
-/// The variant name for an arm, or `None` when no identifier-safe name
-/// can be derived.
+/// The variant name for an arm, or `None` when the arm kind has no naming
+/// strategy.
 fn variant_name(arm: &Ty) -> Option<String> {
     match arm {
         Ty::Int { .. } => Some("Int".to_string()),
@@ -371,16 +379,7 @@ fn variant_name(arm: &Ty) -> Option<String> {
         Ty::List(inner, _) => Some(format!("{}List", variant_name(inner)?)),
         Ty::Map { key: _, value, .. } => Some(format!("{}Map", variant_name(value)?)),
         Ty::Literal(baml_base::Literal::String(value), ..) => {
-            let mut chars = value.chars();
-            let first = chars.next()?;
-            if !first.is_ascii_alphabetic() {
-                return None;
-            }
-            let rest: String = chars.collect();
-            if !rest.chars().all(|c| c.is_alphanumeric() || c == '_') {
-                return None;
-            }
-            Some(format!("{}{rest}", first.to_ascii_uppercase()))
+            Some(string_literal_variant_name(value))
         }
         Ty::Union(items, _) => {
             // Only reachable for the degenerate single-arm nested case.
@@ -403,5 +402,80 @@ fn variant_name(arm: &Ty) -> Option<String> {
         | Ty::PromptAst { .. }
         | Ty::Never { .. }
         | Ty::RustType { .. } => None,
+    }
+}
+
+/// Turn any string literal into a valid, variant-style Rust identifier while
+/// preserving the old spelling for literals that were already supported.
+fn string_literal_variant_name(value: &str) -> String {
+    let mut chars = value.chars();
+    if let Some(first) = chars.next()
+        && first.is_ascii_alphabetic()
+    {
+        let rest: String = chars.collect();
+        if rest.chars().all(|c| c.is_alphanumeric() || c == '_') {
+            return format!("{}{rest}", first.to_ascii_uppercase());
+        }
+    }
+
+    let mut variant = String::new();
+    let mut capitalize_next = true;
+    for c in value.chars() {
+        if c.is_ascii_alphanumeric() {
+            if capitalize_next {
+                variant.push(c.to_ascii_uppercase());
+                capitalize_next = false;
+            } else {
+                variant.push(c);
+            }
+        } else {
+            capitalize_next = true;
+        }
+    }
+    if variant.is_empty() {
+        variant.push_str("Value");
+    } else if !variant
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic())
+    {
+        variant.insert_str(0, "Value");
+    }
+    variant
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn string_literal(value: &str) -> Ty {
+        Ty::Literal(
+            baml_base::Literal::String(value.to_string()),
+            baml_codegen_types::Freshness::Regular,
+            baml_base::TyAttr::EMPTY,
+        )
+    }
+
+    #[test]
+    fn string_literal_variants_are_identifier_safe_and_unique() {
+        let arms = [
+            string_literal("graph.query"),
+            string_literal("graph-query"),
+            string_literal("utf8-lossy"),
+            string_literal("3d"),
+            string_literal("---"),
+            string_literal("..."),
+        ];
+        assert_eq!(
+            unique_variant_names(&arms).unwrap(),
+            [
+                "GraphQuery",
+                "GraphQuery_",
+                "Utf8Lossy",
+                "Value3d",
+                "Value",
+                "Value_",
+            ]
+        );
     }
 }

--- a/baml_language/sdks/rust/sdkgen_rust/src/unions.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/unions.rs
@@ -427,7 +427,11 @@ fn string_literal_variant_name(value: &str) -> String {
     {
         let rest: String = chars.collect();
         if rest.chars().all(|c| c.is_alphanumeric() || c == '_') {
-            return format!("{}{rest}", first.to_ascii_uppercase());
+            let mut variant = format!("{}{rest}", first.to_ascii_uppercase());
+            if variant == "Self" {
+                variant.push('_');
+            }
+            return variant;
         }
     }
 
@@ -454,6 +458,9 @@ fn string_literal_variant_name(value: &str) -> String {
     {
         variant.insert_str(0, "Value");
     }
+    if variant == "Self" {
+        variant.push('_');
+    }
     variant
 }
 
@@ -471,6 +478,7 @@ mod tests {
 
     #[test]
     fn string_literal_variants_are_identifier_safe_and_unique() {
+        assert_eq!(string_literal_variant_name("self!"), "Self_");
         let arms = [
             string_literal("graph.query"),
             string_literal("graph-query"),
@@ -478,6 +486,8 @@ mod tests {
             string_literal("3d"),
             string_literal("---"),
             string_literal("..."),
+            string_literal("self"),
+            string_literal("Self_"),
         ];
         assert_eq!(
             unique_variant_names(&arms).unwrap(),
@@ -488,6 +498,8 @@ mod tests {
                 "Value3d",
                 "Value",
                 "Value_",
+                "Self_",
+                "Self__",
             ]
         );
     }

--- a/baml_language/sdks/rust/sdkgen_rust/src/unions.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/unions.rs
@@ -201,9 +201,15 @@ pub(crate) fn shape_error(arms: &[Ty]) -> Option<String> {
     let mut has_bare_string_arm = false;
     let mut has_string_literal_arm = false;
     let mut seen_payload_variants = HashSet::new();
+    let mut seen_string_literals = HashSet::new();
     for arm in arms {
         match arm {
-            Ty::Literal(baml_base::Literal::String(_), ..) => has_string_literal_arm = true,
+            Ty::Literal(baml_base::Literal::String(value), ..) => {
+                has_string_literal_arm = true;
+                if !seen_string_literals.insert(value.as_str()) {
+                    return Some(format!("union contains duplicate string literal {value:?}"));
+                }
+            }
             // Non-string literal arms have no variant-name story yet.
             Ty::Literal(lit, ..) => {
                 return Some(format!(
@@ -426,7 +432,7 @@ fn string_literal_variant_name(value: &str) -> String {
         && first.is_ascii_alphabetic()
     {
         let rest: String = chars.collect();
-        if rest.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        if rest.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
             let mut variant = format!("{}{rest}", first.to_ascii_uppercase());
             if variant == "Self" {
                 variant.push('_');
@@ -479,6 +485,7 @@ mod tests {
     #[test]
     fn string_literal_variants_are_identifier_safe_and_unique() {
         assert_eq!(string_literal_variant_name("self!"), "Self_");
+        assert_eq!(string_literal_variant_name("a²"), "A");
         let arms = [
             string_literal("graph.query"),
             string_literal("graph-query"),
@@ -537,5 +544,15 @@ mod tests {
 
         assert_eq!(shape_error(&arms), None);
         assert_eq!(unique_variant_names(&arms).unwrap(), ["Int", "Int_"]);
+    }
+
+    #[test]
+    fn duplicate_string_literal_wire_values_are_rejected() {
+        let arms = [string_literal("draft"), string_literal("draft")];
+
+        assert_eq!(
+            shape_error(&arms).as_deref(),
+            Some("union contains duplicate string literal \"draft\"")
+        );
     }
 }

--- a/baml_language/sdks/rust/sdkgen_rust/src/unions.rs
+++ b/baml_language/sdks/rust/sdkgen_rust/src/unions.rs
@@ -194,12 +194,13 @@ fn register_unions_in(ty: &Ty, leaf: &[String], analysis: &Analysis, registry: &
 
 /// The pure (emitted-set-independent) reasons a null-stripped arm list
 /// cannot become a Rust enum: undecodable arm kinds, wire-ambiguous arm
-/// combinations, or underivable variant names. Shared by the
+/// combinations, or underivable/duplicate payload variant names. Shared by the
 /// class-fixpoint checks in `analyze` and [`collect`] so the two can
 /// never disagree.
 pub(crate) fn shape_error(arms: &[Ty]) -> Option<String> {
     let mut has_bare_string_arm = false;
     let mut has_string_literal_arm = false;
+    let mut seen_payload_variants = HashSet::new();
     for arm in arms {
         match arm {
             Ty::Literal(baml_base::Literal::String(_), ..) => has_string_literal_arm = true,
@@ -212,8 +213,20 @@ pub(crate) fn shape_error(arms: &[Ty]) -> Option<String> {
             Ty::String { .. } => has_bare_string_arm = true,
             _ => {}
         }
-        if variant_name(arm).is_none() {
+        let Some(variant) = variant_name(arm) else {
             return Some(format!("unsupported union arm: {arm}"));
+        };
+        // Two payload arms with the same derived name can erase to the same
+        // Rust type (for example `Status.A | Status.B`) and would emit
+        // conflicting `From<Status>` implementations. String literals are
+        // unit variants with distinct wire values, so their naming collisions
+        // are safe to resolve during synthesis.
+        if !matches!(arm, Ty::Literal(baml_base::Literal::String(_), ..))
+            && !seen_payload_variants.insert(variant.clone())
+        {
+            return Some(format!(
+                "union payload arms produce a duplicate variant name `{variant}`"
+            ));
         }
     }
     // A bare `string` arm makes string-literal arms indistinguishable on
@@ -264,9 +277,9 @@ fn synthesize(arms: &[Ty], analysis: &Analysis) -> Option<UnionEnum> {
 
 /// Derive one distinct Rust variant name per arm. Different wire values can
 /// normalize to the same identifier (`"graph.query"` and `"graph-query"`),
-/// and nominal arms from different namespaces can share a leaf name. Trailing
-/// underscores keep all of those shapes representable without changing their
-/// wire identities.
+/// or collide with a payload arm's name. Trailing underscores keep those
+/// variants distinct without changing their wire identities. Duplicate payload
+/// names are rejected by [`shape_error`] because they may erase to one Rust type.
 fn unique_variant_names(arms: &[Ty]) -> Option<Vec<String>> {
     let mut names = Vec::with_capacity(arms.len());
     let mut seen = HashSet::new();
@@ -477,5 +490,40 @@ mod tests {
                 "Value_",
             ]
         );
+    }
+
+    #[test]
+    fn payload_arms_with_the_same_rust_type_are_rejected() {
+        let status = baml_codegen_types::Name::new(
+            baml_base::Name::new("user"),
+            Vec::new(),
+            baml_base::Name::new("Status"),
+        );
+        let arms = [
+            Ty::EnumVariant(
+                status.clone(),
+                baml_base::Name::new("A"),
+                baml_base::TyAttr::EMPTY,
+            ),
+            Ty::EnumVariant(status, baml_base::Name::new("B"), baml_base::TyAttr::EMPTY),
+        ];
+
+        assert_eq!(
+            shape_error(&arms).as_deref(),
+            Some("union payload arms produce a duplicate variant name `Status`")
+        );
+    }
+
+    #[test]
+    fn string_literal_name_can_be_deconflicted_from_a_payload_arm() {
+        let arms = [
+            Ty::Int {
+                attr: baml_base::TyAttr::EMPTY,
+            },
+            string_literal("int"),
+        ];
+
+        assert_eq!(shape_error(&arms), None);
+        assert_eq!(unique_variant_names(&arms).unwrap(), ["Int", "Int_"]);
     }
 }


### PR DESCRIPTION
## Summary

- derive valid Rust enum variant names from string-literal union arms containing separators or leading non-identifier characters
- deterministically de-collide normalized variant names without changing their wire values
- keep classes and transitive function bindings emitted for literals such as `"graph.query"` and `"utf8-lossy"`

Fixes #4371

## Testing

- `cargo test -p sdkgen_rust --lib`
- `cargo clippy -p sdkgen_rust --all-targets -- -D warnings`
- `cargo build -p bridge_cffi && cargo test --lib`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated Rust enums for unions containing arbitrary string literals.
  * Ensured generated variant names are valid and unique, including punctuation, numeric, empty, colliding, and reserved `Self` values.
  * Preserved original string values during serialization and verified variant-to-wire-value mappings.
  * Rejected duplicate string-literal wire values and duplicate payload-derived variants.
  * Corrected normalization of non-ASCII string literals.
  * Improved round-trip support for unions containing punctuation and UTF-8 string values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->