### PR TITLE
fix: return a well-formed error, not a panic, when `naming_convention = "language"` is used for SDKs

### DIFF
--- a/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
+++ b/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
@@ -287,7 +287,7 @@ generator:
     - `"cpp"` — C++17
     - `"csharp"` — C#
 
-    `naming_convention` accepts `"preserve-case"` or `"language"`. Go requires `"language"` and also requires `sdk_import_path`. Rust currently requires `"preserve-case"`.
+    `naming_convention` accepts `"preserve-case"` or `"language"`. Go and C# require `"language"`; Go also requires `sdk_import_path`. All other targets require `"preserve-case"`.
 
 test:
   summary: "Defines a named executable test using ordinary BAML expressions."

--- a/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
+++ b/baml_language/crates/baml_builtins2/keyword_docs/baml_keywords.yaml
@@ -287,7 +287,7 @@ generator:
     - `"cpp"` — C++17
     - `"csharp"` — C#
 
-    `naming_convention` accepts `"preserve-case"` or `"language"`. Go requires `"language"` and also requires `sdk_import_path`.
+    `naming_convention` accepts `"preserve-case"` or `"language"`. Go requires `"language"` and also requires `sdk_import_path`. Rust currently requires `"preserve-case"`.
 
 test:
   summary: "Defines a named executable test using ordinary BAML expressions."

