### PR TITLE
fix(compiler2): preserve type-ref diagnostic ownership

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -4430,16 +4430,14 @@ fn compute_function_metadata<'db>(
                 .filter_map(|&(store, id)| {
                     let ctx = baml_compiler2_hir_ty::lower::lower_ctx_for_file(db, file)
                         .with_bounds(scope_bounds.clone())
-                        .with_frame(frame.clone())
-                        .with_diagnostics();
-                    let lowered = ctx
-                        .lower_type_ref_at(
-                            store,
-                            id,
-                            baml_compiler2_hir_ty::lower::TypePosition::ConstraintHead,
-                        )
-                        .to_plain();
-                    let clean = ctx.take_diagnostics().is_empty();
+                        .with_frame(frame.clone());
+                    let (lowered, diagnostics) = ctx.lower_type_ref_at_with_diagnostics(
+                        store,
+                        id,
+                        baml_compiler2_hir_ty::lower::TypePosition::ConstraintHead,
+                    );
+                    let lowered = lowered.to_plain();
+                    let clean = diagnostics.is_empty();
                     let bound_ty = if enclosing_interface.is_some() {
                         substitute_ty(&lowered, &interface_signature_bindings)
                     } else {

--- a/baml_language/crates/baml_compiler2_hir/src/body_type_refs.rs
+++ b/baml_language/crates/baml_compiler2_hir/src/body_type_refs.rs
@@ -6,7 +6,7 @@
 //! The collection walks the body's arenas in allocation order, so ids are a
 //! pure function of body shape - stable under whitespace edits (`TypeExpr`
 //! equality already ignores spans; this makes the span-freedom structural).
-//! Spans stay in the lockstep [`TypeRefSourceMap`] for future diagnostics.
+//! Spans stay in the lockstep [`BodyTypeRefSourceMap`] for future diagnostics.
 //!
 //! Collected today: pattern type ascriptions (`let x: T`, type patterns in
 //! match arms), array-pattern ascriptions, explicit expression-position type
@@ -20,6 +20,24 @@ use rustc_hash::FxHashMap;
 
 use crate::type_ref::{TypeRefBuilder, TypeRefId, TypeRefSourceMap, TypeRefStore};
 
+/// Identity of a type reference in a body-owned arena.
+///
+/// This is intentionally distinct from declaration [`TypeRefId`]s. Converting
+/// back to the raw arena index requires the owning [`BodyTypeRefs`], keeping
+/// body-relative diagnostic anchors out of signature lowering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BodyTypeRefId(TypeRefId);
+
+/// Spans for one body's type-reference arena.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BodyTypeRefSourceMap(TypeRefSourceMap);
+
+impl BodyTypeRefSourceMap {
+    pub fn span(&self, id: BodyTypeRefId) -> text_size::TextRange {
+        self.0.span(id.0)
+    }
+}
+
 /// All type references written in one body, keyed by the nodes that carry
 /// them. A missing key means the position had no written annotation.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -27,21 +45,21 @@ pub struct BodyTypeRefs {
     pub store: TypeRefStore,
     /// `Pattern::Type` nodes: `let x: T` ascriptions (as the bind's
     /// sub-pattern) and bare type patterns in match arms.
-    pub pattern_types: FxHashMap<PatId, TypeRefId>,
+    pub pattern_types: FxHashMap<PatId, BodyTypeRefId>,
     /// Array-pattern `[...]: T` ascriptions.
-    pub array_ascriptions: FxHashMap<PatId, TypeRefId>,
+    pub array_ascriptions: FxHashMap<PatId, BodyTypeRefId>,
     /// Class-destructure generic args (`Box<int> { v }` patterns), in
     /// written order. Never empty when present.
-    pub pattern_class_args: FxHashMap<PatId, Box<[TypeRefId]>>,
+    pub pattern_class_args: FxHashMap<PatId, Box<[BodyTypeRefId]>>,
     /// Destructure-head associated bindings (`Source<Item = int> { v }`
     /// patterns), in written order. Never empty when present.
-    pub pattern_assoc_bindings: FxHashMap<PatId, Box<[(Name, TypeRefId)]>>,
+    pub pattern_assoc_bindings: FxHashMap<PatId, Box<[(Name, BodyTypeRefId)]>>,
     /// Explicit expression-position type arguments (`Call`, `GenericApply`,
     /// and `Object` constructors), in written order. Never empty when
     /// present.
     pub expr_type_args: FxHashMap<ExprId, Box<[BodyTypeArgRef]>>,
     /// `.as<T>` upcast targets.
-    pub upcast_targets: FxHashMap<ExprId, TypeRefId>,
+    pub upcast_targets: FxHashMap<ExprId, BodyTypeRefId>,
     /// The two written halves of a `(Base as Interface).item` reference.
     pub qualified_path_anchors: FxHashMap<ExprId, QualifiedPathTypeRefs>,
     /// Lambda signature slots, keyed by the lambda expression.
@@ -55,9 +73,9 @@ pub struct BodyTypeRefs {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct QualifiedPathTypeRefs {
     /// The `Self` type: `Base` in `(Base as Interface).item`.
-    pub qself: TypeRefId,
+    pub qself: BodyTypeRefId,
     /// The interface the item is projected through.
-    pub interface: TypeRefId,
+    pub interface: BodyTypeRefId,
 }
 
 /// One explicit expression-position type argument, preserving whether the
@@ -68,7 +86,7 @@ pub struct QualifiedPathTypeRefs {
 /// inference variables.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BodyTypeArgRef {
-    Static(TypeRefId),
+    Static(BodyTypeRefId),
     Runtime { operand: ExprId },
 }
 
@@ -77,28 +95,40 @@ pub enum BodyTypeArgRef {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LambdaTypeRefs {
     /// Per declared parameter, in order.
-    pub params: Box<[Option<TypeRefId>]>,
-    pub return_type: Option<TypeRefId>,
-    pub throws: Option<TypeRefId>,
+    pub params: Box<[Option<BodyTypeRefId>]>,
+    pub return_type: Option<BodyTypeRefId>,
+    pub throws: Option<BodyTypeRefId>,
+}
+
+impl BodyTypeRefs {
+    pub fn raw_id(&self, id: BodyTypeRefId) -> TypeRefId {
+        id.0
+    }
+
+    pub fn diagnostic_id(&self, id: TypeRefId) -> BodyTypeRefId {
+        let _ = &self.store[id];
+        BodyTypeRefId(id)
+    }
 }
 
 /// Lowers every type expression in `body` into one store. Pure; ppir wraps
 /// this in salsa queries over its canonical bodies.
-pub fn collect_body_type_refs(body: &ExprBody) -> (BodyTypeRefs, TypeRefSourceMap) {
+pub fn collect_body_type_refs(body: &ExprBody) -> (BodyTypeRefs, BodyTypeRefSourceMap) {
     let mut builder = TypeRefBuilder::new();
     let mut refs = BodyTypeRefs::default();
 
     for (pat_id, pattern) in body.patterns.iter() {
         match pattern {
             Pattern::Type(type_expr) => {
-                refs.pattern_types.insert(pat_id, builder.lower(type_expr));
+                refs.pattern_types
+                    .insert(pat_id, BodyTypeRefId(builder.lower(type_expr)));
             }
             Pattern::Array {
                 ascription: Some(type_expr),
                 ..
             } => {
                 refs.array_ascriptions
-                    .insert(pat_id, builder.lower(type_expr));
+                    .insert(pat_id, BodyTypeRefId(builder.lower(type_expr)));
             }
             Pattern::Class {
                 generic_args,
@@ -108,7 +138,10 @@ pub fn collect_body_type_refs(body: &ExprBody) -> (BodyTypeRefs, TypeRefSourceMa
                 if !generic_args.is_empty() {
                     refs.pattern_class_args.insert(
                         pat_id,
-                        generic_args.iter().map(|arg| builder.lower(arg)).collect(),
+                        generic_args
+                            .iter()
+                            .map(|arg| BodyTypeRefId(builder.lower(arg)))
+                            .collect(),
                     );
                 }
                 if !associated_type_bindings.is_empty() {
@@ -116,7 +149,12 @@ pub fn collect_body_type_refs(body: &ExprBody) -> (BodyTypeRefs, TypeRefSourceMa
                         pat_id,
                         associated_type_bindings
                             .iter()
-                            .map(|binding| (binding.name.clone(), builder.lower(&binding.ty)))
+                            .map(|binding| {
+                                (
+                                    binding.name.clone(),
+                                    BodyTypeRefId(builder.lower(&binding.ty)),
+                                )
+                            })
                             .collect(),
                     );
                 }
@@ -133,7 +171,9 @@ pub fn collect_body_type_refs(body: &ExprBody) -> (BodyTypeRefs, TypeRefSourceMa
                     type_args
                         .iter()
                         .map(|arg| match arg {
-                            TypeArg::Static(ty) => BodyTypeArgRef::Static(builder.lower(ty)),
+                            TypeArg::Static(ty) => {
+                                BodyTypeArgRef::Static(BodyTypeRefId(builder.lower(ty)))
+                            }
                             TypeArg::Unreflect(operand) => {
                                 BodyTypeArgRef::Runtime { operand: *operand }
                             }
@@ -148,12 +188,13 @@ pub fn collect_body_type_refs(body: &ExprBody) -> (BodyTypeRefs, TypeRefSourceMa
                     expr_id,
                     type_args
                         .iter()
-                        .map(|arg| BodyTypeArgRef::Static(builder.lower(arg)))
+                        .map(|arg| BodyTypeArgRef::Static(BodyTypeRefId(builder.lower(arg))))
                         .collect(),
                 );
             }
             Expr::Upcast { target, .. } => {
-                refs.upcast_targets.insert(expr_id, builder.lower(target));
+                refs.upcast_targets
+                    .insert(expr_id, BodyTypeRefId(builder.lower(target)));
             }
             Expr::QualifiedPath {
                 qself, interface, ..
@@ -161,8 +202,8 @@ pub fn collect_body_type_refs(body: &ExprBody) -> (BodyTypeRefs, TypeRefSourceMa
                 refs.qualified_path_anchors.insert(
                     expr_id,
                     QualifiedPathTypeRefs {
-                        qself: builder.lower(qself),
-                        interface: builder.lower(interface),
+                        qself: BodyTypeRefId(builder.lower(qself)),
+                        interface: BodyTypeRefId(builder.lower(interface)),
                     },
                 );
             }
@@ -173,10 +214,21 @@ pub fn collect_body_type_refs(body: &ExprBody) -> (BodyTypeRefs, TypeRefSourceMa
                         params: def
                             .params
                             .iter()
-                            .map(|param| param.type_expr.as_ref().map(|ty| builder.lower(ty)))
+                            .map(|param| {
+                                param
+                                    .type_expr
+                                    .as_ref()
+                                    .map(|ty| BodyTypeRefId(builder.lower(ty)))
+                            })
                             .collect(),
-                        return_type: def.return_type.as_ref().map(|ty| builder.lower(ty)),
-                        throws: def.throws.as_ref().map(|ty| builder.lower(ty)),
+                        return_type: def
+                            .return_type
+                            .as_ref()
+                            .map(|ty| BodyTypeRefId(builder.lower(ty))),
+                        throws: def
+                            .throws
+                            .as_ref()
+                            .map(|ty| BodyTypeRefId(builder.lower(ty))),
                     },
                 );
             }
@@ -186,7 +238,7 @@ pub fn collect_body_type_refs(body: &ExprBody) -> (BodyTypeRefs, TypeRefSourceMa
 
     let (store, source_map) = builder.finish();
     refs.store = store;
-    (refs, source_map)
+    (refs, BodyTypeRefSourceMap(source_map))
 }
 
 #[cfg(test)]

--- a/baml_language/crates/baml_compiler2_hir_ty/src/diagnostics.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/diagnostics.rs
@@ -2250,9 +2250,10 @@ pub enum DiagnosticLocation {
     /// A pattern's span (`hir_ty`'s emissions stay arena-anchored; TIR
     /// resolved pattern spans eagerly through its held source map).
     Pat(baml_compiler2_ast::PatId),
-    /// A written type reference (body annotation), resolved through the
-    /// body's `TypeRefSourceMap` at render time.
-    TypeRef(baml_compiler2_hir::type_ref::TypeRefId),
+    /// A written body type reference, resolved through the owning body's
+    /// source map at render time. Declaration type-reference ids have a
+    /// distinct type and cannot inhabit this location.
+    BodyTypeRef(baml_compiler2_hir::body_type_refs::BodyTypeRefId),
     /// The field-NAME portion of an object-literal entry:
     /// `(object_expr, field_value_expr)` resolves through
     /// `object_field_name_span` at render time.
@@ -2293,17 +2294,17 @@ impl<'db> TirDiagnostic<'db> {
         scope_file: SourceFile,
         source_map: Option<&AstSourceMap>,
     ) -> RenderedTirDiagnostic {
-        self.render_with_type_refs(db, scope_file, source_map, None)
+        self.render_with_body_type_refs(db, scope_file, source_map, None)
     }
 
     /// [`Self::render`] with the body's type-ref span map, for the
-    /// annotation-anchored diagnostics (`DiagnosticLocation::TypeRef`).
-    pub fn render_with_type_refs(
+    /// annotation-anchored diagnostics (`DiagnosticLocation::BodyTypeRef`).
+    pub fn render_with_body_type_refs(
         &self,
         db: &'db dyn baml_compiler2_ppir::Db,
         scope_file: SourceFile,
         source_map: Option<&AstSourceMap>,
-        type_ref_spans: Option<&baml_compiler2_hir::type_ref::TypeRefSourceMap>,
+        type_ref_spans: Option<&baml_compiler2_hir::body_type_refs::BodyTypeRefSourceMap>,
     ) -> RenderedTirDiagnostic {
         let primary_range = match &self.primary {
             DiagnosticLocation::Expr(id) => {
@@ -2327,7 +2328,7 @@ impl<'db> TirDiagnostic<'db> {
             DiagnosticLocation::Pat(id) => source_map
                 .map(|sm| sm.pattern_span(*id))
                 .unwrap_or_default(),
-            DiagnosticLocation::TypeRef(id) => type_ref_spans
+            DiagnosticLocation::BodyTypeRef(id) => type_ref_spans
                 .map(|spans| spans.span(*id))
                 .unwrap_or_default(),
             DiagnosticLocation::UnreflectArg { carrier, .. } => source_map

--- a/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/infer.rs
@@ -31,7 +31,7 @@ use baml_compiler2_ast::{
 };
 use baml_compiler2_hir::{
     body::BodyOwnerId,
-    body_type_refs::{BodyTypeArgRef, BodyTypeRefs},
+    body_type_refs::{BodyTypeArgRef, BodyTypeRefId, BodyTypeRefs},
     contributions::Definition,
     scope::FileScopeId,
     semantic_index::{
@@ -627,7 +627,7 @@ enum TaggedTagIssue {
 /// body-position type annotation's ref.
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum HoleAnchor {
-    TypeRef(baml_compiler2_hir::type_ref::TypeRefId),
+    TypeRef(BodyTypeRefId),
 }
 
 /// S17 pending diagnostic (engine-internal): arena-anchored, payload
@@ -663,7 +663,7 @@ enum PendingDiag<'db> {
     /// A body annotation failing the written-type well-formedness
     /// judgment (generic-argument bounds).
     AnnotWf {
-        type_ref: baml_compiler2_hir::type_ref::TypeRefId,
+        type_ref: BodyTypeRefId,
         error: crate::diagnostics::TirTypeError,
     },
     /// A tagged-template tag failing BEP-049 SS10's contract.
@@ -962,7 +962,7 @@ enum PendingDiag<'db> {
         rhs: Option<Ty>,
     },
     BodyAnnot {
-        type_ref: baml_compiler2_hir::type_ref::TypeRefId,
+        type_ref: BodyTypeRefId,
         kind: crate::lower::LoweringDiagKind,
     },
     InterpolatedMaybeNull {
@@ -1349,8 +1349,7 @@ fn infer_body_impl<'db>(
         .with_frame(frame)
         .with_bounds(bounds.clone())
         .with_self_ty(concrete_self)
-        .with_impl_target(impl_target)
-        .with_diagnostics();
+        .with_impl_target(impl_target);
     let type_refs = baml_compiler2_ppir::body_type_refs(db, owner);
     let plain_bounds = bounds
         .into_iter()
@@ -1624,9 +1623,9 @@ struct InferenceContext<'db> {
     /// One lowering per written body annotation (rust-analyzer's
     /// discipline): the let rule, the pattern walk, and the backfill all
     /// read the SAME lowered type - and so the same instantiated hole
-    /// vars - for one `TypeRefId`. Without this, a `_` hole instantiates
+    /// vars - for one `BodyTypeRefId`. Without this, a `_` hole instantiates
     /// once per consumer and only the demand-connected copy solves.
-    annotation_cache: FxHashMap<baml_compiler2_hir::type_ref::TypeRefId, Ty>,
+    annotation_cache: FxHashMap<BodyTypeRefId, Ty>,
     /// Per-body memoization of ground canonical forms. Inference-bearing types
     /// bypass it because their meaning changes as the table solves variables.
     canonical_cache: baml_type::normalize::InternedCanonicalCache,
@@ -2208,11 +2207,11 @@ impl<'db> InferenceContext<'db> {
                     .get(&expr)
                     .copied()
                     .map(|target_ref| {
-                        let lowered = self.lower_scoped_type_ref_at(
-                            &self.type_refs.store,
+                        let (lowered, diagnostics) = self.lower_scoped_body_type_ref_at(
                             target_ref,
                             crate::lower::TypePosition::Existential,
                         );
+                        self.queue_body_lowering_diagnostics(diagnostics);
                         self.reject_expr_position_holes(&lowered, expr)
                     })
                     .unwrap_or_else(Ty::error);
@@ -2939,18 +2938,29 @@ impl<'db> InferenceContext<'db> {
             .map(|binding| &binding.parameter)
     }
 
-    fn lower_scoped_type_ref_at(
+    fn lower_scoped_body_type_ref_at(
         &self,
-        store: &baml_compiler2_hir::type_ref::TypeRefStore,
-        type_ref: baml_compiler2_hir::type_ref::TypeRefId,
+        type_ref: BodyTypeRefId,
         position: crate::lower::TypePosition,
-    ) -> Ty {
-        self.lower.lower_type_ref_with_overlay(
-            store,
-            type_ref,
+    ) -> (Ty, Vec<crate::lower::LoweringDiag>) {
+        self.lower.lower_type_ref_with_overlay_and_diagnostics(
+            &self.type_refs.store,
+            self.type_refs.raw_id(type_ref),
             position,
             &self.scoped_type_params(),
         )
+    }
+
+    fn queue_body_lowering_diagnostics(&mut self, diagnostics: Vec<crate::lower::LoweringDiag>) {
+        self.pending_diags
+            .extend(
+                diagnostics
+                    .into_iter()
+                    .map(|diagnostic| PendingDiag::BodyAnnot {
+                        type_ref: self.type_refs.diagnostic_id(diagnostic.type_ref),
+                        kind: diagnostic.kind,
+                    }),
+            );
     }
 
     fn lower_scoped_type_path(&self, segments: &[baml_type::Name]) -> Ty {
@@ -6570,7 +6580,8 @@ impl<'db> InferenceContext<'db> {
         let member = member.clone();
 
         let lower = |this: &mut Self, type_ref, position| {
-            let ty = this.lower_scoped_type_ref_at(&this.type_refs.store, type_ref, position);
+            let (ty, diagnostics) = this.lower_scoped_body_type_ref_at(type_ref, position);
+            this.queue_body_lowering_diagnostics(diagnostics);
             this.reject_expr_position_holes(&ty, expr)
         };
         let qself = lower(self, anchors.qself, crate::lower::TypePosition::Existential);
@@ -7758,10 +7769,17 @@ impl<'db> InferenceContext<'db> {
             match slot {
                 BodyTypeArgRef::Static(type_ref) => {
                     let computed = self.computed_generic_argument_name(*type_ref, site);
-                    let lowered =
-                        self.lower_scoped_type_ref_at(&self.type_refs.store, *type_ref, position);
+                    let (lowered, diagnostics) =
+                        self.lower_scoped_body_type_ref_at(*type_ref, position);
                     if let Some(name) = computed {
-                        self.specialize_computed_generic_diagnostic(*type_ref, site, &name);
+                        self.specialize_computed_generic_diagnostic(
+                            diagnostics,
+                            *type_ref,
+                            site,
+                            &name,
+                        );
+                    } else {
+                        self.queue_body_lowering_diagnostics(diagnostics);
                     }
                     let ty = self.reject_expr_position_holes(&lowered, site);
                     slots.push(CallTypeArgPlan::Static {
@@ -7998,11 +8016,11 @@ impl<'db> InferenceContext<'db> {
 
     fn computed_generic_argument_name(
         &self,
-        type_ref: baml_compiler2_hir::type_ref::TypeRefId,
+        type_ref: BodyTypeRefId,
         site: ExprId,
     ) -> Option<baml_type::Name> {
         use baml_compiler2_hir::type_ref::TypeRefKind;
-        let written = &self.type_refs.store[type_ref];
+        let written = &self.type_refs.store[self.type_refs.raw_id(type_ref)];
         let TypeRefKind::Path {
             segments,
             generic_args,
@@ -8031,18 +8049,19 @@ impl<'db> InferenceContext<'db> {
         (is_value && !is_type).then(|| name.clone())
     }
 
-    /// Replace the lowering sink's generic unresolved-type finding for a
-    /// value-shaped slot with M-1's targeted whole-slot diagnostic. Any other
-    /// lowering findings already queued retain their original anchors.
+    /// Replace a generic unresolved-type finding for a value-shaped slot with
+    /// M-1's targeted whole-slot diagnostic. Any other findings from the same
+    /// lowering operation retain their original anchors.
     fn specialize_computed_generic_diagnostic(
         &mut self,
-        type_ref: baml_compiler2_hir::type_ref::TypeRefId,
+        diagnostics: Vec<crate::lower::LoweringDiag>,
+        type_ref: BodyTypeRefId,
         site: ExprId,
         name: &baml_type::Name,
     ) {
         let mut replaced = false;
-        for lowering in self.lower.take_diagnostics() {
-            if lowering.type_ref == type_ref
+        for lowering in diagnostics {
+            if lowering.type_ref == self.type_refs.raw_id(type_ref)
                 && matches!(
                     &lowering.kind,
                     crate::lower::LoweringDiagKind::Unresolved { name: unresolved, .. }
@@ -8052,7 +8071,7 @@ impl<'db> InferenceContext<'db> {
                 replaced = true;
             } else {
                 self.pending_diags.push(PendingDiag::BodyAnnot {
-                    type_ref: lowering.type_ref,
+                    type_ref: self.type_refs.diagnostic_id(lowering.type_ref),
                     kind: lowering.kind,
                 });
             }
@@ -9248,15 +9267,13 @@ impl<'db> InferenceContext<'db> {
     /// One body-position annotation, lowered and hole-instantiated - the
     /// single entry for every type written inside a body (let ascriptions,
     /// lambda signature slots, turbofish go through `instantiation_args`).
-    fn lower_body_annotation(&mut self, type_ref: baml_compiler2_hir::type_ref::TypeRefId) -> Ty {
+    fn lower_body_annotation(&mut self, type_ref: BodyTypeRefId) -> Ty {
         if let Some(cached) = self.annotation_cache.get(&type_ref) {
             return cached.clone();
         }
-        let lowered = self.lower_scoped_type_ref_at(
-            &self.type_refs.store,
-            type_ref,
-            crate::lower::TypePosition::Existential,
-        );
+        let (lowered, diagnostics) =
+            self.lower_scoped_body_type_ref_at(type_ref, crate::lower::TypePosition::Existential);
+        self.queue_body_lowering_diagnostics(diagnostics);
         // Written-type well-formedness (rustc's wfcheck at body
         // annotations): generic arguments must satisfy their heads'
         // declared bounds. Hole-carrying annotations skip - their holes
@@ -10054,14 +10071,6 @@ impl<'db> InferenceContext<'db> {
                     related: Vec::new(),
                 });
             }
-            // The body LowerCtx's sink: every written annotation whose
-            // path resolved nowhere (E0002), anchored at its TypeRefId.
-            for lowering in self.lower.take_diagnostics() {
-                self.pending_diags.push(PendingDiag::BodyAnnot {
-                    type_ref: lowering.type_ref,
-                    kind: lowering.kind,
-                });
-            }
             // A `_` hole that never solved reports E0147 at the hole
             // (rustc's E0282). One WRITTEN hole may instantiate several
             // times (the typing drive and the pattern walk both lower the
@@ -10085,7 +10094,7 @@ impl<'db> InferenceContext<'db> {
                     continue;
                 }
                 let location = match at {
-                    HoleAnchor::TypeRef(type_ref) => DiagnosticLocation::TypeRef(type_ref),
+                    HoleAnchor::TypeRef(type_ref) => DiagnosticLocation::BodyTypeRef(type_ref),
                 };
                 diags.push(TirDiagnostic {
                     error: TirTypeError::CannotInferType,
@@ -10151,7 +10160,7 @@ impl<'db> InferenceContext<'db> {
                         diags.push(TirDiagnostic {
                             error,
                             severity: DiagnosticSeverity::Error,
-                            primary: DiagnosticLocation::TypeRef(type_ref),
+                            primary: DiagnosticLocation::BodyTypeRef(type_ref),
                             related: Vec::new(),
                         });
                         continue;
@@ -10897,7 +10906,7 @@ impl<'db> InferenceContext<'db> {
                         diags.push(TirDiagnostic {
                             error: crate::lower::lowering_diag_error(&kind),
                             severity: DiagnosticSeverity::Error,
-                            primary: DiagnosticLocation::TypeRef(type_ref),
+                            primary: DiagnosticLocation::BodyTypeRef(type_ref),
                             related: Vec::new(),
                         });
                         continue;
@@ -10941,7 +10950,9 @@ impl<'db> InferenceContext<'db> {
                 DiagnosticLocation::Stmt(id) => (1, u32::from(id.into_raw())),
                 DiagnosticLocation::TypeAnnot(id) => (2, u32::from(id.into_raw())),
                 DiagnosticLocation::Pat(id) => (4, u32::from(id.into_raw())),
-                DiagnosticLocation::TypeRef(id) => (5, u32::from(id.into_raw())),
+                DiagnosticLocation::BodyTypeRef(id) => {
+                    (5, u32::from(self.type_refs.raw_id(id).into_raw()))
+                }
                 DiagnosticLocation::UnreflectArg { carrier, .. } => {
                     (6, u32::from(carrier.into_raw()))
                 }

--- a/baml_language/crates/baml_compiler2_hir_ty/src/interfaces.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/interfaces.rs
@@ -82,7 +82,6 @@ fn scope_ctx<'db>(scope: &LowerScope<'_, 'db>) -> crate::lower::LowerCtx<'db> {
                 .as_ref()
                 .map(baml_type::interned::Ty::from_plain),
         )
-        .with_diagnostics()
 }
 
 pub(crate) fn lower_ref_in(
@@ -111,13 +110,14 @@ pub(crate) fn lower_ref_in_at(
     diags: &mut Vec<TirTypeError>,
 ) -> Ty {
     let ctx = scope_ctx(scope);
-    let lowered = ctx.lower_type_ref_at(store, id, position).to_plain();
+    let (lowered, lowering_diagnostics) =
+        ctx.lower_type_ref_at_with_diagnostics(store, id, position);
     diags.extend(
-        ctx.take_diagnostics()
+        lowering_diagnostics
             .into_iter()
             .map(|diag| crate::lower::lowering_diag_error(&diag.kind)),
     );
-    lowered
+    lowered.to_plain()
 }
 
 /// [`lower_expr_in`] at an explicit [`crate::lower::TypePosition`].

--- a/baml_language/crates/baml_compiler2_hir_ty/src/lower.rs
+++ b/baml_language/crates/baml_compiler2_hir_ty/src/lower.rs
@@ -44,9 +44,10 @@ enum ResolvedTypeDefinition<'db> {
 
 /// Everything needed to lower type syntax appearing in one file, for one
 /// generic frame.
-/// One unresolved written type (E0002), anchored at its `TypeRefId` -
-/// r-a's `TyLoweringDiagnostic` shape (ids here; the check layer resolves
-/// spans through the body's `TypeRefSourceMap` on demand).
+/// One unresolved written type (E0002), anchored at its `TypeRefId`.
+///
+/// The caller resolves the id through the source map paired with the store
+/// passed to the one-shot lowering operation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LoweringDiag {
     pub type_ref: TypeRefId,
@@ -100,8 +101,8 @@ pub enum TypePosition {
 }
 
 pub struct LowerCtx<'db> {
-    /// Sink for lowering diagnostics, enabled by [`LowerCtx::with_diagnostics`]
-    /// (signatures/declarations lower without one; bodies collect).
+    /// A short-lived sink used only by the one-shot diagnostic lowering APIs.
+    /// Persistent lowering contexts never retain diagnostics across stores.
     diags: Option<std::cell::RefCell<Vec<LoweringDiag>>>,
     /// The innermost `TypeRefId` currently lowering - the anchor an
     /// unresolved path reports at.
@@ -174,14 +175,6 @@ pub fn lower_ctx_for_package<'db>(
 }
 
 impl<'db> LowerCtx<'db> {
-    /// Enable the lowering-diagnostic sink (bodies; declarations lower
-    /// silent). Drain with [`LowerCtx::take_diagnostics`].
-    #[must_use]
-    pub fn with_diagnostics(mut self) -> LowerCtx<'db> {
-        self.diags = Some(std::cell::RefCell::new(Vec::new()));
-        self
-    }
-
     /// The namespace path this context resolves relative names in.
     pub fn namespace_context(&self) -> &[Name] {
         &self.ns_context
@@ -205,7 +198,7 @@ impl<'db> LowerCtx<'db> {
         }
     }
 
-    pub fn take_diagnostics(&self) -> Vec<LoweringDiag> {
+    fn take_diagnostics(&self) -> Vec<LoweringDiag> {
         self.diags
             .as_ref()
             .map(|cell| std::mem::take(&mut *cell.borrow_mut()))
@@ -252,6 +245,27 @@ impl<'db> LowerCtx<'db> {
         self.lower_type_ref_at(store, id, TypePosition::Existential)
     }
 
+    /// Lower one type-reference tree and return only the diagnostics produced
+    /// by that tree. The sink cannot outlive this call, so arena-local ids can
+    /// never leak into diagnostics from a later store.
+    pub fn lower_type_ref_with_diagnostics(
+        &self,
+        store: &TypeRefStore,
+        id: TypeRefId,
+    ) -> (Ty, Vec<LoweringDiag>) {
+        self.lower_type_ref_at_with_diagnostics(store, id, TypePosition::Existential)
+    }
+
+    /// [`Self::lower_type_ref_with_diagnostics`] at an explicit position.
+    pub fn lower_type_ref_at_with_diagnostics(
+        &self,
+        store: &TypeRefStore,
+        id: TypeRefId,
+        position: TypePosition,
+    ) -> (Ty, Vec<LoweringDiag>) {
+        self.lower_type_ref_with_overlay_and_diagnostics(store, id, position, &[])
+    }
+
     /// [`Self::lower_type_ref`] at an explicit [`TypePosition`]. The
     /// position applies to the reference's HEAD only; nested references
     /// (generic args, union members, binding values) are existential.
@@ -287,6 +301,21 @@ impl<'db> LowerCtx<'db> {
         ty
     }
 
+    /// Diagnostic-producing counterpart to
+    /// [`Self::lower_type_ref_with_overlay`]. The returned diagnostics are
+    /// scoped to `store` and this call only.
+    pub fn lower_type_ref_with_overlay_and_diagnostics(
+        &self,
+        store: &TypeRefStore,
+        id: TypeRefId,
+        position: TypePosition,
+        overlay: &[ParamTy],
+    ) -> (Ty, Vec<LoweringDiag>) {
+        let fork = self.fork_with_overlay_and_diagnostics(overlay);
+        let ty = fork.lower_type_ref_at(store, id, position);
+        (ty, fork.take_diagnostics())
+    }
+
     /// [`Self::lower_type_path`] through the same body-local overlay.
     pub fn lower_type_path_with_overlay(&self, segments: &[Name], overlay: &[ParamTy]) -> Ty {
         if overlay.is_empty() {
@@ -315,6 +344,12 @@ impl<'db> LowerCtx<'db> {
             self_impl_target: self.self_impl_target.clone(),
             bounds: self.bounds.clone(),
         }
+    }
+
+    fn fork_with_overlay_and_diagnostics(&self, overlay: &[ParamTy]) -> LowerCtx<'db> {
+        let mut fork = self.fork_with_overlay(overlay);
+        fork.diags = Some(std::cell::RefCell::new(Vec::new()));
+        fork
     }
 
     fn merge_fork_diagnostics(&self, fork: &LowerCtx<'db>) {
@@ -2119,6 +2154,19 @@ pub fn lowering_diag_error(kind: &LoweringDiagKind) -> crate::diagnostics::TirTy
     }
 }
 
+fn extend_lowering_diagnostics(
+    out: &mut Vec<(text_size::TextRange, crate::diagnostics::TirTypeError)>,
+    source_map: &baml_compiler2_hir::type_ref::TypeRefSourceMap,
+    diagnostics: Vec<LoweringDiag>,
+) {
+    out.extend(diagnostics.into_iter().map(|diag| {
+        (
+            source_map.span(diag.type_ref),
+            lowering_diag_error(&diag.kind),
+        )
+    }));
+}
+
 /// Whether a declared throws clause is an open contract: it names `unknown`
 /// directly, through a union member, or through a type alias. An open
 /// contract deliberately admits any thrown value, so throws-coverage
@@ -2167,8 +2215,7 @@ pub fn signature_lowering_diagnostics<'db>(
         .with_frame(frame)
         .with_bounds(bounds)
         .with_self_ty(concrete_self)
-        .with_impl_target(impl_target)
-        .with_diagnostics();
+        .with_impl_target(impl_target);
     // Params/ret/throws lowered from the ELABORATED store: their ids index
     // the elaborated source map, not the written one (the two stores number
     // independently - a raw-map lookup here is an out-of-bounds panic on any
@@ -2179,13 +2226,14 @@ pub fn signature_lowering_diagnostics<'db>(
     // judged for generic-argument well-formedness (rustc's wfcheck:
     // `Box<int>` under `class Box<T extends Named>` reports here).
     let scope_env = plain_scope_bounds(function_generic_bounds(db, function));
-    let mut wf: Vec<(text_size::TextRange, TirTypeError)> = Vec::new();
+    let mut out: Vec<(text_size::TextRange, TirTypeError)> = Vec::new();
     let mut lower_and_judge = |type_ref: baml_compiler2_hir::type_ref::TypeRefId| {
-        let lowered = ctx.lower_type_ref(&data.type_refs, type_ref);
+        let (lowered, diagnostics) = ctx.lower_type_ref_with_diagnostics(&data.type_refs, type_ref);
+        extend_lowering_diagnostics(&mut out, &elaborated_map.type_refs, diagnostics);
         for error in
             crate::interfaces::type_generic_bound_errors(db, &scope_env, &lowered.to_plain())
         {
-            wf.push((elaborated_map.type_refs.span(type_ref), error));
+            out.push((elaborated_map.type_refs.span(type_ref), error));
         }
     };
     for param in &data.params {
@@ -2204,17 +2252,6 @@ pub fn signature_lowering_diagnostics<'db>(
     if let Some(throws) = data.throws {
         lower_and_judge(throws);
     }
-    let mut out: Vec<(text_size::TextRange, TirTypeError)> = ctx
-        .take_diagnostics()
-        .into_iter()
-        .map(|diag| {
-            (
-                elaborated_map.type_refs.span(diag.type_ref),
-                lowering_diag_error(&diag.kind),
-            )
-        })
-        .collect();
-    out.extend(wf);
     // A bound must name an interface DIRECTLY (E0145): an alias denotes
     // a type, never the interface itself. `function_generic_bounds`
     // silently skips such bounds; the diagnostic walk names them. Bounds
@@ -2227,8 +2264,12 @@ pub fn signature_lowering_diagnostics<'db>(
         .iter()
         .flat_map(|g| g.bounds.iter())
     {
-        let lowered =
-            ctx.lower_type_ref_at(&func_data.type_refs, *bound, TypePosition::ConstraintHead);
+        let (lowered, diagnostics) = ctx.lower_type_ref_at_with_diagnostics(
+            &func_data.type_refs,
+            *bound,
+            TypePosition::ConstraintHead,
+        );
+        extend_lowering_diagnostics(&mut out, &source_map.type_refs, diagnostics);
         match lowered.kind() {
             // The compiler-derived builtin interface is a VALUE type,
             // never a bound (E0154).
@@ -2256,14 +2297,6 @@ pub fn signature_lowering_diagnostics<'db>(
             }
         }
     }
-    // The bounds walk's own sink records (an unresolved name INSIDE a
-    // bound's arguments) - written-store ids, written-map spans.
-    out.extend(ctx.take_diagnostics().into_iter().map(|diag| {
-        (
-            source_map.type_refs.span(diag.type_ref),
-            lowering_diag_error(&diag.kind),
-        )
-    }));
     out
 }
 
@@ -2368,8 +2401,7 @@ pub fn class_lowering_diagnostics<'db>(
     let frame = class_generic_frame(db, class);
     let ctx = lower_ctx_for_file(db, class.file(db))
         .with_frame(frame)
-        .with_bounds(class_generic_bounds(db, class))
-        .with_diagnostics();
+        .with_bounds(class_generic_bounds(db, class));
     let source_map = baml_compiler2_ppir::item_data::class_source_map(db, class);
     let mut out = Vec::new();
     // Field annotations: every written field type re-lowers with the sink
@@ -2377,7 +2409,9 @@ pub fn class_lowering_diagnostics<'db>(
     // and is judged for generic-argument well-formedness.
     let scope_env = plain_scope_bounds(class_generic_bounds(db, class));
     for field in &data.fields {
-        let lowered = ctx.lower_type_ref(&data.type_refs, field.type_ref);
+        let (lowered, diagnostics) =
+            ctx.lower_type_ref_with_diagnostics(&data.type_refs, field.type_ref);
+        extend_lowering_diagnostics(&mut out, &source_map.type_refs, diagnostics);
         for error in
             crate::interfaces::type_generic_bound_errors(db, &scope_env, &lowered.to_plain())
         {
@@ -2385,7 +2419,12 @@ pub fn class_lowering_diagnostics<'db>(
         }
     }
     for bound in data.generic_params.iter().flat_map(|g| g.bounds.iter()) {
-        let lowered = ctx.lower_type_ref_at(&data.type_refs, *bound, TypePosition::ConstraintHead);
+        let (lowered, diagnostics) = ctx.lower_type_ref_at_with_diagnostics(
+            &data.type_refs,
+            *bound,
+            TypePosition::ConstraintHead,
+        );
+        extend_lowering_diagnostics(&mut out, &source_map.type_refs, diagnostics);
         match lowered.kind() {
             TyKind::Interface(qtn, ..) if qtn.is_builtin_root_type("AnyFunction") => {
                 out.push((
@@ -2411,12 +2450,6 @@ pub fn class_lowering_diagnostics<'db>(
             }
         }
     }
-    out.extend(ctx.take_diagnostics().into_iter().map(|diag| {
-        (
-            source_map.type_refs.span(diag.type_ref),
-            lowering_diag_error(&diag.kind),
-        )
-    }));
     out
 }
 
@@ -2432,8 +2465,7 @@ pub fn interface_lowering_diagnostics<'db>(
     let frame = interface_frame(db, interface);
     let ctx = lower_ctx_for_file(db, interface.file(db))
         .with_frame(frame)
-        .with_bounds(interface_scope_bounds(db, interface))
-        .with_diagnostics();
+        .with_bounds(interface_scope_bounds(db, interface));
     let source_map = baml_compiler2_ppir::item_data::interface_source_map(db, interface);
     let mut out = Vec::new();
     // Field and required-method annotations judge for generic-argument
@@ -2441,7 +2473,8 @@ pub fn interface_lowering_diagnostics<'db>(
     let scope_env = plain_scope_bounds(interface_scope_bounds(db, interface));
     let judge = |type_ref: baml_compiler2_hir::type_ref::TypeRefId,
                  out: &mut Vec<(text_size::TextRange, TirTypeError)>| {
-        let lowered = ctx.lower_type_ref(&data.type_refs, type_ref);
+        let (lowered, diagnostics) = ctx.lower_type_ref_with_diagnostics(&data.type_refs, type_ref);
+        extend_lowering_diagnostics(out, &source_map.type_refs, diagnostics);
         for error in
             crate::interfaces::type_generic_bound_errors(db, &scope_env, &lowered.to_plain())
         {
@@ -2566,7 +2599,12 @@ pub fn interface_lowering_diagnostics<'db>(
         ));
     }
     for &target in &data.requires {
-        let lowered = ctx.lower_type_ref_at(&data.type_refs, target, TypePosition::ConstraintHead);
+        let (lowered, diagnostics) = ctx.lower_type_ref_at_with_diagnostics(
+            &data.type_refs,
+            target,
+            TypePosition::ConstraintHead,
+        );
+        extend_lowering_diagnostics(&mut out, &source_map.type_refs, diagnostics);
         if !lowered.has_error() && !matches!(lowered.kind(), TyKind::Interface(..)) {
             out.push((
                 source_map.type_refs.span(target),
@@ -2577,12 +2615,6 @@ pub fn interface_lowering_diagnostics<'db>(
             ));
         }
     }
-    out.extend(ctx.take_diagnostics().into_iter().map(|diag| {
-        (
-            source_map.type_refs.span(diag.type_ref),
-            lowering_diag_error(&diag.kind),
-        )
-    }));
     out
 }
 
@@ -2625,19 +2657,11 @@ pub fn type_alias_lowering_diagnostics<'db>(
     let Some(value) = data.value else {
         return Vec::new();
     };
-    let ctx = lower_ctx_for_file(db, alias.file(db)).with_diagnostics();
-    let lowered = ctx.lower_type_ref(&data.type_refs, value);
+    let ctx = lower_ctx_for_file(db, alias.file(db));
+    let (lowered, diagnostics) = ctx.lower_type_ref_with_diagnostics(&data.type_refs, value);
     let source_map = baml_compiler2_ppir::item_data::type_alias_source_map(db, alias);
-    let mut out: Vec<(text_size::TextRange, crate::diagnostics::TirTypeError)> = ctx
-        .take_diagnostics()
-        .into_iter()
-        .map(|diag| {
-            (
-                source_map.type_refs.span(diag.type_ref),
-                lowering_diag_error(&diag.kind),
-            )
-        })
-        .collect();
+    let mut out = Vec::new();
+    extend_lowering_diagnostics(&mut out, &source_map.type_refs, diagnostics);
     // The RHS judges for generic-argument well-formedness (aliases are
     // non-generic, so the scope env is empty). The walk expands nested
     // aliases itself; judging the WRITTEN body here keeps one report at

--- a/baml_language/crates/baml_compiler2_ppir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/lib.rs
@@ -768,7 +768,12 @@ pub fn body_type_ref_spans(
                 LetBody::Missing => None,
             }
         }
-        BodyOwnerId::ParameterDefaults(_) => None,
+        BodyOwnerId::ParameterDefaults(function) => Some(
+            baml_compiler2_hir::body_type_refs::collect_body_type_refs(
+                &function_parameter_defaults(db, function).defaults.exprs,
+            )
+            .1,
+        ),
     }
 }
 

--- a/baml_language/crates/baml_compiler2_ppir/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_ppir/src/lib.rs
@@ -751,7 +751,7 @@ pub fn function_body_type_refs<'db>(
 pub fn body_type_ref_spans(
     db: &dyn Db,
     owner: baml_compiler2_hir::body::BodyOwnerId<'_>,
-) -> Option<baml_compiler2_hir::type_ref::TypeRefSourceMap> {
+) -> Option<baml_compiler2_hir::body_type_refs::BodyTypeRefSourceMap> {
     use baml_compiler2_hir::body::{BodyOwnerId, FunctionBody, LetBody};
     match owner {
         BodyOwnerId::Function(function) => match function_body(db, function).as_ref() {

--- a/baml_language/crates/baml_lsp2_actions/src/check.rs
+++ b/baml_language/crates/baml_lsp2_actions/src/check.rs
@@ -137,7 +137,7 @@ pub fn check_file(db: &dyn Db, file: SourceFile) -> Vec<Diagnostic> {
             let source_map = baml_compiler2_ppir::body_source_map(db, owner);
             let type_ref_spans = baml_compiler2_ppir::body_type_ref_spans(db, owner);
             for diagnostic in &result.diagnostics {
-                let rendered = diagnostic.render_with_type_refs(
+                let rendered = diagnostic.render_with_body_type_refs(
                     db,
                     file,
                     source_map.as_ref(),
@@ -1217,7 +1217,7 @@ fn new_tir_diagnostic(
         // slot says why the inline spelling cannot reach past this call —
         // naming whichever published type the runtime parameter reached, the
         // value or the error. The rewrite rides along as related info, built
-        // from the file text in `render_with_type_refs`.
+        // from the file text in `render_with_body_type_refs`.
         return runtime_type::runtime_type_must_be_named()
             .with_primary(span, escape.note())
             .with_phase(DiagnosticPhase::Type);

--- a/baml_language/crates/baml_lsp2_actions_tests/src/b1607_diagnostic_ownership.rs
+++ b/baml_language/crates/baml_lsp2_actions_tests/src/b1607_diagnostic_ownership.rs
@@ -1,0 +1,49 @@
+use std::path::Path;
+
+use baml_compiler_diagnostics::DiagnosticId;
+use baml_lsp2_actions::check::check_file;
+use baml_project::ProjectDatabase;
+use text_size::{TextRange, TextSize};
+
+#[test]
+fn unresolved_throws_types_are_reported_once_at_the_signature() {
+    let source = r#"function unresolved_throws_empty() -> string throws MissingEmpty {
+  `x`
+}
+
+function unresolved_throws_with_body_annotations() -> string throws MissingInBounds {
+  let a: int = 1
+  let b: string = `b`
+  let c: bool = true
+  let d: float = 4.0
+  let e: int[] = [5]
+  let f: map<string, int> = { "f": 6 }
+  `${a}${b}${c}${d}${e}${f}`
+}
+"#;
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(Path::new("."));
+    let file = db.add_or_update_file(Path::new("b1607.baml"), source);
+
+    let diagnostics = check_file(&db, file);
+    let unresolved: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.id == DiagnosticId::UnknownType)
+        .collect();
+    assert_eq!(unresolved.len(), 2, "each signature should report once");
+
+    for (diagnostic, missing) in unresolved
+        .into_iter()
+        .zip(["MissingEmpty", "MissingInBounds"])
+    {
+        assert_eq!(diagnostic.message, format!("unresolved type: {missing}"));
+        let start = source.find(missing).expect("missing type in source") as u32;
+        let expected = TextRange::at(TextSize::new(start), TextSize::new(missing.len() as u32));
+        let primary = diagnostic
+            .annotations
+            .iter()
+            .find(|annotation| annotation.is_primary)
+            .expect("primary annotation");
+        assert_eq!(primary.span.range, expected);
+    }
+}

--- a/baml_language/crates/baml_lsp2_actions_tests/src/b1607_diagnostic_ownership.rs
+++ b/baml_language/crates/baml_lsp2_actions_tests/src/b1607_diagnostic_ownership.rs
@@ -47,3 +47,34 @@ function unresolved_throws_with_body_annotations() -> string throws MissingInBou
         assert_eq!(primary.span.range, expected);
     }
 }
+
+#[test]
+fn unresolved_type_in_parameter_default_has_its_source_span() {
+    let source = r#"function parameter_default(
+  value: int = { let typed: MissingDefault = 1; 1 }
+) -> int {
+  value
+}
+"#;
+    let mut db = ProjectDatabase::new();
+    db.set_project_root(Path::new("."));
+    let file = db.add_or_update_file(Path::new("b1607-default.baml"), source);
+
+    let diagnostics = check_file(&db, file);
+    let unresolved: Vec<_> = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.id == DiagnosticId::UnknownType)
+        .collect();
+    assert_eq!(unresolved.len(), 1);
+
+    let diagnostic = unresolved[0];
+    let missing = "MissingDefault";
+    let start = source.find(missing).expect("missing type in source") as u32;
+    let expected = TextRange::at(TextSize::new(start), TextSize::new(missing.len() as u32));
+    let primary = diagnostic
+        .annotations
+        .iter()
+        .find(|annotation| annotation.is_primary)
+        .expect("primary annotation");
+    assert_eq!(primary.span.range, expected);
+}

--- a/baml_language/crates/baml_lsp2_actions_tests/src/lib.rs
+++ b/baml_language/crates/baml_lsp2_actions_tests/src/lib.rs
@@ -1,4 +1,6 @@
 #[cfg(test)]
+mod b1607_diagnostic_ownership;
+#[cfg(test)]
 mod lsp_issues_authoring;
 #[cfg(test)]
 mod lsp_issues_generic_hover;

--- a/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/mod.rs
@@ -1255,7 +1255,7 @@ pub(crate) mod support {
                 let type_ref_spans = baml_compiler2_ppir::body_type_ref_spans(db, owner);
                 let mut rendered = Vec::new();
                 for diagnostic in &inference.diagnostics {
-                    rendered.push(diagnostic.render_with_type_refs(
+                    rendered.push(diagnostic.render_with_body_type_refs(
                         db,
                         file,
                         source_map.as_ref(),
@@ -1270,7 +1270,7 @@ pub(crate) mod support {
                     let defaults_spans =
                         baml_compiler2_ppir::body_type_ref_spans(db, defaults_owner);
                     for diagnostic in &defaults.diagnostics {
-                        rendered.push(diagnostic.render_with_type_refs(
+                        rendered.push(diagnostic.render_with_body_type_refs(
                             db,
                             file,
                             defaults_map.as_ref(),

--- a/baml_language/crates/baml_tests/src/compiler2_tir/phase5.rs
+++ b/baml_language/crates/baml_tests/src/compiler2_tir/phase5.rs
@@ -22,9 +22,9 @@ fn lower_type_expr_hir_in(
     let mut builder = baml_compiler2_hir::type_ref::TypeRefBuilder::new();
     let id = builder.lower(expr);
     let (store, _spans) = builder.finish();
-    let ctx = baml_compiler2_hir_ty::lower::lower_ctx_for_file(db, file).with_diagnostics();
-    let ty = ctx.lower_type_ref(&store, id).to_plain();
-    (ty, ctx.take_diagnostics())
+    let ctx = baml_compiler2_hir_ty::lower::lower_ctx_for_file(db, file);
+    let (ty, diagnostics) = ctx.lower_type_ref_with_diagnostics(&store, id);
+    (ty.to_plain(), diagnostics)
 }
 
 fn lower_type_expr_hir(

--- a/baml_language/crates/baml_tests/tests/runtime_type_escape.rs
+++ b/baml_language/crates/baml_tests/tests/runtime_type_escape.rs
@@ -221,7 +221,7 @@ function main(t: reflect.Type) -> unknown throws unknown { wrap<unreflect(t)>(1)
 /// The same report from the CALL side, whose span and rewrite travel a
 /// different road than the class literal's: the slot span comes from
 /// `DiagnosticLocation::UnreflectArg` through `AstSourceMap`, and the rewrite
-/// is assembled in `TirDiagnostic::render_with_type_refs` from the file text.
+/// is assembled in `TirDiagnostic::render_with_body_type_refs` from the file text.
 /// The code+message assertions above would not notice either degrading.
 #[test]
 fn the_report_at_a_call_site_names_the_slot_and_spells_the_fix() {


### PR DESCRIPTION
Fixes B-1607 by making body type-reference diagnostic anchors owner-specific and making diagnostic-producing type lowering transactional per TypeRefStore. This prevents signature diagnostics from being rendered through a body source map. Adds regression coverage for both the panic and the in-bounds mislocation case. Tests: cargo test -p baml_tests --lib; cargo test -p baml_lsp2_actions_tests; affected-crate clippy with warnings denied; cargo fmt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type diagnostic ownership and source locations, preventing duplicate or misattributed errors.
  * Unresolved types in function `throws` signatures now report one accurate diagnostic per issue.
  * Unresolved types in parameter defaults now point to the correct source range.

* **Improvements**
  * Type diagnostics are collected more reliably during compilation.
  * Diagnostic rendering preserves body-specific type reference locations across compiler and language-server features.

* **Tests**
  * Added regression coverage for unresolved types and diagnostic source ranges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->