### PR TITLE
fix: prove stack-carried locals by predecessor coverage

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -28,7 +28,7 @@ use crate::stack_carry;
 // ============================================================================
 
 /// A reference to either a statement or a terminator within a block.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum StatementRef {
     /// A statement at the given index.
     Statement(usize),
@@ -1076,14 +1076,8 @@ fn classify_locals(
             } else {
                 LocalClassification::Virtual
             }
-        } else if is_phi_like(local, du, body, predecessors, def_use) {
+        } else if is_stack_covered_phi(local, du, body, predecessors) {
             // Stack-carry candidate validated in a later stack simulation pass.
-            stack_carry_candidates.insert(local, stack_carry::StackCarryKind::PhiLike);
-            LocalClassification::Real
-        } else if is_short_circuit_phi(local, du, body) {
-            // ShortCircuit destination: the JumpIfFalse keeps lhs on TOS on the
-            // short-circuit path, and the rhs block leaves its result on TOS.
-            // Treated like PhiLike — value stays on the stack, no store/load.
             stack_carry_candidates.insert(local, stack_carry::StackCarryKind::PhiLike);
             LocalClassification::Real
         } else if is_return_phi(local, body, def_use, redirect_targets) {
@@ -1115,120 +1109,157 @@ fn classify_locals(
     (classifications, copy_sources)
 }
 
-/// Check if a local is "phi-like": assigned in each predecessor of a join block,
-/// used exactly once at that join block.
+/// Check if a local is "phi-like": every path into its single use leaves the
+/// local's value on top of the operand stack, so the emitter can drop the
+/// `StoreVar`/`LoadVar` pair and let the value ride the CFG edge instead.
 ///
-/// Phi-like locals can skip Store/Load because:
-/// - Each predecessor leaves the value on the stack
-/// - At the join point, the value is already on top of the stack
-/// - No need for explicit Store/Load through a named variable
-fn is_phi_like(
+/// This predicate is the *entire* soundness proof for `StackCarryKind::PhiLike`.
+/// The stack simulation in [`crate::stack_carry`] starts AT the use block and
+/// only validates that block's own statement prefix — it never inspects the
+/// local's definitions, nor the use block's predecessors. So every def this
+/// function accepts is emitted as a push with no store, and the use pops
+/// exactly one value: an uncovered incoming edge leaves the pop consuming an
+/// unrelated value, and a definition off the covered paths leaves a push that
+/// nothing pops. Inside a loop the latter grows the operand stack every
+/// iteration.
+///
+/// A local qualifies when all of:
+///
+/// 1. It has exactly one use, in block `U`.
+/// 2. `U` is a join — at least two predecessors. Single-predecessor edges are a
+///    different shape and deliberately out of scope here.
+/// 3. Every predecessor covers the block it flows into, per
+///    [`predecessors_cover_block`].
+/// 4. Every definition of the local was recorded while proving (3); any other
+///    definition is a stray push.
+///
+/// Checking only that a `ShortCircuit` terminator's `join` equals `U` is not a
+/// substitute for (3): `merge_passthrough_blocks` in `baml_compiler2_mir`
+/// rewrites a `ShortCircuit`'s `join` when the original join block is an empty
+/// passthrough, and can retarget it onto a block that has unrelated incoming
+/// edges. `let x = false; if (c) { x = a && b } x` ends up with the `if` join as
+/// both the `ShortCircuit` join and the use block, while its other predecessor
+/// is the `Branch` false edge, which pushes nothing.
+fn is_stack_covered_phi(
     local: Local,
     du: &LocalDefUse,
     body: &MirFunctionBody,
     predecessors: &HashMap<BlockId, Vec<BlockId>>,
-    def_use: &HashMap<Local, LocalDefUse>,
 ) -> bool {
-    // Must have exactly one use
-    if du.uses.len() != 1 {
+    if du.uses.len() != 1 || du.all_defs.is_empty() {
         return false;
     }
 
-    let use_loc = &du.uses[0];
-    let use_block = use_loc.block;
+    let use_block = du.uses[0].block;
 
-    // Get predecessors of the use block
-    let preds = match predecessors.get(&use_block) {
-        Some(p) if !p.is_empty() => p,
-        _ => return false,
+    if predecessors
+        .get(&use_block)
+        .is_none_or(|preds| preds.len() < 2)
+    {
+        return false;
+    }
+
+    let mut visited = HashSet::new();
+    let mut covered_defs = HashSet::new();
+    if !predecessors_cover_block(
+        local,
+        use_block,
+        body,
+        predecessors,
+        &mut visited,
+        &mut covered_defs,
+    ) {
+        return false;
+    }
+
+    // No stray defs: everything that writes the local must be one of the pushes
+    // the coverage walk accounted for.
+    du.all_defs.iter().all(|def| covered_defs.contains(def))
+}
+
+/// Prove that control cannot reach `block` without the local's value on top of
+/// the operand stack, recording the definitions that put it there.
+///
+/// Each predecessor must do one of:
+///
+/// a. End in `Goto { target: block }` with its last statement assigning the
+///    local — under `PhiLike` the emitter emits the rvalue and skips the store,
+///    so the value is left on the stack.
+/// b. End in `ShortCircuit { destination: local, join: block, .. }` — the
+///    `JumpIfFalse` peek leaves the LHS on the stack on the short-circuit edge.
+/// c. Be a statement-free block ending in `Goto { target: block }` whose own
+///    predecessors all cover it. The intermediate joins of a chain such as
+///    `a && b && c` have this shape.
+///
+/// `visited` rejects back-edges: a block reachable from itself would need a push
+/// per trip to stay balanced, which this shape cannot prove.
+///
+/// A predecessor that defines the local from a call-like terminator and
+/// continues at `block` also leaves the result on the stack, but it is not
+/// accepted here: `is_call_result_immediate` documents that the carry path is
+/// not wired for every call terminator, so proving that edge needs its own
+/// argument rather than a fourth arm bolted onto this one. Locals with such a
+/// predecessor stay in a slot — correct, one store/load short of optimal.
+fn predecessors_cover_block(
+    local: Local,
+    block: BlockId,
+    body: &MirFunctionBody,
+    predecessors: &HashMap<BlockId, Vec<BlockId>>,
+    visited: &mut HashSet<BlockId>,
+    covered_defs: &mut HashSet<(BlockId, StatementRef)>,
+) -> bool {
+    if !visited.insert(block) {
+        return false;
+    }
+
+    let Some(preds) = predecessors.get(&block).filter(|preds| !preds.is_empty()) else {
+        return false;
     };
 
-    // Need at least 2 predecessors for this to be a join point
-    if preds.len() < 2 {
-        return false;
-    }
-
-    // Get all definitions of this local
-    let defs = &def_use[&local].all_defs;
-    if defs.is_empty() {
-        return false;
-    }
-
-    // Check that each predecessor:
-    // 1. Defines this local
-    // 2. The definition is the last statement in the block
-    // 3. The block ends with Goto to the use block
     for &pred_id in preds {
-        let pred_block = body.block(pred_id);
+        let pred = body.block(pred_id);
 
-        // Must end with Goto to use_block
-        let goes_to_use_block = matches!(
-            &pred_block.terminator,
-            Some(Terminator::Goto { target }) if *target == use_block
+        if let Some(Terminator::ShortCircuit {
+            destination: Place::Local(destination),
+            join,
+            ..
+        }) = &pred.terminator
+            && *destination == local
+            && *join == block
+        {
+            covered_defs.insert((pred_id, StatementRef::Terminator));
+            continue;
+        }
+
+        let goes_to_block = matches!(
+            &pred.terminator,
+            Some(Terminator::Goto { target }) if *target == block
         );
-        if !goes_to_use_block {
+        if !goes_to_block {
             return false;
         }
 
-        // Must have at least one statement
-        if pred_block.statements.is_empty() {
-            return false;
-        }
-
-        // Last statement must be an assignment to this local
-        let last_stmt_idx = pred_block.statements.len() - 1;
-        let last_stmt = &pred_block.statements[last_stmt_idx];
+        let Some(last) = pred.statements.last() else {
+            // Empty passthrough — push the proof up to its own predecessors.
+            if !predecessors_cover_block(local, pred_id, body, predecessors, visited, covered_defs)
+            {
+                return false;
+            }
+            continue;
+        };
 
         let assigns_local = matches!(
-            &last_stmt.kind,
+            &last.kind,
             StatementKind::Assign { destination: Place::Local(l), .. } if *l == local
         );
         if !assigns_local {
             return false;
         }
 
-        // Verify this definition is in our defs list
-        let has_def = defs
-            .iter()
-            .any(|&(b, s)| b == pred_id && s == StatementRef::Statement(last_stmt_idx));
-        if !has_def {
-            return false;
-        }
+        covered_defs.insert((pred_id, StatementRef::Statement(pred.statements.len() - 1)));
     }
 
     true
-}
-
-/// Check if a local is the destination of a `ShortCircuit` terminator and has
-/// exactly one use in the join block. The `JumpIfFalse` peek instruction keeps
-/// the LHS on TOS for the short-circuit path, while the rhs block leaves its
-/// result on TOS. At the join, the value is on TOS from whichever path ran.
-fn is_short_circuit_phi(local: Local, du: &LocalDefUse, body: &MirFunctionBody) -> bool {
-    if du.uses.len() != 1 {
-        return false;
-    }
-
-    let use_block = du.uses[0].block;
-
-    // `_0` is the return place; all other named locals are source variables
-    // and may be reassigned. Keep them in slots rather than stack-carrying a
-    // value across control-flow edges. This mirrors MIR copy propagation,
-    // which only optimizes unnamed compiler temporaries for the same reason.
-    if local != Local(0) && body.local(local).name.is_some() {
-        return false;
-    }
-
-    du.all_defs.iter().any(|&(block_id, statement_ref)| {
-        statement_ref == StatementRef::Terminator
-            && matches!(
-                &body.block(block_id).terminator,
-                Some(Terminator::ShortCircuit {
-                    destination: Place::Local(destination),
-                    join,
-                    ..
-                }) if *destination == local && *join == use_block
-            )
-    })
 }
 
 /// Check if a MIR statement is stack-neutral (doesn't push or pop from the eval stack).
@@ -2374,21 +2405,17 @@ mod tests {
         }
     }
 
+    /// `a && b && c`: two chained `ShortCircuit` terminators whose inner join
+    /// (bb3) is an empty passthrough into the outer join (bb4).
     fn nested_short_circuit_body(
         name: Option<&str>,
         with_prior_definition: bool,
     ) -> MirFunctionBody {
         let destination = Local(1);
-        let prior_definition = with_prior_definition.then_some(Statement {
-            kind: StatementKind::Assign {
-                destination: Place::Local(destination),
-                value: Rvalue::Use(Operand::Constant(Constant::Bool(false))),
-            },
-            span: None,
-        });
+        let prior_definition = with_prior_definition.then(|| assign_bool(destination, false));
 
-        MirFunctionBody {
-            blocks: vec![
+        bool_body(
+            vec![
                 BasicBlock {
                     id: BlockId(0),
                     statements: prior_definition.into_iter().collect(),
@@ -2417,13 +2444,7 @@ mod tests {
                 },
                 BasicBlock {
                     id: BlockId(2),
-                    statements: vec![Statement {
-                        kind: StatementKind::Assign {
-                            destination: Place::Local(destination),
-                            value: Rvalue::Use(Operand::Constant(Constant::Bool(true))),
-                        },
-                        span: None,
-                    }],
+                    statements: vec![assign_bool(destination, true)],
                     terminator: Some(Terminator::Goto { target: BlockId(3) }),
                     span: None,
                     terminator_span: None,
@@ -2435,68 +2456,255 @@ mod tests {
                     span: None,
                     terminator_span: None,
                 },
-                BasicBlock {
-                    id: BlockId(4),
-                    statements: vec![Statement {
-                        kind: StatementKind::Assign {
-                            destination: Place::Local(Local(0)),
-                            value: Rvalue::Use(Operand::copy_local(destination)),
-                        },
-                        span: None,
-                    }],
-                    terminator: Some(Terminator::Return),
-                    span: None,
-                    terminator_span: None,
-                },
+                return_local_block(BlockId(4), destination),
             ],
+            name,
+        )
+    }
+
+    fn bool_local_decl(name: Option<&str>) -> LocalDecl {
+        LocalDecl {
+            name: name.map(baml_base::Name::new),
+            ty: RuntimeTy::Bool {
+                attr: TyAttr::default(),
+            },
+            span: None,
+            scope_span: None,
+            is_captured: false,
+        }
+    }
+
+    fn assign_bool(destination: Local, value: bool) -> Statement {
+        Statement {
+            kind: StatementKind::Assign {
+                destination: Place::Local(destination),
+                value: Rvalue::Use(Operand::Constant(Constant::Bool(value))),
+            },
+            span: None,
+        }
+    }
+
+    /// `_0 = copy destination; return` — the single use of the carried local.
+    fn return_local_block(id: BlockId, destination: Local) -> BasicBlock {
+        BasicBlock {
+            id,
+            statements: vec![Statement {
+                kind: StatementKind::Assign {
+                    destination: Place::Local(Local(0)),
+                    value: Rvalue::Use(Operand::copy_local(destination)),
+                },
+                span: None,
+            }],
+            terminator: Some(Terminator::Return),
+            span: None,
+            terminator_span: None,
+        }
+    }
+
+    fn bool_body(blocks: Vec<BasicBlock>, name: Option<&str>) -> MirFunctionBody {
+        MirFunctionBody {
+            blocks,
             entry: BlockId(0),
-            locals: vec![
-                LocalDecl {
-                    name: None,
-                    ty: RuntimeTy::Bool {
-                        attr: TyAttr::default(),
-                    },
-                    span: None,
-                    scope_span: None,
-                    is_captured: false,
-                },
-                LocalDecl {
-                    name: name.map(baml_base::Name::new),
-                    ty: RuntimeTy::Bool {
-                        attr: TyAttr::default(),
-                    },
-                    span: None,
-                    scope_span: None,
-                    is_captured: false,
-                },
-            ],
+            locals: vec![bool_local_decl(None), bool_local_decl(name)],
             catch_regions: vec![],
             viz_nodes: vec![],
         }
     }
 
-    #[test]
-    fn nested_short_circuit_definitions_are_stack_carried() {
-        let body = nested_short_circuit_body(None, false);
-        let def_use = collect_def_use(&body);
+    fn is_stack_covered(body: &MirFunctionBody, local: Local) -> bool {
+        let def_use = collect_def_use(body);
+        let predecessors = build_predecessors(body);
 
-        assert!(is_short_circuit_phi(Local(1), &def_use[&Local(1)], &body));
+        is_stack_covered_phi(local, &def_use[&local], body, &predecessors)
     }
 
     #[test]
-    fn named_short_circuit_local_is_materialized() {
-        let body = nested_short_circuit_body(Some("result"), false);
-        let def_use = collect_def_use(&body);
+    fn nested_short_circuit_definitions_are_stack_carried() {
+        let body = nested_short_circuit_body(None, false);
 
-        assert!(!is_short_circuit_phi(Local(1), &def_use[&Local(1)], &body));
+        assert!(is_stack_covered(&body, Local(1)));
+    }
+
+    /// A user-named local is not special: what matters is that every edge into
+    /// the use block pushes its value, and that nothing else defines it.
+    #[test]
+    fn named_short_circuit_local_is_stack_carried() {
+        let body = nested_short_circuit_body(Some("result"), false);
+
+        assert!(is_stack_covered(&body, Local(1)));
     }
 
     #[test]
     fn reassigned_named_short_circuit_local_is_materialized() {
         let body = nested_short_circuit_body(Some("result"), true);
-        let def_use = collect_def_use(&body);
 
-        assert!(!is_short_circuit_phi(Local(1), &def_use[&Local(1)], &body));
+        assert!(!is_stack_covered(&body, Local(1)));
+    }
+
+    /// The stray initializer is just as unbalanced when the local is a compiler
+    /// temp, so the name plays no part in rejecting it.
+    #[test]
+    fn reassigned_unnamed_short_circuit_local_is_materialized() {
+        let body = nested_short_circuit_body(None, true);
+
+        assert!(!is_stack_covered(&body, Local(1)));
+    }
+
+    /// `let x = false; if (c) { x = a && b } x` — MIR merges the short circuit's
+    /// own join into the `if` join, so the `ShortCircuit`'s `join` really is the
+    /// use block. The `Branch` false edge still reaches that block without
+    /// pushing anything, so the local has to stay in its slot.
+    fn merged_join_body(name: Option<&str>) -> MirFunctionBody {
+        let destination = Local(1);
+
+        bool_body(
+            vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    statements: vec![],
+                    terminator: Some(Terminator::Branch {
+                        condition: Operand::Constant(Constant::Bool(true)),
+                        then_block: BlockId(1),
+                        else_block: BlockId(3),
+                    }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    statements: vec![],
+                    terminator: Some(Terminator::ShortCircuit {
+                        operand: Operand::Constant(Constant::Bool(true)),
+                        is_and: true,
+                        destination: Place::Local(destination),
+                        eval_rhs: BlockId(2),
+                        join: BlockId(3),
+                    }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(2),
+                    statements: vec![assign_bool(destination, true)],
+                    terminator: Some(Terminator::Goto { target: BlockId(3) }),
+                    span: None,
+                    terminator_span: None,
+                },
+                return_local_block(BlockId(3), destination),
+            ],
+            name,
+        )
+    }
+
+    #[test]
+    fn short_circuit_join_shared_with_a_branch_edge_is_materialized() {
+        assert!(!is_stack_covered(&merged_join_body(Some("x")), Local(1)));
+        assert!(!is_stack_covered(&merged_join_body(None), Local(1)));
+    }
+
+    /// One predecessor short-circuits into the join, the other assigns and
+    /// falls through. Neither of the two predicates this replaced accepted the
+    /// mix on its own.
+    #[test]
+    fn mixed_short_circuit_and_assignment_predecessors_are_stack_carried() {
+        let destination = Local(1);
+        let body = bool_body(
+            vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    statements: vec![],
+                    terminator: Some(Terminator::Branch {
+                        condition: Operand::Constant(Constant::Bool(true)),
+                        then_block: BlockId(1),
+                        else_block: BlockId(3),
+                    }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    statements: vec![],
+                    terminator: Some(Terminator::ShortCircuit {
+                        operand: Operand::Constant(Constant::Bool(true)),
+                        is_and: true,
+                        destination: Place::Local(destination),
+                        eval_rhs: BlockId(2),
+                        join: BlockId(4),
+                    }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(2),
+                    statements: vec![assign_bool(destination, true)],
+                    terminator: Some(Terminator::Goto { target: BlockId(4) }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(3),
+                    statements: vec![assign_bool(destination, false)],
+                    terminator: Some(Terminator::Goto { target: BlockId(4) }),
+                    span: None,
+                    terminator_span: None,
+                },
+                return_local_block(BlockId(4), destination),
+            ],
+            Some("x"),
+        );
+
+        assert!(is_stack_covered(&body, Local(1)));
+    }
+
+    /// The classic phi-like diamond: both arms assign and fall through.
+    fn diamond_body(with_prior_definition: bool) -> MirFunctionBody {
+        let destination = Local(1);
+        let prior_definition = with_prior_definition.then(|| assign_bool(destination, false));
+
+        bool_body(
+            vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    statements: prior_definition.into_iter().collect(),
+                    terminator: Some(Terminator::Branch {
+                        condition: Operand::Constant(Constant::Bool(true)),
+                        then_block: BlockId(1),
+                        else_block: BlockId(2),
+                    }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    statements: vec![assign_bool(destination, true)],
+                    terminator: Some(Terminator::Goto { target: BlockId(3) }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(2),
+                    statements: vec![assign_bool(destination, false)],
+                    terminator: Some(Terminator::Goto { target: BlockId(3) }),
+                    span: None,
+                    terminator_span: None,
+                },
+                return_local_block(BlockId(3), destination),
+            ],
+            Some("x"),
+        )
+    }
+
+    #[test]
+    fn assignment_in_every_predecessor_is_stack_carried() {
+        assert!(is_stack_covered(&diamond_body(false), Local(1)));
+    }
+
+    /// `let x = 0; if (c) { x = 1 } else { x = 2 }; use(x)` — the initializer is
+    /// emitted as a push that nothing pops, so inside a loop it grew the operand
+    /// stack once per iteration.
+    #[test]
+    fn diamond_with_a_definition_outside_the_predecessors_is_materialized() {
+        assert!(!is_stack_covered(&diamond_body(true), Local(1)));
     }
 
     /// A single static use in a CFG cycle represents repeated dynamic uses.

--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -1190,16 +1190,13 @@ fn is_stack_covered_phi(
 /// c. Be a statement-free block ending in `Goto { target: block }` whose own
 ///    predecessors all cover it. The intermediate joins of a chain such as
 ///    `a && b && c` have this shape.
+/// d. End in a call terminator that defines the local and returns into `block`
+///    — see [`call_result_carried_into`]. `a || b.starts_with(c)` lowers the rhs
+///    this way, so without this arm every short circuit over a call keeps its
+///    destination in a slot.
 ///
 /// `visited` rejects back-edges: a block reachable from itself would need a push
 /// per trip to stay balanced, which this shape cannot prove.
-///
-/// A predecessor that defines the local from a call-like terminator and
-/// continues at `block` also leaves the result on the stack, but it is not
-/// accepted here: `is_call_result_immediate` documents that the carry path is
-/// not wired for every call terminator, so proving that edge needs its own
-/// argument rather than a fourth arm bolted onto this one. Locals with such a
-/// predecessor stay in a slot — correct, one store/load short of optimal.
 fn predecessors_cover_block(
     local: Local,
     block: BlockId,
@@ -1227,6 +1224,11 @@ fn predecessors_cover_block(
             && *destination == local
             && *join == block
         {
+            covered_defs.insert((pred_id, StatementRef::Terminator));
+            continue;
+        }
+
+        if call_result_carried_into(pred.terminator.as_ref(), block) == Some(local) {
             covered_defs.insert((pred_id, StatementRef::Terminator));
             continue;
         }
@@ -1260,6 +1262,62 @@ fn predecessors_cover_block(
     }
 
     true
+}
+
+/// The local a call terminator leaves on top of the operand stack in `block`,
+/// when the call's result is stack-carried rather than stored.
+///
+/// `Call` and `VirtualCall` both emit as `<call opcode>`, then
+/// `emit_store_place(destination)` — a no-op for a stack-carried destination —
+/// then the jump to `target`. So control arrives at `target` with the call's one
+/// result on top, exactly like a predecessor that assigns and falls through.
+///
+/// The other call-shaped terminators are deliberately not here:
+///
+/// - `Await` and `AwaitAny` suspend the engine, and the note on
+///   `is_call_result_immediate` records that their opcodes rewind and
+///   re-execute across that suspend.
+/// - `SysOp` also suspends, and its dispatch asserts that the arguments are the
+///   whole of the frame's operand stack.
+/// - `Spawn` defines the spawned future rather than a call result, and
+///   continues at `resume`.
+///
+/// None of those covers a join anywhere in the corpus, so allowing them would be
+/// speculation instead of a proof.
+///
+/// `is_call_result_immediate` also excludes `VirtualCall`, but for a reason that
+/// does not apply here: that exclusion exists because the `CallResultImmediate`
+/// stack simulation has to recognize the *defining* terminator to know which
+/// block to start simulating from, and its match has no `VirtualCall` arm. The
+/// `PhiLike` simulation starts at the use block and never looks at the def.
+fn call_result_carried_into(terminator: Option<&Terminator>, block: BlockId) -> Option<Local> {
+    let (Terminator::Call {
+        destination,
+        target,
+        unwind,
+        ..
+    }
+    | Terminator::VirtualCall {
+        destination,
+        target,
+        unwind,
+        ..
+    }) = terminator?
+    else {
+        return None;
+    };
+
+    // A call that unwinds into `block` also reaches it on the throwing edge,
+    // where nothing was pushed. `Terminator::successors` reports both edges, so
+    // without this the same predecessor would be counted as covering twice.
+    if *target != block || *unwind == Some(block) {
+        return None;
+    }
+
+    match destination {
+        Place::Local(local) => Some(*local),
+        _ => None,
+    }
 }
 
 /// Check if a MIR statement is stack-neutral (doesn't push or pop from the eval stack).
@@ -2654,6 +2712,112 @@ mod tests {
         );
 
         assert!(is_stack_covered(&body, Local(1)));
+    }
+
+    /// `a && f(b)`: the short circuit joins at bb2, and the rhs block reaches
+    /// that same join through `rhs`, a terminator that defines the destination.
+    fn short_circuit_over_call_body(name: Option<&str>, rhs: Terminator) -> MirFunctionBody {
+        let destination = Local(1);
+
+        bool_body(
+            vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    statements: vec![],
+                    terminator: Some(Terminator::ShortCircuit {
+                        operand: Operand::Constant(Constant::Bool(true)),
+                        is_and: true,
+                        destination: Place::Local(destination),
+                        eval_rhs: BlockId(1),
+                        join: BlockId(2),
+                    }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    statements: vec![],
+                    terminator: Some(rhs),
+                    span: None,
+                    terminator_span: None,
+                },
+                return_local_block(BlockId(2), destination),
+            ],
+            name,
+        )
+    }
+
+    fn call_into(target: BlockId, unwind: Option<BlockId>) -> Terminator {
+        Terminator::Call {
+            callee: Operand::Constant(Constant::Null),
+            args: vec![],
+            ntypeargs: 0,
+            runtime_type_check: false,
+            runtime_id: None,
+            destination: Place::Local(Local(1)),
+            target,
+            unwind,
+        }
+    }
+
+    fn virtual_call_into(target: BlockId) -> Terminator {
+        Terminator::VirtualCall {
+            iface: baml_type::TyTemplateInterface::new(
+                baml_type::TypeName::from_dotted_path("baml.ops.Equals"),
+                Vec::new(),
+                Vec::new(),
+            ),
+            method: "eq".to_string(),
+            args: vec![],
+            ntypeargs: 0,
+            runtime_type_check: false,
+            runtime_id: None,
+            destination: Place::Local(Local(1)),
+            target,
+            unwind: None,
+        }
+    }
+
+    /// `a && f(b)` and `a && (b == c)`: the call opcode leaves its result on the
+    /// stack and jumps to the join, exactly like an assignment that falls
+    /// through. Both are common enough that materializing them would cost the
+    /// stdlib's comparison operators a store/load pair.
+    #[test]
+    fn short_circuit_joining_a_call_result_is_stack_carried() {
+        for name in [None, Some("ok")] {
+            let call = short_circuit_over_call_body(name, call_into(BlockId(2), None));
+            assert!(is_stack_covered(&call, Local(1)));
+
+            let virtual_call = short_circuit_over_call_body(name, virtual_call_into(BlockId(2)));
+            assert!(is_stack_covered(&virtual_call, Local(1)));
+        }
+    }
+
+    /// The throwing edge reaches the join without the call ever pushing a
+    /// result, so the join cannot assume anything is on the stack.
+    #[test]
+    fn call_that_unwinds_into_the_join_is_materialized() {
+        let body = short_circuit_over_call_body(None, call_into(BlockId(2), Some(BlockId(2))));
+
+        assert!(!is_stack_covered(&body, Local(1)));
+    }
+
+    /// `Await` suspends the engine and its opcode re-executes across the
+    /// suspend, so its result is not carried even though it lands on the stack
+    /// the same way a call's does.
+    #[test]
+    fn awaited_result_in_the_join_is_materialized() {
+        let body = short_circuit_over_call_body(
+            None,
+            Terminator::Await {
+                future: Place::Local(Local(0)),
+                destination: Place::Local(Local(1)),
+                target: BlockId(2),
+                unwind: None,
+            },
+        );
+
+        assert!(!is_stack_covered(&body, Local(1)));
     }
 
     /// The classic phi-like diamond: both arms assign and fall through.

--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -1208,12 +1208,25 @@ fn is_short_circuit_phi(local: Local, du: &LocalDefUse, body: &MirFunctionBody) 
         return false;
     }
 
-    // One of the defs must be a ShortCircuit terminator targeting this local.
-    du.all_defs.iter().any(|&(block_id, ref stmt_ref)| {
-        *stmt_ref == StatementRef::Terminator
+    let use_block = du.uses[0].block;
+
+    // `_0` is the return place; all other named locals are source variables
+    // and may be reassigned. Keep them in slots rather than stack-carrying a
+    // value across control-flow edges. This mirrors MIR copy propagation,
+    // which only optimizes unnamed compiler temporaries for the same reason.
+    if local != Local(0) && body.local(local).name.is_some() {
+        return false;
+    }
+
+    du.all_defs.iter().any(|&(block_id, statement_ref)| {
+        statement_ref == StatementRef::Terminator
             && matches!(
                 &body.block(block_id).terminator,
-                Some(Terminator::ShortCircuit { destination: Place::Local(l), .. }) if *l == local
+                Some(Terminator::ShortCircuit {
+                    destination: Place::Local(destination),
+                    join,
+                    ..
+                }) if *destination == local && *join == use_block
             )
     })
 }
@@ -2359,6 +2372,131 @@ mod tests {
             scope_span: None,
             is_captured: false,
         }
+    }
+
+    fn nested_short_circuit_body(
+        name: Option<&str>,
+        with_prior_definition: bool,
+    ) -> MirFunctionBody {
+        let destination = Local(1);
+        let prior_definition = with_prior_definition.then_some(Statement {
+            kind: StatementKind::Assign {
+                destination: Place::Local(destination),
+                value: Rvalue::Use(Operand::Constant(Constant::Bool(false))),
+            },
+            span: None,
+        });
+
+        MirFunctionBody {
+            blocks: vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    statements: prior_definition.into_iter().collect(),
+                    terminator: Some(Terminator::ShortCircuit {
+                        operand: Operand::Constant(Constant::Bool(true)),
+                        is_and: true,
+                        destination: Place::Local(destination),
+                        eval_rhs: BlockId(1),
+                        join: BlockId(4),
+                    }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    statements: vec![],
+                    terminator: Some(Terminator::ShortCircuit {
+                        operand: Operand::Constant(Constant::Bool(true)),
+                        is_and: true,
+                        destination: Place::Local(destination),
+                        eval_rhs: BlockId(2),
+                        join: BlockId(3),
+                    }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(2),
+                    statements: vec![Statement {
+                        kind: StatementKind::Assign {
+                            destination: Place::Local(destination),
+                            value: Rvalue::Use(Operand::Constant(Constant::Bool(true))),
+                        },
+                        span: None,
+                    }],
+                    terminator: Some(Terminator::Goto { target: BlockId(3) }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(3),
+                    statements: vec![],
+                    terminator: Some(Terminator::Goto { target: BlockId(4) }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(4),
+                    statements: vec![Statement {
+                        kind: StatementKind::Assign {
+                            destination: Place::Local(Local(0)),
+                            value: Rvalue::Use(Operand::copy_local(destination)),
+                        },
+                        span: None,
+                    }],
+                    terminator: Some(Terminator::Return),
+                    span: None,
+                    terminator_span: None,
+                },
+            ],
+            entry: BlockId(0),
+            locals: vec![
+                LocalDecl {
+                    name: None,
+                    ty: RuntimeTy::Bool {
+                        attr: TyAttr::default(),
+                    },
+                    span: None,
+                    scope_span: None,
+                    is_captured: false,
+                },
+                LocalDecl {
+                    name: name.map(baml_base::Name::new),
+                    ty: RuntimeTy::Bool {
+                        attr: TyAttr::default(),
+                    },
+                    span: None,
+                    scope_span: None,
+                    is_captured: false,
+                },
+            ],
+            catch_regions: vec![],
+            viz_nodes: vec![],
+        }
+    }
+
+    #[test]
+    fn nested_short_circuit_definitions_are_stack_carried() {
+        let body = nested_short_circuit_body(None, false);
+        let def_use = collect_def_use(&body);
+
+        assert!(is_short_circuit_phi(Local(1), &def_use[&Local(1)], &body));
+    }
+
+    #[test]
+    fn named_short_circuit_local_is_materialized() {
+        let body = nested_short_circuit_body(Some("result"), false);
+        let def_use = collect_def_use(&body);
+
+        assert!(!is_short_circuit_phi(Local(1), &def_use[&Local(1)], &body));
+    }
+
+    #[test]
+    fn reassigned_named_short_circuit_local_is_materialized() {
+        let body = nested_short_circuit_body(Some("result"), true);
+        let def_use = collect_def_use(&body);
+
+        assert!(!is_short_circuit_phi(Local(1), &def_use[&Local(1)], &body));
     }
 
     /// A single static use in a CFG cycle represents repeated dynamic uses.

--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -1197,6 +1197,9 @@ fn is_stack_covered_phi(
 ///
 /// `visited` rejects back-edges: a block reachable from itself would need a push
 /// per trip to stay balanced, which this shape cannot prove.
+///
+/// Two kinds of block are refused outright, because the predecessor list is not
+/// a complete account of how they are entered — see the guard below.
 fn predecessors_cover_block(
     local: Local,
     block: BlockId,
@@ -1206,6 +1209,31 @@ fn predecessors_cover_block(
     covered_defs: &mut HashSet<(BlockId, StatementRef)>,
 ) -> bool {
     if !visited.insert(block) {
+        return false;
+    }
+
+    // `build_predecessors` is built purely from `Terminator::successors`, so it
+    // only knows about entries that traverse a CFG edge. Two blocks are also
+    // entered without one, and nothing is on the stack when they are:
+    //
+    // - `entry`, on every call of the function. A CFG predecessor set can look
+    //   complete for it if the entry block is also a loop header.
+    // - a catch region's handler, when the VM unwinds into it. A call's
+    //   `unwind` target is a `successors` edge, but a same-frame panic — an
+    //   overflowing `add_int`, a division by zero — reaches the handler from
+    //   the middle of a block, with no edge at all. `compute_rpo` has to seed
+    //   those handlers separately for exactly this reason, and `collect_def_use`
+    //   records the VM's write of the error local there as an implicit use.
+    //
+    // Only the block being *covered* is refused. A handler that is itself a
+    // predecessor stays fine: it reaches its successor over a real edge, having
+    // pushed the value like any other predecessor.
+    if block == body.entry
+        || body
+            .catch_regions
+            .iter()
+            .any(|region| region.handler == block)
+    {
         return false;
     }
 
@@ -2274,7 +2302,8 @@ fn get_copy_source(
 #[cfg(test)]
 mod tests {
     use baml_compiler2_mir::{
-        BasicBlock, Constant, LocalDecl, MirFunctionBody, Operand, Place, Statement, Terminator,
+        BasicBlock, CatchRegion, Constant, LocalDecl, MirFunctionBody, Operand, Place, Statement,
+        Terminator,
     };
     use baml_type::{RuntimeTy, TyAttr};
 
@@ -2816,6 +2845,76 @@ mod tests {
                 unwind: None,
             },
         );
+
+        assert!(!is_stack_covered(&body, Local(1)));
+    }
+
+    /// The entry block is entered on every call without traversing an edge, so
+    /// a predecessor set that looks complete is not. Contrived — a real MIR
+    /// entry block is never a loop header — but it is the shape the guard
+    /// exists for, and nothing else in the predicate would reject it.
+    #[test]
+    fn entry_block_as_the_join_is_materialized() {
+        let destination = Local(1);
+        let body = bool_body(
+            vec![
+                BasicBlock {
+                    id: BlockId(0),
+                    statements: vec![Statement {
+                        kind: StatementKind::Assign {
+                            destination: Place::Local(Local(0)),
+                            value: Rvalue::Use(Operand::copy_local(destination)),
+                        },
+                        span: None,
+                    }],
+                    terminator: Some(Terminator::Branch {
+                        condition: Operand::Constant(Constant::Bool(true)),
+                        then_block: BlockId(1),
+                        else_block: BlockId(2),
+                    }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(1),
+                    statements: vec![assign_bool(destination, true)],
+                    terminator: Some(Terminator::Goto { target: BlockId(0) }),
+                    span: None,
+                    terminator_span: None,
+                },
+                BasicBlock {
+                    id: BlockId(2),
+                    statements: vec![assign_bool(destination, false)],
+                    terminator: Some(Terminator::Goto { target: BlockId(0) }),
+                    span: None,
+                    terminator_span: None,
+                },
+            ],
+            Some("x"),
+        );
+
+        assert!(!is_stack_covered(&body, Local(1)));
+    }
+
+    /// The VM enters a handler on unwind rather than over an edge, so a block
+    /// the walk would otherwise pass through as an empty passthrough cannot be
+    /// proven covered once it is one.
+    #[test]
+    fn catch_handler_inside_the_coverage_walk_is_materialized() {
+        let mut body = nested_short_circuit_body(None, false);
+
+        // bb3 is the chain's inner join, the empty passthrough arm (c) recurses
+        // through. Everything below is unchanged except that it is now a
+        // handler, so the region is the only reason the answer flips.
+        assert!(is_stack_covered(&body, Local(1)));
+
+        body.catch_regions.push(CatchRegion {
+            body_entry: BlockId(0),
+            handler: BlockId(3),
+            handler_body: vec![BlockId(3)],
+            error_local: Local(0),
+            stack_trace_local: None,
+        });
 
         assert!(!is_stack_covered(&body, Local(1)));
     }

--- a/baml_language/crates/baml_compiler2_emit/src/analysis.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/analysis.rs
@@ -2605,11 +2605,19 @@ mod tests {
         is_stack_covered_phi(local, &def_use[&local], body, &predecessors)
     }
 
+    fn analyzed_classification(body: &MirFunctionBody, local: Local) -> LocalClassification {
+        AnalysisResult::analyze(body, 0, OptLevel::One).classifications[&local]
+    }
+
     #[test]
     fn nested_short_circuit_definitions_are_stack_carried() {
         let body = nested_short_circuit_body(None, false);
 
         assert!(is_stack_covered(&body, Local(1)));
+        assert_eq!(
+            analyzed_classification(&body, Local(1)),
+            LocalClassification::PhiLike
+        );
     }
 
     /// A user-named local is not special: what matters is that every edge into
@@ -2619,6 +2627,10 @@ mod tests {
         let body = nested_short_circuit_body(Some("result"), false);
 
         assert!(is_stack_covered(&body, Local(1)));
+        assert_eq!(
+            analyzed_classification(&body, Local(1)),
+            LocalClassification::PhiLike
+        );
     }
 
     #[test]
@@ -2626,6 +2638,10 @@ mod tests {
         let body = nested_short_circuit_body(Some("result"), true);
 
         assert!(!is_stack_covered(&body, Local(1)));
+        assert_eq!(
+            analyzed_classification(&body, Local(1)),
+            LocalClassification::Real
+        );
     }
 
     /// The stray initializer is just as unbalanced when the local is a compiler
@@ -2635,6 +2651,10 @@ mod tests {
         let body = nested_short_circuit_body(None, true);
 
         assert!(!is_stack_covered(&body, Local(1)));
+        assert_eq!(
+            analyzed_classification(&body, Local(1)),
+            LocalClassification::Real
+        );
     }
 
     /// `let x = false; if (c) { x = a && b } x` — MIR merges the short circuit's
@@ -2911,6 +2931,7 @@ mod tests {
         body.catch_regions.push(CatchRegion {
             body_entry: BlockId(0),
             handler: BlockId(3),
+            body_blocks: vec![BlockId(0)],
             handler_body: vec![BlockId(3)],
             error_local: Local(0),
             stack_trace_local: None,

--- a/baml_language/crates/baml_tests/baml_src/ns_fixtures/ns_short_circuit_locals/short_circuit_locals.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_fixtures/ns_short_circuit_locals/short_circuit_locals.baml
@@ -1,0 +1,68 @@
+// Bindings whose value the emitter may leave on the operand stack instead of
+// storing to a slot. Each function pins one shape of the predecessor-coverage
+// rule in baml_compiler2_emit::analysis::is_stack_covered_phi, so the bytecode
+// snapshot is the point of these — a store_var/load_var pair appearing or
+// disappearing here is a classification change.
+
+// Every edge into the use of `ok` pushes its value: the two ShortCircuit
+// terminators, and the trailing assignment in the innermost rhs block. Stack
+// carried, so `ok` gets no store_var/load_var.
+function chained_and(a: bool, b: bool, c: bool) -> bool {
+    let ok = a && b && c;
+    ok
+}
+
+// The short circuit's join is merged into the `if` join, which is also the use
+// block. The false edge of the `if` still reaches that block without pushing
+// anything, and `let x = false` defines `x` a second time, so `x` needs a slot.
+function conditional_short_circuit(a: bool, b: bool, cond: bool) -> bool {
+    let x = false;
+    if (cond) {
+        x = a && b
+    }
+    x
+}
+
+// The same shape inside a loop, where stack-carrying `x` left one extra value
+// on the operand stack per iteration.
+function conditional_short_circuit_in_loop(items: int[], a: bool, b: bool) -> int {
+    let x = false;
+    let hits = 0;
+    for (let i in items) {
+        if (i > 0) {
+            x = a && b
+        }
+        if (x) {
+            hits = hits + 1
+        }
+    }
+    hits
+}
+
+// Both arms assign `x` and fall through to its use, but `let x = 0` defines it
+// once more outside them. Stack-carrying `x` pushed that initializer every
+// iteration with nothing to pop it.
+function initialized_local_in_branch_loop(items: int[]) -> int {
+    let total = 0;
+    for (let i in items) {
+        let x = 0;
+        if (i > 0) {
+            x = 1
+        } else {
+            x = 2
+        }
+        total = x + total
+    }
+    total
+}
+
+// One predecessor of the use is a ShortCircuit joining there, the other a plain
+// assignment: a mix that neither half of the old rule accepted on its own.
+function mixed_join(a: bool, b: bool, cond: bool) -> bool {
+    let x = if (cond) {
+        a && b
+    } else {
+        false
+    };
+    x
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_arrays/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_arrays/bytecode.snap
@@ -1498,7 +1498,6 @@ function arrays.sum_int_overflow_(a: int, b: int) -> int {
     load_type baml.Summable<Sum = int>
     load_const "sum"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L2
     load_var e
     is_type baml.panics.IntegerOverflow
@@ -1511,10 +1510,8 @@ function arrays.sum_int_overflow_(a: int, b: int) -> int {
 
   L1:
     load_const -1
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_comparable_sort/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_comparable_sort/bytecode.snap
@@ -339,15 +339,12 @@ function comparable_sort.Wrap$for$T[].g(self: #0[]) -> int {
     load_type comparable_sort.HasErr
     load_const "f"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L2
 
   L1:
     load_const 0
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_env_ref_clients/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_env_ref_clients/bytecode.snap
@@ -1587,7 +1587,6 @@ function env_ref_clients.resolve_of_a_ref_reads_at_call_time() -> string {
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L2
     load_var e
     is_type ai.errors.InvalidRequest
@@ -1601,10 +1600,8 @@ function env_ref_clients.resolve_of_a_ref_reads_at_call_time() -> string {
   L1:
     load_var e
     load_field .detail
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -1649,7 +1646,6 @@ function env_ref_clients.resolve_unknown_prefix_is_typed() -> string {
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L2
     load_var e
     is_type ai.errors.InvalidRequest
@@ -1676,10 +1672,8 @@ function env_ref_clients.resolve_unknown_prefix_is_typed() -> string {
     bin_op +
     load_var _8
     bin_op +
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -1689,7 +1683,6 @@ function env_ref_clients.resolve_without_a_slash_is_typed() -> string {
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L2
     load_var e
     is_type ai.errors.InvalidRequest
@@ -1703,10 +1696,8 @@ function env_ref_clients.resolve_without_a_slash_is_typed() -> string {
   L1:
     load_var e
     load_field .detail
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_errorcontext/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_errorcontext/bytecode.snap
@@ -198,35 +198,53 @@ function errorcontext.ec_deferthrow_check() -> bool {
   L3:
     jump_if_false L4
     pop 1
+    jump L5
+
+  L4:
+    store_var all_present
+    jump L6
+
+  L5:
     load_var cleanup_at
     load_const 0
     cmp_int_op >=
+    store_var all_present
 
-  L4:
+  L6:
     load_var2 2 4
     cmp_int_op <
-    jump_if_false L5
+    jump_if_false L7
     pop 1
+    jump L8
+
+  L7:
+    store_var ordered
+    jump L9
+
+  L8:
     load_var2 4 6
     cmp_int_op <
+    store_var ordered
 
-  L5:
+  L9:
     load_var rendered
     load_const "During handling of the above error, another error occurred"
     call baml.String.split
     container_len
     store_var pieces
-    jump_if_false L6
+    load_var all_present
+    jump_if_false L10
     pop 1
+    load_var ordered
 
-  L6:
-    jump_if_false L7
+  L10:
+    jump_if_false L11
     pop 1
     load_var pieces
     load_const 3
     cmp_int_op ==
 
-  L7:
+  L11:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_errorcontext/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_errorcontext/bytecode.snap
@@ -255,7 +255,6 @@ function errorcontext.ec_deferthrow_fail_low() -> string {
 
 function errorcontext.ec_deferthrow_main() -> string {
     call user.errorcontext.ec_deferthrow_mid
-    store_var _0
     jump L0
     load_var e
     throw_if_panic
@@ -263,10 +262,8 @@ function errorcontext.ec_deferthrow_main() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
 
   L0:
-    load_var _0
     return
 }
 
@@ -682,7 +679,6 @@ function errorcontext.ec_tostring_fail_low() -> string {
 
 function errorcontext.ec_tostring_main() -> string {
     call user.errorcontext.ec_tostring_mid
-    store_var _0
     jump L0
     load_var e
     throw_if_panic
@@ -690,10 +686,8 @@ function errorcontext.ec_tostring_main() -> string {
     load_type baml.ToString
     load_const "to_string"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
 
   L0:
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_expressions/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_expressions/bytecode.snap
@@ -37,15 +37,25 @@ function fixtures.parser_expressions.IndexAccess(users: fixtures.parser_expressi
 function fixtures.parser_expressions.TestPrecedence() -> bool {
     load_const true
     jump_if_false L0
-    jump L1
+    store_var d
+    jump L3
 
   L0:
     pop 1
     load_const false
     jump_if_false L1
     pop 1
-    load_const false
+    jump L2
 
   L1:
+    store_var d
+    jump L3
+
+  L2:
+    load_const false
+    store_var d
+
+  L3:
+    load_var d
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_expressions/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_parser_expressions/bytecode.snap
@@ -37,25 +37,15 @@ function fixtures.parser_expressions.IndexAccess(users: fixtures.parser_expressi
 function fixtures.parser_expressions.TestPrecedence() -> bool {
     load_const true
     jump_if_false L0
-    store_var d
-    jump L3
+    jump L1
 
   L0:
     pop 1
     load_const false
     jump_if_false L1
     pop 1
-    jump L2
+    load_const false
 
   L1:
-    store_var d
-    jump L3
-
-  L2:
-    load_const false
-    store_var d
-
-  L3:
-    load_var d
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_short_circuit_locals/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_short_circuit_locals/bytecode.snap
@@ -1,0 +1,162 @@
+---
+source: crates/baml_tests/src/corpus.rs
+---
+function fixtures.short_circuit_locals.chained_and(a: bool, b: bool, c: bool) -> bool {
+    load_var a
+    jump_if_false L0
+    pop 1
+    load_var b
+
+  L0:
+    jump_if_false L1
+    pop 1
+    load_var c
+
+  L1:
+    return
+}
+
+function fixtures.short_circuit_locals.conditional_short_circuit(a: bool, b: bool, cond: bool) -> bool {
+    load_const false
+    store_var x
+    load_var cond
+    pop_jump_if_false L2
+    load_var a
+    jump_if_false L0
+    pop 1
+    jump L1
+
+  L0:
+    store_var x
+    jump L2
+
+  L1:
+    load_var b
+    store_var x
+
+  L2:
+    load_var x
+    return
+}
+
+function fixtures.short_circuit_locals.conditional_short_circuit_in_loop(items: int[], a: bool, b: bool) -> int {
+    load_const false
+    store_var x
+    load_const 0
+    store_var hits
+    load_var items
+    load_type baml.iter.Iterable<Error = never, Item = int>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _6
+
+  L0:
+    load_var _6
+    load_type baml.iter.Iterator<Error = never, Item = int>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _7
+    load_var _7
+    is_type baml.iter.Done
+    pop_jump_if_false L1
+    jump L5
+
+  L1:
+    load_var _7
+    load_const 0
+    cmp_int_op >
+    pop_jump_if_false L4
+    load_var a
+    jump_if_false L2
+    pop 1
+    jump L3
+
+  L2:
+    store_var x
+    jump L4
+
+  L3:
+    load_var b
+    store_var x
+
+  L4:
+    load_var x
+    pop_jump_if_false L0
+    load_var hits
+    load_const 1
+    add_int
+    store_var hits
+    jump L0
+
+  L5:
+    load_var hits
+    return
+}
+
+function fixtures.short_circuit_locals.initialized_local_in_branch_loop(items: int[]) -> int {
+    load_const 0
+    store_var total
+    load_var items
+    load_type baml.iter.Iterable<Error = never, Item = int>
+    load_const "iter"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _3
+
+  L0:
+    load_var _3
+    load_type baml.iter.Iterator<Error = never, Item = int>
+    load_const "next"
+    virtual_call nargs=1 ntypeargs=0
+    store_var _4
+    load_var _4
+    is_type baml.iter.Done
+    pop_jump_if_false L1
+    jump L5
+
+  L1:
+    load_const 0
+    store_var x
+    load_var _4
+    load_const 0
+    cmp_int_op >
+    pop_jump_if_false L2
+    jump L3
+
+  L2:
+    load_const 2
+    store_var x
+    jump L4
+
+  L3:
+    load_const 1
+    store_var x
+
+  L4:
+    load_var2 5 2
+    bin_op +
+    store_var total
+    jump L0
+
+  L5:
+    load_var total
+    return
+}
+
+function fixtures.short_circuit_locals.mixed_join(a: bool, b: bool, cond: bool) -> bool {
+    load_var cond
+    pop_jump_if_false L0
+    jump L1
+
+  L0:
+    load_const false
+    jump L2
+
+  L1:
+    load_var a
+    jump_if_false L2
+    pop 1
+    load_var b
+
+  L2:
+    return
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_short_circuit_locals/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_short_circuit_locals/mir.snap
@@ -1,0 +1,247 @@
+---
+source: crates/baml_tests/src/corpus.rs
+---
+=== MIR2 ===
+fn user.fixtures.short_circuit_locals.chained_and(a: bool, b: bool, c: bool) -> bool {
+    // Locals:
+    let _0: bool // _0 // return
+    let _1: bool // a // param
+    let _2: bool // b // param
+    let _3: bool // c // param
+    let _4: bool // ok
+    let _5: bool
+
+    bb0: {
+        _5 = short_circuit(&&) copy _1 -> [eval: bb1, join: bb2];
+    }
+
+    bb1: {
+        _5 = copy _2;
+        goto -> bb2;
+    }
+
+    bb2: {
+        _4 = short_circuit(&&) copy _5 -> [eval: bb3, join: bb4];
+    }
+
+    bb3: {
+        _4 = copy _3;
+        goto -> bb4;
+    }
+
+    bb4: {
+        _0 = copy _4;
+        goto -> bb5;
+    }
+
+    bb5: {
+        return;
+    }
+}
+
+fn user.fixtures.short_circuit_locals.conditional_short_circuit(a: bool, b: bool, cond: bool) -> bool {
+    // Locals:
+    let _0: bool // _0 // return
+    let _1: bool // a // param
+    let _2: bool // b // param
+    let _3: bool // cond // param
+    let _4: bool // x
+
+    bb0: {
+        _4 = const false;
+        branch copy _3 -> [bb1, bb3];
+    }
+
+    bb1: {
+        _4 = short_circuit(&&) copy _1 -> [eval: bb2, join: bb3];
+    }
+
+    bb2: {
+        _4 = copy _2;
+        goto -> bb3;
+    }
+
+    bb3: {
+        _0 = copy _4;
+        goto -> bb4;
+    }
+
+    bb4: {
+        return;
+    }
+}
+
+fn user.fixtures.short_circuit_locals.conditional_short_circuit_in_loop(items: int[], a: bool, b: bool) -> int {
+    // Locals:
+    let _0: int // _0 // return
+    let _1: int[] // items // param
+    let _2: bool // a // param
+    let _3: bool // b // param
+    let _4: bool // x
+    let _5: int // hits
+    let _6: baml.iter.Iterator<Error = never, Item = int>
+    let _7: unknown
+    let _8: bool
+    let _9: int
+    let _10: int // i
+    let _11: bool
+    let _12: int
+    let _13: bool
+    let _14: int
+
+    bb0: {
+        _4 = const false;
+        _5 = const 0_i64;
+        _6 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int>(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _7 = virtual_call next as baml.iter.Iterator<Error = never, Item = int>(copy _6) -> [bb2];
+    }
+
+    bb2: {
+        _8 = is_type(copy _7, baml.iter.Done);
+        branch copy _8 -> [bb8, bb3];
+    }
+
+    bb3: {
+        _9 = copy _7;
+        fresh_cell(_10);
+        _10 = copy _9;
+        _12 = copy _10;
+        _11 = copy _12 > const 0_i64;
+        branch copy _11 -> [bb4, bb6];
+    }
+
+    bb4: {
+        _4 = short_circuit(&&) copy _2 -> [eval: bb5, join: bb6];
+    }
+
+    bb5: {
+        _4 = copy _3;
+        goto -> bb6;
+    }
+
+    bb6: {
+        _13 = copy _4;
+        branch copy _13 -> [bb7, bb1];
+    }
+
+    bb7: {
+        _14 = copy _5;
+        _5 = copy _14 + const 1_i64;
+        goto -> bb1;
+    }
+
+    bb8: {
+        _0 = copy _5;
+        goto -> bb9;
+    }
+
+    bb9: {
+        return;
+    }
+}
+
+fn user.fixtures.short_circuit_locals.initialized_local_in_branch_loop(items: int[]) -> int {
+    // Locals:
+    let _0: int // _0 // return
+    let _1: int[] // items // param
+    let _2: int // total
+    let _3: baml.iter.Iterator<Error = never, Item = int>
+    let _4: unknown
+    let _5: bool
+    let _6: int
+    let _7: int // i
+    let _8: int // x
+    let _9: bool
+    let _10: int
+    let _11: 1 | 2
+    let _12: int
+
+    bb0: {
+        _2 = const 0_i64;
+        _3 = virtual_call iter as baml.iter.Iterable<Error = never, Item = int>(copy _1) -> [bb1];
+    }
+
+    bb1: {
+        _4 = virtual_call next as baml.iter.Iterator<Error = never, Item = int>(copy _3) -> [bb2];
+    }
+
+    bb2: {
+        _5 = is_type(copy _4, baml.iter.Done);
+        branch copy _5 -> [bb7, bb3];
+    }
+
+    bb3: {
+        _6 = copy _4;
+        fresh_cell(_7);
+        _7 = copy _6;
+        _8 = const 0_i64;
+        _10 = copy _7;
+        _9 = copy _10 > const 0_i64;
+        branch copy _9 -> [bb5, bb4];
+    }
+
+    bb4: {
+        _8 = const 2_i64;
+        goto -> bb6;
+    }
+
+    bb5: {
+        _8 = const 1_i64;
+        goto -> bb6;
+    }
+
+    bb6: {
+        _11 = copy _8;
+        _12 = copy _2;
+        _2 = copy _11 + copy _12;
+        goto -> bb1;
+    }
+
+    bb7: {
+        _0 = copy _2;
+        goto -> bb8;
+    }
+
+    bb8: {
+        return;
+    }
+}
+
+fn user.fixtures.short_circuit_locals.mixed_join(a: bool, b: bool, cond: bool) -> bool {
+    // Locals:
+    let _0: bool // _0 // return
+    let _1: bool // a // param
+    let _2: bool // b // param
+    let _3: bool // cond // param
+    let _4: bool // x
+
+    bb0: {
+        branch copy _3 -> [bb2, bb1];
+    }
+
+    bb1: {
+        _4 = const false;
+        goto -> bb4;
+    }
+
+    bb2: {
+        _4 = short_circuit(&&) copy _1 -> [eval: bb3, join: bb4];
+    }
+
+    bb3: {
+        _4 = copy _2;
+        goto -> bb4;
+    }
+
+    bb4: {
+        _0 = copy _4;
+        goto -> bb5;
+    }
+
+    bb5: {
+        return;
+    }
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_short_circuit_locals/ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_short_circuit_locals/ppir.snap
@@ -1,0 +1,19 @@
+---
+source: crates/baml_tests/src/corpus.rs
+---
+=== PPIR ===
+function user.fixtures.short_circuit_locals.chained_and(a: bool, b: bool, c: bool) -> bool  [expr] {
+  { let ok = a And b And c } ok
+}
+function user.fixtures.short_circuit_locals.conditional_short_circuit(a: bool, b: bool, cond: bool) -> bool  [expr] {
+  { let x = false; if (cond) { x = a And b } } x
+}
+function user.fixtures.short_circuit_locals.conditional_short_circuit_in_loop(items: int[], a: bool, b: bool) -> int  [expr] {
+  { let x = false; let hits = 0; for i in items { if (i Gt 0) { x = a And b } } if (x) { hits = hits Add 1 } } hits
+}
+function user.fixtures.short_circuit_locals.initialized_local_in_branch_loop(items: int[]) -> int  [expr] {
+  { let total = 0; for i in items { let x = 0; if (i Gt 0) { x = 1 } else { x = 2 }; total = x Add total } } total
+}
+function user.fixtures.short_circuit_locals.mixed_join(a: bool, b: bool, cond: bool) -> bool  [expr] {
+  { let x = if (cond) {  } a And b else {  } false } x
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_short_circuit_locals/short_circuit_locals.fmt.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_fixtures/ns_short_circuit_locals/short_circuit_locals.fmt.snap
@@ -1,0 +1,71 @@
+---
+source: crates/baml_tests/src/corpus.rs
+---
+// Bindings whose value the emitter may leave on the operand stack instead of
+// storing to a slot. Each function pins one shape of the predecessor-coverage
+// rule in baml_compiler2_emit::analysis::is_stack_covered_phi, so the bytecode
+// snapshot is the point of these — a store_var/load_var pair appearing or
+// disappearing here is a classification change.
+
+// Every edge into the use of `ok` pushes its value: the two ShortCircuit
+// terminators, and the trailing assignment in the innermost rhs block. Stack
+// carried, so `ok` gets no store_var/load_var.
+function chained_and(a: bool, b: bool, c: bool) -> bool {
+    let ok = a && b && c;
+    ok
+}
+
+// The short circuit's join is merged into the `if` join, which is also the use
+// block. The false edge of the `if` still reaches that block without pushing
+// anything, and `let x = false` defines `x` a second time, so `x` needs a slot.
+function conditional_short_circuit(a: bool, b: bool, cond: bool) -> bool {
+    let x = false;
+    if (cond) {
+        x = a && b
+    }
+    x
+}
+
+// The same shape inside a loop, where stack-carrying `x` left one extra value
+// on the operand stack per iteration.
+function conditional_short_circuit_in_loop(items: int[], a: bool, b: bool) -> int {
+    let x = false;
+    let hits = 0;
+    for (let i in items) {
+        if (i > 0) {
+            x = a && b
+        }
+        if (x) {
+            hits = hits + 1
+        }
+    }
+    hits
+}
+
+// Both arms assign `x` and fall through to its use, but `let x = 0` defines it
+// once more outside them. Stack-carrying `x` pushed that initializer every
+// iteration with nothing to pop it.
+function initialized_local_in_branch_loop(items: int[]) -> int {
+    let total = 0;
+    for (let i in items) {
+        let x = 0;
+        if (i > 0) {
+            x = 1
+        } else {
+            x = 2
+        }
+        total = x + total
+    }
+    total
+}
+
+// One predecessor of the use is a ShortCircuit joining there, the other a plain
+// assignment: a mix that neither half of the old rule accepted on its own.
+function mixed_join(a: bool, b: bool, cond: bool) -> bool {
+    let x = if (cond) {
+        a && b
+    } else {
+        false
+    };
+    x
+}

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_for_loops/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_for_loops/bytecode.snap
@@ -409,19 +409,16 @@ function for_loops.for_loops_joined_map_arm(xs: int[], b: bool) -> int {
     load_var xs
     make_closure .<lambda(for_loops_joined_map_arm, 0)>, 0
     call baml.Array.map
-    store_var ys
     jump L2
 
   L1:
     load_const 0
     load_type int
     alloc_array 1
-    store_var ys
 
   L2:
     load_const 0
     store_var n
-    load_var ys
     load_type baml.iter.Iterable<Error = never, Item = int>
     load_const "iter"
     virtual_call nargs=1 ntypeargs=0
@@ -439,7 +436,7 @@ function for_loops.for_loops_joined_map_arm(xs: int[], b: bool) -> int {
     jump L5
 
   L4:
-    load_var2 4 6
+    load_var2 3 5
     add_int
     store_var n
     jump L3

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_generic_union_returns/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_generic_union_returns/bytecode.snap
@@ -177,15 +177,12 @@ function generic_union_returns.sap_nullable_container_types_are_preserved() -> b
     load_var statuses
     load_const 0
     call baml.Array.at
-    store_var _37
     jump L15
 
   L14:
     load_const null
-    store_var _37
 
   L15:
-    load_var _37
     load_const user.generic_union_returns.ParsedStatus.Ready
     alloc_variant user.generic_union_returns.ParsedStatus
     call baml.ops.equals_equals

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces/bytecode.snap
@@ -2534,15 +2534,12 @@ function interfaces.b1180_optional_get(value: interfaces.B1180Getter<int> | null
     load_type interfaces.B1180Getter<int>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
     jump L2
 
   L1:
     load_const null
-    store_var _3
 
   L2:
-    load_var _3
     store_var_load_var _2
     load_const null
     cmp_op ==
@@ -2567,15 +2564,12 @@ function interfaces.b1180_optional_name(value: interfaces.B1180Named | null) -> 
     load_type interfaces.B1180Named
     load_const "name"
     virtual_call nargs=1 ntypeargs=0
-    store_var _3
     jump L2
 
   L1:
     load_const null
-    store_var _3
 
   L2:
-    load_var _3
     store_var_load_var _2
     load_const null
     cmp_op ==
@@ -3421,7 +3415,6 @@ function interfaces.fz03_accepts_optional(a: interfaces.Fz03Animal | null) -> st
 
   L0:
     load_const "none"
-    store_var _0
     jump L2
 
   L1:
@@ -3429,10 +3422,8 @@ function interfaces.fz03_accepts_optional(a: interfaces.Fz03Animal | null) -> st
     load_type interfaces.Fz03Animal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -3785,13 +3776,12 @@ function interfaces.fz41_maybe_speak(a: interfaces.Fz41Animal | null) -> string 
     load_var a
     store_var _2
     load_var _2
-    narrow_bind interfaces.Fz41Animal, slot=3
+    narrow_bind interfaces.Fz41Animal, slot=2
     pop_jump_if_false L0
     jump L1
 
   L0:
     load_const "silent"
-    store_var _0
     jump L2
 
   L1:
@@ -3799,10 +3789,8 @@ function interfaces.fz41_maybe_speak(a: interfaces.Fz41Animal | null) -> string 
     load_type interfaces.Fz41Animal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -3849,13 +3837,12 @@ function interfaces.fz45_describe(x: interfaces.Fz45Animal | string) -> string {
     load_var x
     store_var _2
     load_var _2
-    narrow_bind interfaces.Fz45Animal, slot=3
+    narrow_bind interfaces.Fz45Animal, slot=2
     pop_jump_if_false L0
     jump L1
 
   L0:
     load_var x
-    store_var _0
     jump L2
 
   L1:
@@ -3863,10 +3850,8 @@ function interfaces.fz45_describe(x: interfaces.Fz45Animal | string) -> string {
     load_type interfaces.Fz45Animal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -4376,13 +4361,12 @@ function interfaces.itic_main() -> string {
     alloc_instance user.interfaces.IticDog
     store_var _3
     load_var _3
-    narrow_bind interfaces.IticDog, slot=2
+    narrow_bind interfaces.IticDog, slot=1
     pop_jump_if_false L0
     jump L1
 
   L0:
     load_const "not a swimmer"
-    store_var _0
     jump L2
 
   L1:
@@ -4390,10 +4374,8 @@ function interfaces.itic_main() -> string {
     load_type interfaces.IticSwimmer
     load_const "swim"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -4937,12 +4919,11 @@ function interfaces.tidu_main() -> string {
     load_type interfaces.TiduFallible
     load_const "run"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L2
     load_var e
     store_var _3
     load_var _3
-    narrow_bind interfaces.TiduBoom, slot=3
+    narrow_bind interfaces.TiduBoom, slot=2
     pop_jump_if_false L0
     jump L1
 
@@ -4953,10 +4934,8 @@ function interfaces.tidu_main() -> string {
   L1:
     load_var _3
     load_field .message
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -5140,13 +5119,12 @@ function interfaces.uf09_main() -> string {
     alloc_instance user.interfaces.Uf09Cat
     store_var _2
     load_var _2
-    narrow_bind interfaces.Uf09Animal, slot=2
+    narrow_bind interfaces.Uf09Animal, slot=1
     pop_jump_if_false L0
     jump L1
 
   L0:
     load_const "none"
-    store_var _0
     jump L2
 
   L1:
@@ -5154,10 +5132,8 @@ function interfaces.uf09_main() -> string {
     load_type interfaces.Uf09Animal
     load_const "speak"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces_associated_types/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_interfaces_associated_types/bytecode.snap
@@ -858,13 +858,12 @@ function interfaces_associated_types.rmf_score(source: interfaces_associated_typ
     load_var source
     store_var _2
     load_var _2
-    narrow_bind interfaces_associated_types.RmfSource<Item = int>, slot=3
+    narrow_bind interfaces_associated_types.RmfSource<Item = int>, slot=2
     pop_jump_if_false L0
     jump L1
 
   L0:
     load_const 0
-    store_var _0
     jump L2
 
   L1:
@@ -872,10 +871,8 @@ function interfaces_associated_types.rmf_score(source: interfaces_associated_typ
     load_type interfaces_associated_types.RmfSource<Item = int>
     load_const "get"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_invoke_error_normalization/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_invoke_error_normalization/bytecode.snap
@@ -213,38 +213,32 @@ function invoke_error_normalization.capture_agent_timeout(client: ai.Client) -> 
     store_var _3
     call user.invoke_error_normalization.TimeoutSpec$spec
     store_var _5
-    load_var2 4 5
+    load_var2 3 4
     load_type ai.Runner<string, Error = baml.errors.InvalidArgument | baml.errors.Timeout | baml.errors.UnknownError | baml.panics.Cancelled | baml.reflect.errors.CompilationError | ai.errors.Failure, Output = ai.RunResult<string>>
     load_const "run"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
     jump L0
     load_var e
     throw_if_panic
     load_var e
-    store_var _0
 
   L0:
-    load_var _0
     return
 }
 
 function invoke_error_normalization.capture_client_timeout(client: ai.Client) -> unknown {
     call user.invoke_error_normalization.timeout_input
     store_var _3
-    load_var2 1 4
+    load_var2 1 3
     load_type ai.Client
     load_const "invoke"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
     jump L0
     load_var e
     throw_if_panic
     load_var e
-    store_var _0
 
   L0:
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_iter_impl_generics_only/ns_core/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_iter_impl_generics_only/ns_core/bytecode.snap
@@ -75,7 +75,6 @@ function iter_impl_generics_only.core.Chain.Iterator<T, E>.next(self: iter_impl_
 
   L0:
     load_var _4
-    store_var _0
     jump L3
 
   L1:
@@ -89,10 +88,8 @@ function iter_impl_generics_only.core.Chain.Iterator<T, E>.next(self: iter_impl_
     load_type iter_impl_generics_only.core.Iterator<#0, #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
 
   L3:
-    load_var _0
     return
 }
 
@@ -659,7 +656,6 @@ function iter_impl_generics_only.core.Peekable.Iterator<T, E>.next(self: iter_im
     load_type iter_impl_generics_only.core.Iterator<#0, #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L2
 
   L1:
@@ -673,10 +669,8 @@ function iter_impl_generics_only.core.Peekable.Iterator<T, E>.next(self: iter_im
     load_const false
     store_field .has_buffer
     load_var v
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -834,7 +828,7 @@ function iter_impl_generics_only.core.StepBy.Iterator<T, E>.next(self: iter_impl
     store_var i
 
   L1:
-    load_var2 3 1
+    load_var2 2 1
     load_field .n
     load_const 1
     sub_int
@@ -848,7 +842,6 @@ function iter_impl_generics_only.core.StepBy.Iterator<T, E>.next(self: iter_impl
     load_type iter_impl_generics_only.core.Iterator<#0, #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L7
 
   L3:
@@ -872,7 +865,6 @@ function iter_impl_generics_only.core.StepBy.Iterator<T, E>.next(self: iter_impl
 
   L5:
     alloc_instance user.iter_impl_generics_only.core.Done
-    store_var _0
     jump L7
 
   L6:
@@ -884,10 +876,8 @@ function iter_impl_generics_only.core.StepBy.Iterator<T, E>.next(self: iter_impl
     load_type iter_impl_generics_only.core.Iterator<#0, #1>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
 
   L7:
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_lexical_scoping/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_lexical_scoping/bytecode.snap
@@ -236,7 +236,6 @@ function lexical_scoping.catch_base_uses_outer_lambda() -> int {
     make_closure .<lambda(catch_base_uses_outer_lambda, 0)>, 0
     call_indirect
     call user.lexical_scoping.throw_string_arg
-    store_var caught
     jump L2
     load_var e
     is_type string
@@ -249,10 +248,8 @@ function lexical_scoping.catch_base_uses_outer_lambda() -> int {
 
   L1:
     load_var e
-    store_var caught
 
   L2:
-    load_var caught
     is_type "base"
     pop_jump_if_false L3
     jump L4

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_operators/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_operators/bytecode.snap
@@ -1197,7 +1197,6 @@ function operators.ord_catch_ge() -> bool {
     load_type baml.ops.Compare
     load_const "ge"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
     jump L2
     load_var e
     is_type baml.panics.DivisionByZero
@@ -1210,10 +1209,8 @@ function operators.ord_catch_ge() -> bool {
 
   L1:
     load_const true
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -1225,7 +1222,6 @@ function operators.ord_catch_gt() -> bool {
     load_type baml.ops.Compare
     load_const "gt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
     jump L2
     load_var e
     is_type baml.panics.DivisionByZero
@@ -1238,10 +1234,8 @@ function operators.ord_catch_gt() -> bool {
 
   L1:
     load_const true
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -1253,7 +1247,6 @@ function operators.ord_catch_le() -> bool {
     load_type baml.ops.Compare
     load_const "le"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
     jump L2
     load_var e
     is_type baml.panics.DivisionByZero
@@ -1266,10 +1259,8 @@ function operators.ord_catch_le() -> bool {
 
   L1:
     load_const true
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -1281,7 +1272,6 @@ function operators.ord_catch_lt() -> bool {
     load_type baml.ops.Compare
     load_const "lt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
     jump L2
     load_var e
     is_type baml.panics.DivisionByZero
@@ -1294,10 +1284,8 @@ function operators.ord_catch_lt() -> bool {
 
   L1:
     load_const true
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -1367,22 +1355,13 @@ function operators.ord_in_short_circuit() -> bool {
     load_var _1
     jump_if_false L0
     pop 1
-    jump L1
-
-  L0:
-    store_var _0
-    jump L2
-
-  L1:
     load_const true
     load_const false
     load_type baml.ops.Compare
     load_const "gt"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
 
-  L2:
-    load_var _0
+  L0:
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_operators/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_operators/bytecode.snap
@@ -1367,13 +1367,22 @@ function operators.ord_in_short_circuit() -> bool {
     load_var _1
     jump_if_false L0
     pop 1
+    jump L1
+
+  L0:
+    store_var _0
+    jump L2
+
+  L1:
     load_const true
     load_const false
     load_type baml.ops.Compare
     load_const "gt"
     virtual_call nargs=2 ntypeargs=0
+    store_var _0
 
-  L0:
+  L2:
+    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_optional_chain_type_args/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_optional_chain_type_args/bytecode.snap
@@ -264,15 +264,12 @@ function optional_chain_type_args.callable_field_eval_count_fn() -> string {
     load_var _7
     load_field .0
     call_indirect
-    store_var out
     jump L2
 
   L1:
     load_const null
-    store_var out
 
   L2:
-    load_var out
     store_var_load_var _12
     load_const null
     cmp_op ==
@@ -316,15 +313,12 @@ function optional_chain_type_args.callable_field_null_after_two_fn() -> string {
     load_var _7
     load_field .0
     call_indirect
-    store_var out
     jump L2
 
   L1:
     load_const null
-    store_var out
 
   L2:
-    load_var out
     store_var_load_var _12
     load_const null
     cmp_op ==
@@ -542,15 +536,12 @@ function optional_chain_type_args.concrete_receiver_interface_method_fn() -> str
     load_type optional_chain_type_args.Speaker
     load_const "speak"
     virtual_call nargs=1 ntypeargs=1
-    store_var _0
     jump L2
 
   L1:
     load_const null
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -736,15 +727,12 @@ function optional_chain_type_args.interface_receiver_fn() -> string | null {
     load_type optional_chain_type_args.Speaker
     load_const "speak"
     virtual_call nargs=1 ntypeargs=1
-    store_var _0
     jump L2
 
   L1:
     load_const null
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -763,15 +751,12 @@ function optional_chain_type_args.method_eval_count_fn() -> string {
     call user.optional_chain_type_args.counted
     load_const 1
     call user.optional_chain_type_args.Callables.method
-    store_var out
     jump L2
 
   L1:
     load_const null
-    store_var out
 
   L2:
-    load_var out
     store_var_load_var _11
     load_const null
     cmp_op ==
@@ -996,7 +981,6 @@ function optional_chain_type_args.reflected_field_wrong_type_arg_fn() -> string 
     load_type string
     load_var _8
     call baml.reflect.class.Field.value
-    store_var read
     jump L6
     load_var e
     is_type baml.errors.TypeMismatch
@@ -1013,10 +997,8 @@ function optional_chain_type_args.reflected_field_wrong_type_arg_fn() -> string 
 
   L5:
     load_const null
-    store_var read
 
   L6:
-    load_var read
     store_var_load_var _12
     load_const null
     cmp_op ==
@@ -1176,15 +1158,12 @@ function optional_chain_type_args.union_class_type_args_fn(which: int) -> string
     load_type optional_chain_type_args.Tagged
     load_const "tag"
     virtual_call nargs=1 ntypeargs=1
-    store_var _0
     jump L2
 
   L1:
     load_const null
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -1205,14 +1184,11 @@ function optional_chain_type_args.union_receiver_fn(which: int) -> string | null
     load_type optional_chain_type_args.Speaker
     load_const "speak"
     virtual_call nargs=1 ntypeargs=1
-    store_var _0
     jump L2
 
   L1:
     load_const null
-    store_var _0
 
   L2:
-    load_var _0
     return
 }

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_while_let/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_while_let/bytecode.snap
@@ -269,11 +269,13 @@ function while_let.alternate() -> int {
 
 function while_let.body_local() -> int {
     load_const 2
+    store_var cur
 
   L0:
+    load_var cur
     store_var _3
     load_var _3
-    narrow_bind int, slot=1
+    narrow_bind int, slot=2
     pop_jump_if_false L1
     jump L2
 
@@ -290,6 +292,7 @@ function while_let.body_local() -> int {
     cmp_int_op >
     pop_jump_if_false L3
     load_const null
+    store_var cur
 
   L3:
     load_var v
@@ -302,10 +305,12 @@ function while_let.body_local() -> int {
     load_var v
     load_const 1
     sub_int
+    store_var cur
     jump L0
 
   L5:
     load_const null
+    store_var cur
     jump L0
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/ai/bytecode.snap
@@ -1182,7 +1182,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
     load_field .name
     call baml.String.from
     store_var _44
-    load_var2 4 18
+    load_var2 4 17
     load_const "tool is not in the active toolbox: "
     load_var _44
     bin_op +
@@ -1200,7 +1200,6 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
     load_var2 6 3
     load_field .args
     call ai.tools.Tool.call
-    store_var outcome
     jump L8
     load_var e
     throw_if_panic
@@ -1211,7 +1210,7 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
     load_var e
     call baml.String.from
     store_var _16
-    load_var2 4 9
+    load_var2 4 8
     load_var _16
     init_instance ai.events.ToolFailed .id, .message
     load_type ai.events.RunStarted | ai.events.UserMessage | ai.events.AssistantMessage | ai.events.ToolRequested | ai.events.ToolCompleted | ai.events.ToolFailed | ai.events.Usage | ai.events.FinalProduced
@@ -1238,14 +1237,13 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
 
   L3:
     load_const null
-    store_var outcome
     jump L8
 
   L4:
     load_var e
     store_var _24
     load_var _24
-    narrow_bind ai.errors.Failure, slot=13
+    narrow_bind ai.errors.Failure, slot=12
     pop_jump_if_false L5
     jump L6
 
@@ -1269,16 +1267,15 @@ function ai.Agent._run_one_tool(self: ai.Agent<#0>, tb: ai.tools.Toolbox, call: 
     load_var e
     call baml.String.from
     store_var _29
-    load_var2 14 15
-    load_var2 16 12
+    load_var2 13 14
+    load_var2 15 11
     init_instance ai.errors.ToolFailedError .id, .name, .message, .cause
     throw
 
   L8:
-    load_var outcome
     store_var _32
     load_var _32
-    narrow_bind string, slot=17
+    narrow_bind string, slot=16
     pop_jump_if_false L9
     load_var2 4 3
     load_field .id
@@ -1856,13 +1853,12 @@ function ai.clients.Fallback.root.Client.id(self: ai.clients.Fallback) -> string
     call baml.Array.at
     store_var _5
     load_var _5
-    narrow_bind ai.Client, slot=3
+    narrow_bind ai.Client, slot=2
     pop_jump_if_false L0
     jump L1
 
   L0:
     load_const "fallback"
-    store_var _0
     jump L2
 
   L1:
@@ -1870,10 +1866,8 @@ function ai.clients.Fallback.root.Client.id(self: ai.clients.Fallback) -> string
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -2205,13 +2199,12 @@ function ai.clients.RoundRobin.root.Client.id(self: ai.clients.RoundRobin) -> st
     call baml.Array.at
     store_var _5
     load_var _5
-    narrow_bind ai.Client, slot=3
+    narrow_bind ai.Client, slot=2
     pop_jump_if_false L0
     jump L1
 
   L0:
     load_const "round-robin"
-    store_var _0
     jump L2
 
   L1:
@@ -2219,10 +2212,8 @@ function ai.clients.RoundRobin.root.Client.id(self: ai.clients.RoundRobin) -> st
     load_type ai.Client
     load_const "id"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -3874,7 +3865,6 @@ function ai.internal._int_header(headers: map<string, string>, lower: string, ca
     load_var _5
     call baml.String.trim
     call baml.Int.parse
-    store_var parsed
     jump L2
     load_var e
     is_type baml.errors.ParseError
@@ -3887,13 +3877,11 @@ function ai.internal._int_header(headers: map<string, string>, lower: string, ca
 
   L1:
     load_const null
-    store_var parsed
 
   L2:
-    load_var parsed
     store_var _11
     load_var _11
-    narrow_bind int, slot=7
+    narrow_bind int, slot=6
     pop_jump_if_false L3
     load_var _11
     store_var_load_var value

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
@@ -4260,7 +4260,6 @@ function baml.iter.Skip.Iterator.next(self: baml.iter.Skip<#0, #1>) -> #0 | baml
     load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L5
 
   L2:
@@ -4289,10 +4288,8 @@ function baml.iter.Skip.Iterator.next(self: baml.iter.Skip<#0, #1>) -> #0 | baml
     load_const 0
     store_field .remaining
     alloc_instance baml.iter.Done
-    store_var _0
 
   L5:
-    load_var _0
     return
 }
 
@@ -4314,7 +4311,6 @@ function baml.iter.SkipWhile.Iterator.next(self: baml.iter.SkipWhile<#0, #1, #2>
     load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L5
 
   L2:
@@ -4341,7 +4337,6 @@ function baml.iter.SkipWhile.Iterator.next(self: baml.iter.SkipWhile<#0, #1, #2>
     load_const false
     store_field .skipping
     load_var x
-    store_var _0
     jump L5
 
   L4:
@@ -4349,10 +4344,8 @@ function baml.iter.SkipWhile.Iterator.next(self: baml.iter.SkipWhile<#0, #1, #2>
     load_const false
     store_field .skipping
     alloc_instance baml.iter.Done
-    store_var _0
 
   L5:
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
@@ -3431,7 +3431,6 @@ function baml.iter.Chain.Iterator.next(self: baml.iter.Chain<#0, #1, #2>) -> #0 
 
   L0:
     load_var _4
-    store_var _0
     jump L3
 
   L1:
@@ -3445,10 +3444,8 @@ function baml.iter.Chain.Iterator.next(self: baml.iter.Chain<#0, #1, #2>) -> #0 
     load_type baml.iter.Iterator<Error = #2, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
 
   L3:
-    load_var _0
     return
 }
 
@@ -4087,7 +4084,6 @@ function baml.iter.Peekable.Iterator.next(self: baml.iter.Peekable<#0, #1>) -> #
     load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L2
 
   L1:
@@ -4101,10 +4097,8 @@ function baml.iter.Peekable.Iterator.next(self: baml.iter.Peekable<#0, #1>) -> #
     load_const false
     store_field .has_buffer
     load_var v
-    store_var _0
 
   L2:
-    load_var _0
     return
 }
 
@@ -4378,7 +4372,7 @@ function baml.iter.StepBy.Iterator.next(self: baml.iter.StepBy<#0, #1>) -> #0 | 
     store_var i
 
   L1:
-    load_var2 3 1
+    load_var2 2 1
     load_field .n
     load_const 1
     sub_int
@@ -4392,7 +4386,6 @@ function baml.iter.StepBy.Iterator.next(self: baml.iter.StepBy<#0, #1>) -> #0 | 
     load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L7
 
   L3:
@@ -4416,7 +4409,6 @@ function baml.iter.StepBy.Iterator.next(self: baml.iter.StepBy<#0, #1>) -> #0 | 
 
   L5:
     alloc_instance baml.iter.Done
-    store_var _0
     jump L7
 
   L6:
@@ -4428,10 +4420,8 @@ function baml.iter.StepBy.Iterator.next(self: baml.iter.StepBy<#0, #1>) -> #0 | 
     load_type baml.iter.Iterator<Error = #1, Item = #0>
     load_const "next"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
 
   L7:
-    load_var _0
     return
 }
 
@@ -5563,7 +5553,6 @@ function baml.ops.Compare.le(self: baml.ops.Compare, other: #0) -> bool {
     store_var _3
     load_var _3
     jump_if_false L0
-    store_var _0
     jump L1
 
   L0:
@@ -5572,10 +5561,8 @@ function baml.ops.Compare.le(self: baml.ops.Compare, other: #0) -> bool {
     load_type baml.ops.Equals
     load_const "eq"
     virtual_call nargs=2 ntypeargs=0
-    store_var _0
 
   L1:
-    load_var _0
     return
 }
 
@@ -8447,7 +8434,6 @@ function baml.toml.item_to_json(item: baml.toml.Item) -> baml.json.json {
     load_type baml.ToJson
     load_const "to_json"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L7
 
   L1: PlainDate
@@ -8455,7 +8441,6 @@ function baml.toml.item_to_json(item: baml.toml.Item) -> baml.json.json {
     load_type baml.ToJson
     load_const "to_json"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L7
 
   L2: PlainDateTime
@@ -8463,7 +8448,6 @@ function baml.toml.item_to_json(item: baml.toml.Item) -> baml.json.json {
     load_type baml.ToJson
     load_const "to_json"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L7
 
   L3: ZonedDateTime
@@ -8471,7 +8455,6 @@ function baml.toml.item_to_json(item: baml.toml.Item) -> baml.json.json {
     load_type baml.ToJson
     load_const "to_json"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L7
 
   L4: list
@@ -8481,7 +8464,6 @@ function baml.toml.item_to_json(item: baml.toml.Item) -> baml.json.json {
     load_var item
     load_const baml.toml.item_to_json
     call baml.Array.map
-    store_var _0
     jump L7
 
   L5: Table
@@ -8489,15 +8471,12 @@ function baml.toml.item_to_json(item: baml.toml.Item) -> baml.json.json {
     load_type baml.ToJson
     load_const "to_json"
     virtual_call nargs=1 ntypeargs=0
-    store_var _0
     jump L7
 
   L6: string
     load_var item
-    store_var _0
 
   L7:
-    load_var _0
     return
 
   L8:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
@@ -5563,6 +5563,7 @@ function baml.ops.Compare.le(self: baml.ops.Compare, other: #0) -> bool {
     store_var _3
     load_var _3
     jump_if_false L0
+    store_var _0
     jump L1
 
   L0:
@@ -5571,8 +5572,10 @@ function baml.ops.Compare.le(self: baml.ops.Compare, other: #0) -> bool {
     load_type baml.ops.Equals
     load_const "eq"
     virtual_call nargs=2 ntypeargs=0
+    store_var _0
 
   L1:
+    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/testing/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/testing/bytecode.snap
@@ -2764,21 +2764,25 @@ function testing.pattern_may_match_descendant(pattern: string, prefix: string) -
     load_var _4
     call baml.String.slice
     store_var literal
-    load_var2 3 5
+    load_var2 4 6
     call baml.String.starts_with
     jump_if_false L1
+    store_var _0
     jump L3
 
   L1:
     pop 1
-    load_var2 5 3
+    load_var2 6 4
     call baml.String.starts_with
+    store_var _0
     jump L3
 
   L2:
     load_const true
+    store_var _0
 
   L3:
+    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/testing/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/testing/bytecode.snap
@@ -2764,25 +2764,21 @@ function testing.pattern_may_match_descendant(pattern: string, prefix: string) -
     load_var _4
     call baml.String.slice
     store_var literal
-    load_var2 4 6
+    load_var2 3 5
     call baml.String.starts_with
     jump_if_false L1
-    store_var _0
     jump L3
 
   L1:
     pop 1
-    load_var2 6 4
+    load_var2 5 3
     call baml.String.starts_with
-    store_var _0
     jump L3
 
   L2:
     load_const true
-    store_var _0
 
   L3:
-    load_var _0
     return
 }
 

--- a/baml_language/crates/baml_tests/tests/loop_reassignment.rs
+++ b/baml_language/crates/baml_tests/tests/loop_reassignment.rs
@@ -1,0 +1,82 @@
+//! Regression tests for outer-variable reassignment across loop branches.
+
+use baml_tests::{baml_test, baml_test_optimized};
+use bex_engine::BexExternalValue;
+
+const SOURCE: &str = r###"
+        class Fact {
+            subject_id string
+            section string
+            text string
+        }
+
+        function parse_subject_file(content: string, subject_id: string) -> Fact[] {
+            let facts: Fact[] = []
+            let current_section = ""
+            let in_scope = false
+            for (let raw_line in content.lines()) {
+                let line = raw_line.trim()
+                if (line.starts_with("## ")) {
+                    let heading = line.slice(3, line.length())
+                    in_scope = heading != "One-Sentence Takeaway" && heading != "References & Rabbit Holes"
+                    current_section = heading
+                } else if (in_scope && line.starts_with("- ")) {
+                    facts.push(Fact {
+                        subject_id: subject_id,
+                        section: current_section,
+                        text: line.slice(2, line.length()),
+                    })
+                }
+            }
+            facts
+        }
+
+        function main() -> string {
+            let content = #"# Created Pipeline (Marketing)
+
+---
+
+## 1. First Idea
+
+- Bullet one here.
+
+## One-Sentence Takeaway
+
+- This bullet should be ignored.
+
+## 2. Second Idea
+
+- Bullet two here.
+"#
+            let facts = parse_subject_file(content, "x")
+            facts[0].section + ":" + facts[0].text + "|" + facts[1].section + ":" + facts[1].text
+        }
+        "###;
+
+fn expected_result() -> Result<BexExternalValue, String> {
+    Ok(BexExternalValue::String(
+        "1. First Idea:Bullet one here.|2. Second Idea:Bullet two here."
+            .to_string()
+            .into(),
+    ))
+}
+
+#[tokio::test]
+async fn multiple_outer_reassignments_with_array_push() {
+    let output = baml_test!(SOURCE);
+
+    assert_eq!(
+        output.result.map_err(|error| format!("{error:?}")),
+        expected_result()
+    );
+}
+
+#[tokio::test]
+async fn multiple_outer_reassignments_with_array_push_optimized() {
+    let output = baml_test_optimized!(SOURCE);
+
+    assert_eq!(
+        output.result.map_err(|error| format!("{error:?}")),
+        expected_result()
+    );
+}

--- a/baml_language/crates/baml_tests/tests/short_circuit_locals.rs
+++ b/baml_language/crates/baml_tests/tests/short_circuit_locals.rs
@@ -1,0 +1,93 @@
+//! Regression tests for locals the emitter may carry on the operand stack.
+//!
+//! Both shapes here used to be classified as stack-carried even though one
+//! definition of the local was never balanced by the single use, so each loop
+//! iteration left an extra value on the operand stack.
+
+use baml_tests::{baml_test, baml_test_optimized};
+use bex_engine::BexExternalValue;
+
+/// The short circuit's join is merged into the `if` join, which is also where
+/// `x` is read — but the `if`'s false edge reaches that block without pushing
+/// anything, and `let x = false` is a second definition.
+const CONDITIONAL_SHORT_CIRCUIT: &str = r###"
+        function count_while_short_circuiting(items: int[], a: bool, b: bool) -> int {
+            let x = false
+            let hits = 0
+            for (let i in items) {
+                if (i > 0) {
+                    x = a && b
+                }
+                if (x) {
+                    hits = hits + 1
+                }
+            }
+            hits
+        }
+
+        function main() -> int {
+            count_while_short_circuiting([0, 1, 2, 0, 3], true, true)
+        }
+        "###;
+
+/// Both arms assign `x` and fall through to its use, but `let x = 0` defines it
+/// once more outside them.
+const INITIALIZED_LOCAL_IN_BRANCH: &str = r###"
+        function sum_branch_local(items: int[]) -> int {
+            let total = 0
+            for (let i in items) {
+                let x = 0
+                if (i > 0) {
+                    x = 1
+                } else {
+                    x = 2
+                }
+                total = x + total
+            }
+            total
+        }
+
+        function main() -> int {
+            sum_branch_local([1, -1, 2, -2, 0])
+        }
+        "###;
+
+#[tokio::test]
+async fn short_circuit_under_a_conditional_in_a_loop() {
+    let output = baml_test!(CONDITIONAL_SHORT_CIRCUIT);
+
+    assert_eq!(
+        output.result.map_err(|error| format!("{error:?}")),
+        Ok(BexExternalValue::Int(4))
+    );
+}
+
+#[tokio::test]
+async fn short_circuit_under_a_conditional_in_a_loop_optimized() {
+    let output = baml_test_optimized!(CONDITIONAL_SHORT_CIRCUIT);
+
+    assert_eq!(
+        output.result.map_err(|error| format!("{error:?}")),
+        Ok(BexExternalValue::Int(4))
+    );
+}
+
+#[tokio::test]
+async fn initialized_local_assigned_in_both_branches_of_a_loop() {
+    let output = baml_test!(INITIALIZED_LOCAL_IN_BRANCH);
+
+    assert_eq!(
+        output.result.map_err(|error| format!("{error:?}")),
+        Ok(BexExternalValue::Int(8))
+    );
+}
+
+#[tokio::test]
+async fn initialized_local_assigned_in_both_branches_of_a_loop_optimized() {
+    let output = baml_test_optimized!(INITIALIZED_LOCAL_IN_BRANCH);
+
+    assert_eq!(
+        output.result.map_err(|error| format!("{error:?}")),
+        Ok(BexExternalValue::Int(8))
+    );
+}


### PR DESCRIPTION
Stacked on #4508.

The parent PR's guards fix #4421 but overshoot in one direction and undershoot in another:

- Every named `let x = a && b` loses the stack-carry optimization, even where it is sound.
- The sibling `is_phi_like` predicate still accepts the same broken shape. At the parent head, this program leaves one value on the VM operand stack per loop iteration, because nothing checks for definitions outside the covering predecessors:

```baml
for (let i in items) {
    let x = 0;
    if (i > 0) { x = 1 } else { x = 2 }
    total = x + total
}
```

This replaces `is_phi_like` and `is_short_circuit_phi` with one predicate that proves the property the emitter actually relies on: a local may ride the operand stack only when every predecessor of its single use block leaves its value on top — a trailing assignment falling through, a `ShortCircuit` joining there, an empty passthrough whose own predecessors are covered, or a `Call`/`VirtualCall` returning into it — and no definition of the local exists outside that covered set. The stack-carry simulation starts at the use block and never inspects definitions or predecessors, so this predicate carries the entire soundness burden. In particular `join == use_block` alone is not enough: `merge_passthrough_blocks` can retarget a short circuit's join onto a block with unrelated incoming edges, as in `let x = false; if (c) { x = a && b } x`.

The local's name no longer matters. Before (parent) and after (this PR) for `let d = true || false && false; return d;`:

```
load_const true          |  load_const true
jump_if_false L0         |  jump_if_false L0
store_var d              |  jump L1
jump L3                  |
L0:                      |  L0:
pop 1                    |  pop 1
load_const false         |  load_const false
jump_if_false L1         |  jump_if_false L1
pop 1                    |  pop 1
jump L2                  |  load_const false
L1:                      |
store_var d              |  L1:
jump L3                  |  return
L2:                      |
load_const false         |
store_var d              |
L3:                      |
load_var d               |
return                   |
```

The coverage proof also extends to joins reached through call results — `a || b.starts_with(c)`, `expr catch (e) { ... }`, `a?.m()` — so `baml.ops.Compare.le` and the other short-circuits-over-calls return to their pre-#4508 bytecode, and catch/optional-chain joins across the corpus drop a store/load pair each. Every changed snapshot hunk removes instructions; none adds any. The stray-definition rule also fixes a second latent leak, visible in `while_let.body_local`'s snapshot, where `cur = null` in a non-predecessor block used to be an unbalanced push.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved local-variable handling across short-circuit expressions, conditional branches, loops, and mixed assignment paths.
  - Corrected stack balancing for locals initialized or reassigned across complex control flow.
  - Improved reliability for calls, virtual calls, awaits, and unwind paths.
  - Prevented invalid local-variable state from propagating through unsupported control-flow paths.

- **Tests**
  - Added regression coverage for chained short-circuit logic, loops, branch joins, and optimized execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->