--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -681,36 +681,8 @@ fn discover_generators(root: &Path) -> (Vec<GeneratorDef>, Vec<Diagnostic>) {
         let (Some(output_type), Some(naming_convention)) = (output_type, naming_convention) else {
             continue;
         };
-        if output_type == OutputType::Go {
-            if naming_convention != NamingConvention::Language {
-                let range = generator
-                    .naming_convention
-                    .as_ref()
-                    .map(|value| to_text_range(value.span()))
-                    .unwrap_or(table_range);
-                diags.push(
-                    Diagnostic::error(
-                        DiagnosticId::InvalidGeneratorPropertyValue,
-                        format!(
-                            "Go generator `{name}` requires `naming_convention = \"language\"`"
-                        ),
-                    )
-                    .with_primary(
-                        Span {
-                            file_id: manifest_file_id(),
-                            range,
-                        },
-                        "Go identifiers use the canonical language projection",
-                    )
-                    .with_phase(DiagnosticPhase::Validation),
-                );
-                continue;
-            }
-            if sdk_import_path.is_none() {
-                continue;
-            }
-        }
-        if output_type == OutputType::Rust && naming_convention != NamingConvention::PreserveCase {
+        let required_naming_convention = output_type.required_naming_convention();
+        if naming_convention != required_naming_convention {
             let range = generator
                 .naming_convention
                 .as_ref()
@@ -720,7 +692,7 @@ fn discover_generators(root: &Path) -> (Vec<GeneratorDef>, Vec<Diagnostic>) {
                 Diagnostic::error(
                     DiagnosticId::InvalidGeneratorPropertyValue,
                     format!(
-                        "Rust generator `{name}` does not yet support `naming_convention = \"language\"`; use `\"preserve-case\"`"
+                        "generator `{name}` with `output_type = \"{output_type}\"` requires `naming_convention = \"{required_naming_convention}\"`"
                     ),
                 )
                 .with_primary(
@@ -728,10 +700,13 @@ fn discover_generators(root: &Path) -> (Vec<GeneratorDef>, Vec<Diagnostic>) {
                         file_id: manifest_file_id(),
                         range,
                     },
-                    "unsupported naming convention for Rust",
+                    format!("use `{required_naming_convention}` for `{output_type}`"),
                 )
                 .with_phase(DiagnosticPhase::Validation),
             );
+            continue;
+        }
+        if output_type == OutputType::Go && sdk_import_path.is_none() {
             continue;
         }
 
@@ -1065,7 +1040,7 @@ mod tests {
 
     #[test]
     fn go_union_threshold_on_non_go_generator_is_rejected() {
-        let manifest = "[package]\nname = \"test\"\n\n[generator.ts]\noutput_type = \"typescript/node\"\nnaming_convention = \"language\"\nmax_typed_union_arity = 3\n";
+        let manifest = "[package]\nname = \"test\"\n\n[generator.ts]\noutput_type = \"typescript/node\"\nnaming_convention = \"preserve-case\"\nmax_typed_union_arity = 3\n";
         let (_, diagnostics) = discover_with_manifest(manifest);
         assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
         assert!(
@@ -1075,20 +1050,44 @@ mod tests {
     }
 
     #[test]
-    fn rust_language_naming_convention_is_rejected() {
-        let manifest = "[package]\nname = \"test\"\n\n[generator.rust_client]\noutput_type = \"rust\"\nnaming_convention = \"language\"\n";
+    fn naming_convention_is_validated_for_every_output_type() {
+        for &output_type in OutputType::all() {
+            let required = output_type.required_naming_convention();
+            let unsupported = match required {
+                baml_codegen_types::NamingConvention::PreserveCase => "language",
+                baml_codegen_types::NamingConvention::Language => "preserve-case",
+            };
+            let sdk_import_path = if output_type == OutputType::Go {
+                "sdk_import_path = \"example.com/test/baml_sdk\"\n"
+            } else {
+                ""
+            };
+            let valid_manifest = format!(
+                "[package]\nname = \"test\"\n\n[generator.client]\noutput_type = \"{output_type}\"\nnaming_convention = \"{required}\"\n{sdk_import_path}"
+            );
+            let (generators, diagnostics) = discover_with_manifest(&valid_manifest);
+            assert_eq!(generators.len(), 1, "{output_type}: {diagnostics:?}");
+            assert!(diagnostics.is_empty(), "{output_type}: {diagnostics:?}");
 
-        let (generators, diagnostics) = discover_with_manifest(manifest);
+            let manifest = format!(
+                "[package]\nname = \"test\"\n\n[generator.client]\noutput_type = \"{output_type}\"\nnaming_convention = \"{unsupported}\"\n{sdk_import_path}"
+            );
 
-        assert!(generators.is_empty());
-        assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
-        assert_eq!(
-            diagnostics[0].id,
-            baml_db::baml_compiler_diagnostics::DiagnosticId::InvalidGeneratorPropertyValue
-        );
-        assert_eq!(
-            diagnostics[0].message,
-            "Rust generator `rust_client` does not yet support `naming_convention = \"language\"`; use `\"preserve-case\"`"
-        );
+            let (generators, diagnostics) = discover_with_manifest(&manifest);
+
+            assert!(generators.is_empty(), "{output_type}");
+            assert_eq!(diagnostics.len(), 1, "{output_type}: {diagnostics:?}");
+            assert_eq!(
+                diagnostics[0].id,
+                baml_db::baml_compiler_diagnostics::DiagnosticId::InvalidGeneratorPropertyValue
+            );
+            assert_eq!(
+                diagnostics[0].message,
+                format!(
+                    "generator `client` with `output_type = \"{output_type}\"` requires `naming_convention = \"{}\"`",
+                    required
+                )
+            );
+        }
     }
 }

--- a/baml_language/crates/baml_cli/src/generate.rs
+++ b/baml_language/crates/baml_cli/src/generate.rs
@@ -710,6 +710,30 @@ fn discover_generators(root: &Path) -> (Vec<GeneratorDef>, Vec<Diagnostic>) {
                 continue;
             }
         }
+        if output_type == OutputType::Rust && naming_convention != NamingConvention::PreserveCase {
+            let range = generator
+                .naming_convention
+                .as_ref()
+                .map(|value| to_text_range(value.span()))
+                .unwrap_or(table_range);
+            diags.push(
+                Diagnostic::error(
+                    DiagnosticId::InvalidGeneratorPropertyValue,
+                    format!(
+                        "Rust generator `{name}` does not yet support `naming_convention = \"language\"`; use `\"preserve-case\"`"
+                    ),
+                )
+                .with_primary(
+                    Span {
+                        file_id: manifest_file_id(),
+                        range,
+                    },
+                    "unsupported naming convention for Rust",
+                )
+                .with_phase(DiagnosticPhase::Validation),
+            );
+            continue;
+        }
 
         generators.push(GeneratorDef {
             name: name.clone(),
@@ -1047,6 +1071,24 @@ mod tests {
         assert!(
             format!("{diagnostics:?}").contains("Go-only property"),
             "{diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn rust_language_naming_convention_is_rejected() {
+        let manifest = "[package]\nname = \"test\"\n\n[generator.rust_client]\noutput_type = \"rust\"\nnaming_convention = \"language\"\n";
+
+        let (generators, diagnostics) = discover_with_manifest(manifest);
+
+        assert!(generators.is_empty());
+        assert_eq!(diagnostics.len(), 1, "{diagnostics:?}");
+        assert_eq!(
+            diagnostics[0].id,
+            baml_db::baml_compiler_diagnostics::DiagnosticId::InvalidGeneratorPropertyValue
+        );
+        assert_eq!(
+            diagnostics[0].message,
+            "Rust generator `rust_client` does not yet support `naming_convention = \"language\"`; use `\"preserve-case\"`"
         );
     }
 }

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_generator.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_generator.snap
@@ -26,4 +26,4 @@ Accepted `output_type` values:
 - `"cpp"` — C++17
 - `"csharp"` — C#
 
-`naming_convention` accepts `"preserve-case"` or `"language"`. Go requires `"language"` and also requires `sdk_import_path`.
+`naming_convention` accepts `"preserve-case"` or `"language"`. Go requires `"language"` and also requires `sdk_import_path`. Rust currently requires `"preserve-case"`.

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_generator.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_keyword_generator.snap
@@ -26,4 +26,4 @@ Accepted `output_type` values:
 - `"cpp"` — C++17
 - `"csharp"` — C#
 
-`naming_convention` accepts `"preserve-case"` or `"language"`. Go requires `"language"` and also requires `sdk_import_path`. Rust currently requires `"preserve-case"`.
+`naming_convention` accepts `"preserve-case"` or `"language"`. Go and C# require `"language"`; Go also requires `sdk_import_path`. All other targets require `"preserve-case"`.

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -324,7 +324,7 @@ fn generate_rust_language_naming_convention_returns_diagnostic() {
     );
     assert!(
         stderr.contains(
-            "Rust generator `rust_client` does not yet support `naming_convention = \"language\"`; use `\"preserve-case\"`"
+            "generator `rust_client` with `output_type = \"rust\"` requires `naming_convention = \"preserve-case\"`"
         ),
         "stderr: {stderr}"
     );

--- a/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
+++ b/baml_language/crates/baml_cli/tests/exit_code_e2e.rs
@@ -290,6 +290,48 @@ fn generate_valid_project_returns_zero_exit_code() {
 }
 
 #[test]
+fn generate_rust_language_naming_convention_returns_diagnostic() {
+    let built = &common::baml_cli();
+    let tmp = tempfile::tempdir().unwrap();
+    create_project(
+        tmp.path(),
+        "function greet(name: string) -> string {\n  \"Hello, \" + name\n}\n",
+    );
+    std::fs::write(
+        tmp.path().join("baml.toml"),
+        "[package]\nname = \"test-project\"\n\n\
+         [generator.rust_client]\n\
+         output_type = \"rust\"\n\
+         output_dir = \".\"\n\
+         naming_convention = \"language\"\n",
+    )
+    .unwrap();
+
+    let output = run_baml_cli(built, tmp.path(), &["generate", "--from", "."]);
+
+    assert_eq!(
+        output.status.code(),
+        Some(4),
+        "Expected exit code 4, got: {:?}\nstdout: {}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.lines().any(|line| line.trim() == "E0019"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(
+            "Rust generator `rust_client` does not yet support `naming_convention = \"language\"`; use `\"preserve-case\"`"
+        ),
+        "stderr: {stderr}"
+    );
+    assert!(!stderr.contains("panicked at"), "stderr: {stderr}");
+}
+
+#[test]
 fn generate_go_writes_sdk_through_cli() {
     if !gofmt_is_available() {
         return;

--- a/baml_language/crates/baml_codegen_types/src/generator_fields.rs
+++ b/baml_language/crates/baml_codegen_types/src/generator_fields.rs
@@ -69,6 +69,14 @@ impl OutputType {
             _ => "baml_sdk",
         }
     }
+
+    /// The naming convention currently implemented by this generator.
+    pub const fn required_naming_convention(self) -> NamingConvention {
+        match self {
+            Self::Go | Self::CSharp => NamingConvention::Language,
+            _ => NamingConvention::PreserveCase,
+        }
+    }
 }
 
 /// Identifier-casing policy a code generator must respect. Surfaces as
@@ -102,15 +110,10 @@ pub struct Generator {
 
 impl From<OutputType> for Generator {
     fn from(output_type: OutputType) -> Self {
-        let naming_convention = match output_type {
-            OutputType::Go | OutputType::CSharp => NamingConvention::Language,
-            _ => NamingConvention::PreserveCase,
-        };
-
         Self {
             output_type,
             output_dir: None,
-            naming_convention,
+            naming_convention: output_type.required_naming_convention(),
             sdk_import_path: None,
             max_typed_union_arity: None,
         }
@@ -136,11 +139,19 @@ mod tests {
         for &output_type in OutputType::all() {
             let generator = Generator::from(output_type);
             assert_eq!(generator.output_type, output_type);
+            assert_eq!(
+                generator.naming_convention,
+                output_type.required_naming_convention()
+            );
             assert!(!output_type.add_name().is_empty());
         }
 
         assert_eq!(
             Generator::from(OutputType::Go).naming_convention,
+            NamingConvention::Language
+        );
+        assert_eq!(
+            Generator::from(OutputType::CSharp).naming_convention,
             NamingConvention::Language
         );
         assert_eq!(


### PR DESCRIPTION
## Summary

- centralize the naming convention implemented by every generator target
- require `language` for Go and C#, and require `preserve-case` for every other output type
- report a span-aware `E0019` diagnostic pointing at `baml.toml` before unsupported settings reach or are ignored by a backend
- document the per-target naming convention contract

## Root cause

The CLI parsed both naming conventions as globally valid but did not validate each backend's target-specific capability before dispatch. Unsupported user configuration could therefore reach an internal generator assertion or be silently ignored.

## Validation

- `cargo test -p baml_codegen_types --lib`
- `cargo test -p baml_cli --lib naming_convention_is_validated_for_every_output_type`
- `cargo test -p baml_cli --lib go_union_threshold_on_non_go_generator_is_rejected`
- `cargo test -p baml_cli --lib render_keyword_generator`
- `cargo test -p baml_cli --test exit_code_e2e generate_rust_language_naming_convention_returns_diagnostic -- --nocapture`
- `cargo clippy -p baml_cli -p baml_codegen_types --all-targets -- -D warnings`
- `cargo fmt --check -- --config imports_granularity="Crate" --config group_imports="StdExternalCrate"`

Fixes #4335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Generator configuration validation now enforces the naming convention required by each output language.
  * Improved diagnostics identify the output language and required setting, preventing confusing failures and panics.
  * Rust configurations using an unsupported naming convention now return a clear error with corrective guidance.

* **Documentation**
  * Updated C# generator documentation to clarify that `naming_convention = "language"` and `sdk_import_path` are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->