### PR TITLE
fix: suppress cascading match and call diagnostics

### DIFF
--- a/baml_language/crates/baml_compiler2_hir_ty/src/diagnostics.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/diagnostics.rs
@@ -277,6 +277,8 @@ pub enum TirTypeError {
     },
     /// Wrong number of arguments in a function call.
     ArgumentCountMismatch { expected: usize, got: usize },
+    /// One or more positional call arguments do not correspond to parameters.
+    UnexpectedArguments { expected: usize, extra_count: usize },
     /// A positional argument appeared after a named argument in the same call.
     PositionalArgumentAfterNamed,
     /// A named argument was supplied more than once.
@@ -1192,6 +1194,23 @@ impl fmt::Display for TirTypeError {
             }
             TirTypeError::ArgumentCountMismatch { expected, got } => {
                 write!(f, "expected {expected} argument(s), got {got}")
+            }
+            TirTypeError::UnexpectedArguments {
+                expected,
+                extra_count,
+            } => {
+                let argument_suffix = if *expected == 1 { "" } else { "s" };
+                if *extra_count == 1 {
+                    write!(
+                        f,
+                        "unexpected argument; this function accepts {expected} argument{argument_suffix}, remove it"
+                    )
+                } else {
+                    write!(
+                        f,
+                        "{extra_count} unexpected arguments; this function accepts {expected} argument{argument_suffix}, remove them"
+                    )
+                }
             }
             TirTypeError::PositionalArgumentAfterNamed => {
                 write!(

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -610,6 +610,136 @@ pub enum ParamBinding {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CallArgMatch {
+    RuntimeId,
+    Parameter {
+        param_index: usize,
+        fills_parameter: bool,
+    },
+    Extra,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CallArgPlan {
+    matches: Vec<CallArgMatch>,
+    slots: Vec<Option<ExprId>>,
+}
+
+impl CallArgPlan {
+    fn new(
+        params: &[baml_type::interned::FunctionParam],
+        args: &[baml_compiler2_ast::CallArg],
+    ) -> Self {
+        let matches =
+            args.iter()
+                .enumerate()
+                .map(|(index, arg)| match &arg.label {
+                    Some(label) if label.as_str() == "$id" => CallArgMatch::RuntimeId,
+                    Some(label) => match params
+                        .iter()
+                        .position(|param| param.name.as_ref() == Some(label))
+                    {
+                        Some(param_index) => CallArgMatch::Parameter {
+                            param_index,
+                            fills_parameter: true,
+                        },
+                        None => params.get(index).map_or(CallArgMatch::Extra, |_| {
+                            CallArgMatch::Parameter {
+                                param_index: index,
+                                fills_parameter: false,
+                            }
+                        }),
+                    },
+                    None => {
+                        params
+                            .get(index)
+                            .map_or(CallArgMatch::Extra, |_| CallArgMatch::Parameter {
+                                param_index: index,
+                                fills_parameter: true,
+                            })
+                    }
+                })
+                .collect();
+        let mut plan = Self {
+            matches,
+            slots: vec![None; params.len()],
+        };
+        plan.rebuild_slots(args);
+        plan
+    }
+
+    fn rebuild_slots(&mut self, args: &[baml_compiler2_ast::CallArg]) {
+        self.slots.fill(None);
+        for (arg, matched) in args.iter().zip(&self.matches) {
+            if let CallArgMatch::Parameter {
+                param_index,
+                fills_parameter: true,
+            } = *matched
+            {
+                self.slots[param_index].get_or_insert(arg.expr);
+            }
+        }
+    }
+
+    fn recover_positionals(
+        &mut self,
+        args: &[baml_compiler2_ast::CallArg],
+        arg_indices: &[usize],
+        matched_params: &[Option<usize>],
+    ) {
+        for (&arg_index, &param_index) in arg_indices.iter().zip(matched_params) {
+            self.matches[arg_index] =
+                param_index.map_or(CallArgMatch::Extra, |param_index| CallArgMatch::Parameter {
+                    param_index,
+                    fills_parameter: true,
+                });
+        }
+        self.rebuild_slots(args);
+    }
+}
+
+fn align_extra_arguments(compatibility: &[Vec<bool>]) -> Vec<Option<usize>> {
+    let arg_count = compatibility.len();
+    let param_count = compatibility.first().map_or(0, Vec::len);
+    debug_assert!(compatibility.iter().all(|row| row.len() == param_count));
+
+    // Every complete alignment skips exactly `arg_count - param_count`
+    // arguments, so minimizing incompatible bindings identifies the extras.
+    let mut costs = vec![vec![param_count + 1; param_count + 1]; arg_count + 1];
+    costs[arg_count][param_count] = 0;
+    for arg_index in (0..arg_count).rev() {
+        costs[arg_index][param_count] = 0;
+    }
+    for arg_index in (0..arg_count).rev() {
+        for param_index in (0..param_count).rev() {
+            if arg_count - arg_index < param_count - param_index {
+                continue;
+            }
+            let skip = costs[arg_index + 1][param_index];
+            let mismatch = usize::from(!compatibility[arg_index][param_index]);
+            let bind = mismatch + costs[arg_index + 1][param_index + 1];
+            costs[arg_index][param_index] = skip.min(bind);
+        }
+    }
+
+    let mut result = vec![None; arg_count];
+    let (mut arg_index, mut param_index) = (0, 0);
+    while arg_index < arg_count {
+        if param_index < param_count {
+            let mismatch = usize::from(!compatibility[arg_index][param_index]);
+            let bind = mismatch + costs[arg_index + 1][param_index + 1];
+            let skip = costs[arg_index + 1][param_index];
+            if bind <= skip {
+                result[arg_index] = Some(param_index);
+                param_index += 1;
+            }
+        }
+        arg_index += 1;
+    }
+    result
+}
+
 /// Inference side tables for one body owner, keyed by arena ids, mirroring
 /// rust-analyzer's `InferenceResult`. Types are the hash-consed
 /// `baml_type::interned` representation (this crate's native vocabulary);
@@ -816,6 +946,11 @@ enum PendingDiag<'db> {
         expr: ExprId,
         expected: usize,
         got: usize,
+    },
+    UnexpectedArguments {
+        expr: ExprId,
+        expected: usize,
+        extra_count: usize,
     },
     UnknownNamedArg {
         expr: ExprId,
@@ -1627,6 +1762,14 @@ struct InferenceContext<'db> {
     /// vars - for one `TypeRefId`. Without this, a `_` hole instantiates
     /// once per consumer and only the demand-connected copy solves.
     annotation_cache: FxHashMap<baml_compiler2_hir::type_ref::TypeRefId, Ty>,
+    /// Body annotations whose recovered type came from an invalid written
+    /// type. Kept separately from the usable recovered `Ty` so later
+    /// consumers cannot mistake successful recovery for valid source.
+    invalid_annotations: rustc_hash::FxHashSet<baml_compiler2_hir::type_ref::TypeRefId>,
+    /// Pattern roots whose lowering emitted a primary diagnostic. Match
+    /// usefulness requires every matrix row to be trustworthy, so one entry
+    /// here suppresses dependent exhaustiveness and reachability findings.
+    invalid_patterns: rustc_hash::FxHashSet<PatId>,
     /// Per-body memoization of ground canonical forms. Inference-bearing types
     /// bypass it because their meaning changes as the table solves variables.
     canonical_cache: baml_type::normalize::InternedCanonicalCache,
@@ -1763,6 +1906,8 @@ impl<'db> InferenceContext<'db> {
             pending_diags: Vec::new(),
             hole_vars: Vec::new(),
             annotation_cache: FxHashMap::default(),
+            invalid_annotations: rustc_hash::FxHashSet::default(),
+            invalid_patterns: rustc_hash::FxHashSet::default(),
             canonical_cache: baml_type::normalize::InternedCanonicalCache::default(),
             member_probe_depth: 0,
             or_probe_depth: 0,
@@ -4978,41 +5123,7 @@ impl<'db> InferenceContext<'db> {
             .remove(&call)
             .unwrap_or_default();
         let ret = ret.clone();
-        // The matching is decided ONCE, checked below and recorded as the
-        // call plan's bindings: a LABELED argument selects its parameter
-        // by NAME (`options(cancel = tok)` checks against `cancel`, not
-        // whatever sits at its position); unlabeled arguments fill
-        // positionally; an unmatched label falls back to position. The
-        // label/arity diagnostics are S17's. `$id = ...` is the runtime-id
-        // side channel (TIR's rule: not a parameter binding) - it never
-        // matches a parameter; its own LocalId check lives at the capture.
-        let matched: Vec<Option<usize>> = args
-            .iter()
-            .enumerate()
-            .map(|(index, arg)| match &arg.label {
-                Some(label) if label.as_str() == "$id" => None,
-                Some(label) => params
-                    .iter()
-                    .position(|param| param.name.as_ref() == Some(label))
-                    .or_else(|| params.get(index).map(|_| index)),
-                None => params.get(index).map(|_| index),
-            })
-            .collect();
-        // An UNKNOWN label's positional fallback types the value but
-        // never FILLS the parameter: `search(q = "cats")` still owes
-        // `query`, so both the unknown-label and missing-required
-        // diagnostics report.
-        let label_fallback: Vec<bool> = args
-            .iter()
-            .map(|arg| {
-                arg.label.as_ref().is_some_and(|label| {
-                    label.as_str() != "$id"
-                        && !params
-                            .iter()
-                            .any(|param| param.name.as_ref() == Some(label))
-                })
-            })
-            .collect();
+        let mut arg_plan = CallArgPlan::new(&params, args);
         let is_lambda_arg =
             |arg: &baml_compiler2_ast::CallArg| matches!(body.exprs[arg.expr], Expr::Lambda(_));
         for pass in 0..2 {
@@ -5020,8 +5131,10 @@ impl<'db> InferenceContext<'db> {
                 if (pass == 0) == is_lambda_arg(arg) {
                     continue;
                 }
-                match matched[index] {
-                    Some(param_index) if runtime_dependent.contains_key(&param_index) => {
+                match arg_plan.matches[index] {
+                    CallArgMatch::Parameter { param_index, .. }
+                        if runtime_dependent.contains_key(&param_index) =>
+                    {
                         // The value still participates in ordinary inference;
                         // only its runtime-dependent expectation is deferred.
                         self.infer_expr(body, arg.expr, &Expectation::None);
@@ -5036,22 +5149,56 @@ impl<'db> InferenceContext<'db> {
                                 expected,
                             });
                     }
-                    Some(param_index) => {
+                    CallArgMatch::Parameter { param_index, .. } => {
                         self.check_expr(body, arg.expr, &params[param_index].ty);
                     }
-                    None => {
+                    CallArgMatch::RuntimeId | CallArgMatch::Extra => {
                         // Extra argument: the arity diagnostic is S17's.
                         self.infer_expr(body, arg.expr, &Expectation::None);
                     }
                 }
             }
         }
-        // Parameter-ordered bindings: provided slots from the matching,
-        // omitted OPTIONAL slots as defaults (required gaps get no entry;
-        // arity is S17's).
-        let mut slots: Vec<Option<ExprId>> = vec![None; params.len()];
+
+        let provided = args
+            .iter()
+            .filter(|arg| arg.label.as_ref().map(smol_str::SmolStr::as_str) != Some("$id"))
+            .count();
+        let positional_indices: Vec<usize> = args
+            .iter()
+            .enumerate()
+            .filter_map(|(index, arg)| arg.label.is_none().then_some(index))
+            .collect();
+        if provided > params.len() && positional_indices.len() == provided {
+            let compatibility: Vec<Vec<bool>> = positional_indices
+                .iter()
+                .map(|&arg_index| {
+                    let actual = self.result.type_of_expr[&args[arg_index].expr].clone();
+                    params
+                        .iter()
+                        .map(|param| {
+                            actual.has_error()
+                                || param.ty.has_error()
+                                || actual.has_infer()
+                                || param.ty.has_infer()
+                                || self.cached_subtype(&actual, &param.ty)
+                        })
+                        .collect()
+                })
+                .collect();
+            let recovered = align_extra_arguments(&compatibility);
+            arg_plan.recover_positionals(args, &positional_indices, &recovered);
+
+            for &arg_index in &positional_indices {
+                let expr = args[arg_index].expr;
+                self.result.type_mismatches.remove(&expr);
+                self.provisional_checks
+                    .retain(|(checked, _, _)| *checked != expr);
+            }
+        }
+
         let mut runtime_id = None;
-        for (index, arg) in args.iter().enumerate() {
+        for arg in args {
             if arg
                 .label
                 .as_ref()
@@ -5089,32 +5236,36 @@ impl<'db> InferenceContext<'db> {
                 self.pending_diags
                     .push(PendingDiag::RuntimeIdArgNotLast { at: arg.expr });
             }
-            if let Some(param_index) = matched[index]
-                && slots[param_index].is_none()
-                && !label_fallback[index]
-            {
-                slots[param_index] = Some(arg.expr);
-            }
         }
         // Arity + label diagnostics (S17): counts exclude the `$id`
         // side channel; an over-supplied call reports against the full
         // parameter count, an unfilled REQUIRED slot against the
         // required count.
         {
-            let provided = args
-                .iter()
-                .filter(|arg| arg.label.as_ref().map(smol_str::SmolStr::as_str) != Some("$id"))
-                .count();
             let required = params
                 .iter()
                 .filter(|param| param.mode == baml_type::FunctionParamMode::Required)
                 .count();
             if provided > params.len() {
-                self.pending_diags.push(PendingDiag::ArgCountMismatch {
-                    expr: call,
-                    expected: params.len(),
-                    got: provided,
-                });
+                let extra = args
+                    .iter()
+                    .zip(&arg_plan.matches)
+                    .find_map(|(arg, matched)| {
+                        matches!(matched, CallArgMatch::Extra).then_some(arg.expr)
+                    });
+                if let Some(expr) = extra {
+                    self.pending_diags.push(PendingDiag::UnexpectedArguments {
+                        expr,
+                        expected: params.len(),
+                        extra_count: provided - params.len(),
+                    });
+                } else {
+                    self.pending_diags.push(PendingDiag::ArgCountMismatch {
+                        expr: call,
+                        expected: params.len(),
+                        got: provided,
+                    });
+                }
             } else {
                 let saw_named = args
                     .iter()
@@ -5122,7 +5273,7 @@ impl<'db> InferenceContext<'db> {
                 let unfilled: Vec<usize> = (0..params.len())
                     .filter(|&param_index| {
                         params[param_index].mode == baml_type::FunctionParamMode::Required
-                            && slots[param_index].is_none()
+                            && arg_plan.slots[param_index].is_none()
                     })
                     .collect();
                 if !unfilled.is_empty() {
@@ -5174,7 +5325,7 @@ impl<'db> InferenceContext<'db> {
                             .push(PendingDiag::PositionalAfterNamed { expr: arg.expr });
                     }
                     None => {
-                        if let Some(param_index) = matched[index]
+                        if let CallArgMatch::Parameter { param_index, .. } = arg_plan.matches[index]
                             && params[param_index].mode == baml_type::FunctionParamMode::Optional
                             && let Some(name) = params[param_index].name.clone()
                         {
@@ -5201,7 +5352,8 @@ impl<'db> InferenceContext<'db> {
                 }
             }
         }
-        let bindings: Vec<ParamBinding> = slots
+        let bindings: Vec<ParamBinding> = arg_plan
+            .slots
             .iter()
             .enumerate()
             .filter_map(|(param_index, slot)| match slot {
@@ -9218,6 +9370,8 @@ impl<'db> InferenceContext<'db> {
         if let Some(cached) = self.annotation_cache.get(&type_ref) {
             return cached.clone();
         }
+        let lowering_before = self.lower.diagnostic_count();
+        let pending_before = self.pending_diags.len();
         let lowered = self.lower_scoped_type_ref_at(
             &self.type_refs.store,
             type_ref,
@@ -9260,6 +9414,11 @@ impl<'db> InferenceContext<'db> {
                 self.pending_diags
                     .push(PendingDiag::AnnotWf { type_ref, error });
             }
+        }
+        if self.lower.diagnostic_count() > lowering_before
+            || self.pending_diags.len() > pending_before
+        {
+            self.invalid_annotations.insert(type_ref);
         }
         let instantiated = self.instantiate_holes(&lowered, HoleAnchor::TypeRef(type_ref));
         self.annotation_cache.insert(type_ref, instantiated.clone());
@@ -10339,6 +10498,17 @@ impl<'db> InferenceContext<'db> {
                         expected,
                         got,
                     } => (TirTypeError::ArgumentCountMismatch { expected, got }, expr),
+                    PendingDiag::UnexpectedArguments {
+                        expr,
+                        expected,
+                        extra_count,
+                    } => (
+                        TirTypeError::UnexpectedArguments {
+                            expected,
+                            extra_count,
+                        },
+                        expr,
+                    ),
                     PendingDiag::UnknownNamedArg { expr, name } => {
                         (TirTypeError::UnknownNamedArgument { name }, expr)
                     }

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer/pat.rs
@@ -84,11 +84,10 @@ impl<'db> InferenceContext<'db> {
         // catch-all arm sees the complement - the catch-residual
         // mechanism generalized to match.
         let mut residual = scrut_resolved.clone();
-        let pending_before = self.pending_diags.len();
         for &arm_id in arms {
             let arm = &body.match_arms[arm_id];
             let outcome = self.lower_pattern(body, arm.pattern, &scrut_resolved);
-            any_pattern_error |= outcome.matched_ty.has_error();
+            any_pattern_error |= self.invalid_patterns.contains(&arm.pattern);
             // A pattern irrefutable against the full scrutinee is really
             // matching the residual; typed arms take their own refinement.
             let narrow_ty = if outcome.covers_type {
@@ -137,12 +136,10 @@ impl<'db> InferenceContext<'db> {
             }
         }
         self.diverges = entry_diverges.or(all_diverge);
-        // An unknown-FIELD in some arm's class pattern makes that arm's
-        // matrix row a lie (the bad field dropped out), so usefulness
-        // verdicts are noise - same suppression as an errored pattern.
-        any_pattern_error |= self.pending_diags[pending_before..]
-            .iter()
-            .any(|pending| matches!(pending, super::PendingDiag::UnknownPatternField { .. }));
+
+        if any_pattern_error {
+            return self.join(&arm_tys);
+        }
 
         if scrut_resolved.has_error() || scrut_resolved.has_infer() {
             return Ty::error();
@@ -150,12 +147,7 @@ impl<'db> InferenceContext<'db> {
         let col_ty = scrut_resolved.to_plain();
         let ctx = HirPatCtx { infer: self };
         let report = compute_match_usefulness(&ctx, &matrix_arms, col_ty);
-        // An errored arm pattern makes the reachability verdicts noise
-        // (TIR's pattern_had_error suppression).
         for arm in &report.unreachable_arms {
-            if any_pattern_error {
-                break;
-            }
             if let Some(&arm_body) = matrix_arm_bodies.get(arm.0) {
                 self.pending_diags.push(super::PendingDiag::UnreachableArm {
                     expr: arm_body,
@@ -380,7 +372,17 @@ impl<'db> InferenceContext<'db> {
         pat: PatId,
         scrut: &Ty,
     ) -> PatternOutcome {
+        let pending_before = self.pending_diags.len();
+        let lowering_before = self.lower.diagnostic_count();
+        let invalid_before = self.invalid_patterns.len();
         let outcome = self.lower_pattern_inner(body, pat, scrut);
+        if outcome.matched_ty.has_error()
+            || self.pending_diags.len() > pending_before
+            || self.lower.diagnostic_count() > lowering_before
+            || self.invalid_patterns.len() > invalid_before
+        {
+            self.invalid_patterns.insert(pat);
+        }
         // Every pattern node records its type (TIR's pattern_types
         // single-write-point discipline); ascriptions record the WRITTEN
         // form (ruling 3) while narrowing keeps the refined one.
@@ -423,13 +425,13 @@ impl<'db> InferenceContext<'db> {
                 inner
             }
             Pattern::Type(_) => {
-                let pat_ty = self
-                    .type_refs
-                    .pattern_types
-                    .get(&pat)
-                    .copied()
+                let type_ref = self.type_refs.pattern_types.get(&pat).copied();
+                let pat_ty = type_ref
                     .map(|type_ref| self.lower_body_annotation(type_ref))
                     .unwrap_or_else(Ty::error);
+                if type_ref.is_none_or(|type_ref| self.invalid_annotations.contains(&type_ref)) {
+                    self.invalid_patterns.insert(pat);
+                }
                 self.type_pattern_outcome(pat, scrut, &pat_ty)
             }
             Pattern::Unreflect(operand) => {

--- a/baml_language/crates/baml_compiler2_hir_ty/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/lower.rs
@@ -212,6 +212,10 @@ impl<'db> LowerCtx<'db> {
             .unwrap_or_default()
     }
 
+    pub fn diagnostic_count(&self) -> usize {
+        self.diags.as_ref().map_or(0, |cell| cell.borrow().len())
+    }
+
     #[must_use]
     /// The in-scope rigid params (function + owner generics, `Self` in
     /// interface-owned bodies) - the overlap oracle's `vars` input.

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -1517,6 +1517,7 @@ fn tir_type_error_to_diagnostic_id(
         TirTypeError::UnknownAssociatedType { .. } => DiagnosticId::UnknownType,
         TirTypeError::AmbiguousAssociatedTypeProjection { .. } => DiagnosticId::TypeMismatch,
         TirTypeError::ArgumentCountMismatch { .. }
+        | TirTypeError::UnexpectedArguments { .. }
         | TirTypeError::PositionalArgumentAfterNamed
         | TirTypeError::DuplicateNamedArgument { .. }
         | TirTypeError::UnknownNamedArgument { .. }

--- a/baml_language/crates/baml_tests/projects/diagnostic_errors/match_exhaustiveness/match_exhaustiveness.baml
+++ b/baml_language/crates/baml_tests/projects/diagnostic_errors/match_exhaustiveness/match_exhaustiveness.baml
@@ -1047,3 +1047,25 @@ function DistinctInstantiationWitnesses(x: unknown) -> int {
         WitBox<string> { v: "a" } => 2
     }
 }
+
+class InvalidArityBox<T> {
+    value T
+}
+
+class InvalidArityPlainBox {
+    value int
+}
+
+function InvalidGenericPatternArity(boxed: InvalidArityBox<int>) -> int {
+    match (boxed) {
+        InvalidArityBox<int, string> => 1,
+        _ => 0
+    }
+}
+
+function InvalidNonGenericPatternArity(boxed: InvalidArityPlainBox) -> int {
+    match (boxed) {
+        InvalidArityPlainBox<int> => 1,
+        _ => 0
+    }
+}

--- a/baml_language/crates/baml_tests/projects/diagnostic_errors/optional_parameter_defaults/call_binding.baml
+++ b/baml_language/crates/baml_tests/projects/diagnostic_errors/optional_parameter_defaults/call_binding.baml
@@ -41,3 +41,27 @@ function BadForwardRef(a: int = b, b: int = 1) -> int {
 function BadRequiredAfterDefault(a: int = 1, b: int) -> int {
   b
 }
+
+function Transform(text: string) -> string {
+  text
+}
+
+function Pair(count: int, text: string) -> string {
+  text
+}
+
+function ExtraFirst() -> string {
+  Transform(1, "hello")
+}
+
+function ExtraMiddle() -> string {
+  Pair(1, true, "hello")
+}
+
+function ExtraLast() -> string {
+  Pair(1, "hello", true)
+}
+
+function MultipleExtras() -> string {
+  Pair(false, 1, true, "hello")
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/closure_errors/baml_tests__diagnostic_errors__closure_errors__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/closure_errors/baml_tests__diagnostic_errors__closure_errors__05_diagnostics.snap
@@ -4,19 +4,10 @@ source: crates/baml_tests/src/generated_tests.rs
 === COMPILER2 DIAGNOSTICS ===
   [type] E0005
 
-  × expected 1 argument(s), got 2
-    ╭─[closure_errors.baml:21:3]
- 21 │   transform(fmt, "hello")
-    ·   ───────────────────────
-    ╰────
-
-  [type] E0001
-
-  × mismatched types
+  × unexpected argument; this function accepts 1 argument, remove it
     ╭─[closure_errors.baml:21:13]
  21 │   transform(fmt, "hello")
-    ·             ─┬─
-    ·              ╰── expected `string`, found `Formatter`
+    ·             ───
     ╰────
 
   [type] E0005

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/format_checks/baml_tests__diagnostic_errors__format_checks__05_diagnostics.snap
@@ -154,20 +154,20 @@ source: crates/baml_tests/src/generated_tests.rs
      ·                                                                                          ────────────────────────
      ╰────
 
-  [type] E0005
-
-  × expected 2 argument(s), got 3
-     ╭─[chain_expr.baml:161:5]
- 161 │     user.profile.items.slice(0, user.profile.items.len() - 1, user.profile.settings.preferences.size);
-     ·     ─────────────────────────────────────────────────────────────────────────────────────────────────
-     ╰────
-
   [type] E0007
 
   × type `ChainItem[]` has no member `len`
      ╭─[chain_expr.baml:161:33]
  161 │     user.profile.items.slice(0, user.profile.items.len() - 1, user.profile.settings.preferences.size);
      ·                                 ────────────────────────
+     ╰────
+
+  [type] E0005
+
+  × unexpected argument; this function accepts 2 arguments, remove it
+     ╭─[chain_expr.baml:161:63]
+ 161 │     user.profile.items.slice(0, user.profile.items.len() - 1, user.profile.settings.preferences.size);
+     ·                                                               ──────────────────────────────────────
      ╰────
 
   [type] E0007
@@ -1219,22 +1219,6 @@ source: crates/baml_tests/src/generated_tests.rs
  161 │         "bye" => "farewell",
      ·         ──┬──
      ·           ╰── expected `"hello"`, found `"bye"`
-     ╰────
-
-  [type] E0063
-
-  × unreachable arm
-     ╭─[match_exprs.baml:161:18]
- 161 │         "bye" => "farewell",
-     ·                  ──────────
-     ╰────
-
-  [type] E0063
-
-  × unreachable arm
-     ╭─[match_exprs.baml:162:14]
- 162 │         _ => "other"
-     ·              ───────
      ╰────
 
   [type] E0004

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/function_type_missing_throws/baml_tests__diagnostic_errors__function_type_missing_throws__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/function_type_missing_throws/baml_tests__diagnostic_errors__function_type_missing_throws__05_diagnostics.snap
@@ -66,15 +66,6 @@ source: crates/baml_tests/src/generated_tests.rs
     ·                   ───────────────────
     ╰────
 
-  [type] E0062
-
-  × non-exhaustive match on type (int) -> int throws callback; missing: _
-    ╭─[negative.baml:31:3]
- 31 │ ╭─▶   match (cb) {
- 32 │ │       let f: (value: int) -> int => f(1)
- 33 │ ╰─▶   }
-    ╰────
-
   [type] E0151
 
   × function type must declare an explicit `throws` clause; add `throws never` if calling it cannot throw

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/match_exhaustiveness/baml_tests__diagnostic_errors__match_exhaustiveness__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/match_exhaustiveness/baml_tests__diagnostic_errors__match_exhaustiveness__03_ppir.snap
@@ -32,6 +32,18 @@ class user.Fish {
 class user.Fish$stream {
   name: string | null
 }
+class user.InvalidArityBox {
+  value: T
+}
+class user.InvalidArityBox$stream {
+  value: T | null
+}
+class user.InvalidArityPlainBox {
+  value: int
+}
+class user.InvalidArityPlainBox$stream {
+  value: int | null
+}
 class user.Pending {
   eta: int
 }
@@ -210,6 +222,12 @@ function user.HighLineNumberNonExhaustive(s: user.Status) -> string  [expr] {
 }
 function user.IntLiteralUnionPattern(code: user.SuccessCode) -> string  [expr] {
   {  } match (code) { 200 | 201 => "success with body", 204 => "no content" }
+}
+function user.InvalidGenericPatternArity(boxed: user.InvalidArityBox<int>) -> int  [expr] {
+  {  } match (boxed) { user.InvalidArityBox<int, string> => 1, _ => 0 }
+}
+function user.InvalidNonGenericPatternArity(boxed: user.InvalidArityPlainBox) -> int  [expr] {
+  {  } match (boxed) { user.InvalidArityPlainBox<int> => 1, _ => 0 }
 }
 function user.JumpTableClassTypeTag(pet: user.Cat | user.Dog | user.Bird | user.Fish) -> string  [expr] {
   {  } match (pet) { c: user.Cat => "cat", d: user.Dog => "dog", b: user.Bird => "bird", f: user.Fish => "fish" }

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/match_exhaustiveness/baml_tests__diagnostic_errors__match_exhaustiveness__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/match_exhaustiveness/baml_tests__diagnostic_errors__match_exhaustiveness__05_diagnostics.snap
@@ -54,15 +54,6 @@ source: crates/baml_tests/src/generated_tests.rs
  253 │ ╰─▶     }
      ╰────
 
-  [type] E0062
-
-  × non-exhaustive match on type true; missing: true
-     ╭─[match_exhaustiveness.baml:296:5]
- 296 │ ╭─▶     match (t) {
- 297 │ │           false => "wrong!"
- 298 │ ╰─▶     }
-     ╰────
-
   [type] E0001
 
   × mismatched types
@@ -283,15 +274,6 @@ source: crates/baml_tests/src/generated_tests.rs
      ·                          ─────────────
      ╰────
 
-  [type] E0062
-
-  × non-exhaustive match on type bool; missing: true, false
-     ╭─[match_exhaustiveness.baml:774:5]
- 774 │ ╭─▶     match (b) {
- 775 │ │           42 => "wrong type"
- 776 │ ╰─▶     }
-     ╰────
-
   [type] E0001
 
   × mismatched types
@@ -299,15 +281,6 @@ source: crates/baml_tests/src/generated_tests.rs
  775 │         42 => "wrong type"
      ·         ─┬
      ·          ╰── expected `bool`, found `42`
-     ╰────
-
-  [type] E0062
-
-  × non-exhaustive match on type int; missing: _
-     ╭─[match_exhaustiveness.baml:781:5]
- 781 │ ╭─▶     match (x) {
- 782 │ │           "hello" => "wrong type"
- 783 │ ╰─▶     }
      ╰────
 
   [type] E0001
@@ -393,4 +366,20 @@ source: crates/baml_tests/src/generated_tests.rs
  1046 │ │           WitBox<int> { v: 1 } => 1,
  1047 │ │           WitBox<string> { v: "a" } => 2
  1048 │ ╰─▶     }
+      ╰────
+
+  [type] E0001
+
+  × type `InvalidArityBox` expects 1 type argument(s), got 2
+      ╭─[match_exhaustiveness.baml:1061:9]
+ 1061 │         InvalidArityBox<int, string> => 1,
+      ·         ────────────────────────────
+      ╰────
+
+  [type] E0001
+
+  × type `InvalidArityPlainBox` expects 0 type argument(s), got 1
+      ╭─[match_exhaustiveness.baml:1068:9]
+ 1068 │         InvalidArityPlainBox<int> => 1,
+      ·         ─────────────────────────
       ╰────

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/match_exhaustiveness/baml_tests__diagnostic_errors__match_exhaustiveness__10_formatter__match_exhaustiveness.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/match_exhaustiveness/baml_tests__diagnostic_errors__match_exhaustiveness__10_formatter__match_exhaustiveness.snap
@@ -1056,3 +1056,25 @@ function DistinctInstantiationWitnesses(x: unknown) -> int {
         WitBox<string> { v: "a" } => 2,
     }
 }
+
+class InvalidArityBox<T> {
+    value: T,
+}
+
+class InvalidArityPlainBox {
+    value: int,
+}
+
+function InvalidGenericPatternArity(boxed: InvalidArityBox<int>) -> int {
+    match (boxed) {
+        InvalidArityBox<int, string> => 1,
+        _ => 0,
+    }
+}
+
+function InvalidNonGenericPatternArity(boxed: InvalidArityPlainBox) -> int {
+    match (boxed) {
+        InvalidArityPlainBox<int> => 1,
+        _ => 0,
+    }
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/optional_parameter_defaults/baml_tests__diagnostic_errors__optional_parameter_defaults__03_ppir.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/optional_parameter_defaults/baml_tests__diagnostic_errors__optional_parameter_defaults__03_ppir.snap
@@ -20,6 +20,18 @@ function user.BadRequiredAfterDefault(a: int = 1, b: int) -> int  [expr] {
 function user.BadUnknownNamed() -> string  [expr] {
   {  } Search(q = "cats")
 }
+function user.ExtraFirst() -> string  [expr] {
+  {  } Transform(1, "hello")
+}
+function user.ExtraLast() -> string  [expr] {
+  {  } Pair(1, "hello", true)
+}
+function user.ExtraMiddle() -> string  [expr] {
+  {  } Pair(1, true, "hello")
+}
+function user.MultipleExtras() -> string  [expr] {
+  {  } Pair(false, 1, true, "hello")
+}
 function user.OkNamedDefault() -> string  [expr] {
   {  } Search("cats", max_results = 5)
 }
@@ -32,8 +44,14 @@ function user.OkOmit() -> string  [expr] {
 function user.OkSkipFirstDefault() -> string  [expr] {
   {  } Search("cats", filter = "recent")
 }
+function user.Pair(count: int, text: string) -> string  [expr] {
+  {  } text
+}
 function user.Search(query: string, max_results: int = 10, filter: string = "none") -> string  [expr] {
   {  } query
+}
+function user.Transform(text: string) -> string  [expr] {
+  {  } text
 }
 class user.Counter {
   value: int

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/optional_parameter_defaults/baml_tests__diagnostic_errors__optional_parameter_defaults__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/optional_parameter_defaults/baml_tests__diagnostic_errors__optional_parameter_defaults__05_diagnostics.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/baml_tests/src/generated_tests.rs
-assertion_line: 40002
 ---
 === COMPILER2 DIAGNOSTICS ===
   [type] E0005
@@ -57,6 +56,38 @@ assertion_line: 40002
     ╭─[call_binding.baml:41:46]
  41 │ function BadRequiredAfterDefault(a: int = 1, b: int) -> int {
     ·                                              ──────
+    ╰────
+
+  [type] E0005
+
+  × unexpected argument; this function accepts 1 argument, remove it
+    ╭─[call_binding.baml:54:13]
+ 54 │   Transform(1, "hello")
+    ·             ─
+    ╰────
+
+  [type] E0005
+
+  × unexpected argument; this function accepts 2 arguments, remove it
+    ╭─[call_binding.baml:58:11]
+ 58 │   Pair(1, true, "hello")
+    ·           ────
+    ╰────
+
+  [type] E0005
+
+  × unexpected argument; this function accepts 2 arguments, remove it
+    ╭─[call_binding.baml:62:20]
+ 62 │   Pair(1, "hello", true)
+    ·                    ────
+    ╰────
+
+  [type] E0005
+
+  × 2 unexpected arguments; this function accepts 2 arguments, remove them
+    ╭─[call_binding.baml:66:8]
+ 66 │   Pair(false, 1, true, "hello")
+    ·        ─────
     ╰────
 
   [type] E0001

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/optional_parameter_defaults/baml_tests__diagnostic_errors__optional_parameter_defaults__10_formatter__call_binding.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/optional_parameter_defaults/baml_tests__diagnostic_errors__optional_parameter_defaults__10_formatter__call_binding.snap
@@ -44,3 +44,27 @@ function BadForwardRef(a: int = b, b: int = 1) -> int {
 function BadRequiredAfterDefault(a: int = 1, b: int) -> int {
     b
 }
+
+function Transform(text: string) -> string {
+    text
+}
+
+function Pair(count: int, text: string) -> string {
+    text
+}
+
+function ExtraFirst() -> string {
+    Transform(1, "hello")
+}
+
+function ExtraMiddle() -> string {
+    Pair(1, true, "hello")
+}
+
+function ExtraLast() -> string {
+    Pair(1, "hello", true)
+}
+
+function MultipleExtras() -> string {
+    Pair(false, 1, true, "hello")
+}

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_array_rest_binding/baml_tests__diagnostic_errors__patterns_array_rest_binding__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_array_rest_binding/baml_tests__diagnostic_errors__patterns_array_rest_binding__05_diagnostics.snap
@@ -10,28 +10,12 @@ source: crates/baml_tests/src/generated_tests.rs
     ·            ────
     ╰────
 
-  [type] E0063
-
-  × unreachable arm
-    ╭─[patterns_array_rest_binding.baml:38:14]
- 38 │         _ => 0
-    ·              ─
-    ╰────
-
   [type] E0001
 
   × rest pattern `..` can only carry a binding; write `..let name` or `..let name: T[]`
     ╭─[patterns_array_rest_binding.baml:45:12]
  45 │         [..[..let r]] => r.length(),
     ·            ─────────
-    ╰────
-
-  [type] E0063
-
-  × unreachable arm
-    ╭─[patterns_array_rest_binding.baml:46:14]
- 46 │         _ => 0
-    ·              ─
     ╰────
 
   [type] E0001
@@ -64,12 +48,4 @@ source: crates/baml_tests/src/generated_tests.rs
     ╭─[patterns_array_rest_binding.baml:84:12]
  84 │         [..Wrapper { value }] => value,
     ·            ─────────────────
-    ╰────
-
-  [type] E0063
-
-  × unreachable arm
-    ╭─[patterns_array_rest_binding.baml:85:14]
- 85 │         _ => 0
-    ·              ─
     ╰────

--- a/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure_namespaces/baml_tests__diagnostic_errors__patterns_class_destructure_namespaces__05_diagnostics.snap
+++ b/baml_language/crates/baml_tests/snapshots/diagnostic_errors/patterns_class_destructure_namespaces/baml_tests__diagnostic_errors__patterns_class_destructure_namespaces__05_diagnostics.snap
@@ -26,14 +26,6 @@ source: crates/baml_tests/src/generated_tests.rs
     ·         ────────────────────────────────
     ╰────
 
-  [type] E0063
-
-  × unreachable arm
-    ╭─[main.baml:16:14]
- 16 │         _ => 0
-    ·              ─
-    ╰────
-
   [type] E0001
 
   × type `Response` expects 0 type argument(s), got 1

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase3a.rs
@@ -1055,7 +1055,7 @@ fn too_many_args() {
       { : never
         return add(1, 2, 3) : int
       }
-      !! 83..95: expected 2 argument(s), got 3
+      !! 93..94: unexpected argument; this function accepts 2 arguments, remove it
     }
     ");
 }

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase6.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase6.rs
@@ -1667,7 +1667,7 @@ function f(callback: ((x: int) -> int throws never)?) -> int? {
       { : never
         return callback?.(1, 2) : int | null
       }
-      !! 76..92: expected 1 argument(s), got 2
+      !! 90..91: unexpected argument; this function accepts 1 argument, remove it
     }
     ");
 }

--- a/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__pattern_corpus__corpus__match_exhaustiveness.snap
+++ b/baml_language/crates/baml_tests/src/type_spec/snapshots/baml_tests__type_spec__pattern_corpus__corpus__match_exhaustiveness.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/baml_tests/src/type_spec/pattern_corpus.rs
+assertion_line: 49
 expression: "corpus_verdicts(\"projects/diagnostic_errors/match_exhaustiveness/match_exhaustiveness.baml\")"
 ---
 UnreachableAfterCatchAll: hir_ty=0
@@ -28,7 +29,7 @@ BoolUnionPattern: hir_ty=0
 ExhaustiveTrueType: hir_ty=0
 ExhaustiveFalseType: hir_ty=0
 ExhaustiveCustomBool: hir_ty=0
-NonExhaustiveTrueTypeWrongLiteral: hir_ty=1
+NonExhaustiveTrueTypeWrongLiteral: hir_ty=0
 NonExhaustiveCustomBoolMissing: hir_ty=1
 ExhaustiveOptional: hir_ty=0
 OptionalWithCatchAll: hir_ty=0
@@ -71,8 +72,8 @@ NonExhaustiveClassPlusLiteralMissingLiteral: hir_ty=1
 NonExhaustiveClassPlusLiteralMissingClass: hir_ty=1
 ExhaustiveEnumWithTypedPattern: hir_ty=0
 EnumVariantAfterTypedEnum: hir_ty=0
-WrongLiteralTypeBoolWithInt: hir_ty=1
-WrongLiteralTypeIntWithString: hir_ty=1
+WrongLiteralTypeBoolWithInt: hir_ty=0
+WrongLiteralTypeIntWithString: hir_ty=0
 PartialUnionPatternCoverage: hir_ty=1
 LiteralAfterTypedPattern: hir_ty=0
 BoolLiteralAfterTypedBool: hir_ty=0
@@ -94,3 +95,5 @@ JumpTableEnumDiscriminant: hir_ty=0
 JumpTableTypeTag: hir_ty=0
 JumpTableClassTypeTag: hir_ty=0
 DistinctInstantiationWitnesses: hir_ty=1
+InvalidGenericPatternArity: hir_ty=0
+InvalidNonGenericPatternArity: hir_ty=0


### PR DESCRIPTION
Summary:
- carry invalid-pattern provenance through recovered annotations and skip match usefulness after any invalid pattern
- use one argument-binding plan with order-preserving type alignment to identify positional extras
- suppress dependent over-arity type mismatches and anchor one actionable diagnostic to the extra argument

Tests:
- cargo test --manifest-path baml_language/Cargo.toml -p baml_tests --lib
- cargo clippy --manifest-path baml_language/Cargo.toml -p baml_compiler2_hir_ty -p baml_lsp2_actions -p baml_tests --all-targets -- -D warnings
- cargo fmt --manifest-path baml_language/Cargo.toml --all -- --check

Linear: B-917, B-921, B-928

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved diagnostics for calls with extra positional arguments, identifying the specific unexpected argument and recommending its removal.
  - Preserved valid argument bindings when extra arguments appear in different positions, improving follow-up type checking.
  - Improved handling of invalid type annotations and match patterns to prevent misleading exhaustiveness warnings.
  - Added clearer errors for incorrect type-argument counts in match patterns.

- **Tests**
  - Expanded coverage for extra arguments and invalid match-pattern arity scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->