### PR TITLE
ci(ix): reuse the shared R2 sccache

### DIFF
--- a/.github/workflows/ix-cargo-tests.reusable.yaml
+++ b/.github/workflows/ix-cargo-tests.reusable.yaml
@@ -84,13 +84,6 @@ env:
   # lane. Set here, not in the machine image, so the value is deterministic
   # per commit.
   VITEST_MAX_WORKERS: "4"
-  # nextest and libtest size their thread pools from the visible CPU count
-  # too (100 on an ix guest). bex_engine's cancellation tests assert
-  # wall-clock budgets (cancel returns in <2s) and the snapshot suite talks
-  # to mock servers on loopback; both fail when 100 test threads per job
-  # compete across concurrent machines. Match the build's 16.
-  NEXTEST_TEST_THREADS: "16"
-  RUST_TEST_THREADS: "16"
   RUSTUP_MAX_RETRIES: 10
 
 jobs:

--- a/.github/workflows/ix-cargo-tests.reusable.yaml
+++ b/.github/workflows/ix-cargo-tests.reusable.yaml
@@ -21,9 +21,8 @@
 # no build output). This copy never SAVES cache entries (save-if: false on
 # every step): the env pins below shift rust-cache's keys, so saving here
 # would write a parallel set of entries into the repo's shared cache quota
-# and evict the gating workflow's. On ix, compiled output comes from the
-# shared R2 sccache bucket (ix-ci.yml passes the credentials through); the
-# seed disk adds the registry and toolchains on top when a seed restores.
+# and evict the gating workflow's. On ix, warmth comes from the seed disk,
+# not the Actions cache.
 #
 # mise installs sccache and direnv, then each cargo job loads .envrc via
 # `direnv export gha` so CI uses the exact same sccache config as local shells:

--- a/.github/workflows/ix-cargo-tests.reusable.yaml
+++ b/.github/workflows/ix-cargo-tests.reusable.yaml
@@ -21,8 +21,9 @@
 # no build output). This copy never SAVES cache entries (save-if: false on
 # every step): the env pins below shift rust-cache's keys, so saving here
 # would write a parallel set of entries into the repo's shared cache quota
-# and evict the gating workflow's. On ix, warmth comes from the seed disk,
-# not the Actions cache.
+# and evict the gating workflow's. On ix, compiled output comes from the
+# shared R2 sccache bucket (ix-ci.yml passes the credentials through); the
+# seed disk adds the registry and toolchains on top when a seed restores.
 #
 # mise installs sccache and direnv, then each cargo job loads .envrc via
 # `direnv export gha` so CI uses the exact same sccache config as local shells:
@@ -83,6 +84,13 @@ env:
   # lane. Set here, not in the machine image, so the value is deterministic
   # per commit.
   VITEST_MAX_WORKERS: "4"
+  # nextest and libtest size their thread pools from the visible CPU count
+  # too (100 on an ix guest). bex_engine's cancellation tests assert
+  # wall-clock budgets (cancel returns in <2s) and the snapshot suite talks
+  # to mock servers on loopback; both fail when 100 test threads per job
+  # compete across concurrent machines. Match the build's 16.
+  NEXTEST_TEST_THREADS: "16"
+  RUST_TEST_THREADS: "16"
   RUSTUP_MAX_RETRIES: 10
 
 jobs:

--- a/.github/workflows/ix-ci.yml
+++ b/.github/workflows/ix-ci.yml
@@ -111,17 +111,14 @@ jobs:
     name: "Cargo Tests"
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/canary'
-    # The same R2 sccache bucket the gating lane reads. Without it every ix
-    # job compiles the workspace from scratch: the seed disk was meant to
-    # carry target/, but seed restore is refused by the platform today
-    # ("snapshot has no captured block-volume root"), so each machine boots
-    # cold and a 90s build on the hosted lane takes 20 minutes here. PR code
-    # runs on these machines; point these at a read-only R2 token once one
-    # exists so a PR can read the cache but never write it.
+    # The same R2 sccache bucket the gating lane reads. Its current token can
+    # write, so only canary and manual dispatch runs receive it. PR jobs run
+    # checked-out code and fall back to the machine-local cache until the
+    # bucket has a read-only token.
     uses: ./.github/workflows/ix-cargo-tests.reusable.yaml
     secrets:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ (github.ref == 'refs/heads/canary' || github.event_name == 'workflow_dispatch') && secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID || '' }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ (github.ref == 'refs/heads/canary' || github.event_name == 'workflow_dispatch') && secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY || '' }}
 
   size-gate:
     name: "Size Gate"
