### PR TITLE
fix: preserve array ascriptions in match coverage

### DIFF
--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
@@ -1296,7 +1296,12 @@ impl<'db> InferenceContext<'db> {
         // only a UNIQUE fit claims - B-633's provable-overlap
         // conservatism: "cannot tell" keeps the member, several
         // survivors stay unclaimed.
-        let claimed_union = match effective.kind() {
+        // Keep the original scrutinee as the matrix column. The narrowed
+        // `effective` type belongs inside the UnionMember constructor; using
+        // it as the column loses the union discriminator and makes equal-shape
+        // slices cover one another regardless of their ascriptions.
+        let scrut_structure = self.structurally_resolve(scrut);
+        let claimed_union = match scrut_structure.kind() {
             TyKind::Union(members, _) => {
                 let members = members.to_vec();
                 let mut lists: Vec<Ty> = Vec::new();
@@ -1321,7 +1326,7 @@ impl<'db> InferenceContext<'db> {
                         }
                     }
                 };
-                claimed.map(|member| (effective.clone(), member))
+                claimed.map(|member| (scrut.clone(), member))
             }
             _ => None,
         };
@@ -1428,6 +1433,15 @@ impl<'db> InferenceContext<'db> {
                 let TyKind::List(element, _) = expanded.kind() else {
                     return false;
                 };
+                if let Some(type_ref) = self.type_refs.array_ascriptions.get(&pat).copied() {
+                    let ascribed = self.lower_body_annotation(type_ref);
+                    if !ascribed.has_error()
+                        && !self.provable_subtype(&ascribed, &expanded)
+                        && !self.provable_subtype(&expanded, &ascribed)
+                    {
+                        return false;
+                    }
+                }
                 let element = element.clone();
                 let subs: Vec<PatId> = prefix.iter().chain(suffix.iter()).copied().collect();
                 let rest_pat = rest.as_ref().and_then(|rest| rest.pat);

--- a/baml_language/crates/baml_tests/baml_src/ns_match_container_types/match_container_types.baml
+++ b/baml_language/crates/baml_tests/baml_src/ns_match_container_types/match_container_types.baml
@@ -17,8 +17,8 @@
 
 function classify_list(x: int[] | string[]) -> string {
     match (x) {
-        let a: int[] => "ints",
-        let b: string[] => "strings",
+        [..]: int[] => "ints",
+        [..]: string[] => "strings",
     }
 }
 

--- a/baml_language/crates/baml_tests/snapshots/baml_src/ns_match_container_types/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/ns_match_container_types/bytecode.snap
@@ -147,9 +147,16 @@ function match_container_types.classify_int_map_fn() -> string {
 
 function match_container_types.classify_list(x: int[] | string[]) -> string {
     load_var x
-    store_var _2
-    load_var _2
-    narrow_bind int[], slot=2
+    is_type int[]
+    pop_jump_if_false L0
+    load_var x
+    is_type int[]
+    pop_jump_if_false L0
+    load_var x
+    container_len
+    store_var_load_var _4
+    load_const 0
+    cmp_int_op >=
     pop_jump_if_false L0
     jump L1
 


### PR DESCRIPTION
## Issue Reference

- B-469

## Changes

- Preserve the original union scrutinee as the pattern matrix column.
- Lower array ascriptions as union-member refinements during coverage analysis.
- Add a native BAML regression for int[] | string[] array arms.

## Testing

- [x] prek run --all-files
- [x] Native match_container_int_list and match_container_string_list tests
- [x] baml_compiler2_hir_ty tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pattern matching for list types within union values.
  * Preserved correct union-member selection when list patterns have similar structures.
  * Prevented incompatible list type annotations from being incorrectly accepted.

* **Tests**
  * Updated list-matching coverage to use slice-pattern syntax while maintaining existing classification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->