### PR TITLE
fix(playground): remove obsolete profile chunk protocol

### DIFF
--- a/baml_language/crates/baml_compiler2_emit/src/lib.rs
+++ b/baml_language/crates/baml_compiler2_emit/src/lib.rs
@@ -6,6 +6,7 @@ mod analysis;
 mod emit;
 mod pull_semantics;
 mod stack_carry;
+#[cfg(any(debug_assertions, test))]
 mod verifier;
 
 use std::collections::{HashMap, HashSet};

--- a/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
+++ b/typescript2/app-promptfiddle/src/playground/baml-lsp-worker.ts
@@ -439,9 +439,6 @@ function onPlaygroundNotification(notification: PlaygroundNotification): void {
         type: 'runPatch',
       } as WorkerOutMessage);
       break;
-    case 'profileArtifactChunk':
-      postOut(notification as WorkerOutMessage);
-      break;
     case 'runSnapshot':
       postOut({
         boundaryId: notification.boundaryId,

--- a/typescript2/app-website/playground/baml-worker.ts
+++ b/typescript2/app-website/playground/baml-worker.ts
@@ -349,9 +349,6 @@ function onPlaygroundNotification(notification: PlaygroundNotification): void {
         type: 'commandError',
       });
       break;
-    case 'profileArtifactChunk':
-      postOut(notification as WorkerOutMessage);
-      break;
     default:
       postOut({
         notification: notification as unknown as WorkerPlaygroundNotification,

--- a/typescript2/pkg-playground/src/ExecutionPanel.tsx
+++ b/typescript2/pkg-playground/src/ExecutionPanel.tsx
@@ -1399,7 +1399,6 @@ export const ExecutionPanel: FC<ExecutionPanelProps> = ({
         case 'runSnapshot':
         case 'valueBody':
         case 'runCursorExpired':
-        case 'profileArtifactChunk':
           // RunStoreClient consumes these during the staged migration. The
           // legacy reducer keeps ignoring them until the UI cutover.
           break;

--- a/typescript2/pkg-playground/src/worker-protocol.ts
+++ b/typescript2/pkg-playground/src/worker-protocol.ts
@@ -191,23 +191,7 @@ export type PlaygroundNotification =
       data: number[];
       expandError?: { testsetName: string; message: string };
     }
-  | {
-      type: 'profileArtifactChunk';
-      boundaryId?: BoundaryId;
-      engineId: number;
-      processId: string;
-      bytesBase64: string;
-      retainedBytes: number;
-      maxBytes?: number;
-      droppedBytes: number;
-      droppedChunks: number;
-    }
   | ({ type: 'valueBody' } & ValueBodyResponse);
-
-export type ProfileArtifactChunkMessage = Extract<
-  PlaygroundNotification,
-  { type: 'profileArtifactChunk' }
->;
 
 // ---------------------------------------------------------------------------
 // Control flow graph types (matches Rust serde output from baml_compiler2_visualization)
@@ -810,7 +794,6 @@ export type WebSocketInMessage =
 export type WorkerOutMessage =
   | { type: 'ready'; version?: string; commit?: string }
   | { type: 'playgroundNotification'; notification: PlaygroundNotification }
-  | ProfileArtifactChunkMessage
   | { type: 'diagnostics'; entries: DiagnosticEntry[] }
   | { type: 'runStarted'; requestId?: number; run: Run }
   | { type: 'runPatch'; patch: RunPatch }


### PR DESCRIPTION
## Summary

- remove stale profileArtifactChunk handling after WASM profile chunk delivery was removed
- remove the obsolete shared worker message variant
- compile the MIR invariant verifier only for debug and test builds

## Validation

- PromptFiddle production build
- PromptFiddle and playground typechecks
- 155 playground tests
- 56 baml_compiler2_emit tests
- release Clippy with warnings denied
- repository pre-commit hooks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified playground notification handling by routing profile artifact updates through the standard notification flow.
  * Removed legacy profile artifact message handling to improve consistency across execution views.

* **Refactor**
  * Limited compiler verification support to development and test builds, reducing unnecessary production compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->