### PR TITLE
fix(release): unblock musl and C# verification

### DIFF
--- a/.github/workflows/build2-nodejs-sdk.reusable.yaml
+++ b/.github/workflows/build2-nodejs-sdk.reusable.yaml
@@ -223,11 +223,13 @@ jobs:
           set -euo pipefail
           native="$(find npm -name 'baml_node.*-musl.node' -print -quit)"
           test -n "$native"
-          dynamic="$(readelf --dynamic "$native")"
-          versions="$(readelf --version-info "$native")"
-          printf '%s\n' "$dynamic"
-          if grep -q 'GLIBC_' <<<"$versions"; then
-            echo "::error::$native contains GLIBC-versioned symbols"
+          dynamic="$(readelf --wide --dynamic "$native")"
+          needed="$(grep NEEDED <<<"$dynamic")"
+          printf '%s\n' "$needed"
+          # ARM musl's libgcc_s uses GLIBC_2.0 as a compatibility symbol-version
+          # label. DT_NEEDED records the libraries the runtime actually loads.
+          if ! grep -Eq '\[libc\.so\]' <<<"$needed"; then
+            echo "::error::$native does not depend on the expected musl libc.so"
             exit 1
           fi
           glibc_sonames=(
@@ -246,7 +248,7 @@ jobs:
             'ld-linux[^]]*\.so[^]]*'
           )
           for soname in "${glibc_sonames[@]}"; do
-            if grep -Eq "\[${soname}\]" <<<"$dynamic"; then
+            if grep -Eq "\[${soname}\]" <<<"$needed"; then
               echo "::error::$native depends on glibc runtime soname matching $soname"
               exit 1
             fi

--- a/baml_language/sdk_tests/crates/csharp/phase12_resources/Program.cs
+++ b/baml_language/sdk_tests/crates/csharp/phase12_resources/Program.cs
@@ -270,7 +270,7 @@ if (CanCreateLoopbackSockets())
             Headers = new Dictionary<string, string>(),
             Body = "",
         },
-        networkTimeout.Token);
+        cancellationToken: networkTimeout.Token);
     string? firstEvent = await sse.NextAsync(networkTimeout.Token);
     Require(
         sse.Url == sseUrl

--- a/scripts/tests/test_release_pipeline_contract.py
+++ b/scripts/tests/test_release_pipeline_contract.py
@@ -30,6 +30,9 @@ NUGET_PUBLISHER = ROOT / ".github" / "workflows" / "publish2-csharp-sdk.yaml"
 NODE_NPM_PUBLISHER = (
     ROOT / ".github" / "workflows" / "publish2-nodejs-sdk.yaml"
 )
+NODE_BUILDER = (
+    ROOT / ".github" / "workflows" / "build2-nodejs-sdk.reusable.yaml"
+)
 WEB_NPM_PUBLISHER = ROOT / ".github" / "workflows" / "publish2-web-sdk.yaml"
 CSHARP_PREPARER = (
     ROOT / ".github" / "workflows" / "prepare-csharp-sdk.reusable.yaml"
@@ -703,6 +706,17 @@ class WorkflowGraphTests(unittest.TestCase):
             workflow.index("scripts/baml-language-version stamp"),
             workflow.index("cmake -S baml_language/sdks/cpp/bridge_cpp/tests"),
         )
+
+    def test_node_musl_abi_check_uses_runtime_dependencies(self) -> None:
+        workflow = NODE_BUILDER.read_text(encoding="utf-8")
+        verify = step_block(workflow, "Verify musl native addon ABI")
+
+        self.assertIn('readelf --wide --dynamic "$native"', verify)
+        self.assertIn('needed="$(grep NEEDED <<<"$dynamic")"', verify)
+        self.assertIn("'\\[libc\\.so\\]'", verify)
+        self.assertIn("'libc\\.so\\.6'", verify)
+        self.assertNotIn("readelf --version-info", verify)
+        self.assertNotIn("grep -q 'GLIBC_'", verify)
 
     def test_cargo_jobs_name_targets_and_run_pack_e2e_on_musl(self) -> None:
         workflow = CARGO_TESTS.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- validate musl Node addons using DT_NEEDED instead of GLIBC symbol-version labels
- require musl libc.so while retaining glibc SONAME rejection
- pass the C# fetch_sse cancellation token by name after the new optional timeout arguments

## Testing

- `python3 -m unittest scripts.tests.test_release_pipeline_contract`
- `mise exec -- actionlint .github/workflows/build2-nodejs-sdk.reusable.yaml`
- `prek run --files .github/workflows/build2-nodejs-sdk.reusable.yaml scripts/tests/test_release_pipeline_contract.py baml_language/sdk_tests/crates/csharp/phase12_resources/Program.cs --show-diff-on-failure --color never`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility checks for Node.js packages built with musl-based environments.
  * Corrected network timeout handling for SSE requests.

* **Tests**
  * Added automated validation to ensure runtime library dependencies are checked correctly during Node.js release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->