@@ -129,8 +126,8 @@ jobs:
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/ix-size-gate.reusable.yaml
     secrets:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ (github.ref == 'refs/heads/canary' || github.event_name == 'workflow_dispatch') && secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID || '' }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ (github.ref == 'refs/heads/canary' || github.event_name == 'workflow_dispatch') && secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY || '' }}
     # The ix copy drops the report's PR-comment step outright, so the
     # gating workflow's comment stays the only one; the report is still in
     # the job summary.

--- a/.github/workflows/ix-ci.yml
+++ b/.github/workflows/ix-ci.yml
@@ -111,14 +111,13 @@ jobs:
     name: "Cargo Tests"
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/canary'
-    # The same R2 sccache bucket the gating lane reads. Its current token can
-    # write, so only canary and manual dispatch runs receive it. PR jobs run
-    # checked-out code and fall back to the machine-local cache until the
-    # bucket has a read-only token.
+    # Match ci.yaml's Blacksmith gating lane: same-repository PRs receive the
+    # existing R2 credentials, while GitHub withholds repository secrets from
+    # fork and Dependabot PRs. Both lanes execute the same checked-out code.
     uses: ./.github/workflows/ix-cargo-tests.reusable.yaml
     secrets:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ (github.ref == 'refs/heads/canary' || github.event_name == 'workflow_dispatch') && secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID || '' }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ (github.ref == 'refs/heads/canary' || github.event_name == 'workflow_dispatch') && secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY || '' }}
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
 
   size-gate:
     name: "Size Gate"
@@ -126,8 +125,8 @@ jobs:
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/ix-size-gate.reusable.yaml
     secrets:
-      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ (github.ref == 'refs/heads/canary' || github.event_name == 'workflow_dispatch') && secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID || '' }}
-      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ (github.ref == 'refs/heads/canary' || github.event_name == 'workflow_dispatch') && secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY || '' }}
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     # The ix copy drops the report's PR-comment step outright, so the
     # gating workflow's comment stays the only one; the report is still in
     # the job summary.

--- a/.github/workflows/ix-ci.yml
+++ b/.github/workflows/ix-ci.yml
@@ -111,16 +111,26 @@ jobs:
     name: "Cargo Tests"
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/canary'
-    # No secrets, deliberately: these jobs run PR-controlled code on ix
-    # machines, so nothing secret may flow to them. .envrc sees no R2
-    # credentials and sccache falls back to the machine-local cache.
+    # The same R2 sccache bucket the gating lane reads. Without it every ix
+    # job compiles the workspace from scratch: the seed disk was meant to
+    # carry target/, but seed restore is refused by the platform today
+    # ("snapshot has no captured block-volume root"), so each machine boots
+    # cold and a 90s build on the hosted lane takes 20 minutes here. PR code
+    # runs on these machines; point these at a read-only R2 token once one
+    # exists so a PR can read the cache but never write it.
     uses: ./.github/workflows/ix-cargo-tests.reusable.yaml
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
 
   size-gate:
     name: "Size Gate"
     needs: determine_changes
     if: needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/canary'
     uses: ./.github/workflows/ix-size-gate.reusable.yaml
+    secrets:
+      BAML_SCCACHE_R2_ACCESS_KEY_ID: ${{ secrets.BAML_SCCACHE_R2_ACCESS_KEY_ID }}
+      BAML_SCCACHE_R2_SECRET_ACCESS_KEY: ${{ secrets.BAML_SCCACHE_R2_SECRET_ACCESS_KEY }}
     # The ix copy drops the report's PR-comment step outright, so the
     # gating workflow's comment stays the only one; the report is still in
     # the job summary.


### PR DESCRIPTION
Nothing outside the `ix-*` workflow files.

#4537 withheld the R2 credentials from the ix lane because the seed disk was expected to carry `target/`. 

Seed restore is currently refused with `snapshot has no captured block-volume root`, so cold jobs rebuild the workspace and can overrun the 40-minute MSRV ceiling.

## What changes

`ix-ci.yml` passes the existing `BAML_SCCACHE_R2_*` secrets to cargo tests and the size gate. This matches `ci.yaml`, where the Blacksmith gating lane passes the same repository secrets to the same checked-out code with `secrets: inherit`

GitHub withholds repository secrets from fork and Dependabot pull requests. 

Those runs remain secretless and use the machine-local sccache. `.envrc` switches to R2 only when both values are present.