### PR TITLE
fix(rust): stop baml_bridge from enabling serde_json semantic features

### DIFF
--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -243,6 +243,8 @@ salsa = { version = "0.26", default-features = false, features = [
 serde = { version = "1.0.197", features = [ "derive" ] }
 serde-wasm-bindgen = "0.6"
 serde_json = { version = "1.0.113", features = [ "arbitrary_precision", "preserve_order" ] }
+# Feature-free alias for published crates that must not impose JSON semantics on consumers.
+serde_json_feature_free = { package = "serde_json", version = "1.0.113" }
 semver = { version = "1" }
 # The maintained fork of the archived serde_yaml, published by the YAML org;
 # package-renamed so `use serde_yaml::` imports stay unchanged.

--- a/baml_language/sdks/rust/bridge_rust/Cargo.toml
+++ b/baml_language/sdks/rust/bridge_rust/Cargo.toml
@@ -36,7 +36,9 @@ indexmap = { workspace = true }
 libloading = { workspace = true }
 num-bigint = { workspace = true }
 prost = { workspace = true }
-serde_json = { workspace = true }
+# Keep this direct instead of inheriting the workspace's `serde_json` features.
+# Cargo unifies dependency features, and `baml_bridge` only serializes strings.
+serde_json = "1.0.113"
 sha2 = { workspace = true }
 tokio = { workspace = true, features = [ "rt", "rt-multi-thread" ] }
 ureq = { workspace = true }

--- a/baml_language/sdks/rust/bridge_rust/Cargo.toml
+++ b/baml_language/sdks/rust/bridge_rust/Cargo.toml
@@ -36,9 +36,7 @@ indexmap = { workspace = true }
 libloading = { workspace = true }
 num-bigint = { workspace = true }
 prost = { workspace = true }
-# Keep this direct instead of inheriting the workspace's `serde_json` features.
-# Cargo unifies dependency features, and `baml_bridge` only serializes strings.
-serde_json = "1.0.113"
+serde_json_feature_free = { workspace = true }
 sha2 = { workspace = true }
 tokio = { workspace = true, features = [ "rt", "rt-multi-thread" ] }
 ureq = { workspace = true }

--- a/baml_language/sdks/rust/bridge_rust/src/runtime.rs
+++ b/baml_language/sdks/rust/bridge_rust/src/runtime.rs
@@ -57,7 +57,7 @@ pub fn initialize_from_files(
     let api = capi::api()?;
     let root = CString::new(root_path)
         .map_err(|_| SdkError::new("root path contains an interior NUL byte"))?;
-    let files_json = serde_json::to_string(files)
+    let files_json = serde_json_feature_free::to_string(files)
         .map_err(|e| SdkError::new(format!("failed to encode source files: {e}")))?;
     let files_json = CString::new(files_json)
         .map_err(|_| SdkError::new("source contents contain an interior NUL byte"))?;

--- a/baml_language/sdks/rust/bridge_rust/tests/manifest.rs
+++ b/baml_language/sdks/rust/bridge_rust/tests/manifest.rs
@@ -30,22 +30,28 @@ fn serde_json_dependency_does_not_force_semantic_features() {
         .iter()
         .find(|package| package["name"] == "baml_bridge")
         .expect("metadata should contain baml_bridge");
-    let serde_json = bridge["dependencies"]
+    let serde_json_dependencies = bridge["dependencies"]
         .as_array()
         .expect("package dependencies should be an array")
         .iter()
-        .find(|dependency| {
-            dependency["name"] == "serde_json" && dependency["rename"] == "serde_json_feature_free"
-        })
-        .expect("baml_bridge should use the feature-free serde_json alias");
-    let features = serde_json["features"]
-        .as_array()
-        .expect("dependency features should be an array");
+        .filter(|dependency| dependency["name"] == "serde_json")
+        .collect::<Vec<_>>();
+    assert!(
+        serde_json_dependencies
+            .iter()
+            .any(|dependency| dependency["rename"] == "serde_json_feature_free"),
+        "baml_bridge should use the feature-free serde_json alias"
+    );
 
-    for unwanted in ["arbitrary_precision", "preserve_order"] {
-        assert!(
-            !features.iter().any(|feature| feature == unwanted),
-            "baml_bridge must not enable serde_json/{unwanted}; Cargo unifies dependency features across consumers"
-        );
+    for dependency in serde_json_dependencies {
+        let features = dependency["features"]
+            .as_array()
+            .expect("dependency features should be an array");
+        for unwanted in ["arbitrary_precision", "preserve_order"] {
+            assert!(
+                !features.iter().any(|feature| feature == unwanted),
+                "baml_bridge must not enable serde_json/{unwanted}; Cargo unifies dependency features across consumers"
+            );
+        }
     }
 }

--- a/baml_language/sdks/rust/bridge_rust/tests/manifest.rs
+++ b/baml_language/sdks/rust/bridge_rust/tests/manifest.rs
@@ -1,0 +1,48 @@
+use std::{path::PathBuf, process::Command};
+
+#[test]
+fn serde_json_dependency_does_not_force_semantic_features() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let output = Command::new(env!("CARGO"))
+        .args([
+            "metadata",
+            "--format-version",
+            "1",
+            "--no-deps",
+            "--locked",
+            "--manifest-path",
+        ])
+        .arg(manifest)
+        .output()
+        .expect("cargo metadata should run");
+    assert!(
+        output.status.success(),
+        "cargo metadata failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let metadata: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("cargo metadata should emit JSON");
+    let bridge = metadata["packages"]
+        .as_array()
+        .expect("metadata packages should be an array")
+        .iter()
+        .find(|package| package["name"] == "baml_bridge")
+        .expect("metadata should contain baml_bridge");
+    let serde_json = bridge["dependencies"]
+        .as_array()
+        .expect("package dependencies should be an array")
+        .iter()
+        .find(|dependency| dependency["name"] == "serde_json")
+        .expect("baml_bridge should depend on serde_json");
+    let features = serde_json["features"]
+        .as_array()
+        .expect("dependency features should be an array");
+
+    for unwanted in ["arbitrary_precision", "preserve_order"] {
+        assert!(
+            !features.iter().any(|feature| feature == unwanted),
+            "baml_bridge must not enable serde_json/{unwanted}; Cargo unifies dependency features across consumers"
+        );
+    }
+}

--- a/baml_language/sdks/rust/bridge_rust/tests/manifest.rs
+++ b/baml_language/sdks/rust/bridge_rust/tests/manifest.rs
@@ -21,8 +21,9 @@ fn serde_json_dependency_does_not_force_semantic_features() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let metadata: serde_json::Value =
-        serde_json::from_slice(&output.stdout).expect("cargo metadata should emit JSON");
+    let metadata: serde_json_feature_free::Value =
+        serde_json_feature_free::from_slice(&output.stdout)
+            .expect("cargo metadata should emit JSON");
     let bridge = metadata["packages"]
         .as_array()
         .expect("metadata packages should be an array")
@@ -33,8 +34,10 @@ fn serde_json_dependency_does_not_force_semantic_features() {
         .as_array()
         .expect("package dependencies should be an array")
         .iter()
-        .find(|dependency| dependency["name"] == "serde_json")
-        .expect("baml_bridge should depend on serde_json");
+        .find(|dependency| {
+            dependency["name"] == "serde_json" && dependency["rename"] == "serde_json_feature_free"
+        })
+        .expect("baml_bridge should use the feature-free serde_json alias");
     let features = serde_json["features"]
         .as_array()
         .expect("dependency features should be an array");


### PR DESCRIPTION
## Summary

- add a feature-free workspace alias for `serde_json`, while preserving the existing semantic features for crates that intentionally need them
- make `baml_bridge` use that alias so its published package does not enable `arbitrary_precision` or `preserve_order` in consumer dependency graphs
- add a Cargo metadata regression test that prevents either semantic feature from being reintroduced

## Validation

- `mise run stow`
- `cargo fmt --manifest-path baml_language/Cargo.toml -p baml_bridge -- --check --config imports_granularity=Crate --config group_imports=StdExternalCrate`
- `cargo test --manifest-path baml_language/Cargo.toml -p baml_bridge --lib`
- `cargo test --manifest-path baml_language/Cargo.toml -p baml_bridge --test manifest`
- `cargo package -p baml_bridge --allow-dirty`
- isolated rerun of the unrelated workspace timeout: `cargo test -p bex_project --lib bex_lsp::multi_project::tests::source_lease_fences_failure_publication_against_a_racing_edit -- --exact`

Fixes #4377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSON serialization consistency in the Rust integration.
  - Prevented optional JSON behaviors from being enabled unintentionally, supporting more predictable runtime behavior.
  - Added safeguards to ensure the integration uses the expected JSON configuration.

- **Tests**
  - Added automated validation to confirm JSON dependency settings remain stable and consistent across builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->