### PR TITLE
perf(engine): cut interpreter hot-path overheads (permit churn, VC-key hashing, futures-map rehash)

### DIFF
--- a/baml_language/crates/bex_engine/src/future.rs
+++ b/baml_language/crates/bex_engine/src/future.rs
@@ -570,7 +570,11 @@ impl FutureManagerInner {
         Self {
             tlab,
             next_future_id: AtomicUsize::new(0),
-            active_futures: HashMap::new(),
+            // Pre-sized: a test-corpus run keeps thousands of futures live at
+            // once, and rehashing this map happens under the manager's mutex —
+            // profiled as a whole-engine stall (`reserve_rehash` on the one
+            // busy thread while every worker parks).
+            active_futures: HashMap::with_capacity(4096),
         }
     }
 

--- a/baml_language/crates/bex_heap/src/heap_guard.rs
+++ b/baml_language/crates/bex_heap/src/heap_guard.rs
@@ -146,10 +146,20 @@ impl<T: RootHaver> InactiveHeapPermit<T> {
     /// Wait for a permit to become available (i.e. as soon as there is no GC or other exclusive access operation running),
     /// and return a [`ActiveHeapPermit`] that can be used to access the heap with the permit.
     pub async fn acquire(self) -> ActiveHeapPermit<T> {
-        let permit = Arc::clone(&self.active)
-            .acquire_owned()
-            .await
-            .unwrap_or_else(|_| unreachable!("Semaphore should never be closed"));
+        // Fast path: when no GC park is draining the semaphore, a permit is
+        // available and `try_acquire_owned` takes it without constructing and
+        // polling the fair-queue acquire future. This acquisition runs on
+        // every VM task resume, so the setup cost of the slow path is a
+        // measurable interpreter tax under high task counts. Fairness only
+        // matters once a park request is queued — exactly the case where
+        // try fails and we fall through to the fair wait.
+        let permit = match Arc::clone(&self.active).try_acquire_owned() {
+            Ok(permit) => permit,
+            Err(_) => Arc::clone(&self.active)
+                .acquire_owned()
+                .await
+                .unwrap_or_else(|_| unreachable!("Semaphore should never be closed")),
+        };
         ActiveHeapPermit {
             state: self,
             _permit: permit,

--- a/baml_language/crates/bex_vm/Cargo.toml
+++ b/baml_language/crates/bex_vm/Cargo.toml
@@ -18,6 +18,7 @@ doctest = false
 workspace = true
 
 [dependencies]
+rustc-hash = { workspace = true }
 baml_builtins2 = { workspace = true }
 baml_compiler_diagnostics = { workspace = true }
 baml_type = { workspace = true }

--- a/baml_language/crates/bex_vm/src/vm.rs
+++ b/baml_language/crates/bex_vm/src/vm.rs
@@ -187,6 +187,12 @@ struct StaticVirtualCallKey {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 enum StaticVirtualReceiverKey {
+    /// Argument-less primitive receivers (int, string, float, ...) keyed by a
+    /// bare discriminant. These are the hottest virtual-call receivers in
+    /// practice (every string/int method), and the previous `Other(RealizedTy)`
+    /// path built and deep-hashed a realized type per call — the dominant
+    /// frame in VM profiles of test-corpus runs.
+    Primitive(u8),
     /// Static program classes have immutable, program-unique tags. Generic
     /// arguments remain part of identity; the overwhelmingly common
     /// non-generic case clones an empty box without allocating.
@@ -514,7 +520,7 @@ pub(crate) mod tests {
             pending_call_type_values: Vec::new(),
             static_mint_cache: HashMap::new(),
             static_load_type_cache: HashMap::new(),
-            static_virtual_call_cache: HashMap::new(),
+            static_virtual_call_cache: rustc_hash::FxHashMap::default(),
             packages: Arc::new(crate::package_load::PackageIndex::default()),
             dynamic_dispatch: Arc::new(crate::package_load::DynDispatchTables::default()),
         }
@@ -1275,7 +1281,11 @@ pub struct BexVm {
     /// receiver/interface instantiation observed there. Only immutable
     /// program-image rules enter this cache, so runtime package loading and
     /// dynamic builder registration remain live on every dynamic dispatch.
-    static_virtual_call_cache: HashMap<StaticVirtualCallKey, StaticVirtualCallTarget>,
+    /// `FxHashMap`: this map is keyed per virtual call executed, so hasher
+    /// throughput is on the interpreter hot path; `FxHash` over `SipHash` is
+    /// a measurable win and `DoS` resistance is irrelevant for an in-process
+    /// cache keyed by program structure.
+    static_virtual_call_cache: rustc_hash::FxHashMap<StaticVirtualCallKey, StaticVirtualCallTarget>,
 }
 
 /// VM execution state.
@@ -1803,7 +1813,7 @@ impl BexVm {
             pending_call_type_values: Vec::new(),
             static_mint_cache: HashMap::new(),
             static_load_type_cache: HashMap::new(),
-            static_virtual_call_cache: HashMap::new(),
+            static_virtual_call_cache: rustc_hash::FxHashMap::default(),
             packages,
             dynamic_dispatch,
         }
@@ -3351,15 +3361,40 @@ impl BexVm {
     /// class name on every method call. Runtime-built classes stay off this
     /// cache because their dispatch tables are live.
     fn static_virtual_receiver_key(&self, value: Value) -> Option<StaticVirtualReceiverKey> {
-        if let Some(ptr) = value.as_object_ptr()
-            && let Object::Instance(instance) = self.get_object(ptr)
-            && let Object::Class(class) = self.get_object(instance.class)
-            && self.heap.is_compile_time_ptr(instance.class)
-        {
-            return Some(StaticVirtualReceiverKey::Class {
-                type_tag: class.type_tag,
-                type_args: instance.class_type_args.clone(),
-            });
+        // Fast discriminants for the argument-less primitives, mirroring the
+        // corresponding arms of `value_concrete_ty` — no realized type is
+        // built or hashed. Receivers whose identity carries type arguments
+        // (instances, containers, enums, futures, media) fall through to the
+        // structural keys below.
+        if value.as_int().is_some() {
+            return Some(StaticVirtualReceiverKey::Primitive(0));
+        }
+        if value.as_bool().is_some() {
+            return Some(StaticVirtualReceiverKey::Primitive(1));
+        }
+        if value.is_null() {
+            return Some(StaticVirtualReceiverKey::Primitive(2));
+        }
+        if let Some(ptr) = value.as_object_ptr() {
+            match self.get_object(ptr) {
+                Object::Float(_) => return Some(StaticVirtualReceiverKey::Primitive(3)),
+                Object::String(_) => return Some(StaticVirtualReceiverKey::Primitive(4)),
+                Object::Bigint(_) => return Some(StaticVirtualReceiverKey::Primitive(5)),
+                Object::Uint8Array(_) => return Some(StaticVirtualReceiverKey::Primitive(6)),
+                Object::Instance(instance)
+                    if matches!(self.get_object(instance.class), Object::Class(_))
+                        && self.heap.is_compile_time_ptr(instance.class) =>
+                {
+                    let Object::Class(class) = self.get_object(instance.class) else {
+                        unreachable!("matched Class above");
+                    };
+                    return Some(StaticVirtualReceiverKey::Class {
+                        type_tag: class.type_tag,
+                        type_args: instance.class_type_args.clone(),
+                    });
+                }
+                _ => {}
+            }
         }
         self.value_concrete_ty(value)
             .map(baml_type::RealizedTy::from)


### PR DESCRIPTION
## Issue Reference
- Follow-up from profiling test-corpus runs during #4541's test-infrastructure work; no filed issue.

## Changes

Profiling a release-grade corpus run (3,448 tests, `sample`-based, thread-state census + symbolized frame buckets) showed the engine averaging ~1 core on a 12-core machine, with three concrete taxes. This PR removes them; all changes are behavior-preserving.

**1. Heap-permit fast path** (`bex_heap`). Every VM task resume paid a full fair-queue acquire on the global heap-permit semaphore — 17 of 39 sampled threads sat inside `InactiveHeapPermit::acquire` / `batch_semaphore::poll` machinery. `acquire` now tries `try_acquire_owned` first. Fairness only matters once a GC park's `acquire_many(MAX_PERMITS)` is pending — and in exactly that case zero permits are available, the try fails, and acquisition falls through to the fair wait, so **GC parks cannot be starved** by the bypass.

**2. Primitive receiver keys for the virtual-call cache** (`bex_vm`). Every virtual call on a primitive receiver — string/int methods, the hottest calls in any workload — built a `RealizedTy` and deep-hashed it under SipHash to key the static virtual-call cache (in an earlier debug-profile these hash/clone frames were ~65% of VM samples). `StaticVirtualReceiverKey` gains a `Primitive(u8)` variant: bare discriminants for the argument-less primitives, nothing built or hashed. Receivers whose identity carries type arguments (instances, containers, enums) keep the structural keys. The cache also switches SipHash → FxHash (in-process cache keyed by program structure; DoS resistance irrelevant).

**3. Futures-map presizing** (`bex_engine`). The `FutureManager`'s `active_futures` map rehashed under the manager's single mutex mid-run — sampled as one thread in `hashbrown::reserve_rehash` while every other worker parked. Pre-sized to 4096 so corpus-scale future churn never rehashes inside the lock.

## Measurements

Back-to-back A/B on the full corpus, same machine, `fasttest` profile (release-grade codegen, debug assertions on):

| | wall | user CPU | sys CPU | total CPU |
|---|---|---|---|---|
| canary | 69.0s | 71.2s | 17.0s | 88.2s |
| this PR | 67.1s | 62.2s | **1.9s** | **64.1s** |

Total CPU **−27%**; sys time **−89%** (the semaphore's kernel wake/park traffic — the permit fast path); user time −13% (hashing). Wall moves little because the corpus floor is timer-bound (sleep- and timeout-shaped tests), not CPU-bound.

## Testing

- [x] `cargo nextest run -p bex_vm -p bex_heap -p bex_engine` — 580/580
- [x] Full corpus via `baml-cli test` — 3,447/3,448 (the one failure is the known contention-flaky `vertex_stream_time_to_first_token_timeout_ms`, which fails identically on baseline runs)
- [x] clippy/fmt clean on the three crates
- [x] Manual: profiled before/after; the permit-acquire and rehash frames are gone from the after-sample

## Reviewer notes — what this deliberately does NOT do

The remaining parallelism ceiling is structural, and these are documented for follow-up rather than attempted here:

- **`FutureManager` sharding**: one `tokio::Mutex` still guards the futures map + TLAB; every spawn/settle serializes through it. Sharding or a lock-free map is the next real win.
- **Permit-holding across resumes**: resumes still round-trip the (now cheap) semaphore; holding permits across iterations needs care against the GC-park protocol.
- **Monomorphic inline caches**: the VC cache key still includes `caller_function_addr + call_pc` — a per-PC IC comparing receiver tags would skip the map entirely.
- **Test-runner concurrency bounding** (`TaskGroup` gating in `testing/registry.baml`): the corpus spawns all ~3,400 tests at once; bounding admission fixes fd storms, tight-timeout flakiness, and makes per-test durations meaningful. Separate stdlib PR.

Raw `sample` profiles are available on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches GC-permit fairness and virtual-dispatch cache identity. Logic is intended to be equivalent, but a keying or try-acquire mistake would mis-dispatch methods or starve GC parks.
> 
> **Overview**
> Behavior-preserving hot-path speedups from corpus profiling: less semaphore churn on every VM resume, cheaper virtual-call cache keys, and no futures-map rehash under the manager mutex.
> 
> **Heap permits:** `InactiveHeapPermit::acquire` now `try_acquire_owned` first and only fair-waits when a GC park has drained the semaphore, so parks cannot be starved.
> 
> **Virtual-call cache:** primitive receivers (int/string/etc.) key as a `Primitive(u8)` discriminant instead of hashing a `RealizedTy`. The cache uses `FxHashMap` instead of SipHash.
> 
> **Futures:** `active_futures` is pre-sized to 4096 so corpus-scale churn does not rehash while holding the manager lock.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5f01044cc09959940dd9f4fd4745d4706eb81b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved runtime efficiency when managing large numbers of concurrent operations.
  * Reduced overhead for common virtual calls involving primitive values.
  * Improved memory and lookup performance for virtual-call caching.
  * Optimized resource acquisition to respond immediately when capacity is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->