### PR TITLE
fix(hir_ty): diagnose unknown methods on inferred generics

### DIFF
--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -5605,6 +5605,20 @@ impl<'db> InferenceContext<'db> {
             self.member_probe_depth += 1;
             let (field, field_resolution) = self.field_access_resolved(call, &resolved, member);
             self.member_probe_depth -= 1;
+            // A nested inference variable can already have enough evidence
+            // to resolve even though the receiver's class head was known
+            // (`Probe.new(1)` initially returns `Probe<?T>`). Keep the first
+            // pass non-committal so conditional impl probing can constrain the
+            // receiver, but after the ordinary lookup tiers miss, force the evidence
+            // we have and retry. Otherwise the `has_infer` cascade guard below
+            // permanently suppresses E0007 even though finalization later
+            // records a fully-ground `Probe<int>` receiver.
+            if field.has_error() && resolved.has_infer() {
+                let forced = self.force_occurring_vars(&resolved);
+                if forced != resolved {
+                    return self.member_callee(call, member_expr, &forced, member);
+                }
+            }
             // `recv.to_json()` is language sugar for `baml.json.from(recv)`
             // (universal serialization; TIR's builder lowers the call the
             // same way). It is a FALLBACK tier: an `implements baml.ToJson`

--- a/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/inference.rs
@@ -158,6 +158,144 @@ fn unresolved_field() {
 }
 
 #[test]
+fn unresolved_method_on_inferred_generic_factory_result() {
+    let mut db = make_db();
+    let source = r#"
+class Probe<T> {
+  value T
+
+  function new(value: T) -> Probe<T> {
+    Probe<T> { value }
+  }
+
+  function get(self) -> T {
+    self.value
+  }
+}
+
+function inferred_missing() -> int {
+  Probe.new(1).zzz_probe_delta()
+}
+"#;
+    let file = db.add_file("test.baml", source);
+
+    let output = render_tir(&db, file);
+    assert!(
+        output.contains("type `Probe<int>` has no member `zzz_probe_delta`"),
+        "an inferred generic receiver must report its missing member:\n{output}"
+    );
+    assert_span_aware_e0007(&db, source, "zzz_probe_delta");
+}
+
+#[test]
+fn unresolved_method_on_explicit_generic_receiver() {
+    let mut db = make_db();
+    let source = r#"
+class Probe<T> {
+  value T
+
+  function new(value: T) -> Probe<T> {
+    Probe<T> { value }
+  }
+}
+
+function explicit_missing() -> int {
+  Probe<int>.new(1).zzz_probe_delta()
+}
+"#;
+    let file = db.add_file("test.baml", source);
+
+    let output = render_tir(&db, file);
+    assert!(
+        output.contains("type `Probe<int>` has no member `zzz_probe_delta`"),
+        "an explicit generic receiver must keep the normal missing-member diagnostic:\n{output}"
+    );
+    assert_span_aware_e0007(&db, source, "zzz_probe_delta");
+}
+
+#[test]
+fn unresolved_method_on_stdlib_inferred_generic_factory_results() {
+    for (source, member) in [
+        (
+            "function repeat_missing() -> int { baml.iter.Repeat.new(7).zzz_probe_repeat() }",
+            "zzz_probe_repeat",
+        ),
+        (
+            "function iterator_missing() -> int { baml.iter.ArrayIterator.new([1, 2]).zzz_probe_iterator() }",
+            "zzz_probe_iterator",
+        ),
+    ] {
+        let mut db = make_db();
+        let file = db.add_file("test.baml", source);
+        let output = render_tir(&db, file);
+        assert!(
+            output.contains(&format!("has no member `{member}`")),
+            "a stdlib inferred generic receiver must report its missing member:\n{output}"
+        );
+        assert_span_aware_e0007(&db, source, member);
+    }
+}
+
+#[test]
+fn valid_method_on_inferred_generic_factory_result() {
+    let mut db = make_db();
+    let file = db.add_file(
+        "test.baml",
+        r#"
+class Probe<T> {
+  value T
+
+  function new(value: T) -> Probe<T> {
+    Probe<T> { value }
+  }
+
+  function get(self) -> T {
+    self.value
+  }
+}
+
+function inferred_valid() -> int {
+  Probe.new(1).get()
+}
+"#,
+    );
+
+    let output = render_tir(&db, file);
+    assert!(
+        output.contains("Probe.new(1).get() : int"),
+        "a valid method must keep resolving on an inferred generic receiver:\n{output}"
+    );
+    assert!(!output.contains("!!"), "unexpected diagnostics:\n{output}");
+}
+
+fn assert_span_aware_e0007(db: &baml_project::ProjectDatabase, source: &str, member: &str) {
+    let diagnostics = baml_project::collect_compiler2_diagnostics(db);
+    let matching = diagnostics
+        .iter()
+        .filter(|diagnostic| {
+            diagnostic.id == baml_compiler_diagnostics::DiagnosticId::NoSuchField
+                && diagnostic.message.contains(member)
+        })
+        .collect::<Vec<_>>();
+    assert_eq!(
+        matching.len(),
+        1,
+        "expected exactly one E0007 for {member}: {diagnostics:#?}"
+    );
+    assert_eq!(matching[0].code(), "E0007");
+    let span = matching[0]
+        .primary_span()
+        .expect("E0007 must retain its source span");
+    let start = usize::from(span.range.start());
+    let end = usize::from(span.range.end());
+    assert!(
+        source[start..end].contains(member),
+        "E0007 span must cover the missing member: {:?}",
+        &source[start..end]
+    );
+}
+
+#[test]
 fn unresolved_field_chained_access() {
     // Test: in `data.inner.foo`, if `inner` doesn't exist on the class,
     // the squiggly should only cover "inner", not "data.inner".


### PR DESCRIPTION
## Summary

- Retry call-site member resolution after ordinary lookup misses when nested receiver inference variables already have enough evidence to become concrete.
- Preserve the noncommittal conditional-impl probe first, so valid generic factory/member calls keep their existing behavior.
- Add span-aware E0007 regressions for inferred and explicit user-defined generic receivers, inferred stdlib `Repeat` and `ArrayIterator` receivers, and a valid inferred generic method control.

## Root cause

`Probe.new(1)` initially produces `Probe<?T>` while the argument constraint `1 <: ?T` is pending. Call member resolution knew the class head but left the nested variable unresolved; after all lookup tiers missed, the `has_infer` cascade guard suppressed E0007. Finalization later grounded the receiver to `Probe<int>`, leaving MIR to encounter an impossible unknown field and emit the internal compiler error. The fix commits already-sufficient nested inference evidence at the call-resolution miss point and retries normal lookup, so the existing span-aware E0007 path owns the error before MIR.

## Relationship to #4468

This does not share the root cause of #4468. #4468 was fixed by #4490 and involved stale syntactic union/projection canonicalization plus a for-loop inference verdict/report mismatch. #4506 is an earlier member-call diagnostic deferral hole on a structured receiver containing nested inference variables, so this PR remains focused on that invariant.

## Validation

- `cargo test -p baml_compiler2_hir_ty --lib`
- `cargo test -p baml_tests --lib compiler2_tir`
- Focused inferred, explicit, stdlib, valid-member, and LSP iterator inference controls
- `mise run fmt`
- `mise run clippy`
- `mise run clippy-wasm`
- `cargo insta test --test-runner nextest -p baml_tests -p baml_cli -p baml_lsp2_actions_tests --all-features --unreferenced=reject` (2,969 passed; the sole shared-temp generator collision passed when rerun with an isolated `TMPDIR`)

Fixes #4506

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved member and method resolution when receiver types are inferred or generic.
  * Missing-method diagnostics now appear reliably once types become concrete.
  * Prevented duplicate diagnostics while preserving valid method resolution.

* **Tests**
  * Added coverage for inferred and explicit generic receivers, including standard-library factory results.
  * Verified accurate diagnostic codes, source spans, and missing-member reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->