### PR TITLE
feat(baml_language): platform-gated process signalling via `baml.sys.platform()`

### DIFF
--- a/baml_language/Cargo.lock
+++ b/baml_language/Cargo.lock
@@ -6973,6 +6973,7 @@ dependencies = [
  "hyper-util",
  "indexmap",
  "jiff",
+ "libc",
  "num-bigint",
  "once_cell",
  "prost",
@@ -6989,6 +6990,7 @@ dependencies = [
  "tokio-tungstenite",
  "tracing",
  "walkdir",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/baml_language/Cargo.toml
+++ b/baml_language/Cargo.toml
@@ -284,6 +284,9 @@ unicode-normalization = "0.1.25"
 ureq = { version = "3", default-features = false, features = [ "rustls", "gzip" ] }
 uuid = { version = "1", features = [ "serde", "v4" ] }
 walkdir = { version = "2.4" }
+# `baml.sys.is_alive` uses OpenProcess/GetExitCodeProcess on Windows; matches
+# the version already in the lockfile via tokio.
+windows-sys = "0.61.2"
 tsify = { version = "0.5", features = [ "js" ] }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/platform.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/platform.baml
@@ -1,0 +1,171 @@
+/// Platform capability tokens.
+///
+/// `platform()` returns the host platform as a capability token: the concrete
+/// class (`Linux`, `MacOs`, `Windows`, `Browser`) witnesses which
+/// platform-gated operations this host can perform. Platform-specific
+/// operations are reachable only by narrowing the token — a `Unix`
+/// capability, for example, proves the host speaks `kill(2)`, so
+/// `terminate`/`signal_group` exist only on it.
+///
+/// The token classes carry an opaque native handle and cannot be constructed
+/// from BAML code, so there is no way to forge a capability for a platform
+/// the program is not running on.
+
+/// A capability token identifying the host platform.
+///
+/// Obtain one from `platform()` and narrow it with `match`, keeping an
+/// explicit arm for the platforms you do not handle:
+///
+/// ```baml
+/// match (baml.sys.platform()) {
+///     let u: baml.sys.Unix => u.terminate(pid),
+///     _ => { /* explicit unsupported-platform handling */ },
+/// }
+/// ```
+interface Platform {
+    /// Returns this platform as a `Unix` capability, or `null` when the host
+    /// is not a Unix platform.
+    ///
+    /// Prefer narrowing `platform()` with `match` (see `Platform`) so the
+    /// unsupported-platform case is handled explicitly. Chaining off this
+    /// method with `?.` silently no-ops on other platforms — reserve that
+    /// form for genuinely optional behavior, such as a cleanup only Unix
+    /// needs.
+    function unix(self) -> Unix? throws never {
+        null
+    }
+
+    /// Returns this platform as a `Windows` capability, or `null` when the
+    /// host is not Windows.
+    ///
+    /// Prefer narrowing `platform()` with `match` (see `Platform`) so the
+    /// unsupported-platform case is handled explicitly. Chaining off this
+    /// method with `?.` silently no-ops on other platforms — reserve that
+    /// form for genuinely optional behavior.
+    function windows(self) -> Windows? throws never {
+        null
+    }
+}
+
+/// Unix process-control capability.
+///
+/// Narrows a `Platform` token to the operations every Unix host supports.
+/// Obtained from `Platform.unix()` or by matching a `Platform` value against
+/// `Unix`.
+interface Unix requires Platform {
+    /// Sends `SIGTERM` to the process with the given OS process ID.
+    ///
+    /// `SIGTERM` requests a graceful shutdown — the target may catch or
+    /// ignore it. Mirrors `Process.kill`-adjacent control but for an
+    /// arbitrary PID, so one BAML invocation can signal a process started by
+    /// another.
+    ///
+    /// Throws `root.errors.Io` when `pid` is not positive, no such process
+    /// exists, or the OS denies the signal.
+    function terminate(self, pid: int) -> null throws root.errors.Io
+
+    /// Sends a signal to every process in the Unix process group `pgid`
+    /// (`kill(-pgid, sig)`).
+    ///
+    /// Group signalling is the reliable way to take down a whole spawned
+    /// tree: a child started detached (its own session/process group) can be
+    /// signalled as a unit by its pgid.
+    ///
+    /// Throws `root.errors.Io` when `pgid` is not positive, no such process
+    /// group exists, or the OS denies the signal.
+    function signal_group(self, pgid: int, sig: Signal) -> null throws root.errors.Io
+}
+
+/// The signals `Unix.signal_group` can deliver, mapped to their POSIX signal
+/// numbers: `Terminate` → `SIGTERM`, `Interrupt` → `SIGINT`, `Kill` →
+/// `SIGKILL`, `Hangup` → `SIGHUP`.
+enum Signal {
+    Terminate,
+    Interrupt,
+    Kill,
+    Hangup,
+}
+
+/// Capability token for Linux hosts. Obtained only from `platform()`.
+///
+/// Also returned on Unix platforms other than Linux and macOS (the BSDs and
+/// so on): those share the same POSIX `kill(2)` signalling surface, and the
+/// `Unix` capability — not the concrete class — is the gate for those
+/// operations.
+class Linux {
+    /// Opaque native token; user code cannot construct a capability by hand.
+    _handle: $rust_type,
+
+    implements Platform {
+        function unix(self) -> Unix? throws never {
+            self
+        }
+    }
+
+    implements Unix {
+        function terminate(self, pid: int) -> null throws root.errors.Io {
+            $rust_io_function
+        }
+
+        function signal_group(self, pgid: int, sig: Signal) -> null throws root.errors.Io {
+            $rust_io_function
+        }
+    }
+}
+
+/// Capability token for macOS hosts. Obtained only from `platform()`.
+class MacOs {
+    /// Opaque native token; user code cannot construct a capability by hand.
+    _handle: $rust_type,
+
+    implements Platform {
+        function unix(self) -> Unix? throws never {
+            self
+        }
+    }
+
+    implements Unix {
+        function terminate(self, pid: int) -> null throws root.errors.Io {
+            $rust_io_function
+        }
+
+        function signal_group(self, pgid: int, sig: Signal) -> null throws root.errors.Io {
+            $rust_io_function
+        }
+    }
+}
+
+/// Capability token for Windows hosts. Obtained only from `platform()`.
+///
+/// No Windows-specific operations ship yet; the class exists so
+/// `Platform.windows()` has a capability to narrow to as they are added.
+class Windows {
+    /// Opaque native token; user code cannot construct a capability by hand.
+    _handle: $rust_type,
+
+    implements Platform {
+        function windows(self) -> Windows? throws never {
+            self
+        }
+    }
+}
+
+/// Capability token for browser (wasm) hosts. Obtained only from
+/// `platform()`.
+///
+/// Browsers expose no process-control surface, so this token narrows to no
+/// further capabilities.
+class Browser {
+    /// Opaque native token; user code cannot construct a capability by hand.
+    _handle: $rust_type,
+
+    implements Platform { }
+}
+
+/// Returns a capability token for the platform this program is running on.
+///
+/// Narrow the result with `match` (see `Platform`) to reach platform-gated
+/// operations.
+function platform() -> Platform throws never {
+    $rust_io_function
+}

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/platform.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/platform.baml
@@ -67,9 +67,8 @@ interface Unix requires Platform {
     /// Sends a signal to every process in the Unix process group `pgid`
     /// (`kill(-pgid, sig)`).
     ///
-    /// Group signalling is the reliable way to take down a whole spawned
-    /// tree: a child started detached (its own session/process group) can be
-    /// signalled as a unit by its pgid.
+    /// Group signalling is the reliable way to take down a whole process
+    /// tree whose leader was started in its own process group.
     ///
     /// Throws `root.errors.Io` when `pgid` is not positive, no such process
     /// group exists, or the OS denies the signal.

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/sys.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/sys.baml
@@ -256,8 +256,8 @@ function pid() -> int throws never {
 ///
 /// Unix probes with `kill(pid, 0)`: `ESRCH` (no such process) reports
 /// `false`, while a live process — including one this process lacks
-/// permission to signal (`EPERM`) — reports `true`. Windows opens the
-/// process and reports `true` while its exit code is `STILL_ACTIVE`.
+/// permission to signal (`EPERM`) — reports `true`. Windows opens and polls
+/// the process handle; access denied also means the process exists.
 ///
 /// The result is a snapshot: the process may exit immediately after the
 /// probe, and a reaped-zombie PID may already read as dead.

--- a/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/sys.baml
+++ b/baml_language/crates/baml_builtins2/baml_std/baml/ns_sys/sys.baml
@@ -251,3 +251,19 @@ function argv() -> string[] throws never {
 function pid() -> int throws never {
     $rust_io_function
 }
+
+/// Returns `true` if a process with the given OS process ID currently exists.
+///
+/// Unix probes with `kill(pid, 0)`: `ESRCH` (no such process) reports
+/// `false`, while a live process — including one this process lacks
+/// permission to signal (`EPERM`) — reports `true`. Windows opens the
+/// process and reports `true` while its exit code is `STILL_ACTIVE`.
+///
+/// The result is a snapshot: the process may exit immediately after the
+/// probe, and a reaped-zombie PID may already read as dead.
+///
+/// Throws `root.errors.Io` when `pid` is not positive or the OS probe fails
+/// for a reason other than "no such process".
+function is_alive(pid: int) -> bool throws root.errors.Io {
+    $rust_io_function
+}

--- a/baml_language/crates/baml_builtins2/src/lib.rs
+++ b/baml_language/crates/baml_builtins2/src/lib.rs
@@ -111,6 +111,7 @@ pub const ALL: &[BuiltinFile] = &[
     builtin!("baml", "ns_events/events.baml"),
     builtin!("baml", "ns_id/id.baml"),
     builtin!("baml", "ns_sys/sys.baml"),
+    builtin!("baml", "ns_sys/platform.baml"),
     builtin!("baml", "ns_fs/fs.baml"),
     builtin!("baml", "ns_glob/glob.baml"),
     builtin!("baml", "ns_net/net.baml"),

--- a/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
+++ b/baml_language/crates/baml_cli/src/snapshots/baml_cli__describe_command_tests__render_builtin_package_listing.snap
@@ -265,6 +265,14 @@ class            baml.spawn.SpawnParams           <builtin>/baml/ns_spawn/spawn.
 class            baml.spawn.TaskGroup             <builtin>/baml/ns_spawn/spawn.baml:31
 class            baml.spawn.CancelToken           <builtin>/baml/ns_spawn/spawn.baml:85
 function         baml.spawn.options               <builtin>/baml/ns_spawn/spawn.baml:123
+interface        baml.sys.Platform                <builtin>/baml/ns_sys/platform.baml:25
+interface        baml.sys.Unix                    <builtin>/baml/ns_sys/platform.baml:55
+enum             baml.sys.Signal                  <builtin>/baml/ns_sys/platform.baml:81
+class            baml.sys.Linux                   <builtin>/baml/ns_sys/platform.baml:94
+class            baml.sys.MacOs                   <builtin>/baml/ns_sys/platform.baml:116
+class            baml.sys.Windows                 <builtin>/baml/ns_sys/platform.baml:141
+class            baml.sys.Browser                 <builtin>/baml/ns_sys/platform.baml:157
+function         baml.sys.platform                <builtin>/baml/ns_sys/platform.baml:168
 class            baml.sys.ProcessOptions          <builtin>/baml/ns_sys/sys.baml:2
 enum             baml.sys.StderrMode              <builtin>/baml/ns_sys/sys.baml:18
 class            baml.sys.ShellOutput             <builtin>/baml/ns_sys/sys.baml:29
@@ -283,6 +291,7 @@ function         baml.sys.panic                   <builtin>/baml/ns_sys/sys.baml
 function         baml.sys.exit                    <builtin>/baml/ns_sys/sys.baml:236
 function         baml.sys.argv                    <builtin>/baml/ns_sys/sys.baml:242
 function         baml.sys.pid                     <builtin>/baml/ns_sys/sys.baml:251
+function         baml.sys.is_alive                <builtin>/baml/ns_sys/sys.baml:267
 class            baml.time.Duration               <builtin>/baml/ns_time/duration.baml:4
 class            baml.time.Instant                <builtin>/baml/ns_time/instant.baml:2
 class            baml.time.PlainDate              <builtin>/baml/ns_time/plaindate.baml:5

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/bytecode.snap
@@ -6124,6 +6124,38 @@ function baml.spawn.options(group: baml.spawn.TaskGroup | null, cancel: baml.spa
     return
 }
 
+function baml.sys.Linux.Platform.unix(self: baml.sys.Linux) -> baml.sys.Unix | null {
+    load_var self
+    return
+}
+
+function baml.sys.Linux.Unix.signal_group(self: baml.sys.Linux, pgid: int, sig: baml.sys.Signal) -> null {
+}
+
+function baml.sys.Linux.Unix.terminate(self: baml.sys.Linux, pid: int) -> null {
+}
+
+function baml.sys.MacOs.Platform.unix(self: baml.sys.MacOs) -> baml.sys.Unix | null {
+    load_var self
+    return
+}
+
+function baml.sys.MacOs.Unix.signal_group(self: baml.sys.MacOs, pgid: int, sig: baml.sys.Signal) -> null {
+}
+
+function baml.sys.MacOs.Unix.terminate(self: baml.sys.MacOs, pid: int) -> null {
+}
+
+function baml.sys.Platform.unix(self: baml.sys.Platform) -> baml.sys.Unix | null {
+    load_const null
+    return
+}
+
+function baml.sys.Platform.windows(self: baml.sys.Platform) -> baml.sys.Windows | null {
+    load_const null
+    return
+}
+
 function baml.sys.Process.close(self: baml.sys.Process) -> null {
 }
 
@@ -6278,6 +6310,11 @@ function baml.sys.ShellOutput.ok(self: baml.sys.ShellOutput) -> bool {
     return
 }
 
+function baml.sys.Windows.Platform.windows(self: baml.sys.Windows) -> baml.sys.Windows | null {
+    load_var self
+    return
+}
+
 function baml.sys.WritePipe.close(self: baml.sys.WritePipe) -> void {
 }
 
@@ -6336,10 +6373,16 @@ function baml.sys.exec(program: string, args: string[] | null, options: baml.sys
 function baml.sys.exit(code: int) -> never {
 }
 
+function baml.sys.is_alive(pid: int) -> bool {
+}
+
 function baml.sys.panic(message: string) -> never {
 }
 
 function baml.sys.pid() -> int {
+}
+
+function baml.sys.platform() -> baml.sys.Platform {
 }
 
 function baml.sys.shell(command: string, options: baml.sys.ProcessOptions | null) -> baml.sys.ShellOutput {

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/mir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/mir.snap
@@ -9068,6 +9068,114 @@ fn .<lambda(options, 0)>(params: baml.spawn.SpawnParams<T, E>) -> baml.spawn.Spa
     }
 }
 
+fn baml.sys.Platform.unix(self: baml.sys.Platform) -> null | baml.sys.Unix {
+    // Locals:
+    let _0: null | baml.sys.Unix // _0 // return
+    let _1: baml.sys.Platform // self // param
+
+    bb0: {
+        _0 = const null;
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.sys.Platform.windows(self: baml.sys.Platform) -> null | baml.sys.Windows {
+    // Locals:
+    let _0: null | baml.sys.Windows // _0 // return
+    let _1: baml.sys.Platform // self // param
+
+    bb0: {
+        _0 = const null;
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.sys.Unix.terminate(_1: void, _2: void) -> void {
+    // Locals:
+    let _0: void // return
+    let _1: void // param
+    let _2: void // param
+
+    bb0: {
+        unreachable;
+    }
+}
+
+fn baml.sys.Unix.signal_group(_1: void, _2: void, _3: void) -> void {
+    // Locals:
+    let _0: void // return
+    let _1: void // param
+    let _2: void // param
+    let _3: void // param
+
+    bb0: {
+        unreachable;
+    }
+}
+
+fn baml.sys.Linux.Platform.unix(self: baml.sys.Linux) -> null | baml.sys.Unix {
+    // Locals:
+    let _0: null | baml.sys.Unix // _0 // return
+    let _1: baml.sys.Linux // self // param
+
+    bb0: {
+        _0 = copy _1;
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.sys.Linux.Unix.terminate = builtin(io)
+
+fn baml.sys.Linux.Unix.signal_group = builtin(io)
+
+fn baml.sys.MacOs.Platform.unix(self: baml.sys.MacOs) -> null | baml.sys.Unix {
+    // Locals:
+    let _0: null | baml.sys.Unix // _0 // return
+    let _1: baml.sys.MacOs // self // param
+
+    bb0: {
+        _0 = copy _1;
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.sys.MacOs.Unix.terminate = builtin(io)
+
+fn baml.sys.MacOs.Unix.signal_group = builtin(io)
+
+fn baml.sys.Windows.Platform.windows(self: baml.sys.Windows) -> null | baml.sys.Windows {
+    // Locals:
+    let _0: null | baml.sys.Windows // _0 // return
+    let _1: baml.sys.Windows // self // param
+
+    bb0: {
+        _0 = copy _1;
+        goto -> bb1;
+    }
+
+    bb1: {
+        return;
+    }
+}
+
+fn baml.sys.platform = builtin(io)
+
 fn baml.sys.ShellOutput.ok(self: baml.sys.ShellOutput) -> bool {
     // Locals:
     let _0: bool // _0 // return
@@ -9374,6 +9482,8 @@ fn baml.sys.exit = builtin(vm)
 fn baml.sys.argv = builtin(vm)
 
 fn baml.sys.pid = builtin(io)
+
+fn baml.sys.is_alive = builtin(io)
 
 fn baml.time.Duration.abs(self: baml.time.Duration) -> baml.time.Duration {
     // Locals:

--- a/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/baml_src/stdlib/baml/ppir.snap
@@ -1907,6 +1907,55 @@ function baml.spawn.set_limit(self: ?, limit: int) -> void  [builtin]
 --- captures ---
 lambda (params) in options: captures [group, cancel, detach]
 
+--- <builtin>/baml/ns_sys/platform.baml ---
+class baml.sys.Browser {
+  _handle: $rust_type
+}
+class baml.sys.Browser$stream {
+  _handle: $rust_type
+}
+class baml.sys.Linux {
+  _handle: $rust_type
+}
+class baml.sys.Linux$stream {
+  _handle: $rust_type
+}
+class baml.sys.MacOs {
+  _handle: $rust_type
+}
+class baml.sys.MacOs$stream {
+  _handle: $rust_type
+}
+class baml.sys.Windows {
+  _handle: $rust_type
+}
+class baml.sys.Windows$stream {
+  _handle: $rust_type
+}
+enum baml.sys.Signal {Terminate, Interrupt, Kill, Hangup}
+function baml.sys.platform() -> Platform  [builtin]
+function baml.sys.signal_group(self: ?, pgid: int, sig: baml.sys.Signal) -> null  [missing]
+function baml.sys.signal_group(self: ?, pgid: int, sig: baml.sys.Signal) -> null  [builtin]
+function baml.sys.signal_group(self: ?, pgid: int, sig: baml.sys.Signal) -> null  [builtin]
+function baml.sys.terminate(self: ?, pid: int) -> null  [missing]
+function baml.sys.terminate(self: ?, pid: int) -> null  [builtin]
+function baml.sys.terminate(self: ?, pid: int) -> null  [builtin]
+function baml.sys.unix(self: ?) -> Unix?  [expr] {
+  {  } null
+}
+function baml.sys.unix(self: ?) -> Unix?  [expr] {
+  {  } self
+}
+function baml.sys.unix(self: ?) -> Unix?  [expr] {
+  {  } self
+}
+function baml.sys.windows(self: ?) -> baml.sys.Windows?  [expr] {
+  {  } null
+}
+function baml.sys.windows(self: ?) -> baml.sys.Windows?  [expr] {
+  {  } self
+}
+
 --- <builtin>/baml/ns_sys/sys.baml ---
 class baml.sys.Process {
   _handle: $rust_type
@@ -1984,6 +2033,7 @@ function baml.sys.collect_garbage() -> null  [builtin]
 function baml.sys.exec(program: string, args: string[]?, options: baml.sys.ProcessOptions?) -> baml.sys.ShellOutput  [builtin]
 function baml.sys.exit(code: int) -> never  [builtin]
 function baml.sys.flush(self: ?) -> void  [builtin]
+function baml.sys.is_alive(pid: int) -> bool  [builtin]
 function baml.sys.iter(self: ?) -> root.iter.Iterator<Item = string, Error = root.errors.Io>  [expr] {
   {  } self
 }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/snapshots/baml_tests__compiler2_tir__phase5__snapshot_baml_package_items.snap
@@ -288,21 +288,30 @@ namespace baml.spawn:
   class TaskGroup { methods: [new, cancel, set_limit, limit, name, active_count, queued_count] }
   function options<T, E>
 namespace baml.sys:
+  class Browser { methods: [] }
+  class Linux { methods: [unix, terminate, signal_group] }
+  class MacOs { methods: [unix, terminate, signal_group] }
+  type Platform
   class Process { methods: [wait, kill, close] }
   class ProcessExit { methods: [ok] }
   class ProcessOptions { methods: [] }
   class ReadPipe { methods: [close, lines, read] }
   class ReadPipeLines { methods: [iter, next] }
   class ShellOutput { methods: [ok] }
+  enum Signal
   enum StderrMode
+  type Unix
+  class Windows { methods: [windows] }
   class WritePipe { methods: [close, write_some, flush] }
   function _strip_carriage_return
   function argv
   function collect_garbage
   function exec
   function exit
+  function is_alive
   function panic
   function pid
+  function platform
   function shell
   function sleep
   function start_process

--- a/baml_language/crates/baml_tests/tests/shell.rs
+++ b/baml_language/crates/baml_tests/tests/shell.rs
@@ -676,7 +676,11 @@ async fn is_alive_and_terminate_by_pid() {
                 let process = baml.sys.start_process("sh", ["-c", "echo $$; exec sleep 30"], null);
                 defer { process.close() }
 
-                let pid = baml.json.from_string<int>(process.stdout.lines().next() ?? "0") catch_all (e) {
+                let pid_text = match (process.stdout.lines().next()) {
+                    let line: string => line,
+                    baml.iter.Done => "0",
+                };
+                let pid = baml.json.from_string<int>(pid_text) catch_all (e) {
                     _ => 0,
                 };
                 if (pid <= 0 || !baml.sys.is_alive(pid)) {
@@ -733,7 +737,11 @@ async fn is_alive_tracks_child_lifetime() {
                 );
                 defer { process.close() }
 
-                let pid = baml.json.from_string<int>(process.stdout.lines().next() ?? "0") catch_all (e) {
+                let pid_text = match (process.stdout.lines().next()) {
+                    let line: string => line,
+                    baml.iter.Done => "0",
+                };
+                let pid = baml.json.from_string<int>(pid_text) catch_all (e) {
                     _ => 0,
                 };
                 if (pid <= 0 || !baml.sys.is_alive(pid)) {
@@ -770,7 +778,11 @@ async fn signal_group_takes_down_process_group() {
                 );
                 defer { process.close() }
 
-                let pgid = baml.json.from_string<int>(process.stdout.lines().next() ?? "0") catch_all (e) {
+                let pgid_text = match (process.stdout.lines().next()) {
+                    let line: string => line,
+                    baml.iter.Done => "0",
+                };
+                let pgid = baml.json.from_string<int>(pgid_text) catch_all (e) {
                     _ => 0,
                 };
                 if (pgid <= 0 || !baml.sys.is_alive(pgid)) {

--- a/baml_language/crates/baml_tests/tests/shell.rs
+++ b/baml_language/crates/baml_tests/tests/shell.rs
@@ -633,3 +633,195 @@ async fn start_process_stderr_modes_without_pipe() {
 
     assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
 }
+
+// === platform() capability token / is_alive / Unix signalling tests ===
+
+/// `baml.sys.platform()` hands out exactly one platform capability: a native
+/// host is either Unix (`unix()` non-null, `windows()` null) or Windows (the
+/// reverse).
+#[tokio::test]
+async fn platform_capability_shape() {
+    let output = baml_test!(
+        r#"
+            function main() -> bool {
+                let p = baml.sys.platform();
+                let has_unix = match (p.unix()) {
+                    let u: baml.sys.Unix => true,
+                    null => false,
+                };
+                let has_windows = match (p.windows()) {
+                    let w: baml.sys.Windows => true,
+                    null => false,
+                };
+                has_unix != has_windows
+            }
+        "#
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+/// Matching `baml.sys.platform()` against `baml.sys.Unix` yields the
+/// capability whose `terminate` (SIGTERM) lets `wait()` observe signal 15,
+/// and `baml.sys.is_alive` tracks the child across the call: alive before,
+/// dead once `wait()` has reaped it. The child prints its own pid (`$$`,
+/// kept across `exec`) so the test can signal it by pid without any
+/// handle-to-pid API.
+#[tokio::test]
+#[cfg(not(target_os = "windows"))]
+async fn is_alive_and_terminate_by_pid() {
+    let output = baml_test!(
+        r#"
+            function main() -> bool throws baml.errors.Io | baml.errors.Timeout {
+                let process = baml.sys.start_process("sh", ["-c", "echo $$; exec sleep 30"], null);
+                defer { process.close() }
+
+                let pid = baml.json.from_string<int>(process.stdout.lines().next() ?? "0") catch_all (e) {
+                    _ => 0,
+                };
+                if (pid <= 0 || !baml.sys.is_alive(pid)) {
+                    return false;
+                }
+                match (baml.sys.platform()) {
+                    let u: baml.sys.Unix => u.terminate(pid),
+                    _ => { return false; },
+                }
+                let exit = process.wait();
+                // After wait() reaps the child, the pid reads as dead.
+                if (baml.sys.is_alive(pid)) {
+                    return false;
+                }
+                match (exit.signal) {
+                    let signal: string => signal == "15",
+                    null => false,
+                }
+            }
+        "#
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+/// `baml.sys.is_alive` always reports true for the current process, on every
+/// platform.
+#[tokio::test]
+async fn is_alive_reports_self() {
+    let output = baml_test!(
+        r#"
+            function main() -> bool throws baml.errors.Io {
+                baml.sys.is_alive(baml.sys.pid())
+            }
+        "#
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+/// Windows variant of the liveness probe: a live child reads as alive, and
+/// once killed its exit code is no longer `STILL_ACTIVE`, so it reads as
+/// dead even if the process object has not been fully torn down yet.
+#[tokio::test]
+#[cfg(target_os = "windows")]
+async fn is_alive_tracks_child_lifetime() {
+    let output = baml_test!(
+        r#"
+            function main() -> bool throws baml.errors.Io | baml.errors.Timeout {
+                let process = baml.sys.start_process(
+                    "powershell",
+                    ["-NoProfile", "-Command", "$PID; Start-Sleep -Seconds 30"],
+                    null,
+                );
+                defer { process.close() }
+
+                let pid = baml.json.from_string<int>(process.stdout.lines().next() ?? "0") catch_all (e) {
+                    _ => 0,
+                };
+                if (pid <= 0 || !baml.sys.is_alive(pid)) {
+                    return false;
+                }
+                process.kill();
+                process.wait();
+                !baml.sys.is_alive(pid)
+            }
+        "#
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+/// `Unix.signal_group` signals every process in a process group at once.
+/// `setsid` runs the child as leader of a brand-new session (and process
+/// group), so the pid it prints is also its pgid; a freshly spawned child is
+/// never a process-group leader, so `setsid` execs directly without forking
+/// and `wait()` observes the SIGKILL'd child itself.
+///
+/// Linux-only: `setsid(1)` ships with util-linux; macOS has no equivalent
+/// command.
+#[tokio::test]
+#[cfg(target_os = "linux")]
+async fn signal_group_takes_down_process_group() {
+    let output = baml_test!(
+        r#"
+            function main() -> bool throws baml.errors.Io | baml.errors.Timeout {
+                let process = baml.sys.start_process(
+                    "setsid",
+                    ["sh", "-c", "echo $$; exec sleep 30"],
+                    null,
+                );
+                defer { process.close() }
+
+                let pgid = baml.json.from_string<int>(process.stdout.lines().next() ?? "0") catch_all (e) {
+                    _ => 0,
+                };
+                if (pgid <= 0 || !baml.sys.is_alive(pgid)) {
+                    return false;
+                }
+                match (baml.sys.platform()) {
+                    let u: baml.sys.Unix => u.signal_group(pgid, baml.sys.Signal.Kill),
+                    _ => { return false; },
+                }
+                let exit = process.wait();
+                match (exit.signal) {
+                    let signal: string => signal == "9",
+                    null => false,
+                }
+            }
+        "#
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}
+
+/// Non-positive pids/pgids are rejected before any syscall: `0` and negative
+/// values have process-group semantics in `kill(2)` and must never reach the
+/// kernel.
+#[tokio::test]
+#[cfg(not(target_os = "windows"))]
+async fn signal_functions_reject_non_positive_ids() {
+    let output = baml_test!(
+        r#"
+            function main() -> bool throws baml.errors.Io {
+                match (baml.sys.platform()) {
+                    let u: baml.sys.Unix => {
+                        u.terminate(0) catch (e) {
+                            let io: baml.errors.Io => { },
+                            _ => { return false; },
+                        };
+                        u.signal_group(-1, baml.sys.Signal.Terminate) catch (e) {
+                            let io: baml.errors.Io => { },
+                            _ => { return false; },
+                        };
+                        baml.sys.is_alive(0) catch (e) {
+                            let io: baml.errors.Io => { return true; },
+                            _ => { return false; },
+                        };
+                        false
+                    },
+                    _ => false,
+                }
+            }
+        "#
+    );
+
+    assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
+}

--- a/baml_language/crates/baml_tests/tests/shell.rs
+++ b/baml_language/crates/baml_tests/tests/shell.rs
@@ -717,9 +717,9 @@ async fn is_alive_reports_self() {
     assert_eq!(output.result, Ok(BexExternalValue::Bool(true)));
 }
 
-/// Windows variant of the liveness probe: a live child reads as alive, and
-/// once killed its exit code is no longer `STILL_ACTIVE`, so it reads as
-/// dead even if the process object has not been fully torn down yet.
+/// Windows variant of the liveness probe: a live child handle is unsignalled,
+/// and once killed its handle becomes signalled, so it reads as dead even if
+/// the process object has not been fully torn down yet.
 #[tokio::test]
 #[cfg(target_os = "windows")]
 async fn is_alive_tracks_child_lifetime() {

--- a/baml_language/crates/bridge_wasm/src/wasm_sys.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_sys.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use js_sys::{Function, Promise, Reflect, Uint8Array};
-use sys_ops::io::{self, IoNamespaceSys};
+use sys_ops::io::{self, AsBexExternalValue, IoNamespaceSys};
 use sys_types::{
     BexExternalValue, BexHeap, CallId, SysOpContext, SysOpOutput, VmBamlError, VmPanic,
     VmRustFnError,
@@ -202,6 +202,69 @@ impl io::IoClassSysProcess for WasmSys {
     }
 }
 
+/// Marker placed in the `_handle` of the `baml.sys.Browser` capability token
+/// returned by `platform()`. It carries no state — its presence is what makes
+/// the token class unconstructible from BAML code.
+struct WasmPlatformToken;
+
+impl io::IoClassSysLinux for WasmSys {
+    fn terminate(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        _linux: io::owned::sys::Linux,
+        _pid: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        SysOpOutput::err(VmBamlError::Unsupported {
+            message: "Signalling processes by ID is not supported on this platform".to_string(),
+        })
+    }
+
+    fn signal_group(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        _linux: io::owned::sys::Linux,
+        _pgid: i64,
+        _sig: BexExternalValue,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        SysOpOutput::err(VmBamlError::Unsupported {
+            message: "Signalling process groups is not supported on this platform".to_string(),
+        })
+    }
+}
+
+impl io::IoClassSysMacOs for WasmSys {
+    fn terminate(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        _macos: io::owned::sys::MacOs,
+        _pid: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        SysOpOutput::err(VmBamlError::Unsupported {
+            message: "Signalling processes by ID is not supported on this platform".to_string(),
+        })
+    }
+
+    fn signal_group(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        _macos: io::owned::sys::MacOs,
+        _pgid: i64,
+        _sig: BexExternalValue,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        SysOpOutput::err(VmBamlError::Unsupported {
+            message: "Signalling process groups is not supported on this platform".to_string(),
+        })
+    }
+}
+
 impl IoNamespaceSys for WasmSys {
     fn collect_garbage(
         &self,
@@ -337,6 +400,34 @@ impl IoNamespaceSys for WasmSys {
                 message: "the host JavaScript environment does not provide process.pid".to_string(),
             }),
         }
+    }
+
+    fn is_alive(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        _pid: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<bool> {
+        SysOpOutput::err(VmBamlError::Unsupported {
+            message: "Probing processes by ID is not supported on this platform".to_string(),
+        })
+    }
+
+    fn platform(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<BexExternalValue> {
+        // Browser hosts get the `Browser` capability token, which narrows to
+        // no further capabilities.
+        SysOpOutput::ok(
+            io::owned::sys::Browser {
+                _handle: Arc::new(WasmPlatformToken),
+            }
+            .into_bex_external_value(),
+        )
     }
 }
 

--- a/baml_language/crates/bridge_wasm/src/wasm_sys.rs
+++ b/baml_language/crates/bridge_wasm/src/wasm_sys.rs
@@ -409,7 +409,8 @@ impl IoNamespaceSys for WasmSys {
         _pid: i64,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<bool> {
-        SysOpOutput::err(VmBamlError::Unsupported {
+        SysOpOutput::err(VmPanic::HostUnavailable {
+            resource: "process-id".to_string(),
             message: "Probing processes by ID is not supported on this platform".to_string(),
         })
     }

--- a/baml_language/crates/sys_native/Cargo.toml
+++ b/baml_language/crates/sys_native/Cargo.toml
@@ -77,6 +77,18 @@ tokio-tungstenite = { workspace = true, optional = true, features = [
 tracing = { workspace = true }
 walkdir = { workspace = true }
 
+# `baml.sys.is_alive` and the `baml.sys.Unix` capability methods signal
+# processes by pid; std can only signal a live `Child` handle.
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
+# `baml.sys.is_alive` uses OpenProcess + GetExitCodeProcess on Windows.
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = [
+  "Win32_Foundation",
+  "Win32_System_Threading",
+] }
+
 [lints]
 workspace = true
 

--- a/baml_language/crates/sys_native/Cargo.toml
+++ b/baml_language/crates/sys_native/Cargo.toml
@@ -82,7 +82,7 @@ walkdir = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 
-# `baml.sys.is_alive` uses OpenProcess + GetExitCodeProcess on Windows.
+# `baml.sys.is_alive` uses OpenProcess + WaitForSingleObject on Windows.
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = [
   "Win32_Foundation",

--- a/baml_language/crates/sys_native/src/io_impls.rs
+++ b/baml_language/crates/sys_native/src/io_impls.rs
@@ -8,7 +8,8 @@ use std::sync::{Arc, OnceLock};
 
 use bex_heap::{BexExternalValue, BexHeap};
 use sys_ops::io::{
-    self, CallId, SysOpContext, SysOpOutput, VmBamlError, VmPanic, VmRustFnError, owned,
+    self, AsBexExternalValue, CallId, SysOpContext, SysOpOutput, VmBamlError, VmPanic,
+    VmRustFnError, owned,
 };
 
 const MAX_READ_CHUNK: usize = 64 * 1024;
@@ -1577,6 +1578,115 @@ impl io::IoClassSysProcess for NativeSysOps {
     }
 }
 
+/// Marker placed in the `_handle` of the platform capability tokens
+/// (`baml.sys.Linux`/`MacOs`/`Windows`/`Browser`). It carries no state — its
+/// presence is what makes the token classes unconstructible from BAML code,
+/// so a capability cannot be forged for another platform.
+struct PlatformToken;
+
+/// The capability token for this host, backing `baml.sys.platform()`.
+///
+/// Unixes other than Linux and macOS also hand out the `Linux` token: they
+/// share the same POSIX `kill(2)` signalling surface, and the `Unix`
+/// capability — not the concrete class — gates those operations.
+#[cfg(all(unix, not(target_os = "macos")))]
+fn platform_token() -> BexExternalValue {
+    owned::sys::Linux {
+        _handle: Arc::new(PlatformToken),
+    }
+    .into_bex_external_value()
+}
+
+/// The capability token for macOS hosts, backing `baml.sys.platform()`.
+#[cfg(target_os = "macos")]
+fn platform_token() -> BexExternalValue {
+    owned::sys::MacOs {
+        _handle: Arc::new(PlatformToken),
+    }
+    .into_bex_external_value()
+}
+
+/// The capability token for Windows hosts, backing `baml.sys.platform()`.
+#[cfg(windows)]
+fn platform_token() -> BexExternalValue {
+    owned::sys::Windows {
+        _handle: Arc::new(PlatformToken),
+    }
+    .into_bex_external_value()
+}
+
+/// Fallback capability token for hosts with no process-control surface,
+/// backing `baml.sys.platform()`.
+#[cfg(not(any(unix, windows)))]
+fn platform_token() -> BexExternalValue {
+    owned::sys::Browser {
+        _handle: Arc::new(PlatformToken),
+    }
+    .into_bex_external_value()
+}
+
+impl io::IoClassSysLinux for NativeSysOps {
+    fn terminate(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        _linux: owned::sys::Linux,
+        pid: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        match terminate_process_by_pid(pid) {
+            Ok(()) => SysOpOutput::ok(()),
+            Err(error) => SysOpOutput::err(error),
+        }
+    }
+
+    fn signal_group(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        _linux: owned::sys::Linux,
+        pgid: i64,
+        sig: BexExternalValue,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        match signal_process_group(pgid, &sig) {
+            Ok(()) => SysOpOutput::ok(()),
+            Err(error) => SysOpOutput::err(error),
+        }
+    }
+}
+
+impl io::IoClassSysMacOs for NativeSysOps {
+    fn terminate(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        _macos: owned::sys::MacOs,
+        pid: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        match terminate_process_by_pid(pid) {
+            Ok(()) => SysOpOutput::ok(()),
+            Err(error) => SysOpOutput::err(error),
+        }
+    }
+
+    fn signal_group(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        _macos: owned::sys::MacOs,
+        pgid: i64,
+        sig: BexExternalValue,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        match signal_process_group(pgid, &sig) {
+            Ok(()) => SysOpOutput::ok(()),
+            Err(error) => SysOpOutput::err(error),
+        }
+    }
+}
+
 /// Shared helper: apply `ProcessOptions` to a `tokio::process::Command`, run
 /// it, and collect its output. Both `exec()` and `shell()` use this.
 async fn run_process(
@@ -1853,6 +1963,221 @@ impl io::IoNamespaceSys for NativeSysOps {
         // for, so the widening into BAML's i63 `int` is always exact.
         SysOpOutput::ok(i64::from(std::process::id()))
     }
+
+    fn is_alive(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        pid: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<bool> {
+        match probe_process_alive(pid) {
+            Ok(alive) => SysOpOutput::ok(alive),
+            Err(error) => SysOpOutput::err(error),
+        }
+    }
+
+    fn platform(
+        &self,
+        _heap: &Arc<BexHeap>,
+        _call_id: CallId,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<BexExternalValue> {
+        SysOpOutput::ok(platform_token())
+    }
+}
+
+/// Validate a BAML `int` as a positive OS process ID. `0` and negative
+/// values have process-group semantics in `kill(2)` — passing them through
+/// could signal unrelated processes — so they are rejected before any
+/// syscall, as is anything that does not fit the platform's pid type.
+#[cfg(unix)]
+fn validate_pid(pid: i64) -> Result<i32, VmBamlError> {
+    match i32::try_from(pid) {
+        Ok(raw_pid) if raw_pid > 0 => Ok(raw_pid),
+        _ => Err(VmBamlError::Io {
+            message: format!("Invalid process ID {pid}"),
+        }),
+    }
+}
+
+/// Validate a BAML `int` as a positive Windows process ID.
+#[cfg(windows)]
+fn validate_pid(pid: i64) -> Result<u32, VmBamlError> {
+    match u32::try_from(pid) {
+        Ok(raw_pid) if raw_pid > 0 => Ok(raw_pid),
+        _ => Err(VmBamlError::Io {
+            message: format!("Invalid process ID {pid}"),
+        }),
+    }
+}
+
+/// Liveness probe backing `baml.sys.is_alive`: `kill(pid, 0)` performs error
+/// checking without delivering a signal. `ESRCH` means no such process;
+/// `EPERM` means the process exists but may not be signalled.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn probe_process_alive(pid: i64) -> Result<bool, VmBamlError> {
+    let raw_pid = validate_pid(pid)?;
+    // SAFETY: `kill` takes plain scalar arguments; signal `0` delivers
+    // nothing, so this only probes the validated pid.
+    let result = unsafe { libc::kill(raw_pid, 0) };
+    if result == 0 {
+        Ok(true)
+    } else {
+        match std::io::Error::last_os_error().raw_os_error() {
+            Some(libc::ESRCH) => Ok(false),
+            Some(libc::EPERM) => Ok(true),
+            _ => Err(VmBamlError::Io {
+                message: format!(
+                    "Failed to probe process {pid}: {}",
+                    std::io::Error::last_os_error()
+                ),
+            }),
+        }
+    }
+}
+
+/// Liveness probe backing `baml.sys.is_alive`: open the process and check
+/// whether its exit code is still `STILL_ACTIVE`. `OpenProcess` fails with
+/// `ERROR_INVALID_PARAMETER` when no such process exists.
+#[cfg(windows)]
+#[allow(unsafe_code)]
+fn probe_process_alive(pid: i64) -> Result<bool, VmBamlError> {
+    use windows_sys::Win32::Foundation::{CloseHandle, ERROR_INVALID_PARAMETER};
+    use windows_sys::Win32::System::Threading::{
+        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+    };
+
+    // `STILL_ACTIVE` (`STATUS_PENDING`) is the exit code of a running
+    // process.
+    const STILL_ACTIVE: u32 = 259;
+
+    let raw_pid = validate_pid(pid)?;
+    // SAFETY: all handles are checked for validity, and `handle` is closed
+    // exactly once before returning.
+    unsafe {
+        let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, raw_pid);
+        if handle.is_null() {
+            let error = std::io::Error::last_os_error();
+            if error.raw_os_error() == Some(i32::try_from(ERROR_INVALID_PARAMETER).unwrap_or(0)) {
+                return Ok(false);
+            }
+            return Err(VmBamlError::Io {
+                message: format!("Failed to open process {pid}: {error}"),
+            });
+        }
+        let mut exit_code: u32 = 0;
+        let queried = GetExitCodeProcess(handle, &mut exit_code);
+        let error = std::io::Error::last_os_error();
+        CloseHandle(handle);
+        if queried == 0 {
+            Err(VmBamlError::Io {
+                message: format!("Failed to read exit code of process {pid}: {error}"),
+            })
+        } else {
+            Ok(exit_code == STILL_ACTIVE)
+        }
+    }
+}
+
+#[cfg(not(any(unix, windows)))]
+fn probe_process_alive(pid: i64) -> Result<bool, VmBamlError> {
+    Err(VmBamlError::Unsupported {
+        message: format!("Probing process {pid} is not supported on this platform"),
+    })
+}
+
+/// Map a `baml.sys.Signal` value to its POSIX signal number.
+#[cfg(unix)]
+fn signal_number(sig: &BexExternalValue) -> Result<i32, VmBamlError> {
+    match sig {
+        BexExternalValue::Variant { variant_name, .. } => match variant_name.as_str() {
+            "Terminate" => Ok(libc::SIGTERM),
+            "Interrupt" => Ok(libc::SIGINT),
+            "Kill" => Ok(libc::SIGKILL),
+            "Hangup" => Ok(libc::SIGHUP),
+            other => Err(VmBamlError::Io {
+                message: format!("Unknown baml.sys.Signal variant '{other}'"),
+            }),
+        },
+        other => Err(VmBamlError::Io {
+            message: format!(
+                "signal_group sig must be a baml.sys.Signal, got {}",
+                other.type_name()
+            ),
+        }),
+    }
+}
+
+/// Send `SIGTERM` to an arbitrary process by OS process ID. Backs
+/// `Unix.terminate`; `std` can only signal a live `Child` handle, not a pid.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn terminate_process_by_pid(pid: i64) -> Result<(), VmBamlError> {
+    let raw_pid = validate_pid(pid)?;
+    // SAFETY: `kill` takes plain scalar arguments; `raw_pid` is validated
+    // above, so this can only target the single requested process.
+    let result = unsafe { libc::kill(raw_pid, libc::SIGTERM) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(VmBamlError::Io {
+            message: format!(
+                "Failed to terminate process {pid}: {}",
+                std::io::Error::last_os_error()
+            ),
+        })
+    }
+}
+
+/// Non-Unix hosts never hand out a `Unix` capability, so this is only
+/// reachable by dispatching a stale token across runtimes.
+#[cfg(not(unix))]
+fn terminate_process_by_pid(pid: i64) -> Result<(), VmBamlError> {
+    let _ = pid;
+    Err(VmBamlError::Unsupported {
+        message: "baml.sys.Unix.terminate is only supported on Unix platforms".to_string(),
+    })
+}
+
+/// Send a signal to every process in a Unix process group
+/// (`kill(-pgid, sig)`). Backs `Unix.signal_group`.
+#[cfg(unix)]
+#[allow(unsafe_code)]
+fn signal_process_group(pgid: i64, sig: &BexExternalValue) -> Result<(), VmBamlError> {
+    let raw_pgid = match i32::try_from(pgid) {
+        Ok(raw_pgid) if raw_pgid > 0 => raw_pgid,
+        _ => {
+            return Err(VmBamlError::Io {
+                message: format!("Invalid process group ID {pgid}"),
+            });
+        }
+    };
+    let signo = signal_number(sig)?;
+    // SAFETY: `kill` takes plain scalar arguments; `raw_pgid` is validated
+    // positive above, so `-raw_pgid` targets exactly the requested group.
+    let result = unsafe { libc::kill(-raw_pgid, signo) };
+    if result == 0 {
+        Ok(())
+    } else {
+        Err(VmBamlError::Io {
+            message: format!(
+                "Failed to signal process group {pgid}: {}",
+                std::io::Error::last_os_error()
+            ),
+        })
+    }
+}
+
+/// Non-Unix hosts never hand out a `Unix` capability, so this is only
+/// reachable by dispatching a stale token across runtimes.
+#[cfg(not(unix))]
+fn signal_process_group(pgid: i64, sig: &BexExternalValue) -> Result<(), VmBamlError> {
+    let _ = (pgid, sig);
+    Err(VmBamlError::Unsupported {
+        message: "baml.sys.Unix.signal_group is only supported on Unix platforms".to_string(),
+    })
 }
 
 fn sleep_nanos_from_delay(delay: BexExternalValue) -> Result<u64, VmRustFnError> {

--- a/baml_language/crates/sys_native/src/io_impls.rs
+++ b/baml_language/crates/sys_native/src/io_impls.rs
@@ -1971,10 +1971,16 @@ impl io::IoNamespaceSys for NativeSysOps {
         pid: i64,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<bool> {
+        #[cfg(any(unix, windows))]
         match probe_process_alive(pid) {
             Ok(alive) => SysOpOutput::ok(alive),
             Err(error) => SysOpOutput::err(error),
         }
+        #[cfg(not(any(unix, windows)))]
+        SysOpOutput::err(VmPanic::HostUnavailable {
+            resource: "process-id".to_string(),
+            message: "Probing processes by ID is not supported on this platform".to_string(),
+        })
     }
 
     fn platform(
@@ -2038,20 +2044,16 @@ fn probe_process_alive(pid: i64) -> Result<bool, VmBamlError> {
     }
 }
 
-/// Liveness probe backing `baml.sys.is_alive`: open the process and check
-/// whether its exit code is still `STILL_ACTIVE`. `OpenProcess` fails with
-/// `ERROR_INVALID_PARAMETER` when no such process exists.
+/// Liveness probe backing `baml.sys.is_alive`: open the process and poll its
+/// handle. `OpenProcess` fails with `ERROR_INVALID_PARAMETER` when no such
+/// process exists; access denied means it exists but cannot be inspected.
 #[cfg(windows)]
 #[allow(unsafe_code)]
 fn probe_process_alive(pid: i64) -> Result<bool, VmBamlError> {
-    use windows_sys::Win32::Foundation::{CloseHandle, ERROR_INVALID_PARAMETER};
+    use windows_sys::Win32::Foundation::CloseHandle;
     use windows_sys::Win32::System::Threading::{
-        GetExitCodeProcess, OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION,
+        OpenProcess, PROCESS_QUERY_LIMITED_INFORMATION, WaitForSingleObject,
     };
-
-    // `STILL_ACTIVE` (`STATUS_PENDING`) is the exit code of a running
-    // process.
-    const STILL_ACTIVE: u32 = 259;
 
     let raw_pid = validate_pid(pid)?;
     // SAFETY: all handles are checked for validity, and `handle` is closed
@@ -2059,33 +2061,49 @@ fn probe_process_alive(pid: i64) -> Result<bool, VmBamlError> {
     unsafe {
         let handle = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, 0, raw_pid);
         if handle.is_null() {
-            let error = std::io::Error::last_os_error();
-            if error.raw_os_error() == Some(i32::try_from(ERROR_INVALID_PARAMETER).unwrap_or(0)) {
-                return Ok(false);
-            }
-            return Err(VmBamlError::Io {
-                message: format!("Failed to open process {pid}: {error}"),
-            });
+            return classify_open_process_error(pid, std::io::Error::last_os_error());
         }
-        let mut exit_code: u32 = 0;
-        let queried = GetExitCodeProcess(handle, &mut exit_code);
+        let wait_result = WaitForSingleObject(handle, 0);
         let error = std::io::Error::last_os_error();
         CloseHandle(handle);
-        if queried == 0 {
-            Err(VmBamlError::Io {
-                message: format!("Failed to read exit code of process {pid}: {error}"),
-            })
-        } else {
-            Ok(exit_code == STILL_ACTIVE)
-        }
+        classify_process_wait(pid, wait_result, error)
     }
 }
 
-#[cfg(not(any(unix, windows)))]
-fn probe_process_alive(pid: i64) -> Result<bool, VmBamlError> {
-    Err(VmBamlError::Unsupported {
-        message: format!("Probing process {pid} is not supported on this platform"),
-    })
+#[cfg(windows)]
+fn classify_open_process_error(pid: i64, error: std::io::Error) -> Result<bool, VmBamlError> {
+    use windows_sys::Win32::Foundation::{ERROR_ACCESS_DENIED, ERROR_INVALID_PARAMETER};
+
+    match error
+        .raw_os_error()
+        .and_then(|code| u32::try_from(code).ok())
+    {
+        Some(ERROR_INVALID_PARAMETER) => Ok(false),
+        Some(ERROR_ACCESS_DENIED) => Ok(true),
+        _ => Err(VmBamlError::Io {
+            message: format!("Failed to open process {pid}: {error}"),
+        }),
+    }
+}
+
+#[cfg(windows)]
+fn classify_process_wait(
+    pid: i64,
+    wait_result: u32,
+    error: std::io::Error,
+) -> Result<bool, VmBamlError> {
+    use windows_sys::Win32::Foundation::{WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT};
+
+    match wait_result {
+        WAIT_TIMEOUT => Ok(true),
+        WAIT_OBJECT_0 => Ok(false),
+        WAIT_FAILED => Err(VmBamlError::Io {
+            message: format!("Failed to query process {pid}: {error}"),
+        }),
+        other => Err(VmBamlError::Io {
+            message: format!("Unexpected wait result {other} for process {pid}"),
+        }),
+    }
 }
 
 /// Map a `baml.sys.Signal` value to its POSIX signal number.
@@ -3874,3 +3892,83 @@ impl io::IoNamespaceAiInternal for NativeSysOps {
 // state + SetOnce + cancel token) and are dispatched via the native-call
 // path (`$rust_function` in `ns_future/future.baml`), not through sys-ops.
 // See `bex_vm::package_baml` for the trait impl.
+
+#[cfg(test)]
+mod process_control_tests {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn validate_pid_enforces_unix_pid_range() {
+        assert_eq!(validate_pid(1).unwrap(), 1);
+        assert_eq!(validate_pid(i64::from(i32::MAX)).unwrap(), i32::MAX);
+        for pid in [0, -1, i64::MAX, i64::from(u32::MAX) + 1] {
+            assert!(matches!(validate_pid(pid), Err(VmBamlError::Io { .. })));
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn validate_pid_enforces_windows_pid_range() {
+        assert_eq!(validate_pid(1).unwrap(), 1);
+        assert_eq!(validate_pid(i64::from(u32::MAX)).unwrap(), u32::MAX);
+        for pid in [0, -1, i64::MAX, i64::from(u32::MAX) + 1] {
+            assert!(matches!(validate_pid(pid), Err(VmBamlError::Io { .. })));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn signal_number_maps_all_known_variants_and_rejects_unknown_values() {
+        let signal = |variant_name: &str| BexExternalValue::Variant {
+            enum_name: "baml.sys.Signal".to_string(),
+            variant_name: variant_name.to_string(),
+        };
+
+        assert_eq!(signal_number(&signal("Terminate")).unwrap(), libc::SIGTERM);
+        assert_eq!(signal_number(&signal("Interrupt")).unwrap(), libc::SIGINT);
+        assert_eq!(signal_number(&signal("Kill")).unwrap(), libc::SIGKILL);
+        assert_eq!(signal_number(&signal("Hangup")).unwrap(), libc::SIGHUP);
+        assert!(matches!(
+            signal_number(&signal("Unknown")),
+            Err(VmBamlError::Io { .. })
+        ));
+        assert!(matches!(
+            signal_number(&BexExternalValue::Null),
+            Err(VmBamlError::Io { .. })
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_open_process_errors_preserve_liveness_contract() {
+        use windows_sys::Win32::Foundation::{ERROR_ACCESS_DENIED, ERROR_INVALID_PARAMETER};
+
+        let os_error = |code| {
+            std::io::Error::from_raw_os_error(i32::try_from(code).expect("Win32 error fits i32"))
+        };
+        assert!(!classify_open_process_error(42, os_error(ERROR_INVALID_PARAMETER)).unwrap());
+        assert!(classify_open_process_error(42, os_error(ERROR_ACCESS_DENIED)).unwrap());
+        assert!(matches!(
+            classify_open_process_error(42, os_error(1234)),
+            Err(VmBamlError::Io { .. })
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_wait_result_distinguishes_running_exited_and_failed() {
+        use windows_sys::Win32::Foundation::{WAIT_FAILED, WAIT_OBJECT_0, WAIT_TIMEOUT};
+
+        let no_error = std::io::Error::from_raw_os_error(0);
+        assert!(classify_process_wait(42, WAIT_TIMEOUT, no_error).unwrap());
+        assert!(
+            !classify_process_wait(42, WAIT_OBJECT_0, std::io::Error::from_raw_os_error(0))
+                .unwrap()
+        );
+        assert!(matches!(
+            classify_process_wait(42, WAIT_FAILED, std::io::Error::from_raw_os_error(1234)),
+            Err(VmBamlError::Io { .. })
+        ));
+    }
+}

--- a/baml_language/crates/sys_ops/src/lib.rs
+++ b/baml_language/crates/sys_ops/src/lib.rs
@@ -1881,6 +1881,91 @@ impl io::IoNamespaceSys for DefaultIoOps {
             message: "Operation not supported on this platform".to_string(),
         })
     }
+
+    fn is_alive(
+        &self,
+        _h: &Arc<BexHeap>,
+        _c: CallId,
+        _pid: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<bool> {
+        SysOpOutput::err(VmBamlError::Unsupported {
+            message: "Operation not supported on this platform".to_string(),
+        })
+    }
+
+    // `baml.sys.platform` declares `throws never`; every real platform
+    // produces a token, so the fallback reports the missing host resource as
+    // a `baml.panics.HostUnavailable` panic, mirroring `pid`.
+    fn platform(
+        &self,
+        _h: &Arc<BexHeap>,
+        _c: CallId,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<BexExternalValue> {
+        SysOpOutput::err(VmPanic::HostUnavailable {
+            resource: "platform".to_string(),
+            message: "Operation not supported on this platform".to_string(),
+        })
+    }
+}
+
+impl io::IoClassSysLinux for DefaultIoOps {
+    fn terminate(
+        &self,
+        _h: &Arc<BexHeap>,
+        _c: CallId,
+        _linux: io::owned::sys::Linux,
+        _pid: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        SysOpOutput::err(VmBamlError::Unsupported {
+            message: "Operation not supported on this platform".to_string(),
+        })
+    }
+
+    fn signal_group(
+        &self,
+        _h: &Arc<BexHeap>,
+        _c: CallId,
+        _linux: io::owned::sys::Linux,
+        _pgid: i64,
+        _sig: BexExternalValue,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        SysOpOutput::err(VmBamlError::Unsupported {
+            message: "Operation not supported on this platform".to_string(),
+        })
+    }
+}
+
+impl io::IoClassSysMacOs for DefaultIoOps {
+    fn terminate(
+        &self,
+        _h: &Arc<BexHeap>,
+        _c: CallId,
+        _macos: io::owned::sys::MacOs,
+        _pid: i64,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        SysOpOutput::err(VmBamlError::Unsupported {
+            message: "Operation not supported on this platform".to_string(),
+        })
+    }
+
+    fn signal_group(
+        &self,
+        _h: &Arc<BexHeap>,
+        _c: CallId,
+        _macos: io::owned::sys::MacOs,
+        _pgid: i64,
+        _sig: BexExternalValue,
+        _ctx: &SysOpContext,
+    ) -> SysOpOutput<()> {
+        SysOpOutput::err(VmBamlError::Unsupported {
+            message: "Operation not supported on this platform".to_string(),
+        })
+    }
 }
 
 impl io::IoClassGlobGlob for DefaultIoOps {
@@ -2669,9 +2754,21 @@ impl IoSysOpsBuilder {
             })
         };
         self.inner.baml_sys_pid = {
-            let t = instance;
+            let t = instance.clone();
             Arc::new(move |heap, permit, args, ctx, call_id| {
                 t.__glue_baml_sys_pid(heap, permit, args, ctx, call_id)
+            })
+        };
+        self.inner.baml_sys_is_alive = {
+            let t = instance.clone();
+            Arc::new(move |heap, permit, args, ctx, call_id| {
+                t.__glue_baml_sys_is_alive(heap, permit, args, ctx, call_id)
+            })
+        };
+        self.inner.baml_sys_platform = {
+            let t = instance;
+            Arc::new(move |heap, permit, args, ctx, call_id| {
+                t.__glue_baml_sys_platform(heap, permit, args, ctx, call_id)
             })
         };
         self

--- a/baml_language/crates/sys_ops/src/lib.rs
+++ b/baml_language/crates/sys_ops/src/lib.rs
@@ -1889,7 +1889,8 @@ impl io::IoNamespaceSys for DefaultIoOps {
         _pid: i64,
         _ctx: &SysOpContext,
     ) -> SysOpOutput<bool> {
-        SysOpOutput::err(VmBamlError::Unsupported {
+        SysOpOutput::err(VmPanic::HostUnavailable {
+            resource: "process-id".to_string(),
             message: "Operation not supported on this platform".to_string(),
         })
     }


### PR DESCRIPTION
## Issue Reference

No tracking issue — third slice of the process-control primitives discussed with @2kai2kai2 on Discord. This PR has been respun around the platform capability-token design proposed in review.

## Changes

```baml
interface Platform {
    function unix(self) -> Unix? throws never
    function windows(self) -> Windows? throws never
}

interface Unix requires Platform {
    function terminate(self, pid: int) -> null throws root.errors.Io
    function signal_group(self, pgid: int, sig: Signal) -> null throws root.errors.Io
}

class Linux implements Platform + Unix
class MacOs implements Platform + Unix
class Windows implements Platform
class Browser implements Platform

function platform() -> Platform throws never
function is_alive(pid: int) -> bool throws root.errors.Io

enum Signal { Terminate, Interrupt, Kill, Hangup }
```

`platform()` returns a host-created capability token. Callers narrow it with `match` to reach platform-specific operations:

```baml
match (baml.sys.platform()) {
    let unix: baml.sys.Unix => unix.terminate(pid),
    _ => { /* explicit unsupported-platform handling */ },
}
```

- `Linux` and `MacOs` implement the `Unix` capability; `Windows` and `Browser` do not advertise Unix operations.
- Every concrete token carries an opaque `$rust_type` handle, following `Process`/`File`, so BAML code cannot forge a token for another platform.
- `Platform.unix()` / `windows()` remain convenience accessors. Their docs recommend explicit `match`; optional chaining intentionally no-ops and is documented for genuinely optional behavior only.
- `Unix.terminate(pid)` sends `SIGTERM`.
- `Unix.signal_group(pgid, sig)` sends SIGTERM/SIGINT/SIGKILL/SIGHUP via `kill(-pgid, sig)`.
- Portable `baml.sys.is_alive(pid)` uses `kill(pid, 0)` on Unix (ESRCH → false, EPERM → true) and `OpenProcess` + `GetExitCodeProcess == STILL_ACTIVE` on Windows.
- Non-positive and out-of-range pid/pgid values are rejected before any syscall.
- wasm returns a `Browser` token and does not expose process-control capabilities.

The previous nested `baml.sys.unix` namespace and its unrelated nested-IO codegen fix have been removed from this PR.

## Testing

- [x] `cargo check -p sys_ops -p sys_native`
- [x] `cargo check -p bridge_wasm --target wasm32-unknown-unknown`
- [x] `cargo check -p sys_native --target x86_64-pc-windows-msvc --no-default-features`
- [x] `cargo test -p baml_tests --test shell` — 21/21 on Linux
- [x] Snapshot regeneration and clean rerun: stdlib corpus, package items, and builtin package listing
- [x] `cargo fmt --all -- --check`
- [x] Clippy reports no warnings in the changed code; existing `sys_native/src/registry.rs` warnings remain unchanged

New tests cover host capability shape, interface-pattern narrowing, SIGTERM exit status, process-group SIGKILL, liveness before/after reap, and validation before syscalls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added platform detection for Linux, macOS, Windows, and browser environments.
  * Added process-liveness checks with clear validation errors for invalid process IDs.
  * Added Unix process termination and process-group signaling with common signal options.
  * Added capability checks so platform-specific operations are exposed only where supported.
  * Browser environments now report capabilities while safely rejecting unavailable process operations.

* **Bug Fixes**
  * Improved handling of inaccessible, nonexistent, and invalid processes.

* **Tests**
  * Added coverage for platform capabilities, process lifetimes, signaling, termination, and invalid IDs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->