### PR TITLE
ci: bump ix-runners to 2b432e5b (seed-integrity fixes)

### DIFF
--- a/.github/workflows/ix-runners.yml
+++ b/.github/workflows/ix-runners.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Reconcile
         if: steps.optin.outputs.ok == 'true'
-        uses: indexable-inc/ix-runners@768d545e0cce8c62f2ce2005f2da3ec904775e35
+        uses: indexable-inc/ix-runners@2b432e5b609ec2418277ce10dd5f593d288bd2ca
         with:
           ix-token: ${{ secrets.IX_TOKEN }}
           token-source: ix


### PR DESCRIPTION
Bumps the ix-runners action pin 768d545e -> 2b432e5b (indexable-inc/ix-runners#39).

What the new pin fixes, all hit live on this repo's runner pool overnight (2026-08-20 00:07-06:30 UTC):
- promote no longer adopts a snapshot that predates the winner's green job: a forked runner is born with a ready 'birth' snapshot that is never warm-restorable, and the old pin deterministically promoted it into the lineage seed whenever a fork-descended runner won - wedging the lane with 'snapshot has no captured block-volume root' spawn refusals every tick (sdk-tests queued 3+ hours tonight).
- a seed whose snapshot the platform refuses as not restorable is now retired automatically (cold boots + re-seed next green run) instead of retrying forever.
- fixes leaked machine handles in the spawn-failure path ('unclosed Machine' warnings).

Operational note: seeds key on the action rev, so this bump re-seeds every lane from its next green canary run - one-time cold boots, then warm forks resume.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the runner reconciliation workflow to use a newer verified action version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->